### PR TITLE
fix(desktop): attach err.statusCode in fetchJson so mint 401s classify as reauth

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -1342,3 +1342,25 @@ test('OAuth ticket-mint 401 stays on the reauth path (never Cloud-down)', () => 
   assert.equal((wrapped as any).needsOauthLogin, true)
   assert.equal((wrapped as any).statusCode, 401)
 })
+
+// Regression (#98647): fetchJson (electron/main.ts) attaches err.statusCode on
+// 4xx/5xx responses. Before that, a dead-session 401 from the WS-ticket mint
+// carried the code only in the message text; isGatewayAuthRejection read
+// Number(undefined) === NaN and every expired/revoked session was reported as
+// "Could not reach the remote Hermes gateway" (and retried by
+// withTransientRetries, hammering a session that cannot recover). This pins
+// the exact error shape fetchJson produces — message prefix AND structured
+// statusCode — so the fetch-layer → classifier contract cannot silently
+// regress again.
+test('ticket-mint 401 from fetchJson routes to reauth via structured statusCode (#98647)', () => {
+  const ticketErr = new Error(
+    '401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}'
+  ) as any
+  ticketErr.statusCode = 401
+
+  const wrapped = gatewayTicketFailure(ticketErr, 'auth message', 'transport message') as any
+
+  assert.equal(wrapped.message, 'auth message')
+  assert.equal(wrapped.needsOauthLogin, true)
+  assert.equal(wrapped.statusCode, 401)
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5052,7 +5052,13 @@ function fetchJson(url, token, options: any = {}) {
               const text = Buffer.concat(chunks).toString('utf8')
 
               if ((res.statusCode || 500) >= 400) {
-                reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+                // Downstream classification (isGatewayAuthRejection /
+                // isServerSideHttpError) reads err.statusCode, never the
+                // "401: ..." message prefix — same contract as
+                // fetchJsonViaOauthSession below.
+                const err = new Error(`${res.statusCode}: ${text || res.statusMessage}`) as any
+                err.statusCode = res.statusCode || 500
+                reject(err)
 
                 return
               }


### PR DESCRIPTION
## What does this PR do?

When a gated gateway rejects a WebSocket-ticket mint with 401 (expired, revoked, or wholesale-invalidated session), the desktop reported it as a *connectivity* failure — "Could not reach the remote Hermes gateway" — instead of the actionable "sign in again" branch, and `withTransientRetries` retried the dead session 3× before giving up.

Root cause: `fetchJson` (`apps/desktop/electron/main.ts`) formats the HTTP status into the reject **message** but never sets `err.statusCode`. Every downstream classifier reads the structured property: `isGatewayAuthRejection` (connection-config.ts) does `Number(error.statusCode)` → `NaN` → "not an auth rejection", and `isServerSideHttpError` / `makeNousCloudBackendDownError` have the same blind spot on this path for 502/503/504. The sibling `fetchJsonViaOauthSession` already sets the property (and its cookie-mode 401s classify correctly); the comments in both `backend-health.ts` and `connection-config.ts` document "the fetch layer attaches err.statusCode" as the contract — `fetchJson` just never fulfilled it.

The fix attaches the property at the fetch layer, where the status is already known. No call site changes: everything downstream already reads it. Verified `fetchPublicJson` (the other function with a bare `reject(new Error(...))`) was deliberately left alone — its consumers either degrade via `catch` using only `error.message` or classify via the legacy `/^40[13]:/` message prefix, so nothing downstream of it reads the property.

## Related Issue

Fixes #98647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — `fetchJson`'s 4xx/5xx branch now attaches `err.statusCode = res.statusCode || 500` to the rejected error (mirrors `fetchJsonViaOauthSession`), so 401/403 route to reauth and 502/503/504 reach the Cloud-down classifier.
- `apps/desktop/electron/connection-config.test.ts` — regression test pinning the exact error shape `fetchJson` produces (message prefix + structured `statusCode`) through `gatewayTicketFailure`, asserting the auth branch and `needsOauthLogin: true`.

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/connection-config.test.ts`
   - Observed result: 116 passed, including the new `ticket-mint 401 from fetchJson routes to reauth via structured statusCode (#98647)`.
2. `cd apps/desktop && npx vitest run --project electron`
   - Observed result: 1959 passed; the single failure (`electron/managed-ssh-update.test.ts`, exit 127) reproduces on a clean `upstream/main` checkout with this change stashed — pre-existing, unrelated.
3. `npx tsc --noEmit -p tsconfig.electron.json` — passes.
4. Behavioral check (from the issue): with a stored native session invalidated by a gateway restart, the WS-ticket mint now rejects with a 401 carrying `statusCode: 401` → `gatewayTicketFailure` selects the auth message ("Reached the gateway over HTTP, but the OAuth session was rejected… Open Settings → Gateway and sign in again") and sets `needsOauthLogin: true`, so the renderer surfaces the re-auth prompt instead of the unreachable-gateway message, and `withTransientRetries` fails fast instead of hammering the dead session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (change is desktop-TS only; the equivalent suite `vitest run --project electron` passes except one pre-existing failure unrelated to this change, reproduced on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64, Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (code comment added at the fixed branch documenting the classifier contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Node fetch layer, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — behavior verified via unit tests (see How to Test).
