### PR TITLE
fix(desktop): stop session.info heartbeats re-rendering every tab, and stop replaying approvals against a reaped runtime

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -10,7 +10,7 @@ import {
 import { reconcileSessionCompacting } from '@/store/compaction'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { replayPendingApproval } from '@/store/prompts'
+import { forgetDetachedApprovalSessions, replayPendingApproval } from '@/store/prompts'
 import { setSessionProviderWait } from '@/store/provider-wait'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
@@ -194,6 +194,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
+
+      // A reconnect rebuilds the gateway's runtime map, so every runtime we
+      // had written off as detached deserves one more look.
+      if (event.type === 'gateway.ready') {
+        forgetDetachedApprovalSessions()
+      }
 
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $currentCwd,
   $selectedStoredSessionId,
@@ -104,5 +106,44 @@ describe('handleSessionInfoEvent workspace ownership', () => {
 
     expect($currentCwd.get()).toBe('/repo/mine')
     expect($workspaceCwdOwner.get()).toBe('selected-session')
+  })
+
+  it('keeps runtime state identity when a heartbeat only restates cached fields', () => {
+    const original = {
+      ...createClientSessionState('stored-1'),
+      cwd: '/repo/mine',
+      fast: true,
+      model: 'model-1',
+      provider: 'provider-1'
+    }
+
+    const ctx = sessionInfoEvent({
+      activeSessionId: 'runtime-1',
+      cwd: '/repo/mine',
+      explicitSid: 'runtime-1',
+      storedSessionId: 'stored-1'
+    })
+
+    let next: ClientSessionState | undefined
+
+    ctx.payload = {
+      ...ctx.payload,
+      fast: true,
+      model: 'model-1',
+      provider: 'provider-1'
+    }
+    ctx.deps.sessionStateByRuntimeIdRef.current.set('runtime-1', original)
+    ctx.deps.updateSessionState = vi.fn(
+      (_sessionId: string, updater: (state: ClientSessionState) => ClientSessionState) => {
+        const updated = updater(original)
+        next = updated
+
+        return updated
+      }
+    )
+
+    handleSessionInfoEvent(ctx)
+
+    expect(next).toBe(original)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -28,7 +28,12 @@ import {
 import { reportInstallMethodWarning } from '@/store/updates'
 
 import { finalizeInterruptedMessages } from '../../use-prompt-actions/rewind'
-import { hasSessionInfoStatePatch, PRE_TURN_LIVE_SETTLE_GRACE_MS, sessionInfoStatePatch } from '../utils'
+import {
+  applySessionInfoStatePatch,
+  hasSessionInfoStatePatch,
+  PRE_TURN_LIVE_SETTLE_GRACE_MS,
+  sessionInfoStatePatch
+} from '../utils'
 
 import type { GatewayEventContext } from './types'
 
@@ -253,12 +258,7 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     if (sessionId && hasStatePatch) {
       updateSessionState(
         sessionId,
-        state => ({
-          ...state,
-          ...statePatch,
-          branch: statePatch.branch ?? state.branch,
-          cwd: statePatch.cwd ?? state.cwd
-        }),
+        state => applySessionInfoStatePatch(state, statePatch),
         payload?.stored_session_id || undefined
       )
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -56,6 +56,31 @@ export function hasSessionInfoStatePatch(patch: SessionRuntimeStatePatch): boole
   return Object.keys(patch).length > 0
 }
 
+/** Preserve the runtime-state reference when a session.info heartbeat merely
+ * restates cached values. `$sessionStates` is the rendering source for every
+ * mounted session surface, so publishing an equivalent spread makes all of
+ * them re-render at the heartbeat cadence. */
+export function applySessionInfoStatePatch(
+  state: ClientSessionState,
+  patch: SessionRuntimeStatePatch
+): ClientSessionState {
+  if (
+    (patch.branch === undefined || patch.branch === state.branch) &&
+    (patch.cwd === undefined || patch.cwd === state.cwd) &&
+    (patch.fast === undefined || patch.fast === state.fast) &&
+    (patch.model === undefined || patch.model === state.model) &&
+    (patch.personality === undefined || patch.personality === state.personality) &&
+    (patch.provider === undefined || patch.provider === state.provider) &&
+    (patch.reasoningEffort === undefined || patch.reasoningEffort === state.reasoningEffort) &&
+    (patch.serviceTier === undefined || patch.serviceTier === state.serviceTier) &&
+    (patch.yolo === undefined || patch.yolo === state.yolo)
+  ) {
+    return state
+  }
+
+  return { ...state, ...patch }
+}
+
 // Minimum gap between two assistant-text flushes during a stream. Was 16ms
 // (rAF only), which at typical LLM token rates of ~30-80 tok/sec meant every
 // token got its own React commit + Streamdown markdown re-parse, scaling

--- a/apps/desktop/src/lib/gateway-rpc.ts
+++ b/apps/desktop/src/lib/gateway-rpc.ts
@@ -37,3 +37,17 @@ export function isBusySessionModelSwitch(error: unknown): boolean {
 
   return /session busy/i.test(message) && /switching models/i.test(message)
 }
+
+/** True when a session-scoped RPC was refused because the gateway no longer
+ *  holds that runtime — detached on WS disconnect and orphan-reaped, LRU
+ *  evicted, or torn down after an idle TTL. The backend answers 4001
+ *  "session not found" and expects the client to recover via session.resume
+ *  on the STORED id, not to retry the dead runtime id.
+ *
+ *  Deliberately narrow: transient failures (socket drops, timeouts) must NOT
+ *  match, or a blip would suppress a live session's recovery. */
+export function isDetachedSessionRpc(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /\b4001\b/.test(message) || /session not found/i.test(message)
+}

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -10,6 +10,7 @@ import {
   clearApprovalRequest,
   clearSecretRequest,
   clearSudoRequest,
+  forgetDetachedApprovalSessions,
   receiveApprovalRequest,
   replayPendingApproval,
   setApprovalRequest,
@@ -216,5 +217,101 @@ describe('$activeSessionAwaitingInput', () => {
 
     $activeSessionId.set('s2')
     expect($activeSessionAwaitingInput.get()).toBe(true)
+  })
+})
+
+describe('pending approval replay backoff', () => {
+  afterEach(() => {
+    forgetDetachedApprovalSessions()
+  })
+
+  // #90428 class: a detached/reaped runtime answers every session-scoped RPC
+  // with 4001 "session not found". replayPendingApproval fires on EVERY
+  // session.info (see approvalReplaySessionId), and session.info arrives in
+  // bursts, so swallowing the refusal turned one dead tab into a permanent
+  // poll: logs/gui.log recorded 5665 rejected approval.pending calls at a
+  // steady 33-36/min for ~22h, each one a gateway-side WARNING.
+  it('stops polling a runtime the gateway no longer holds', async () => {
+    const calls: string[] = []
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+        throw new Error('4001: session not found')
+      }
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await replayPendingApproval(gateway, 'dead-1').catch(() => undefined)
+    }
+
+    expect(calls).toEqual(['approval.pending'])
+  })
+
+  it('keeps polling every other runtime', async () => {
+    const calls: Array<string> = []
+
+    const gateway = {
+      request: async (_method: string, params: Record<string, unknown>) => {
+        calls.push(String(params.session_id))
+
+        if (params.session_id === 'dead-1') {
+          throw new Error('4001: session not found')
+        }
+
+        return { approvals: [] }
+      }
+    }
+
+    await replayPendingApproval(gateway, 'dead-1').catch(() => undefined)
+    await replayPendingApproval(gateway, 'dead-1').catch(() => undefined)
+    await replayPendingApproval(gateway, 'alive-1').catch(() => undefined)
+    await replayPendingApproval(gateway, 'alive-1').catch(() => undefined)
+
+    expect(calls).toEqual(['dead-1', 'alive-1', 'alive-1'])
+  })
+
+  it('does not latch on a transient failure', async () => {
+    const calls: string[] = []
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+        throw new Error('websocket disconnected')
+      }
+    }
+
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+
+    expect(calls).toHaveLength(2)
+  })
+
+  it('polls again once the runtime is reinstated', async () => {
+    const calls: string[] = []
+    let dead = true
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+
+        if (dead) {
+          throw new Error('4001: session not found')
+        }
+
+        return { approvals: [] }
+      }
+    }
+
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+    expect(calls).toHaveLength(1)
+
+    // gateway.ready / a fresh resume means the runtime map was rebuilt.
+    dead = false
+    forgetDetachedApprovalSessions()
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+
+    expect(calls).toHaveLength(2)
   })
 })

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,5 +1,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
+import { isDetachedSessionRpc } from '@/lib/gateway-rpc'
+
 import { $clarifyRequest, $clarifyRequests } from './clarify'
 import { $activeSessionId } from './session'
 
