### PR TITLE
fix(cron): gate drift-skip sentinel out of ERROR+traceback logging in run_one_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6712,10 +6712,40 @@ def run_job(
 
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
-        logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        # Best-effort audit write on failure path. _audit_fire_id
-        # may be unset if the exception fired before submit() — guard
-        # with a None check so the audit write itself never raises.
+        # Expected, fail-closed sentinel skips (#44585 drift guard, #72056
+        # pre-dispatch config validation) raise RuntimeError as a control-flow
+        # signal. The delivery path already applies alert-once dedup for the
+        # user-facing alert; gate the *log* the same way. Before this fix the
+        # run-wide except logged the benign, already-alerted sentinel at ERROR
+        # with a full traceback on every tick, polluting errors.log /
+        # ERROR-level alerting and drowning out genuine job failures.
+        _is_benign_sentinel = (
+            DRIFT_SKIP_MARKER in error_msg
+            or DRIFT_SKIP_SILENT_MARKER in error_msg
+            or BLOCKED_CONFIG_MARKER in error_msg
+            or BLOCKED_CONFIG_SILENT_MARKER in error_msg
+        )
+        _is_already_alerted = (
+            DRIFT_SKIP_SILENT_MARKER in error_msg
+            or BLOCKED_CONFIG_SILENT_MARKER in error_msg
+        )
+        if _is_benign_sentinel and _is_already_alerted:
+            # `:silent` = operator already alerted on a previous tick
+            # (alert-once). Keep it at DEBUG so errors.log stays quiet.
+            logger.debug(
+                "Job '%s': skipped (sentinel, already alerted): %s",
+                job_name, error_msg, 
+            )
+        elif _is_benign_sentinel:
+            # First (loud) sentinel tick: one WARNING, no traceback.
+            logger.warning(
+                "Job '%s': skipped (sentinel): %s", job_name, error_msg
+            )
+        else:
+            logger.exception("Job '%s' failed: %s", job_name, error_msg)
+         # Best-effort audit write on failure path. _audit_fire_id
+         # may be unset if the exception fired before submit() — guard
+         # with a None check so the audit write itself never raises.
         if "_audit_fire_id" in locals():
             _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
             _write_usage_audit({

--- a/tests/cron/test_cron_drift_alert_once.py
+++ b/tests/cron/test_cron_drift_alert_once.py
@@ -16,6 +16,7 @@ Contract:
 - Only the drift branch gets the bit — other failures keep alerting per tick.
 """
 
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -159,3 +160,148 @@ class TestDriftAlertOnce:
 
         assert len(deliveries) == 1, "non-drift failure must still deliver"
         assert "boom unrelated" in deliveries[0]
+
+
+class TestDriftSkipLogging:
+    """Regression: a drift-skip tick must NOT be logged at ERROR with a
+    full traceback. The existing ``TestDriftAlertOnce`` only asserts delivery
+    dedup (``len(deliveries) == 1``) and never inspects the log record, so it
+    stayed green even though ``run_one_job``'s run-wide ``except`` logged the
+    benign sentinel at ERROR + exc_info on *every* tick (#44585 drift guard).
+
+    Contract under test:
+    - First (loud ``[drift_skip]``) tick: one WARNING, no traceback.
+    - Subsequent (``[drift_skip:silent]``) ticks: no ERROR record at all
+      (DEBUG), so errors.log / ERROR-level alerting stays clean.
+    - A *genuine* failure (no sentinel) must still ERROR + full traceback,
+      so the fix does not hide real breakage.
+    """
+
+    def test_drift_ticks_dont_emit_error_with_traceback(self, tmp_path):
+        class _Capture(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        cap = _Capture()
+        old_level = sched.logger.level
+        old_prop = sched.logger.propagate
+        sched.logger.setLevel(logging.DEBUG)
+        sched.logger.addHandler(cap)
+        sched.logger.propagate = False
+        all_records = []  # not cleared between ticks — keep tick-1 WARNING
+        try:
+            with cron_jobs.use_cron_store(tmp_path):
+                job = _job()
+                cron_jobs.save_jobs([job])
+                # Two drifted ticks: 1st raises [drift_skip] (loud), 2nd
+                # raises [drift_skip:silent] (already alerted on tick 1).
+                deliveries = []
+                for _ in range(2):
+                    fresh = [
+                        j for j in cron_jobs.load_jobs() if j["id"] == job["id"]
+                    ][0]
+                    cap.records.clear()
+                    _tick(fresh, tmp_path, "nous", deliveries)
+                    all_records.extend(cap.records)
+                error_records = [
+                    r for r in all_records
+                    if r.levelno >= logging.ERROR and r.exc_info
+                ]
+        finally:
+            sched.logger.removeHandler(cap)
+            sched.logger.level = old_level
+            sched.logger.propagate = old_prop
+
+        assert not error_records, (
+            f"drift-skip tick logged {len(error_records)} ERROR record(s) with "
+            f"traceback — expected 0 (already-alerted silent ticks must stay "
+            f"quiet). Got: {[r.getMessage() for r in error_records]}"
+        )
+        # Sanity: a WARNING *was* emitted (the loud, first-tick alert) and
+        # carries no traceback — proving the sentinel is handled, not dropped.
+        warning_records = [
+            r for r in all_records
+            if r.levelname == "WARNING" and "sentinel" in r.getMessage()
+        ]
+        assert warning_records, (
+            "expected a WARNING sentinel record; "
+            f"got levels {[r.levelname for r in all_records]}"
+        )
+
+    def test_real_failure_still_errors_with_traceback(self, tmp_path):
+        """Guard against the fix hiding genuine breakage: a non-sentinel
+        RuntimeError must still produce an ERROR record with exc_info."""
+
+        class _Capture(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        cap = _Capture()
+        old_level = sched.logger.level
+        old_prop = sched.logger.propagate
+        sched.logger.setLevel(logging.DEBUG)
+        sched.logger.addHandler(cap)
+        sched.logger.propagate = False
+        try:
+            with cron_jobs.use_cron_store(tmp_path):
+                job = _job()  # provider_snapshot matches current -> drift guard
+                # passes; the failure comes from the agent raising.
+                job["provider_snapshot"] = "openrouter"
+                cron_jobs.save_jobs([job])
+                fresh = [
+                     j for j in cron_jobs.load_jobs() if j["id"] == job["id"]
+                ][0]
+                cap.records.clear()
+
+                def _fail_deliver(jb, content, adapters=None, loop=None):
+                    return None
+
+                with patch("cron.scheduler._hermes_home", tmp_path), \
+                     patch("cron.scheduler._resolve_origin", return_value=None), \
+                     patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+                     patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                     patch("hermes_state.SessionDB", return_value=MagicMock()), \
+                     patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+                     patch(
+                        "hermes_cli.runtime_provider.resolve_runtime_provider",
+                        return_value={
+                            "api_key": "test-key",
+                            "base_url": "https://example.invalid/v1",
+                            "provider": "openrouter",
+                            "api_mode": "chat_completions",
+                        },
+                     ), \
+                     patch.object(
+                        sched, "_deliver_result", side_effect=_fail_deliver
+                     ), \
+                     patch("run_agent.AIAgent") as mock_agent_cls:
+                    mock_agent = MagicMock()
+                    mock_agent.run_conversation.side_effect = RuntimeError(
+                        "genuine boom — not a sentinel"
+                    )
+                    mock_agent_cls.return_value = mock_agent
+                    sched.run_one_job(fresh)
+                error_records = [
+                    r for r in cap.records
+                    if r.levelno >= logging.ERROR and r.exc_info
+                ]
+        finally:
+            sched.logger.removeHandler(cap)
+            sched.logger.level = old_level
+            sched.logger.propagate = old_prop
+
+        assert len(error_records) == 1, (
+            "genuine failure must still log exactly one ERROR record with a "
+            f"traceback; got {len(error_records)}: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+        assert "genuine boom" in error_records[0].getMessage()
+        assert error_records[0].exc_info is not None


### PR DESCRIPTION
## Summary

The run-wide `except Exception` in `run_one_job` (`cron/scheduler.py`)
logged the **fail-closed sentinel skips** at `ERROR` with a **full
traceback on every tick**. Those sentinels are *expected control-flow
signals*, not job failures:

- `[drift_skip]` / `[drift_skip:silent]` — #44585 global-inference-config
  drift guard
- the `BLOCKED_CONFIG` sentinels — #72056 pre-dispatch config validation

They raise `RuntimeError` only to signal "do not run this tick". The
**delivery path** already applies alert-once dedup for the user-facing
alert, but the **log** was not gated the same way, so a benign,
already-alerted drift tick kept emitting `ERROR` + traceback into
`errors.log` / `gateway.error.log` / `agent.log` — polluting
ERROR-level alerting and drowning out genuine job failures.

## Reproduction

1. Let a cron job's global inference config drift from its
   `provider_snapshot` (e.g. swap the default model/provider after the
   job was created).
2. Wait for the next tick. The ticker raises
   `RuntimeError: [drift_skip] ...` (first, loud) then
   `[drift_skip:silent] ...` (subsequent, already-alerted) on **every**
   tick.
3. Observe `errors.log`: the sentinel is logged with `logger.exception`
   (full traceback) each tick, not just once.

The user-facing alert is already deduped (alert-once) — only the *log*
isn't.

## Root cause

`cron/scheduler.py`, `run_one_job`, run-wide `except` (was line 6715):

```python
except Exception as e:
    error_msg = f"{type(e).__name__}: {str(e)}"
    logger.exception("Job '%s' failed: %s", job_name, error_msg)
```

`logger.exception` is unconditional — it fires for the expected sentinel
skips too, with `exc_info=True` (the full traceback) on every tick.

## Fix

Gate the log the same way the delivery path gates the alert:

- `[drift_skip]` / `BLOCKED_CONFIG` **first (loud) tick** → single
  `WARNING`, no traceback (the user-facing alert already fired).
- `[drift_skip:silent]` / `BLOCKED_CONFIG:SILENT` **subsequent ticks** →
  `DEBUG`, no traceback (operator already alerted — alert-once).
- **Genuine failure** (no sentinel marker) → `ERROR` + full traceback
  **unchanged**, so real breakage is never hidden.

```python
_is_benign_sentinel = (
    DRIFT_SKIP_MARKER in error_msg
    or DRIFT_SKIP_SILENT_MARKER in error_msg
    or BLOCKED_CONFIG_MARKER in error_msg
    or BLOCKED_CONFIG_SILENT_MARKER in error_msg
)
_is_already_alerted = (
    DRIFT_SKIP_SILENT_MARKER in error_msg
    or BLOCKED_CONFIG_SILENT_MARKER in error_msg
)
if _is_benign_sentinel and _is_already_alerted:
    logger.debug("Job '%s': skipped (sentinel, already alerted): %s", ...)
elif _is_benign_sentinel:
    logger.warning("Job '%s': skipped (sentinel): %s", ...)
else:
    logger.exception("Job '%s' failed: %s", ...)
```

## Tests

Adds `TestDriftSkipLogging` to
`tests/cron/test_cron_drift_alert_once.py` (the existing
`TestDriftAlertOnce` only asserts *delivery* dedup and never inspects the
log record, so it stayed green even with this bug):

- `test_drift_ticks_dont_emit_error_with_traceback` — two drifted ticks
  (loud → silent) emit **zero** `ERROR`+`exc_info` records, and the first
  tick emits a `WARNING` sentinel record (proving the sentinel is
  handled, not dropped).
- `test_real_failure_still_errors_with_traceback` — a genuine
  non-sentinel `RuntimeError` still produces an `ERROR`+traceback record
  (guards against the fix hiding real breakage).

All 5 tests in the file pass (3 pre-existing + 2 new):

```
tests/cron/test_cron_drift_alert_once.py::TestDriftAlertOnce::test_two_drifted_ticks_alert_exactly_once PASSED
tests/cron/test_cron_drift_alert_once.py::TestDriftAlertOnce::test_healed_drift_clears_bit_and_redrift_realerts PASSED
tests/cron/test_cron_drift_alert_once.py::TestDriftAlertOnce::test_non_drift_failures_untouched_by_the_bit PASSED
tests/cron/test_cron_drift_alert_once.py::TestDriftSkipLogging::test_drift_ticks_dont_emit_error_with_traceback PASSED
tests/cron/test_cron_drift_alert_once.py::TestDriftSkipLogging::test_real_failure_still_errors_with_traceback PASSED
============================== 5 passed in 1.59s ===============================
```

## Environment

- OS: macOS (Darwin)
- Python: 3.11.15
- Hermes: v0.20.4 (2026.8.18), rebased onto current `origin/main`
- Affected component: **Cron / scheduler**
