### PR TITLE
fix(security): add terminal/execute_code/skill_view to _UNTRUSTED_TOOL_NAMES for prompt-injection defense

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -642,7 +642,17 @@ def make_tool_result_message(
 # payload is data, not instructions — the architectural piece of the
 # promptware defense.  Skipped for short outputs (under 32 chars) where the
 # overhead of the wrapper outweighs any indirect-injection risk.
+# Tools whose output comes from sources the operator did not author and cannot
+# fully review — open-web content, third-party CLI output, community skill
+# libraries, files from attacker-accessible disk paths.  Every result from
+# these tools is wrapped in <untrusted_tool_result> delimiters so the model
+# treats it as data rather than instructions (indirect prompt injection).
+# Extended from {web_search, web_extract} to cover terminal, execute_code, and
+# skill_view per #98587.
 _UNTRUSTED_TOOL_NAMES = frozenset({
+    "execute_code",
+    "skill_view",
+    "terminal",
     "web_extract",
     "web_search",
 })


### PR DESCRIPTION
## Problem (#98587)

\_UNTRUSTED_TOOL_NAMES\ only wrapped \web_extract\ and \web_search\ results in \<untrusted_tool_result>\ delimiters. \	erminal\ and \execute_code\ can surface attacker-influenced content through compromised files, poisoned env vars, third-party CLI output, or Docker container inspection. \skill_view\ surfaces community skill libraries the operator may not have reviewed.

A real prompt injection attempt was observed during a Docker diagnostic session — not through web_search.

## Fix

Add \	erminal\, \execute_code\, and \skill_view\ to the \_UNTRUSTED_TOOL_NAMES\ frozenset. The wrapper is established, well-tested (delimiter-neutralization against forged closing tags), and already covers the \mcp_\ / \rowser_\ prefixes.

Fixes #98587