### PR TITLE
fix(context): allow staged file.attach refs to expand inline

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -216,6 +216,7 @@ def preprocess_context_references(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    extra_allowed_roots: tuple[str | Path, ...] | list[str | Path] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -223,6 +224,7 @@ def preprocess_context_references(
         context_length=context_length,
         url_fetcher=url_fetcher,
         allowed_root=allowed_root,
+        extra_allowed_roots=extra_allowed_roots,
     )
     # Safe for both CLI (no loop) and gateway (loop already running).
     try:
@@ -243,6 +245,7 @@ async def preprocess_context_references_async(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    extra_allowed_roots: tuple[str | Path, ...] | list[str | Path] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -253,6 +256,9 @@ async def preprocess_context_references_async(
     # the active workspace unless a caller explicitly widens the root.
     allowed_root_path = (
         Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
+    )
+    extra_allowed_root_paths = tuple(
+        Path(root).expanduser().resolve() for root in (extra_allowed_roots or ())
     )
     warnings: list[str] = []
     blocks: list[str] = []
@@ -271,6 +277,7 @@ async def preprocess_context_references_async(
                 cwd_path,
                 url_fetcher=url_fetcher,
                 allowed_root=allowed_root_path,
+                extra_allowed_roots=extra_allowed_root_paths,
             )
             for ref in refs
         )
@@ -331,12 +338,17 @@ async def _expand_reference(
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: Path | None = None,
+    extra_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_file_reference(
+                ref, cwd, allowed_root=allowed_root, extra_allowed_roots=extra_allowed_roots
+            )
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_folder_reference(
+                ref, cwd, allowed_root=allowed_root, extra_allowed_roots=extra_allowed_roots
+            )
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
@@ -370,8 +382,11 @@ def _expand_file_reference(
     cwd: Path,
     *,
     allowed_root: Path | None = None,
+    extra_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(
+        cwd, ref.target, allowed_root=allowed_root, extra_allowed_roots=extra_allowed_roots
+    )
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: file not found", None
@@ -404,8 +419,11 @@ def _expand_folder_reference(
     cwd: Path,
     *,
     allowed_root: Path | None = None,
+    extra_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(
+        cwd, ref.target, allowed_root=allowed_root, extra_allowed_roots=extra_allowed_roots
+    )
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: folder not found", None
@@ -468,16 +486,31 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
+def _resolve_path(
+    cwd: Path,
+    target: str,
+    *,
+    allowed_root: Path | None = None,
+    extra_allowed_roots: tuple[Path, ...] = (),
+) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
     resolved = path.resolve()
     if allowed_root is not None:
-        try:
-            resolved.relative_to(allowed_root)
-        except ValueError as exc:
-            raise ValueError("path is outside the allowed workspace") from exc
+        # The primary workspace root plus explicitly-widened extra roots (the
+        # session's staged-attachment dir, whose files arrive only through the
+        # authenticated file.attach RPC). Anything resolving under one of them
+        # is allowed; the credential deny-list in _ensure_reference_path_allowed
+        # still runs on the resolved path afterwards.
+        for root in (allowed_root, *extra_allowed_roots):
+            try:
+                resolved.relative_to(root)
+                break
+            except ValueError:
+                continue
+        else:
+            raise ValueError("path is outside the allowed workspace")
     return resolved
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -301,3 +301,84 @@ def test_format_reference_value_round_trips_through_the_parser(value):
 
     assert match is not None
     assert match.group("value").strip("`\"'") == value
+
+
+@pytest.mark.asyncio
+async def test_extra_allowed_root_lets_outside_file_expand(tmp_path: Path):
+    """A staged attachment outside the cwd expands when its dir is passed as
+    an extra allowed root — the file.attach staging dir is never inside the
+    session workspace, so without the extra root every staged @file: ref died
+    with "path is outside the allowed workspace"."""
+    from agent.context_references import preprocess_context_references_async
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    staging = tmp_path / "attachments"
+    staging.mkdir()
+    (staging / "notes.txt").write_text("staged content\n", encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"look at @file:{staging / 'notes.txt'}",
+        cwd=workspace,
+        allowed_root=workspace,
+        extra_allowed_roots=(staging,),
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "staged content" in result.message
+    assert not any("outside the allowed workspace" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_extra_allowed_root_not_granted_without_explicit_param(tmp_path: Path):
+    """The same outside-workspace ref must still be refused when the caller
+    does not widen the roots — the extra root is opt-in, not ambient."""
+    from agent.context_references import preprocess_context_references_async
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    staging = tmp_path / "attachments"
+    staging.mkdir()
+    (staging / "notes.txt").write_text("staged content\n", encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"look at @file:{staging / 'notes.txt'}",
+        cwd=workspace,
+        allowed_root=workspace,
+        context_length=100_000,
+    )
+
+    assert "staged content" not in result.message
+    assert any("outside the allowed workspace" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_extra_allowed_root_keeps_credential_deny_list(tmp_path: Path, monkeypatch):
+    """Widening the root widens WHERE files can live, not WHAT they can be:
+    a secret-bearing file staged inside the extra root must still be refused
+    by the credential deny-list."""
+    from agent.context_references import preprocess_context_references_async
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    staging = tmp_path / "attachments"
+    staging.mkdir()
+    (staging / ".env").write_text("API_KEY=SECRET\n", encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"look at @file:{staging / '.env'}",
+        cwd=workspace,
+        allowed_root=workspace,
+        extra_allowed_roots=(staging,),
+        context_length=100_000,
+    )
+
+    assert "SECRET" not in result.message
+    assert any(
+        "sensitive credential" in warning or "cannot be attached" in warning
+        for warning in result.warnings
+    )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10587,13 +10587,16 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
 
     fake_ctx = types.ModuleType("agent.context_references")
     fake_ctx.preprocess_context_references = (
-        lambda message, **kwargs: types.SimpleNamespace(
-            blocked=False,
-            message="expanded prompt",
-            warnings=[],
-            references=[],
-            injected_tokens=0,
-        )
+        lambda message, **kwargs: (
+            captured.update(kwargs),
+            types.SimpleNamespace(
+                blocked=False,
+                message="expanded prompt",
+                warnings=[],
+                references=[],
+                injected_tokens=0,
+            ),
+        )[1]
     )
     fake_meta = types.ModuleType("agent.model_metadata")
     fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
@@ -10615,6 +10618,67 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     )
 
     assert captured["prompt"] == "expanded prompt"
+
+def test_prompt_submit_passes_attachment_staging_dir_as_extra_allowed_root(monkeypatch, tmp_path):
+    """file.attach stages uploads into the profile home's attachments/ dir,
+    which is never inside the session cwd — prompt expansion must widen its
+    allowed roots with that dir or every staged @file: ref is refused."""
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    fake_ctx = types.ModuleType("agent.context_references")
+    fake_ctx.preprocess_context_references = (
+        lambda message, **kwargs: (
+            captured.update(kwargs),
+            types.SimpleNamespace(
+                blocked=False,
+                message="expanded prompt",
+                warnings=[],
+                references=[],
+                injected_tokens=0,
+            ),
+        )[1]
+    )
+    fake_meta = types.ModuleType("agent.model_metadata")
+    fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
+
+    profile_home = tmp_path / "profile-home"
+    server._sessions["sid"] = _session(agent=_Agent(), profile_home=str(profile_home))
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "@file:probe.txt"},
+        }
+    )
+
+    extra = captured.get("extra_allowed_roots") or ()
+    assert str(profile_home / "attachments") in [str(Path(p)) for p in extra]
 
 
 def test_image_attach_appends_local_image(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12732,6 +12732,9 @@ def _run_prompt_submit(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
+                    extra_allowed_roots=(
+                        str(_desktop_attachment_root(session)),
+                    ),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -13706,6 +13709,13 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
         return str(target.resolve())
 
 
+def _desktop_attachment_root(session: dict) -> Path:
+    """The session's file-attachment staging dir, without creating it."""
+    profile_home = session.get("profile_home")
+    base = Path(profile_home) if profile_home else _hermes_home
+    return base / "attachments"
+
+
 def _desktop_attachment_dir(session: dict) -> Path:
     """Resolve the file-attachment staging dir against the session's effective home.
 
@@ -13717,9 +13727,7 @@ def _desktop_attachment_dir(session: dict) -> Path:
     container can never see it (#76577). ``attachments/`` is registered in
     ``tools.credential_files._CACHE_DIRS`` and auto-mounted into containers.
     """
-    profile_home = session.get("profile_home")
-    base = Path(profile_home) if profile_home else _hermes_home
-    root = base / "attachments"
+    root = _desktop_attachment_root(session)
     root.mkdir(parents=True, exist_ok=True)
     return root
 


### PR DESCRIPTION
## What

`file.attach` stages uploads into the session profile's `attachments/` dir and hands back an absolute `@file:` ref — but `preprocess_context_references` was called with `allowed_root=cwd` only, so every staged attachment (i.e. every remote upload, the exact case the RPC exists for) died with `path is outside the allowed workspace`: no `📄` inline block, no `📎` binary pointer, just a `--- Context Warnings ---` block persisted into history.

## Root cause

Each piece was individually fine, composed they contradicted each other:

- `_stage_session_file_attachment` deliberately stages outside the workspace (bind-mount visibility, #76577), and `_attachment_ref_path` correctly returns an absolute ref for it;
- `_resolve_path` accepted exactly one allowed root, and all callers passed the session cwd.

## Fix

Opt-in widening, as suggested in the issue:

- `preprocess_context_references(_async)` and the file/folder expanders take `extra_allowed_roots`; `_resolve_path` now accepts a path under the primary root **or** any extra root;
- `_run_prompt_submit` passes the session's `_desktop_attachment_root` (its own staged-attachment dir — pure path computation, no `mkdir` on the submit path) as the extra root;
- the credential deny-list is unchanged and still runs on the resolved path afterwards: a secret-bearing file staged inside `attachments/` (e.g. `.env`) is still refused.

Only files that arrived through the authenticated `file.attach` RPC can live in that dir, so this doesn't widen what untrusted remote text can reach — the workspace boundary for arbitrary paths is intact (verified: an unrelated outside-workspace path is still refused).

## Testing

- 3 new unit tests in `tests/agent/test_context_references.py`: staged file expands with the extra root; the same ref is still refused without it; the credential deny-list still fires inside the extra root.
- New gateway test: `prompt.submit` now passes `extra_allowed_roots` containing the session's `attachments/` dir.
- Full local suites green: `test_context_references.py`, `test_context_refs_concurrent.py`, `test_plugin_context_references.py`, `test_context_ref_expansion_runtime.py` (34 passed), `test_tui_gateway_server.py -k "attach or context or prompt_submit"` (95 passed), including both `prompt.submit` context-expansion tests.
- End-to-end repro of the issue scenario (workspace cwd + staging dir under the profile home): before → `path is outside the allowed workspace`, no inline content; after → `📄` block with the file content, zero warnings; `attachments/.env` still refused by the deny-list; unrelated outside path still refused.

Fixes #98634