### PR TITLE
fix(tools): default search_files output_mode to files_only

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -305,6 +305,49 @@ class TestSearchHandler:
         assert "error" in result
 
 
+class TestSearchFilesDefaultOutputMode:
+    """The schema default is obeyed on every call while the description is
+    read once — the cheap mode has to be the default, not merely offered.
+    Full content costs multiples of files_only per call."""
+
+    def test_schema_default_is_files_only(self):
+        from tools.file_tools import SEARCH_FILES_SCHEMA
+        assert (
+            SEARCH_FILES_SCHEMA["parameters"]["properties"]["output_mode"]["default"]
+            == "files_only"
+        )
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_omits_output_mode_defaults_to_files_only(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"matches": ["file1.py"]}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_search_files
+        _handle_search_files({"pattern": "TODO"}, task_id="t-default-mode")
+
+        _, kwargs = mock_ops.search.call_args
+        assert kwargs.get("output_mode") == "files_only"
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_respects_explicit_content_request(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"matches": ["file1.py:3:match"]}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_search_files
+        _handle_search_files(
+            {"pattern": "TODO", "output_mode": "content"}, task_id="t-explicit-mode"
+        )
+
+        _, kwargs = mock_ops.search.call_args
+        assert kwargs.get("output_mode") == "content"
+
+
 # ---------------------------------------------------------------------------
 # Windows MSYS path resolution (salvage of #50488 / #46995)
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2744,7 +2744,7 @@ SEARCH_FILES_SCHEMA = {
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
-            "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
+            "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'files_only' lists file paths (cheapest, default), 'content' shows matching lines with line numbers, 'count' shows match counts per file", "default": "files_only"},
             "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
         },
         "required": ["pattern"]
@@ -2803,7 +2803,7 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode") or "files_only", context=args.get("context", 0), task_id=tid)
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)


### PR DESCRIPTION
Fixes #98626.

## What

`search_files` defaulted `output_mode` to `"content"`, so every grep-mode call that omitted the parameter returned full matching lines instead of just paths. The parameter's own description already frames `files_only` as the cheap lookup and `content` as the expensive one — but the default pointed at the expensive path, and the usual next step after a match is `read_file` on the matched file anyway, so the extra lines were paid for and then discarded.

A tool description is read once; a default is obeyed on every call. The cheap mode has to be the default, not merely offered.

## Change

- `SEARCH_FILES_SCHEMA` `output_mode` default: `"content"` → `"files_only"`, with the description reordered to lead with the cheapest mode.
- `_handle_search_files` fallback: `args.get("output_mode", "content")` → `args.get("output_mode") or "files_only"`.
- Explicit `output_mode` requests (`content`/`count`) and `target="files"` calls are unaffected.
- Low-level `search_tool()` / `file_ops.search()` function defaults are left untouched — existing tests pin those independently at that layer, and changing them would widen the blast radius beyond what this fix needs.

## Tests

Three regression tests at the schema/handler seam (`TestSearchFilesDefaultOutputMode`):
1. schema default value is `files_only`;
2. handler with omitted `output_mode` passes `files_only` downstream;
3. handler with explicit `content` still passes `content` downstream.

```
tests/tools/test_file_tools.py: 46 passed, 2 skipped
```
Two pre-existing failures on clean `origin/main` (mock assertion mismatches in `TestWriteFileHandler` / `TestPatchHandler`, unrelated to search) verified identical before/after via stash — not touched here.