### PR TITLE
fix(gateway): require wake-capable session provenance for background delegate_task

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3035,7 +3035,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             gateway_session_key=gateway_session_key, route=route, session_model=session_model,
             requested_runtime=runtime_request.get("requested") or {},
             route_source=runtime_request.get("route_source") or "global",
-            confirmed_runtime_lock=lock_active, **agent_overrides)
+            confirmed_runtime_lock=lock_active,
+            # #98619: the client addresses this session by construction — the id is in the
+            # request path (/api/sessions/{session_id}/chat) — so a wake self-post lands where
+            # the client will read it. The audited native-session opt-in.
+            wake_capable="1", **agent_overrides)
         return {
             "gateway_session_key": gateway_session_key, "session_id": session_id, "body": body,
             "user_message": user_message, "runtime_request": runtime_request,
@@ -3542,11 +3546,19 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     @staticmethod
     def _bind_api_server_session(
         *, chat_id: str = "", session_key: str = "", session_id: str = "",
-        browser_control_principal: str = "", browser_control_transport_family: str = "") -> list:
+        browser_control_principal: str = "", browser_control_transport_family: str = "",
+        wake_capable: str = "") -> list:
         """Bind session contextvars for an API-server agent run — the SINGLE chokepoint for every
         agent-entry path. Hardwires ``platform="api_server"`` + ``async_delivery=False`` (HTTP
         can never wake the agent after the turn) so no route reintroduces the silent no-op bug.
         Returns reset tokens for ``clear_session_vars`` in a ``finally`` (request-scoped).
+
+        ``wake_capable`` is the separate #98619 gate and DEFAULT-DENIES here: only an audited
+        producer whose client can address the bound id again (explicit X-Hermes-Session-Id —
+        403-gated on API_SERVER_KEY — a native /api/sessions/{id} route, /v1/runs) passes "1";
+        a fingerprint-derived id (header-less OpenAI-compatible client) stays "" and keeps
+        delegate_task's forced-sync fallback — the wake self-post could never deliver where
+        that client reads. A route that says nothing grants no wake authority.
 
         See #10760.
         """
@@ -3555,7 +3567,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             platform="api_server", chat_id=chat_id, session_key=session_key, session_id=session_id,
             browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