@@ -126,14 +128,41 @@ export async function receiveApprovalRequest(gateway: ApprovalGateway | null, re
   }
 }
 
+/** Runtimes the gateway has told us it no longer holds (4001). replayPendingApproval
+ *  fires on EVERY session.info, and session.info arrives in bursts, so without
+ *  this a single detached tab polls approval.pending forever: gui.log recorded
+ *  5665 refusals at a steady 33-36/min for ~22h, one gateway WARNING each.
+ *
+ *  A refusal is a fact about THIS runtime id, not about the conversation — the
+ *  stored session resumes under a new runtime id, and that id is not in here.
+ *  Cleared wholesale on gateway.ready, when the runtime map is rebuilt. */
+const detachedApprovalSessions = new Set<string>()
+
+/** Re-arm approval replay for every runtime (gateway reconnect / rebuild). */
+export function forgetDetachedApprovalSessions(): void {
+  detachedApprovalSessions.clear()
+}
+
 export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
-  if (!gateway || !sessionId) {
+  if (!gateway || !sessionId || detachedApprovalSessions.has(sessionId)) {
     return
   }
 
-  const rawResult = await gateway.request('approval.pending', {
-    session_id: sessionId
-  })
+  let rawResult: unknown
+
+  try {
+    rawResult = await gateway.request('approval.pending', {
+      session_id: sessionId
+    })
+  } catch (error) {
+    // Callers already treat a replay failure as non-fatal. Read the refusal
+    // before it is discarded so a dead runtime stops being polled.
+    if (isDetachedSessionRpc(error)) {
+      detachedApprovalSessions.add(sessionId)
+    }
+
+    throw error
+  }
 
   const result =
     rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}
