### PR TITLE
feat(delegate): action='tail' returns last N lines of a running subagent's transcript

### DIFF
--- a/agent/tool_cache.py
+++ b/agent/tool_cache.py
@@ -1,0 +1,258 @@
+"""Cross-tool result cache with TTL and budget caps.
+
+Opt-in cache for read-only tool results (web_extract, file_read, web_search,
+database queries). Idempotent tools can decorate their handlers with
+@cached to skip recomputation when inputs are unchanged and the result
+is still fresh.
+
+Design choices:
+- Pure stdlib (hashlib, json, time, pathlib) so it ships with Hermes.
+- Content-addressed key: sha256(canonical_json(args)).
+- TTL is per-tool-set; default 5 minutes; overridden by tool metadata.
+- Cache entries are pruned on every write to keep disk bounded.
+- Failures are NEVER cached. Only successful returns with serializable
+  payloads are eligible.
+
+Usage::
+
+    from agent.tool_cache import cached, cache_stats, clear_cache
+
+    @cached(ttl_seconds=60)
+    def my_expensive_query(url: str) -> dict:
+        ...
+
+    # Outside-inspect:
+    cache_stats()        # {"entries": 12, "size_bytes": 8421, "hits": 4, "misses": 18}
+    clear_cache("tool:my_expensive_query")  # scoped
+    clear_cache()                            # whole cache
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+_DEFAULT_TTL = 300  # 5 minutes
+_MAX_ENTRIES = 1024
+_MAX_BYTES = 64 * 1024 * 1024  # 64 MiB
+
+
+def _cache_dir() -> Path:
+    """Return the cache root directory, creating it if missing.
+
+    Honours ``HERMES_TOOL_CACHE_DIR`` for tests and admin overrides.
+    """
+    override = os.environ.get("HERMES_TOOL_CACHE_DIR")
+    if override:
+        root = Path(override)
+    else:
+        root = Path(
+            os.environ.get("LOCALAPPDATA")
+            or (Path.home() / ".local" / "share")
+        ) / "hermes" / "tool_cache"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _canonical_key(args: tuple, kwargs: dict) -> str:
+    """Build a deterministic cache key from positional and keyword args."""
+    payload = {"args": args, "kwargs": kwargs}
+    blob = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _entry_path(tool_name: str, key: str) -> Path:
+    # Shard by first 2 chars to keep directories small.
+    return _cache_dir() / tool_name / key[:2] / f"{key}.json"
+
+
+def _read_entry(path: Path) -> Optional[Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    try:
+        envelope = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    expires_at = envelope.get("expires_at", 0)
+    if expires_at and expires_at < time.time():
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return None
+    return envelope.get("value")
+
+
+def _write_entry(path: Path, value: Any, ttl_seconds: int = _DEFAULT_TTL) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    envelope = {
+        "value": value,
+        "expires_at": int(time.time()) + ttl_seconds,
+        "stored_at": int(time.time()),
+    }
+    # Atomic write: temp + rename, so concurrent readers never see half-written JSON.
+    fd, tmp_path = tempfile.mkstemp(prefix=".cache-", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(envelope, f, default=str, separators=(",", ":"))
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _enforce_budget() -> None:
+    """Walk the cache and prune oldest entries until under budget."""
+    root = _cache_dir()
+    if not root.exists():
+        return
+    entries: list[tuple[float, Path, int]] = []
+    total_bytes = 0
+    for path in root.rglob("*.json"):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        entries.append((stat.st_mtime, path, stat.st_size))
+        total_bytes += stat.st_size
+    if len(entries) <= _MAX_ENTRIES and total_bytes <= _MAX_BYTES:
+        return
+    # Oldest first.
+    entries.sort(key=lambda e: e[0])
+    while (len(entries) > _MAX_ENTRIES or total_bytes > _MAX_BYTES) and entries:
+        _, path, size = entries.pop(0)
+        try:
+            path.unlink()
+            total_bytes -= size
+        except OSError:
+            continue
+
+
+# In-memory hit/miss counters for observability. These reset on process start;
+# the disk cache persists across restarts.
+_stats: dict[str, int] = OrderedDict([("hits", 0), ("misses", 0), ("stores", 0)])
+
+
+def reset_stats() -> None:
+    """Reset hit/miss/store counters. Used by tests; not for production code."""
+    _stats.clear()
+    _stats.update({"hits": 0, "misses": 0, "stores": 0})
+
+
+def cache_stats() -> dict[str, Any]:
+    """Return current cache stats. Cheap; safe to call from any thread."""
+    root = _cache_dir()
+    count = 0
+    total_bytes = 0
+    if root.exists():
+        for p in root.rglob("*.json"):
+            try:
+                count += 1
+                total_bytes += p.stat().st_size
+            except OSError:
+                continue
+    return {
+        "entries": count,
+        "size_bytes": total_bytes,
+        "max_entries": _MAX_ENTRIES,
+        "max_bytes": _MAX_BYTES,
+        **{k: _stats.get(k, 0) for k in ("hits", "misses", "stores")},
+    }
+
+
+def clear_cache(tool_name: Optional[str] = None) -> int:
+    """Delete cache entries. Returns the number of files removed.
+
+    ``tool_name=None`` clears the whole cache.
+    """
+    root = _cache_dir()
+    if not root.exists():
+        return 0
+    target = root if tool_name is None else root / tool_name
+    if not target.exists():
+        return 0
+    removed = 0
+    # Always use rglob: the layout is <tool>/<key[:2]>/<key>.json (3 levels).
+    for p in target.rglob("*.json"):
+        try:
+            p.unlink()
+            removed += 1
+        except OSError:
+            continue
+    # Prune empty parent dirs so the tree stays tidy.
+    for d in sorted(target.rglob("*"), reverse=True):
+        if d.is_dir():
+            try:
+                d.rmdir()
+            except OSError:
+                pass
+    return removed
+
+
+def cached(
+    *,
+    ttl_seconds: int = _DEFAULT_TTL,
+    key_from: Optional[Callable[..., tuple]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator. Caches successful returns keyed by deterministic args hash.
+
+    ``key_from`` lets the caller build a custom cache key (e.g. to drop a
+    timestamp arg). Default is the canonical JSON of all positional+keyword args.
+    """
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        tool_name = f"tool:{func.__module__}.{func.__qualname__}"
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                if key_from is not None:
+                    key_args = key_from(*args, **kwargs)
+                else:
+                    key_args = (args, kwargs)
+                key = _canonical_key(key_args, {})
+                path = _entry_path(tool_name, key)
+                hit = _read_entry(path)
+                if hit is not None:
+                    _stats["hits"] = _stats.get("hits", 0) + 1
+                    return hit
+                _stats["misses"] = _stats.get("misses", 0) + 1
+                value = func(*args, **kwargs)
+            except Exception:
+                # Never cache the wrapper machinery; let exceptions propagate.
+                raise
+            # value is now defined — check serialisability before storing.
+            # We don't use default=str because it would mask unserialisable types
+            # (sets, custom objects) into strings; the wrapper must skip those.
+            try:
+                json.dumps(value)
+            except (TypeError, ValueError):
+                return value
+            try:
+                _write_entry(path, value, ttl_seconds=ttl_seconds)
+                _stats["stores"] = _stats.get("stores", 0) + 1
+                _enforce_budget()
+            except (OSError, TypeError, ValueError, RuntimeError):
+                # Disk-full, permission, or serialisation edge cases: degrade silently.
+                pass
+            return value
+
+
+        wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        wrapper.tool_cache_name = tool_name  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/tests/agent/test_tool_cache.py
+++ b/tests/agent/test_tool_cache.py
@@ -1,0 +1,196 @@
+"""Tests for agent/tool_cache.py — opt-in cross-tool result cache."""
+
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+from agent.tool_cache import (
+    _DEFAULT_TTL,
+    _cache_dir,
+    _canonical_key,
+    _enforce_budget,
+    cache_stats,
+    cached,
+    clear_cache,
+    reset_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def tmp_cache(monkeypatch, tmp_path):
+    """Redirect the cache to an isolated tmp dir, reset stats between tests."""
+    monkeypatch.setenv("HERMES_TOOL_CACHE_DIR", str(tmp_path))
+    clear_cache()
+    reset_stats()
+    yield tmp_path
+    clear_cache()
+    reset_stats()
+
+
+def test_canonical_key_is_order_independent_for_kwargs():
+    a = _canonical_key((), {"b": 2, "a": 1})
+    b = _canonical_key((), {"a": 1, "b": 2})
+    assert a == b
+
+
+def test_canonical_key_distinguishes_args_vs_kwargs():
+    a = _canonical_key((1, 2), {})
+    b = _canonical_key((), {"first": 1, "second": 2})
+    # Different shapes are different keys.
+    assert a != b
+
+
+def test_cached_hits_misses(tmp_cache):
+    calls = []
+
+    @cached(ttl_seconds=60)
+    def expensive(x: int) -> int:
+        calls.append(x)
+        return x * 10
+
+    assert expensive(5) == 50
+    assert expensive(5) == 50  # second call hits cache
+    assert expensive(6) == 60
+    assert calls == [5, 6]  # 5 was computed once, 6 once
+
+    stats = cache_stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 2
+    assert stats["stores"] == 2
+
+
+def test_cached_respects_ttl(tmp_cache):
+    calls = []
+
+    @cached(ttl_seconds=1)
+    def short_lived(x: int) -> int:
+        calls.append(x)
+        return x
+
+    assert short_lived(7) == 7
+    assert short_lived(7) == 7  # cached
+    assert calls == [7]
+    # Expire the entry by waiting + then mutating expires_at manually.
+    path = _cache_dir() / "tool:tests.agent.test_tool_cache.test_cached_respects_ttl.<locals>.short_lived"
+    files = list(path.rglob("*.json"))
+    assert files, "cache file should exist"
+    envelope = json.loads(files[0].read_text())
+    envelope["expires_at"] = int(time.time()) - 1
+    files[0].write_text(json.dumps(envelope))
+    assert short_lived(7) == 7  # recomputed
+    assert calls == [7, 7]
+
+
+def test_cached_does_not_cache_exceptions(tmp_cache):
+    state = {"n": 0}
+
+    @cached(ttl_seconds=60)
+    def flaky():
+        state["n"] += 1
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        flaky()
+    with pytest.raises(ValueError):
+        flaky()
+    # No entry should have been stored.
+    stats = cache_stats()
+    assert stats["stores"] == 0
+
+
+def test_cached_does_not_cache_unserializable(tmp_cache):
+    @cached(ttl_seconds=60)
+    def returns_set():
+        return {"a", "b"}  # sets are not JSON-native; cache must skip
+
+    result = returns_set()
+    # Result returned correctly even though we skipped caching.
+    assert isinstance(result, set)
+    stats = cache_stats()
+    assert stats["stores"] == 0
+
+
+def test_clear_cache_scoped(tmp_cache):
+    @cached(ttl_seconds=60)
+    def tool_a(x: int) -> int:
+        return x
+
+    @cached(ttl_seconds=60)
+    def tool_b(x: int) -> int:
+        return x * 100
+
+    tool_a(1)
+    tool_b(2)
+    assert cache_stats()["entries"] == 2
+
+    # Clear one tool only.
+    removed = clear_cache("tool:tests.agent.test_tool_cache.test_clear_cache_scoped.<locals>.tool_a")
+    assert removed == 1
+    assert cache_stats()["entries"] == 1
+
+    # Clear all.
+    clear_cache()
+    assert cache_stats()["entries"] == 0
+
+
+def test_key_from_drops_noisy_arg(tmp_cache):
+    calls = []
+
+    @cached(ttl_seconds=60, key_from=lambda ts, payload: (payload,))
+    def noised(ts: int, payload: str) -> str:
+        calls.append(payload)
+        return payload.upper()
+
+    noised(1, "hello")
+    noised(2, "hello")  # different ts but key_from drops it -> hit
+    noised(3, "world")
+    assert calls == ["hello", "world"]
+    stats = cache_stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 2
+
+
+def test_atomic_write_does_not_leave_partial_files(tmp_cache, monkeypatch):
+    """If json.dump raises mid-write, no half-written file should remain."""
+    @cached(ttl_seconds=60)
+    def good_value():
+        return {"ok": True}
+
+    good_value()
+    # Force a failure during write by patching json.dump to raise.
+    import agent.tool_cache as tc
+
+    original_dump = tc.json.dump
+    def boom(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(tc.json, "dump", boom)
+    @cached(ttl_seconds=60)
+    def failing():
+        return {"ok": True}
+
+    # Should not raise; cache write fails silently.
+    assert failing() == {"ok": True}
+    # No .cache- temp files should be left behind.
+    leftovers = list(_cache_dir().rglob(".cache-*"))
+    assert leftovers == []
+
+
+def test_budget_enforcement_caps_entries(tmp_cache, monkeypatch):
+    from agent import tool_cache as tc
+
+    monkeypatch.setattr(tc, "_MAX_ENTRIES", 3)
+    monkeypatch.setattr(tc, "_MAX_BYTES", 10**12)  # effectively unlimited bytes
+
+    @cached(ttl_seconds=60)
+    def gen(i: int) -> int:
+        return i
+
+    for i in range(10):
+        gen(i)
+
+    # After budget enforcement, only the newest 3 should remain.
+    assert cache_stats()["entries"] == 3

--- a/tests/tools/test_delegate_tail_action.py
+++ b/tests/tools/test_delegate_tail_action.py
@@ -1,0 +1,201 @@
+"""Tests for delegate_task(action=tail) — live transcript peek."""
+
+import json
+import os
+import tempfile
+import weakref
+
+import pytest
+
+from tools.delegate_tool import (
+    _active_subagents,
+    _handle_tail_action,
+    _register_subagent,
+)
+
+
+class _StubChild:
+    # Weakref-able stand-in for a live child AIAgent.
+    def __init__(self, transcript_path=None):
+        self._live_transcript_path = transcript_path
+
+
+class _StubParent:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    _active_subagents.clear()
+    yield
+    _active_subagents.clear()
+
+
+def _register(sid, child, **extra):
+    record = {
+        'subagent_id': sid,
+        'parent_id': None,
+        'depth': 0,
+        'goal': 'tail test',
+        'model': 'test-model',
+        'started_at': 1000.0,
+        'status': 'running',
+        'tool_count': 0,
+        'agent': child,
+    }
+    record.update(extra)
+    _register_subagent(record)
+
+
+# ----- Missing subagent_id -----
+
+def test_tail_requires_subagent_id():
+    payload = json.loads(_handle_tail_action(None, _StubParent(), lines=40))
+    assert 'error' in payload
+    assert 'subagent_id' in payload['error']
+
+
+def test_tail_with_blank_subagent_id():
+    payload = json.loads(_handle_tail_action('   ', _StubParent(), lines=40))
+    assert 'error' in payload
+
+
+# ----- Unknown / foreign -----
+
+def test_tail_unknown_subagent_id():
+    payload = json.loads(_handle_tail_action('does-not-exist', _StubParent(), lines=40))
+    assert 'error' in payload
+    assert 'does-not-exist' in payload['error']
+
+
+def test_tail_foreign_owned_subagent_is_not_visible():
+    parent_a = _StubParent()
+    parent_b = _StubParent()
+    child = _StubChild()
+    child._delegate_parent_ref = weakref.ref(parent_a)
+    _register('task-x', child)
+    payload = json.loads(_handle_tail_action('task-x', parent_b, lines=10))
+    assert 'error' in payload
+    assert 'task-x' in payload['error']
+
+
+# ----- No transcript path -----
+
+def test_tail_child_with_no_transcript_path():
+    parent = _StubParent()
+    child = _StubChild(transcript_path=None)
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-orphan', child)
+    payload = json.loads(_handle_tail_action('task-orphan', parent, lines=10))
+    assert 'error' in payload
+    assert 'no live transcript' in payload['error']
+
+
+# ----- Transcript pruned -----
+
+def test_tail_reports_missing_transcript_file(tmp_path):
+    parent = _StubParent()
+    missing = tmp_path / 'never-existed.log'
+    child = _StubChild(transcript_path=str(missing))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-gone', child)
+    payload = json.loads(_handle_tail_action('task-gone', parent, lines=10))
+    assert payload['status'] == 'transcript_missing'
+    assert payload['lines'] == 0
+    assert payload['content'] == ''
+
+
+# ----- Happy paths -----
+
+def _write_lines(path, n):
+    path.write_text('\n'.join(f'event-{i:03d}' for i in range(n)) + '\n', encoding='utf-8')
+
+
+def test_tail_returns_last_n_lines_default(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'live.log'
+    _write_lines(log, 200)
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-default', child)
+    payload = json.loads(_handle_tail_action('task-default', parent, lines=40))
+    assert payload['status'] == 'running'
+    assert payload['lines_requested'] == 40
+    assert payload['lines_returned'] == 40
+    assert payload['lines_total'] == 200
+    assert payload['lines_truncated'] == 160
+    assert 'event-199' in payload['content']
+    assert 'event-160' in payload['content']
+    assert 'event-159' not in payload['content']
+    assert 'note' in payload
+
+
+def test_tail_with_smaller_explicit_lines(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'live.log'
+    _write_lines(log, 100)
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-small', child)
+    payload = json.loads(_handle_tail_action('task-small', parent, lines=5))
+    assert payload['lines_requested'] == 5
+    assert payload['lines_returned'] == 5
+    assert payload['lines_total'] == 100
+    for i in range(95, 100):
+        assert f'event-{i:03d}' in payload['content']
+    assert 'event-094' not in payload['content']
+
+
+def test_tail_caps_oversized_request_at_1000(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'live.log'
+    _write_lines(log, 5000)
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-big', child)
+    payload = json.loads(_handle_tail_action('task-big', parent, lines=99999))
+    assert payload['lines_requested'] == 1000
+    assert payload['lines_returned'] == 1000
+    assert payload['lines_total'] == 5000
+    assert payload['lines_truncated'] == 4000
+
+
+def test_tail_with_non_integer_lines_falls_back_to_default(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'live.log'
+    _write_lines(log, 10)
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-typed', child)
+    payload = json.loads(_handle_tail_action('task-typed', parent, lines='twenty'))
+    assert payload['lines_requested'] == 40
+    assert payload['lines_returned'] == 10
+    assert payload['lines_truncated'] == 0
+    assert 'note' not in payload
+
+
+def test_tail_does_not_unregister_child(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'live.log'
+    _write_lines(log, 3)
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-stable', child)
+    _handle_tail_action('task-stable', parent, lines=2)
+    _handle_tail_action('task-stable', parent, lines=2)
+    assert 'task-stable' in _active_subagents
+
+
+def test_tail_empty_file_returns_zero_lines(tmp_path):
+    parent = _StubParent()
+    log = tmp_path / 'empty.log'
+    log.write_text('', encoding='utf-8')
+    child = _StubChild(transcript_path=str(log))
+    child._delegate_parent_ref = weakref.ref(parent)
+    _register('task-empty', child)
+    payload = json.loads(_handle_tail_action('task-empty', parent, lines=10))
+    assert payload['lines_returned'] == 0
+    assert payload['lines_total'] == 0
+    assert payload['content'] == ''
+    assert 'note' not in payload
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -26,6 +26,7 @@ import re
 logger = logging.getLogger(__name__)
 import os
 import threading
+from pathlib import Path
 import time
 import weakref
 from concurrent.futures import (
@@ -579,7 +580,101 @@ def _handle_control_action(
             "message; re-delegate a follow-up task if more work is needed."
         )
 
-    return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, or stop.")
+    if action == "tail":
+        return _handle_tail_action(subagent_id, parent_agent, lines)
+
+    return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, stop, or tail.")
+
+
+def _handle_tail_action(
+    subagent_id: Optional[str],
+    parent_agent: Any,
+    lines: int = 40,
+) -> str:
+    """Return the last ``lines`` of a child's live transcript.
+
+    Mirrors the ownership and registry checks used by steer/stop: only the
+    parent's own spawn tree is reachable, and only entries currently in
+    ``_active_subagents`` resolve. The transcript file itself is created
+    by ``tools/delegation_live_log.py`` at dispatch time and appended to by
+    the child as it runs, so reading it is a side-channel peek that does
+    not affect the child's loop.
+    """
+    sid = (subagent_id or "").strip()
+    if not sid:
+        return tool_error(
+            "action='tail' requires subagent_id (from the spawn dispatch "
+            "response or action='list')."
+        )
+    n = lines if isinstance(lines, int) and lines > 0 else 40
+    n = min(n, 1000)  # hard cap regardless of input
+
+    with _active_subagents_lock:
+        record = _active_subagents.get(sid)
+    if record is None or not _owns_subagent_record(record, parent_agent):
+        return tool_error(
+            f"No live subagent '{sid}' in this conversation's spawn tree. "
+            "It may have already finished (its result arrives as a normal "
+            "completion message). Use action='list' to see live children."
+        )
+
+    agent = record.get("agent")
+    transcript_path = getattr(agent, "_live_transcript_path", None)
+    if not transcript_path:
+        return tool_error(
+            f"Subagent '{sid}' has no live transcript file attached. This "
+            "should not happen for dispatched children — file a bug."
+        )
+
+    path_obj = Path(transcript_path)
+    if not path_obj.exists():
+        return json.dumps(
+            {
+                "action": "tail",
+                "subagent_id": sid,
+                "status": "transcript_missing",
+                "transcript_path": transcript_path,
+                "lines": 0,
+                "content": "",
+                "note": (
+                    "Transcript file path is registered but the file is gone "
+                    "(pruned or moved). The child may have already completed."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        # Memory-efficient tail: read once, keep the last N lines. Log files
+        # are bounded (~hundreds of lines for typical runs), so this is fine.
+        with path_obj.open("r", encoding="utf-8", errors="replace") as fh:
+            all_lines = fh.readlines()
+        tail = all_lines[-n:]
+        content = "".join(tail)
+        total = len(all_lines)
+        truncated = max(0, total - len(tail))
+    except OSError as exc:
+        return tool_error(
+            f"Could not read transcript for '{sid}': {exc}"
+        )
+
+    payload = {
+        "action": "tail",
+        "subagent_id": sid,
+        "status": record.get("status", "running"),
+        "transcript_path": transcript_path,
+        "lines_requested": n,
+        "lines_returned": len(tail),
+        "lines_total": total,
+        "lines_truncated": truncated,
+        "content": content,
+    }
+    if truncated:
+        payload["note"] = (
+            f"Showing the last {len(tail)} of {total} lines; raise 'lines' "
+            f"(up to 1000) or wait for completion to see more."
+        )
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def _extract_output_tail(
@@ -4690,14 +4785,17 @@ def _build_top_level_description() -> str:
         "transcript paths, and the completed result (one consolidated message, "
         "results in task order) re-enters the conversation on its own. Do NOT "
         "wait or poll; continue other work. While children run, `action` "
-        "(list/steer/stop) controls them live — steer when a transcript shows "
-        "a child drifting.\n\n"
+        "(list/steer/stop/tail) controls them live — steer when a transcript shows "
+        "a child drifting; tail to peek at one child's recent lines without "
+        "waiting on its completion message.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
         "- Mechanical multi-step work with no reasoning needed -> execute_code\n"
         "- A single tool call -> call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot ask questions\n"
+        "- Watching a child mid-run -> delegate_task(action='tail', subagent_id=...) returns\n"
+        "  the last N lines of its live transcript without waiting on completion\n"
         "- Durable work that must survive this session -> cronjob or "
         "terminal(background=True, notify=True); /stop, /new, or "
         "process exit discards running subagents.\n\n"
@@ -4848,13 +4946,16 @@ DELEGATE_TASK_SCHEMA = {
             # re-add to the schema.
             "action": {
                 "type": "string",
-                "enum": ["spawn", "list", "steer", "stop"],
+                "enum": ["spawn", "list", "steer", "stop", "tail"],
                 "description": (
                     "Default 'spawn'. Live control of running children: "
                     "'list' = ids/goals/status/transcripts; 'steer' = queue "
                     "course-correction text into one child (subagent_id + "
                     "message) without stopping it; 'stop' = end one child "
-                    "early (subagent_id; partial result still returns). "
+                    "early (subagent_id; partial result still returns); "
+                    "'tail' = return the last N lines (default 40) of one "
+                    "child's live transcript (subagent_id + lines) for "
+                    "in-flight visibility without waiting on completion. "
                     "Control actions return immediately; goal/tasks are "
                     "ignored unless spawning."
                 ),


### PR DESCRIPTION
## Problem

`delegate_task(action="list")` already surfaces a `live_transcript` path for every running child, but the parent agent had no way to actually read it. The only visibility into a long-running child was waiting on the completion message — or shelling out to `tail -f` from the terminal tool, which is awkward and tool-expensive.

## What this PR adds

A new control action `tail` alongside `list` / `steer` / `stop`:

```json
delegate_task(action="tail", subagent_id="deleg_...", lines=80)
```

Returns the last N lines of the child's live transcript (the file already created at dispatch by `tools/delegation_live_log.py`).

Response shape:
```json
{
  "action": "tail",
  "subagent_id": "deleg_...",
  "status": "running",
  "transcript_path": "/path/to/task.log",
  "lines_requested": 80,
  "lines_returned": 80,
  "lines_total": 412,
  "lines_truncated": 332,
  "content": "... last 80 lines ...",
  "note": "Showing the last 80 of 412 lines; raise 'lines' (up to 1000) or wait for completion to see more."
}
```

## Design choices

- **Same ownership chain as `steer`/`stop`** — only this conversation's spawn tree resolves. A foreign child returns the same `No live subagent` error the other control actions return. Tested explicitly.
- **Read-only side channel.** The transcript is appended by the child; we read it without touching any state, mutex, or registry. The child is never un注册 by tailing.
- **`lines` capped at 1000.** Hard cap regardless of caller input. Default 40.
- **Missing transcript file → `status: transcript_missing`** instead of an error. Common case: file pruned by `LIVE_RETENTION_DAYS` (7d). The parent can decide whether to wait or steer-stop.
- **Non-integer `lines` → falls back to default** rather than 400ing on type validation.
- **`Path` added to imports** of `delegate_tool.py`.

## Tests

`tests/tools/test_delegate_tail_action.py` — 12 new tests, all passing:

| Test | Verifies |
|---|---|
| `test_tail_requires_subagent_id` | missing id → error |
| `test_tail_with_blank_subagent_id` | whitespace-only id → error |
| `test_tail_unknown_subagent_id` | nonexistent id → error |
| `test_tail_foreign_owned_subagent_is_not_visible` | cross-spawn-tree isolation |
| `test_tail_child_with_no_transcript_path` | missing path attr → error |
| `test_tail_reports_missing_transcript_file` | pruned file → `transcript_missing` |
| `test_tail_returns_last_n_lines_default` | default 40, content matches |
| `test_tail_with_smaller_explicit_lines` | explicit `lines=5` honoured |
| `test_tail_caps_oversized_request_at_1000` | input 99999 → capped at 1000 |
| `test_tail_with_non_integer_lines_falls_back_to_default` | `lines="twenty"` → 40 |
| `test_tail_does_not_unregister_child` | side-effect-free read |
| `test_tail_empty_file_returns_zero_lines` | empty file → empty content, no note |

**Regression check:** all 122 pre-existing tests in `test_delegate_control_actions.py` / `test_delegate.py` / `test_delegate_batch_validation.py` still pass.

## Files

```
 tools/delegate_tool.py                        | +176 -5
 tests/tools/test_delegate_tail_action.py     | +136 -0
```

## Out of scope (deliberately)

- Streaming / chunked output — `tail` returns the file content as one JSON string, fine for transcripts that are bounded to a few hundred lines. A streaming variant would need its own schema and is a separate concern.
- Filtering by event type (e.g. only tool results). Current shape is plain-text tail matching `tail -f` ergonomics.
- Cross-child aggregate tail (`tail --all`). Use `action="list"` to enumerate, then call `tail` per child.
