### PR TITLE
feat(email): configurable outbound subject prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -421,6 +421,9 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # EMAIL_ALLOWED_USERS=your@email.com
 # EMAIL_HOME_ADDRESS=your@email.com
 
+# Prefix for outbound email subjects when no thread context exists (default: "Hermes Agent")
+# EMAIL_SUBJECT_PREFIX=Hermes Agent
+
 # Gateway-wide: allow ALL users without an allowlist (default: false = deny)
 # Only set to true if you intentionally want open access.
 # GATEWAY_ALLOW_ALL_USERS=false

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -605,6 +605,12 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
+        # Outbound subject prefix: distinguishes Hermes mail in busy inboxes and
+        # keeps spam filters from reading a generic "Hermes Agent" as bot traffic.
+        self._subject_prefix = (
+            _get_secret("EMAIL_SUBJECT_PREFIX", "") or "Hermes Agent"
+        ).strip() or "Hermes Agent"
+
         logger.info("[Email] Adapter initialized for %s", self._address)
 
     def _trim_seen_uids(self) -> None:
@@ -1170,7 +1176,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", self._subject_prefix)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1284,7 +1290,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", self._subject_prefix)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1364,7 +1370,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", self._subject_prefix)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1458,7 +1464,7 @@ async def _standalone_send(
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        msg["Subject"] = self._subject_prefix
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)


### PR DESCRIPTION
## Summary

Outbound Hermes mail today carries the hardcoded `"Hermes Agent"` / `"Re: Hermes Agent"` subject on every path, which reads as generic bot traffic to both inboxes and spam filters, and makes cron-job notifications indistinguishable from each other (#98649).

This adds `EMAIL_SUBJECT_PREFIX` (default `"Hermes Agent"`, so zero behavior change unless configured): the adapter resolves it once at init and consumes it at all five outbound subject sites — the three reply paths (`_send_email` and its thread-context siblings), the fresh-subject send path, and the standalone module-level sender. Thread replies keep their existing `Re: <thread subject>` behavior: the prefix only substitutes the hardcoded fallback, never the remembered thread subject.

Follows the same env-first pattern as `EMAIL_ADDRESS` / `EMAIL_SMTP_HOST` / the merged `EMAIL_DEFAULT_SUBJECT` work, so operators set it the same way as every other email knob.

Fixes #98649