### PR TITLE
perf(desktop): measure compositing, and stop a sidebar full of working agents from growing the layer tree

### DIFF
--- a/apps/desktop/scripts/perf/lib/cdp.mjs
+++ b/apps/desktop/scripts/perf/lib/cdp.mjs
@@ -124,6 +124,32 @@ export class CDP {
     }
 
     this.listeners.get(method).push(handler)
+    let subscribed = true
+
+    return () => {
+      if (!subscribed) {
+        return
+      }
+
+      subscribed = false
+      const handlers = this.listeners.get(method)
+
+      if (!handlers) {
+        return
+      }
+
+      const index = handlers.indexOf(handler)
+
+      if (index === -1) {
+        return
+      }
+
+      handlers.splice(index, 1)
+
+      if (handlers.length === 0) {
+        this.listeners.delete(method)
+      }
+    }
   }
 
   /** Evaluate an expression in the page and return its value (awaits promises). */

--- a/apps/desktop/scripts/perf/lib/compositing.mjs
+++ b/apps/desktop/scripts/perf/lib/compositing.mjs
@@ -1,0 +1,206 @@
+// Collect rendering timeline phases and layer-tree observations alongside the
+// harness's JavaScript, commit-count and frame-pacing metrics. These helpers
+// report what a scenario emits; their synthetic tests are not hardware benchmarks.
+//
+// Usage mirrors withCpuProfile:
+//
+//   const { result, compositing } = await withCompositingTrace(cdp, () => driveScenario())
+//   const layers = await layerSnapshot(cdp)
+
+import { sleep } from './cdp.mjs'
+
+/** Timeline events worth attributing. Names are stable devtools.timeline phases. */
+const TRACKED = ['Layerize', 'Commit', 'PrePaint', 'Paint', 'UpdateLayoutTree', 'Layout', 'UpdateLayer', 'HitTest']
+
+/**
+ * Fold raw trace events into per-phase totals.
+ *
+ * Pure so it can be unit-tested without a browser: the CDP plumbing below is
+ * thin, the arithmetic is what regressions hide in. `wallMs` is the trace
+ * window, used to express each phase as a share of wall clock — the only form
+ * that is comparable across machines of different speeds.
+ */
+export function aggregateTraceEvents(events, wallMs) {
+  const byName = new Map()
+
+  for (const e of events) {
+    // 'X' is a complete event; anything else has no duration to attribute.
+    if (e.ph !== 'X' || typeof e.dur !== 'number') {
+      continue
+    }
+
+    const cur = byName.get(e.name) || { us: 0, n: 0, maxUs: 0 }
+
+    cur.us += e.dur
+    cur.n += 1
+    cur.maxUs = Math.max(cur.maxUs, e.dur)
+    byName.set(e.name, cur)
+  }
+
+  const wallUs = Math.max(1, wallMs * 1000)
+  const phases = {}
+
+  for (const name of TRACKED) {
+    const v = byName.get(name) || { us: 0, n: 0, maxUs: 0 }
+
+    phases[name] = {
+      ms: Math.round(v.us / 100) / 10,
+      pct: Math.round((1000 * v.us) / wallUs) / 10,
+      n: v.n,
+      max_ms: Math.round(v.maxUs / 100) / 10
+    }
+  }
+
+  return phases
+}
+
+/**
+ * Run `body` with a devtools.timeline trace open and return its phase totals.
+ *
+ * Only `devtools.timeline` is enabled by default to limit collection scope.
+ * Callers can explicitly request other categories for their scenario.
+ */
+export async function withCompositingTrace(cdp, body, { categories = ['devtools.timeline'] } = {}) {
+  const events = []
+  let completed
+
+  const done = new Promise(resolve => {
+    completed = resolve
+  })
+
+  const removeDataListener = cdp.on('Tracing.dataCollected', params => events.push(...params.value))
+  const removeCompleteListener = cdp.on('Tracing.tracingComplete', () => completed())
+  let result
+  let startedAt
+  let traceStarted = false
+
+  try {
+    await cdp.send('Tracing.start', {
+      transferMode: 'ReportEvents',
+      traceConfig: { includedCategories: categories }
+    })
+    traceStarted = true
+    startedAt = Date.now()
+    result = await body()
+  } finally {
+    try {
+      // Always close the trace so a scenario error can't leave tracing armed
+      // and poison every later scenario in the same run.
+      if (traceStarted) {
+        await cdp.send('Tracing.end')
+        await done
+      }
+    } finally {
+      removeDataListener()
+      removeCompleteListener()
+    }
+  }
+
+  const wallMs = Date.now() - startedAt
+  const phases = aggregateTraceEvents(events, wallMs)
+
+  return {
+    result,
+    compositing: {
+      wall_ms: wallMs,
+      layerize_pct: phases.Layerize.pct,
+      layerize_ms: phases.Layerize.ms,
+      layerize_n: phases.Layerize.n,
+      commit_pct: phases.Commit.pct,
+      recalc_pct: phases.UpdateLayoutTree.pct,
+      layout_pct: phases.Layout.pct,
+      paint_pct: phases.Paint.pct,
+      phases
+    }
+  }
+}
+
+/**
+ * Layer-tree shape: how many layers exist, how much surface they cover, and
+ * why they were promoted.
+ *
+ * `layer_area_mp` sums layer areas, not viewport area. `reasons` is a bounded
+ * sample because each sampled layer requires a separate backend request.
+ * Interpretation depends on the scenario; no universal performance threshold
+ * or sample representativeness is asserted here.
+ */
+export async function layerSnapshot(cdp, { settleMs = 1200, reasonSample = 60 } = {}) {
+  let layers = []
+
+  const removeListener = cdp.on('LayerTree.layerTreeDidChange', params => {
+    layers = params.layers || []
+  })
+
+  try {
+    await cdp.send('DOM.enable')
+    await cdp.send('LayerTree.enable')
+    await sleep(settleMs)
+
+    const areaPx = layers.reduce((sum, l) => sum + (l.width || 0) * (l.height || 0), 0)
+    const reasons = {}
+
+    for (const layer of layers.slice(0, reasonSample)) {
+      try {
+        const r = await cdp.send('LayerTree.compositingReasons', { layerId: layer.layerId })
+
+        for (const id of r.compositingReasonIds || r.compositingReasons || []) {
+          reasons[id] = (reasons[id] || 0) + 1
+        }
+      } catch {
+        // A layer can vanish between the snapshot and the query on a live tree;
+        // a missing reason must not fail the whole scenario.
+      }
+    }
+
+    return {
+      layer_count: layers.length,
+      layer_area_mp: Math.round((areaPx / 1e6) * 10) / 10,
+      reasons_sampled: Math.min(layers.length, reasonSample),
+      reasons
+    }
+  } finally {
+    removeListener()
+  }
+}
+
+/**
+ * Count layer-tree invalidations over a window the CALLER defines.
+ *
+ * Separate from `layerSnapshot` so callers can choose the observation window
+ * instead of implicitly measuring only snapshot settling. Requires
+ * `LayerTree.enable` to be active — call `layerSnapshot` first.
+ *
+ *   const stop = watchLayerTreeRate(cdp)
+ *   ... drive the scenario ...
+ *   const { layer_tree_rate } = stop()
+ */
+export function watchLayerTreeRate(cdp) {
+  let changes = 0
+  const startedAt = Date.now()
+  let stopped = false
+
+  const removeListener = cdp.on('LayerTree.layerTreeDidChange', () => {
+    changes += 1
+  })
+
+  return () => {
+    if (!stopped) {
+      stopped = true
+      removeListener()
+    }
+
+    return {
+      layer_tree_rate: Math.round(changes / Math.max(0.001, (Date.now() - startedAt) / 1000)),
+      layer_tree_changes: changes
+    }
+  }
+}
+
+/** Stop listening to layer-tree churn once a scenario is done with it. */
+export async function endLayerSnapshot(cdp) {
+  try {
+    await cdp.send('LayerTree.disable')
+  } catch {
+    // Best effort: teardown must never mask a scenario's real failure.
+  }
+}

