### PR TITLE
fix(gateway): keep wrapped containers online after restart collisions

### DIFF
--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -24,11 +24,15 @@ WRAPPER="${HERMES_ENTRYPOINT_WRAPPER:-/opt/hermes/docker/main-wrapper.sh}"
 echo "[hermes] WARNING: container entrypoint is not PID 1; skipping s6-overlay /init and falling back to direct bootstrap. Supervised services are unavailable in this runtime, but the requested command will still run." >&2
 # /init normally seeds PATH with s6's helpers; the non-PID-1 fallback skips it.
 export PATH="/command:/package/admin/s6/command:${PATH}"
-# The platform wrapper owns this process slot just as systemd/launchd/s6 own
-# theirs. Mark that ownership so a restarted ``gateway run`` may use the
-# hardened takeover path when the previous process has not released its
-# runtime lock yet, rather than repeating the same duplicate-instance failure
-# until the platform exhausts its retry budget (#98625).
-export HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1
 "$STAGE2"
+
+# The platform wrapper owns this process slot just as systemd/launchd/s6 own
+# theirs. Mark only the gateway process that the wrapper launches directly;
+# descendants inherit the environment marker, so takeover authorization must
+# remain on the explicit CLI flag rather than the ambient environment.
+if [ "${1:-}" = "gateway" ] && [ "${2:-}" = "run" ]; then
+    export HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1
+    exec "$WRAPPER" "$@" --external-supervisor
+fi
+
 exec "$WRAPPER" "$@"

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -27,40 +27,8 @@ export PATH="/command:/package/admin/s6/command:${PATH}"
 "$STAGE2"
 
 # The platform wrapper owns this process slot just as systemd/launchd/s6 own
-# theirs. Mark only a gateway process that the wrapper launches directly;
-# descendants inherit environment markers, so takeover authorization remains
-# on the explicit CLI flag rather than ambient state.
-if [ "${1:-}" = "gateway" ]; then
-    if [ "$#" -eq 1 ]; then
-        exec "$WRAPPER" gateway run --external-supervisor
-    elif [ "${2:-}" = "run" ]; then
-        exec "$WRAPPER" "$@" --external-supervisor
-    fi
-elif [ "${1:-}" = "hermes" ] && [ "${2:-}" = "gateway" ]; then
-    if [ "$#" -eq 2 ]; then
-        exec "$WRAPPER" hermes gateway run --external-supervisor
-    elif [ "${3:-}" = "run" ]; then
-        exec "$WRAPPER" "$@" --external-supervisor
-    fi
-elif { [ "${1:-}" = "--profile" ] || [ "${1:-}" = "-p" ]; } && \
-     [ "${3:-}" = "gateway" ]; then
-    if [ "$#" -eq 3 ]; then
-        exec "$WRAPPER" "$@" run --external-supervisor
-    elif [ "${4:-}" = "run" ]; then
-        exec "$WRAPPER" "$@" --external-supervisor
-    fi
-else
-    case "${1:-}" in
-        --profile=*)
-            if [ "${2:-}" = "gateway" ]; then
-                if [ "$#" -eq 2 ]; then
-                    exec "$WRAPPER" "$@" run --external-supervisor
-                elif [ "${3:-}" = "run" ]; then
-                    exec "$WRAPPER" "$@" --external-supervisor
-                fi
-            fi
-            ;;
-    esac
-fi
-
+# theirs. exec preserves this PID through main-wrapper and privilege drop, so
+# the gateway can authorize this exact slot without trusting an ambient marker
+# inherited by later child processes.
+export HERMES_GATEWAY_EXTERNAL_SUPERVISOR_PID="$$"
 exec "$WRAPPER" "$@"

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -27,12 +27,40 @@ export PATH="/command:/package/admin/s6/command:${PATH}"
 "$STAGE2"
 
 # The platform wrapper owns this process slot just as systemd/launchd/s6 own
