### PR TITLE
feat(agent): compose context files with `@` include directives

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1437,6 +1437,102 @@ def _truncate_content(
     return content[:head_chars] + marker + content[-tail_chars:]
 
 
+CONTEXT_INCLUDE_MAX_DEPTH = 10
+
+
+def _expand_context_includes(
+    content: str,
+    base_dir: Path,
+    *,
+    confine: bool = False,
+    _depth: int = 0,
+    _visited: Optional[set] = None,
+) -> str:
+    """Expand ``@path`` include directives in a context file.
+
+    A line whose only non-whitespace content is ``@<path>`` is replaced by the
+    contents of ``<path>``, resolved relative to ``base_dir`` (the directory of
+    the file the directive appears in). Includes nest: an included file's own
+    ``@`` directives are expanded relative to that file's directory. This lets a
+    single ``SOUL.md`` compose separate, independently-edited files (a global
+    identity, an agent role, a project overlay) that stay live on disk - editing
+    an included file changes the next prompt build with no reinstall.
+
+    Robustness is deliberate: only a whole-line ``@path`` (no space after the
+    ``@``) is a directive, so an email address or an inline ``@handle`` is never
+    mistaken for one. Every file is expanded at most once across the whole
+    tree - a repeated include, a diamond, or a cycle collapses to a single copy
+    and later encounters leave a visible ``[include skipped ...]`` marker rather
+    than duplicating content or looping. Missing, unreadable, over-deep, and
+    (when ``confine``) out-of-tree targets each leave their own visible marker
+    instead of raising. The single shared visited set also bounds total work:
+    each file is read once, so a fan-out cannot amplify into N**depth copies.
+
+    ``confine`` controls the trust boundary. Operator-owned files (``SOUL.md``)
+    leave it False so an include may reach across the filesystem (e.g. a vault
+    checked out elsewhere) - that author can already put anything in the prompt.
+    Files discovered from the working directory (``.hermes.md``, ``AGENTS.md``,
+    ``CLAUDE.md``) may come from an untrusted cloned repo, so they set it True:
+    absolute paths and ``..``/symlink escapes out of ``base_dir`` are refused,
+    which stops a hostile checked-in context file from reading host secrets
+    (``@/etc/passwd``, ``@~/.ssh/id_rsa``) into the model's context.
+    """
+    if "@" not in content:
+        return content
+    if _visited is None:
+        _visited = set()
+    if _depth >= CONTEXT_INCLUDE_MAX_DEPTH:
+        return content
+
+    out_lines: List[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("@"):
+            out_lines.append(line)
+            continue
+        # A directive is a bare @path on its own line: no space after the @ and
+        # no whitespace inside. Prose that merely starts with @, or "@ foo", is
+        # left untouched.
+        rel = stripped[1:]
+        if not rel or any(c.isspace() for c in rel):
+            out_lines.append(line)
+            continue
+        target = (base_dir / rel).resolve()
+        if confine:
+            try:
+                target.relative_to(base_dir.resolve())
+            except ValueError:
+                out_lines.append(f"[include outside base dir: {rel}]")
+                continue
+        key = str(target)
+        if key in _visited:
+            # Already expanded somewhere in the tree (repeat, diamond, or cycle):
+            # emit once, skip the rest - this is what bounds total work.
+            out_lines.append(f"[include skipped (already included): {rel}]")
+            continue
+        if not target.is_file():
+            out_lines.append(f"[include not found: {rel}]")
+            continue
+        try:
+            included = target.read_text(encoding="utf-8").strip()
+        except Exception as e:
+            logger.debug("Could not read include %s: %s", target, e)
+            out_lines.append(f"[include unreadable: {rel}]")
+            continue
+        _visited.add(key)
+        expanded = _expand_context_includes(
+            included,
+            target.parent,
+            confine=confine,
+            _depth=_depth + 1,
+            _visited=_visited,
+        )
+        if _depth + 1 >= CONTEXT_INCLUDE_MAX_DEPTH and "@" in expanded:
+            expanded += f"\n[include depth limit reached at: {rel}]"
+        out_lines.append(expanded)
+    return "\n".join(out_lines)
+
+
 def load_soul_md(context_length: Optional[int] = None, home_override: "Path | None" = None) -> Optional[str]:
     """SOUL.md from HERMES_HOME (identity slot #1), or None.
 
@@ -1465,6 +1561,7 @@ def load_soul_md(context_length: Optional[int] = None, home_override: "Path | No
             content = strip_legacy_protocol(content).strip()
         if not content:
             return None
+        content = _expand_context_includes(content, soul_path.parent)
         return _truncate_content(_scan_context_content(content, "SOUL.md"), "SOUL.md", context_length=context_length,
                                  read_path=str(soul_path))
     except Exception as e:
@@ -1493,8 +1590,9 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     """.hermes.md / HERMES.md — nearest match walking up to the git root."""
     hermes_md_path = _find_hermes_md(cwd_path)
     content = _read_context_file(hermes_md_path) if hermes_md_path else ""
-    if not content:
+    if not content or hermes_md_path is None:
         return ""
+    content = _expand_context_includes(content, hermes_md_path.parent, confine=True)
     label = str(hermes_md_path.relative_to(cwd_path)) if hermes_md_path.is_relative_to(cwd_path) else hermes_md_path.name
     return _context_section(_strip_yaml_frontmatter(content), label, ".hermes.md", hermes_md_path, context_length)
 
@@ -1534,6 +1632,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                 continue
             if content not in seen_content:  # else: identical copy along the chain
                 seen_content.add(content)
+                content = _expand_context_includes(content, directory, confine=True)
                 label = name if directory == cwd_resolved else os.path.relpath(candidate, cwd_resolved)
                 sections.append(_context_section(content, label, label, candidate, context_length))
             break  # first name match wins per directory
@@ -1549,6 +1648,7 @@ def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     for name in ("CLAUDE.md", "claude.md"):
         content = _read_context_file(cwd_path / name)
         if content:
+            content = _expand_context_includes(content, cwd_path, confine=True)
             return _context_section(content, name, "CLAUDE.md", cwd_path / name, context_length)
     return ""
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -12,6 +12,8 @@ import pytest
 
 from agent.prompt_builder import (
     _scan_context_content,
+    _expand_context_includes,
+    load_soul_md,
     _truncate_content,
     _parse_skill_file,
     _skill_should_show,
@@ -1213,3 +1215,131 @@ class TestContextFileReadTimeout:
 
         with pytest.raises(FileNotFoundError):
             _read_text_with_timeout(tmp_path / "missing.md", timeout=1.0)
+
+
+class TestExpandContextIncludes:
+    """`@path` include directives in context files (SOUL.md, AGENTS.md, ...)."""
+
+    def test_no_directive_returns_content_unchanged(self, tmp_path):
+        content = "# Identity\n\nPlain content, no includes.\n"
+        assert _expand_context_includes(content, tmp_path) == content
+
+    def test_includes_a_sibling_file(self, tmp_path):
+        (tmp_path / "role.md").write_text("You are the assistant.", encoding="utf-8")
+        content = "# Identity\n\n@role.md\n"
+        out = _expand_context_includes(content, tmp_path)
+        assert "You are the assistant." in out
+        assert "@role.md" not in out
+
+    def test_directive_must_be_alone_on_the_line(self, tmp_path):
+        # An email-like token or inline @ is NOT an include directive.
+        (tmp_path / "role.md").write_text("SHOULD NOT APPEAR", encoding="utf-8")
+        content = "Contact me at foo@role.md for details.\n"
+        out = _expand_context_includes(content, tmp_path)
+        assert "Contact me at foo@role.md for details." in out
+        assert "SHOULD NOT APPEAR" not in out
+
+    def test_leading_whitespace_allowed(self, tmp_path):
+        (tmp_path / "role.md").write_text("INCLUDED", encoding="utf-8")
+        out = _expand_context_includes("   @role.md\n", tmp_path)
+        assert "INCLUDED" in out
+
+    def test_nested_includes_resolve_relative_to_each_file(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "a.md").write_text("A\n@sub/b.md\n", encoding="utf-8")
+        (sub / "b.md").write_text("B\n@c.md\n", encoding="utf-8")
+        (sub / "c.md").write_text("C", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n", tmp_path)
+        assert "A" in out and "B" in out and "C" in out
+        assert "@" not in out
+
+    def test_missing_target_leaves_a_marker_not_crash(self, tmp_path):
+        out = _expand_context_includes("@nope.md\n", tmp_path)
+        assert "nope.md" in out  # a visible marker names the missing file
+        # the whole load must not raise and must not silently vanish
+        assert out.strip() != ""
+
+    def test_cycle_is_broken(self, tmp_path):
+        (tmp_path / "a.md").write_text("A\n@b.md\n", encoding="utf-8")
+        (tmp_path / "b.md").write_text("B\n@a.md\n", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n", tmp_path)
+        # both bodies appear once; the back-reference is stopped, not infinite
+        assert "A" in out and "B" in out
+
+    def test_depth_is_bounded(self, tmp_path):
+        # A long chain must terminate rather than recurse without bound.
+        for i in range(30):
+            (tmp_path / f"f{i}.md").write_text(f"L{i}\n@f{i + 1}.md\n", encoding="utf-8")
+        (tmp_path / "f30.md").write_text("END", encoding="utf-8")
+        out = _expand_context_includes("@f0.md\n", tmp_path)
+        assert "L0" in out  # starts expanding
+        # terminates and leaves a visible marker rather than a dangling directive
+        assert "depth limit reached" in out
+        assert "END" not in out  # never reached the bottom of the over-deep chain
+
+    def test_diamond_includes_each_file_once(self, tmp_path):
+        # root -> a, b; both -> shared. shared must appear once, not twice.
+        (tmp_path / "a.md").write_text("A\n@shared.md\n", encoding="utf-8")
+        (tmp_path / "b.md").write_text("B\n@shared.md\n", encoding="utf-8")
+        (tmp_path / "shared.md").write_text("SHARED_BODY", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n@b.md\n", tmp_path)
+        assert out.count("SHARED_BODY") == 1
+        assert "already included" in out  # the second reference is marked
+
+    def test_unreadable_target_leaves_a_marker(self, tmp_path):
+        # A directory (not a file) is not a valid include target.
+        (tmp_path / "adir").mkdir()
+        out = _expand_context_includes("@adir\n", tmp_path)
+        assert "adir" in out
+        assert out.strip() != ""
+
+
+class TestExpandContextIncludesConfinement:
+    """confine=True refuses escapes; confine=False (SOUL) allows cross-tree."""
+
+    def test_confined_rejects_absolute_path(self, tmp_path):
+        outside = tmp_path / "secret.md"
+        outside.write_text("TOP SECRET", encoding="utf-8")
+        base = tmp_path / "repo"
+        base.mkdir()
+        out = _expand_context_includes(f"@{outside}\n", base, confine=True)
+        assert "TOP SECRET" not in out
+        assert "outside base dir" in out
+
+    def test_confined_rejects_parent_traversal(self, tmp_path):
+        (tmp_path / "secret.md").write_text("TOP SECRET", encoding="utf-8")
+        base = tmp_path / "repo"
+        base.mkdir()
+        out = _expand_context_includes("@../secret.md\n", base, confine=True)
+        assert "TOP SECRET" not in out
+        assert "outside base dir" in out
+
+    def test_confined_allows_in_tree_include(self, tmp_path):
+        base = tmp_path / "repo"
+        base.mkdir()
+        (base / "role.md").write_text("IN TREE", encoding="utf-8")
+        out = _expand_context_includes("@role.md\n", base, confine=True)
+        assert "IN TREE" in out
+
+    def test_unconfined_allows_absolute_path(self, tmp_path):
+        # SOUL.md (confine=False) may compose files anywhere - e.g. a vault.
+        outside = tmp_path / "vault" / "global.md"
+        outside.parent.mkdir()
+        outside.write_text("VAULT GLOBAL", encoding="utf-8")
+        base = tmp_path / "home"
+        base.mkdir()
+        out = _expand_context_includes(f"@{outside}\n", base, confine=False)
+        assert "VAULT GLOBAL" in out
+
+
+class TestSoulMdIncludes:
+    """load_soul_md expands @ includes relative to HERMES_HOME."""
+
+    def test_soul_expands_includes(self, tmp_path, monkeypatch):
+        (tmp_path / "SOUL.md").write_text("# Soul\n\n@global.md\n", encoding="utf-8")
+        (tmp_path / "global.md").write_text("GLOBAL RULES", encoding="utf-8")
+        out = load_soul_md(home_override=tmp_path)
+        assert out is not None
+        assert "GLOBAL RULES" in out
+        assert "@global.md" not in out

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -162,6 +162,30 @@ The following project context files have been loaded and should be followed:
 
 Notice that SOUL content is inserted directly, without extra wrapper text.
 
+## Composing files with `@` includes
+
+Any context file (`SOUL.md`, `.hermes.md`, `AGENTS.md`, `CLAUDE.md`) can pull in another file with an `@` include directive. A line whose only content is `@<path>` is replaced by the contents of that file, resolved relative to the directory of the file the directive appears in:
+
+```markdown
+# SOUL.md
+
+@identity/global.md
+@identity/role.md
+```
+
+This keeps a single identity or instruction file composed of smaller, independently-edited pieces that stay live on disk - editing an included file changes the next prompt build with no reinstall or copy step. It is the natural way to share one global identity across agents while layering a per-agent role or a per-project overlay on top.
+
+Includes nest: an included file's own `@` directives are expanded relative to *that* file's location, so a directory of building blocks can reference its siblings.
+
+Rules and safeguards:
+
+- **Whole-line only.** A directive must be a bare `@path` alone on its line (leading whitespace is allowed, but no space after the `@`). An email address or an inline `@handle` in prose is never treated as an include.
+- **Relative paths.** The path resolves against the including file's directory. Use forward slashes; subdirectories like `@sub/role.md` work.
+- **Each file is included once.** A file referenced more than once across the whole tree (a repeat, a diamond, or a cycle) is expanded on first encounter; later references collapse to an `[include skipped (already included): <path>]` marker. This also bounds the work: no include chain can amplify into an exponential blow-up, because every file is read at most once.
+- **Missing files are visible, not fatal.** A directive pointing at a file that does not exist is replaced by an `[include not found: <path>]` marker (or `[include unreadable: ...]` / `[include depth limit reached at: ...]` for the other failure modes) rather than raising or silently vanishing.
+- **Trust boundary depends on the file.** `SOUL.md` lives in the Hermes home and is operator-owned, so its includes may point anywhere on the filesystem (for example a vault checked out under a different path). The working-directory files (`.hermes.md`, `AGENTS.md`, `CLAUDE.md`) may come from an untrusted cloned repo, so their includes are **confined**: absolute paths and `..`/symlink targets that escape the file's own directory are refused with an `[include outside base dir: <path>]` marker. This prevents a hostile checked-in context file from reading host secrets into the prompt.
+- **Same scanning as the top-level file.** Included content is run through the same prompt-injection scan and size cap after expansion, so an include cannot smuggle content past those checks.
+
 ## Security: Prompt Injection Protection
 
 All context files are scanned for potential prompt injection before being included. The scanner checks for:


### PR DESCRIPTION
## What does this PR do?

Adds `@path` include directives to Hermes context files (`SOUL.md`, `.hermes.md`, `AGENTS.md`, `CLAUDE.md`). A line whose only content is `@<path>` is replaced by the contents of that file, resolved relative to the directory of the file the directive appears in. Includes nest, resolving each file's own directives against its own location.

**Problem it solves.** Today a context file is a single monolithic blob. There is no way to share one global identity across agents while layering a per-agent role or a per-project overlay on top without copying text between files (and re-copying on every edit). You either duplicate content or maintain one giant file.

With `@` includes, a single `SOUL.md` can compose separate, independently-edited pieces:

```markdown
# SOUL.md
@identity/global.md
@identity/role.md
```

Each included file stays live on disk, so editing it changes the next prompt build with no reinstall or copy step. This is the natural building block for a "setup as code" layout where identity and instructions live in a versioned directory and are assembled at load time.

**Why this approach.** Every context file already flows through one shared `read -> scan -> truncate` seam in `prompt_builder.py`. Expansion is inserted at that single seam (`read -> expand -> scan -> truncate`), so all four file types gain the feature with no per-loader duplication, and included content is still run through the existing prompt-injection scan and size cap. No new dependencies, no new config keys, no changes to the tool surface.

## Related Issue

Related to #502 (Project Context System / `@` References). That issue asks for `@file:`/`@folder:` references inside *chat messages* (Cursor-style, to feed the agent context on the fly). This PR is the complementary, file-side half: composing the *context files themselves*. It does not implement message-level `@` references, so it does not close #502.

Related to #5200 (docs vs. code on `AGENTS.md` discovery): `@` includes give an explicit, discovery-independent way to assemble instructions, which sidesteps the working-directory-dependent `AGENTS.md` chain for the global identity slot.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py`
  - New `_expand_context_includes(content, base_dir, *, confine=False)` helper plus a `CONTEXT_INCLUDE_MAX_DEPTH` cap. Whole-line `@path` directives only (a space after `@`, an inline `@handle`, or an email address is never treated as a directive). Nested includes resolve relative to each included file's own directory.
  - Wired into all four loaders at the shared read/scan seam: `load_soul_md`, `_load_hermes_md`, `_load_agents_md`, `_load_claude_md`. Expansion runs **before** `_scan_context_content` and `_truncate_content`, so included text is injection-scanned and the merged result is size-capped.
- `tests/agent/test_prompt_builder.py`
  - 19 new tests covering happy path, nesting, whole-line parsing, missing/unreadable targets, cycles, depth cap, diamond dedup, path-confinement (both directions), and `load_soul_md` end-to-end expansion.
- `website/docs/user-guide/features/context-files.md`
  - New "Composing files with `@` includes" section documenting syntax, nesting, the per-scope trust boundary, and every failure marker.

### Security design (trust boundary)

`@` includes deliberately treat the two file classes differently:

- **`SOUL.md`** lives in the Hermes home and is operator-owned (same trust as the prompt itself), so its includes are **unconfined** - they may point anywhere on the filesystem (e.g. a vault checked out under a different path). That author can already put arbitrary text in the prompt, so this is not an escalation.
- **`.hermes.md` / `AGENTS.md` / `CLAUDE.md`** are discovered from the working directory, which may be an untrusted cloned repo. Their includes are **confined**: absolute paths and `..`/symlink targets that escape the file's own directory are refused with an `[include outside base dir: ...]` marker. This prevents a hostile checked-in context file from reading host secrets (`@/etc/passwd`, `@~/.ssh/id_rsa`) into the model's context - a surface that did not exist before this feature.

A single shared visited-set expands each file at most once across the whole tree (repeat, diamond, or cycle collapses to one copy with an `[include skipped ...]` marker), which also bounds total work - a fan-out cannot amplify into `N**depth` copies. Missing, unreadable, and over-deep targets each leave their own visible marker rather than raising.

## How to Test

1. Create a home dir with a composed `SOUL.md`:
   ```bash
   mkdir -p /tmp/soulhome
   printf '# Soul\n\n@global.md\n' > /tmp/soulhome/SOUL.md
   printf 'GLOBAL IDENTITY RULES' > /tmp/soulhome/global.md
   ```
2. Confirm the include expands (via the same loader the prompt builder uses):
   ```bash
   python3 -c "from agent.prompt_builder import load_soul_md; print(load_soul_md(home_override='/tmp/soulhome'))"
   # -> prints '# Soul' followed by 'GLOBAL IDENTITY RULES'; no '@global.md' remains
   ```
3. Confirm the confinement guard on a workspace file: an `AGENTS.md` containing a single line `@/etc/hostname` yields an `[include outside base dir: /etc/hostname]` marker, and the file's contents are NOT injected.
4. Run the test suite:
   ```bash
   scripts/run_tests.sh                                   # matches CI
   # or, focused:
   pytest tests/agent/test_prompt_builder.py -k "Include or Soul or Confinement" -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(agent):`, `docs(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the test suite and all tests pass (147 relevant tests green; injection-scan and soul-isolation suites included)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (aarch64, Debian-based / Raspberry Pi OS, Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/context-files.md` + the `_expand_context_includes` docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) — paths use `pathlib` throughout (`Path` joins, `.resolve()`, `.relative_to()`); no platform-specific separators or shell calls introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool behavior changed)

## Screenshots / Logs

Focused test run:

```
$ pytest tests/agent/test_prompt_builder.py -k "Include or Soul or Confinement" -q
...................                                                       [100%]
19 passed, 65 deselected

$ ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py
All checks passed!
```

Fan-out / confinement proof (isolated run of the helper):

```
1) confined absolute path blocked:  True
2) confined ../ traversal blocked:  True
3) SOUL (unconfined) cross-tree ok: True
4) fan-out copies of leaf body:     1 (was 19,683 before dedup); 0.007s; 1.8 KB output
```
