### PR TITLE
fix(email): default authserv_id to the agent From-domain

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -588,8 +588,13 @@ class EmailAdapter(BasePlatformAdapter):
         # Optional authserv-id to pin Authentication-Results to the operator's
         # own receiving server (defends against an injected header that sorts
         # first). Defaults to the From-domain of the agent's own address.
+        # The "@" guard keeps _domain_of from returning the whole address when
+        # EMAIL_ADDRESS is malformed (no domain to derive — no pinning, same
+        # as before the fallback existed).
         self._authserv_id = (
-            extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")
+            extra.get("authserv_id", "")
+            or _get_secret("EMAIL_AUTHSERV_ID", "")
+            or (_domain_of(self._address) if "@" in self._address else "")
         ).strip().lower()
 
         # Track message IDs we've already processed to avoid duplicates

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1059,6 +1059,55 @@ class TestConnectionConfigResolution(unittest.TestCase):
                 self.assertFalse(check_email_requirements())
 
 
+class TestAuthservIdDefault(unittest.TestCase):
+    """_authserv_id defaults to the From-domain of the agent's own address when
+    neither the config key nor EMAIL_AUTHSERV_ID is set (#98599).
+
+    The comment above the assignment documents this fallback; an empty value
+    silently disables Authentication-Results pinning, making the adapter trust
+    the topmost header even when it was injected by an attacker.
+    """
+
+    def _make_adapter(self, address="hermes@example.com", extra=None, authserv_env=None):
+        from gateway.config import PlatformConfig
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": address,
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.example.com",
+            "EMAIL_SMTP_HOST": "smtp.example.com",
+        }, clear=False):
+            if authserv_env is None:
+                # Ensure the fallback path is exercised: no EMAIL_AUTHSERV_ID.
+                os.environ.pop("EMAIL_AUTHSERV_ID", None)
+            else:
+                os.environ["EMAIL_AUTHSERV_ID"] = authserv_env
+            from plugins.platforms.email.adapter import EmailAdapter
+
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+    def test_defaults_to_from_domain(self):
+        """No config key and no env var: pin to the agent's own From-domain."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._authserv_id, "example.com")
+
+    def test_config_key_wins_over_default(self):
+        """An explicit authserv_id in config.yaml overrides the From-domain."""
+        adapter = self._make_adapter(extra={"authserv_id": "mx.operator.net"})
+        self.assertEqual(adapter._authserv_id, "mx.operator.net")
+
+    def test_env_wins_over_default(self):
+        """EMAIL_AUTHSERV_ID overrides the From-domain fallback."""
+        adapter = self._make_adapter(authserv_env="mx.operator.net")
+        self.assertEqual(adapter._authserv_id, "mx.operator.net")
+
+    def test_empty_address_keeps_empty_authserv_id(self):
+        """No derivable domain (no '@' in the address) must not fabricate a
+        pinning value — behavior stays identical to the pre-fix default."""
+        adapter = self._make_adapter(address="not-an-email")
+        self.assertEqual(adapter._authserv_id, "")
+
+
 class TestSenderAuthentication(unittest.TestCase):
     """Verify _verify_sender_authentication parses Authentication-Results
     correctly and resists From: spoofing (GHSA-rxqh-5572-8m77)."""


### PR DESCRIPTION
Closes #98599

## Problem

`_authserv_id` in the email platform adapter defaults to `""` when neither the `authserv_id` config key nor the `EMAIL_AUTHSERV_ID` env var is set, contradicting the comment directly above it, which documents a default of the agent's own From-domain:

```python
# Optional authserv-id to pin Authentication-Results to the operator's
# own receiving server (defends against an injected header that sorts
# first). Defaults to the From-domain of the agent's own address.
self._authserv_id = (
    extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")
).strip().lower()
```

## Security impact

This is not cosmetic: with `authserv_id == ""`, the selection loop in `_verify_sender_authentication` skips its pinning branch (`if authserv_id:`) and unconditionally trusts the **topmost** `Authentication-Results` header. The pinning defense documented above the code is therefore **silently disabled by default** — an attacker who can influence header ordering (or a provider that stamps multiple `Authentication-Results` headers, e.g. iCloud) defeats the trust boundary that `authserv_id` exists to enforce. This matters most with the default `require_authenticated_sender: true`, where the From-domain gate is the authorization boundary (GHSA-rxqh-5572-8m77).

## Fix

Implement the documented default: when neither config nor env provides a value, derive the authserv-id from the agent's own `EMAIL_ADDRESS` domain, matching the comment's stated intent:

```python
self._authserv_id = (
    extra.get("authserv_id", "")
    or _get_secret("EMAIL_AUTHSERV_ID", "")
    or (_domain_of(self._address) if "@" in self._address else "")
).strip().lower()
```

The `"@"` guard preserves the pre-fix behavior for a malformed `EMAIL_ADDRESS` (no derivable domain → no pinning) instead of pinning to a nonsense value, which would otherwise fail-closed every message.

## Tests

Added `TestAuthservIdDefault` in `tests/gateway/test_email.py`:
- `test_defaults_to_from_domain` — no config key, no env var → `_authserv_id` is the agent's From-domain (the repro for #98599)
- `test_config_key_wins_over_default` — explicit `authserv_id` in config still wins
- `test_env_wins_over_default` — `EMAIL_AUTHSERV_ID` still wins
- `test_empty_address_keeps_empty_authserv_id` — malformed address keeps the pre-fix no-pinning behavior

All 66 email adapter tests pass (`test_email.py`, `test_email_robustness.py`, `test_email_secret_scope.py`, `test_email_charset_fallback.py`).