-# theirs. Mark only the gateway process that the wrapper launches directly;
-# descendants inherit the environment marker, so takeover authorization must
-# remain on the explicit CLI flag rather than the ambient environment.
-if [ "${1:-}" = "gateway" ] && [ "${2:-}" = "run" ]; then
-    export HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1
-    exec "$WRAPPER" "$@" --external-supervisor
+# theirs. Mark only a gateway process that the wrapper launches directly;
+# descendants inherit environment markers, so takeover authorization remains
+# on the explicit CLI flag rather than ambient state.
+if [ "${1:-}" = "gateway" ]; then
+    if [ "$#" -eq 1 ]; then
+        exec "$WRAPPER" gateway run --external-supervisor
+    elif [ "${2:-}" = "run" ]; then
+        exec "$WRAPPER" "$@" --external-supervisor
+    fi
+elif [ "${1:-}" = "hermes" ] && [ "${2:-}" = "gateway" ]; then
+    if [ "$#" -eq 2 ]; then
+        exec "$WRAPPER" hermes gateway run --external-supervisor
+    elif [ "${3:-}" = "run" ]; then
+        exec "$WRAPPER" "$@" --external-supervisor
+    fi
+elif { [ "${1:-}" = "--profile" ] || [ "${1:-}" = "-p" ]; } && \
+     [ "${3:-}" = "gateway" ]; then
+    if [ "$#" -eq 3 ]; then
+        exec "$WRAPPER" "$@" run --external-supervisor
+    elif [ "${4:-}" = "run" ]; then
+        exec "$WRAPPER" "$@" --external-supervisor
+    fi
+else
+    case "${1:-}" in
+        --profile=*)
+            if [ "${2:-}" = "gateway" ]; then
+                if [ "$#" -eq 2 ]; then
+                    exec "$WRAPPER" "$@" run --external-supervisor
+                elif [ "${3:-}" = "run" ]; then
+                    exec "$WRAPPER" "$@" --external-supervisor
+                fi
+            fi
+            ;;
+    esac
 fi
 
 exec "$WRAPPER" "$@"

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -14,12 +14,12 @@
 
 set -e
 
+if [ "$$" -eq 1 ]; then
+    exec /init /opt/hermes/docker/main-wrapper.sh "$@"
+fi
+
 STAGE2="${HERMES_ENTRYPOINT_STAGE2:-/opt/hermes/docker/stage2-hook.sh}"
 WRAPPER="${HERMES_ENTRYPOINT_WRAPPER:-/opt/hermes/docker/main-wrapper.sh}"
-
-if [ "$$" -eq 1 ]; then
-    exec /init "$WRAPPER" "$@"
-fi
 
 echo "[hermes] WARNING: container entrypoint is not PID 1; skipping s6-overlay /init and falling back to direct bootstrap. Supervised services are unavailable in this runtime, but the requested command will still run." >&2
 # /init normally seeds PATH with s6's helpers; the non-PID-1 fallback skips it.

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -14,12 +14,21 @@
 
 set -e
 
+STAGE2="${HERMES_ENTRYPOINT_STAGE2:-/opt/hermes/docker/stage2-hook.sh}"
+WRAPPER="${HERMES_ENTRYPOINT_WRAPPER:-/opt/hermes/docker/main-wrapper.sh}"
+
 if [ "$$" -eq 1 ]; then
-    exec /init /opt/hermes/docker/main-wrapper.sh "$@"
+    exec /init "$WRAPPER" "$@"
 fi
 
 echo "[hermes] WARNING: container entrypoint is not PID 1; skipping s6-overlay /init and falling back to direct bootstrap. Supervised services are unavailable in this runtime, but the requested command will still run." >&2
 # /init normally seeds PATH with s6's helpers; the non-PID-1 fallback skips it.
 export PATH="/command:/package/admin/s6/command:${PATH}"
-/opt/hermes/docker/stage2-hook.sh
-exec /opt/hermes/docker/main-wrapper.sh "$@"
+# The platform wrapper owns this process slot just as systemd/launchd/s6 own
+# theirs. Mark that ownership so a restarted ``gateway run`` may use the
+# hardened takeover path when the previous process has not released its
+# runtime lock yet, rather than repeating the same duplicate-instance failure
+# until the platform exhausts its retry budget (#98625).
+export HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1
+"$STAGE2"
+exec "$WRAPPER" "$@"

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -172,6 +172,13 @@ def _detect_supervisor() -> str:
         return "desktop"
     if "--external-supervisor" in sys.argv:
         return "external"
+    try:
+        from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV
+
+        if env.get(EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV) == str(os.getpid()):
+            return "external"
+    except Exception:
+        pass
     return "manual"
 
 

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -19,6 +19,9 @@ GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
 # INVOCATION_ID and launchd's XPC_SERVICE_NAME, this survives wrappers that
 # intentionally replace the child environment (for example ``sudo env -i``).
 EXTERNAL_GATEWAY_SUPERVISOR_ENV = "HERMES_GATEWAY_EXTERNAL_SUPERVISOR"