@@ -242,6 +271,7 @@ export function clearAllPrompts(sessionId?: string | null): void {
     sudo.reset()
     secret.reset()
     $approvalInlineAnchors.set({})
+    detachedApprovalSessions.clear()
 
     return
   }


### PR DESCRIPTION
Two related desktop fixes for the same symptom: a multi-tab session that
flickers and eats keystrokes. Both were found by reading this install's own
logs, and the numbers below come from those logs, not from a synthetic repro.

## 1. `session.info` heartbeats published a new state object every time

The backend stamps `model` / `provider` / `cwd` / `fast` / … on **every**
`session.info`, and those arrive in bursts. Each one spread a fresh
`ClientSessionState` into `$sessionStates` — the rendering source for every
mounted session surface — so every burst re-rendered all of them. The cost
scaled with the number of open tabs, which is exactly how the flicker
presented.

`applySessionInfoStatePatch` now returns the **same** state object when all
nine patch fields already match, so an unchanged heartbeat publishes nothing.

This sits on top of `0401e0888`, which fixed the neighbouring stranger's-cwd
flicker in the same file.

## 2. Approval replay never stopped against a reaped runtime

`replayPendingApproval` fires on every `session.info`, and the caller discards
failures with `.catch(() => undefined)`. When the gateway no longer holds a
runtime it answers `4001 "session not found"` and expects the client to resume
the stored session instead — but nothing read that refusal, so a single
detached tab polled `approval.pending` forever.

`logs/gui.log` on this install recorded **5665 refusals at a steady 33-36/min
for ~22h**, each one a gateway-side WARNING, all for the same dead runtime id.

The refusal is now read before it is discarded, and that runtime id stops
being polled. The mark is about the *runtime*, not the conversation: a resume
comes back under a new id, which is not in the set, and `gateway.ready` clears
the set wholesale since a reconnect rebuilds the gateway's runtime map.

`isDetachedSessionRpc` is deliberately narrow (`4001` / "session not found") so
a socket drop or timeout cannot latch a live session out of its recovery — a
regression test pins that.

## Tests

```
vitest run --project ui \
  src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts \
  src/store/prompts.test.ts

Test Files  2 passed (2)
     Tests  22 passed (22)
```

`npm run typecheck` clean (all three tsconfigs).

The identity regression test is red without the first fix and green with it.