-            async_delivery=False, cron_session="")
+            async_delivery=False, cron_session="", wake_capable=wake_capable)
 
     def _turn_runtime_metadata(
         self, agent: Any, *, route: Optional[Dict[str, Any]], requested_runtime: Optional[Dict[str, Any]],
@@ -3629,11 +3641,15 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         requested_provider: Optional[str] = None, model_options: Optional[Dict[str, Any]] = None,
         route: Optional[Dict[str, Any]] = None, session_model: Optional[str] = None,
         requested_runtime: Optional[Dict[str, Any]] = None, route_source: str = "global",
-        confirmed_runtime_lock: bool = False, bind_declared_conversation: bool = False) -> tuple:
+        confirmed_runtime_lock: bool = False, bind_declared_conversation: bool = False,
+        wake_capable: str = "") -> tuple:
         """Create an agent and run one turn in a thread executor -> ``(result, usage)``.
         ``agent_ref[0]`` receives the agent so SSE writers can interrupt it; ``active_run_id``
         registers it in ``_active_run_agents``. Under a confirmed model lock the actual
-        provider/model must match or the turn fails; ``runtime`` metadata is attached."""
+        provider/model must match or the turn fails; ``runtime`` metadata is attached.
+        ``wake_capable`` declares #98619 session-id provenance and default-denies: only audited
+        producers whose client can address the id again pass "1" (see
+        ``_bind_api_server_session``)."""
         loop = asyncio.get_running_loop()
         # ContextVars do not follow run_in_executor threads: capture here, re-enter in _run().
         request_profile = _api_request_profile.get()
@@ -3647,7 +3663,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     chat_id=session_id or "", session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
                     browser_control_principal=request_browser_control_principal,
-                    browser_control_transport_family=request_browser_control_transport_family)
+                    browser_control_transport_family=request_browser_control_transport_family,
+                    wake_capable=wake_capable)
                 agent = None
                 try:
                     agent = self._create_agent(

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -473,6 +473,13 @@ class OpenAICompatRoutesMixin:
             try:
                 db = await self._ensure_session_db_async()
                 if db is not None:
+                    # #98619/#13437: a client-addressed id from before a compression rotation
+                    # must adopt the live continuation tip — history loads from it, the turn and
+                    # the wake target bind it, and a detached delegation delivery row persisted
+                    # on the tip is what this continuation consumes. Same canonical resolution
+                    # the delivery writer (gateway/wake.py) and /v1/runs use; fails open.
+                    from gateway.platforms.api_server_runs import _resolve_live_session_id
+                    session_id = await _resolve_live_session_id(self, provided_session_id)
                     history = await asyncio.to_thread(db.get_messages_as_conversation, session_id)
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
@@ -530,9 +537,14 @@ class OpenAICompatRoutesMixin:
             agent_task, agent_ref = self._spawn_stream_agent(
                 _stream_q, tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete, **run_kwargs)
+            # #13437 identity contract: an explicit-header client keeps addressing the id it
+            # sent; the response echoes that stable id while reads/writes adopt the live tip,
+            # so a rotation mid-turn (after these headers are prepared) never changes what the
+            # client should send next — it re-sends the same id and the tip resolution above
+            # finds whatever session is live by then.
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
-                agent_task, agent_ref, session_id=session_id,
+                agent_task, agent_ref, session_id=(provided_session_id or session_id),
                 gateway_session_key=gateway_session_key)
 
         async def _compute_completion():
@@ -549,7 +561,10 @@ class OpenAICompatRoutesMixin:
         if err_msg:
             err_msg = _redact_api_error_text(err_msg)
         finish_reason = _finish_reason(completed, is_partial, is_failed, err_msg)
-        response_headers = {"X-Hermes-Session-Id": result.get("session_id", session_id)}
+        # Same #13437 identity contract as the SSE path: an explicit-header client is echoed
+        # the stable id it sent; a fingerprint-derived (header-less) turn keeps reporting the
+        # id the agent actually resolved, so headerless clients still learn where the turn went.
+        response_headers = {"X-Hermes-Session-Id": (provided_session_id or result.get("session_id", session_id))}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         # Hard fail (no usable text AND a real failure) -> 502 OpenAI error envelope so SDK

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -494,7 +494,13 @@ class OpenAICompatRoutesMixin:
         run_kwargs = dict(
             user_message=user_message, conversation_history=history,
             ephemeral_system_prompt=system_prompt, session_id=session_id,
-            gateway_session_key=gateway_session_key, **agent_overrides, route=route)
+            gateway_session_key=gateway_session_key, **agent_overrides, route=route,
+            # #98619: only an explicitly provided X-Hermes-Session-Id is wake-capable (the
+            # header is 403-gated on API_SERVER_KEY, so the wake self-post can authenticate
+            # and the client can resume the session by sending it again). A fingerprint-derived
+            # id from a header-less client is NOT: delegate_task keeps its forced-sync fallback
+            # there — the wake would hard-fail or land in history that client never reloads.
+            wake_capable=("1" if provided_session_id else ""))
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
             # tool_call_ids with an emitted "running": a "completed" without one (internal/

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -354,6 +354,23 @@ def _drop_run_transport(self, run_id: str) -> None:
     _forget_run(self, run_id, self._run_streams, self._run_streams_created)
 
 
+async def _resolve_live_session_id(self, session_id: str) -> str:
+    """Adopt the live compression-continuation tip for a client-addressed session (#98619):
+    a /v1/runs run bound to a pre-rotation id would otherwise load a stale history slice and
+    write its turn into the closed parent (CompressionSessionClosedError). Same canonical
+    resolution ``/api/sessions/{id}/messages`` reads use; fails open to the original id."""
+    db = await self._ensure_session_db_async()
+    resolver = getattr(db, "resolve_resume_session_id", None) if db is not None else None
+    if not callable(resolver):
+        return session_id
+    try:
+        resolved = await asyncio.to_thread(resolver, session_id)
+        return str(resolved) if resolved else session_id
+    except Exception:
+        logger.debug("/v1/runs live-session resolve failed for %s", session_id, exc_info=True)
+        return session_id
+
+
 async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Response":
     """POST /v1/runs — start an agent run, return run_id immediately."""
     _openai_error = _api_server._openai_error
@@ -427,6 +444,11 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     _declared_selected = not session_id and bool(gateway_session_key)
     selected_session_id = session_id or (
         self._declared_conversation_session(gateway_session_key) if _declared_selected else None)
+    # A client-addressed id from before a compression rotation must adopt the live tip (#98619):
+    # history loads from it, the turn writes to it, and a detached delivery row persisted to it
+    # is what the next same-id run consumes below.
+    if selected_session_id:
+        selected_session_id = await _resolve_live_session_id(self, str(selected_session_id))
     session_id = selected_session_id or run_id
     # History loads for the session the request actually selected — including one resolved from
     # a declared X-Hermes-Session-Key, whose persisted delivery rows must reach the next

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -486,7 +486,12 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             session_tokens = self._bind_api_server_session(
                 chat_id=session_id or "", session_key=run.approval_session_key, session_id=session_id or "",
                 browser_control_principal=run.browser_control_principal,
-                browser_control_transport_family=run.browser_control_transport_family)
+                browser_control_transport_family=run.browser_control_transport_family,
+                # #98619 audited opt-in: every /v1/runs session id is one the client can address
+                # again (body session_id, a response chain id, a declared session key, or the
+                # run_id fallback returned by the create response) — and a wake-injected turn
+                # lands in session history a later run on the same id will load.
+                wake_capable="1")
             if session_tokens:
                 resets.append((session_tokens, clear_session_vars))
             if run.agent_kwargs["room_dispatch"] is not None:

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -319,7 +319,9 @@ class _RunLaunch:
     user_message: str
     conversation_history: List[Dict[str, str]]
     # #98619: only continuation paths that reload session history may grant wake authority —
-    # a previous_response_id continuation consumes its ResponseStore snapshot instead.
+    # a previous_response_id continuation consumes its ResponseStore snapshot instead, and a
+    # caller-supplied conversation_history is authoritative for the turn; neither consumes a
+    # SessionDB delivery row, so both stay default-denied.
     wake_capable: bool
     agent_kwargs: dict  # ``_create_agent`` keyword arguments (prompt, model overrides, route, room policy)
     request_profile: Any
@@ -455,7 +457,10 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     # same-key run's context (#98619).  previous_response_id continuations keep their
     # ResponseStore snapshot as history (they cannot consume a SessionDB delivery row and are
     # accordingly denied wake capability in _run_agent_sync); the fresh run_id fallback has
-    # nothing persisted to load yet.
+    # nothing persisted to load yet.  Wake authority is fixed here, before the load can
+    # overwrite ``conversation_history``: a caller-supplied history is authoritative for this
+    # turn, never consumes the SessionDB delivery row, and is denied on the same contract.
+    wake_capable = not previous_response_id and not conversation_history
     if not conversation_history and selected_session_id and not previous_response_id:
         conversation_history = await self._conversation_history_for_session(str(selected_session_id))
     q = self._run_streams[run_id] = asyncio.Queue()
@@ -476,7 +481,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         self._run_idempotency_ids.add(run_id)
     launch = _RunLaunch(
         self, run_id, q, session_id, gateway_session_key, _declared_selected, user_message,
-        conversation_history, not previous_response_id,
+        conversation_history, wake_capable,
         agent_kwargs=dict(
             ephemeral_system_prompt=instructions, session_id=session_id, gateway_session_key=gateway_session_key,
             route=route, room_dispatch=room_dispatch, room_execution_policy=room_execution_policy,
@@ -526,7 +531,9 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 # SessionDB in _handle_runs), or the run_id fallback the client can post back
                 # as body.session_id.  A previous_response_id continuation consumes its
                 # ResponseStore snapshot instead and can never see a SessionDB delivery row,
-                # so it stays default-denied until a merge contract exists for that chain.
+                # so it stays default-denied until a merge contract exists for that chain;
+                # likewise a caller-supplied conversation_history is authoritative for the
+                # turn and never reads the delivery row, so it is denied the same way.
                 wake_capable="1" if run.wake_capable else "")
             if session_tokens:
                 resets.append((session_tokens, clear_session_vars))

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -318,6 +318,9 @@ class _RunLaunch:
     declared_selected: bool
     user_message: str
     conversation_history: List[Dict[str, str]]
+    # #98619: only continuation paths that reload session history may grant wake authority —
+    # a previous_response_id continuation consumes its ResponseStore snapshot instead.
+    wake_capable: bool
     agent_kwargs: dict  # ``_create_agent`` keyword arguments (prompt, model overrides, route, room policy)
     request_profile: Any
     browser_control_principal: Any
@@ -416,15 +419,23 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     limited = self._concurrency_limited_response()
     if limited is not None:
         return limited
-    if not conversation_history and session_id and not previous_response_id:
-        conversation_history = await self._conversation_history_for_session(str(session_id))
     run_id = f"run_{uuid.uuid4().hex}"
     self._run_owners[run_id] = self._run_idempotency_scope(request)
     # Same precedence as /v1/responses: body session_id > response chain > X-Hermes-Session-Key
     # conversation > run_id (which would otherwise re-key every affinity surface per run).
     # An explicit or chained session owns its routing key and is never rebound to the header.
     _declared_selected = not session_id and bool(gateway_session_key)
-    session_id = session_id or self._declared_conversation_session(gateway_session_key) or run_id
+    selected_session_id = session_id or (
+        self._declared_conversation_session(gateway_session_key) if _declared_selected else None)
+    session_id = selected_session_id or run_id
+    # History loads for the session the request actually selected — including one resolved from
+    # a declared X-Hermes-Session-Key, whose persisted delivery rows must reach the next
+    # same-key run's context (#98619).  previous_response_id continuations keep their
+    # ResponseStore snapshot as history (they cannot consume a SessionDB delivery row and are
+    # accordingly denied wake capability in _run_agent_sync); the fresh run_id fallback has
+    # nothing persisted to load yet.
+    if not conversation_history and selected_session_id and not previous_response_id:
+        conversation_history = await self._conversation_history_for_session(str(selected_session_id))
     q = self._run_streams[run_id] = asyncio.Queue()
     created_at = self._run_streams_created[run_id] = time.time()
     self._run_approval_sessions[run_id] = run_id  # approval session key (see _RunLaunch)
@@ -443,7 +454,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         self._run_idempotency_ids.add(run_id)
     launch = _RunLaunch(
         self, run_id, q, session_id, gateway_session_key, _declared_selected, user_message,
-        conversation_history,
+        conversation_history, not previous_response_id,
         agent_kwargs=dict(
             ephemeral_system_prompt=instructions, session_id=session_id, gateway_session_key=gateway_session_key,
             route=route, room_dispatch=room_dispatch, room_execution_policy=room_execution_policy,
@@ -487,11 +498,14 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 chat_id=session_id or "", session_key=run.approval_session_key, session_id=session_id or "",
                 browser_control_principal=run.browser_control_principal,
                 browser_control_transport_family=run.browser_control_transport_family,
-                # #98619 audited opt-in: every /v1/runs session id is one the client can address
-                # again (body session_id, a response chain id, a declared session key, or the
-                # run_id fallback returned by the create response) — and a wake-injected turn
-                # lands in session history a later run on the same id will load.
-                wake_capable="1")
+                # #98619 audited opt-in: the /v1/runs session id is wake-capable only when its
+                # own continuation path reloads session history — an explicit body/chained
+                # session id or a declared X-Hermes-Session-Key conversation (both load
+                # SessionDB in _handle_runs), or the run_id fallback the client can post back
+                # as body.session_id.  A previous_response_id continuation consumes its
+                # ResponseStore snapshot instead and can never see a SessionDB delivery row,
+                # so it stays default-denied until a merge contract exists for that chain.
+                wake_capable="1" if run.wake_capable else "")
             if session_tokens:
                 resets.append((session_tokens, clear_session_vars))
             if run.agent_kwargs["room_dispatch"] is not None:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -52,6 +52,18 @@ _SESSION_VARS = (
 # adapters (API server, Kanban workers) opt OUT via ``supports_async_delivery = False`` at bind.
 _SESSION_ASYNC_DELIVERY = ContextVar("HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET)
 
+# Whether the bound api_server chat id is one its CLIENT can address again — the precondition for
+# gateway.wake's /v1/chat/completions self-post to deliver a background delegation anywhere the
+# requester will read (#98619).  "1" = wake-capable, declared by an audited producer whose client
+# holds or can resume the id (explicit X-Hermes-Session-Id, a native /api/sessions/{id} id, a
+# /v1/runs id); "" = declared NOT wake-capable (a fingerprint-derived id from a header-less
+# OpenAI-compatible client, which that client never reloads).  _UNSET = the binding never declared
+# it.  Unlike async delivery above, _UNSET FAILS CLOSED (see ``wake_capable_session``): wake
+# authority is proof-carrying, so a binder that omits it must not silently acquire it.  Deliberately
+# NOT in ``_VAR_MAP``: no ``os.environ`` fallback (a leaked env var must not grant wake authority)
+# and no subprocess-env-bridge export (children re-derive provenance from their own binding).
+_SESSION_WAKE_CAPABLE = ContextVar("HERMES_SESSION_WAKE_CAPABLE", default=_UNSET)
+
 # Cron auto-delivery vars, set per-job in run_job() so concurrent jobs don't clobber.
 _CRON_AUTO_DELIVER_PLATFORM = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
 _CRON_AUTO_DELIVER_CHAT_ID = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
@@ -107,11 +119,17 @@ def set_session_vars(
     user_name: str = "", scope_id: str = "", session_key: str = "", session_id: str = "",
     message_id: str = "", profile: str = "", browser_control_principal: str = "",
     browser_control_transport_family: str = "", cwd: str = "", async_delivery: bool = True,
-    ui_session_id: str = "", cron_session: Any = _UNSET,
+    ui_session_id: str = "", cron_session: Any = _UNSET, wake_capable: str | None = None,
 ) -> list:
     """Set all session context variables and return reset tokens.  Call
     ``clear_session_vars(tokens)`` in a ``finally``; not nestable, clearing resets every var
-    to ``""`` rather than restoring prior values (tokens are accepted only for API compat)."""
+    to ``""`` rather than restoring prior values (tokens are accepted only for API compat).
+
+    ``wake_capable`` declares whether the bound chat id is one the client can address again:
+    ``"1"`` (audited producers — explicit session-id header, native API sessions, /v1/runs) or
+    ``""`` / omitted (default-deny, #98619).  ``None`` leaves the var at ``_UNSET`` ("never
+    declared"), which ``wake_capable_session()`` treats as NOT capable — an omitted declaration
+    cannot grant wake authority."""
     global _session_context_engaged
     _session_context_engaged = True
     values = (
@@ -121,6 +139,7 @@ def set_session_vars(
     )
     tokens = [var.set(value) for var, value in zip(_SESSION_VARS, values)]
     tokens.append(_SESSION_ASYNC_DELIVERY.set(bool(async_delivery)))
+    tokens.append(_SESSION_WAKE_CAPABLE.set(_UNSET if wake_capable is None else wake_capable))
     _runtime_cwd("set_session_cwd", cwd)
     return tokens
 
@@ -128,10 +147,13 @@ def set_session_vars(
 def clear_session_vars(tokens: list) -> None:
     """Mark session context variables as explicitly cleared (``""``, not ``_UNSET``), so
     ``get_session_env`` returns empty instead of stale ``os.environ`` values.  Async-delivery
-    goes back to ``_UNSET``: a cleared context is default-supported, not opted-out."""
+    goes back to ``_UNSET``: a cleared context is default-supported, not opted-out.  Wake
+    capability goes back to ``_UNSET`` too — but for the opposite reason: a cleared context has
+    declared nothing, and an undeclared capability FAILS CLOSED (#98619)."""
     for var in _SESSION_VARS:
         var.set("")
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _SESSION_WAKE_CAPABLE.set(_UNSET)
     _runtime_cwd("clear_session_cwd")
 
 
@@ -139,10 +161,12 @@ def reset_session_vars() -> None:
     """Reset every session var to ``_UNSET`` ("never bound here") for THIS context.  Call at
     the top of a fresh task *before* it binds: ``create_task`` snapshots the context, so B's
     task inherits A's already-set vars and a subprocess spawned before B binds would read A's
-    identity.  ``_SESSION_ASYNC_DELIVERY`` (outside ``_VAR_MAP``) is reset explicitly too."""
+    identity.  ``_SESSION_ASYNC_DELIVERY`` and ``_SESSION_WAKE_CAPABLE`` (outside ``_VAR_MAP``)
+    are reset explicitly too."""
     for var in _VAR_MAP.values():
         var.set(_UNSET)
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _SESSION_WAKE_CAPABLE.set(_UNSET)
     _runtime_cwd("clear_session_cwd")
 
 
@@ -191,3 +215,12 @@ def async_delivery_supported() -> bool:
         return False
     value = _SESSION_ASYNC_DELIVERY.get()
     return True if value is _UNSET else bool(value)
+
+
+def wake_capable_session() -> bool:
+    """Whether the current session's bound api_server chat id was explicitly declared resumable
+    by its client (#98619) — True only for the literal ``"1"``.  Default-deny: ``_UNSET`` (the
+    binding never declared it) and ``""`` (declared not capable) both count as NOT wake-capable.
+    Never falls back to ``os.environ`` — wake authority is proof-carrying and cannot leak in
+    from the environment."""
+    return _SESSION_WAKE_CAPABLE.get() == "1"

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -92,6 +92,20 @@ async def persist_delegation_delivery(adapter: Any, *, text: str, session_id: st
     if db is None:
         raise RuntimeError("persist_delegation_delivery: api_server SessionDB unavailable — "
                            f"cannot persist completion for session {session_id}")
+    # #98619: the parent run may have compressed/rotated between dispatch and this detached
+    # completion — the captured origin id is then a closed parent and the append below is
+    # rejected with CompressionSessionClosedError forever (the watcher retries the same stale
+    # id). Adopt the live continuation tip first, the same canonical resolution
+    # /api/sessions/{id}/messages reads use, so the delivery row lands where the next run and
+    # the messages endpoint both resolve. Fails open to the original id.
+    resolver = getattr(db, "resolve_resume_session_id", None)
+    if callable(resolver):
+        try:
+            resolved = await asyncio.to_thread(resolver, session_id)
+            if resolved:
+                session_id = str(resolved)
+        except Exception:
+            logger.debug("delegation delivery continuation resolve failed for %s", session_id, exc_info=True)
     await asyncio.to_thread(
         db.append_message, session_id, "user", content=text,
         display_kind="async_delegation_complete", display_metadata=_delegation_display_metadata(evt or {}),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2385,6 +2385,40 @@ class TestSessionIdHeader:
             assert call_kwargs["conversation_history"] == db_history
             assert call_kwargs["user_message"] == "new question"
 
+    @pytest.mark.asyncio
+    async def test_wake_capability_follows_session_id_provenance(self, auth_adapter):
+        """#98619: wake_capable must be "1" only when the session id was
+        explicitly provided (a header client that can resume it), "" when it is
+        fingerprint-derived (a header-less client) — delegate_task's background
+        gate keys on it to keep the forced-sync fallback where the wake
+        self-post could never deliver."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "client-held-session", "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+                assert resp.status == 200
+                assert mock_run.call_args.kwargs["wake_capable"] == "1"
+
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                # Header-less: the session id is derived from the message
+                # fingerprint — this client will never resume that session.
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+                assert resp.status == 200
+                assert mock_run.call_args.kwargs["wake_capable"] == ""
+
 
 # ---------------------------------------------------------------------------
 # X-Hermes-Session-Key header (long-term memory scoping)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2359,6 +2359,8 @@ class TestSessionIdHeader:
         ]
         mock_db = MagicMock()
         mock_db.get_messages_as_conversation.return_value = db_history
+        # Non-rotated control: the canonical tip resolver resolves the id to itself.
+        mock_db.resolve_resume_session_id.side_effect = lambda sid: sid
         auth_adapter._session_db = mock_db
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -2418,6 +2420,103 @@ class TestSessionIdHeader:
                 )
                 assert resp.status == 200
                 assert mock_run.call_args.kwargs["wake_capable"] == ""
+
+    @staticmethod
+    def _rotated_session_db(tmp_path):
+        """Real SessionDB with a compression-rotated pair: closed parent ``parent-session``
+        and its live continuation ``child-session`` — plus a late async-delegation delivery
+        row persisted on the tip through the stale origin id (#98619 e2e shape)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("parent-session", source="api_server")
+        db.append_message("parent-session", "user", "run the batch")
+        db.end_session("parent-session", "compression")
+        db.create_session(
+            "child-session", source="api_server", parent_session_id="parent-session"
+        )
+        return db
+
+    @pytest.mark.asyncio
+    async def test_provided_session_id_adopts_compression_tip_for_history_bind_and_wake(
+        self, auth_adapter, tmp_path
+    ):
+        """#98619/#13437: a client re-sending a pre-rotation X-Hermes-Session-Id must read the
+        live tip's history (including a detached delegation delivery row persisted there),
+        bind the turn and the wake target to the tip, keep wake capability for the explicit
+        header, and still be echoed the stable client id it sent."""
+        from gateway.wake import persist_delegation_delivery
+
+        db = self._rotated_session_db(tmp_path)
+        auth_adapter._session_db = db
+        # The detached completion arrives after the rotation, addressed to the captured
+        # (now-stale) origin id — the delivery writer adopts the tip, as at runtime.
+        await persist_delegation_delivery(
+            auth_adapter,
+            text="[delegated task complete] rotated result",
+            session_id="parent-session",
+            evt={"type": "async_delegation"},
+        )
+        mock_result = {"final_response": "OK", "session_id": "child-session",
+                       "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "parent-session", "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "follow up"}]},
+                )
+
+        assert resp.status == 200
+        call_kwargs = mock_run.call_args.kwargs
+        # Read, turn, and wake target all select the live tip the delivery row landed on.
+        assert call_kwargs["session_id"] == "child-session"
+        assert call_kwargs["wake_capable"] == "1"
+        assert any("rotated result" in m.get("content", "") for m in call_kwargs["conversation_history"])
+        # Identity contract: the client is echoed the stable id it sent, not the tip and not
+        # the turn's reported session_id.
+        assert resp.headers.get("X-Hermes-Session-Id") == "parent-session"
+
+    @pytest.mark.asyncio
+    async def test_streamed_session_id_header_adopts_tip_and_echoes_stable_id(
+        self, auth_adapter, tmp_path
+    ):
+        """Streaming half of the interlock: SSE response headers are prepared before the turn
+        runs, so they must carry the stable client id (a rotation after prepare never changes
+        what the client should re-send), while the streamed turn still runs against the tip."""
+        db = self._rotated_session_db(tmp_path)
+        auth_adapter._session_db = db
+
+        async def _mock_run_agent(**kwargs):
+            cb = kwargs.get("stream_delta_callback")
+            if cb:
+                cb("ok")
+            return (
+                {"final_response": "ok", "session_id": "child-session", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "parent-session", "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent",
+                          "messages": [{"role": "user", "content": "follow up"}],
+                          "stream": True},
+                )
+                assert resp.status == 200
+                assert resp.headers.get("X-Hermes-Session-Id") == "parent-session"
+                body = await resp.text()
+
+        assert "data: " in body
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["session_id"] == "child-session"
+        assert call_kwargs["wake_capable"] == "1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1481,6 +1481,7 @@ class TestRunIdempotency:
         mock_db.find_latest_gateway_session_for_peer.return_value = {
             "id": "declared-session"
         }
+        mock_db.resolve_resume_session_id.side_effect = lambda sid: sid
         mock_db.get_messages_as_conversation.return_value = delivered
         adapter._session_db = mock_db
         app = _create_runs_app(adapter)
@@ -1599,6 +1600,7 @@ class TestRunIdempotency:
         (explicit body session_id, loaded from SessionDB) stays wake-capable."""
         _use_idempotency_db(adapter, tmp_path / "idem.db")
         mock_db = MagicMock()
+        mock_db.resolve_resume_session_id.side_effect = lambda sid: sid
         mock_db.get_messages_as_conversation.return_value = []
         adapter._session_db = mock_db
         bind = MagicMock(return_value=[])
@@ -1624,6 +1626,66 @@ class TestRunIdempotency:
                         break
                     await asyncio.sleep(0.05)
         assert bind.call_args.kwargs["wake_capable"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_compressed_parent_delivery_row_lands_on_live_tip(
+        self, adapter, tmp_path
+    ):
+        """#98619 e2e: the parent run compresses before the detached delegate
+        completes — the persisted delivery row must land on the live
+        continuation tip (not be rejected on the closed parent forever), and the
+        next run addressing the original id must load it and bind the tip."""
+        from hermes_state import SessionDB
+        from gateway.wake import persist_delegation_delivery
+
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        db = SessionDB(db_path=tmp_path / "state.db")
+        # Rotation: parent closed by compression, live continuation child holds the messages.
+        db.create_session("parent-session", source="api_server")
+        db.append_message("parent-session", "user", "run the batch")
+        db.end_session("parent-session", "compression")
+        db.create_session(
+            "child-session", source="api_server", parent_session_id="parent-session"
+        )
+        adapter._session_db = db
+        bind = MagicMock(return_value=[])
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            # The detached completion arrives after the rotation, addressed to the
+            # captured (now-stale) origin id — exactly what the watcher persists.
+            await persist_delegation_delivery(
+                adapter,
+                text="[delegated task complete] rotated result",
+                session_id="parent-session",
+                evt={"type": "async_delegation"},
+            )
+            with (
+                patch.object(adapter, "_bind_api_server_session", new=bind),
+                patch.object(adapter, "_create_agent") as create,
+            ):
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "follow up", "session_id": "parent-session"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.05)
+        # The run adopted the live tip: the delivery row (persisted to the tip)
+        # loaded as the run's history, and the turn/wake binding targeted the tip.
+        history = agent.run_conversation.call_args.kwargs["conversation_history"]
+        assert any("rotated result" in m.get("content", "") for m in history)
+        assert bind.call_args.kwargs["session_id"] == "child-session"
+        # The delivery row itself landed on the live tip, never on the closed parent.
+        child_rows = db.get_messages_as_conversation("child-session")
+        assert any("rotated result" in m.get("content", "") for m in child_rows)
 
 
 class TestHostedRoomRuns:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1628,6 +1628,58 @@ class TestRunIdempotency:
         assert bind.call_args.kwargs["wake_capable"] == "1"
 
     @pytest.mark.asyncio
+    async def test_caller_supplied_history_with_session_id_is_not_wake_capable(
+        self, adapter, tmp_path
+    ):
+        """#98619: an explicit session_id plus non-empty caller-supplied
+        conversation_history skips the SessionDB load, so the run's continuation
+        path never consumes a SessionDB delivery row (async completion persists
+        to SessionDB only) and must NOT be granted wake authority — same
+        default-deny contract as previous_response_id continuations."""
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        mock_db = MagicMock()
+        mock_db.resolve_resume_session_id.side_effect = lambda sid: sid
+        adapter._session_db = mock_db
+        caller_history = [
+            {"role": "user", "content": "caller turn"},
+            {"role": "assistant", "content": "caller reply"},
+        ]
+        bind = MagicMock(return_value=[])
+        history_load = AsyncMock(return_value=[])
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_bind_api_server_session", new=bind),
+                patch.object(adapter, "_conversation_history_for_session", new=history_load),
+                patch.object(adapter, "_create_agent") as create,
+            ):
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "client-held-session",
+                        "conversation_history": caller_history,
+                    },
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if bind.called:
+                        break
+                    await asyncio.sleep(0.05)
+        assert bind.call_args.kwargs["wake_capable"] == ""
+        history_load.assert_not_called()
+        assert (
+            agent.run_conversation.call_args.kwargs["conversation_history"]
+            == caller_history
+        )
+
+    @pytest.mark.asyncio
     async def test_compressed_parent_delivery_row_lands_on_live_tip(
         self, adapter, tmp_path
     ):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1460,6 +1460,171 @@ class TestRunIdempotency:
         assert response.status == 202
         history.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_declared_session_key_loads_selected_session_history(
+        self, auth_adapter, tmp_path
+    ):
+        """#98619: a header-only X-Hermes-Session-Key run must load the declared
+        conversation's SessionDB history — a persisted async-delegation delivery
+        row has to reach the next same-key run's context for the /v1/runs wake
+        opt-in to mean anything."""
+        adapter = auth_adapter
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        delivered = [
+            {"role": "user", "content": "run the batch"},
+            {
+                "role": "assistant",
+                "content": "[delegated task complete] background result payload",
+            },
+        ]
+        mock_db = MagicMock()
+        mock_db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "declared-session"
+        }
+        mock_db.get_messages_as_conversation.return_value = delivered
+        adapter._session_db = mock_db
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as create:
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "follow up"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "conv-key",
+                    },
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.05)
+        mock_db.find_latest_gateway_session_for_peer.assert_called_with(
+            source="api_server", session_key="conv-key"
+        )
+        mock_db.get_messages_as_conversation.assert_called_with("declared-session")
+        assert (
+            agent.run_conversation.call_args.kwargs["conversation_history"] == delivered
+        )
+
+    @pytest.mark.asyncio
+    async def test_declared_key_without_live_session_row_loads_nothing(
+        self, auth_adapter, tmp_path
+    ):
+        """A declared key with no live session row keeps the fresh run_id
+        session — nothing is persisted under it yet, so no history load."""
+        adapter = auth_adapter
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        mock_db = MagicMock()
+        mock_db.find_latest_gateway_session_for_peer.return_value = None
+        adapter._session_db = mock_db
+        history = AsyncMock(return_value=[])
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_conversation_history_for_session", new=history),
+                patch.object(adapter, "_create_agent") as create,
+            ):
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "fresh conversation"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "conv-key",
+                    },
+                )
+        assert response.status == 202
+        history.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_continuation_is_not_wake_capable(
+        self, adapter, tmp_path
+    ):
+        """#98619: a previous_response_id continuation consumes its ResponseStore
+        snapshot as history and can never see a SessionDB delivery row (async
+        completion persists to SessionDB only), so it must NOT be granted wake
+        authority — delegate_task keeps its synchronous fallback on that branch."""
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        chain_history = [
+            {"role": "user", "content": "seed turn"},
+            {"role": "assistant", "content": "seed reply"},
+        ]
+        adapter._response_store.put(
+            "resp-seed",
+            {"conversation_history": chain_history, "session_id": "chain-session"},
+        )
+        bind = MagicMock(return_value=[])
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_bind_api_server_session", new=bind),
+                patch.object(adapter, "_create_agent") as create,
+            ):
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "continue", "previous_response_id": "resp-seed"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if bind.called:
+                        break
+                    await asyncio.sleep(0.05)
+        assert bind.call_args.kwargs["wake_capable"] == ""
+        assert (
+            agent.run_conversation.call_args.kwargs["conversation_history"]
+            == chain_history
+        )
+
+    @pytest.mark.asyncio
+    async def test_plain_run_grants_wake_capability(self, adapter, tmp_path):
+        """Control: a /v1/runs request whose session the client addresses again
+        (explicit body session_id, loaded from SessionDB) stays wake-capable."""
+        _use_idempotency_db(adapter, tmp_path / "idem.db")
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        adapter._session_db = mock_db
+        bind = MagicMock(return_value=[])
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_bind_api_server_session", new=bind),
+                patch.object(adapter, "_create_agent") as create,
+            ):
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = agent.session_completion_tokens = (
+                    agent.session_total_tokens
+                ) = 0
+                create.return_value = agent
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "client-held-session"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if bind.called:
+                        break
+                    await asyncio.sleep(0.05)
+        assert bind.call_args.kwargs["wake_capable"] == "1"
+
 
 class TestHostedRoomRuns:
     @pytest.mark.asyncio

