### PR TITLE
fix(gateway): allowlist session attachment staging dir in @file: ref expansion

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Sequence
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
@@ -215,7 +215,7 @@ def preprocess_context_references(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: str | Path | None = None,
+    allowed_root: str | Path | Sequence[str | Path] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -242,7 +242,7 @@ async def preprocess_context_references_async(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: str | Path | None = None,
+    allowed_root: str | Path | Sequence[str | Path] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -250,10 +250,10 @@ async def preprocess_context_references_async(
 
     cwd_path = Path(cwd).expanduser().resolve()
     # Default to the current working directory so @ references cannot escape
-    # the active workspace unless a caller explicitly widens the root.
-    allowed_root_path = (
-        Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
-    )
+    # the active workspace unless a caller explicitly widens the root. A
+    # sequence widens the boundary to several roots at once (e.g. the
+    # gateway's workspace plus the session's attachment staging dir, #98634).
+    allowed_roots = _normalize_allowed_roots(allowed_root) or (cwd_path,)
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
@@ -270,7 +270,7 @@ async def preprocess_context_references_async(
                 ref,
                 cwd_path,
                 url_fetcher=url_fetcher,
-                allowed_root=allowed_root_path,
+                allowed_root=allowed_roots,
             )
             for ref in refs
         )
@@ -330,7 +330,7 @@ async def _expand_reference(
     cwd: Path,
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: Path | None = None,
+    allowed_root: tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
@@ -369,7 +369,7 @@ def _expand_file_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_root: tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     _ensure_reference_path_allowed(path)
@@ -403,7 +403,7 @@ def _expand_folder_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_root: tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     _ensure_reference_path_allowed(path)
@@ -468,16 +468,32 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
+def _normalize_allowed_roots(
+    allowed_root: str | Path | Sequence[str | Path] | None,
+) -> tuple[Path, ...] | None:
+    """Coerce a single allowed root or a sequence of them into resolved paths.
+
+    A sequence never *narrows* the boundary — each entry widens it, and a
+    resolved path under ANY root passes (see ``_resolve_path``).
+    """
+    if allowed_root is None:
+        return None
+    if isinstance(allowed_root, (str, Path)):
+        allowed_root = (allowed_root,)
+    return tuple(Path(root).expanduser().resolve() for root in allowed_root)
+
+
+def _resolve_path(
+    cwd: Path, target: str, *, allowed_root: tuple[Path, ...] | None = None
+) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
     resolved = path.resolve()
-    if allowed_root is not None:
-        try:
-            resolved.relative_to(allowed_root)
-        except ValueError as exc:
-            raise ValueError("path is outside the allowed workspace") from exc
+    if allowed_root is not None and not any(
+        resolved.is_relative_to(root) for root in allowed_root
+    ):
+        raise ValueError("path is outside the allowed workspace")
     return resolved
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -281,6 +281,77 @@ async def test_canonical_guard_fails_closed_when_lookup_raises(tmp_path: Path, m
     )
 
 
+@pytest.mark.asyncio
+async def test_allowed_root_sequence_widens_boundary_to_each_root(tmp_path: Path):
+    """A sequence of allowed roots admits a path under ANY of them — and only
+    under them. The gateway needs this to let file.attach refs (staged into the
+    profile attachments/ dir, outside the workspace) expand without throwing
+    the workspace boundary open entirely (#98634).
+    """
+    from agent.context_references import preprocess_context_references_async
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    staged = uploads / "staged.txt"
+    staged.write_text("STAGED-CONTENT\n", encoding="utf-8")
+    secret = elsewhere / "secret.txt"
+    secret.write_text("ELSEWHERE-CONTENT\n", encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"read @file:{staged} and @file:{secret}",
+        cwd=workspace,
+        allowed_root=(workspace, uploads),
+        context_length=100_000,
+    )
+
+    # The secondary root's file inlines instead of being refused...
+    assert "STAGED-CONTENT" in result.message
+    # ...a path under neither root is still refused, with the body kept out.
+    assert "ELSEWHERE-CONTENT" not in result.message
+    assert any("outside the allowed workspace" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_allowed_root_sequence_still_applies_credential_denylist(
+    tmp_path: Path, monkeypatch
+):
+    """Widening the allowed roots must NOT widen the credential deny-list: a
+    staged-attachment root that happens to contain a credential store (hermes
+    home placed under it) still refuses to inline the secret (#98634).
+    """
+    from agent.context_references import preprocess_context_references_async
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    uploads = tmp_path / "uploads"
+    hermes_home = uploads / ".hermes"
+    hermes_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(uploads))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"openai": "sk-STAGED-ROOT-SECRET"}\n', encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"inspect @file:{auth_json}",
+        cwd=workspace,
+        allowed_root=(workspace, uploads),
+        context_length=100_000,
+    )
+
+    assert "sk-STAGED-ROOT-SECRET" not in result.message
+    assert any(
+        "credential deny-list" in warning or "sensitive credential" in warning
+        for warning in result.warnings
+    )
+
+
 @pytest.mark.parametrize(
     "value",
     [

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10617,6 +10617,71 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     assert captured["prompt"] == "expanded prompt"
 
 
+def test_prompt_submit_expands_staged_attachment_refs(tmp_path, monkeypatch):
+    """file.attach stages uploads into the profile home's attachments/ dir,
+    outside the session workspace, and returns absolute @file: refs. The
+    submit-path expansion must allowlist that staging dir so the gateway's own
+    refs inline instead of being refused (#98634) — while the workspace
+    boundary itself keeps refusing unrelated outside paths.
+    """
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "home"
+    attachments = profile_home / "attachments"
+    attachments.mkdir(parents=True)
+    (attachments / "probe.txt").write_text("STAGED-ATTACHMENT-BODY\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("OUTSIDE-BODY\n", encoding="utf-8")
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(), cwd=str(workspace), profile_home=str(profile_home)
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    try:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": f"see @file:{attachments / 'probe.txt'} and @file:{outside}",
+                },
+            }
+        )
+
+        # The staged attachment inlines; the unrelated outside path does not.
+        assert "STAGED-ATTACHMENT-BODY" in captured["prompt"]
+        assert "OUTSIDE-BODY" not in captured["prompt"]
+        assert "outside the allowed workspace" in captured["prompt"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_image_attach_appends_local_image(monkeypatch):
     fake_cli = types.ModuleType("cli")
     fake_cli._IMAGE_EXTENSIONS = {".png"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12728,10 +12728,26 @@ def _run_prompt_submit(
                         agent, "_config_context_length", None
                     ),
                 )
+                # Allowlist the workspace plus the session's attachment staging
+                # dir: file.attach stages uploads into the profile home's
+                # attachments/ dir — deliberately OUTSIDE the workspace so
+                # container bind mounts can see them (#76577) — and hands back
+                # absolute @file: refs. Without the staging dir in the allowed
+                # roots, the expansion would refuse the gateway's own refs and
+                # staged uploads would never inline (#98634). That dir holds
+                # only files uploaded through the authenticated file.attach
+                # RPC; the credential deny-list in _ensure_reference_path_allowed
+                # still applies on top of it.
+                allowed_roots: list[str | Path] = [cwd]
+                try:
+                    allowed_roots.append(_desktop_attachment_dir(session))
+                except Exception:
+                    # Staging-dir resolution must never break the submit itself.
+                    pass
                 ctx = preprocess_context_references(
                     prompt,
                     cwd=cwd,
-                    allowed_root=cwd,
+                    allowed_root=allowed_roots,
                     context_length=ctx_len,
                 )
                 if ctx.blocked:


### PR DESCRIPTION
## What does this PR do?

`file.attach` stages uploaded files into the profile home's `attachments/` dir — deliberately **outside** the session workspace so container bind mounts can see them (#76577) — and hands back absolute `@file:` refs for the client to include in the prompt. But `_run_prompt_submit` expands refs with a single `allowed_root` (the session cwd), so `_resolve_path` refused the gateway's own refs (`path is outside the allowed workspace`): staged attachments never inlined (`📄`/`📎` blocks) and every such prompt was persisted with a `--- Context Warnings ---` block.

This follows the allowlist direction from the issue: `preprocess_context_references(_async)` now accepts a **sequence** of allowed roots (a resolved path under ANY root passes; a single root value keeps working; `None`/empty still defaults to the cwd boundary), and `_run_prompt_submit` passes `(cwd, _desktop_attachment_dir(session))`. The staging dir holds only files uploaded through the authenticated `file.attach` RPC, so this does not widen what untrusted message text can reach, and the credential deny-list in `_ensure_reference_path_allowed` still runs on the resolved path. Staging-dir resolution is wrapped so a failure there can never break the submit itself.

## Related Issue

Fixes #98634

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_references.py` — `allowed_root` now accepts a single root or a sequence; new `_normalize_allowed_roots` helper; `_resolve_path` accepts a path under any of the allowed roots (same refusal message otherwise). Internal signatures thread `tuple[Path, ...]`.
- `tui_gateway/server.py` — `_run_prompt_submit` passes `[cwd, _desktop_attachment_dir(session)]` as the allowed roots, with a guard so staging-dir resolution failures degrade to the previous single-root behavior.
- `tests/agent/test_context_references.py` — regression tests: a secondary root's file inlines while a path under neither root is still refused; the credential deny-list still fires for sensitive files inside an allowed secondary root.
- `tests/test_tui_gateway_server.py` — end-to-end wiring test: a `prompt.submit` with a staged-attachment `@file:` ref inlines the file body, while an unrelated outside path is still refused.

## How to Test

1. `python -m pytest tests/agent/test_context_references.py -q` — 15 passed (includes the two new multi-root regressions).
2. `python -m pytest tests/test_tui_gateway_server.py -q` — 620 passed (includes the new staged-attachment submit test).
3. `python -m pytest tests/agent/test_context_refs_concurrent.py tests/agent/test_plugin_context_references.py tests/cli/test_cli_codex_context_reference.py tests/gateway/test_context_ref_expansion_runtime.py tests/tools/test_send_message_tool.py -q` — 83 passed.
4. Manual reproduction per the issue (observed on the fix): `session.create` → `file.attach` with a `data_url` → `prompt.submit` with the returned `ref_text`; the persisted user row now contains `--- Attached Context ---` with the inline block instead of the `path is outside the allowed workspace` warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A