### PR TITLE
fix(dashboard): run plugin discovery before the auth gate

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19526,6 +19526,17 @@ def start_server(
         # provider to be registered, else fail closed — there is no longer an
         # escape hatch that serves the dashboard without authentication.
         from hermes_cli.dashboard_auth import list_providers
+        # Plugin-registered auth providers (e.g. the bundled basic password
+        # provider) only register during plugin discovery, which this server
+        # process doesn't otherwise run before this gate — trigger it
+        # explicitly (idempotent) or a fully-configured provider stays
+        # invisible here and the gate fails closed.
+        try:
+            from hermes_cli.plugins import discover_plugins
+
+            discover_plugins()
+        except Exception:
+            _log.warning("plugin discovery before auth gate failed", exc_info=True)
         if not list_providers():
             # Surface the *specific* reason any bundled provider declined
             # to register (e.g. missing HERMES_DASHBOARD_OAUTH_CLIENT_ID).

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -479,3 +479,78 @@ def test_should_require_dashboard_auth_truth_table(
     else:
         monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_URL", public_url)
     assert should_require_dashboard_auth(host) is expected
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery before the auth gate
+# ---------------------------------------------------------------------------
+
+
+def test_start_server_auth_gate_runs_plugin_discovery(monkeypatch):
+    """The gate triggers plugin discovery before checking for providers.
+
+    Plugin-registered auth providers (e.g. the bundled basic password
+    provider) only register during plugin discovery, and the dashboard
+    server process doesn't otherwise run discovery before this gate — so
+    a fully configured provider was invisible here and the bind failed
+    closed even with valid ``dashboard.basic_auth`` credentials on disk.
+    """
+    import hermes_cli.plugins as plugins_mod
+
+    calls: list = []
+
+    def _fake_discover_plugins(*args, **kwargs):
+        calls.append(1)
+        # Simulate the bundled basic provider plugin registering during
+        # discovery.
+        from hermes_cli.dashboard_auth import register_provider
+        from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+        register_provider(StubAuthProvider())
+
+    monkeypatch.setattr(
+        plugins_mod, "discover_plugins", _fake_discover_plugins
+    )
+    from hermes_cli.dashboard_auth import clear_providers
+
+    clear_providers()
+    captured = _stub_uvicorn_run(monkeypatch)
+    try:
+        web_server.app.state.auth_required = None
+        web_server.start_server(
+            host="0.0.0.0", port=9119,
+            open_browser=False, allow_public=False,
+        )
+        # Discovery ran before the gate and its provider satisfied it.
+        assert calls == [1]
+        assert web_server.app.state.auth_required is True
+        assert captured["kwargs"].get("host") == "0.0.0.0"
+    finally:
+        clear_providers()
+
+
+def test_start_server_auth_gate_still_fails_closed_without_providers(monkeypatch):
+    """Discovery running is not an escape hatch — zero providers still fails.
+
+    Even when discovery runs and registers nothing (e.g. no basic-auth
+    credentials configured), the gate must keep failing closed.
+    """
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(
+        plugins_mod, "discover_plugins", lambda *a, **kw: None
+    )
+    from hermes_cli.dashboard_auth import clear_providers
+
+    clear_providers()
+    _stub_uvicorn_run(monkeypatch)
+    web_server.app.state.auth_required = None
+    try:
+        with pytest.raises(SystemExit):
+            web_server.start_server(
+                host="0.0.0.0", port=9119,
+                open_browser=False, allow_public=False,
+            )
+        assert web_server.app.state.auth_required is True
+    finally:
+        clear_providers()


### PR DESCRIPTION
## Problem

With `dashboard.basic_auth` correctly configured in `config.yaml` (and the bundled `basic` plugin enabled), `hermes dashboard --host 0.0.0.0` still refuses to start on v0.20.6 and current `main`:

```
Refusing to bind dashboard to 0.0.0.0 — the auth gate engages on non-loopback binds, but no auth providers are registered.
```

## Root cause

The gate in `start_server()` (`hermes_cli/web_server.py`) checks `list_providers()` and fails closed when it's empty. But auth providers register through the plugin hook (`ctx.register_dashboard_auth_provider`), which only runs during plugin discovery — and the dashboard startup path never triggers discovery before this check.

The only `discover_plugins()` calls in `web_server.py` live in request-time helpers (channels-page rendering, terminal-backend picker), so at gate-check time the provider registry is empty unless some unrelated import happened to trigger discovery as a side effect. Notably, the gate's own diagnostics import `plugins.dashboard_auth.nous` to read its `LAST_SKIP_REASON` — the plugin module is importable right there, but its `register()` hook never ran.

This is the "same symptom, additional root cause" case reported by @hoekbrwr in #54489 (plugin enabled + credentials configured, still refused), and is distinct from the `plugins.disabled` diagnostics proposed in #54610.

## Fix

Trigger `discover_plugins()` right before the provider check. It is idempotent (it joins any background discovery first), matching the existing idiom already used elsewhere in this file. The gate keeps failing closed when discovery registers no providers.

## Testing

- Added two regression tests in `tests/hermes_cli/test_dashboard_auth_gate.py`:
  - the gate runs discovery and proceeds when a provider registers during it;
  - the gate still fails closed when discovery runs but registers nothing.
- Verified end to end on device (Termux/aarch64, v0.20.6 + this patch): dashboard binds on `0.0.0.0:9119`, the login page serves, and password login via `POST /auth/password-login` succeeds with configured credentials.
