### PR TITLE
fix(desktop): clear latched boot-failure overlay when backend recovers after renderer timeout

### DIFF
--- a/apps/desktop/src/store/boot.ts
+++ b/apps/desktop/src/store/boot.ts
@@ -35,7 +35,13 @@ export function applyDesktopBootProgress(progress: DesktopBootProgress) {
 
   // Don't let a late progress event (error: null) clobber a previously-set
   // boot failure — failDesktopBoot is terminal for this boot cycle.
-  const error = progress.error ?? (current.running ? null : current.error)
+  // EXCEPTION: if the new progress.running is true, the backend has recovered
+  // (e.g. on a slow Windows machine with AV scanning, the backend announces
+  // HERMES_BACKEND_READY after the 45s renderer timeout already latched the
+  // error overlay — #98486). A live running=true event resets the latch so
+  // the overlay clears and the desktop reconnects rather than staying
+  // permanently wedged until the user kills the process.
+  const error = progress.error ?? ((!current.running && !progress.running) ? current.error : null)
 
   $desktopBoot.set({
     ...current,


### PR DESCRIPTION
## Problem (#98486)

On Windows with AV scanning, \hermes serve\ can take 60–90 s to bind its port. The renderer's \getConnection()\ times out at ~45 s and latches the boot-failure overlay. When the backend then announces \HERMES_BACKEND_READY\, \pplyDesktopBootProgress\ receives \progress.running = true\ but preserved \current.error\ because \!current.running\ (already failed). The overlay stayed permanently wedged; only killing all \Hermes.exe\ processes recovered.

## Fix

In \oot.ts\, clear the latched error when the new \progress.running\ is \	rue\ — the backend is actively running and the previous failure is superseded. The guard still prevents a late \error: null\ from clearing a current failure.

Fixes #98486