### PR TITLE
fix(langfuse): warn once when credentials are missing instead of failing silently

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -290,7 +290,27 @@ def _get_langfuse() -> Optional[Langfuse]:
 
         public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
         secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+        # Missing credentials used to short-circuit with zero log output
+        # (#98631): a half-configured setup (e.g. a placeholder public key
+        # with the secret left unset) registered the hooks, marked init
+        # failed, and silently dropped every trace. Warn once here, same
+        # one-shot contract as the placeholder branch below.
         if not (public_key and secret_key):
+            missing = [
+                name
+                for name, value in (
+                    ("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+                    ("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+                )
+                if not value
+            ]
+            logger.warning(
+                "Langfuse plugin: missing credentials (%s), traces will NOT be "
+                "emitted. Set both HERMES_LANGFUSE_PUBLIC_KEY (pk-lf-...) and "
+                "HERMES_LANGFUSE_SECRET_KEY (sk-lf-...) — e.g. via `hermes tools` — "
+                "or disable the plugin to silence this warning.",
+                ", ".join(missing),
+            )
             _LANGFUSE_CLIENT = _INIT_FAILED
             return None
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -578,6 +578,42 @@ class TestPlaceholderKeyDetection:
             "expected 1 (cached via _INIT_FAILED)"
         )
 
+    def test_missing_secret_key_warns_and_skips(self, monkeypatch, caplog):
+        """A half-configured setup (placeholder public key, secret unset)
+        must warn once instead of failing silently (#98631) — the empty
+        branch runs before the placeholder guard, so without a warning
+        here the operator gets zero signal that tracing is dead."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "your-public-key-here")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            for _ in range(3):
+                assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert len(warnings) == 1, (
+            f"Expected exactly one missing-credentials warning; got "
+            f"{len(warnings)}:\n" + "\n".join(r.getMessage() for r in warnings)
+        )
+        text = warnings[0].getMessage()
+        assert "missing credentials" in text
+        assert "HERMES_LANGFUSE_SECRET_KEY" in text
+        assert "traces will NOT be emitted" in text
+        # Never constructed the SDK client — short-circuited before that.
+        assert _FakeLangfuse.instances == []
+
+    def test_both_keys_missing_warning_names_both(self, monkeypatch, caplog):
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert len(warnings) == 1
+        text = warnings[0].getMessage()
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in text
+        assert "HERMES_LANGFUSE_SECRET_KEY" in text
+
 
 class TestRequestMessageCoercion:
     def test_prefers_request_messages_then_messages_then_history_then_user_message(self):


### PR DESCRIPTION
## What does this PR do?

Fixes a silent-failure path in the bundled `observability/langfuse` plugin: when one or both Langfuse credentials resolve to empty, `_get_langfuse()` short-circuited to the cached `_INIT_FAILED` sentinel with **zero log output**. The plugin still registered its hooks, so a half-configured setup (e.g. `HERMES_LANGFUSE_PUBLIC_KEY=your-public-key-here` with `HERMES_LANGFUSE_SECRET_KEY` left unset — the exact repro in the issue) dropped every trace and produced no error or warning anywhere.

The other two init-failure branches already warn once (the placeholder branch from #23823; the missing-SDK branch). This gives the missing-credentials branch the same one-shot warning contract: name the missing env var(s), state that traces will NOT be emitted, and point at `hermes tools`. No behavior change beyond the log line — the `_INIT_FAILED` caching and `return None` semantics are untouched.

## Related Issue

Fixes #98631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py`: the `not (public_key and secret_key)` branch in `_get_langfuse()` now emits one `logger.warning` naming the missing env var(s) before caching `_INIT_FAILED`.
- `tests/plugins/test_langfuse_plugin.py`: two regression tests in `TestPlaceholderKeyDetection` — (a) placeholder public key + unset secret key warns exactly once, never constructs the SDK client, and the warning says traces will NOT be emitted; (b) both keys unset warns once naming both env vars.

## How to Test

1. Enable the Langfuse plugin, set `HERMES_LANGFUSE_PUBLIC_KEY=your-public-key-here`, leave `HERMES_LANGFUSE_SECRET_KEY` unset, start Hermes and chat. Observed result before this PR: no log output at all. Observed result after: exactly one `WARNING Langfuse plugin: missing credentials (HERMES_LANGFUSE_SECRET_KEY), traces will NOT be emitted ...` on the first hook call, then silence (cached via `_INIT_FAILED`).
2. `pytest tests/plugins/test_langfuse_plugin.py -q` — Observed result: 91 passed (includes the 2 new tests).
3. Red-green check: with the `__init__.py` change reverted, both new tests fail; with it restored, all pass.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate — #72487 scopes the placeholder *prefix* guard to Langfuse Cloud hosts (different branch/root cause); this PR only touches the empty-credentials branch, complementary, no overlap in changed logic
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run pytest and all tests pass — targeted suites: `tests/plugins/test_langfuse_plugin.py` (91 passed) plus every other suite referencing the Langfuse env vars (`tests/hermes_cli/test_config.py`, `tests/hermes_cli/test_memory_setup_env_denylist.py`: 132 passed, 4 skipped)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] N/A — behavior is identical except one log line; the module docstring already documents the required env vars
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — no cross-platform surface touched (pure-Python logging + env handling)
- [x] N/A — no tool behavior or schema changes

## For New Skills

N/A — not a skill.