### PR TITLE
fix(desktop): store transparent pre-paint background when glass/vibrancy is active (macOS dark mode white flash)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16521,6 +16521,15 @@ ipcMain.on('hermes:translucency:support', event => {
   event.returnValue = { glass: GLASS_SUPPORTED, translucency: TRANSLUCENCY_SUPPORTED }
 })
 
+// Synchronous read used by the renderer's applyTheme() to store the correct
+// pre-paint boot background: 'transparent' when glass/vibrancy is active so
+// the NSVisualEffectView shows through on the first painted pixel rather than
+// being buried under an opaque fallback color (macOS dark-mode white flash,
+// issue #98561).
+ipcMain.on('hermes:glass-enabled', event => {
+  event.returnValue = glassActive(translucencyState)
+})
+
 ipcMain.on('hermes:translucency', (_event, payload) => {
   const next = normalizeTranslucency(payload, GLASS_SUPPORTED)
   const previous = translucencyState

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -266,6 +266,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
+  // Synchronous read — does the current window have an active glass/vibrancy
+  // backing?  Used by applyTheme() to store 'transparent' as the pre-paint
+  // boot background instead of the opaque themed color, preventing the
+  // blinding-white first frame on macOS in dark mode (#98561).
+  glassEnabled: () => ipcRenderer.sendSync('hermes:glass-enabled'),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setDisableF12: blocked => ipcRenderer.send('hermes:devtools:disable-f12', blocked),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -291,6 +291,8 @@ declare global {
       setActiveWork?: (payload: HermesActiveWork) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
+      /** Synchronous read: is the window currently backed by glass/vibrancy? */
+      glassEnabled?: () => boolean
       /** Main-process fact: this OS can back glass with a native material. */
       glassSupported?: boolean
       /** Main-process fact: this OS can do any translucency at all (not Linux). */

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -282,8 +282,20 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
   // Raw (non-JSON) keys read by the inline pre-paint script in index.html —
   // they let a brand-new window paint the themed background on its very first
   // frame, before this module has even loaded.
+  //
+  // When glass/vibrancy is active the window backing is transparent and the
+  // NSVisualEffectView provides the background.  Storing the opaque chromeBg
+  // here causes the pre-paint script to paint a solid opaque layer that sits
+  // on top of the vibrancy compositor, producing a blinding white first frame
+  // in dark mode on macOS (#98561).  Store 'transparent' instead so the
+  // vibrancy material shows through from the first painted pixel.
+  //
+  // hermesDesktop.glassEnabled is a cheap synchronous read set by the Electron
+  // preload from the current translucency state — no async import needed.
+  const glassEnabled = Boolean((window as any).hermesDesktop?.glassEnabled?.())
+  const bootBg = glassEnabled ? 'transparent' : chromeBg
   try {
-    window.localStorage.setItem('hermes-boot-background', chromeBg)
+    window.localStorage.setItem('hermes-boot-background', bootBg)
     window.localStorage.setItem('hermes-boot-color-scheme', rendered)
   } catch {
     // Storage may be unavailable (private mode / quota); the inline script


### PR DESCRIPTION
## Problem (#98561)

On macOS with glass/vibrancy, the Electron window backing is transparent and \NSVisualEffectView\ provides the surface. \pplyTheme()\ was storing the opaque \chromeBg\ as \hermes-boot-background\ in localStorage. On the next window open, the pre-paint script in \index.html\ painted that opaque color before the app bundle loaded — sitting on top of the vibrancy compositor and producing a blinding white first frame in dark mode.

## Fix

- Add a synchronous IPC channel \hermes:glass-enabled\ answered by \glassActive(translucencyState)\ in \main.ts\.
- Expose it as \hermesDesktop.glassEnabled()\ in the preload bridge.
- In \pplyTheme()\: store \'transparent'\ when glass is active, \chromeBg\ otherwise.

The pre-paint script sets \document.documentElement.style.backgroundColor = bg\; \'transparent'\ lets the vibrancy compositor show through from the first pixel.

Fixes #98561