### PR TITLE
fix(desktop): promote primary when setting lastUsed so connection switch actually reconnects backend

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14733,7 +14733,15 @@ ipcMain.handle('hermes:connections:set-launch-mode', async (_event, mode) => {
   return { ok: true, registry: sanitizeConnectionsRegistry(registry) }
 })
 ipcMain.handle('hermes:connections:set-last-used', async (_event, id) => {
-  const registry = setLastUsedConnection(readDesktopConnectionsRegistry(), String(id || ''))
+  const connId = String(id || '')
+  let registry = setLastUsedConnection(readDesktopConnectionsRegistry(), connId)
+  // Also promote to primary so the backend reconnects to the chosen connection.
+  // Without this, setLastUsed only updated lastUsed while primary kept pointing
+  // at the old connection, and subsequent backend requests silently routed to
+  // the previous gateway (#97742).
+  if (registry.connections.some(c => c.id === connId)) {
+    registry = { ...registry, primary: connId }
+  }
   writeDesktopConnectionsRegistry(registry)
 
   return { ok: true, registry: sanitizeConnectionsRegistry(registry) }


### PR DESCRIPTION
## Problem (#97742)

\hermes:connections:set-last-used\ IPC handler only called \setLastUsedConnection\, which updates \lastUsed\ but leaves \primary\ unchanged. After switching from remote to local (or vice versa) in the connection switcher, \connections.json\ ended up with \lastUsed: 'local'\ but \primary: 'connection'\ (the old remote). The backend kept routing to the previous gateway.

## Fix

Also set \primary = connId\ in the IPC handler. The guard re-checks \connections.some()\ to stay consistent with \setLastUsedConnection\'s own validation.

Fixes #97742