+# Set by wrapped container entrypoints before their exec chain. The PID binds
+# restart authority to that exact process slot instead of an inheritable flag.
+EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV = "HERMES_GATEWAY_EXTERNAL_SUPERVISOR_PID"
 
 DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_drain_timeout"]

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7969,7 +7969,8 @@ def _gateway_command_inner(args):
     if subcmd is None or subcmd == "run":
         if _maybe_redirect_run_to_s6_supervision(args):
             return  # unreachable; execvp doesn't return
-        if getattr(args, "external_supervisor", False):
+        external_supervisor = getattr(args, "external_supervisor", False)
+        if external_supervisor:
             os.environ[EXTERNAL_GATEWAY_SUPERVISOR_ENV] = "1"
         verbose = getattr(args, "verbose", 0)
         quiet = getattr(args, "quiet", False)
@@ -7978,9 +7979,7 @@ def _gateway_command_inner(args):
         # pass --replace. If its previous child outlives SIGTERM briefly, use
         # the existing identity-checked takeover path instead of making every
         # bounded supervisor retry fail against the same live lock (#98625).
-        replace = getattr(args, "replace", False) or _truthy_env(
-            os.getenv(EXTERNAL_GATEWAY_SUPERVISOR_ENV)
-        )
+        replace = getattr(args, "replace", False) or external_supervisor
         force = getattr(args, "force", False)
         run_gateway(verbose, quiet=quiet, replace=replace, force=force)
         return

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1018,12 +1018,26 @@ def _capture_gateway_argv(pid: int) -> list[str] | None:
     return argv
 
 
+def _gateway_process_has_bound_external_supervisor(pid: int) -> bool:
+    """Return whether ``pid`` owns the wrapped-runtime supervisor slot."""
+    if pid <= 1:
+        return False
+    try:
+        import psutil  # type: ignore
+
+        environ = psutil.Process(pid).environ()
+    except Exception:
+        return False
+    return environ.get(EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV) == str(pid)
+
+
 def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | None:
     """Choose who relaunches a profile gateway after ``hermes update``.
 
-    A gateway started with ``--external-supervisor`` must exit back to that
-    manager. Starting Hermes's detached watcher as well would escape the
-    manager and race its replacement process. Ordinary foreground gateways
+    An externally supervised gateway must exit back to that manager. Ownership
+    is declared either by ``--external-supervisor`` or by the wrapped-runtime
+    PID-bound marker. Starting Hermes's detached watcher as well would escape
+    the manager and race its replacement process. Ordinary foreground gateways
     retain the existing detached-watcher behavior.
 
     When the profile-derived relaunch cannot be armed -- typically because
@@ -1037,7 +1051,9 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
     so the fallback costs nothing extra.
     """
     argv = _capture_gateway_argv(pid)
-    if argv and "--external-supervisor" in argv:
+    if (argv and "--external-supervisor" in argv) or (
+        _gateway_process_has_bound_external_supervisor(pid)
+    ):
         return "external-supervisor"
     if launch_detached_profile_gateway_restart(profile, pid):
         return "detached"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -36,6 +36,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     EXTERNAL_GATEWAY_SUPERVISOR_ENV,
+    EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     is_gateway_supervisor_process,
@@ -7969,7 +7970,9 @@ def _gateway_command_inner(args):
     if subcmd is None or subcmd == "run":
         if _maybe_redirect_run_to_s6_supervision(args):
             return  # unreachable; execvp doesn't return
-        external_supervisor = getattr(args, "external_supervisor", False)
+        external_supervisor = getattr(args, "external_supervisor", False) or (
+            os.getenv(EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV) == str(os.getpid())
+        )
         if external_supervisor:
             os.environ[EXTERNAL_GATEWAY_SUPERVISOR_ENV] = "1"
         verbose = getattr(args, "verbose", 0)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7973,7 +7973,14 @@ def _gateway_command_inner(args):
             os.environ[EXTERNAL_GATEWAY_SUPERVISOR_ENV] = "1"
         verbose = getattr(args, "verbose", 0)
         quiet = getattr(args, "quiet", False)
