### PR TITLE
fix(desktop): sync right sidebar file tree to focused session tile

### DIFF
--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -25,7 +25,7 @@ import { getLogs } from '@/hermes'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { openPreview } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $focusedWorkspaceCwd } from '@/store/session-states'
 
 // ---------------------------------------------------------------------------
 // Logs — live agent-log tail. ⌘K-only chrome: the pane contribution exists
@@ -71,7 +71,7 @@ export const $restartPreviewServer = atom<((url: string, context?: string) => Pr
 
 /** Open a file from the tree in the real preview pipeline. */
 function previewFile(path: string) {
-  void normalizeOrLocalPreviewTarget(path, $currentCwd.get() || undefined)
+  void normalizeOrLocalPreviewTarget(path, $focusedWorkspaceCwd.get() || undefined)
     .then(target => {
       if (target) {
         openPreview(target, 'file-browser')
@@ -98,7 +98,7 @@ export function FilesPane() {
 // ---------------------------------------------------------------------------
 
 export function ReviewPaneContent() {
-  const cwd = useStore($currentCwd)
+  const cwd = useStore($focusedWorkspaceCwd)
 
   // Keyed by cwd like DesktopController so switching projects rebuilds the
   // diff state instead of showing the previous repo's files.

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -11,9 +11,13 @@ import { resetProjectTreeState } from './files/use-project-tree'
 import { RightSidebarPane } from './index'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+const repoStatus = vi.fn<(cwd: string) => Promise<null>>()
 
 function installBridge() {
-  ;(window as unknown as { hermesDesktop: { readDir: typeof readDir } }).hermesDesktop = { readDir }
+  ;(window as unknown as { hermesDesktop: { git: { repoStatus: typeof repoStatus }; readDir: typeof readDir } }).hermesDesktop = {
+    git: { repoStatus },
+    readDir
+  }
 }
 
 describe('RightSidebarPane', () => {
@@ -24,6 +28,8 @@ describe('RightSidebarPane', () => {
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
+    repoStatus.mockReset()
+    repoStatus.mockResolvedValue(null)
     installBridge()
   })
 
@@ -95,8 +101,12 @@ describe('RightSidebarPane', () => {
 
     const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
     readDir.mockClear()
+    repoStatus.mockClear()
     fireEvent.click(refresh)
-    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-tile'))
+    await waitFor(() => {
+      expect(readDir).toHaveBeenCalledWith('/repo-tile')
+      expect(repoStatus).toHaveBeenCalledWith('/repo-tile')
+    })
   })
 
   it('keeps the focused tile workspace cwd even when clicking into the sidebar group', async () => {
@@ -123,7 +133,11 @@ describe('RightSidebarPane', () => {
 
     const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
     readDir.mockClear()
+    repoStatus.mockClear()
     fireEvent.click(refresh)
-    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-tile'))
+    await waitFor(() => {
+      expect(readDir).toHaveBeenCalledWith('/repo-tile')
+      expect(repoStatus).toHaveBeenCalledWith('/repo-tile')
+    })
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -98,4 +98,32 @@ describe('RightSidebarPane', () => {
     fireEvent.click(refresh)
     await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-tile'))
   })
+
+  it('keeps the focused tile workspace cwd even when clicking into the sidebar group', async () => {
+    $selectedStoredSessionId.set('main-session')
+    $workspaceCwdOwner.set('main-session')
+    setCurrentCwd('/repo-main')
+
+    $sessions.set([
+      { cwd: '/repo-tile', id: 'tile-session' } as any
+    ])
+    $sessionTiles.set([
+      { storedSessionId: 'tile-session', runtimeId: 'rt-tile', workspaceMode: 'sessions' } as any
+    ])
+    $layoutTree.set({
+      id: 'grp-main',
+      type: 'group',
+      panes: ['workspace', 'session-tile:tile-session'],
+      active: 'session-tile:tile-session'
+    } as any)
+    // User clicks into the files sidebar group:
+    $activeTreeGroup.set('grp-files')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
+    readDir.mockClear()
+    fireEvent.click(refresh)
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-tile'))
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -2,7 +2,9 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd } from '@/store/session'
+import { $activeTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
+import { $connection, $selectedStoredSessionId, $sessions, $workspaceCwdOwner, setCurrentCwd } from '@/store/session'
+import { $sessionStates, $sessionTiles } from '@/store/session-states'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -68,5 +70,32 @@ describe('RightSidebarPane', () => {
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('reads the focused tile workspace cwd when a tile tab is focused', async () => {
+    $selectedStoredSessionId.set('main-session')
+    $workspaceCwdOwner.set('main-session')
+    setCurrentCwd('/repo-main')
+
+    $sessions.set([
+      { cwd: '/repo-tile', id: 'tile-session' } as any
+    ])
+    $sessionTiles.set([
+      { storedSessionId: 'tile-session', runtimeId: 'rt-tile', workspaceMode: 'sessions' } as any
+    ])
+    $layoutTree.set({
+      id: 'grp-1',
+      type: 'group',
+      panes: ['session-tile:tile-session'],
+      active: 'session-tile:tile-session'
+    } as any)
+    $activeTreeGroup.set('grp-1')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
+    readDir.mockClear()
+    fireEvent.click(refresh)
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-tile'))
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import type { ComponentProps } from 'react'
+import { type ComponentProps, useCallback, useEffect } from 'react'
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { ErrorBoundary } from '@/components/error-boundary'
@@ -10,6 +10,7 @@ import { useDelayedTrue } from '@/hooks/use-delayed-true'
 import { useI18n } from '@/i18n'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
+import { refreshRepoStatus, registerRepoStatusCwd } from '@/store/coding-status'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
@@ -44,6 +45,25 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     rootLoading,
     setNodeOpen
   } = useProjectTree(hasWorkspace ? targetCwd : '')
+
+  useEffect(() => {
+    const activeCwd = effectiveCwd || (hasWorkspace ? targetCwd : '')
+
+    if (!activeCwd) {
+      return
+    }
+
+    return registerRepoStatusCwd(activeCwd)
+  }, [effectiveCwd, hasWorkspace, targetCwd])
+
+  const handleRefresh = useCallback(() => {
+    void refreshRoot()
+    const activeCwd = effectiveCwd || (hasWorkspace ? targetCwd : '')
+
+    if (activeCwd) {
+      void refreshRepoStatus(activeCwd)
+    }
+  }, [effectiveCwd, hasWorkspace, refreshRoot, targetCwd])
 
   const cwdName =
     effectiveCwd
@@ -92,7 +112,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         onLoadChildren={loadChildren}
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
-        onRefresh={() => void refreshRoot()}
+        onRefresh={handleRefresh}
         openState={openState}
       />
     </aside>

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,8 +13,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $sessions, $workspaceCwdOwner, sessionMatchesStoredId } from '@/store/session'
-import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
+import { $focusedWorkspaceCwd } from '@/store/session-states'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -30,29 +29,8 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
-  const currentCwd = useStore($currentCwd).trim()
-  const selectedStoredSessionId = useStore($selectedStoredSessionId)
-  const workspaceCwdOwner = useStore($workspaceCwdOwner)
-  const focusedStoredSessionId = useStore($focusedStoredSessionId)
-  const focusedSessionState = useStore($focusedSessionState)
-  const sessions = useStore($sessions)
-
-  // When a tile tab is focused, use the focused tile's workspace cwd;
-  // otherwise fall back to the primary session's cwd.
-  const isTileFocused = Boolean(focusedStoredSessionId && focusedStoredSessionId !== selectedStoredSessionId)
-  const tileCwd =
-    isTileFocused && focusedStoredSessionId
-      ? (
-          focusedSessionState?.cwd ||
-          sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))?.cwd ||
-          ''
-        ).trim()
-      : ''
-
-  const targetCwd = isTileFocused ? tileCwd : currentCwd
-  const hasWorkspace = isTileFocused
-    ? Boolean(tileCwd)
-    : Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  const targetCwd = useStore($focusedWorkspaceCwd)
+  const hasWorkspace = Boolean(targetCwd)
 
   const {
     collapseAll,

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,7 +13,8 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+import { $currentCwd, $selectedStoredSessionId, $sessions, $workspaceCwdOwner, sessionMatchesStoredId } from '@/store/session'
+import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -32,11 +33,26 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const currentCwd = useStore($currentCwd).trim()
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const workspaceCwdOwner = useStore($workspaceCwdOwner)
+  const focusedStoredSessionId = useStore($focusedStoredSessionId)
+  const focusedSessionState = useStore($focusedSessionState)
+  const sessions = useStore($sessions)
 
-  // A transition intentionally retains the old CWD until the new session
-  // confirms its workspace. Do not issue a filesystem read against that path:
-  // under a gateway switch it may belong to a different remote machine.
-  const hasWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  // When a tile tab is focused, use the focused tile's workspace cwd;
+  // otherwise fall back to the primary session's cwd.
+  const isTileFocused = Boolean(focusedStoredSessionId && focusedStoredSessionId !== selectedStoredSessionId)
+  const tileCwd =
+    isTileFocused && focusedStoredSessionId
+      ? (
+          focusedSessionState?.cwd ||
+          sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))?.cwd ||
+          ''
+        ).trim()
+      : ''
+
+  const targetCwd = isTileFocused ? tileCwd : currentCwd
+  const hasWorkspace = isTileFocused
+    ? Boolean(tileCwd)
+    : Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
 
   const {
     collapseAll,
@@ -49,7 +65,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(hasWorkspace ? currentCwd : '')
+  } = useProjectTree(hasWorkspace ? targetCwd : '')
 
   const cwdName =
     effectiveCwd

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -284,4 +284,35 @@ describe('repoChangeKindForPath', () => {
 
     unsubscribe()
   })
+
+  it('maps changes across multiple probed CWDs independently of active session ownership', () => {
+    $repoStatusByCwd.set({
+      '/repo-a': {
+        ...sampleStatus,
+        files: [{ path: 'src/file1.ts', untracked: false, conflicted: false } as HermesRepoStatus['files'][number]]
+      },
+      '/repo-b': {
+        ...otherStatus,
+        files: [{ path: 'src/file2.ts', untracked: true, conflicted: false } as HermesRepoStatus['files'][number]]
+      }
+    })
+
+    expect(repoChangeKindForPath('/repo-a/src/file1.ts').get()).toBe('modified')
+    expect(repoChangeKindForPath('/repo-b/src/file2.ts').get()).toBe('added')
+    expect(repoChangeKindForPath('/repo-a/src/clean.ts').get()).toBeUndefined()
+  })
+
+  it('inherits added kind for nested files inside untracked directories', () => {
+    $repoStatusByCwd.set({
+      '/repo': {
+        ...sampleStatus,
+        files: [{ path: 'brand_new_dir', untracked: true, conflicted: false } as HermesRepoStatus['files'][number]]
+      }
+    })
+
+    expect(repoChangeKindForPath('/repo/brand_new_dir').get()).toBe('added')
+    expect(repoChangeKindForPath('/repo/brand_new_dir/nested.ts').get()).toBe('added')
+    expect(repoChangeKindForPath('/repo/brand_new_dir/deep/nested/sub.ts').get()).toBe('added')
+    expect(repoChangeKindForPath('/repo/other_dir/file.ts').get()).toBeUndefined()
+  })
 })

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -139,20 +139,24 @@ export function repoWorktreesForCwd(cwd?: null | string): ReadableAtom<HermesGit
 export type RepoChangeKind = 'added' | 'conflicted' | 'modified'
 
 // Absolute file path → its git change kind, for VS Code-style file-tree tinting.
-// Reuses the same bounded $repoStatus probe (capped file list); git reports
-// repo-root-relative paths, so we join them onto the active cwd. Deletions never
-// appear — the file is gone from disk, so there's no tree row to tint.
-export const $repoChangeByPath = computed([$repoStatus, $currentCwd], (status, cwd) => {
+// Reuses the bounded per-CWD repo-status probes (capped file list); git reports
+// repo-root-relative paths, so we join them onto their corresponding probed cwd.
+// Deletions never appear — the file is gone from disk, so there's no tree row to tint.
+export const $repoChangeByPath = computed([$repoStatusByCwd], byCwd => {
   const map = new Map<string, RepoChangeKind>()
-  const root = (cwd || '').replace(/[/\\]+$/, '')
 
-  if (!status || !root) {
-    return map
-  }
+  for (const [cwd, status] of Object.entries(byCwd)) {
+    const root = (cwd || '').trim().replace(/[/\\]+$/, '')
 
-  for (const file of status.files) {
-    const kind: RepoChangeKind = file.conflicted ? 'conflicted' : file.untracked ? 'added' : 'modified'
-    map.set(`${root}/${file.path}`, kind)
+    if (!status || !root) {
+      continue
+    }
+
+    for (const file of status.files) {
+      const cleanPath = (file.path || '').replace(/^[/\\]+/, '')
+      const kind: RepoChangeKind = file.conflicted ? 'conflicted' : file.untracked ? 'added' : 'modified'
+      map.set(`${root}/${cleanPath}`, kind)
+    }
   }
 
   return map
@@ -161,9 +165,36 @@ export const $repoChangeByPath = computed([$repoStatus, $currentCwd], (status, c
 /**
  * Per-row Git decoration subscription. A visible file row reads one scalar, so
  * a fresh repo-status map only re-renders that row when its own kind changed.
+ * Supports directory inheritance for untracked folders under `--untracked-files=normal`.
  */
 export function repoChangeKindForPath(path: string): ReadableAtom<RepoChangeKind | undefined> {
-  return computed($repoChangeByPath, changes => changes.get(path))
+  return computed($repoChangeByPath, changes => {
+    const direct = changes.get(path)
+
+    if (direct) {
+      return direct
+    }
+
+    // Check if an ancestor directory is marked 'added' (untracked directory).
+    let parent = path.replace(/[/\\]+$/, '')
+
+    while (true) {
+      const lastSlash = Math.max(parent.lastIndexOf('/'), parent.lastIndexOf('\\'))
+
+      if (lastSlash <= 0) {
+        break
+      }
+
+      parent = parent.slice(0, lastSlash)
+      const parentKind = changes.get(parent)
+
+      if (parentKind === 'added') {
+        return 'added'
+      }
+    }
+
+    return undefined
+  })
 }
 
 // Cwds whose rails are on screen right now (refcounted — two tiles in one

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -11,7 +11,7 @@ import {
   workspaceScopeKey
 } from '@/components/pane-shell/workspace-scope'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
+import { $activeSessionId, $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd, setSessions } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
@@ -965,6 +965,24 @@ describe('$focusedStoredSessionId in Bot Mode (#96062)', () => {
 
     expect($focusedStoredSessionId.get()).toBe('stacked')
     expect($focusedWorkspaceCwd.get()).toBe('/repo-stacked')
+  })
+
+  it('falls back to sessions list cwd for primary session when workspaceCwdOwner is mismatched', () => {
+    $selectedStoredSessionId.set('primary-1')
+    $workspaceCwdOwner.set('other-session-from-different-project')
+    setCurrentCwd('/repo-other')
+    setSessions([{ cwd: '/repo-primary-project', id: 'primary-1' } as any])
+    $sessionTiles.set([])
+    $sessionStates.set({})
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'grp-main' })
+      ])
+    )
+    noteActiveTreeGroup('grp-main')
+
+    expect($focusedStoredSessionId.get()).toBe('primary-1')
+    expect($focusedWorkspaceCwd.get()).toBe('/repo-primary-project')
   })
 })
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -17,6 +17,7 @@ import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
 import {
   $focusedStoredSessionId,
+  $focusedWorkspaceCwd,
   $sessionStates,
   $sessionTiles,
   blankDraftTile,
@@ -931,7 +932,7 @@ describe('$focusedStoredSessionId in Bot Mode (#96062)', () => {
     expect($focusedStoredSessionId.get()).toBeNull()
   })
 
-  it('sessions mode keeps collapsing to the primary selection (derivation gated to Bot Mode)', () => {
+  it('sessions mode retains the active main-zone tile when the tracker sits on side chrome', () => {
     $selectedStoredSessionId.set('primary-1')
     $layoutTree.set(
       split('row', [
@@ -941,10 +942,29 @@ describe('$focusedStoredSessionId in Bot Mode (#96062)', () => {
     )
     noteActiveTreeGroup('grp-sessions')
 
-    // The main-zone tile must NOT answer here: in sessions mode the sidebar
-    // highlight follows the primary selection exactly as it always has.
     expect($workspaceMode.get()).toBe('sessions')
-    expect($focusedStoredSessionId.get()).toBe('primary-1')
+    expect($focusedStoredSessionId.get()).toBe('stacked')
+  })
+
+  it('computes $focusedWorkspaceCwd from the focused tile session state or sessions list', () => {
+    $selectedStoredSessionId.set('primary-1')
+    setSessions([{ cwd: '/repo-stacked', id: 'stacked' } as any])
+    $sessionTiles.set([
+      { storedSessionId: 'stacked', runtimeId: 'rt-stacked', workspaceMode: 'sessions' } as any
+    ])
+    $sessionStates.set({
+      'rt-stacked': { cwd: '/repo-stacked' } as any
+    })
+    $layoutTree.set(
+      split('row', [
+        group(['files'], { active: 'files', id: 'grp-files' }),
+        group(['workspace', tilePane('stacked')], { active: tilePane('stacked'), id: 'grp-main' })
+      ])
+    )
+    noteActiveTreeGroup('grp-files')
+
+    expect($focusedStoredSessionId.get()).toBe('stacked')
+    expect($focusedWorkspaceCwd.get()).toBe('/repo-stacked')
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1863,7 +1863,7 @@ export const $focusedSessionState = computed([$focusedRuntimeId, $sessionStates]
 )
 
 /** The workspace CWD of the currently focused session (the focused tile's cwd,
- *  else the primary session's confirmed workspace cwd). */
+ *  else the primary session's confirmed workspace cwd, with fallback to historical session cwd). */
 export const $focusedWorkspaceCwd = computed(
   [
     $focusedStoredSessionId,
@@ -1888,7 +1888,23 @@ export const $focusedWorkspaceCwd = computed(
 
     const hasPrimaryWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredId ?? null)
 
-    return hasPrimaryWorkspace ? currentCwd.trim() : ''
+    if (hasPrimaryWorkspace) {
+      return currentCwd.trim()
+    }
+
+    if (selectedStoredId) {
+      const fallbackCwd = (
+        focusedSessionState?.cwd ||
+        sessions.find(s => sessionMatchesStoredId(s, selectedStoredId))?.cwd ||
+        ''
+      ).trim()
+
+      if (fallbackCwd) {
+        return fallbackCwd
+      }
+    }
+
+    return ''
   }
 )
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -40,9 +40,11 @@ import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait
 import {
   $activeSessionId,
   $connection,
+  $currentCwd,
   $lastReadAtBySessionId,
   $selectedStoredSessionId,
   $sessions,
+  $workspaceCwdOwner,
   clearReadBaseline,
   getSessionOwnerHint,
   knownSessionOwner,
@@ -1817,20 +1819,11 @@ export const $focusedStoredSessionId = computed(
       return active.slice(TILE_PANE_PREFIX.length)
     }
 
-    // The interaction tracker can point at sidebar CHROME while a chat still
-    // holds the main zone's active tab — clicking a Bots-pane roster row moves
-    // it to the sidebar group, whose active pane ('hermes-bots:pane') is not a
-    // session tile. In sessions mode the primary selection answers, exactly as
-    // always. In Bot Mode that fallback alone publishes a NULL "focused"
-    // edge: bot chats open as TILES and never set $selectedStoredSessionId,
-    // so the selection is null while the chat is plainly on screen. The Bots
-    // plugin reads that null edge as "the chat lost the center", releases its
-    // open claim, and re-asserts the Bots home over the still-visible chat —
-    // the reported "clicking a bot chat jumps to the list" (#96062). Bot
-    // Mode's on-screen truth is the main zone's active TILE; only when the
-    // main zone holds no tile (chat closed) does the selection answer, so a
-    // genuine close still lets the home return.
-    if (workspaceMode === 'bots' && tree) {
+    // The interaction tracker can point at sidebar or tool CHROME (files,
+    // terminal, sessions list, bots roster) while a chat still holds the main
+    // zone's active tab. In both sessions and Bot Mode, the main zone's active
+    // tile answers so clicks in side chrome do not drop the on-screen session.
+    if (tree) {
       const mainActive = findGroupOfPane(tree, 'workspace')?.active
 
       if (mainActive?.startsWith(TILE_PANE_PREFIX)) {
@@ -1867,6 +1860,36 @@ export const $focusedRuntimeId = computed(
 /** The focused session's state slice (undefined while unresolved/unbound). */
 export const $focusedSessionState = computed([$focusedRuntimeId, $sessionStates], (runtimeId, states) =>
   runtimeId ? states[runtimeId] : undefined
+)
+
+/** The workspace CWD of the currently focused session (the focused tile's cwd,
+ *  else the primary session's confirmed workspace cwd). */
+export const $focusedWorkspaceCwd = computed(
+  [
+    $focusedStoredSessionId,
+    $selectedStoredSessionId,
+    $focusedSessionState,
+    $sessions,
+    $currentCwd,
+    $workspaceCwdOwner
+  ],
+  (focusedStoredId, selectedStoredId, focusedSessionState, sessions: readonly SessionInfo[], currentCwd, workspaceCwdOwner) => {
+    const isTile = Boolean(focusedStoredId && focusedStoredId !== selectedStoredId)
+
+    if (isTile && focusedStoredId) {
+      const tileCwd = (
+        focusedSessionState?.cwd ||
+        sessions.find(s => sessionMatchesStoredId(s, focusedStoredId))?.cwd ||
+        ''
+      ).trim()
+
+      return tileCwd
+    }
+
+    const hasPrimaryWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredId ?? null)
+
+    return hasPrimaryWorkspace ? currentCwd.trim() : ''
+  }
 )
 
 /** A PRIMARY navigation (sidebar resume, route change, new chat) homes focus to


### PR DESCRIPTION
## Summary
The right sidebar file browser (`RightSidebarPane`) and its Git status decorations now immediately update and synchronize when focusing or switching between open session tabs/tiles in the desktop app. Previously, clicking an open session tile retained the primary session's working directory (`$selectedStoredSessionId`), primary workspace switches could temporarily display an empty workspace before ownership caught up, and Git change tints would drop or desync across sessions and refreshes.

### Root Cause
1. **Workspace CWD Disconnect & Switch Lag:** When multi-tab session tiles were introduced, focus tracking atoms (`$focusedStoredSessionId`, `$focusedRuntimeId`) were added, but `RightSidebarPane` was left reading only the primary session's `$selectedStoredSessionId` and `$currentCwd`. Furthermore, for primary sessions, `$focusedWorkspaceCwd` required strict `workspaceCwdOwner === selectedStoredId` without fallback, causing false "No project open" states when switching between multiple project tabs.
2. **Git Change Decoration Drop:** `$repoChangeByPath` was bound solely to `$currentCwd` and single-session `$repoStatus`. When switching sessions, focusing tiles, or using detached chats, ownership mismatches resulted in `null` repo status, stripping all green (added) and yellow (modified) decorations from visible files. Furthermore, `RightSidebarPane` was not registered in `registerRepoStatusCwd`, and the manual refresh button did not re-probe Git status.

---

## Changes

### 1. Unified Workspace CWD & Historical Session Fallback
- `apps/desktop/src/store/session-states.ts`:
  - Expose unified `$focusedWorkspaceCwd` with fallback to `$focusedSessionState?.cwd` and historical `$sessions` list for both tiles and primary sessions, eliminating transient empty workspace states during tab switches.
  - Ensure `$focusedStoredSessionId` preserves focus on sidebar clicks.
- `apps/desktop/src/app/right-sidebar/index.tsx`: Connect `RightSidebarPane` to `$focusedWorkspaceCwd` for instant, flicker-free file tree updates across tiles.
- `apps/desktop/src/app/contrib/panes.tsx`: Route file previews and review pane content to the focused workspace CWD.

### 2. Multi-CWD Git Decorations & Untracked Inheritance
- `apps/desktop/src/store/coding-status.ts`:
  - Bind `$repoChangeByPath` to `$repoStatusByCwd` across all probed CWDs so file decorations persist independently of single-session ownership.
  - Add hierarchical directory inheritance in `repoChangeKindForPath` so nested files inside untracked directories (reported compactly under `--untracked-files=normal`) correctly inherit the `added` (green) tint.
- `apps/desktop/src/app/right-sidebar/index.tsx`:
  - Register active sidebar CWD via `registerRepoStatusCwd` to receive live Git status refreshes (file mutations, turn settle, window focus).
  - Trigger `refreshRepoStatus(activeCwd)` alongside `refreshRoot()` on the sidebar refresh button.

---

## Validation

| Scenario | Before (origin/main) | After |
|---|---|---|
| Open project A in main, open project B in tile, click tab B | Right sidebar retains Project A files | Right sidebar immediately switches to Project B files |
| Multiple tabs with same/different projects | Occasional transient "No project open" on primary | Instant, persistent workspace resolution via session fallback |
| Focus detached / home session tile | Retained previous project files | Correctly switches to home workspace |
| File change tints (added/modified) across session switches | Tints dropped / cleared on navigation | Tints persist and update per worktree |
| Nested files inside newly created untracked folders | Unstyled / regular text | Correctly styled with `added` (green) tint |
| Manual sidebar refresh button (🔄) | File list reloaded, Git decorations stale | Both file tree and Git repo status refreshed |

### Test Suite
- `tsc -b tsconfig.json` passes cleanly (0 errors).
- `vitest run src/store/session-states.test.ts src/store/coding-status.test.ts src/app/right-sidebar/index.test.tsx src/app/right-sidebar/files/use-project-tree.test.ts` (115/115 tests pass).