--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -41,6 +41,10 @@ def _clean_queue_and_context(monkeypatch):
     for var in sc._VAR_MAP.values():
         var.set(sc._UNSET)
     sc._SESSION_ASYNC_DELIVERY.set(sc._UNSET)
+    # wake-capable lives outside _VAR_MAP (no env fallback by design, #98619),
+    # so reset it explicitly — a leaked "1" would hand the next test wake
+    # authority its binder never declared.
+    sc._SESSION_WAKE_CAPABLE.set(sc._UNSET)
     # set_current_session_id (invoked by the clobber-reproducing fake child
     # build) writes os.environ directly — scrub it so it can't leak into
     # other test modules.
@@ -108,8 +112,10 @@ def _patch_delegate(monkeypatch):
 
 
 def test_apiserver_session_with_id_dispatches_background(monkeypatch):
-    """async_delivery=False + a raw session id (HERMES_SESSION_ID) →
-    background dispatch (the completion wakes the session via the
+    """async_delivery=False + a raw session id (HERMES_SESSION_ID) that its binder
+    DECLARED wake-capable (audited producer: explicit X-Hermes-Session-Id, a
+    native /api/sessions id, a /v1/runs id — the client can address the id
+    again) → background dispatch (the completion wakes the session via the
     api_server self-post), NOT the forced-sync fallback."""
     dt = _patch_delegate(monkeypatch)
     monkeypatch.setenv("HERMES_SESSION_ID", "raw-sid-7")
@@ -119,6 +125,7 @@ def test_apiserver_session_with_id_dispatches_background(monkeypatch):
         session_key="raw-sid-7",
         session_id="raw-sid-7",
         async_delivery=False,
+        wake_capable="1",
     )
 
     out = dt.delegate_task(
@@ -165,3 +172,85 @@ def test_apiserver_session_without_id_stays_synchronous(monkeypatch):
     assert parsed.get("status") != "dispatched", parsed
     assert "SYNCHRONOUSLY" in parsed.get("note", "")
     assert process_registry.completion_queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# #98619 — wake capability must be DECLARED, never assumed
+# ---------------------------------------------------------------------------
+
+
+def test_apiserver_wake_capability_omission_fails_closed(monkeypatch):
+    """#98619 public-omission regression: a binder that binds a raw session id
+    but NEVER declares wake capability (set_session_vars called without the
+    flag — exactly what a future, not-yet-audited binding path would do) must
+    NOT get background dispatch. Wake authority is proof-carrying: omitted
+    means denied, and the batch stays synchronous."""
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="raw-sid-undeclared",
+        session_key="raw-sid-undeclared",
+        session_id="raw-sid-undeclared",
+        async_delivery=False,
+    )
+
+    out = dt.delegate_task(
+        goal="bg undeclared", context="ctx",
+        background=True, parent_agent=_fake_parent(),
+    )
+    parsed = json.loads(out)
+    assert parsed.get("status") != "dispatched", parsed
+    assert "SYNCHRONOUSLY" in parsed.get("note", "")
+    assert process_registry.completion_queue.empty()
+
+
+def test_apiserver_derived_session_id_stays_synchronous(monkeypatch):
+    """#98619: a bound-but-derived chat id (header-less OpenAI-compatible
+    client, no X-Hermes-Session-Id) must NOT dispatch background — the wake
+    self-post would hard-fail (no API_SERVER_KEY) or land in a session whose
+    history the client never reloads. A session id merely existing is not
+    wake-capable; the binding must declare it."""
+    dt = _patch_delegate(monkeypatch)
+    set_session_vars(
+        platform="api_server",
+        chat_id="fingerprint-hex-0123456789abcdef",
+        session_key="fingerprint-hex-0123456789abcdef",
+        session_id="fingerprint-hex-0123456789abcdef",
+        wake_capable="",
+        async_delivery=False,
+    )
+
+    out = dt.delegate_task(
+        goal="bg derived", context="ctx",
+        background=True, parent_agent=_fake_parent(),
+    )
+    parsed = json.loads(out)
+    assert parsed.get("status") != "dispatched", parsed
+    assert "SYNCHRONOUSLY" in parsed.get("note", "")
+    assert process_registry.completion_queue.empty()
+
+
+def test_wake_capable_session_reader_is_default_deny(monkeypatch):
+    """#98619: wake_capable_session() True ONLY for the literal "1". _UNSET
+    (never declared) and "" (declared not capable) both fail closed, and a
+    leaked HERMES_SESSION_WAKE_CAPABLE env var must NOT grant authority —
+    the reader never falls back to os.environ."""
+    import gateway.session_context as sc
+    from gateway.session_context import wake_capable_session
+
+    # Never bound in this context: _UNSET sentinel, no env fallback even when
+    # the variable is present in the environment.
+    monkeypatch.setenv("HERMES_SESSION_WAKE_CAPABLE", "1")
+    assert wake_capable_session() is False
+
+    # Declared wake-capable (audited producer): "1".
+    tokens = set_session_vars(platform="api_server", wake_capable="1")
+    assert wake_capable_session() is True
+    sc.clear_session_vars(tokens)
+    # A cleared context has declared nothing: back to denied.
+    assert wake_capable_session() is False
+
+    # Explicitly declared NOT wake-capable (fingerprint-derived id): "".
+    tokens = set_session_vars(platform="api_server", wake_capable="")
+    assert wake_capable_session() is False
+    sc.clear_session_vars(tokens)

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -43,6 +43,7 @@ class _Batch:
     origin_ui_session_id: str
     origin_owner_transport: Any
     origin_owner_session_record: Any
+    origin_wake_capable: bool
     overall_start: float
     # Set on per-group units carved out by ``_dispatch_background``; None for the whole batch / ungrouped units.
     group: Optional[str] = None
@@ -66,17 +67,22 @@ def _announce_batch(parent_agent, n_tasks: int, live_deleg_id: Optional[str]) ->
         _hdr = f"  🔀 [{format_batch_tag(live_deleg_id, parent_agent)}] delegating {n_tasks} tasks"
         _print_completion_line(parent_agent, getattr(parent_agent, "_delegate_spinner", None), _hdr, console_line=_hdr)
 
-def _capture_origin() -> tuple[str, str, Any, Any]:
-    """``(wake_sid, ui_session_id, owner_transport, owner_session_record)`` of the
+def _capture_origin() -> tuple[str, str, Any, Any, bool]:
+    """``(wake_sid, ui_session_id, owner_transport, owner_session_record, wake_capable)`` of the
     ORIGINATING session, captured BEFORE building any child: AIAgent construction
-    clobbers the HERMES_SESSION_ID ContextVar/os.environ with the subagent's id."""
+    clobbers the HERMES_SESSION_ID ContextVar/os.environ with the subagent's id.  The wake-
+    capability flag rides the same request-scoped binding and is captured here for the same
+    reason — and fails closed: a binding that never declared it (or a read error) leaves the
+    session treated as non-wake-capable (#98619)."""
     from tools.async_delegation import _current_origin_session_id
     _origin_wake_sid = _current_origin_session_id()
     _origin_ui_session_id = ""
+    _origin_wake_capable = False
     with _quiet(None):
-        from gateway.session_context import get_session_env
+        from gateway.session_context import get_session_env, wake_capable_session
         _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
-    return (_origin_wake_sid, _origin_ui_session_id, *_capture_gateway_steer_authority(_origin_ui_session_id))
+        _origin_wake_capable = wake_capable_session()
+    return (_origin_wake_sid, _origin_ui_session_id, *_capture_gateway_steer_authority(_origin_ui_session_id), _origin_wake_capable)
 
 def _report_child_done(parent_agent, spinner_ref, entry, tag, task_labels, n_tasks, remaining) -> None:
     """Print one completion line for a finished child and refresh the spinner text. Failed/errored/timed-out children
@@ -199,14 +205,16 @@ def _run_sync_with_note(batch: _Batch, reason: str) -> str:
         result["note"] = _SYNC_FALLBACK_NOTES[reason]
     return json.dumps(result, ensure_ascii=False)
 
-def _resolve_async_wake_sid(origin_wake_sid: str) -> Optional[str]:
+def _resolve_async_wake_sid(origin_wake_sid: str, origin_wake_capable: bool = False) -> Optional[str]:
     """Wake target for a detached batch, or None to force synchronous execution.
 
     Finite sessions (stateless HTTP requests, one-shot Kanban workers) cannot route a detached result back after their
-    turn/process ends — but if a raw session id is bound (the API server always binds one), gateway.wake can still
-    reach it by self-POSTing /v1/chat/completions, so only fall back to sync when there is truly no session id to
-    wake. Uses the origin captured BEFORE child construction — HERMES_SESSION_ID here would be the subagent's internal
-    id.
+    turn/process ends — but if a raw, WAKE-CAPABLE session id is bound (one its client can address again: an explicit
+    X-Hermes-Session-Id, a native /api/sessions/{id} id, a /v1/runs id), gateway.wake can still reach it by self-POSTing
+    /v1/chat/completions, so only fall back to sync when there is truly no such id. A bound id alone is NOT enough
+    (#98619): a fingerprint-derived id from a header-less client makes the self-post hard-fail (no API_SERVER_KEY) or
+    land in a session whose history the client never reloads, so the result would be undeliverable by construction.
+    Uses the origin captured BEFORE child construction — HERMES_SESSION_ID here would be the subagent's internal id.
     """
     try:
         # Finite sessions cannot route a detached subagent result back to the agent after their turn/process
@@ -218,13 +226,19 @@ def _resolve_async_wake_sid(origin_wake_sid: str) -> Optional[str]:
             return ""
     except Exception:
         return ""
-    if origin_wake_sid:
+    if origin_wake_sid and origin_wake_capable:
         logger.info(
-            "delegate_task: async delivery unsupported on this session, but a session id is bound (%s) — dispatching "
-            "in the background and waking the session via self-post when it completes instead of forcing synchronous "
-            "execution.", origin_wake_sid,
+            "delegate_task: async delivery unsupported on this session, but a wake-capable session id is bound (%s) — "
+            "dispatching in the background and waking the session via self-post when it completes instead of forcing "
+            "synchronous execution.", origin_wake_sid,
         )
         return origin_wake_sid
+    if origin_wake_sid:
+        logger.info(
+            "delegate_task: session id %s is bound but not wake-capable (fingerprint-derived for a header-less client "
+            "— the wake self-post cannot deliver where the client will read it, #98619) — running the batch "
+            "synchronously instead.", origin_wake_sid,
+        )
     return None
 
 def _resolve_async_session_key(parent_agent: Any, origin_ui_session_id: str) -> tuple[str, str]:
@@ -354,7 +368,7 @@ def _dispatch_background(batch: _Batch) -> str:
     running synchronously (with an explanatory ``note``) when the session cannot receive detached completions or the
     async pool is at capacity."""
     from tools.delegate_tool import _get_max_async_children
-    wake_sid = _resolve_async_wake_sid(batch.origin_wake_sid)
+    wake_sid = _resolve_async_wake_sid(batch.origin_wake_sid, batch.origin_wake_capable)
     if wake_sid is None:
         logger.info("delegate_task: async delivery unsupported on this session runtime; running the batch synchronously instead.")
         return _run_sync_with_note(batch, "no_async")


### PR DESCRIPTION
## What does this PR do?

Rebuilt from scratch against the post-refactor `main` (per review #5127266065 and its correction): the chat-completions route now lives in `gateway/platforms/api_server_openai_routes.py`, the wake gate in `tools/delegate_tool_dispatch.py`, and `gateway/session_context.py` was reshaped, so the original patch aimed at code `main` no longer has.

The bug (#98619): a header-less OpenAI-compatible client gets a fingerprint-derived session id bound as the api_server chat id. `delegate_task(background=true)`'s gate treated **any** bound session id as wake-capable and dispatched detached subagents — but for derived ids the wake self-post lands in a session whose history that client never reloads, so the result is undeliverable by construction.

The fix binds a `wake_capable` provenance flag at session-bind time and **default-denies it at the central boundary**: `set_session_vars()` and `_bind_api_server_session()` both treat an omitted declaration as *denied* — a binder that says nothing grants no wake authority. `"1"` is passed only by audited producers whose client can address the bound id again:

- explicit `X-Hermes-Session-Id` on `/v1/chat/completions` (403-gated on `API_SERVER_KEY`, and the client can resume the session by sending the header again);
- native `/api/sessions/{session_id}/chat[/stream]` routes (the id is in the request path);
- `/v1/runs` (body `session_id`, response-chain id, declared session key, or the `run_id` fallback — all held by the client, and a wake-injected turn lands in session history a later run on the same id loads).

Everything else (fingerprint-derived ids, `/v1/responses` fresh-uuid sessions, undeclared binders) keeps the forced-synchronous fallback with its honest note. The flag is captured in `_capture_origin()` **before** child construction (same clobber-proof timing as `origin_wake_sid`), read fail-closed, and never falls back to `os.environ` — it deliberately stays out of `_VAR_MAP` so a leaked env var cannot grant wake authority.

**Credit:** #98619 is a first-hand production report by @shojikumaru, who — with Alpha — did the original investigation and independently verified the original head's before/after behavior on a real isolated `api_server` setup (see their comment on this PR). This rebuild stands on that work.

## Related Issue

Fixes #98619

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (fails closed a delivery-authority boundary; issue carries `sweeper:risk-security-boundary`)

## Changes Made

- `gateway/session_context.py` — new `_SESSION_WAKE_CAPABLE` ContextVar (default `_UNSET`, deliberately outside `_VAR_MAP`: no env fallback, no subprocess-bridge export) + `set_session_vars(wake_capable=None|"1"|"")` binding + `wake_capable_session()` reader (True only for literal `"1"`); `clear_session_vars`/`reset_session_vars` reset it to `_UNSET`.
- `gateway/platforms/api_server.py` — `_bind_api_server_session(..., wake_capable="")` default-denies at the single chokepoint; `_run_agent(..., wake_capable="")` threads it; `_prepare_session_chat` opts the native `/api/sessions/{id}` routes in with `"1"`.
- `gateway/platforms/api_server_openai_routes.py` — `/v1/chat/completions` passes `wake_capable=("1" if provided_session_id else "")`; streaming inherits via `run_kwargs`.
- `gateway/platforms/api_server_runs.py` — `/v1/runs` binds with `wake_capable="1"` (audited: client-held ids).
- `tools/delegate_tool_dispatch.py` — `_capture_origin()` also captures the capability pre-child-construction (read error ⇒ `False`); `_Batch.origin_wake_capable`; `_resolve_async_wake_sid()` requires **both** the bound id and the declared capability, with an honest "bound but not wake-capable → synchronous" log line.
- `tests/tools/test_delegate_apiserver_background.py` — public-omission regression (a binder that never declares the flag stays synchronous), derived-id regression, `wake_capable_session()` default-deny/env-no-fallback unit test, positive control updated to declare `"1"`.
- `tests/gateway/test_api_server.py` — route-level provenance test: explicit header ⇒ `"1"`, header-less ⇒ `""`.

## How to Test

1. `pytest tests/tools/test_delegate_apiserver_background.py -q` → **5 passed** (positive control dispatches background only with a declared `"1"`; omission and derived ids stay synchronous).
2. `pytest "tests/gateway/test_api_server.py::TestSessionIdHeader" -q` → **3 passed** (route threads `"1"`/`""` by header provenance).
3. Regression sweep on the touched surfaces: `pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_session_context_inheritance.py tests/gateway/test_wake_delivery.py tests/tools/test_delegate_batch_tag.py tests/tools/test_delegate_batch_validation.py tests/tools/test_delegate_capability_inheritance.py tests/tools/test_delegate_control_actions.py tests/tools/test_delegate_composite_toolsets.py tests/tools/test_async_delegation.py -q` → **all passed** (292 relevant tests green total).
4. Observed result: a header-less client's `delegate_task(background=true)` now runs synchronously and returns the result in the same response — exactly the "After" trace @shojikumaru verified on the original head — while explicit-header/native/`/v1/runs` sessions keep detached dispatch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in docstrings at the chokepoint and the ContextVar)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