--- a/apps/desktop/scripts/perf/lib/compositing.test.mjs
+++ b/apps/desktop/scripts/perf/lib/compositing.test.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { CDP } from './cdp.mjs'
+import { aggregateTraceEvents, layerSnapshot, watchLayerTreeRate, withCompositingTrace } from './compositing.mjs'
+
+const complete = (name, durUs) => ({ name, ph: 'X', dur: durUs, ts: 0 })
+
+test('attributes a phase as a share of the trace window', () => {
+  // Synthetic durations exercise proportional aggregation, not measured performance.
+  const phases = aggregateTraceEvents([complete('Layerize', 6_871_000)], 15_000)
+
+  assert.equal(phases.Layerize.pct, 45.8)
+  assert.equal(phases.Layerize.ms, 6871)
+  assert.equal(phases.Layerize.n, 1)
+})
+
+test('sums repeated events and keeps the worst single pass', () => {
+  const phases = aggregateTraceEvents(
+    [complete('Layerize', 4000), complete('Layerize', 10_000), complete('Layerize', 6000)],
+    1000
+  )
+
+  assert.equal(phases.Layerize.n, 3)
+  assert.equal(phases.Layerize.ms, 20)
+  assert.equal(phases.Layerize.max_ms, 10)
+})
+
+test('reports every tracked phase, including ones the trace never emitted', () => {
+  // A scenario that never painted must still publish paint_pct: 0, otherwise
+  // the baseline gate sees a missing key instead of a real zero.
+  const phases = aggregateTraceEvents([complete('Layerize', 1000)], 1000)
+
+  assert.equal(phases.Paint.pct, 0)
+  assert.equal(phases.Paint.n, 0)
+  assert.equal(phases.Commit.ms, 0)
+})
+
+test('ignores instant and async events that carry no duration', () => {
+  // Begin/End pairs and instant marks share the stream; counting them as
+  // complete events would inflate every phase.
+  const phases = aggregateTraceEvents(
+    [
+      { name: 'Layerize', ph: 'B', ts: 0 },
+      { name: 'Layerize', ph: 'E', ts: 5000 },
+      { name: 'Layerize', ph: 'I', ts: 1 },
+      complete('Layerize', 2000)
+    ],
+    1000
+  )
+
+  assert.equal(phases.Layerize.n, 1)
+  assert.equal(phases.Layerize.ms, 2)
+})
+
+test('survives a zero-length window without dividing by zero', () => {
+  const phases = aggregateTraceEvents([complete('Layerize', 1000)], 0)
+
+  assert.ok(Number.isFinite(phases.Layerize.pct))
+})
+
+test('ignores untracked phases so the metric set stays stable', () => {
+  const phases = aggregateTraceEvents([complete('SomeFutureBlinkPhase', 9_000_000)], 1000)
+
+  assert.equal(phases.Layerize.ms, 0)
+  assert.equal(Object.hasOwn(phases, 'SomeFutureBlinkPhase'), false)
+})
+
+function fakeCdp() {
+  const listeners = new Map()
+  const removed = []
+
+  return {
+    listeners,
+    removed,
+    on(method, handler) {
+      const handlers = listeners.get(method) ?? []
+      handlers.push(handler)
+      listeners.set(method, handlers)
+
+      return () => {
+        removed.push(method)
+        listeners.set(method, (listeners.get(method) ?? []).filter(candidate => candidate !== handler))
+      }
+    },
+    async send(method) {
+      if (method === 'Tracing.end') {
+        for (const handler of listeners.get('Tracing.tracingComplete') ?? []) {
+          handler()
+        }
+      }
+
+      return {}
+    }
+  }
+}
+
+test('cleans compositing CDP listeners after each scoped measurement', async () => {
+  const cdp = fakeCdp()
+
+  for (let i = 0; i < 2; i++) {
+    await withCompositingTrace(cdp, async () => undefined)
+    await layerSnapshot(cdp, { settleMs: 0 })
+    const stop = watchLayerTreeRate(cdp)
+    stop()
+  }
+
+  assert.deepEqual(cdp.removed.sort(), [
+    'LayerTree.layerTreeDidChange',
+    'LayerTree.layerTreeDidChange',
+    'LayerTree.layerTreeDidChange',
+    'LayerTree.layerTreeDidChange',
+    'Tracing.dataCollected',
+    'Tracing.dataCollected',
+    'Tracing.tracingComplete',
+    'Tracing.tracingComplete'
+  ])
+  assert.equal(cdp.listeners.get('Tracing.dataCollected').length, 0)
+  assert.equal(cdp.listeners.get('Tracing.tracingComplete').length, 0)
+  assert.equal(cdp.listeners.get('LayerTree.layerTreeDidChange').length, 0)
+})
+
+test('cleans trace listeners when the measured scenario rejects', async () => {
+  const cdp = fakeCdp()
+
+  await assert.rejects(
+    withCompositingTrace(cdp, async () => {
+      throw new Error('scenario failed')
+    }),
+    /scenario failed/
+  )
+
+  assert.equal(cdp.listeners.get('Tracing.dataCollected').length, 0)
+  assert.equal(cdp.listeners.get('Tracing.tracingComplete').length, 0)
+})
+
+test('CDP subscriptions return idempotent unsubscribe functions', () => {
+  const cdp = { listeners: new Map() }
+  const handler = () => undefined
+  const unsubscribe = CDP.prototype.on.call(cdp, 'Tracing.dataCollected', handler)
+
+  assert.equal(cdp.listeners.get('Tracing.dataCollected').length, 1)
+  unsubscribe()
+  unsubscribe()
+
+  assert.equal(cdp.listeners.has('Tracing.dataCollected'), false)
+})
+
+test('repeated unsubscribe preserves a duplicate callback registration', () => {
+  const cdp = new CDP(null)
+  const handler = () => undefined
+  const first = cdp.on('Tracing.dataCollected', handler)
+  const second = cdp.on('Tracing.dataCollected', handler)
+
+  first()
+  first()
+  assert.deepEqual(cdp.listeners.get('Tracing.dataCollected'), [handler])
+  second()
+  second()
+  assert.equal(cdp.listeners.has('Tracing.dataCollected'), false)
+})

