### PR TITLE
test: add behavioral tests for hermes_cli/sqlite_util.py add_column_if_missing

### DIFF
--- a/tests/hermes_cli/test_sqlite_util.py
+++ b/tests/hermes_cli/test_sqlite_util.py
@@ -1,0 +1,26 @@
+"""Tests for hermes_cli/sqlite_util.py — add_column_if_missing."""
+
+import sqlite3
+
+
+def test_adds_column_when_missing():
+    from hermes_cli.sqlite_util import add_column_if_missing
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (a)")
+    assert add_column_if_missing(conn, "t", "b", "b TEXT") is True
+    rows = conn.execute("SELECT b FROM t").fetchall()
+    assert rows == [(None,)]
+
+
+def test_idempotent_when_column_already_exists():
+    from hermes_cli.sqlite_util import add_column_if_missing
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (a, b TEXT)")
+    assert add_column_if_missing(conn, "t", "b", "b TEXT") is False
+
+
+def test_raises_on_other_operational_errors():
+    from hermes_cli.sqlite_util import add_column_if_missing
+    conn = sqlite3.connect(":memory:")
+    with pytest.raises(sqlite3.OperationalError):
+        add_column_if_missing(conn, "no_such_table", "c", "c INT")


### PR DESCRIPTION
﻿Behavioral tests for hermes_cli/sqlite_util.py — a shared SQLite migration helper used by the projects and kanban stores.

Covers the dd_column_if_missing function:
- Column added when genuinely missing (returns True)
- Idempotent when column already exists (returns False, swallows duplicate-column error)
- Other OperationalError propagates (e.g. table missing)
