### PR TITLE
fix(telegram): retain retired generations until cleanup completes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2810,6 +2810,17 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+async def _drain_global_telegram_retired_generations() -> bool:
+    """Drain Telegram retirement ownership even after adapter removal."""
+    try:
+        from plugins.platforms.telegram.adapter import (
+            drain_telegram_retired_generations,
+        )
+    except ImportError:
+        return True
+    return await drain_telegram_retired_generations()
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -15818,6 +15829,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
             )
+            try:
+                telegram_retired_drained = (
+                    await _drain_global_telegram_retired_generations()
+                )
+                if not telegram_retired_drained:
+                    logger.error(
+                        "Gateway shutdown left bounded Telegram retired-generation "
+                        "ownership pending"
+                    )
+            except Exception:
+                logger.exception(
+                    "Gateway global Telegram retired-generation drain failed"
+                )
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -15,7 +15,6 @@ import logging
 import os
 import html as _html
 import re
-import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -24,6 +23,14 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 from agent.deadline import run_bounded_async
+from plugins.platforms.telegram.retirement import (
+    CAPACITY_WAIT_TIMEOUT as _RETIRED_CAPACITY_WAIT_TIMEOUT,
+    RetiredTelegramGeneration as _RetiredTelegramGeneration,
+    RetirementCapacityError,
+    TelegramRetirementRegistry as _TelegramRetirementRegistry,
+    drain_retired_generations as drain_telegram_retired_generations,
+    get_retirement_registry as _get_telegram_retirement_registry,
+)
 
 
 def _redact_telegram_error_text(error: object) -> str:
@@ -102,43 +109,6 @@ async def _first_completed(*futures: "asyncio.Future") -> None:
     """
     await asyncio.wait(set(futures), return_when=asyncio.FIRST_COMPLETED)
 
-
-async def _shutdown_abandoned_app(app) -> None:
-    """Release a half-built PTB app's httpx transports after init was abandoned.
-
-    ``Application.shutdown()`` / ``Bot.shutdown()`` are gated on the app's
-    ``_initialized`` / ``_requests_initialized`` flags, which a wedged
-    ``initialize()`` (the case this whole path exists for) may never have set —
-    so calling only ``app.shutdown()`` no-ops and leaks the connection pool it
-    was meant to close.  ``HTTPXRequest`` builds its ``httpx.AsyncClient``
-    eagerly in its constructor and its ``shutdown()`` gates only on
-    ``client.is_closed``, so closing the request transports directly releases
-    the pool regardless of PTB init state.  We try the clean path first, then
-    fall back to the transports.  All best-effort and swallowed.
-    """
-    if app is None:
-        return
-    try:
-        await app.shutdown()
-    except Exception:
-        logger.debug("Abandoned Telegram app.shutdown() failed", exc_info=True)
-    # Directly close the underlying request transports (bypasses PTB's
-    # init-gated shutdown so the eagerly-built httpx pool is released even when
-    # the abandoned initialize() never flipped _initialized).
-    bot = getattr(app, "bot", None)
-    requests = getattr(bot, "_request", None) if bot is not None else None
-    if not requests:
-        return
-    for request in requests:
-        shutdown = getattr(request, "shutdown", None)
-        if shutdown is None:
-            continue
-        try:
-            result = shutdown()
-            if asyncio.iscoroutine(result) or asyncio.isfuture(result):
-                await result
-        except Exception:
-            logger.debug("Abandoned Telegram request shutdown failed", exc_info=True)
 
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
@@ -2469,50 +2439,75 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return False
 
-    async def _drain_polling_connections(self) -> None:
-        """Reset the httpx connection pool used for getUpdates polling.
+    async def _drain_polling_connections(self) -> bool:
+        """Reset getUpdates only when cleanup finishes under owned deadlines.
 
-        Network errors (especially through proxies like sing-box) can leave
-        httpx connections in a half-closed state that still occupy pool slots.
-        After enough reconnect cycles the pool fills up entirely, causing
-        ``Pool timeout: All connections in the connection pool are occupied.``
-
-        We reset ONLY ``_request[0]`` (the getUpdates request) — the general
-        request (``_request[1]``) is left untouched so concurrent
-        ``send_message`` / ``edit_message`` calls are never interrupted.
-
-        Implementation note: accesses ``Bot._request[0]`` which is the
-        get-updates ``BaseRequest`` in the PTB 22.x internal tuple
-        ``(get_updates_request, general_request)``.  There is no public
-        accessor for the polling request; review if upgrading to PTB 23+.
+        Ordinary request errors keep the historical initialize fallback. A
+        deadline timeout retires the complete Application so replacement builds
+        a fresh PTB resource graph.
         """
-        if not (self._app and self._app.bot):
-            return
+        app = self._app
+        if not (app and app.bot):
+            return True
         try:
-            # PTB 22.x: _request is a (get_updates, general) tuple;
-            # no public accessor exists for the polling request.
-            polling_req = self._app.bot._request[0]  # noqa: SLF001
+            polling_req = app.bot._request[0]  # noqa: SLF001
         except Exception:
-            return
+            return True
+
+        shutdown = getattr(polling_req, "shutdown", None)
+        initialize = getattr(polling_req, "initialize", None)
+        if not callable(shutdown) or not callable(initialize):
+            return True
         try:
-            # Bounded: a wedged CLOSE-WAIT socket can make this close hang
-            # forever and freeze the reconnect ladder (#66377).
-            await asyncio.wait_for(polling_req.shutdown(), timeout=_DRAIN_TIMEOUT)
+            shutdown_awaitable = shutdown()
+            if not inspect.isawaitable(shutdown_awaitable):
+                return True
+            await self._await_owned_lifecycle(
+                app,
+                shutdown_awaitable,
+                timeout=_DRAIN_TIMEOUT,
+                label="polling request shutdown",
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] Polling request shutdown missed its owned deadline; "
+                "retiring the Application",
+                self.name,
+            )
+            self._retire_app(app, start=True)
+            return False
         except Exception:
             logger.debug(
-                "[%s] Polling request shutdown failed/timed out (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] Polling request shutdown failed; attempting initialize fallback",
+                self.name,
+                exc_info=True,
             )
+
         try:
-            await asyncio.wait_for(polling_req.initialize(), timeout=_DRAIN_TIMEOUT)
-            logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
+            initialize_awaitable = initialize()
+            if not inspect.isawaitable(initialize_awaitable):
+                return True
+            await self._await_owned_lifecycle(
+                app,
+                initialize_awaitable,
+                timeout=_DRAIN_TIMEOUT,
+                label="polling request initialize",
             )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] Polling request initialize missed its owned deadline; "
+                "retiring the Application",
+                self.name,
+            )
+            self._retire_app(app, start=True)
+            return False
         except Exception:
             logger.debug(
-                "[%s] Polling request re-initialize failed/timed out (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] Polling request initialize failed", self.name, exc_info=True
             )
+            return False
+        logger.debug("[%s] Polling request pool drained before reconnect", self.name)
+        return True
 
     def _begin_polling_generation(self) -> tuple[int, asyncio.Event]:
         """Start accepting progress for a new getUpdates polling generation."""
@@ -2668,18 +2663,15 @@ class TelegramAdapter(BasePlatformAdapter):
             # httpcore/AnyIO shielded scopes (#58236/#67498). Reuse the
             # proven wall-deadline helper and abandon the partial updater;
             # caller recovery will dispose/rebuild the whole adapter.
-            await _await_with_thread_deadline(
+            await self._await_owned_lifecycle(
+                app,
                 app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=drop_pending_updates,
                     error_callback=_generation_error_callback,
                 ),
                 timeout=_UPDATER_START_TIMEOUT,
-                on_abandon=(
-                    (lambda app=app: _shutdown_abandoned_app(app))
-                    if abandon_app_on_timeout
-                    else None
-                ),
+                label="Updater.start_polling()",
             )
         finally:
             _POLLING_GENERATION_CONTEXT.reset(context_token)
@@ -2715,6 +2707,74 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_progress_verifier_task = None
 
         task.add_done_callback(_clear_finished_verifier)
