### PR TITLE
fix(tools): skip capability-incapable backends in web auto-detect

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -352,6 +352,80 @@ class TestBackendSelection:
             assert _get_backend() == "firecrawl"
 
 
+class TestCapabilityAwareSelection:
+    """Auto-detect must skip backends that cannot serve the capability (#98618).
+
+    With ddgs installed and no extract-capable credentials, extract used to
+    resolve to the search-only ddgs: selection reported it "available" and
+    the failure only surfaced at call time with the search-only error.
+    """
+
+    def test_extract_skips_search_only_ddgs(self):
+        """ddgs importable + no credentials → extract falls through to the
+        firecrawl default instead of search-only ddgs; search keeps ddgs."""
+        from tools.web_tools import _get_extract_backend, _get_search_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=True), \
+             patch("tools.web_tools._list_registered_web_providers", return_value=[]), \
+             patch("agent.web_search_registry._keyless_tier_enabled", return_value=False):
+            assert _get_extract_backend() == "firecrawl"
+            assert _get_search_backend() == "ddgs"
+
+    def test_extract_prefers_extract_capable_tavily_over_ddgs(self):
+        """Capability filtering must not drop extract-capable backends:
+        a Tavily key still wins over an importable ddgs for extract."""
+        from tools.web_tools import _get_extract_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=True), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            assert _get_extract_backend() == "tavily"
+
+    def test_extract_skips_searxng(self):
+        """A search-only credential (SEARXNG_URL) never satisfies extract —
+        it falls through to the firecrawl default."""
+        from tools.web_tools import _get_extract_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._list_registered_web_providers", return_value=[]), \
+             patch("agent.web_search_registry._keyless_tier_enabled", return_value=False), \
+             patch.dict(os.environ, {"SEARXNG_URL": "http://searxng.local"}):
+            assert _get_extract_backend() == "firecrawl"
+
+    def test_capability_check_uses_registered_provider(self):
+        """A registered provider's supports_extract() wins over any static map."""
+        from tools.web_tools import _backend_supports_capability
+        provider = MagicMock()
+        provider.supports_search.return_value = True
+        provider.supports_extract.return_value = False
+        with patch("tools.web_tools._registered_web_provider", return_value=provider):
+            assert _backend_supports_capability("custom-backend", "search") is True
+            assert _backend_supports_capability("custom-backend", "extract") is False
+
+    def test_capability_check_static_map_without_registry(self):
+        """Registry absent (plugins not loaded) → the static search-only map
+        applies; unknown backends stay extract-capable so a custom provider's
+        strict selection is never silently dropped."""
+        from tools.web_tools import _backend_supports_capability
+        with patch("tools.web_tools._registered_web_provider", return_value=None):
+            assert _backend_supports_capability("ddgs", "search") is True
+            assert _backend_supports_capability("ddgs", "extract") is False
+            assert _backend_supports_capability("brave-free", "extract") is False
+            assert _backend_supports_capability("tavily", "extract") is True
+            assert _backend_supports_capability("never-heard-of", "extract") is True
+
+    def test_is_backend_available_capability_gate(self):
+        """_is_backend_available(backend, capability="extract") reports False
+        for a reachable search-only backend asked about extract (#98618)."""
+        from tools.web_tools import _is_backend_available
+        with patch("tools.web_tools._ddgs_package_importable", return_value=True), \
+             patch("tools.web_tools._registered_web_provider", return_value=None):
+            assert _is_backend_available("ddgs") is True
+            assert _is_backend_available("ddgs", capability="search") is True
+            assert _is_backend_available("ddgs", capability="extract") is False
+
+
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -172,6 +172,12 @@ _LEGACY_WEB_BACKENDS = frozenset(
     {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "keenable"}
 )
 
+# Legacy built-ins that can search but cannot extract. Mirrors the
+# ``supports_extract()`` answer of the corresponding plugins so capability
+# filtering still works before plugins load (subprocess agent runs,
+# delegate children, scripts) — see :func:`_backend_supports_capability`.
+_SEARCH_ONLY_WEB_BACKENDS = frozenset({"searxng", "brave-free", "ddgs", "xai"})
+
 
 def _registered_web_provider(backend: str):
     """Return a plugin-registered web provider by name, or ``None``.
@@ -220,8 +226,37 @@ def _list_registered_web_providers():
         return []
 
 
-def _get_backend() -> str:
+def _backend_supports_capability(backend: str, capability: str) -> bool:
+    """Return True when *backend* can serve *capability* ("search"/"extract").
+
+    Registered providers answer via ``supports_search()`` /
+    ``supports_extract()``; names with no registered provider fall back to
+    :data:`_SEARCH_ONLY_WEB_BACKENDS`. Unknown backends are assumed capable
+    so capability filtering never downgrades a custom provider's strict
+    selection into a silent switch.
+    """
+    provider = _registered_web_provider(backend)
+    if provider is not None:
+        try:
+            if capability == "search":
+                return bool(provider.supports_search())
+            if capability == "extract":
+                return bool(provider.supports_extract())
+        except Exception as exc:  # noqa: BLE001 — fall through to static map
+            logger.debug(
+                "web provider %r.supports_%s raised: %s", backend, capability, exc
+            )
+    if capability == "extract":
+        return (backend or "").lower().strip() not in _SEARCH_ONLY_WEB_BACKENDS
+    return True
+
+
+def _get_backend(capability: Optional[str] = None) -> str:
     """Determine which web backend to use (shared fallback).
