### PR TITLE
fix(achievements): detect local sessions by route

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -4,6 +4,7 @@ Mounted at /api/plugins/hermes-achievements/ by Hermes dashboard.
 """
 from __future__ import annotations
 
+import ipaddress
 import json
 import math
 import re
@@ -11,6 +12,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlparse
 
 try:
     from hermes_constants import get_hermes_home
@@ -258,6 +260,8 @@ def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:
         "last_active": meta.get("last_active"),
         "started_at": meta.get("started_at"),
         "model": meta.get("model"),
+        "billing_provider": meta.get("billing_provider"),
+        "billing_base_url": meta.get("billing_base_url"),
         "title": meta.get("title") or meta.get("preview") or "Untitled",
     }
 
@@ -336,6 +340,36 @@ def is_local_model_name(model_name: str) -> bool:
         return False
     local_markers = ["ollama", "llama.cpp", "localhost", "127.0.0.1", "local/", "local:", "gguf", "vllm-local"]
     return any(marker in name for marker in local_markers)
+
+
+def is_local_model_provider(provider_name: str) -> bool:
+    name = (provider_name or "").strip().lower().replace("_", "-")
+    return name in {"lmstudio", "lm-studio", "ollama", "llama.cpp", "llamacpp", "local", "vllm-local"}
+
+
+def is_local_model_base_url(base_url: str) -> bool:
+    try:
+        hostname = (urlparse((base_url or "").strip()).hostname or "").lower()
+    except ValueError:
+        return False
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def is_local_model_session(
+    model_names: Set[str],
+    provider_names: Set[str],
+    base_urls: Set[str],
+) -> bool:
+    return (
+        any(is_local_model_name(str(name)) for name in model_names)
+        or any(is_local_model_provider(str(name)) for name in provider_names)
+        or any(is_local_model_base_url(str(url)) for url in base_urls)
+    )
 
 
 def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -447,6 +481,8 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
         "release_events": len(re.findall(r"\bgit\s+tag|release|version bump|changelog|publish|pushed? tag", full_text, re.I)),
         "cache_events": len(re.findall(r"cache hit|prompt caching|cache_read", full_text, re.I)),
         "model_names": set(),
+        "model_providers": set(),
+        "model_base_urls": set(),
     }
 
 
@@ -658,15 +694,13 @@ def scan_sessions(
             stats["started_at"] = meta.get("started_at")
             stats["last_active"] = meta.get("last_active")
             stats["source"] = meta.get("source")
-            if meta.get("model"):
-                stats.setdefault("model_names", set())
-                if isinstance(stats["model_names"], set):
-                    stats["model_names"].add(str(meta.get("model")))
-                elif isinstance(stats["model_names"], list):
-                    if str(meta.get("model")) not in stats["model_names"]:
-                        stats["model_names"].append(str(meta.get("model")))
-                else:
-                    stats["model_names"] = {str(meta.get("model"))}
+            # Route metadata belongs to the session row, not its messages. Set
+            # it from the current row even when the message analysis came from
+            # a checkpoint, so stale cached routing data cannot survive a
+            # provider/base-URL correction.
+            stats["model_names"] = {str(meta.get("model"))} if meta.get("model") else set()
+            stats["model_providers"] = {str(meta.get("billing_provider"))} if meta.get("billing_provider") else set()
+            stats["model_base_urls"] = {str(meta.get("billing_base_url"))} if meta.get("billing_base_url") else set()
 
             sessions.append(stats)
             checkpoint_sessions[sid] = {"fingerprint": fp, "stats": _json_safe(stats)}
@@ -766,11 +800,13 @@ def aggregate_stats(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
             agg[key] += s.get(key, 0)
         model_names.update(s.get("model_names") or set())
         session_models = s.get("model_names") or set()
+        session_providers = s.get("model_providers") or set()
+        session_base_urls = s.get("model_base_urls") or set()
         for model_name in session_models:
             provider = model_provider(str(model_name))
             if provider:
                 provider_names.add(provider)
-        if any(is_local_model_name(str(model_name)) for model_name in session_models):
+        if is_local_model_session(session_models, session_providers, session_base_urls):
             agg["local_model_chat_sessions"] += 1
         if s.get("started_at"):
             try:

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -145,6 +145,46 @@ class AchievementEngineTests(unittest.TestCase):
         self.assertEqual(aggregate_local_chat["local_model_chat_sessions"], 1)
         self.assertEqual(plugin_api.evaluate_definition(definition, aggregate_local_chat)["state"], "unlocked")
 
+    def test_open_weights_pilgrim_recognizes_local_provider_and_endpoint_metadata(self):
+        lmstudio_chat = plugin_api.aggregate_stats([
+            {
+                "model_names": {"qwen3.6-27b-mtp"},
+                "model_providers": {"lmstudio"},
+                "model_base_urls": {"http://127.0.0.1:1234/v1"},
+            },
+        ])
+        loopback_custom_chat = plugin_api.aggregate_stats([
+            {
+                "model_names": {"qwen3.6-27b-mtp"},
+                "model_providers": {"custom"},
+                "model_base_urls": {"http://localhost:8000/v1"},
+            },
+        ])
+        remote_qwen_chat = plugin_api.aggregate_stats([
+            {
+                "model_names": {"qwen3.6-27b-mtp"},
+                "model_providers": {"openrouter"},
+                "model_base_urls": {"https://openrouter.ai/api/v1"},
+            },
+        ])
+
+        self.assertEqual(lmstudio_chat["local_model_chat_sessions"], 1)
+        self.assertEqual(loopback_custom_chat["local_model_chat_sessions"], 1)
+        self.assertEqual(remote_qwen_chat["local_model_chat_sessions"], 0)
+
+    def test_session_fingerprint_tracks_model_route_metadata(self):
+        fingerprint = plugin_api.session_fingerprint({
+            "started_at": 100,
+            "last_active": 200,
+            "model": "qwen3.6-27b-mtp",
+            "billing_provider": "lmstudio",
+            "billing_base_url": "http://127.0.0.1:1234/v1",
+            "title": "Local model run",
+        })
+
+        self.assertEqual(fingerprint["billing_provider"], "lmstudio")
+        self.assertEqual(fingerprint["billing_base_url"], "http://127.0.0.1:1234/v1")
+
     def test_config_surgeon_ignores_generic_config_mentions(self):
         stats = plugin_api.analyze_messages("s1", "Config talk", [{"content": "config config configuration not configured"}])
         self.assertEqual(stats["config_events"], 0)

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -115,6 +115,33 @@ class _FakeSessionDB:
         pass
 
 
+class _LocalModelSessionDB(_FakeSessionDB):
+    def __init__(self):
+        super().__init__(session_count=1)
+
+    def list_sessions_rich(
+        self,
+        source: Optional[str] = None,
+        exclude_sources: Optional[List[str]] = None,
+        limit: int = 20,
+        offset: int = 0,
+        include_children: bool = False,
+        project_compression_tips: bool = True,
+    ) -> List[Dict[str, Any]]:
+        now = int(time.time())
+        return [{
+            "id": "local-qwen",
+            "title": "Local model run",
+            "preview": "local model run",
+            "started_at": now - 30,
+            "last_active": now,
+            "source": "cli",
+            "model": "qwen3.6-27b-mtp",
+            "billing_provider": "lmstudio",
+            "billing_base_url": "http://127.0.0.1:1234/v1",
+        }]
+
+
 def _install_fake_session_db(plugin_api, fake_db):
     """Inject a fake SessionDB so ``scan_sessions`` finds it via its local import.
 