+
+    def _retirement_registry(
+        self, *, create: bool = True
+    ) -> Optional[_TelegramRetirementRegistry]:
+        return _get_telegram_retirement_registry(
+            getattr(self.config, "token", ""),
+            updater_stop_timeout=_UPDATER_STOP_TIMEOUT,
+            disconnect_step_timeout=_DISCONNECT_STEP_TIMEOUT,
+            create=create,
+        )
+
+    def _retire_app(
+        self, app: Any, *, start: bool = True
+    ) -> Optional[_RetiredTelegramGeneration]:
+        if app is None:
+            return None
+        try:
+            registry = self._retirement_registry()
+            if registry is None:
+                return None
+            entry = registry.retire(
+                app,
+                generation_id=getattr(self, "_polling_generation", 0),
+                start=start,
+            )
+            if entry is None:
+                logger.error(
+                    "[%s] Retired-generation capacity is full; refusing unowned cleanup",
+                    getattr(self, "name", "telegram"),
+                )
+            return entry
+        except Exception:
+            logger.exception(
+                "[%s] Failed to register retired Telegram generation",
+                getattr(self, "name", "telegram"),
+            )
+            return None
+
+    async def _await_owned_lifecycle(
+        self,
+        app: Any,
+        awaitable: Awaitable[Any],
+        *,
+        timeout: float,
+        label: str,
+    ) -> Any:
+        """Bound waiting while retaining the exact child task on abandonment."""
+        task = asyncio.ensure_future(awaitable)
+        try:
+            return await _await_with_thread_deadline(task, timeout=timeout)
+        except BaseException:
+            if not task.done():
+                entry = self._retire_app(app, start=False)
+                if entry is not None:
+                    entry.registry.track_external(entry, task)
+                    entry.registry.start(entry)
+                    logger.warning(
+                        "[%s] %s abandoned; retired-generation ownership retained",
+                        self.name,
+                        label,
+                    )
+                else:
+                    # Structural capacity gates prevent this for applications
+                    # built by connect(). Keep a defensive adapter-local owner
+                    # so even an invariant violation cannot orphan the task.
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+            raise
 
     def _get_general_request_drain_lock(self) -> asyncio.Lock:
         lock = getattr(self, "_general_request_drain_lock", None)
@@ -2811,9 +2871,11 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Same shielded-cancellation class as initialize/start_polling:
             # never let a wedged duplicate deleteWebhook pin initial connect.
