### PR TITLE
feat(api): expose project workspace resources

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1,7 +1,8 @@
 """OpenAI-compatible API server platform adapter (aiohttp).
 
-Serves /v1/chat/completions, /v1/responses, /v1/models, /v1/capabilities, /api/sessions,
-/v1/runs, /api/jobs and /health* (full table: ``APIServerAdapter._http_route_table``); any
+Serves /v1/chat/completions, /v1/responses, /v1/models, /v1/capabilities, /api/projects,
+/api/sessions, /v1/runs, /api/jobs and /health* (full table:
+``APIServerAdapter._http_route_table``); any
 OpenAI-compatible frontend connects at http://localhost:8642/v1 with API_SERVER_KEY. Under
 ``gateway.multiplex_profiles`` secondary profiles live at ``/p/<profile>/...``.
 """
@@ -67,7 +68,7 @@ _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 _STATIC_FEATURE_FLAGS = {
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
-    "session_resources": True, "model_options": True, "session_chat": True,
+    "project_resources": True, "session_resources": True, "model_options": True, "session_chat": True,
     "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
     "skills_api": True, "audio_api": False, "realtime_voice": False,
@@ -84,7 +85,8 @@ _CAPABILITY_ENDPOINTS = (
     ("run_approval", ("POST", "/v1/runs/{run_id}/approval")),
     ("run_steer", ("POST", "/v1/runs/{run_id}/steer")),
     ("run_stop", ("POST", "/v1/runs/{run_id}/stop")), ("skills", ("GET", "/v1/skills")),
-    ("toolsets", ("GET", "/v1/toolsets")), ("sessions", ("GET", "/api/sessions")),
+    ("toolsets", ("GET", "/v1/toolsets")), ("projects", ("GET", "/api/projects")),
+    ("sessions", ("GET", "/api/sessions")),
     ("session_create", ("POST", "/api/sessions")),
     ("session", ("GET", "/api/sessions/{session_id}")),
     ("session_update", ("PATCH", "/api/sessions/{session_id}")),
@@ -1520,6 +1522,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("GET", "/v1/artifacts/download/{artifact_id}", self._handle_artifact_download),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
+            ("GET", "/api/projects", self._handle_list_projects),
             ("GET", "/api/sessions", self._handle_list_sessions),
             ("POST", "/api/sessions", self._handle_create_session),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
@@ -2682,14 +2685,155 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         return _error_response("Session database unavailable", 503, code="session_db_unavailable")
 
     @staticmethod
-    def _session_response(session: Dict[str, Any]) -> Dict[str, Any]:
+    def _workspace_path_segments(path: Any) -> tuple[str, ...]:
+        """Return cross-platform path segments suitable for identity checks.
+
+        A remote profile can contain Windows paths even when a control-plane
+        client is running on POSIX. Preserve POSIX case sensitivity while
+        treating drive-letter, UNC, and backslash-rooted paths as Windows.
+        """
+        value = str(path or "").strip().rstrip("/\\")
+        if not value:
+            return ()
+        segments = tuple(part for part in re.split(r"[/\\]+", value) if part)
+        is_windows = bool(re.match(r"^[A-Za-z]:[/\\]", value)) or value.startswith(
+            ("\\", "//")
+        )
+        return tuple(part.casefold() for part in segments) if is_windows else segments
+
+    @classmethod
+    def _load_project_snapshot(
+        cls,
+        project_db_path: Path,
+        sessions: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Read the project catalog and associate/count ``sessions``.
+
+        The path is captured on aiohttp's profile-scoped request task before
+        this function is offloaded, rather than making correctness depend on
+        runtime-scope propagation into an executor. A missing DB is a valid
+        empty state and must stay read-only: probing this API does not create
+        projects.db.
+        """
+        empty = {
+            "projects": [],
+            "discovered_repos": [],
+            "active_id": None,
+            "session_projects": [None for _ in sessions],
+        }
+        if not project_db_path.is_file():
+            return empty
+
+        from hermes_cli import projects_db as pdb
+
+        with pdb.connect_closing(project_db_path) as conn:
+            projects = pdb.list_projects(conn)
+            discovered = pdb.list_discovered_repos(conn)
+            active_id = pdb.get_active_id(conn)
+
+        project_matches: List[tuple[tuple[str, ...], Dict[str, Any]]] = []
+        project_rows: List[Dict[str, Any]] = []
+        project_counts: Dict[str, int] = {}
+        for project in projects:
+            row = project.to_dict()
+            project_rows.append(row)
+            project_counts[project.id] = 0
+            for folder in project.folders:
+                parts = cls._workspace_path_segments(folder.path)
+                if parts:
+                    project_matches.append((parts, row))
+        project_matches.sort(key=lambda item: len(item[0]), reverse=True)
+
+        discovered_rows = [dict(repo) for repo in discovered]
+        discovered_counts = [0 for _ in discovered_rows]
+        discovered_matches = sorted(
+            (
+                (parts, index)
+                for index, repo in enumerate(discovered_rows)
+                if (parts := cls._workspace_path_segments(repo.get("root")))
+            ),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        )
+
+        session_projects: List[Optional[Dict[str, Any]]] = []
+        for session in sessions:
+            # Explicit Project membership follows the desktop contract: check
+            # both the selected cwd and the persisted common git root, and let
+            # the most-specific declared project folder win.
+            candidates = [session.get("cwd"), session.get("git_repo_root")]
+            candidate_parts = [
+                cls._workspace_path_segments(candidate)
+                for candidate in candidates
+                if str(candidate or "").strip()
+            ]
+            project_row = next(
+                (
+                    row
+                    for folder_parts, row in project_matches
+                    if any(
+                        parts[: len(folder_parts)] == folder_parts
+                        for parts in candidate_parts
+                    )
+                ),
+                None,
+            )
+            session_projects.append(project_row)
+            if project_row is not None:
+                project_counts[project_row["id"]] += 1
+
+            # A discovered repo is an auto-workspace. Assign each session to
+            # at most one cache row (the deepest matching root), preventing a
+            # nested repo from inflating all of its ancestors' counts.
+            discovered_index = next(
+                (
+                    index
+                    for root_parts, index in discovered_matches
+                    if any(
+                        parts[: len(root_parts)] == root_parts
+                        for parts in candidate_parts
+                    )
+                ),
+                None,
+            )
+            if discovered_index is not None:
+                discovered_counts[discovered_index] += 1
+
+        for row in project_rows:
+            row["session_count"] = project_counts[row["id"]]
+        for index, row in enumerate(discovered_rows):
+            row["session_count"] = discovered_counts[index]
+
+        visible_ids = {row["id"] for row in project_rows}
+        return {
+            "projects": project_rows,
+            "discovered_repos": discovered_rows,
+            "active_id": active_id if active_id in visible_ids else None,
+            "session_projects": session_projects,
+        }
+
+    async def _project_snapshot_for_sessions(
+        self, sessions: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Capture the active profile path, then read it off-loop."""
+        from hermes_cli import projects_db as pdb
+
+        project_db_path = pdb.projects_db_path()
+        return await asyncio.to_thread(
+            self._load_project_snapshot, project_db_path, sessions
+        )
+
+    @staticmethod
+    def _session_response(
+        session: Dict[str, Any], project: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Return a stable, client-safe session representation."""
         safe_keys = (
             "id", "source", "user_id", "model", "title", "started_at", "ended_at", "end_reason",
             "message_count", "tool_call_count", "input_tokens", "output_tokens",
             "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd",
             "actual_cost_usd", "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id", "pinned", "archived", "hidden")
+            "_lineage_root_id", "pinned", "archived", "hidden", "cwd", "git_repo_root")
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # SQLite stores the flags as 0/1.
         payload.update(
@@ -2697,7 +2841,28 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         # Full system prompts / model_config never cross the client API; only their presence.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
         payload["has_model_config"] = bool(session.get("model_config"))
+        payload["project_id"] = project.get("id") if project else None
+        payload["project_slug"] = project.get("slug") if project else None
         return payload
+
+    async def _session_responses(
+        self, sessions: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Serialize sessions with best-effort Project associations."""
+        try:
+            snapshot = await self._project_snapshot_for_sessions(sessions)
+            projects = snapshot["session_projects"]
+        except Exception:
+            logger.warning(
+                "[%s] Failed to resolve session Project associations",
+                self.name,
+                exc_info=True,
+            )
+            projects = [None for _ in sessions]
+        return [
+            self._session_response(session, project)
+            for session, project in zip(sessions, projects)
+        ]
 
     @staticmethod
     def _message_response(message: Dict[str, Any]) -> Dict[str, Any]:
@@ -2735,6 +2900,43 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
+
+    @_require_auth
+    async def _handle_list_projects(self, request: "web.Request") -> "web.Response":
+        """GET /api/projects — list read-only workspace metadata and counts."""
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return self._session_db_unavailable()
+
+        try:
+            # Counts follow the same visibility contract as GET /api/sessions:
+            # active, non-hidden, client-visible conversations only. LIMIT -1
+            # is SQLite's unbounded form, so counts do not depend on a page.
+            sessions = await asyncio.to_thread(
+                db.list_sessions_rich,
+                limit=-1,
+                include_children=False,
+                order_by_last_active=False,
+                compact_rows=True,
+            )
+            snapshot = await self._project_snapshot_for_sessions(sessions)
+        except Exception:
+            logger.exception("[%s] GET /api/projects failed", self.name)
+            return web.json_response(
+                _openai_error(
+                    "Failed to list projects", code="project_list_failed"
+                ),
+                status=500,
+            )
+
+        return web.json_response(
+            {
+                "object": "list",
+                "data": snapshot["projects"],
+                "discovered_repos": snapshot["discovered_repos"],
+                "active_id": snapshot["active_id"],
+            }
+        )
 
     @_require_auth
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
@@ -2781,9 +2983,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         # Back-filled pins arrive PAST the limit, so counting them would report
         # another page that doesn't exist. Only the recency window decides.
         windowed = sum(1 for s in sessions if not s.get("pinned"))
+        session_payloads = await self._session_responses(sessions)
         return web.json_response({
-            "object": "list", "data": [self._session_response(s) for s in sessions],
-            "limit": limit, "offset": offset, "has_more": windowed >= limit})
+            "object": "list",
+            "data": session_payloads,
+            "limit": limit,
+            "offset": offset,
+            "has_more": windowed >= limit,
+        })
 
     @_require_auth
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
@@ -2859,7 +3066,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         session, err = await self._get_existing_session_or_404(request.match_info["session_id"])
         if err:
             return err
-        return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
+        payload = (await self._session_responses([session]))[0]
+        return web.json_response({"object": "hermes.session", "session": payload})
 
     @_require_auth
     async def _handle_patch_session(self, request: "web.Request") -> "web.Response":

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -69,12 +69,14 @@ class TestApiServerRouteTable:
         paths = {path for _method, path, _handler in adapter._http_route_table()}
         assert "/v1/models" in paths
         assert "/api/model/options" in paths
+        assert "/api/projects" in paths
         assert "/v1/chat/completions" in paths
         assert "/api/sessions/{session_id}/model" in paths
         # connect() mirrors every native path under /p/{profile}/…
         mirrored = {f"/p/{{profile}}{path}" for path in paths}
         assert "/p/{profile}/v1/models" in mirrored
         assert "/p/{profile}/api/model/options" in mirrored
+        assert "/p/{profile}/api/projects" in mirrored
         assert "/p/{profile}/v1/chat/completions" in mirrored
         assert "/p/{profile}/api/sessions/{session_id}/model" in mirrored
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -41,6 +41,7 @@ def auth_adapter(session_db):
 def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app = web.Application()
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/api/projects", adapter._handle_list_projects)
     app.router.add_get("/api/sessions", adapter._handle_list_sessions)
     app.router.add_post("/api/sessions", adapter._handle_create_session)
     app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
@@ -62,6 +63,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         data = await resp.json()
 
     features = data["features"]
+    assert features["project_resources"] is True
     assert features["session_resources"] is True
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
@@ -72,6 +74,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["projects"] == {"method": "GET", "path": "/api/projects"}
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
@@ -80,6 +83,203 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         "method": "POST",
         "path": "/v1/runs/{run_id}/steer",
     }
+
+
+@pytest.mark.asyncio
+async def test_sessions_expose_workspace_and_linked_project(
+    adapter, session_db, tmp_path, monkeypatch
+):
+    from hermes_cli import projects_db as pdb
+
+    home = tmp_path / "profile-home"
+    repo = tmp_path / "repos" / "hermes-agent"
+    workdir = repo / "apps" / "desktop"
+    workdir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(
+            conn,
+            name="Hermes Agent",
+            slug="hermes-agent",
+            folders=[str(repo)],
+        )
+
+    session_id = session_db.create_session(
+        "workspace-session",
+        "api_server",
+        cwd=str(workdir),
+        git_repo_root=str(repo),
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        list_resp = await cli.get("/api/sessions")
+        assert list_resp.status == 200, await list_resp.text()
+        listed = next(
+            row
+            for row in (await list_resp.json())["data"]
+            if row["id"] == session_id
+        )
+
+        get_resp = await cli.get(f"/api/sessions/{session_id}")
+        assert get_resp.status == 200, await get_resp.text()
+        fetched = (await get_resp.json())["session"]
+
+    for row in (listed, fetched):
+        assert row["cwd"] == str(workdir)
+        assert row["git_repo_root"] == str(repo)
+        assert row["project_id"] == project_id
+        assert row["project_slug"] == "hermes-agent"
+
+
+@pytest.mark.asyncio
+async def test_projects_list_counts_visible_sessions_without_creating_parallel_state(
+    adapter, session_db, tmp_path, monkeypatch
+):
+    from hermes_cli import projects_db as pdb
+
+    home = tmp_path / "profile-home"
+    project_repo = tmp_path / "repos" / "project"
+    discovered_repo = tmp_path / "repos" / "discovered"
+    project_repo.mkdir(parents=True)
+    discovered_repo.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(
+            conn,
+            name="Project",
+            folders=[str(project_repo)],
+        )
+        pdb.set_active(conn, project_id)
+        pdb.record_discovered_repos(
+            conn,
+            [
+                (str(project_repo), "project-cache"),
+                (str(discovered_repo), "discovered-cache"),
+            ],
+        )
+
+    session_db.create_session(
+        "project-session",
+        "api_server",
+        cwd=str(project_repo / "src"),
+        git_repo_root=str(project_repo),
+    )
+    session_db.create_session(
+        "discovered-session",
+        "api_server",
+        cwd=str(discovered_repo / "src"),
+        git_repo_root=str(discovered_repo),
+    )
+    archived_id = session_db.create_session(
+        "archived-project-session",
+        "api_server",
+        cwd=str(project_repo),
+        git_repo_root=str(project_repo),
+    )
+    session_db.set_session_archived(archived_id, True)
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/api/projects")
+        assert resp.status == 200, await resp.text()
+        payload = await resp.json()
+
+    assert payload["object"] == "list"
+    assert payload["active_id"] == project_id
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["id"] == project_id
+    assert payload["data"][0]["session_count"] == 1
+    repo_counts = {
+        repo["label"]: repo["session_count"]
+        for repo in payload["discovered_repos"]
+    }
+    assert repo_counts == {"project-cache": 1, "discovered-cache": 1}
+
+
+@pytest.mark.asyncio
+async def test_empty_projects_read_does_not_create_projects_db(
+    adapter, tmp_path, monkeypatch
+):
+    from hermes_cli import projects_db as pdb
+
+    home = tmp_path / "empty-profile-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db_path = pdb.projects_db_path()
+    assert not db_path.exists()
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/api/projects")
+        assert resp.status == 200, await resp.text()
+        payload = await resp.json()
+
+        sessions_resp = await cli.get("/api/sessions")
+        assert sessions_resp.status == 200, await sessions_resp.text()
+
+    assert payload == {
+        "object": "list",
+        "data": [],
+        "discovered_repos": [],
+        "active_id": None,
+    }
+    assert not db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_projects_read_captures_context_scoped_profile_before_thread_offload(
+    adapter, session_db, tmp_path, monkeypatch
+):
+    from hermes_cli import projects_db as pdb
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    default_home = tmp_path / "default-home"
+    worker_home = tmp_path / "worker-home"
+    default_repo = tmp_path / "repos" / "default"
+    worker_repo = tmp_path / "repos" / "worker"
+    default_repo.mkdir(parents=True)
+    worker_repo.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    with pdb.connect_closing(default_home / "projects.db") as conn:
+        pdb.create_project(conn, name="Default", folders=[str(default_repo)])
+    with pdb.connect_closing(worker_home / "projects.db") as conn:
+        worker_project_id = pdb.create_project(
+            conn, name="Worker", folders=[str(worker_repo)]
+        )
+    session_db.create_session(
+        "worker-session",
+        "api_server",
+        cwd=str(worker_repo / "src"),
+        git_repo_root=str(worker_repo),
+    )
+
+    @web.middleware
+    async def worker_profile_scope(request, handler):
+        token = set_hermes_home_override(worker_home)
+        try:
+            return await handler(request)
+        finally:
+            reset_hermes_home_override(token)
+
+    app = web.Application(middlewares=[worker_profile_scope])
+    app.router.add_get("/api/projects", adapter._handle_list_projects)
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    async with TestClient(TestServer(app)) as cli:
+        projects_resp = await cli.get("/api/projects")
+        assert projects_resp.status == 200, await projects_resp.text()
+        projects = (await projects_resp.json())["data"]
+
+        sessions_resp = await cli.get("/api/sessions")
+        assert sessions_resp.status == 200, await sessions_resp.text()
+        sessions = (await sessions_resp.json())["data"]
+
+    assert [(project["name"], project["session_count"]) for project in projects] == [
+        ("Worker", 1)
+    ]
+    assert sessions[0]["project_id"] == worker_project_id
 
 
 @pytest.mark.asyncio

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -118,6 +118,8 @@ POST /v1/browser-control/register Register a browser controller
 GET  /v1/browser-control/ws       Browser-controller WebSocket
 GET  /v1/models                  Lists hermes-agent
 GET  /api/model/options          Provider-aware picker inventory
+GET  /api/projects               Projects/discovered repos with session counts
+GET  /api/sessions               Session metadata with workspace association
 GET  /health, /health/detailed
 ```
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -581,6 +581,10 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 
+Session list and detail responses include `cwd`, `git_repo_root`,
+`project_id`, and `project_slug`. The project fields are `null` when the
+session is not owned by an explicit Project.
+
 ```bash
 # fork a session and run one turn
 curl -X POST http://localhost:8642/api/sessions/$ID/fork \
@@ -592,6 +596,27 @@ curl -N -X POST http://localhost:8642/api/sessions/$ID/chat/stream \
   -H "Authorization: Bearer $API_SERVER_KEY" \
   -d '{"input": "what files changed in the last hour?"}'
 ```
+
+## Projects API (read-only workspace discovery)
+
+`GET /api/projects` exposes the active profile's Project catalog to external
+UIs. The `data` array contains non-archived projects from `projects.db`, with
+their folders and a `session_count`. `discovered_repos` contains cached
+repo-first discovery rows with the same count field, and `active_id` identifies
+the selected explicit Project when one is active.
+
+Counts include the same active, non-hidden, client-visible conversations as
+the Sessions API and are not limited by session-list pagination. This endpoint
+does not create `projects.db` for a profile that has never used Projects; it
+returns empty arrays instead.
+
+```bash
+curl http://localhost:8642/api/projects \
+  -H "Authorization: Bearer $API_SERVER_KEY"
+```
+
+`/v1/capabilities` advertises this surface through
+`features.project_resources` and `endpoints.projects`.
 
 ## Skills and toolsets discovery
 


### PR DESCRIPTION
Closes #98540.

## What changed

- adds authenticated, read-only `GET /api/projects` with non-archived Projects, cached discovered repos, and unpaginated visible-session counts
- adds `cwd`, `git_repo_root`, `project_id`, and `project_slug` to session list/detail responses
- resolves explicit Project membership with the same longest-folder rule used by the desktop grouping model
- advertises the surface through `features.project_resources` and `endpoints.projects`
- keeps profile reads scoped before SQLite work is offloaded, and returns an empty catalog without creating `projects.db`
- documents the response contract for external UI authors

## Validation

- `scripts/run_tests.sh tests/gateway/test_session_api.py tests/gateway/test_multiplex_api_server_routing.py -q` — 28 passed
- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/hermes_cli/test_projects_db.py tests/tui_gateway/test_projects_rpc.py -q` — 147 passed
- Ruff on the changed Python files — clean

I also ran the full gateway directory: 6,637 tests passed. Five unrelated tests in unchanged files failed on this macOS host (Unix-socket path length/abstract-socket support and two environment/load-sensitive subprocess/timeout cases); the changed API/session files were green, and the lease timeout file passed when rerun outside the full-load sweep.