### PR TITLE
fix(desktop): stamp sharedRemote on the registry-primary reuse descriptor

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11151,7 +11151,11 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return {
         ...primaryDescriptor,
         profile: profileKey,
-        connectionId: id
+        connectionId: id,
+        // Same contract as the fresh-dial remote/cloud branch below: one host
+        // serves every profile of this source, so REST paths must carry
+        // ?profile= instead of relying on the backend's own home scope.
+        sharedRemote: true
       }
     }
   }

--- a/apps/desktop/electron/registry-primary-scope.test.ts
+++ b/apps/desktop/electron/registry-primary-scope.test.ts
@@ -30,7 +30,10 @@ describe('registry-primary REST scoping (#98578)', () => {
   })
 
   it('the stamped descriptor scopes a profile read the same way a fresh-dial remote does', () => {
+    // Remote/cloud primary descriptors carry no remoteProfile — that is the
+    // isolated-SSH contract — so both shapes below only differ by the stamp.
     const reusedPrimaryDescriptor = {
+      remoteProfile: null,
       baseUrl: 'http://127.0.0.1:8643',
       profile: 'architect',
       connectionId: 'wsl-gentoo',
@@ -43,12 +46,15 @@ describe('registry-primary REST scoping (#98578)', () => {
 
     // Pre-fix shape (no stamp): the translation branch leaves the path
     // unscoped, so the backend serves its home profile's config.
+    const unstampedPrimaryDescriptor = {
+      remoteProfile: null,
+      baseUrl: 'http://127.0.0.1:8643',
+      profile: 'architect',
+      connectionId: 'wsl-gentoo'
+    }
+
     expect(
-      pathForRegistryBackendRequest('/api/config', 'architect', {
-        baseUrl: 'http://127.0.0.1:8643',
-        profile: 'architect',
-        connectionId: 'wsl-gentoo'
-      })
+      pathForRegistryBackendRequest('/api/config', 'architect', unstampedPrimaryDescriptor)
     ).toBe('/api/config')
   })
 })

--- a/apps/desktop/electron/registry-primary-scope.test.ts
+++ b/apps/desktop/electron/registry-primary-scope.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { pathForRegistryBackendRequest } from './connection-config'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('registry-primary REST scoping (#98578)', () => {
+  it('stamps sharedRemote on the primary-owns reuse fast path so REST keeps ?profile=', () => {
+    const branchStart = mainSource.indexOf(
+      "if (id === registry.primary && source.kind !== 'local' && source.kind !== 'ssh') {"
+    )
+    expect(branchStart).toBeGreaterThan(-1)
+
+    const body = mainSource.slice(branchStart, branchStart + 700)
+
+    expect(body).toContain('const primaryDescriptor = await ensureBackend(profile)')
+    expect(body).toContain('if (registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)) {')
+
+    // The reused primary IS the shared remote gateway (one host, every
+    // profile). Without this stamp the descriptor falls into the
+    // self-profile-translation branch, which never appends ?profile=, and
+    // every registry-scoped Settings/Profiles read answers for the
+    // backend's own home instead of the selected profile (#98578).
+    expect(body).toContain('sharedRemote: true')
+  })
+
+  it('the stamped descriptor scopes a profile read the same way a fresh-dial remote does', () => {
+    const reusedPrimaryDescriptor = {
+      baseUrl: 'http://127.0.0.1:8643',
+      profile: 'architect',
+      connectionId: 'wsl-gentoo',
+      sharedRemote: true
+    }
+
+    expect(
+      pathForRegistryBackendRequest('/api/config', 'architect', reusedPrimaryDescriptor)
+    ).toBe('/api/config?profile=architect')
+
+    // Pre-fix shape (no stamp): the translation branch leaves the path
+    // unscoped, so the backend serves its home profile's config.
+    expect(
+      pathForRegistryBackendRequest('/api/config', 'architect', {
+        baseUrl: 'http://127.0.0.1:8643',
+        profile: 'architect',
+        connectionId: 'wsl-gentoo'
+      })
+    ).toBe('/api/config')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

On a desktop whose primary backend is a registered remote/cloud gateway, every profile-scoped REST read dispatched through `dispatchRegistryApiRequest()` arrived at the backend without `?profile=`, so every profile chip in Settings rendered the primary profile's data (#98578).

Root cause: the registry-primary reuse fast path in `ensureRegistryBackend()` (the `registrySourceOwnsPrimaryBackend()` short-circuit introduced in `fd031488a`) returns `{...primaryDescriptor, profile, connectionId}` — without `sharedRemote`. `pathForRegistryBackendRequest()` only appends `?profile=` when the descriptor carries `sharedRemote: true`; otherwise it takes the self-profile-translation branch, which rewrites an existing self-scope but never adds one. A freshly dialed remote/cloud registry connection stamps `sharedRemote: true` in `connectRegistryBackend()`; the reuse fast path silently dropped that contract, so requests went out unscoped and the backend answered from its own home profile.

Fix: stamp `sharedRemote: true` on the descriptor returned by the primary-owns reuse fast path — one line, same contract as the fresh-dial remote/cloud branch right below it. The SSH reuse branch is intentionally untouched: an SSH backend is isolated per profile (its namespace is `remoteProfile`), so translate-only is the correct semantics there.

## Related Issue

Fixes #98578

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts`: the `registrySourceOwnsPrimaryBackend()` reuse fast path in `ensureRegistryBackend()` now returns its descriptor with `sharedRemote: true`, so `pathForRegistryBackendRequest()` scopes REST paths with `?profile=` exactly like a freshly dialed remote/cloud registry connection.
- `apps/desktop/electron/registry-primary-scope.test.ts` (new): source assertion that the reuse fast path stamps `sharedRemote`, plus a behavioral check tying the stamped descriptor to `pathForRegistryBackendRequest()` output (scoped vs. the pre-fix unscoped shape).

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/registry-primary-scope.test.ts` — Observed result: 2 passed.
2. Wider regression face: `npx vitest run --project electron electron/connection-config.test.ts electron/backend-dial-claim.test.ts electron/connection-registry.test.ts` — Observed result: 218 passed.
3. Red/green check: removing the `sharedRemote: true` stamp makes the new source-assertion test fail (`stamps sharedRemote on the primary-owns reuse fast path`), confirming the test locks the contract. Restoring the stamp turns it green again.
4. Full `--project electron` suite: 1960 passed, 1 pre-existing failure in `managed-ssh-update.test.ts` (POSIX managed launcher, exit 127) that reproduces identically on a clean checkout without this change — environment-related, not introduced here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (TypeScript-only change; ran the desktop vitest electron project instead, results above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the changed code path is platform-agnostic Electron main-process routing

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix restores the exact scoping contract already used by the fresh-dial branch, no platform-specific behavior introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — main-process routing change; the issue's instrumented-backend probe (`profile=None` for every Settings request) is the observable, and with the stamp those requests resolve through `pathWithProfileScope()` instead of the translation no-op.