### PR TITLE
fix(gateway): retain original auto-reset lineage in continuity hints

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1035,12 +1035,24 @@ def build_channel_continuity_note(
     if not prev:
         return None
 
+    root = (getattr(entry, "metadata", None) or {}).get(
+        "continuity_root_session_id"
+    )
+    root_hint = ""
+    if root and root != prev:
+        root_hint = (
+            f" The original session in this auto-reset lineage is "
+            f"session_id: {root}."
+        )
+
     where = "thread" if source.thread_id else "channel"
     return (
         f"[System note: This {where} had an earlier Hermes session "
-        f"(session_id: {prev}) that was auto-reset. If the user refers to "
+        f"(session_id: {prev}) that was auto-reset.{root_hint} If the user refers to "
         f"earlier work here, or the request depends on this {where}'s history, "
-        f"use the session_search tool to recall that prior session before "
+        f"use the session_search tool to recall the immediate prior session "
+        f"and, when the request points back to the original topic, the original "
+        f"lineage session before "
         f"acting — do not assume an unrelated recent session is the right "
         f"context.]"
     )
@@ -2127,6 +2139,43 @@ class SessionStore:
             reset_had_activity=bool(had_activity),
         )
 
+    def _continuity_root_session_id(
+        self,
+        session_id: str,
+        *,
+        expected_session_key: str,
+        max_depth: int = 256,
+    ) -> str:
+        """Return the oldest durable parent in one gateway routing lineage.
+
+        Auto-resets already persist ``parent_session_id`` in ``state.db``.  Walk
+        that existing chain once when creating the next session, rather than
+        making the model rediscover a potentially long reset lineage one hop at
+        a time.  Stop at routing-key boundaries and malformed/cyclic rows.
+        """
+        if not self._db:
+            return session_id
+        current = session_id
+        seen = set()
+        for _ in range(max_depth):
+            if current in seen:
+                break
+            seen.add(current)
+            try:
+                row = self._db.get_session(current)
+            except Exception:
+                break
+            if not row:
+                break
+            row_key = row.get("session_key")
+            if row_key and row_key != expected_session_key:
+                break
+            parent = row.get("parent_session_id")
+            if not parent:
+                break
+            current = str(parent)
+        return current
+
     def _find_gateway_session_row(
         self,
         *,
@@ -2910,6 +2959,14 @@ class SessionStore:
             # Create a candidate outside the lock, then publish only if another
             # worker has not already populated this routing key.
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            continuity_metadata: Dict[str, Any] = {}
+            if was_auto_reset and prev_session_id:
+                continuity_metadata["continuity_root_session_id"] = (
+                    self._continuity_root_session_id(
+                        prev_session_id,
+                        expected_session_key=session_key,
+                    )
+                )
             candidate = SessionEntry(
                 session_key=session_key,
                 session_id=session_id,
@@ -2919,6 +2976,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                metadata=continuity_metadata,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -48,6 +48,16 @@ def _slack_source(thread_id=None):
     )
 
 
+def _discord_source(thread_id="1519045187232468993"):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=thread_id,
+        chat_type="thread",
+        user_id="179723474162548736",
+        thread_id=thread_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # SessionStore records prev_session_id on auto-reset
 # ---------------------------------------------------------------------------
@@ -68,13 +78,28 @@ class TestPrevSessionIdCapture:
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
         assert entry2.prev_session_id == entry1.session_id
+        assert entry2.metadata["continuity_root_session_id"] == entry1.session_id
+
+        # A second reset keeps pointing at the original lineage root while the
+        # immediate predecessor advances to entry2.
+        entry2.last_prompt_tokens = 4000
+        entry2.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+        entry3 = store.get_or_create_session(source)
+        assert entry3.prev_session_id == entry2.session_id
+        assert entry3.metadata["continuity_root_session_id"] == entry1.session_id
 
 
 # ---------------------------------------------------------------------------
 # build_channel_continuity_note
 # ---------------------------------------------------------------------------
 
-def _reset_entry(platform, prev="20260101_000000_abc", had_activity=True):
+def _reset_entry(
+    platform,
+    prev="20260101_000000_abc",
+    had_activity=True,
+    root=None,
+):
     return SessionEntry(
         session_key="k",
         session_id="20260101_010000_def",
@@ -85,6 +110,11 @@ def _reset_entry(platform, prev="20260101_000000_abc", had_activity=True):
         auto_reset_reason="daily",
         reset_had_activity=had_activity,
         prev_session_id=prev,
+        metadata=(
+            {"continuity_root_session_id": root}
+            if root
+            else {}
+        ),
     )
 
 
@@ -101,4 +131,24 @@ class TestBuildChannelContinuityNote:
     def test_no_activity_returns_none(self):
         entry = _reset_entry(Platform.SLACK, had_activity=False)
         assert build_channel_continuity_note(entry, _slack_source()) is None
+
+    def test_discord_thread_emits_hint(self):
+        entry = _reset_entry(Platform.DISCORD)
+        note = build_channel_continuity_note(entry, _discord_source())
+        assert note is not None
+        assert entry.prev_session_id is not None
+        assert entry.prev_session_id in note
+        assert "thread" in note
+
+    def test_multi_reset_hint_names_immediate_and_original_sessions(self):
+        entry = _reset_entry(
+            Platform.SLACK,
+            prev="20260102_000000_prev",
+            root="20260101_000000_root",
+        )
+        note = build_channel_continuity_note(entry, _slack_source())
+        assert note is not None
+        assert "20260102_000000_prev" in note
+        assert "20260101_000000_root" in note
+        assert "original session" in note
 


### PR DESCRIPTION
## What does this PR do?

Extends the existing Slack/Discord auto-reset continuity hint so a fresh session receives both:

- the immediate predecessor session ID, and
- the original/root session ID of the contiguous auto-reset lineage.

The gateway already records `parent_session_id` for reset continuations and points the model at the immediate predecessor. After multiple daily/idle resets, however, the model can only walk one hop and may recover an intermediate session that no longer contains the original antecedent.

The new session now walks the existing durable parent chain once at reset time, stores the root ID in the routing entry's lightweight metadata, and includes it in the one-shot turn sidecar note. This preserves the byte-stable system prompt and keeps historical content untrusted: no prior transcript text is elevated into the system prompt.

Explicit `/new` and `/reset` boundaries are unchanged because the root is computed only for `was_auto_reset` entries.

## Problem reproduced

In a long-lived Discord thread with multiple automatic resets:

1. Session A contains the original topic.
2. Daily reset creates session B, whose immediate predecessor is A.
3. Another reset creates session C, whose immediate predecessor is B.
4. The first message in C references the original topic.

Before this change, the note only identifies B. If B is sparse or has drifted, `session_search` cannot reliably recover A without guessing. After this change, the note identifies both B and A and explicitly directs the model to inspect the original lineage session when the request points back to the original topic.

## Implementation

- Adds a bounded, cycle-safe parent walker using the existing `SessionDB.get_session()` records.
- Stops at session-key boundaries, malformed rows, missing parents, or 256 hops.
- Stores `continuity_root_session_id` in `SessionEntry.metadata`, which already persists through gateway restarts.
- Extends `build_channel_continuity_note()` without adding model tools, config keys, transcript injection, or extra lookups on normal turns.
- Adds Discord-specific and multi-reset regression coverage.

## Duplicate sweep

- #36689 is related but injects prior transcript text into the system prompt and is currently stale against main; this PR only carries deterministic session IDs through the existing safe sidecar mechanism.
- #13536 addressed parent-session persistence; current main already contains durable reset parent links, which this PR consumes.

## Verification

```text
18 passed in 6.30s
All checks passed!  # ruff
```

Commands:

```bash
python -m pytest \
  tests/gateway/test_channel_continuity_hint.py \
  tests/gateway/test_session_store_runtime_stale_guard.py \
  tests/gateway/test_10710_auto_reset_evicts_cached_agent.py \
  -q -o 'addopts='
python -m ruff check gateway/session.py tests/gateway/test_channel_continuity_hint.py
git diff --check origin/main...HEAD
```

The regression test was also sabotage-checked against the pre-fix `gateway/session.py`: 2 lineage assertions failed, then passed again after restoring the fix.

## Risk

Low and bounded:

- one parent-chain read only when creating an auto-reset replacement session;
- no behavior change for manual resets, non-Slack/Discord platforms, activity-free resets, or ordinary turns;
- no prior message content is copied into higher-authority context.