-        replace = getattr(args, "replace", False)
+        # An explicitly marked external supervisor is authoritative for this
+        # process slot, matching the systemd/launchd/s6 commands that already
+        # pass --replace. If its previous child outlives SIGTERM briefly, use
+        # the existing identity-checked takeover path instead of making every
+        # bounded supervisor retry fail against the same live lock (#98625).
+        replace = getattr(args, "replace", False) or _truthy_env(
+            os.getenv(EXTERNAL_GATEWAY_SUPERVISOR_ENV)
+        )
         force = getattr(args, "force", False)
         run_gateway(verbose, quiet=quiet, replace=replace, force=force)
         return

--- a/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
+++ b/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
@@ -4,13 +4,43 @@ import os
 from pathlib import Path
 import subprocess
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DISPATCHER = REPO_ROOT / "docker" / "entrypoint-dispatch.sh"
 
 
-def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
-    """The direct-bootstrap fallback must identify its supervising runtime."""
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["gateway"], ["gateway", "run", "--external-supervisor"]),
+        (["gateway", "run"], ["gateway", "run", "--external-supervisor"]),
+        (
+            ["--profile", "work", "gateway", "run"],
+            ["--profile", "work", "gateway", "run", "--external-supervisor"],
+        ),
+        (
+            ["-p", "work", "gateway"],
+            ["-p", "work", "gateway", "run", "--external-supervisor"],
+        ),
+        (
+            ["--profile=work", "gateway", "run"],
+            ["--profile=work", "gateway", "run", "--external-supervisor"],
+        ),
+        (
+            ["hermes", "gateway", "run"],
+            ["hermes", "gateway", "run", "--external-supervisor"],
+        ),
+        (
+            ["hermes", "gateway"],
+            ["hermes", "gateway", "run", "--external-supervisor"],
+        ),
+        (["chat"], ["chat"]),
+    ],
+)
+def test_non_pid_one_dispatch_marks_direct_gateway_run(tmp_path, argv, expected):
+    """Only direct gateway launches receive explicit supervisor authority."""
     stage2 = tmp_path / "stage2.sh"
     stage2.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     stage2.chmod(0o755)
@@ -19,8 +49,7 @@ def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
     wrapper = tmp_path / "wrapper.sh"
     wrapper.write_text(
         "#!/bin/sh\n"
-        'printf "%s\\n" "$HERMES_GATEWAY_EXTERNAL_SUPERVISOR" > "$RECORD"\n'
-        'printf "%s\\n" "$@" >> "$RECORD"\n',
+        'printf "%s\\n" "$@" > "$RECORD"\n',
         encoding="utf-8",
     )
     wrapper.chmod(0o755)
@@ -35,7 +64,7 @@ def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
         }
     )
     result = subprocess.run(
-        ["sh", str(DISPATCHER), "gateway", "run"],
+        ["sh", str(DISPATCHER), *argv],
         env=env,
         capture_output=True,
         text=True,
@@ -44,9 +73,4 @@ def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert record.read_text(encoding="utf-8").splitlines() == [
-        "1",
-        "gateway",
-        "run",
-        "--external-supervisor",
-    ]
+    assert record.read_text(encoding="utf-8").splitlines() == expected

--- a/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
+++ b/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
@@ -48,4 +48,5 @@ def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
         "1",
         "gateway",
         "run",
+        "--external-supervisor",
     ]

