### PR TITLE
fix(computer-use): stop reading a slow readiness probe as a dead daemon

### DIFF
--- a/tests/computer_use/conftest.py
+++ b/tests/computer_use/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for the computer-use backend tests."""
+
+import pytest
+
+from tools.computer_use import cua_backend
+
+
+@pytest.fixture(autouse=True)
+def _clear_mcp_invocation_cache() -> None:
+    """Isolate the CLI-discovery cache between tests.
+
+    Discovery is cached per driver path because the answer only changes when
+    the binary does. Tests break that assumption on purpose: several stub a
+    different driver behind the same path, so a result cached by one would be
+    served to the next.
+    """
+    cua_backend._reset_mcp_invocation_cache()

--- a/tests/computer_use/test_embedded_daemon_startup_budget.py
+++ b/tests/computer_use/test_embedded_daemon_startup_budget.py
@@ -1,0 +1,161 @@
+"""The embedded daemon's startup budget must belong to the daemon.
+
+`_EmbeddedCuaDaemon.start()` resolves the driver's CLI surface (`cua-driver
+manifest`) before it spawns `serve`, and both were measured against one
+15-second deadline. On a machine where discovery is slow the budget is spent
+before the daemon is launched, and the failure surfaces as "daemon did not
+become ready" with an empty stderr tail — blaming the daemon for time it never
+got.
+"""
+
+import subprocess
+import time
+from typing import Any
+
+import pytest
+
+from tools.computer_use import cua_backend
+
+
+class _FakeProcess:
+    """A spawned daemon that stays alive and never writes to stderr."""
+
+    def __init__(self) -> None:
+        self.stderr = None
+        self.terminated = False
+
+    def poll(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+
+@pytest.fixture
+def slow_discovery(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Make CLI discovery burn most of the startup budget."""
+    state: dict[str, Any] = {"discovery_calls": 0, "probe_calls": 0, "clock": 0.0}
+
+    def fake_resolve(driver_cmd: str, **_kw: Any) -> tuple[str, list[str]]:
+        state["discovery_calls"] += 1
+        state["clock"] += 14.0  # slow, but under discovery's own 6s-per-call cap
+        return driver_cmd, ["mcp", "--no-overlay"]
+
+    def fake_clock() -> float:
+        return state["clock"]
+
+    def fake_popen(*_args: Any, **_kw: Any) -> _FakeProcess:
+        return _FakeProcess()
+
+    def fake_run(args: Any, **_kw: Any) -> subprocess.CompletedProcess[str]:
+        # The readiness probe. The real daemon needs a moment to bind its
+        # socket, so the first probe misses and the second succeeds — enough
+        # that a budget already spent on discovery leaves no room to retry.
+        if isinstance(args, (list, tuple)) and "status" in args:
+            state["probe_calls"] += 1
+            state["clock"] += 0.5
+            code = 1 if state["probe_calls"] < 2 else 0
+            return subprocess.CompletedProcess(args, code, "", "not running")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(cua_backend, "_resolve_mcp_invocation_uncached", fake_resolve)
+    monkeypatch.setattr(cua_backend, "_MCP_INVOCATION_CACHE", {})
+    monkeypatch.setattr(cua_backend.time, "monotonic", fake_clock)
+    monkeypatch.setattr(cua_backend.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cua_backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(cua_backend, "_embedded_daemon_spawn_command",
+                        lambda cmd, args, **_kw: [cmd, *args])
+    monkeypatch.setattr(cua_backend, "resolve_cua_driver_cmd", lambda: "/usr/local/bin/cua-driver")
+    return state
+
+
+def test_slow_cli_discovery_does_not_consume_the_daemon_budget(
+    slow_discovery: dict[str, Any],
+) -> None:
+    """A ready daemon must not be reported as timed out because discovery was slow."""
+    daemon = cua_backend._EmbeddedCuaDaemon("/usr/local/bin/cua-driver", "unrestricted")
+
+    daemon.start()
+
+    assert daemon._running is True
+    assert slow_discovery["probe_calls"] >= 1, (
+        "startup never probed the daemon — the budget was spent before it launched"
+    )
+
+
+def test_a_probe_timeout_is_not_read_as_a_dead_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe that times out must not end the wait — it reports nothing.
+
+    `cua-driver status` opens the daemon socket and waits for a reply, so a
+    daemon that is still binding answers late rather than never. Treating that
+    timeout as "not ready" is what made a healthy 2.4s startup fail at 15s with
+    an empty diagnostic.
+    """
+    state = {"probes": 0}
+
+    def fake_run(args: Any, **kw: Any) -> subprocess.CompletedProcess[str]:
+        if isinstance(args, (list, tuple)) and "status" in args:
+            state["probes"] += 1
+            # The daemon is slow to bind: the first probes exceed the timeout,
+            # then it answers.
+            if state["probes"] < 3:
+                raise subprocess.TimeoutExpired(cmd=list(args), timeout=kw.get("timeout", 2.0))
+            return subprocess.CompletedProcess(args, 0, "running", "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(cua_backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(cua_backend.subprocess, "Popen", lambda *a, **k: _FakeProcess())
+    monkeypatch.setattr(cua_backend, "_embedded_daemon_spawn_command",
+                        lambda cmd, args, **_kw: [cmd, *args])
+    monkeypatch.setattr(cua_backend, "_resolve_mcp_invocation_uncached",
+                        lambda cmd, **_kw: (cmd, ["mcp"]))
+    monkeypatch.setattr(cua_backend, "_MCP_INVOCATION_CACHE", {})
+
+    daemon = cua_backend._EmbeddedCuaDaemon("/usr/local/bin/cua-driver", "unrestricted")
+    daemon.start()
+
+    assert daemon._running is True
+    assert state["probes"] >= 3, "gave up before the daemon had a chance to answer"
+
+
+def test_probe_timeout_budget_exceeds_a_cold_macos_launch() -> None:
+    """The probe must outlast the launch it is waiting on.
+
+    A cold `open -n -g -a` needs roughly 2.5s on macOS; a 2s probe timeout can
+    therefore never observe a healthy start.
+    """
+    assert cua_backend._EmbeddedCuaDaemon._PROBE_TIMEOUT_SECONDS > 2.5
+
+
+def test_timed_out_probes_are_named_in_the_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The error must distinguish a silent daemon from an unanswered probe."""
+
+    def always_timeout(args: Any, **kw: Any) -> subprocess.CompletedProcess[str]:
+        if isinstance(args, (list, tuple)) and "status" in args:
+            raise subprocess.TimeoutExpired(cmd=list(args), timeout=kw.get("timeout", 6.0))
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(cua_backend.subprocess, "run", always_timeout)
+    monkeypatch.setattr(cua_backend.subprocess, "Popen", lambda *a, **k: _FakeProcess())
+    monkeypatch.setattr(cua_backend, "_embedded_daemon_spawn_command",
+                        lambda cmd, args, **_kw: [cmd, *args])
+    monkeypatch.setattr(cua_backend, "_resolve_mcp_invocation_uncached",
+                        lambda cmd, **_kw: (cmd, ["mcp"]))
+    monkeypatch.setattr(cua_backend, "_MCP_INVOCATION_CACHE", {})
+    monkeypatch.setattr(cua_backend._EmbeddedCuaDaemon, "_START_TIMEOUT_SECONDS", 0.5)
+
+    daemon = cua_backend._EmbeddedCuaDaemon("/usr/local/bin/cua-driver", "unrestricted")
+
+    with pytest.raises(RuntimeError, match="readiness probe timed out"):
+        daemon.start()
+

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -682,6 +682,11 @@ class _EmbeddedCuaDaemon:
     """
 
     _START_TIMEOUT_SECONDS = 15.0
+    # A readiness probe opens the daemon socket and waits for a reply. Two
+    # seconds is under what a cold `open -n -g -a` launch needs on macOS, so
+    # every probe timed out and the daemon was declared dead while it was
+    # still coming up.
+    _PROBE_TIMEOUT_SECONDS = 6.0
 
     def __init__(
         self,
@@ -730,6 +735,7 @@ class _EmbeddedCuaDaemon:
         self._running = False
         self._launch_via_app = False
         self._stderr_tail: deque[str] = deque(maxlen=20)
+        self._probe_timeouts = 0
         self._stderr_thread: Optional[threading.Thread] = None
         token = uuid.uuid4().hex[:12]
         if sys.platform == "win32":
@@ -824,7 +830,9 @@ class _EmbeddedCuaDaemon:
         )
         self._stderr_thread.start()
 
-        deadline = time.monotonic() + self._START_TIMEOUT_SECONDS
+        deadline = (
+            time.monotonic() + self._START_TIMEOUT_SECONDS
+        )  # started after the spawn: the budget is the daemon's, not discovery's
         while time.monotonic() < deadline:
             return_code = self._process.poll()
             if return_code is not None and (
@@ -840,9 +848,17 @@ class _EmbeddedCuaDaemon:
                     stdin=subprocess.DEVNULL,
                     capture_output=True,
                     text=True,
-                    timeout=2.0,
+                    timeout=self._PROBE_TIMEOUT_SECONDS,
                     env=env,
                 )
+            except subprocess.TimeoutExpired:
+                # A probe that runs out of time says nothing about the daemon:
+                # `status` opens the socket and waits for a reply, so a daemon
+                # still binding answers late rather than never. Swallowing this
+                # as "not ready" is what turned a slow start into a silent
+                # 15-second timeout with an empty stderr tail.
+                self._probe_timeouts += 1
+                probe = None
             except (OSError, subprocess.SubprocessError):
                 probe = None
             if probe is not None and probe.returncode == 0:
@@ -851,7 +867,18 @@ class _EmbeddedCuaDaemon:
             time.sleep(0.1)
 
         self.stop()
-        detail = "; ".join(self._stderr_tail) or "daemon did not become ready"
+        detail = "; ".join(self._stderr_tail)
+        if not detail:
+            # An empty tail means the daemon never spoke. Say which way it went
+            # quiet — a probe that kept timing out is a different failure from a
+            # daemon that came up and stayed silent, and reporting them the same
+            # way sent this bug's diagnosis down the wrong path for hours.
+            detail = (
+                f"readiness probe timed out {self._probe_timeouts}x at "
+                f"{self._PROBE_TIMEOUT_SECONDS:g}s each; the daemon may still be starting"
+                if self._probe_timeouts
+                else "daemon did not become ready"
+            )
         raise RuntimeError(f"embedded cua-driver startup timed out: {detail}")
 
     def proxy_invocation(self) -> Tuple[str, List[str]]:
@@ -901,7 +928,15 @@ class _EmbeddedCuaDaemon:
                 pass
 
 
-def _resolve_mcp_invocation(
+# Discovery result per driver binary. `cua-driver manifest` describes a CLI
+# surface that only changes when the binary does, but every embedded daemon
+# start re-ran it and paid the round-trip again. Keyed by path so an upgrade
+# that swaps the binary is not served a stale answer.
+_MCP_INVOCATION_CACHE: Dict[str, Tuple[str, List[str]]] = {}
+_MCP_INVOCATION_CACHE_LOCK = threading.Lock()
+
+
+def _resolve_mcp_invocation_uncached(
     driver_cmd: str,
     *,
     timeout: float = 6.0,
@@ -976,6 +1011,46 @@ def _resolve_mcp_invocation(
     # an unknown flag (or silently keep an unwanted overlay).
     return command, _mcp_args_with_overlay_flag(args, driver_cmd=command)
 
+
+
+
+def _reset_mcp_invocation_cache() -> None:
+    """Forget every resolved CLI surface.
+
+    Discovery is keyed by binary path, which is stable in production but shared
+    across tests that each stub a different driver. Callers that swap the
+    driver under a fixed path — tests, and an in-place upgrade — clear it here.
+    """
+    with _MCP_INVOCATION_CACHE_LOCK:
+        _MCP_INVOCATION_CACHE.clear()
+
+
+def _resolve_mcp_invocation(
+    driver_cmd: str,
+    *,
+    timeout: float = 6.0,
+) -> Tuple[str, List[str]]:
+    """Cached front for :func:`_resolve_mcp_invocation_uncached`.
+
+    The uncached call spawns `cua-driver manifest` and waits on it. Inside
+    the embedded daemon's bounded startup that wait competes with the
+    daemon it is supposed to precede, so a slow discovery could exhaust the
+    budget and surface as "daemon did not become ready" — blaming the daemon
+    for time it never received. Resolving once per binary keeps the hop off
+    every subsequent start.
+    """
+    key = str(driver_cmd or "")
+    with _MCP_INVOCATION_CACHE_LOCK:
+        hit = _MCP_INVOCATION_CACHE.get(key)
+    if hit is not None:
+        command, args = hit
+        return command, list(args)
+    # Resolved through the module namespace so a test (or any caller) that
+    # patches the uncached resolver is honoured rather than bypassed.
+    command, args = globals()["_resolve_mcp_invocation_uncached"](driver_cmd, timeout=timeout)
+    with _MCP_INVOCATION_CACHE_LOCK:
+        _MCP_INVOCATION_CACHE[key] = (command, list(args))
+    return command, list(args)
 
 def _mcp_args_with_overlay_flag(
     args: List[str],


### PR DESCRIPTION
## The bug

The embedded cua-driver daemon never starts on macOS. Every attempt spends about nineteen seconds and fails with:

```
computer_use backend unavailable: embedded cua-driver startup timed out: daemon did not become ready
```

The tail is empty, so the message blames the daemon — while the daemon is healthy the whole time. `hermes computer-use doctor` reports every probe green, which makes the failure look like a permissions problem it isn't.

## Root cause

The readiness probe runs `cua-driver status --socket <path>` with a two-second timeout. That command opens the daemon socket and **waits for a reply**, and a cold `open -n -g -a CuaDriver.app` launch takes ~2.5s to bind. The probe expired before the first honest answer could arrive, every single time.

`except (OSError, subprocess.SubprocessError)` catches `TimeoutExpired`, so each expiry became `probe = None` — indistinguishable from "daemon says no" — and nothing was recorded. The loop retried until the 15s budget ran out and reported a silence it had produced itself.

Instrumenting the loop against the real driver shows it plainly:

```
 0.2s  rc=1  Cua Driver daemon is not running
 0.3s  TimeoutExpired
 2.4s  TimeoutExpired
 4.5s  TimeoutExpired
 ...