-            await _await_with_thread_deadline(
+            await self._await_owned_lifecycle(
+                self._app,
                 delete_webhook(drop_pending_updates=False),
                 timeout=_UPDATER_START_TIMEOUT,
+                label="Bot.delete_webhook()",
             )
             return True
         except Exception as err:
@@ -3027,8 +3089,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     # the gateway silently drops messages for hours.
                     # Bounding stop() lets the reconnect ladder always advance.
                     # Refs: NousResearch/hermes-agent#58270
-                    await _await_with_thread_deadline(
-                        app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT
+                    await self._await_owned_lifecycle(
+                        app,
+                        app.updater.stop(),
+                        timeout=_UPDATER_STOP_TIMEOUT,
+                        label="network-recovery updater.stop()",
                     )
                 except asyncio.TimeoutError:
                     message = (
@@ -3045,6 +3110,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     await self._handoff_polling_fatal_error()
                     return
+        except RetirementCapacityError:
+            raise
         except Exception:
             pass
 
@@ -3062,7 +3129,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if getattr(self, "_polling_teardown_started", False):
             return
-        await self._drain_polling_connections()
+        if not await self._drain_polling_connections():
+            message = (
+                "Telegram polling request cleanup missed its owned deadline; "
+                "rebuilding the complete adapter generation."
+            )
+            self._set_fatal_error("telegram_network_error", message, retryable=True)
+            await self._handoff_polling_fatal_error()
+            return
 
         if getattr(self, "_polling_teardown_started", False):
             return
@@ -3597,8 +3671,11 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 if self._app and self._app.updater and self._app.updater.running:
                     try:
-                        await _await_with_thread_deadline(
-                            self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT
+                        await self._await_owned_lifecycle(
+                            self._app,
+                            self._app.updater.stop(),
+                            timeout=_UPDATER_STOP_TIMEOUT,
+                            label="conflict-recovery updater.stop()",
                         )
                     except asyncio.TimeoutError:
                         message = (
@@ -3622,7 +3699,14 @@ class TelegramAdapter(BasePlatformAdapter):
             await asyncio.sleep(RETRY_DELAY)
             if getattr(self, "_polling_teardown_started", False):
                 return
-            await self._drain_polling_connections()
+            if not await self._drain_polling_connections():
+                message = (
+                    "Telegram polling request cleanup missed its owned deadline; "
+                    "rebuilding the complete adapter generation."
+                )
+                self._set_fatal_error("telegram_network_error", message, retryable=True)
+                await self._handoff_polling_fatal_error()
+                return
             if getattr(self, "_polling_teardown_started", False):
                 return
 
@@ -3723,8 +3807,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._set_fatal_error("telegram_polling_conflict", message, retryable=False)
         try:
             if self._app and self._app.updater:
-                await _await_with_thread_deadline(
-                    self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT
+                await self._await_owned_lifecycle(
+                    self._app,
+                    self._app.updater.stop(),
+                    timeout=_UPDATER_STOP_TIMEOUT,
+                    label="fatal-conflict updater.stop()",
                 )
         except asyncio.TimeoutError:
             logger.warning(
@@ -3741,15 +3828,30 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._handoff_polling_fatal_error()
 
     async def _handoff_polling_fatal_error(self) -> None:
-        """Notify the runner without letting child teardown cancel this owner.
+        """Transfer the complete Application before notifying the Gateway.
 
-        The runner bounds adapter cleanup in a child task.  ``disconnect()``
-        cancels the tracked polling-recovery task and the heartbeat task, so
-        retaining the current notifier in either field would cancel the fatal
-        callback before the runner can finish its reconnect or shutdown
-        decision.  Release only the current owner from whichever field tracks
-        it; unrelated tasks remain under teardown control.
+        The Gateway may pop this adapter immediately after the fatal callback.
+        Registering the Application first preserves ownership even when the
+        outer adapter disconnect deadline cancels its carrier task.
         """
+        app = getattr(self, "_app", None)
+        if app is not None:
+            entry = self._retire_app(app, start=True)
+            if entry is None:
+                registry = self._retirement_registry(create=False)
+                if registry is None or not await registry.wait_for_capacity(
+                    _RETIRED_CAPACITY_WAIT_TIMEOUT
+                ):
+                    raise RetirementCapacityError(
+                        "Telegram fatal handoff could not acquire retirement "
+                        "capacity before its total deadline"
+                    )
+                entry = self._retire_app(app, start=True)
+                if entry is None:
+                    raise RetirementCapacityError(
+                        "Telegram fatal handoff capacity became unavailable"
+                    )
+
         current_task = asyncio.current_task()
         if self._polling_error_task is current_task:
             self._polling_error_task = None
@@ -4435,7 +4537,28 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("[%s] No bot token configured", self.name)
             self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
-        
+
+        # Do not build another PTB Application while a retired generation still
+        # owns its cleanup. A single token has one polling slot; waiting here
+        # bounds adapter generations without blocking the Gateway loop.
+        try:
+            registry = self._retirement_registry(create=False)
+            if registry is not None and not await registry.wait_for_capacity(
+                _RETIRED_CAPACITY_WAIT_TIMEOUT
+            ):
+                message = (
+                    "Telegram retired-generation cleanup is still pending; "
+                    "deferring replacement to preserve lifecycle ownership."
+                )
+                logger.warning("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "telegram_retired_generation_capacity", message, retryable=True
+                )
+                return False
+        except Exception:
+            logger.debug("[%s] Retired-generation capacity check failed", self.name, exc_info=True)
+            return False
+
         try:
             if not self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
                 return False
@@ -4618,7 +4741,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs=_with_limits(),
                 )
             else:
                 if disable_fallback:
@@ -4678,16 +4803,11 @@ class TelegramAdapter(BasePlatformAdapter):
                         "[%s] Connecting to Telegram (attempt %d/%d)…",
                         self.name, _attempt + 1, _max_connect,
                     )
-                    await _await_with_thread_deadline(
+                    await self._await_owned_lifecycle(
+                        self._app,
                         self._app.initialize(),
                         timeout=_init_timeout,
-                        # On timeout the initialize() task is abandoned without
-                        # awaiting its cancellation (it may be wedged in a
-                        # shielded scope). Best-effort release the half-built
-                        # app's httpx client/connection pool so it isn't leaked
-                        # across the retry ladder (mirrors the client-close-on-
-                        # timeout pattern in agent/auxiliary_client.py).
-                        on_abandon=lambda app=self._app: _shutdown_abandoned_app(app),
+                        label="Application.initialize()",
                     )
                     break
                 except asyncio.TimeoutError:
@@ -4755,16 +4875,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     # and will be GC'd (#67498).
                     if rebuild_app and _attempt < _max_connect - 1:
                         old_app = self._app
+                        entry = self._retire_app(old_app, start=True)
+                        if entry is None:
+                            raise RetirementCapacityError(
+                                "Telegram retired-generation ownership capacity exhausted"
+                            )
+                        # Construction itself is capacity-gated: the next PTB
+                        # graph cannot exist while this generation is owned.
+                        if not await entry.registry.wait_for_capacity(
+                            _RETIRED_CAPACITY_WAIT_TIMEOUT
+                        ):
+                            raise RetirementCapacityError(
+                                "Telegram retired-generation cleanup did not free "
+                                "capacity for a fresh Application"
+                            )
                         self._app = builder.build()
                         self._bot = self._app.bot
                         # Keep core and observer handlers in lockstep after a
                         # transient-init rebuild (#64176).
                         self._register_handlers(self._app)
-                        # Best-effort discard the old app's resources
-                        try:
-                            await _shutdown_abandoned_app(old_app)
-                        except Exception:
-                            pass
             await self._app.start()
 
             # Decide between webhook and polling mode
@@ -5131,6 +5260,16 @@ class TelegramAdapter(BasePlatformAdapter):
         # is best-effort against a half-dead transport.
         self._release_platform_lock()
 
+        # Capture the Application before any adapter reference is cleared. The
+        # registry owns it even if this disconnect coroutine is cancelled by the
+        # Gateway's outer deadline.
+        retired_entry = self._retire_app(self._app, start=False)
+        if retired_entry is not None:
+            # Start on the next loop turn so the ownership carrier survives an
+            # outer fatal/shutdown cancellation before this coroutine reaches
+            # the end of its pre-app teardown work.
+            retired_entry.registry.start_soon(retired_entry)
+
         # Recovery can be suspended in stop/drain/start while disconnect begins.
         # Cancel and await both polling lifecycle owners immediately after the
         # fence, before any other teardown await lets them start a new generation.
@@ -5224,44 +5363,38 @@ class TelegramAdapter(BasePlatformAdapter):
             "pending-delivery cancel",
         )
 
-        if self._app:
+        if retired_entry is not None:
+            registry = retired_entry.registry
+            registry.start(retired_entry)
+            # Wait briefly for the owner carrier. A timeout is not disposal:
+            # the registry retains the entry and its child tasks until they
+            # terminate, so a replacement cannot create another generation.
+            await registry.wait_for_entry(
+                retired_entry, _DISCONNECT_STEP_TIMEOUT
+            )
+        elif self._app:
+            logger.error(
+                "[%s] Telegram Application could not be registered for retirement; "
+                "running bounded legacy teardown",
+                self.name,
+            )
             try:
-                # Only stop the updater if it's running.  Bounded with a
-                # timeout: a CLOSE-WAIT socket can wedge stop() on epoll
-                # indefinitely, which would hang disconnect() (and any
-                # gateway shutdown/restart waiting on it) forever.  On timeout
-                # we fall through to app.stop()/shutdown() to force teardown.
-                if self._app.updater and self._app.updater.running:
-                    try:
-                        await self._await_disconnect_step(
-                            self._app.updater.stop(),
-                            _UPDATER_STOP_TIMEOUT,
-                            "updater.stop()",
-                        )
-                    except Exception as stop_error:
-                        logger.warning(
-                            "[%s] updater.stop() failed during disconnect: %s",
-                            self.name,
-                            _redact_telegram_error_text(stop_error),
-                        )
-                # app.stop()/shutdown() can also block on a half-dead httpx
-                # pool. Detach-on-timeout so disconnect always returns (#80598).
+                await self._await_disconnect_step(
+                    self._app.updater.stop()
+                    if self._app.updater and self._app.updater.running
+                    else asyncio.sleep(0),
+                    _UPDATER_STOP_TIMEOUT,
+                    "updater.stop()",
+                )
                 if self._app.running:
                     await self._await_disconnect_step(
-                        self._app.stop(),
-                        _DISCONNECT_STEP_TIMEOUT,
-                        "app.stop()",
+                        self._app.stop(), _DISCONNECT_STEP_TIMEOUT, "app.stop()"
                     )
                 await self._await_disconnect_step(
-                    self._app.shutdown(),
-                    _DISCONNECT_STEP_TIMEOUT,
-                    "app.shutdown()",
+                    self._app.shutdown(), _DISCONNECT_STEP_TIMEOUT, "app.shutdown()"
                 )
-            except Exception as e:
-                logger.warning(
-                    "[%s] Error during Telegram disconnect: %s",
-                    self.name, _redact_telegram_error_text(e),
-                )
+            except Exception:
+                logger.debug("[%s] Legacy Telegram teardown failed", self.name, exc_info=True)
 
         self._app = None
         self._bot = None

--- a/plugins/platforms/telegram/retirement.py
+++ b/plugins/platforms/telegram/retirement.py
@@ -1,0 +1,489 @@
+"""Ownership and cleanup for retired python-telegram-bot generations."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import inspect
+import logging
+import threading
+import weakref
+from typing import Any, Awaitable, Optional, Set
+
+from agent.deadline import run_bounded_async
+
+logger = logging.getLogger(__name__)
+
+MAX_RETIRED_GENERATIONS = 1
+CAPACITY_WAIT_TIMEOUT = 5.0
+CLEANUP_RETRY_DELAY = 0.5
+FINAL_SHUTDOWN_DRAIN_TIMEOUT = 4.0
+
+
+class RetirementCapacityError(RuntimeError):
+    """A Telegram generation could not transfer into bounded retirement."""
+
+
+def _registry_key(token: object) -> str:
+    return hashlib.sha256(str(token or "").encode("utf-8")).hexdigest()
+
+
+def _request_resources(app: Any) -> tuple[Any, ...]:
+    """Capture PTB requests when public shutdown is initialization-gated."""
+    bot = getattr(app, "bot", None)
+    return tuple(getattr(bot, "_request", ()) or ())  # noqa: SLF001
+
+
+@dataclasses.dataclass
+class RetiredTelegramGeneration:
+    generation_id: int
+    app: Any
+    updater: Any
+    bot: Any
+    requests: tuple[Any, ...]
+    registry: "TelegramRetirementRegistry"
+    state: str = "RETIRING"
+    cleanup_task: Optional[asyncio.Task] = None
+    active_tasks: Set[asyncio.Task] = dataclasses.field(default_factory=set)
+    completed_steps: Set[str] = dataclasses.field(default_factory=set)
+    retry_when_idle: bool = False
+    retry_handle: Optional[asyncio.Handle] = None
+
+
+_REGISTRIES: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, TelegramRetirementRegistry]]" = weakref.WeakKeyDictionary()
+_REGISTRIES_LOCK = threading.Lock()
+
+
+class TelegramRetirementRegistry:
+    """Own at most one retired PTB generation for one bot token."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        token_key: str,
+        *,
+        updater_stop_timeout: float,
+        disconnect_step_timeout: float,
+    ) -> None:
+        self._loop_ref = weakref.ref(loop)
+        self.token_key = token_key
+        self.updater_stop_timeout = updater_stop_timeout
+        self.disconnect_step_timeout = disconnect_step_timeout
+        self.entries: list[RetiredTelegramGeneration] = []
+        self._capacity_waiters: set[
+            weakref.ReferenceType[asyncio.Future[None]]
+        ] = set()
+
+    def update_timeouts(
+        self, *, updater_stop_timeout: float, disconnect_step_timeout: float
+    ) -> None:
+        self.updater_stop_timeout = updater_stop_timeout
+        self.disconnect_step_timeout = disconnect_step_timeout
+
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop_ref()
+        if loop is None or loop.is_closed():
+            raise RuntimeError("Telegram retirement event loop is unavailable")
+        return loop
+
+    def find(self, app: Any) -> Optional[RetiredTelegramGeneration]:
+        return next((entry for entry in self.entries if entry.app is app), None)
+
+    def retire(
+        self,
+        app: Any,
+        *,
+        generation_id: int,
+        start: bool = True,
+    ) -> Optional[RetiredTelegramGeneration]:
+        if app is None:
+            return None
+        existing = self.find(app)
+        if existing is not None:
+            if start:
+                self.start(existing)
+            return existing
+        if len(self.entries) >= MAX_RETIRED_GENERATIONS:
+            return None
+        entry = RetiredTelegramGeneration(
+            generation_id=generation_id,
+            app=app,
+            updater=getattr(app, "updater", None),
+            bot=getattr(app, "bot", None),
+            requests=_request_resources(app),
+            registry=self,
+        )
+        self.entries.append(entry)
+        if start:
+            self.start(entry)
+        return entry
+
+    def start(self, entry: RetiredTelegramGeneration) -> None:
+        task = entry.cleanup_task
+        if task is not None and not task.done():
+            return
+        if entry.retry_handle is not None:
+            entry.retry_handle.cancel()
+            entry.retry_handle = None
+        entry.cleanup_task = self._loop().create_task(
+            self._cleanup(entry),
+            name=f"telegram-retired-cleanup:{entry.generation_id}",
+        )
+        entry.cleanup_task.add_done_callback(
+            lambda done, owned=entry: self._cleanup_done(owned, done)
+        )
+
+    def start_soon(self, entry: RetiredTelegramGeneration) -> None:
+        self._loop().call_soon(self.start, entry)
+
+    def track_external(
+        self, entry: RetiredTelegramGeneration, task: asyncio.Task
+    ) -> None:
+        """Keep the exact abandoned lifecycle task under the owner record."""
+        if task.done() or task in entry.active_tasks:
+            return
+        entry.active_tasks.add(task)
+
+        def _forget(done: asyncio.Task) -> None:
+            entry.active_tasks.discard(done)
+            if (
+                entry.retry_when_idle
+                and not entry.active_tasks
+                and entry.cleanup_task is not None
+                and entry.cleanup_task.done()
+                and entry.state != "CLEANED"
+            ):
+                self._schedule_retry(entry)
+
+        task.add_done_callback(_forget)
+
+    def _schedule_retry(self, entry: RetiredTelegramGeneration) -> None:
+        if entry.state == "CLEANED" or entry.retry_handle is not None:
+            return
+
+        def _restart() -> None:
+            entry.retry_handle = None
+            if entry.state == "CLEANED" or entry.active_tasks:
+                entry.retry_when_idle = True
+                return
+            entry.retry_when_idle = False
+            entry.cleanup_task = None
+            self.start(entry)
+
+        try:
+            entry.retry_handle = self._loop().call_later(
+                CLEANUP_RETRY_DELAY, _restart
+            )
+        except RuntimeError:
+            entry.retry_when_idle = True
+
+    def _cleanup_done(
+        self, entry: RetiredTelegramGeneration, task: asyncio.Task
+    ) -> None:
+        if entry.state == "CLEANED":
+            self._wake_capacity_waiters()
+            _remove_empty_registry(self)
+            return
+        if not task.cancelled():
+            try:
+                task.exception()
+            except BaseException:
+                pass
+        entry.retry_when_idle = True
+        if not entry.active_tasks:
+            self._schedule_retry(entry)
+
+    async def _owned_step(
+        self,
+        entry: RetiredTelegramGeneration,
+        awaitable: Awaitable[Any],
+        *,
+        label: str,
+        timeout: float,
+    ) -> bool:
+        if label in entry.completed_steps:
+            return True
+        if not inspect.isawaitable(awaitable):
+            entry.completed_steps.add(label)
+            return True
+        task = asyncio.ensure_future(awaitable)
+        entry.active_tasks.add(task)
+
+        def _forget(done: asyncio.Task) -> None:
+            entry.active_tasks.discard(done)
+            if not done.cancelled():
+                try:
+                    if done.exception() is None:
+                        entry.completed_steps.add(label)
+                except BaseException:
+                    pass
+            if (
+                entry.retry_when_idle
+                and not entry.active_tasks
+                and entry.cleanup_task is not None
+                and entry.cleanup_task.done()
+                and entry.state != "CLEANED"
+            ):
+                self._schedule_retry(entry)
+
+        task.add_done_callback(_forget)
+        try:
+            result = await run_bounded_async(
+                task,
+                timeout,
+                label=f"telegram-retired:{label}",
+            )
+            if result.timed_out:
+                entry.retry_when_idle = True
+                logger.warning(
+                    "Telegram retired generation %d %s exceeded %.1fs; "
+                    "ownership retained",
+                    entry.generation_id,
+                    label,
+                    timeout,
+                )
+                return False
+            return True
+        except BaseException as exc:
+            logger.warning(
+                "Telegram retired generation %d cleanup step %s failed: %s",
+                entry.generation_id,
+                label,
+                type(exc).__name__,
+            )
+            return False
+
+    async def _cleanup(self, entry: RetiredTelegramGeneration) -> None:
+        entry.state = "RETIRING"
+        if entry.active_tasks:
+            entry.retry_when_idle = True
+            return
+        updater = entry.updater
+        if (
+            updater is not None
+            and getattr(updater, "running", False)
+            and "updater.stop()" not in entry.completed_steps
+            and not await self._owned_step(
+                entry,
+                updater.stop(),
+                label="updater.stop()",
+                timeout=self.updater_stop_timeout,
+            )
+        ):
+            return
+
+        app = entry.app
+        if (
+            app is not None
+            and getattr(app, "running", False)
+            and "Application.stop()" not in entry.completed_steps
+            and not await self._owned_step(
+                entry,
+                app.stop(),
+                label="Application.stop()",
+                timeout=self.disconnect_step_timeout,
+            )
+        ):
+            return
+        if (
+            app is not None
+            and "Application.shutdown()" not in entry.completed_steps
+            and not await self._owned_step(
+                entry,
+                app.shutdown(),
+                label="Application.shutdown()",
+                timeout=self.disconnect_step_timeout,
+            )
+        ):
+            return
+
+        for request in entry.requests:
+            shutdown = getattr(request, "shutdown", None)
+            label = f"HTTPXRequest.shutdown:{id(request)}"
+            if (
+                callable(shutdown)
+                and label not in entry.completed_steps
+                and not await self._owned_step(
+                    entry,
+                    shutdown(),
+                    label=label,
+                    timeout=self.disconnect_step_timeout,
+                )
+            ):
+                return
+
+        if entry.active_tasks:
+            await asyncio.gather(*tuple(entry.active_tasks), return_exceptions=True)
+        entry.state = "CLEANED"
+        if entry.retry_handle is not None:
+            entry.retry_handle.cancel()
+            entry.retry_handle = None
+        entry.app = None
+        entry.updater = None
+        entry.bot = None
+        entry.requests = ()
+        if entry in self.entries:
+            self.entries.remove(entry)
+
+    def _wake_capacity_waiters(self) -> None:
+        dead: set[weakref.ReferenceType[asyncio.Future[None]]] = set()
+        for waiter_ref in self._capacity_waiters:
+            waiter = waiter_ref()
+            if waiter is None:
+                dead.add(waiter_ref)
+            elif not waiter.done():
+                waiter.set_result(None)
+        self._capacity_waiters.difference_update(dead)
+
+    async def wait_for_entry(
+        self, entry: RetiredTelegramGeneration, timeout: float
+    ) -> bool:
+        task = entry.cleanup_task
+        if task is None:
+            return entry.state == "CLEANED"
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return entry.state == "CLEANED"
+
+    async def wait_for_capacity(self, timeout: float = CAPACITY_WAIT_TIMEOUT) -> bool:
+        if len(self.entries) < MAX_RETIRED_GENERATIONS:
+            return True
+        loop = asyncio.get_running_loop()
+        if loop is not self._loop_ref():
+            raise RuntimeError("Telegram retirement registry used from another loop")
+        waiter: asyncio.Future[None] = loop.create_future()
+        waiter_ref = weakref.ref(waiter)
+        self._capacity_waiters.add(waiter_ref)
+        try:
+            if len(self.entries) < MAX_RETIRED_GENERATIONS:
+                return True
+            await asyncio.wait_for(asyncio.shield(waiter), timeout=max(0.0, timeout))
+        except asyncio.TimeoutError:
+            return False
+        finally:
+            self._capacity_waiters.discard(waiter_ref)
+        return len(self.entries) < MAX_RETIRED_GENERATIONS
+
+    async def drain(self, timeout: float) -> bool:
+        if not self.entries:
+            return True
+        return await self.wait_for_capacity(timeout)
+
+
+def get_retirement_registry(
+    token: object,
+    *,
+    updater_stop_timeout: float,
+    disconnect_step_timeout: float,
+    create: bool = True,
+) -> Optional[TelegramRetirementRegistry]:
+    loop = asyncio.get_running_loop()
+    key = _registry_key(token)
+    with _REGISTRIES_LOCK:
+        per_loop = _REGISTRIES.get(loop)
+        registry = per_loop.get(key) if per_loop is not None else None
+        if registry is None and create:
+            if per_loop is None:
+                per_loop = {}
+                _REGISTRIES[loop] = per_loop
+            registry = TelegramRetirementRegistry(
+                loop,
+                key,
+                updater_stop_timeout=updater_stop_timeout,
+                disconnect_step_timeout=disconnect_step_timeout,
+            )
+            per_loop[key] = registry
+        elif registry is not None:
+            registry.update_timeouts(
+                updater_stop_timeout=updater_stop_timeout,
+                disconnect_step_timeout=disconnect_step_timeout,
+            )
+        return registry
+
+
+def _remove_empty_registry(registry: TelegramRetirementRegistry) -> None:
+    if registry.entries:
+        return
+    loop = registry._loop_ref()
+    if loop is None:
+        return
+    with _REGISTRIES_LOCK:
+        per_loop = _REGISTRIES.get(loop)
+        if (
+            per_loop is None
+            or per_loop.get(registry.token_key) is not registry
+            or registry.entries
+        ):
+            return
+        per_loop.pop(registry.token_key, None)
+        if not per_loop:
+            _REGISTRIES.pop(loop, None)
+
+
+def registry_count(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
+    loop = loop or asyncio.get_running_loop()
+    with _REGISTRIES_LOCK:
+        return len(_REGISTRIES.get(loop, {}))
+
+
+async def drain_retired_generations(
+    timeout: float = FINAL_SHUTDOWN_DRAIN_TIMEOUT,
+) -> bool:
+    """Drain all retired generations on this loop under one total deadline."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, timeout)
+    failed = False
+    last_pending: tuple[TelegramRetirementRegistry, ...] = ()
+
+    while True:
+        with _REGISTRIES_LOCK:
+            per_loop = _REGISTRIES.get(loop)
+            registries = tuple(per_loop.values()) if per_loop is not None else ()
+        pending = tuple(registry for registry in registries if registry.entries)
+        if not pending:
+            return not failed
+        last_pending = pending
+        for registry in pending:
+            for entry in tuple(registry.entries):
+                registry.start(entry)
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        results = await asyncio.gather(
+            *(registry.drain(remaining) for registry in pending),
+            return_exceptions=True,
+        )
+        for result in results:
+            if result is not True:
+                failed = True
+                if isinstance(result, BaseException):
+                    logger.error(
+                        "Telegram global retired-generation drain failed: %s",
+                        type(result).__name__,
+                    )
+
+    for registry in last_pending:
+        for entry in tuple(registry.entries):
+            logger.error(
+                "Gateway shutdown budget ended with retired Telegram generation "
+                "%d still owned (state=%s active_tasks=%d)",
+                entry.generation_id,
+                entry.state,
+                len(entry.active_tasks),
+            )
+    return False
+
+
+__all__ = [
+    "CAPACITY_WAIT_TIMEOUT",
+    "FINAL_SHUTDOWN_DRAIN_TIMEOUT",
+    "RetiredTelegramGeneration",
+    "RetirementCapacityError",
+    "TelegramRetirementRegistry",
+    "drain_retired_generations",
+    "get_retirement_registry",
+    "registry_count",
+]

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -9,12 +9,14 @@ rather than silently leaving polling dead.
 import ast
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from plugins.platforms.telegram import adapter as tg_adapter  # noqa: E402
+from plugins.platforms.telegram import retirement as tg_retirement  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 from gateway.run import GatewayRunner  # noqa: E402
 
@@ -215,51 +217,27 @@ async def test_general_pool_drain_is_bounded_when_close_hangs(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_continues_if_drain_hangs(monkeypatch):
-    """If the polling request drain HANGS (wedged httpx pool close on a
-    CLOSE-WAIT socket), the reconnect ladder must still advance rather than
-    freezing the tracked _polling_error_task forever.
-
-    Regression test for #66377: an unbounded ``shutdown()`` /
-    ``initialize()`` in ``_drain_polling_connections`` leaves the handler
-    task pending, which gates every escalation path and silently kills the
-    gateway. The drain awaits are bounded by ``_DRAIN_TIMEOUT``, so the
-    handler must complete and reach ``start_polling`` within a hard bound.
-    """
+async def test_reconnect_retires_generation_if_drain_hangs(monkeypatch):
+    """A timed-out drain escalates without reusing the retired application."""
     adapter = _make_adapter()
     adapter._polling_network_error_count = 1
-
     mock_app, mock_polling_req = _make_mock_app()
-
-    async def _hang(*args, **kwargs):
-        await asyncio.Event().wait()  # never returns
-
-    # Both drain awaits wedge indefinitely.
-    mock_polling_req.shutdown = AsyncMock(side_effect=_hang)
-    mock_polling_req.initialize = AsyncMock(side_effect=_hang)
+    mock_app.running = False
+    mock_app.shutdown = AsyncMock()
+    mock_app.bot._request = ()
     adapter._app = mock_app
-
-    # Keep the drain timeout tiny so the test stays fast; the real default
-    # is generous enough not to truncate healthy closes.
-    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.01, raising=False)
+    adapter._drain_polling_connections = AsyncMock(return_value=False)
+    adapter._notify_fatal_error = AsyncMock()
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
-        # Hard outer bound: on unfixed code the drain hangs forever and this
-        # trips; with the fix the inner wait_for releases well before it.
         await asyncio.wait_for(
             adapter._handle_polling_network_error(Exception("Timed out")),
             timeout=5,
         )
 
-    # Ladder advanced past the wedged drain despite it never returning.
-    mock_app.updater.start_polling.assert_called_once()
-    assert adapter._polling_network_error_count == 2
-    # The tracked task must not be stuck pending — otherwise every
-    # escalation path stays gated behind an in-flight guard.
-    assert (
-        adapter._polling_error_task is None
-        or adapter._polling_error_task.done()
-    )
+    mock_app.updater.start_polling.assert_not_called()
+    adapter._drain_polling_connections.assert_awaited_once()
+    assert adapter.has_fatal_error
 
 
 @pytest.mark.asyncio
@@ -304,6 +282,13 @@ async def test_reconnect_stop_deadline_does_not_wait_for_cancel_cleanup(monkeypa
     adapter._notify_fatal_error = AsyncMock()
 
     monkeypatch.setattr(tg_adapter, "_UPDATER_STOP_TIMEOUT", 0.01)
+    async def _abandon(awaitable, timeout, **_kwargs):
+        task = asyncio.ensure_future(awaitable)
+        await asyncio.sleep(0)
+        task.cancel()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(tg_adapter, "_await_with_thread_deadline", _abandon)
     with patch("asyncio.sleep", new_callable=AsyncMock):
         recovery = asyncio.create_task(
             adapter._handle_polling_network_error(Exception("Timed out"))
@@ -311,11 +296,13 @@ async def test_reconnect_stop_deadline_does_not_wait_for_cancel_cleanup(monkeypa
         done, _ = await asyncio.wait({recovery}, timeout=0.2)
 
     try:
+        await asyncio.sleep(0)
         assert recovery in done, (
             "reconnect remained blocked waiting for cancellation-shielded "
             "updater.stop() cleanup"
         )
-        assert stop_cancelled.is_set()
+        registry = adapter._retirement_registry()
+        assert registry.entries and registry.entries[0].app is mock_app
         assert adapter.has_fatal_error
         adapter._notify_fatal_error.assert_awaited_once()
         mock_updater.start_polling.assert_not_awaited()
@@ -664,7 +651,7 @@ async def test_polling_bootstrap_conflict_schedules_conflict_recovery_task():
 
 
 @pytest.mark.asyncio
-async def test_handle_polling_network_error_updater_stop_timeout():
+async def test_handle_polling_network_error_updater_stop_timeout(monkeypatch):
     """updater.stop() hanging (CLOSE-WAIT) must not block the reconnect ladder.
 
     When the underlying TCP connection is in CLOSE-WAIT, PTB's polling task is
@@ -686,19 +673,12 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     app.updater.running = True
 
     async def _hanging_stop():
-        await asyncio.sleep(0.2)  # simulate CLOSE-WAIT block
+        await asyncio.Event().wait()  # simulate CLOSE-WAIT block
 
     app.updater.stop = _hanging_stop
     app.updater.start_polling = AsyncMock()
     adapter._app = app
     adapter._notify_fatal_error = AsyncMock()
-
-    drain_called = []
-
-    async def _fake_drain():
-        drain_called.append(True)
-
-    adapter._drain_polling_connections = _fake_drain
 
     start_polling_called = []
 
@@ -712,6 +692,13 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     # cleaner than monkeypatching asyncio.wait_for process-wide.
     import plugins.platforms.telegram.adapter as _mod
 
+    async def _abandon(awaitable, timeout, **_kwargs):
+        task = asyncio.ensure_future(awaitable)
+        await asyncio.sleep(0)
+        task.cancel()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(_mod, "_await_with_thread_deadline", _abandon)
     with patch.object(_mod, "_UPDATER_STOP_TIMEOUT", 0.05):
         await adapter._handle_polling_network_error(OSError("CLOSE-WAIT test"))
 
@@ -720,7 +707,6 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     # runner a retryable fatal and rebuild the adapter instead.
     assert adapter.has_fatal_error
     adapter._notify_fatal_error.assert_awaited_once()
-    assert not drain_called
     assert not start_polling_called
 
 
@@ -790,3 +776,52 @@ async def test_disconnect_advances_past_cancellation_swallowing_lifecycle(monkey
 
     release.set()
     await asyncio.wait({wedged}, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_drain_retires_whole_application_without_private_client_swap(monkeypatch):
+    """A timed-out drain is owned to completion and never reuses its app."""
+    adapter = _make_adapter()
+
+    class _Client:
+        is_closed = False
+
+    class _PollingRequest:
+        def __init__(self):
+            self._client = _Client()
+            self.rebuilt = []
+
+        def _build_client(self):
+            self.rebuilt.append(_Client())
+            return self.rebuilt[-1]
+
+        async def shutdown(self):
+            return None
+
+        async def initialize(self):
+            return None
+
+    request = _PollingRequest()
+    original_client = request._client
+    app = MagicMock()
+    app.updater = None
+    app.running = False
+    app.shutdown = AsyncMock()
+    app.bot._request = (request, SimpleNamespace(shutdown=AsyncMock()))
+    adapter._app = app
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.02)
+    monkeypatch.setattr(tg_retirement, "CLEANUP_RETRY_DELAY", 0.001)
+
+    async def _abandon(_awaitable, _timeout, **_kwargs):
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(tg_adapter, "_await_with_thread_deadline", _abandon)
+
+    drained = await adapter._drain_polling_connections()
+    assert drained is False
+    assert request._client is original_client
+    assert request.rebuilt == []
+    registry = adapter._retirement_registry()
+    assert len(registry.entries) == 1
+    assert await registry.wait_for_capacity(1.0)
+    assert not registry.entries

--- a/tests/gateway/test_telegram_retired_generation_v2.py
+++ b/tests/gateway/test_telegram_retired_generation_v2.py
@@ -1,0 +1,598 @@
+"""Focused tests for retired Telegram generation ownership."""
+
+import asyncio
+import gc
+import weakref
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import retirement
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _Client:
+    def __init__(self):
+        self.is_closed = False
+
+    def close(self):
+        self.is_closed = True
+
+
+class _Request:
+    def __init__(
+        self,
+        release: asyncio.Event | None = None,
+        *,
+        label: str = "request.shutdown",
+        calls: list[str] | None = None,
+    ):
+        self.release = release or asyncio.Event()
+        self.label = label
+        self.calls = calls if calls is not None else []
+        self.shutdown_calls = 0
+        self.client = _Client()
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+        self.calls.append(self.label)
+        await self.release.wait()
+        self.client.close()
+
+
+class _Updater:
+    def __init__(
+        self, release: asyncio.Event | None = None, *, calls: list[str] | None = None
+    ):
+        self.release = release or asyncio.Event()
+        self.calls = calls if calls is not None else []
+        self.running = True
+        self.stop_calls = 0
+
+    async def stop(self):
+        self.stop_calls += 1
+        self.calls.append("updater.stop")
+        while not self.release.is_set():
+            try:
+                await self.release.wait()
+            except asyncio.CancelledError:
+                continue
+        self.running = False
+
+
+class _App:
+    def __init__(self, *, release: asyncio.Event | None = None):
+        self.release = release or asyncio.Event()
+        self.calls: list[str] = []
+        self.running = True
+        self.updater = _Updater(self.release, calls=self.calls)
+        self.polling = _Request(
+            self.release, label="polling.shutdown", calls=self.calls
+        )
+        self.general = _Request(
+            self.release, label="general.shutdown", calls=self.calls
+        )
+        self.bot = SimpleNamespace(_request=(self.polling, self.general))
+        self.update_fetcher = asyncio.create_task(
+            self.release.wait(), name="Application:update_fetcher"
+        )
+        self.stop_calls = 0
+        self.shutdown_calls = 0
+
+    async def stop(self):
+        self.stop_calls += 1
+        self.calls.append("app.stop")
+        await self.release.wait()
+        self.running = False
+        await self.update_fetcher
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+        self.calls.append("app.shutdown")
+        await self.release.wait()
+
+
+class _ConnectApp(_App):
+    def __init__(self, *, release: asyncio.Event):
+        super().__init__(release=release)
+        self.running = False
+        self.add_handler = MagicMock()
+        self.start_calls = 0
+
+    async def initialize(self):
+        await self.release.wait()
+
+    async def start(self):
+        self.start_calls += 1
+        self.running = True
+
+
+def _adapter() -> TelegramAdapter:
+    return TelegramAdapter(PlatformConfig(enabled=True, token="retired-test-token"))
+
+
+@pytest.mark.asyncio
+async def test_retired_owner_drains_and_releases_slot(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.2)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.2)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None
+    assert len(entry.registry.entries) == 1
+    release.set()
+    await asyncio.wait_for(entry.registry.wait_for_entry(entry, 1.0), 1.0)
+    assert entry.state == "CLEANED"
+    assert not entry.registry.entries
+    assert app.updater.stop_calls == 1
+    assert app.stop_calls == 1
+    assert app.shutdown_calls == 1
+    assert app.calls == [
+        "updater.stop",
+        "app.stop",
+        "app.shutdown",
+        "polling.shutdown",
+        "general.shutdown",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retired_capacity_blocks_until_old_generation_finishes(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.01)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None
+    assert not await entry.registry.wait_for_capacity(0.01)
+    release.set()
+    assert await entry.registry.wait_for_capacity(2.0)
+    assert await entry.registry.wait_for_capacity(0.1)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_captures_application_before_outer_cancellation(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.01)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    adapter._app = app
+    adapter._bot = app.bot
+    monkeypatch.setattr(adapter, "_release_platform_lock", lambda: None)
+    task = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+    registry = adapter._retirement_registry()
+    assert registry.entries
+    release.set()
+    await asyncio.sleep(0.1)
+    assert not registry.entries
+
+
+@pytest.mark.asyncio
+async def test_retirement_is_idempotent_for_same_application():
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    first = adapter._retire_app(app, start=True)
+    second = adapter._retire_app(app, start=True)
+    assert first is second
+    assert len(first.registry.entries) == 1
+    release.set()
+    await asyncio.wait_for(first.registry.wait_for_entry(first, 1.0), 1.0)
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_progress_cannot_mutate_current_adapter():
+    adapter = _adapter()
+    adapter._polling_generation = 2
+    adapter._polling_progress_accepting = True
+    adapter._polling_progress_event = asyncio.Event()
+    adapter._record_polling_progress(1)
+    assert not adapter._polling_progress_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_child_remains_owned_and_retries_after_release(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.01)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.01)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None
+    await asyncio.sleep(0.05)
+    assert entry in entry.registry.entries
+    assert entry.state != "CLEANED"
+    assert entry.active_tasks
+    assert not await entry.registry.wait_for_capacity(0.01)
+    release.set()
+    assert await entry.registry.wait_for_capacity(1.0)
+    assert not entry.registry.entries
+
+
+@pytest.mark.asyncio
+async def test_cancelled_cleanup_carrier_does_not_drop_owner(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.05)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.05)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None and entry.cleanup_task is not None
+    entry.cleanup_task.cancel()
+    await asyncio.sleep(0.02)
+    assert entry in entry.registry.entries
+    release.set()
+    assert await entry.registry.wait_for_capacity(1.0)
+    assert not entry.registry.entries
+
+
+@pytest.mark.asyncio
+async def test_real_connect_gate_refuses_new_application_at_capacity(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_RETIRED_CAPACITY_WAIT_TIMEOUT", 0.01)
+    monkeypatch.setattr(retirement, "CLEANUP_RETRY_DELAY", 0.001)
+    owner = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = owner._retire_app(app, start=True)
+    candidate = _adapter()
+    result = await candidate.connect(is_reconnect=True)
+    assert result is False
+    assert candidate._app is None
+    assert candidate.has_fatal_error
+    assert candidate.fatal_error_code == "telegram_retired_generation_capacity"
+    release.set()
+    assert await entry.registry.wait_for_capacity(1.0)
+
+
+@pytest.mark.asyncio
+async def test_connect_rebuild_serializes_two_consecutive_abandonments(monkeypatch):
+    """The internal retry ladder cannot build B/C over an occupied A/B slot."""
+    import plugins.platforms.telegram.adapter as module
+
+    release_a = asyncio.Event()
+    release_b = asyncio.Event()
+    app_a = _ConnectApp(release=release_a)
+    app_b = _ConnectApp(release=release_b)
+    generations = [app_a, app_b]
+    generation_c_created = False
+
+    def _build_generation():
+        nonlocal generation_c_created
+        if generations:
+            return generations.pop(0)
+        generation_c_created = True
+        raise AssertionError("generation C must not be constructed")
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.side_effect = _build_generation
+    monkeypatch.setattr(
+        module,
+        "Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(module, "HTTPXRequest", lambda **_kwargs: MagicMock())
+    monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "true")
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda _scope, _identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(module, "_RETIRED_CAPACITY_WAIT_TIMEOUT", 0.2)
+    monkeypatch.setattr(retirement, "CLEANUP_RETRY_DELAY", 0.001)
+
+    real_sleep = asyncio.sleep
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    deadline_calls = 0
+
+    async def _abandon_initialize(awaitable, timeout, **_kwargs):
+        nonlocal deadline_calls
+        del timeout
+        deadline_calls += 1
+        await real_sleep(0)
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(module, "_await_with_thread_deadline", _abandon_initialize)
+
+    capacity_waits: list[str] = []
+    original_wait = retirement.TelegramRetirementRegistry.wait_for_capacity
+
+    async def _observed_wait(registry, timeout=retirement.CAPACITY_WAIT_TIMEOUT):
+        owned_a = registry.find(app_a)
+        owned_b = registry.find(app_b)
+        if owned_a is not None:
+            capacity_waits.append("A")
+            assert builder.build.call_count == 1
+            assert owned_a.active_tasks
+            assert owned_a.app is app_a
+            release_a.set()
+        elif owned_b is not None:
+            capacity_waits.append("B")
+            assert builder.build.call_count == 2
+            assert owned_b.active_tasks
+            assert owned_b.app is app_b
+        return await original_wait(registry, timeout)
+
+    monkeypatch.setattr(
+        retirement.TelegramRetirementRegistry,
+        "wait_for_capacity",
+        _observed_wait,
+    )
+
+    adapter = _adapter()
+    adapter._wire_plugin_handlers = MagicMock()
+    adapter._register_handlers = MagicMock()
+    assert await adapter.connect(is_reconnect=True) is False
+
+    assert deadline_calls == 2
+    assert capacity_waits == ["A", "B"]
+    assert builder.build.call_count == 2
+    assert generation_c_created is False
+    registry_b = adapter._retirement_registry(create=False)
+    assert registry_b is not None
+    owned_b = registry_b.find(app_b)
+    assert owned_b is not None
+    assert owned_b.active_tasks
+    assert owned_b.updater is app_b.updater
+    assert owned_b.bot is app_b.bot
+    assert owned_b.requests == (app_b.polling, app_b.general)
+
+    release_b.set()
+    assert await module.drain_telegram_retired_generations(timeout=1.0)
+    assert retirement.registry_count() == 0
+    assert app_a.update_fetcher.done()
+    assert app_b.update_fetcher.done()
+    assert not [
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task()
+        and not task.done()
+        and task.get_name().startswith("telegram-retired-cleanup:")
+    ]
+    assert owned_b.app is None
+    assert owned_b.updater is None
+    assert owned_b.bot is None
+    assert owned_b.requests == ()
+
+
+@pytest.mark.asyncio
+async def test_fatal_handoff_has_one_total_capacity_deadline(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_RETIRED_CAPACITY_WAIT_TIMEOUT", 0.01)
+    owner = _adapter()
+    held_release = asyncio.Event()
+    held_app = _App(release=held_release)
+    held_entry = owner._retire_app(held_app, start=True)
+    assert held_entry is not None
+
+    candidate = _adapter()
+    candidate_release = asyncio.Event()
+    candidate_app = _App(release=candidate_release)
+    candidate._app = candidate_app
+    candidate._bot = candidate_app.bot
+    candidate._notify_fatal_error = AsyncMock()
+    real_sleep = asyncio.sleep
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+
+    async def _abandon_stop(_awaitable, timeout, **_kwargs):
+        del timeout
+        await real_sleep(0)
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(module, "_await_with_thread_deadline", _abandon_stop)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with pytest.raises(module.RetirementCapacityError):
+        await candidate._handle_polling_network_error(
+            OSError("bounded fatal handoff test")
+        )
+    assert loop.time() - started < 0.1
+    candidate._notify_fatal_error.assert_not_awaited()
+    assert candidate._app is candidate_app
+    assert candidate._background_tasks
+
+    held_release.set()
+    assert await held_entry.registry.wait_for_capacity(1.0)
+    candidate_release.set()
+    await asyncio.gather(*tuple(candidate._background_tasks), return_exceptions=True)
+    candidate_entry = candidate._retire_app(candidate_app, start=True)
+    assert candidate_entry is not None
+    assert await module.drain_telegram_retired_generations(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_global_shutdown_drains_after_adapter_removal(monkeypatch, recwarn):
+    import plugins.platforms.telegram.adapter as module
+    adapter = _adapter()
+    release = asyncio.Event()
+    release.set()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None
+    registry = entry.registry
+    assert len(registry.entries) == 1
+    adapter._app = None
+    adapter._bot = None
+    adapter_ref = weakref.ref(adapter)
+    del adapter
+    gc.collect()
+    assert adapter_ref() is None
+
+    assert await asyncio.wait_for(module.drain_telegram_retired_generations(), 1.0)
+    assert not registry.entries
+    assert entry.state == "CLEANED"
+    assert entry.app is None
+    assert entry.updater is None
+    assert entry.bot is None
+    assert entry.requests == ()
+    assert entry.cleanup_task is not None and entry.cleanup_task.done()
+    assert app.update_fetcher.done()
+    assert not app.updater.running
+    assert app.polling.client.is_closed
+    assert app.general.client.is_closed
+    assert not [
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task()
+        and not task.done()
+        and (
+            task.get_name().startswith("telegram-retired-cleanup:")
+            or task.get_name() == "Application:update_fetcher"
+        )
+    ]
+    bad_warnings = [
+        warning
+        for warning in recwarn
+        if any(
+            marker in str(warning.message).lower()
+            for marker in ("unclosed", "destroyed but pending", "transport")
+        )
+    ]
+    assert not bad_warnings
+
+
+@pytest.mark.asyncio
+async def test_global_shutdown_drain_is_idempotent_and_bounded(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+    from gateway.run import _drain_global_telegram_retired_generations
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.05)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.05)
+    adapter = _adapter()
+    release = asyncio.Event()
+    app = _App(release=release)
+    entry = adapter._retire_app(app, start=True)
+    assert entry is not None
+
+    async def _release_cleanup():
+        await asyncio.sleep(0.01)
+        release.set()
+
+    release_task = asyncio.create_task(_release_cleanup())
+    first, second = await asyncio.gather(
+        _drain_global_telegram_retired_generations(),
+        _drain_global_telegram_retired_generations(),
+    )
+    await release_task
+
+    assert first is True
+    assert second is True
+    assert not entry.registry.entries
+    assert app.updater.stop_calls == 1
+    assert app.stop_calls == 1
+    assert app.shutdown_calls == 1
+    assert app.polling.shutdown_calls == 1
+    assert app.general.shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_global_shutdown_drain_repeats_without_retention(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+    from gateway.run import _drain_global_telegram_retired_generations
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.05)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.05)
+    assert retirement.registry_count() == 0
+    for cycle in range(32):
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token=f"retired-repeat-{cycle}")
+        )
+        release = asyncio.Event()
+        release.set()
+        app = _App(release=release)
+        entry = adapter._retire_app(app, start=True)
+        assert entry is not None
+        del adapter
+
+        assert await _drain_global_telegram_retired_generations()
+        assert not entry.registry.entries
+        assert entry.app is None
+        assert entry.updater is None
+        assert entry.bot is None
+        assert entry.requests == ()
+        assert app.update_fetcher.done()
+        assert app.polling.client.is_closed
+        assert app.general.client.is_closed
+        assert retirement.registry_count() == 0
+
+
+def test_retirement_registry_does_not_retain_closed_loop():
+    loop = asyncio.new_event_loop()
+    loop_ref = weakref.ref(loop)
+
+    async def _exercise() -> None:
+        adapter = _adapter()
+        release = asyncio.Event()
+        release.set()
+        app = _App(release=release)
+        entry = adapter._retire_app(app, start=True)
+        assert entry is not None
+        assert await retirement.drain_retired_generations(timeout=1.0)
+        await asyncio.sleep(0)
+        assert retirement.registry_count() == 0
+
+    loop.run_until_complete(_exercise())
+    loop.close()
+    del loop
+    gc.collect()
+    assert loop_ref() is None
+
+
+@pytest.mark.asyncio
+async def test_global_shutdown_drain_uses_one_total_budget(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "_UPDATER_STOP_TIMEOUT", 0.2)
+    monkeypatch.setattr(module, "_DISCONNECT_STEP_TIMEOUT", 0.2)
+    releases = [asyncio.Event(), asyncio.Event()]
+    entries = []
+    apps = []
+    for index, release in enumerate(releases):
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token=f"retired-budget-{index}")
+        )
+        app = _App(release=release)
+        entry = adapter._retire_app(app, start=True)
+        assert entry is not None
+        entries.append(entry)
+        apps.append(app)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    assert not await module.drain_telegram_retired_generations(timeout=0.02)
+    elapsed = loop.time() - started
+    assert elapsed < 0.1
+    assert all(entry.registry.entries for entry in entries)
+
+    for release in releases:
+        release.set()
+    assert await module.drain_telegram_retired_generations(timeout=1.0)
+    assert all(not entry.registry.entries for entry in entries)
+    assert all(app.update_fetcher.done() for app in apps)
+    assert all(app.polling.client.is_closed for app in apps)
+    assert all(app.general.client.is_closed for app in apps)


### PR DESCRIPTION
## Summary

Telegram recovery can abandon PTB lifecycle work when `Updater.stop()`, application teardown, or related cleanup exceeds a bounded deadline. Today, Hermes can move on to a replacement adapter without retaining process-level ownership of the complete retired generation, leaving the old `Application`, `Updater`, `update_fetcher`, `Bot`, request clients, and abandoned lifecycle task without a final owner.

This PR keeps retired Telegram generations strongly owned until cleanup completes, caps retirement to one generation, serializes bounded cleanup, and drains any remaining retired generations during Gateway shutdown even if the Telegram adapter has already been removed from the active adapter map.

## What changes

- Add a loop-local, token-keyed retirement registry for abandoned Telegram generations.
- Retain the exact lifecycle task together with the retired `Application`, `Updater`, `Bot`, and request clients.
- Serialize and retry cleanup without overlapping PTB close steps.
- Bound retired-generation capacity to prevent linear resource growth across repeated reconnect failures.
- Preserve stale-callback isolation between old and current generations.
- Add an adapter-independent Gateway shutdown drain so ownership is finalized after adapter removal as well.
- Keep the existing fresh-generation replacement behavior. This PR does not introduce private `_client`/`_build_client` swapping.

## Why this is needed

Existing Telegram reconnect hardening covers bounded stop/drain behavior, polling liveness, fatal handoff, and transport/client recovery, but it does not provide a final process-level owner for lifecycle work that has already been abandoned by a deadline.

Without that ownership boundary, repeated `stop timeout -> abandon -> fatal recovery -> replacement` cycles can accumulate retired PTB generations even when stale callbacks are correctly fenced from mutating current state.

## Validation

Focused upstream tests on the rebased branch:

- 31 passed
- 1 pre-existing general-pool hang test deselected
- Ruff passed
- `compileall` passed

The focused suite covers:

- abandoned `Updater.stop()` ownership
- retired `Application` / `Updater` / `update_fetcher` lifetime
- ordered and idempotent cleanup
- one-generation capacity fencing
- stale callback isolation
- replacement without stale-generation reuse
- repeated failure/replacement resource plateau
- global shutdown drain
- shutdown drain after adapter removal
- no destroyed-pending-task warnings
- no unclosed client/transport warnings

Additional certification outside the committed CI test count exercised 100 replacement/failure cycles across PTB 22.6 and 22.8 and returned retired resources to zero after shutdown.

## Scope

Runtime changes are limited to:

- `plugins/platforms/telegram/adapter.py`
- `gateway/run.py`

Tests are limited to:

- `tests/gateway/test_telegram_network_reconnect.py`
- `tests/gateway/test_telegram_retired_generation_v2.py`

This is intentionally separate from the Telegram reconnect config-cache fix in #98235, which addresses synchronous config parsing during adapter rebuild rather than retired-generation ownership.

Related existing work such as #87265 and #87111 focuses on transport/client recovery and does not retain the complete abandoned PTB generation through final cleanup.