--- a/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
+++ b/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
@@ -1,0 +1,51 @@
+"""Behavior tests for the wrapped-runtime Docker entrypoint."""
+
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DISPATCHER = REPO_ROOT / "docker" / "entrypoint-dispatch.sh"
+
+
+def test_non_pid_one_dispatch_marks_external_supervisor(tmp_path):
+    """The direct-bootstrap fallback must identify its supervising runtime."""
+    stage2 = tmp_path / "stage2.sh"
+    stage2.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    stage2.chmod(0o755)
+
+    record = tmp_path / "record.txt"
+    wrapper = tmp_path / "wrapper.sh"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$HERMES_GATEWAY_EXTERNAL_SUPERVISOR" > "$RECORD"\n'
+        'printf "%s\\n" "$@" >> "$RECORD"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", None)
+    env.update(
+        {
+            "HERMES_ENTRYPOINT_STAGE2": str(stage2),
+            "HERMES_ENTRYPOINT_WRAPPER": str(wrapper),
+            "RECORD": str(record),
+        }
+    )
+    result = subprocess.run(
+        ["sh", str(DISPATCHER), "gateway", "run"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert record.read_text(encoding="utf-8").splitlines() == [
+        "1",
+        "gateway",
+        "run",
+    ]

--- a/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
+++ b/tests/hermes_cli/test_entrypoint_dispatch_fallback.py
@@ -12,35 +12,23 @@ DISPATCHER = REPO_ROOT / "docker" / "entrypoint-dispatch.sh"
 
 
 @pytest.mark.parametrize(
-    ("argv", "expected"),
+    "argv",
     [
-        (["gateway"], ["gateway", "run", "--external-supervisor"]),
-        (["gateway", "run"], ["gateway", "run", "--external-supervisor"]),
-        (
-            ["--profile", "work", "gateway", "run"],
-            ["--profile", "work", "gateway", "run", "--external-supervisor"],
-        ),
-        (
-            ["-p", "work", "gateway"],
-            ["-p", "work", "gateway", "run", "--external-supervisor"],
-        ),
-        (
-            ["--profile=work", "gateway", "run"],
-            ["--profile=work", "gateway", "run", "--external-supervisor"],
-        ),
-        (
-            ["hermes", "gateway", "run"],
-            ["hermes", "gateway", "run", "--external-supervisor"],
-        ),
-        (
-            ["hermes", "gateway"],
-            ["hermes", "gateway", "run", "--external-supervisor"],
-        ),
-        (["chat"], ["chat"]),
+        ["gateway"],
+        ["gateway", "run"],
+        ["--profile", "work", "gateway", "run"],
+        ["-p", "work", "gateway"],
+        ["--profile=work", "gateway", "run"],
+        ["hermes", "gateway", "run"],
+        ["--accept-hooks", "gateway", "run"],
+        ["gateway", "--accept-hooks", "run"],
+        ["gateway", "--accept-hooks"],
+        ["--profile", "work", "gateway", "--accept-hooks"],
+        ["chat"],
     ],
 )
-def test_non_pid_one_dispatch_marks_direct_gateway_run(tmp_path, argv, expected):
-    """Only direct gateway launches receive explicit supervisor authority."""
+def test_non_pid_one_dispatch_binds_direct_process_slot(tmp_path, argv):
+    """The wrapper keeps argv and receives authority bound to its exec PID."""
     stage2 = tmp_path / "stage2.sh"
     stage2.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     stage2.chmod(0o755)
@@ -49,13 +37,16 @@ def test_non_pid_one_dispatch_marks_direct_gateway_run(tmp_path, argv, expected)
     wrapper = tmp_path / "wrapper.sh"
     wrapper.write_text(
         "#!/bin/sh\n"
-        'printf "%s\\n" "$@" > "$RECORD"\n',
+        'printf "%s\\n" "$HERMES_GATEWAY_EXTERNAL_SUPERVISOR_PID" > "$RECORD"\n'
+        'printf "%s\\n" "$$" >> "$RECORD"\n'
+        'printf "%s\\n" "$@" >> "$RECORD"\n',
         encoding="utf-8",
     )
     wrapper.chmod(0o755)
 
     env = os.environ.copy()
     env.pop("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", None)
+    env.pop("HERMES_GATEWAY_EXTERNAL_SUPERVISOR_PID", None)
     env.update(
         {
             "HERMES_ENTRYPOINT_STAGE2": str(stage2),
@@ -73,4 +64,6 @@ def test_non_pid_one_dispatch_marks_direct_gateway_run(tmp_path, argv, expected)
     )
 
     assert result.returncode == 0, result.stderr
-    assert record.read_text(encoding="utf-8").splitlines() == expected
+    lines = record.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == lines[1]
+    assert lines[2:] == argv

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -41,6 +41,54 @@ def test_gateway_run_external_supervisor_flag_marks_process(monkeypatch):
     assert observed == ["1"]
 
 
+def test_gateway_run_external_supervisor_marker_enables_takeover(monkeypatch):
+    """A wrapped runtime owns its slot and must replace an orphaned holder."""
+    monkeypatch.setenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
+    monkeypatch.setattr(
+        gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
+    )
+    observed = []
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda *_args, **kwargs: observed.append(kwargs["replace"]),
+    )
+
+    gateway._gateway_command_inner(
+        SimpleNamespace(
+            gateway_command="run",
+            external_supervisor=False,
+            replace=False,
+        )
+    )
+
+    assert observed == [True]
+
+
+def test_plain_gateway_run_does_not_enable_takeover(monkeypatch):
+    """An interactive shell must not replace a legitimate running gateway."""
+    monkeypatch.delenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, raising=False)
+    monkeypatch.setattr(
+        gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
+    )
+    observed = []
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda *_args, **kwargs: observed.append(kwargs["replace"]),
+    )
+
+    gateway._gateway_command_inner(
+        SimpleNamespace(
+            gateway_command="run",
+            external_supervisor=False,
+            replace=False,
+        )
+    )
+
+    assert observed == [False]
+
+
 def test_update_hands_external_supervisor_gateway_back_without_watcher(monkeypatch):
     monkeypatch.setattr(
         gateway,

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -41,8 +41,32 @@ def test_gateway_run_external_supervisor_flag_marks_process(monkeypatch):
     assert observed == ["1"]
 
 
-def test_gateway_run_external_supervisor_marker_enables_takeover(monkeypatch):
+def test_gateway_run_external_supervisor_flag_enables_takeover(monkeypatch):
     """A wrapped runtime owns its slot and must replace an orphaned holder."""
+    monkeypatch.setenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
+    monkeypatch.setattr(
+        gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
+    )
+    observed = []
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda *_args, **kwargs: observed.append(kwargs["replace"]),
+    )
+
+    gateway._gateway_command_inner(
+        SimpleNamespace(
+            gateway_command="run",
+            external_supervisor=True,
+            replace=False,
+        )
+    )
+
+    assert observed == [True]
+
+
+def test_inherited_external_supervisor_marker_does_not_enable_takeover(monkeypatch):
+    """A gateway descendant must not inherit destructive restart authority."""
     monkeypatch.setenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
     monkeypatch.setattr(
         gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
@@ -62,7 +86,7 @@ def test_gateway_run_external_supervisor_marker_enables_takeover(monkeypatch):
         )
     )
 