--- a/apps/desktop/scripts/perf/scenarios/multitab.mjs
+++ b/apps/desktop/scripts/perf/scenarios/multitab.mjs
@@ -20,9 +20,11 @@
 // flush performs — via the __HERMES_SESSION_TILES__ hook.
 //
 //   node scripts/perf/run.mjs multitab --spawn [--tiles 5] [--tokens 240]
+//   node scripts/perf/run.mjs multitab --spawn --tiles 5 --busy 16   # many agents working
 //   node scripts/perf/run.mjs multitab --spawn --tiles 16 --zones 4 --sessions 300
 
 import { sleep } from '../lib/cdp.mjs'
+import { endLayerSnapshot, layerSnapshot, watchLayerTreeRate, withCompositingTrace } from '../lib/compositing.mjs'
 import { frameHistogram, percentile } from '../lib/stats.mjs'
 
 // Same recorder pattern as stream.mjs (generation-guarded rAF + longtasks).
@@ -71,7 +73,7 @@ const COLLECT = `
  *  (wiring cache + in-flight journal + publish + view sync). Driving
  *  `hook.publish` alone under-models a stream: it skips the journal and the
  *  cache, which is exactly where multi-session cost used to hide. */
-const setup = (tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dead, tools) => `
+const setup = (tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dead, tools, busy) => `
   (() => {
     const hook = window.__HERMES_SESSION_TILES__
     if (!hook) return 'no-hook'
@@ -140,7 +142,7 @@ const setup = (tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dea
     // A populated recents list (--sessions): every store publish re-runs the
     // busy/attention/draft projections against it, so an empty list hides
     // that scaling. Restored by CLEANUP.
-    if (${seedSessions} > 0) {
+    if (${seedSessions} > 0 || ${busy} > 0) {
       window.__MT_SAVED_SESSIONS__ = hook.sessions()
       const rows = []
       for (let i = 0; i < ${seedSessions}; i++) {
@@ -151,7 +153,39 @@ const setup = (tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dea
           model: 'hermes-4', preview: 'seeded row', cwd: '/tmp/proj-' + (i % 7)
         })
       }
+      // --busy: sidebar rows in a RUNNING state. Each one renders an
+      // .arc-border ring, and a running ring is an active transform animation
+      // -> its own compositing layer, plus every row it overlaps (the Overlap
+      // promotion reason). This is the axis the scenario was missing: tiles
+      // model what is on screen, --busy models how many agents are working,
+      // and the second number is what a real multi-agent session looks like.
+      for (let i = 0; i < ${busy}; i++) {
+        rows.push({
+          id: 'perf-busy-' + i, title: 'Working session ' + i, ended_at: null,
+          input_tokens: 5200, output_tokens: 900, is_active: false,
+          last_active: Date.now() - i * 1000, message_count: 40,
+          model: 'hermes-4', preview: 'working', cwd: '/tmp/busy-' + i
+        })
+      }
       hook.seedSessions(rows)
+      window.__MT_BUSY__ = []
+      for (let i = 0; i < ${busy}; i++) {
+        const sid = 'perf-busy-' + i
+        const rid = 'perf-busy-rt-' + i
+        window.__MT_BUSY__.push(rid)
+        hook.publish(rid, {
+          storedSessionId: sid,
+          messages: [
+            { id: sid + '-u', role: 'user', timestamp: Date.now(), parts: [{ type: 'text', text: 'Review this diff.' }] },
+            { id: sid + '-a', role: 'assistant', timestamp: Date.now(), pending: true, parts: [{ type: 'text', text: 'Working.' }] }
+          ],
+          branch: '', cwd: '', model: '', provider: '', reasoningEffort: '', serviceTier: '',
+          fast: false, yolo: false, personality: '', busy: true, awaitingResponse: false,
+          streamId: sid + '-stream', sawAssistantPayload: true, pendingBranchGroup: null,
+          interrupted: false, interimBoundaryPending: false, needsInput: false,
+          turnStartedAt: Date.now(), usage: null
+        })
+      }
     }
 
     // Leaked residue (--dead): sessions that ran with no surface referencing
@@ -283,6 +317,13 @@ const CLEANUP = `
       }
       window.__MT__ = null
     }
