### PR TITLE
test(desktop): pin the UI suite's default locale to en-US

### DIFF
--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -38,3 +38,38 @@ if (typeof (globalThis as any).localStorage === 'undefined') {
 // CPU contention in CI. Success still resolves the instant the node appears;
 // the wider deadline only absorbs a starved runner, killing timing flakes.
 configure({ asyncUtilTimeout: 5000 })
+
+// Number and date formatting in the app deliberately follows the host locale
+// (`Intl.*` and `toLocaleString()` called with no locale — see src/lib/time.ts).
+// Tests assert en-US output, which holds silently on CI's en-US runners and
+// breaks for any contributor whose machine is set to another locale: tr-TR
+// renders 1.234.567, de-DE renders 1.234.567, fr-FR renders 1 234 567. An env
+// var cannot fix this portably — ICU reads the locale from the OS on Windows
+// and ignores LANG/LC_ALL — so pin the default the tests were written against.
+const TEST_LOCALE = 'en-US'
+
+type LocaleFormatter = (this: unknown, locales?: unknown, options?: unknown) => string
+
+const withDefaultLocale = <T extends LocaleFormatter>(format: T): T =>
+  function (this: unknown, locales?: unknown, options?: unknown) {
+    return format.call(this, locales ?? TEST_LOCALE, options)
+  } as T
+
+Number.prototype.toLocaleString = withDefaultLocale(Number.prototype.toLocaleString)
+BigInt.prototype.toLocaleString = withDefaultLocale(BigInt.prototype.toLocaleString)
+Date.prototype.toLocaleString = withDefaultLocale(Date.prototype.toLocaleString)
+Date.prototype.toLocaleDateString = withDefaultLocale(Date.prototype.toLocaleDateString)
+Date.prototype.toLocaleTimeString = withDefaultLocale(Date.prototype.toLocaleTimeString)
+
+// `new Intl.NumberFormat(undefined, …)` resolves to the host locale too, so the
+// constructors need the same default. A Proxy keeps `instanceof` and the static
+// `supportedLocalesOf` intact, unlike a hand-rolled subclass.
+for (const name of ['NumberFormat', 'DateTimeFormat', 'RelativeTimeFormat', 'ListFormat', 'PluralRules'] as const) {
+  const Original = Intl[name] as unknown as new (locales?: unknown, options?: unknown) => unknown
+
+  ;(Intl as unknown as Record<string, unknown>)[name] = new Proxy(Original, {
+    construct: (target, [locales, options]) => new target(locales ?? TEST_LOCALE, options),
+    apply: (target, thisArg, [locales, options]) =>
+      Reflect.apply(target as never, thisArg, [locales ?? TEST_LOCALE, options])
+  })
+}


### PR DESCRIPTION
Two UI tests fail on a clean checkout if your machine isn't set to an en-US locale:

```
FAIL  src/app/session/hooks/use-prompt-actions/utils.test.ts
  expected 'Usage: 12 calls · 1.234.567 in / …'
        to be 'Usage: 12 calls · 1,234,567 in / …'

FAIL  src/components/assistant-ui/tool/fallback-model.test.ts
  expected '…' to contain '5,000 more characters truncated'
```

The app formats numbers against the host locale on purpose (`Intl` / `toLocaleString` with no locale argument — same as `src/lib/time.ts`), so this is the tests assuming a locale, not a product bug. CI's runners are en-US so it never showed up there.

`LANG` / `LC_ALL` don't help portably — ICU takes the locale from the OS on Windows and ignores them, which I confirmed before reaching for this:

```
$ LC_ALL=en_US.UTF-8 node -e "console.log((1234567).toLocaleString())"
1.234.567
```

So the default gets pinned in `vitest.setup.ts` instead. Covers the prototype `toLocale*String` methods and the `Intl` constructors, since `new Intl.NumberFormat(undefined, …)` resolves the same way. The `Intl` side uses a `Proxy` so `instanceof` and `supportedLocalesOf` still work.

## Testing

On a tr-TR Windows 11 box both tests pass now. The rest of `vitest run --project ui`
is unaffected — 6756 green. I did have to raise `testTimeout` locally to get a clean
full run, but that's cold-start slowness on this machine and unrelated to this change,
so it's not in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
