### PR TITLE
fix(desktop): let reconnected clarify cards reach their owner

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -100,6 +100,25 @@ describe('clarify.request stream hydration', () => {
     expect(scrollToBottom).not.toHaveBeenCalled()
   })
 
+  it('captures the exact gateway source that delivered the request', () => {
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: 'conn-owner',
+        payload: { choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-scoped' },
+        profile: 'owner-profile',
+        session_id: SID,
+        type: 'clarify.request'
+      })
+    )
+
+    expect($clarifyRequests.get()[SID]).toMatchObject({
+      owner: { connectionId: 'conn-owner', profile: 'owner-profile' },
+      requestId: 'req-scoped'
+    })
+  })
+
   it('preserves multi-select through the store and hydrated tool row', () => {
     mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -13,6 +13,7 @@ import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import type { SessionOwnerScope } from '@/store/session-request-router'
 import { requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
@@ -23,6 +24,10 @@ import type { GatewayEventContext } from './types'
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
   const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+
+  const requestOwner: SessionOwnerScope = event.connectionId
+    ? { connectionId: event.connectionId, profile: event.profile?.trim() || 'default' }
+    : event.profile?.trim() || undefined
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -63,6 +68,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         choices: null,
         lockedAnswers,
         multiSelect: false,
+        owner: requestOwner,
         question: '',
         questions,
         receivedAt: Date.now() / 1000,
@@ -114,6 +120,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         question,
         choices: choices.length > 0 ? choices : null,
         multiSelect,
+        owner: requestOwner,
         receivedAt: Date.now() / 1000,
         sessionId: sessionId ?? null
       }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1128,7 +1128,8 @@ export function useSessionActions({
                 activated,
                 cachedRuntimeId,
                 activateStartedAt,
-                clarifyRequestIdAtActivateStart
+                clarifyRequestIdAtActivateStart,
+                sessionOwner
               )
 
               const pendingClarify = pendingClarifyState.request
@@ -1666,7 +1667,13 @@ export function useSessionActions({
         // the row, or a topology change made the owner resolvable again).
         clearStoredTranscriptReadOnly(storedSessionId)
         const pendingApproval = restorePendingApproval(resumed, resumed.session_id)
-        const pendingClarifyState = restorePendingClarifyFromSnapshot(resumed, resumed.session_id, resumeStartedAt)
+        const pendingClarifyState = restorePendingClarifyFromSnapshot(
+          resumed,
+          resumed.session_id,
+          resumeStartedAt,
+          undefined,
+          sessionOwner
+        )
         const pendingClarify = pendingClarifyState.request
 
         const clarifyAuthoritativelyAbsent =

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
@@ -60,6 +60,20 @@ describe('restorePendingClarifyFromSnapshot', () => {
     )
   })
 
+  it('preserves the routed resume owner on the restored request', () => {
+    const owner = { connectionId: 'conn-owner', profile: 'owner-profile' }
+
+    restorePendingClarifyFromSnapshot(
+      { pending_clarify: { question: 'Proceed?', request_id: 'rid-owner' } },
+      'sess-owner',
+      resumeStartedAt,
+      undefined,
+      owner
+    )
+
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(expect.objectContaining({ owner, requestId: 'rid-owner' }))
+  })
+
   it('carries server-locked answers into the replayed batch card', () => {
     restorePendingClarifyFromSnapshot(
       {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
@@ -7,6 +7,7 @@ import {
   normalizeQuestions,
   setClarifyRequest
 } from '@/store/clarify'
+import type { SessionOwnerScope } from '@/store/session-request-router'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 export interface PendingClarifyResumeState {
@@ -33,7 +34,8 @@ export function restorePendingClarifyFromSnapshot(
   response: Pick<SessionResumeResponse, 'pending_clarify'>,
   sessionId: string,
   resumeStartedAt: number,
-  requestIdAtStart?: string
+  requestIdAtStart?: string,
+  owner?: SessionOwnerScope
 ): PendingClarifyResumeState {
   const pending = response.pending_clarify
 
@@ -73,6 +75,7 @@ export function restorePendingClarifyFromSnapshot(
     choices: choices.length > 0 ? choices : null,
     lockedAnswers,
     multiSelect: pending.multi_select === true,
+    owner,
     question,
     receivedAt: Date.now() / 1000,
     requestId: pending.request_id,

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -788,6 +788,32 @@ describe('ClarifyTool owner routing', () => {
     expect(ambient).not.toHaveBeenCalled()
   })
 
+  it('keeps the request source route when reconnect cleanup loses the session owner hint', async () => {
+    $profiles.set([{ name: OWNER_PROFILE }, { name: 'profile-b' }] as never)
+    const ambient = vi.fn().mockResolvedValue({ ok: true })
+
+    $activeSessionId.set('session-a')
+    $gateway.set({ request: ambient } as never)
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      owner: { connectionId: OWNER_CONNECTION_ID, profile: OWNER_PROFILE },
+      question: 'Which deployment target?',
+      requestId: 'request-reconnected',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    })
+    expectOwnerCall(1, { answer: 'staging', request_id: 'request-reconnected' })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
   it('sends both sequential batch locks on the owner socket, in order', async () => {
     const ambient = armCrossProfileOwner()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -484,7 +484,10 @@ function ClarifyToolSinglePending({
           {
             request_id: matchingRequest.requestId,
             answer
-          }
+          },
+          undefined,
+          undefined,
+          matchingRequest.owner
         )
         triggerHaptic('submit')
         onAnswered()
@@ -1039,7 +1042,10 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
             answer: answer ?? '',
             question_id: question.qid,
             request_id: request.requestId
-          }
+          },
+          undefined,
+          undefined,
+          request.owner
         )
       }
 
@@ -1087,7 +1093,10 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
           request.sessionId,
           gateway.request.bind(gateway) as typeof gateway.request,
           'clarify.respond',
-          { answer: '', request_id: request.requestId }
+          { answer: '', request_id: request.requestId },
+          undefined,
+          undefined,
+          request.owner
         )
       }
     } catch {

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -2,6 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { $gateway } from './gateway'
 import { $activeSessionId } from './session'
+import type { SessionOwnerScope } from './session-request-router'
 
 export interface ClarifyQuestion {
   /** Server-generated wire id (q0..qN) — clarify.respond keys answers by it. */
@@ -19,6 +20,8 @@ export interface ClarifyRequest {
   /** Local receipt time (Unix seconds), used to reject stale resume cleanup. */
   receivedAt?: number
   sessionId: string | null
+  /** Exact gateway source that delivered this blocking request. */
+  owner?: SessionOwnerScope
   /** Batch (multi-question) clarify: present instead of question/choices. */
   questions?: ClarifyQuestion[]
   /** Answers already locked server-side (reconnect replay): qid → answer. */

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1028,9 +1028,14 @@ export function requestForOwnedSession<T>(
   method: string,
   params: Record<string, unknown> = {},
   timeoutMs?: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  capturedOwner?: SessionOwnerScope
 ): Promise<T> {
-  const owner = knownOwnerForSession(sessionId)
+  // A blocking-input request's source socket is the strongest possible owner
+  // evidence: that backend emitted the request and is waiting for the reply.
+  // Keep it ahead of mutable tile/hint/row state, which reconnect cleanup can
+  // legitimately retire while the rendered card remains answerable.
+  const owner = capturedOwner ?? knownOwnerForSession(sessionId)
 
   try {
     assertSessionOwnerResolved(owner, { method, sessionId })


### PR DESCRIPTION
## What does this PR do?

Clarify cards can remain visible across a gateway reconnect, but their session owner metadata can be retired before the user submits an answer. The card then fails closed with "Could not send clarify response" even though the gateway source that emitted the blocking request was known at receipt time.

### Symptom

Submitting a visible Desktop clarify form can show "Could not send clarify response" and leave the agent blocked.

### Impact

Affected reconnect and multi-profile sessions cannot answer the pending clarify request from the rendered card. The broader incidence is unknown.

### Bug Cause

**Trigger:** `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` / `requestForOwnedSession` after the request's session owner hint or row route has been retired.

**Causal chain:**
1. A gateway socket emits `clarify.request`, which proves that exact connection and profile owns the blocking request.
2. The renderer stored only the request and runtime session id, then resolved ownership again at submit time from mutable tile, hint, and row caches.
3. Reconnect cleanup could remove those caches while leaving the visible request card intact, so the fail-closed owner gate rejected `clarify.respond` and the Desktop surfaced the generic failure modal.

**Why it is wrong:** The response discarded stronger request-source evidence and depended on weaker mutable navigation metadata.

**Working sibling / contrast:** Clarify responses succeed while the session owner hint remains available because the existing owner lookup resolves the correct socket.

**Ruled out:** The server-side `clarify.respond` payload shape is unchanged; the regression test fails before any ambient or owner RPC is sent, identifying client-side owner resolution rather than response serialization.

### Fix

Capture the exact connection and profile on live `clarify.request` events, preserve the routed owner when pending requests are restored from activate/resume snapshots, and prefer that captured owner for single, batch, and skip responses. Requests from older or unscoped gateways retain the existing owner lookup and legacy single-backend fallback.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts` - retain the source route with live clarify requests.
- `apps/desktop/src/app/session/hooks/use-session-actions/` - carry the routed owner through pending-clarify snapshot restoration.
- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` - submit every clarify response through the captured request owner.
- `apps/desktop/src/store/clarify.ts` and `session-states.ts` - model and dispatch the captured owner without weakening fail-closed routing.
- Focused Vitest coverage reproduces owner-cache loss and verifies live and restored request routing.

## How to Test

1. Run the focused Desktop tests:

```bash
cd apps/desktop
npx vitest run src/components/assistant-ui/clarify-tool.test.tsx src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts src/store/session-states.test.ts src/store/session-states-runtime-map.test.ts
```

2. Confirm all 135 tests pass.
3. Run `npm run typecheck` from `apps/desktop` and confirm all three TypeScript projects pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested the focused suite and typecheck on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are not applicable
- [x] Config example updates are not applicable
- [x] Contributor guide updates are not applicable
- [x] I've considered cross-platform impact; the routing change is platform-independent
- [x] Tool description and schema updates are not applicable

## Screenshots / Logs

The focused regression suite passes 135 tests, including a request whose owner hint is absent while its captured source route remains available.
