### PR TITLE
fix(desktop): keep remote profile settings isolated

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -51,6 +51,7 @@ import {
   savedProfileSsh,
   tokenPreview,
   translateSelfProfileQuery,
+  withRegistryBackendScope,
   withTransientRetries
 } from './connection-config'
 
@@ -511,6 +512,44 @@ test('pathForRegistryBackendRequest uses the resolved registry backend scope', (
       { remoteProfile: 'remote-research' }
     ),
     '/api/profiles/sessions/sidebar?recents_profile=remote-research&recents_exclude=cron%2Cdesktop'
+  )
+})
+
+test('registry remote descriptors preserve request profile scope across primary reuse', () => {
+  for (const kind of ['remote', 'cloud'] as const) {
+    const descriptor = withRegistryBackendScope(
+      { baseUrl: 'https://shared.example', mode: 'remote' },
+      'architect',
+      'shared-primary',
+      kind
+    )
+
+    assert.equal(descriptor.profile, 'architect')
+    assert.equal(descriptor.connectionId, 'shared-primary')
+    assert.equal(descriptor.sharedRemote, true)
+    assert.equal(
+      pathForRegistryBackendRequest('/api/model/options', 'architect', descriptor),
+      '/api/model/options?profile=architect'
+    )
+    assert.equal(
+      pathForRegistryBackendRequest('/api/model/auxiliary', 'coder', descriptor),
+      '/api/model/auxiliary?profile=coder'
+    )
+  }
+})
+
+test('registry SSH descriptors remain backend-scoped when reused', () => {
+  const descriptor = withRegistryBackendScope(
+    { mode: 'remote', remoteProfile: 'default' },
+    'architect',
+    'ssh-primary',
+    'ssh'
+  )
+
+  assert.equal(descriptor.sharedRemote, undefined)
+  assert.equal(
+    pathForRegistryBackendRequest('/api/model/options?profile=architect', 'architect', descriptor),
+    '/api/model/options?profile=default'
   )
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -835,6 +835,30 @@ export interface RegistryBackendRequestScope {
   sharedRemote?: boolean
 }
 
+type RegistryConnectionKind = 'cloud' | 'local' | 'remote' | 'ssh'
+
+/**
+ * Qualify a registry backend descriptor with both routing identity and request
+ * scope. Remote/cloud registry sources are shared gateways, including when the
+ * registry primary reuses the already-running legacy descriptor; SSH and local
+ * descriptors already belong to one backend profile.
+ */
+function withRegistryBackendScope<T extends object>(
+  backend: T,
+  profile: null | string,
+  connectionId: string,
+  sourceKind: RegistryConnectionKind
+) {
+  const requestScope = sourceKind === 'remote' || sourceKind === 'cloud' ? { sharedRemote: true as const } : {}
+
+  return {
+    ...backend,
+    profile: String(profile ?? '').trim() || 'default',
+    connectionId,
+    ...requestScope
+  }
+}
+
 /**
  * Scope a REST path for a resolved registry backend. Shared remotes serve
  * multiple profiles from one process and need an explicit profile query;
@@ -1039,5 +1063,6 @@ export {
   savedProfileSsh,
   tokenPreview,
   translateSelfProfileQuery,
+  withRegistryBackendScope,
   withTransientRetries
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -121,6 +121,7 @@ import {
   resolveTestWsUrl,
   savedProfileSsh,
   tokenPreview,
+  withRegistryBackendScope,
   withTransientRetries
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
@@ -11127,11 +11128,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
   })
 
   if (primary) {
-    return {
-      ...primary,
-      profile: profileKey,
-      connectionId: id
-    }
+    return withRegistryBackendScope(primary, profileKey, id, source.kind)
   }
 
   // The v1 primary and the registry primary can describe the same remote
@@ -11144,11 +11141,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     const primaryDescriptor = await ensureBackend(profile)
 
     if (registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)) {
-      return {
-        ...primaryDescriptor,
-        profile: profileKey,
-        connectionId: id
-      }
+      return withRegistryBackendScope(primaryDescriptor, profileKey, id, source.kind)
     }
   }
 
@@ -11334,17 +11327,20 @@ async function connectRegistryBackend(
 
     poolEntry.remoteBaseUrl = connection.baseUrl
 
-    return {
-      ...connection,
-      profile: profileKey,
-      connectionId: source.id,
-      // The remote process runs as this profile; the desktop-side profile key
-      // is only the routing label. hermes:api uses it to translate explicit
-      // self-profile query filters into the backend's namespace.
-      remoteProfile: sshConfig.remoteProfile || '',
-      logs: hermesLog.slice(-80),
-      ...getWindowState()
-    }
+    return withRegistryBackendScope(
+      {
+        ...connection,
+        // The remote process runs as this profile; the desktop-side profile key
+        // is only the routing label. hermes:api uses it to translate explicit
+        // self-profile query filters into the backend's namespace.
+        remoteProfile: sshConfig.remoteProfile || '',
+        logs: hermesLog.slice(-80),
+        ...getWindowState()
+      },
+      profileKey,
+      source.id,
+      source.kind
+    )
   }
 
   // remote / cloud: one gateway host serves every profile of that source,
@@ -11366,16 +11362,16 @@ async function connectRegistryBackend(
   await waitForHermes(connection.baseUrl, connection.token, undefined, connection.authMode, connection.headers)
   poolEntry.remoteBaseUrl = connection.baseUrl
 
-  return {
-    ...connection,
-    profile: profileKey,
-    connectionId: source.id,
-    // One host, many profiles: REST paths must carry ?profile= (same contract
-    // as the global-remote shared-primary route).
-    sharedRemote: true,
-    logs: hermesLog.slice(-80),
-    ...getWindowState()
-  }
+  return withRegistryBackendScope(
+    {
+      ...connection,
+      logs: hermesLog.slice(-80),
+      ...getWindowState()
+    },
+    profileKey,
+    source.id,
+    source.kind
+  )
 }
 
 // Restore one scope while its connection-wide managed-update gate is still


### PR DESCRIPTION
## What does this PR do?

Desktop now keeps profile-scoped Settings and Profiles REST requests attached to the selected profile when the registry primary reuses an already-running remote or cloud gateway. Without this fix, the reused descriptor loses its shared-gateway scope marker and the backend silently serves the primary/default profile's configuration for every profile page.

### Symptom

On a desktop whose registry primary is a remote OAuth gateway, requests such as `GET /api/config`, `GET /api/model/options`, and `GET /api/model/auxiliary` can omit `?profile=`. Multiple profile pages then render and edit the primary profile's settings instead of their own.

### Impact

Remote-primary desktop users can see and update the wrong profile configuration even though each profile's on-disk data remains distinct. The UI makes separate profiles appear to share model and auxiliary settings.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts:11129` / `ensureRegistryBackend()` registry-primary reuse paths

**Causal chain:**
1. A renderer REST request targets a named profile through a remote or cloud registry primary.
2. `ensureRegistryBackend()` reuses the already-running primary descriptor but returns it without `sharedRemote: true`.
3. `pathForRegistryBackendRequest()` treats the descriptor as backend-scoped and does not append `?profile=`, so the shared gateway answers from its primary/default home.

**Why it is wrong:** Remote and cloud registry sources are shared gateways whose request profile is part of the routing contract, regardless of whether the connection was freshly dialed or reused from the legacy primary path.

**Working sibling / contrast:** Fresh `connectRegistryBackend()` remote/cloud descriptors already carried `sharedRemote: true`, so the same request was scoped correctly when it missed the primary reuse fast path.

**Ruled out:** The backend profile handlers are not dropping the query. Instrumented requests arrive with `profile=None` only on the broken desktop route, while the web UI against the same backend remains correctly scoped.

### Fix

A single pure descriptor decorator now applies registry identity and transport scope to fresh and reused descriptors. Remote/cloud sources always retain shared request scoping, including the active profile label; SSH and local descriptors remain backend-scoped and preserve SSH alias translation.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/connection-config.ts` - centralize registry descriptor identity and shared-remote request scope.
- `apps/desktop/electron/main.ts` - apply the same descriptor contract to both registry-primary reuse paths and fresh registry connections.
- `apps/desktop/electron/connection-config.test.ts` - cover active and cross-profile remote/cloud scoping plus the SSH non-regression.

## How to Test

1. Run the focused routing tests:
   `npx vitest run electron/connection-config.test.ts`
2. Run Desktop type checking:
   `npm run typecheck`
3. Run Desktop lint:
   `npm run lint`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact (Windows and macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] Tool description/schema update is N/A

## Screenshots / Logs

N/A - this is a request-routing fix covered by focused descriptor and URL assertions.