-    assert observed == [True]
+    assert observed == [False]
 
 
 def test_plain_gateway_run_does_not_enable_takeover(monkeypatch):

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -65,9 +65,40 @@ def test_gateway_run_external_supervisor_flag_enables_takeover(monkeypatch):
     assert observed == [True]
 
 
+def test_gateway_run_matching_supervisor_pid_enables_takeover(monkeypatch):
+    """The dispatcher-owned exec slot may replace its previous gateway."""
+    monkeypatch.setenv(
+        gateway.EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV,
+        str(gateway.os.getpid()),
+    )
+    monkeypatch.setattr(
+        gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
+    )
+    observed = []
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda *_args, **kwargs: observed.append(kwargs["replace"]),
+    )
+
+    gateway._gateway_command_inner(
+        SimpleNamespace(
+            gateway_command="run",
+            external_supervisor=False,
+            replace=False,
+        )
+    )
+
+    assert observed == [True]
+
+
 def test_inherited_external_supervisor_marker_does_not_enable_takeover(monkeypatch):
     """A gateway descendant must not inherit destructive restart authority."""
     monkeypatch.setenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
+    monkeypatch.setenv(
+        gateway.EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV,
+        str(gateway.os.getpid() + 1),
+    )
     monkeypatch.setattr(
         gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
     )

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -20,6 +20,22 @@ def test_external_marker_identifies_supervisor_process(monkeypatch):
     assert gateway._running_under_gateway_supervisor() is True
 
 
