### PR TITLE
feat(gateway): prioritize natural paragraph breaks (\n\n) on message chunking

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7540,7 +7540,10 @@ class BasePlatformAdapter(ABC):
             else:
                 _cp_limit = headroom
             region = remaining[:_cp_limit]
-            split_at = region.rfind("\n")
+            # Prefer paragraph break first (\n\n), then single newline, then space
+            split_at = region.rfind("\n\n")
+            if split_at < _cp_limit // 3:
+                split_at = region.rfind("\n")
             if split_at < _cp_limit // 2:
                 split_at = region.rfind(" ")
             if split_at < 1:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1028,6 +1028,18 @@ class TestTruncateMessage:
                 "No continuation chunk reopened with language tag"
             )
 
+    def test_prefers_paragraph_split_over_single_newline(self):
+        """Verify that chunking prefers natural paragraph boundaries (\n\n) over mid-paragraph line breaks."""
+        p1 = "Paragraph 1 line 1\nParagraph 1 line 2\nParagraph 1 line 3"
+        p2 = "Paragraph 2 line 1\nParagraph 2 line 2\nParagraph 2 line 3"
+        content = f"{p1}\n\n{p2}"
+        # Set max_length so that both paragraphs together exceed the limit, but p1 fits comfortably
+        chunks = BasePlatformAdapter.truncate_message(content, max_length=len(p1) + 20)
+        assert len(chunks) == 2
+        # First chunk should contain exactly p1 (clean split at paragraph break)
+        assert chunks[0].startswith(p1)
+        assert p2 in chunks[1]
+
 
 # ---------------------------------------------------------------------------
 # _get_human_delay


### PR DESCRIPTION
### Summary
When a message exceeds a platform's maximum message limit (such as 4096 code units on Telegram), `BasePlatformAdapter.chunk_message` slices the text into multiple chunks.

Previously, it searched only for single newlines (`\n`) and spaces (` `), which frequently sliced lists, markdown tables, and paragraphs right in the middle even when a clean paragraph break (`\n\n`) was available nearby.

### Changes
- In `gateway/platforms/base.py`, check for paragraph boundary (`\n\n`) first in the headroom region.
- If `split_at < _cp_limit // 3`, fallback to single newline (`\n`), then space (` `).
- Added unit test `test_prefers_paragraph_split_over_single_newline` in `tests/gateway/test_platform_base.py`.