+    if (window.__MT_BUSY__) {
+      for (const rid of window.__MT_BUSY__) {
+        hook.update(rid, prev => ({ ...prev, busy: false, streamId: null }))
+        hook.drop?.(rid)
+      }
+      window.__MT_BUSY__ = null
+    }
     if (window.__MT_SAVED_SESSIONS__) {
       hook.seedSessions(window.__MT_SAVED_SESSIONS__)
       window.__MT_SAVED_SESSIONS__ = null
@@ -302,6 +343,10 @@ export default {
     const seedSessions = Number(opts.sessions ?? 0)
     const streaming = Math.min(Number(opts.streaming ?? tiles), tiles)
     const dead = Number(opts.dead ?? 0)
+    // --busy N: sidebar rows in a running state (animated rings), independent
+    // of how many tiles are on screen. Defaults to `streaming` so the scenario
+    // models the sidebar a real working session shows.
+    const busy = Number(opts.busy ?? streaming)
     // --tools: seeded turns carry settled tool rounds and the live stream
     // opens/completes tool calls between text — an agent working, not talking.
     const tools = Boolean(opts.tools)
@@ -319,7 +364,7 @@ export default {
 
     await cdp.send('Runtime.enable')
 
-    const ok = await cdp.eval(setup(tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dead, tools))
+    const ok = await cdp.eval(setup(tiles, seedTurns, streamSeed, zones, seedSessions, streaming, dead, tools, busy))
 
     if (ok !== 'ok') {
       throw new Error(`multitab setup failed (${ok}) — dev hooks missing? (needs a dev/probe renderer)`)
@@ -357,11 +402,28 @@ export default {
     }
 
     await sleep(1000)
-    await cdp.eval(RECORDERS)
-    await cdp.eval(drive(chunk, intervalMs, tokens, tools))
-    await sleep(tokens * intervalMs + 1500)
 
+    // Layer-tree shape BEFORE the stream: promotion is a property of what is
+    // mounted, so this is the honest count. Taken first because enabling the
+    // LayerTree domain mid-trace would attribute its own churn to the run.
+    const layers = await layerSnapshot(cdp)
+
+    await cdp.eval(RECORDERS)
+
+    // Tree churn is counted across the STREAM, not the settle above.
+    const stopTreeRate = watchLayerTreeRate(cdp)
+
+    // Everything the compositor does during the stream. Layerize is main-thread
+    // work between paint and commit: it competes with keystrokes, and no other
+    // metric in this harness can see it.
+    const { compositing } = await withCompositingTrace(cdp, async () => {
+      await cdp.eval(drive(chunk, intervalMs, tokens, tools))
+      await sleep(tokens * intervalMs + 1500)
+    })
+
+    const treeChurn = stopTreeRate()
     const data = JSON.parse(await cdp.eval(COLLECT))
+    await endLayerSnapshot(cdp)
     await cdp.eval(CLEANUP)
 
     // Drop the first 500ms (recorder install + settle).
@@ -404,7 +466,11 @@ export default {
         frame_p95_ms: Math.round(percentile(frames, 0.95) * 10) / 10,
         frame_p99_ms: Math.round(percentile(frames, 0.99) * 10) / 10,
         slow_frames_33: frames.filter(f => f > 33).length,
-        reveal_max_ms: Math.round(Math.max(...revealMs) * 10) / 10
+        reveal_max_ms: Math.round(Math.max(...revealMs) * 10) / 10,
+        layerize_pct: compositing.layerize_pct,
+        layer_count: layers.layer_count,
+        layer_area_mp: layers.layer_area_mp,
+        layer_tree_rate: treeChurn.layer_tree_rate
       },
       detail: {
         tiles,
@@ -414,7 +480,10 @@ export default {
         sessions: seedSessions,
         tools,
         turns: seedTurns,
+        busy,
         code: Boolean(opts.code),
+        compositing,
+        compositingReasons: layers.reasons,
         windowS: Math.round(windowS * 10) / 10,
         avgFps: Math.round(avgFps * 10) / 10,
         worstSecondFps: Math.round(worstFps * 10) / 10,

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -9,13 +9,16 @@ import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
 import type * as SessionStore from '@/store/session'
-import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $stalledSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
 
 import { SidebarSessionRow } from './session-row'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  $stalledSessionIds.set([])
+})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -178,6 +181,7 @@ const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
 // the wiring rather than the predicate — the arc has gone missing before.
 describe('SidebarSessionRow running arc', () => {
   afterEach(() => {
+    cleanup()
     clearAllSessionStates()
   })
 
@@ -195,6 +199,74 @@ describe('SidebarSessionRow running arc', () => {
     const { container } = renderRow(makeSession({ title: 'Running' }))
 
     expect(arc(container)).toBeTruthy()
+  })
+
+  it('keeps the visible running ring animated for three stalled working rows', () => {
+    for (let i = 0; i < 3; i++) {
+      publishSessionState(`rt${i}`, { ...createClientSessionState(`s${i}`), busy: true })
+    }
+
+    $stalledSessionIds.set(['s0', 's1', 's2'])
+
+    const { container } = render(
+      <>
+        {[0, 1, 2].map(i => (
+          <SidebarSessionRow
+            isPinned={false}
+            isSelected={false}
+            key={i}
+            onArchive={noop}
+            onDelete={noop}
+            onPin={noop}
+            onResume={noop}
+            onToggleUnread={noop}
+            session={makeSession({ id: `s${i}`, title: `Stalled ${i}` })}
+            unread={false}
+          />
+        ))}
+      </>
+    )
+
+    const arcs = container.querySelectorAll<HTMLElement>('.arc-row')
+    expect(arcs).toHaveLength(3)
+
+    for (const ring of arcs) {
+      expect(ring.classList.contains('arc-still')).toBe(false)
+      expect(ring.getAttribute('aria-hidden')).toBe('true')
+    }
+  })
+
+  it('keeps every running ring and makes all five still above the cap', () => {
+    for (let i = 0; i < 5; i++) {
+      publishSessionState(`rt${i}`, { ...createClientSessionState(`s${i}`), busy: true })
+    }
+
+    const { container } = render(
+      <>
+        {[0, 1, 2, 3, 4].map(i => (
+          <SidebarSessionRow
+            isPinned={false}
+            isSelected={false}
+            key={i}
+            onArchive={noop}
+            onDelete={noop}
+            onPin={noop}
+            onResume={noop}
+            onToggleUnread={noop}
+            session={makeSession({ id: `s${i}`, title: `Working ${i}` })}
+            unread={false}
+          />
+        ))}
+      </>
+    )
+
+    const arcs = container.querySelectorAll<HTMLElement>('.arc-row')
+    expect(arcs).toHaveLength(5)
+
+    for (const ring of arcs) {
+      expect(ring.classList.contains('arc-still')).toBe(true)
+      expect(ring.getAttribute('aria-hidden')).toBe('true')
+    }
   })
 
   // The row owns its status subscription so a turn starting repaints that row

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -28,7 +28,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
-import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $runningArcsAnimated, $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
 import { $openStoredSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
@@ -163,6 +163,9 @@ function SidebarSessionRowImpl({
   // rather than threaded as props: the subscription re-renders past the memo
   // below, and a toggle should repaint every row at once anyway.
   const rowMeta = useStore($sidebarRowMeta)
+  // Capped so a sidebar full of working agents cannot grow the compositing
+  // layer tree without bound (see MAX_ANIMATED_RUNNING_ARCS).
+  const arcsAnimated = useStore($runningArcsAnimated)
   // Pinned metadata occupies the actions slot and swaps out for the kebab on
   // hover, so the row reserves the same width either way and never reflows.
   const pinnedAge = rowMeta.includes('updated')
@@ -402,7 +405,9 @@ function SidebarSessionRowImpl({
         style={style}
         {...rest}
       >
-        {showsRunningArc(dotState) && <span aria-hidden="true" className="arc-border arc-row" />}
+        {showsRunningArc(dotState) && (
+          <span aria-hidden="true" className={cn('arc-border arc-row', !arcsAnimated && 'arc-still')} />
+        )}
         <SidebarRowBody
           // Every trailing figure lives in the actions slot, which the row
           // measures — so the title needs a gap from it and nothing else. Hover

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -15,13 +15,15 @@ import {
 } from './session'
 import {
   $delegatingSessionIds,
+  $runningArcsAnimated,
   $sessionDotStateById,
   $unreadSessionCount,
   hasLiveTurn,
+  MAX_ANIMATED_RUNNING_ARCS,
   showsRunningArc,
   unreadSessionCount
 } from './session-dot-state'
-import { clearAllSessionStates, publishSessionState } from './session-states'
+import { clearAllSessionStates, publishSessionState, setSessionStalled } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 
@@ -238,5 +240,76 @@ describe('$unreadSessionCount (titlebar badge)', () => {
 
     expect($unreadSessionCount.get()).toBe(0)
     expect($sessionDotStateById.get()['cron-1']).not.toBe('unread')
+  })
+})
+
+describe('$runningArcsAnimated', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+  })
+
+  const runRows = (n: number) => {
+    setSessions(Array.from({ length: n }, (_, i) => storedRow(`run-${i}`)))
+
+    for (let i = 0; i < n; i++) {
+      publishSessionState(`rt-${i}`, { ...createClientSessionState(`run-${i}`), busy: true })
+    }
+  }
+
+  it('animates while only a few rows are running', () => {
+    runRows(MAX_ANIMATED_RUNNING_ARCS)
+
+    expect($runningArcsAnimated.get()).toBe(true)
+  })
+
+  it('does not count stalled working rows twice toward the animation cap', () => {
+    runRows(MAX_ANIMATED_RUNNING_ARCS - 1)
+
+    for (let i = 0; i < MAX_ANIMATED_RUNNING_ARCS - 1; i++) {
+      setSessionStalled(`run-${i}`, true)
+    }
+
+    expect($runningArcsAnimated.get()).toBe(true)
+
+    for (let i = 0; i < MAX_ANIMATED_RUNNING_ARCS - 1; i++) {
+      expect($sessionDotStateById.get()[`run-${i}`]).toBe('stalled')
+      expect(showsRunningArc($sessionDotStateById.get()[`run-${i}`]!)).toBe(true)
+    }
+  })
+
+  it('goes still once more rows run than the cap allows without disabling their running state', () => {
+    // The cost this guards is not the running cue itself but the animation's
+    // compositing layers (and their overlap promotion). Every row remains a
+    // working session with its ring; only the ring motion is withdrawn.
+    runRows(MAX_ANIMATED_RUNNING_ARCS + 1)
+
+    expect($runningArcsAnimated.get()).toBe(false)
+
+    for (let i = 0; i <= MAX_ANIMATED_RUNNING_ARCS; i++) {
+      expect($sessionDotStateById.get()[`run-${i}`]).toBe('working')
+      expect(showsRunningArc($sessionDotStateById.get()[`run-${i}`]!)).toBe(true)
+    }
+  })
+
+  it('animates again once the extra turns finish', () => {
+    runRows(MAX_ANIMATED_RUNNING_ARCS + 4)
+    expect($runningArcsAnimated.get()).toBe(false)
+
+    clearAllSessionStates()
+    runRows(2)
+
+    expect($runningArcsAnimated.get()).toBe(true)
+  })
+
+  it('animates when nothing is running at all', () => {
+    runRows(0)
+
+    expect($runningArcsAnimated.get()).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -74,6 +74,19 @@ export type SessionDotState = 'background' | 'draft' | 'idle' | 'needs-input' | 
  *  louder cue and two treatments at once fight each other. */
 export const showsRunningArc = (state: SessionDotState): boolean => state === 'stalled' || state === 'working'
 
+/** Product limit for simultaneous running-ring motion, not a benchmark result.
+ *  The ring remains visible for every running row. Above the limit all rings
+ *  become still together, preserving state cues without selecting by row order. */
+export const MAX_ANIMATED_RUNNING_ARCS = 4
+
+/** False once more rows are running than `MAX_ANIMATED_RUNNING_ARCS`. All rings
+ *  then go still together — never a subset, which would make the sidebar's
+ *  motion depend on list order and flicker as rows re-sort. */
+export const $runningArcsAnimated = computed(
+  [$workingSessionIds, $stalledSessionIds],
+  (working, stalled) => new Set([...working, ...stalled]).size <= MAX_ANIMATED_RUNNING_ARCS
+)
+
 /** Whether this turn is the session's own, live: brighter title, and the row's
  *  age yields to the actions menu. Wider than the arc — a turn waiting on an
  *  answer has not ended. */

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -55,6 +55,12 @@
   animation-play-state: paused !important;
 }
 
+/* Withdraw the transform optimization hint while renderer animations are paused.
+   This does not promise a particular compositor layer count or speedup. */
+:root[data-renderer-animations-paused] .arc-border::before {
+  will-change: auto !important;
+}
+
 /* Sidebar sections: tall viewports give each its own scroller; compact ones
    (this variant) flatten everything into one shared scroll. See ChatSidebar. */
 @custom-variant compact (@media (max-height: 768px));
@@ -1057,6 +1063,13 @@
     linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+}
+
+/* Keep the running-state ring visible above MAX_ANIMATED_RUNNING_ARCS, but
+   disable its motion and withdraw the transform optimization hint. */
+.arc-border.arc-still::before {
+  animation: none;
+  will-change: auto;
 }
 
 :root.dark .arc-border {

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -23,7 +23,7 @@ const electronNative: TestProjectConfiguration = {
     // `e2e/**/*.unit.test.ts` is the e2e HELPERS, not the specs: plain node
     // modules that should be provable without booting Electron. Playwright
     // ignores the same pattern so they run in exactly one runner.
-    include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}', 'e2e/**/*.unit.test.ts'],
+    include: ['electron/**/*.test.ts', 'scripts/**/*.test.{ts,mjs}', 'scripts/*.test.{ts,mjs}', 'e2e/**/*.unit.test.ts'],
     // These use node:test and have dedicated npm scripts, not Vitest suites.
     exclude: ['scripts/run-short-session-hang-repro.test.mjs', 'scripts/tasks-scroll.test.mjs']
   }


### PR DESCRIPTION
## Behavior
- Bound sidebar working-ring animation using the union of working and stalled session IDs; overlap does not double-count rows.
- Preserve visible working rings and accessibility treatment when over-cap rings become static.
- Remove scoped CDP listeners on success and failure, with idempotent unsubscribe behavior even for duplicate callback registration.
- Add compositing measurement helpers and fixture discovery without asserting measured hardware performance.

## Validation
- Focused UI/store/row tests: **39 passed**.
- Compositing helper fixtures: **10 passed**.
- Typecheck, changed-file ESLint and staged diff check passed; exact ten-file candidate received independent final review.
- The broad UI suite is **not claimed green**: bounded candidate and clean-base runs timed out, and isolated replay reproduced the same four failures with 114 passes on both. These are outside this delta.
- **No live Electron/GPU benchmark was completed. No measured performance improvement is claimed.** Fixture tests demonstrate logic, not real compositor performance.

## Publication
Updated fork revision: `730c9a493bbb0a8aab4d59558ce28ed3a93bd1f5`, one reviewed commit on upstream base `91adf584a4783d600e8f358a4f32ad95e7e0cdde`. Hosted CI must be evaluated for this exact revision; previous checks do not validate it. No installation or runtime change is included.
