### PR TITLE
fix(context): compact under message-count pressure

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -972,6 +972,13 @@ _MAX_TAIL_MESSAGE_FLOOR = 8
 # Skip the LLM call when the compressible middle is below this fraction of the
 # threshold (and a prior ineffectiveness strike exists); dropping alone suffices.
 # See #60451.
+# A long tool/background-heavy transcript can fit the tail token budget while still
+# exceeding a gateway's hard row limit, leaving no middle window and making every
+# 413 retry a no-op. Past this many rows, force a boundary that keeps the newest
+# _MESSAGE_COUNT_PRESSURE_TAIL rows and summarizes everything older.
+_MESSAGE_COUNT_PRESSURE_THRESHOLD = 600
+_MESSAGE_COUNT_PRESSURE_TAIL = 200
+
 _FEASIBILITY_SKIP_MIDDLE_FRACTION = 0.10
 # Under pressure, demote large tool outputs even inside the protected region but
 # keep this many trailing messages verbatim.
@@ -4333,6 +4340,20 @@ Write only the summary body. Do not include any preamble or prefix."""
         """Return ``(compress_start, compress_end)`` for the summarizable middle."""
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        # Message-count pressure is independent from token pressure: force a conservative
+        # boundary so a row-capped gateway still gets a shrinking transcript.
+        if len(messages) >= _MESSAGE_COUNT_PRESSURE_THRESHOLD:
+            # The flag records that row pressure applied, independently of whether the
+            # token cut already sits deeper: _feasibility_skip keys off it to stay on the
+            # summarizing path, and skipping the LLM here would leave the row count high.
+            telemetry = getattr(self, "_active_compression_telemetry", None)
+            if isinstance(telemetry, dict):
+                telemetry["message_count_pressure"] = True
+            pressure_cut = self._align_boundary_backward(
+                messages, max(compress_start + 1, len(messages) - _MESSAGE_COUNT_PRESSURE_TAIL),
+            )
+            if pressure_cut > compress_end:
+                compress_end = pressure_cut
         # A role collision can merge the summary into the first tail row; keep an actionable user
         # event out of that slot by retaining an older assistant/tool bridge.
         latest_actionable_idx = self._find_last_user_message_idx(messages, 0)
@@ -4368,6 +4389,10 @@ Write only the summary body. Do not include any preamble or prefix."""
     ) -> bool:
         """Pre-LLM skip after a real-usage ineffectiveness strike (reads the counter, never writes)."""
         if self._ineffective_compression_count < 1:
+            return False
+        # Row pressure is not a token-budget verdict: skipping here would leave the
+        # transcript above the gateway's row cap with nothing summarized.
+        if telemetry.get("message_count_pressure"):
             return False
         # Reuse the telemetry estimate so log and telemetry agree; None means the regions helper
         # no-op'd (0 is valid).

--- a/tests/agent/test_message_count_pressure.py
+++ b/tests/agent/test_message_count_pressure.py
@@ -1,0 +1,79 @@
+"""Regression coverage for provider hard message-count limits."""
+
+from unittest.mock import Mock, patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def test_compression_forces_boundary_below_gateway_message_limit():
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=272_000,
+    ):
+        compressor = ContextCompressor(
+            model="subscriptions-quality",
+            threshold_percent=0.55,
+            summary_target_ratio=0.20,
+            protect_first_n=3,
+            protect_last_n=20,
+            min_tail_user_messages=1,
+            quiet_mode=True,
+            config_context_length=272_000,
+        )
+    compressor._generate_summary = lambda *args, **kwargs: "Earlier work summary"
+
+    messages = [{"role": "user", "content": "start"}]
+    for index in range(401):
+        messages.extend(
+            [
+                {"role": "assistant", "content": f"result {index}"},
+                {"role": "user", "content": f"background event {index}"},
+            ]
+        )
+    assert len(messages) == 803
+
+    compressed = compressor.compress(messages, current_tokens=130_000)
+
+    assert len(compressed) < 600
+    assert any("Earlier work summary" in str(row.get("content")) for row in compressed)
+
+
+def test_message_count_pressure_bypasses_feasibility_skip():
+    """Hard row pressure must not be defeated by a token-light middle window."""
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=272_000,
+    ):
+        compressor = ContextCompressor(
+            model="subscriptions-quality",
+            threshold_percent=0.55,
+            summary_target_ratio=0.20,
+            protect_first_n=3,
+            protect_last_n=20,
+            min_tail_user_messages=1,
+            quiet_mode=True,
+            config_context_length=272_000,
+        )
+
+    # A prior ineffective token compression enables the feasibility gate. The
+    # 805-row transcript is intentionally token-light, reproducing the review
+    # case where that gate used to override the hard message-count boundary.
+    compressor._ineffective_compression_count = 1
+    generate_summary = Mock(return_value="Earlier work summary")
+    compressor._generate_summary = generate_summary
+
+    messages = [{"role": "user", "content": "start"}]
+    for index in range(402):
+        messages.extend(
+            [
+                {"role": "assistant", "content": f"ok {index}"},
+                {"role": "user", "content": f"event {index}"},
+            ]
+        )
+    assert len(messages) == 805
+
+    compressed = compressor.compress(messages, current_tokens=155_913)
+
+    assert len(compressed) < 600
+    generate_summary.assert_called_once()
+    assert compressor._last_feasibility_skip is False


### PR DESCRIPTION
## Summary
- treat hard gateway message-row limits independently from token pressure
- force a bounded recent tail once a transcript reaches 600 rows
- keep the manual `/compress` preflight consistent with the actual compression boundary
- add a regression test covering an 803-row transcript and assert the committed result falls below 600 rows

## Why
Some OpenAI-compatible gateways reject chat histories at 800 message rows even when the request still fits the model token window. Token-based tail protection could therefore produce an in-place `800 -> 800` compaction and subsequent `413 Cannot compress further` failures.

## Verification
- `uv run pytest tests/agent/test_message_count_pressure.py tests/agent/test_protected_tail_pressure_61932.py tests/agent/test_compression_progress.py tests/agent/test_compression_attempt_telemetry.py -q` (11 passed)
- `uv run ruff check agent/context_compressor.py tests/agent/test_message_count_pressure.py`
- `git diff --check`