@@ -149,6 +176,17 @@ def test_scan_sessions_default_scans_all_history_not_first_200(plugin_api):
     )
     assert len(result["sessions"]) == 500
     assert result["scan_meta"]["sessions_total"] == 500
+
+
+def test_scan_sessions_counts_lmstudio_route_as_local_model_chat(plugin_api):
+    fake_db = _LocalModelSessionDB()
+    _install_fake_session_db(plugin_api, fake_db)
+
+    result = plugin_api.scan_sessions()
+
+    assert result["aggregate"]["local_model_chat_sessions"] == 1
+    assert result["sessions"][0]["model_providers"] == {"lmstudio"}
+    assert result["sessions"][0]["model_base_urls"] == {"http://127.0.0.1:1234/v1"}
 
 
 def test_evaluate_all_first_run_returns_pending_and_starts_background_scan(plugin_api):


### PR DESCRIPTION
## What does this PR do?

Make **Open Weights Pilgrim** count local-model sessions from the session's recorded route metadata, not only substrings in the model name.

Hermes can record a local LM Studio or OpenAI-compatible session with a plain model identifier such as `qwen3.6-27b-mtp`. That name contains none of the achievement plugin's existing local markers, even though the session row records `billing_provider=lmstudio` and/or a loopback `billing_base_url`. The scan therefore treated genuine local inference as remote inference.

## Changes

- Treat known local providers (`lmstudio`, `ollama`, `llama.cpp`, `local`, and local vLLM aliases) as local-model evidence.
- Treat `localhost` and IP loopback base URLs as local-model evidence.
- Include provider and base-URL route fields in the session fingerprint so checkpoint reuse cannot preserve stale route classification.
- Rehydrate route metadata from the current session row even when message-derived statistics come from the checkpoint cache.
- Add unit and scan-path regression coverage, including a negative control proving that a remote Qwen session does not count merely because the model is open-weight.

## Relationship to #30324

This complements rather than duplicates #30324. That PR recognizes Ollama's native `name:tag` model strings. This PR handles cases where the model name itself is ambiguous and the authoritative evidence is the recorded provider or loopback route, including LM Studio and generic local OpenAI-compatible servers.

## Verification

Rebased onto current `main`, then ran:

```bash
scripts/run_tests.sh \
  tests/plugins/test_achievements_plugin.py \
  plugins/hermes-achievements/tests/test_achievement_engine.py
python3 -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py
```

Result: **19 passed, 0 failed**; Python compilation passed.

The fix was also exercised against an actual Hermes session database containing LM Studio-routed sessions: the scanner recognized the local sessions and unlocked Open Weights Pilgrim without counting remote Qwen sessions.

## Risk

Low and confined to the dashboard-only achievements plugin. No model-visible tools, provider routing, or inference behavior changes. Loopback detection uses parsed hostnames and `ipaddress.is_loopback`; non-loopback remote endpoints remain excluded.