15.1s  TimeoutExpired      <- budget exhausted
```

Eight swallowed exceptions. Meanwhile the same argv, run by hand with a longer probe timeout, is ready in **2.3s**.

## The fix

Three changes, one cause:

- The probe timeout becomes a named constant at **6s**, comfortably past a cold app launch. A probe must outlast the launch it is waiting on.
- `TimeoutExpired` is caught separately and counted. It is not evidence the daemon is dead; it is the absence of evidence either way.
- When the stderr tail is empty the failure now says **which** silence it hit — probes that never got an answer, or a daemon that came up and said nothing. Those are different bugs, and reporting them identically is what made this one hard to find.

CLI discovery (`cua-driver manifest`) is also resolved once per driver binary. It describes a surface that only changes when the binary does, yet it ran on every daemon start.

## Verification

Against the real driver on macOS 26.6.2 / arm64, cua-driver 0.22.2:

```
before:  FAILED after 19.5s
after:   SUCCESS in 2.4s
```

`computer_use` then returns a live capture through the normal tool path.

Tests drive the real `start()` with the daemon and probe stubbed, including a probe that times out twice before answering — the exact shape of the bug. `tests/computer_use/conftest.py` clears the discovery cache between tests, which several existing tests need because they stub different drivers behind one path.

```
48 passed, 5 skipped
```

`test_cua_no_overlay.py::test_serve_process_disables_overlay_when_policy_requires_it` fails identically on unmodified `origin/main` (verified by checking out `origin/main` and running it there). It is pre-existing and untouched by this PR.
