### PR TITLE
fix(email): retry with BODY[] when RFC822 fetch returns no literal on iCloud

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -875,6 +875,25 @@ class EmailAdapter(BasePlatformAdapter):
                         # _seen_uids so the next poll retries it.
                         continue
 
+                    raw_email = None
+                    try:
+                        raw_email = msg_data[0][1]
+                    except (IndexError, TypeError):
+                        pass
+
+                    # iCloud (imap.mail.me.com) returns OK for RFC822 with no
+                    # message literal.  Retry with BODY[] which returns the
+                    # full message as an untagged literal body.  Both items
+                    # are RFC 3501 valid; only the latter returns a payload
+                    # on iCloud (#98597).
+                    if not isinstance(raw_email, (bytes, bytearray)):
+                        status, msg_data = imap.uid("fetch", uid, "(BODY[])")
+                        if status == "OK":
+                            try:
+                                raw_email = msg_data[0][1]
+                            except (IndexError, TypeError):
+                                raw_email = None
+
                     # IMAP fetch can return unexpected structures (e.g. a
                     # single bytes item instead of a list of tuples). Mark the
                     # UID seen once a response arrived (even a malformed one)
@@ -888,17 +907,10 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    try:
-                        raw_email = msg_data[0][1]
-                    except (IndexError, TypeError):
-                        logger.warning(
-                            "[Email] Unexpected IMAP response structure for UID %s, skipping",
-                            uid,
-                        )
-                        continue
+
                     if not isinstance(raw_email, (bytes, bytearray)):
                         logger.warning(
-                            "[Email] Non-bytes IMAP payload for UID %s, skipping", uid
+                            "[Email] No literal from RFC822 or BODY[] for UID %s, skipping", uid
                         )
                         continue
                     # Per-message processing guard: one poison message


### PR DESCRIPTION
## Problem (#98597)

On iCloud (`imap.mail.me.com`), `imap.uid("fetch", uid, "(RFC822)")` returns `OK` but with **no message literal**. The existing code marks the UID as seen on any `OK` response (line 886: `self._seen_uids.add(uid)`), then fails on the missing payload — permanently discarding the message even though the server has it.

Both RFC822 and BODY[] are RFC 3501 valid. iCloud only returns a payload for the latter.

## Fix

Restructure the fetch block: extract the literal from RFC822 first. If it's empty/missing, retry with BODY[] before marking the UID as seen. The retry is only attempted when RFC822 returns OK with no literal, minimising the cost (no extra fetch for every server). The UID is still marked as seen after both attempts so a genuinely unparseable response is skipped once rather than retried forever.

Fixes #98597