+
+    When *capability* is given ("search"/"extract"), candidates that cannot
+    serve it are skipped during auto-detect, so e.g. extract never lands on
+    a search-only backend like ``ddgs`` (#98618).
 
     Reads ``web.backend`` from config.yaml (set by ``hermes tools``). A
     stored backend name is returned as-is — no availability probe, no
@@ -270,7 +305,9 @@ def _get_backend() -> str:
         ("ddgs", _ddgs_package_importable()),
     )
     for backend, available in backend_candidates:
-        if available:
+        if available and (
+            capability is None or _backend_supports_capability(backend, capability)
+        ):
             return backend
 
     # Final fallback: walk plugin-registered providers so a custom backend
@@ -283,7 +320,10 @@ def _get_backend() -> str:
         if provider.name in _LEGACY_WEB_BACKENDS:
             continue
         try:
-            if provider.is_available():
+            if provider.is_available() and (
+                capability is None
+                or _backend_supports_capability(provider.name, capability)
+            ):
                 return provider.name
         except Exception as exc:  # noqa: BLE001 — a broken provider is skipped
             logger.debug("web provider %r.is_available() raised: %s", provider.name, exc)
@@ -305,7 +345,10 @@ def _get_backend() -> str:
                 if provider is None:
                     continue
                 try:
-                    if provider.is_keyless_available():
+                    if provider.is_keyless_available() and (
+                        capability is None
+                        or _backend_supports_capability(name, capability)
+                    ):
                         return name
                 except Exception as exc:  # noqa: BLE001 — skip broken provider
                     logger.debug(
@@ -356,7 +399,7 @@ def _get_capability_backend(capability: str) -> str:
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
     if specific:
         return specific
-    return _get_backend()
+    return _get_backend(capability)
 
 
 def _tavily_explicitly_configured() -> bool:
@@ -367,8 +410,13 @@ def _tavily_explicitly_configured() -> bool:
     )
 
 
-def _is_backend_available(backend: str) -> bool:
+def _is_backend_available(backend: str, capability: Optional[str] = None) -> bool:
     """Return True when the selected backend is currently usable.
+
+    When *capability* is given ("search"/"extract"), a backend that cannot
+    serve it answers False even when otherwise reachable — callers asking
+    "can this backend do the thing I'm about to ask?" get an honest answer
+    (#98618).
 
     For plugin-registered backends (any name outside
     :data:`_LEGACY_WEB_BACKENDS`), availability is delegated to the
@@ -380,6 +428,8 @@ def _is_backend_available(backend: str) -> bool:
     hardcoded probes below.
     """
     backend = (backend or "").lower().strip()
+    if capability and not _backend_supports_capability(backend, capability):
+        return False
     if backend not in _LEGACY_WEB_BACKENDS:
         registered = _registered_web_provider_available(backend)
         if registered is not None:


### PR DESCRIPTION
## What does this PR do?

`_get_backend()` resolved both search and extract through the same availability ladder, so on an install with the `ddgs` package importable and no extract-capable credentials, `web_extract` resolved to `ddgs` — a search-only backend — and only failed at call time with the "search-only backend" error. Availability was answering "is this backend reachable?" where the caller meant "can this backend do the thing I'm about to ask?"

This threads the capability through backend selection:

- New `_backend_supports_capability(backend, capability)` helper: registered providers answer via their own `supports_search()`/`supports_extract()`; names with no registered provider (plugins not yet loaded — subprocess agent runs, delegate children, scripts) fall back to a small static search-only map (`searxng`, `brave-free`, `ddgs`, `xai`). Unknown backends are assumed capable so a custom provider's strict selection is never silently dropped.
- `_get_backend(capability=None)`: the credential ladder, plugin-registered walk, and keyless walk now skip backends that cannot serve the requested capability. Explicit config (`web.backend` / `web.{capability}_backend`) stays strictly returned as-is — the dispatch path's typed search-only error still surfaces misconfiguration honestly.
- `_is_backend_available(backend, capability=None)` gains the same optional gate so callers asking the chokepoint about a capability get an honest answer.

After the fix, extract on a ddgs-only install falls through to the `firecrawl` default (surfacing Firecrawl's own setup error when unconfigured) instead of pretending ddgs will work; search still resolves to ddgs.

## Related Issue

Fixes #98618

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py`: added `_SEARCH_ONLY_WEB_BACKENDS` and `_backend_supports_capability()`; `_get_backend()` takes an optional `capability` and filters the credential ladder / plugin walk / keyless walk; `_get_capability_backend()` passes its capability through; `_is_backend_available()` takes an optional `capability` gate.
- `tests/tools/test_web_tools_config.py`: new `TestCapabilityAwareSelection` covering ddgs/searxng being skipped for extract while search keeps them, extract-capable backends not being dropped, registry-priority vs static-map capability resolution, and the `_is_backend_available` capability gate.

## How to Test

1. `python -m pytest tests/tools/test_web_tools_config.py::TestCapabilityAwareSelection -q` — all 6 tests should pass.
2. Reproduce the original report (no `TAVILY_API_KEY`/`EXA_API_KEY`/`PARALLEL_API_KEY`/`FIRECRAWL_API_KEY` set, no `web.*_backend` config, `ddgs` importable):
   ```python
   from tools.web_tools import _get_extract_backend, _get_search_backend
   _get_extract_backend()  # "firecrawl" (was "ddgs")
   _get_search_backend()   # "ddgs" (unchanged)
   ```
   Observed result: before the fix `_get_extract_backend()` returned `ddgs` and `web_extract_tool` failed with the search-only error; after the fix extract resolves to `firecrawl` and search is unaffected.
3. `python -m pytest tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_xai.py tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py -q` — all pass (2 pre-existing local env failures in `TestParallelClientConfig` reproduce on clean upstream/main and are unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
