### PR TITLE
feat(kanban): per-assignee dispatch exemption for human-owner lanes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9605,6 +9605,24 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+
+def _non_dispatchable_assignees() -> frozenset[str]:
+    """Assignees configured to never be auto-spawned by the dispatcher.
+
+    Reads ``kanban.non_dispatchable_assignees`` (a list of profile names).
+    Lets a real, addressable profile — e.g. a human-owner lane — opt out
+    of autonomous dispatch entirely, the same way ``review_dispatch``
+    lets a whole status opt out, without waiting for the spawn to fail
+    and the block-recurrence breaker to file the card as blocked.
+    """
+    try:
+        raw = (load_config() or {}).get("kanban", {}).get("non_dispatchable_assignees", [])
+    except Exception:
+        return frozenset()
+    if isinstance(raw, str):
+        raw = [raw]
+    return frozenset(str(name).strip() for name in raw if str(name).strip())
+
 def review_dispatch_enabled() -> bool:
     """Return whether first-class review tasks should dispatch automatically.
 
@@ -10169,6 +10187,12 @@ def _dispatch_once_locked(
             else:
                 result.skipped_unassigned.append(row["id"])
                 continue
+        # Operator-designated non-dispatch lanes (human-owner profiles,
+        # review-only roles): skip before the profile check — the assignee
+        # may be a perfectly real profile that must never auto-spawn.
+        if row_assignee in _non_dispatchable_assignees():
+            result.skipped_nonspawnable.append(row["id"])
+            continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -313,6 +313,32 @@ def test_review_budget_still_bounded_by_shared_cap(
     assert len(res.spawned) == 2
 
 def test_non_dispatchable_assignee_skipped_before_profile_check(
+    kanban_home, monkeypatch,
+):
+    """A real profile listed in kanban.non_dispatchable_assignees is
+    bucketed as nonspawnable and never spawned, even though profile_exists
+    returns True for it (human-owner lane)."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(
+        cfgmod,
+        "load_config",
+        lambda *a, **k: {'kanban': {'non_dispatchable_assignees': ['human-owner']}},
+    )
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+
+    spawns: list = []
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title='Human decision', assignee='human-owner')
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory(spawns), max_in_progress=1
+        )
+
+    assert res.skipped_nonspawnable == [tid]
+    assert res.spawned == []
+    assert spawns == []
+def test_non_dispatchable_assignee_skipped_before_profile_check(
     dispatch_env,
 ):
     """A real profile listed in kanban.non_dispatchable_assignees is

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -311,3 +311,26 @@ def test_review_budget_still_bounded_by_shared_cap(
 
     # Budget 2 total across both lanes, reservation notwithstanding.
     assert len(res.spawned) == 2
+
+def test_non_dispatchable_assignee_skipped_before_profile_check(
+    dispatch_env,
+):
+    """A real profile listed in kanban.non_dispatchable_assignees is
+    bucketed as nonspawnable and never spawned, even though profile_exists
+    would return True for it (human-owner lane)."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch = dispatch_env['monkeypatch']
+    conn = dispatch_env['conn']
+
+    monkeypatch.setattr(cfgmod, 'load_config', lambda: {'kanban': {'non_dispatchable_assignees': ['human-owner']}})
+    monkeypatch.setattr(profmod, 'profile_exists', lambda name: True)
+
+    kb.create_task(conn, key='HO-1', title='Human decision', column='todo', assignee='human-owner')
+    kb.recompute_ready(conn)
+
+    res = kb.dispatch_once(conn, dry_run=True)
+    assert res.skipped_nonspawnable == ['HO-1']
+    assert res.spawned == []
+


### PR DESCRIPTION
## Summary

Adds `kanban.non_dispatchable_assignees` (a list of profile names): assignees in the list are skipped by the dispatcher's ready loop and bucketed into `skipped_nonspawnable` — exactly like an assignee that is not a real profile — so a real, addressable profile (a human-owner lane, a review-only role) can opt out of autonomous dispatch entirely (#98560).

The check runs immediately before the existing `profile_exists` guard in `_dispatch_once_locked`, so `recompute_ready()` promotion is untouched and `review_dispatch=false` keeps protecting the review column as before. The gap today: a real profile with no model configured passes `profile_exists`, the dispatcher spawns a worker that exits immediately, and the block-recurrence breaker files the waiting-on-a-human card as `blocked` — on the reporter's fleet this produced 22 stuck human-owner cards and most of the fleet's crash volume.

Config surface follows `review_dispatch`: a `kanban` map key read through `load_config()`, tolerating a bare string, and defaulting to an empty set (no behavior change for existing configs).

Fixes #98560