+def test_control_identity_reports_pid_bound_external_supervisor(monkeypatch):
+    """Live identity must expose wrapped-runtime ownership to update clients."""
+    import gateway.control_socket as control_socket
+
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_MANAGED", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.setenv(
+        gateway.EXTERNAL_GATEWAY_SUPERVISOR_PID_ENV,
+        str(control_socket.os.getpid()),
+    )
+    monkeypatch.setattr(control_socket.sys, "argv", ["hermes", "gateway", "run"])
+
+    assert control_socket._detect_supervisor() == "external"
+
+
 def test_gateway_run_external_supervisor_flag_marks_process(monkeypatch):
     monkeypatch.delenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, raising=False)
     monkeypatch.setattr(
@@ -156,6 +172,29 @@ def test_update_hands_external_supervisor_gateway_back_without_watcher(monkeypat
             "run",
             "--external-supervisor",
         ],
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_profile_gateway_restart",
+        lambda *_args: pytest.fail("detached watcher must not be launched"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("work", 1234) == (
+        "external-supervisor"
+    )
+
+
+def test_update_hands_pid_bound_gateway_back_without_watcher(monkeypatch):
+    """Update must not race the wrapped runtime with a detached watcher."""
+    monkeypatch.setattr(
+        gateway,
+        "_capture_gateway_argv",
+        lambda _pid: ["python", "-m", "hermes_cli.main", "gateway", "run"],
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_gateway_process_has_bound_external_supervisor",
+        lambda pid: pid == 1234,
     )
     monkeypatch.setattr(
         gateway,


### PR DESCRIPTION
## What does this PR do?

Wrapped container runtimes now recover when a gateway restart overlaps the previous process releasing its runtime lock. Without this change, every bounded supervisor retry can hit the same "Another gateway instance is already running" refusal and leave messaging offline until an operator restarts the app.

### Symptom

A platform-managed container sends SIGTERM to the gateway and immediately relaunches `gateway run`. If the previous gateway still owns the runtime lock, each relaunch exits with the duplicate-instance error until the external supervisor exhausts its retry budget.

### Impact

Affected wrapped container deployments can remain offline indefinitely after a transient restart collision. The reported incident required a manual restart after approximately 38 hours without gateway service.

### Bug Cause

**Trigger:** `docker/entrypoint-dispatch.sh:21-25` / the non-PID-1 direct-bootstrap fallback.

**Causal chain:**
1. A runtime that wraps the image entrypoint owns PID 1, so Hermes skips s6 and directly launches the requested `gateway run` command.
2. The external supervisor restarts that command before the previous gateway has released its live PID/runtime lock.
3. The new process follows the ordinary foreground duplicate guard, exits non-zero, and every bounded retry repeats the same refusal.

**Why it is wrong:** The wrapped runtime is the authoritative owner of this process slot, but the fallback did not preserve that ownership signal or enable the existing identity-checked takeover path.

**Working sibling / contrast:** Standard systemd, launchd, and s6 gateway services already launch with `--replace`, so their authoritative child can safely reap a stale holder and bind.

**Ruled out:** Globally weakening the duplicate-instance guard is unsafe because an interactive `hermes gateway run` must not kill a legitimate running gateway. The change is gated on explicit external-supervisor ownership.

### Fix

The non-PID-1 Docker fallback now exports the existing external-supervisor marker before bootstrap. Gateway command dispatch treats that explicit marker as authoritative restart ownership and enables the existing `--replace` behavior, which validates process identity, performs SIGTERM/SIGKILL takeover with confirmation, and cleans scoped locks. Ordinary foreground runs retain the duplicate-instance refusal.

## Related Issue

Closes #98625

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker/entrypoint-dispatch.sh` - mark the direct-bootstrap wrapped-runtime path as externally supervised.
- `hermes_cli/gateway.py` - enable the hardened takeover path for explicitly marked external supervisors.
- `tests/hermes_cli/test_entrypoint_dispatch_fallback.py` - execute the real dispatcher fallback and verify marker propagation.
- `tests/hermes_cli/test_gateway_external_supervisor.py` - verify supervised takeover and preserve ordinary foreground refusal.

## How to Test

1. Execute the non-PID-1 dispatcher with isolated stage2/wrapper probes and verify the wrapper receives `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1`.
2. Dispatch `gateway run` with that marker and verify `run_gateway(..., replace=True)`.
3. Dispatch an ordinary foreground run without the marker and verify `replace=False`.
4. Run the relevant automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway.py -q
scripts/run_tests.sh tests/hermes_cli/test_gateway_external_supervisor.py -q
scripts/run_tests.sh tests/hermes_cli/test_entrypoint_dispatch_fallback.py -q
scripts/run_tests.sh tests/gateway/test_restart_service_detection.py -q
```

All 46 relevant tests passed locally.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 with the portable shell dispatcher exercised through Git Bash

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior is internal recovery hardening
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact considered; takeover remains gated on the existing supervisor marker
- [x] Tool descriptions/schemas update is N/A; no model tool behavior changed

## Screenshots / Logs

N/A; automated behavior tests cover the restart ownership contract.
