### PR TITLE
fix(email): default authserv_id to the agent From-domain as documented

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -587,9 +587,16 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Optional authserv-id to pin Authentication-Results to the operator's
         # own receiving server (defends against an injected header that sorts
-        # first). Defaults to the From-domain of the agent's own address.
-        self._authserv_id = (
+        # first). Defaults to the From-domain of the agent's own address —
+        # the fallback the comment always promised: with an empty value the
+        # pinning loop in _verify_sender_authentication skips its check and
+        # trusts the first header on the message unconditionally (#98599).
+        authserv_raw = (
             extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")
+        ).strip()
+        if not authserv_raw:
+            authserv_raw = self._address.rsplit("@", 1)[-1] if "@" in self._address else ""
+        self._authserv_id = authserv_raw.lower()
         ).strip().lower()
 
         # Track message IDs we've already processed to avoid duplicates

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -597,7 +597,6 @@ class EmailAdapter(BasePlatformAdapter):
         if not authserv_raw:
             authserv_raw = self._address.rsplit("@", 1)[-1] if "@" in self._address else ""
         self._authserv_id = authserv_raw.lower()
-        ).strip().lower()
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -149,6 +149,31 @@ class TestDispatchMessage(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_authserv_id_defaults_to_own_from_domain(self):
+        """With no explicit authserv_id, the pinning value must derive from the
+        agent's own address domain — not stay empty (which silently disables
+        the Authentication-Results pinning check)."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._authserv_id, "test.com")
+
+    def test_authserv_id_explicit_value_wins(self):
+        """An explicit EMAIL_AUTHSERV_ID must override the domain default."""
+        import os
+        from unittest.mock import patch
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+            "EMAIL_AUTHSERV_ID": "mx.custom.org",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        self.assertEqual(adapter._authserv_id, "mx.custom.org")
+
     def test_self_message_filtered(self):
         """Messages from the agent's own address should be skipped."""
         import asyncio


### PR DESCRIPTION
## Summary

The comment above `_authserv_id` promises a default to the From-domain of the agent's own address, but the code leaves the value empty when neither `authserv_id` config nor `EMAIL_AUTHSERV_ID` is set. With an empty value, the pinning branch in `_verify_sender_authentication` is truthiness-guarded off and the loop trusts the **first** `Authentication-Results` header unconditionally — exactly the outcome the documented default exists to prevent (#98599).

This makes the code match its comment: when no explicit value is configured, `authserv_id` derives from the domain part of the agent's own address, so the pinning check engages with zero operator action. Operators who already set `authserv_id` / `EMAIL_AUTHSERV_ID` are unaffected; an address without `@` (misconfigured) degrades to the previous empty behavior.

Two regression tests: the domain default (adapter with `hermes@test.com` → `test.com`) and explicit-env override wins over the default.

Fixes #98599