### PR TITLE
fix(telegram): recover rich-only inbound messages dropped by filters.TEXT

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4381,6 +4381,11 @@ class TelegramAdapter(BasePlatformAdapter):
         ))
         # Handle inline keyboard button callbacks (update prompts)
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+        # Rich-only messages (Bot API rich_message blocks with no text/caption)
+        # match no filter above and would be silently dropped. Late catch-all:
+        # if nothing in group 0 claimed the message, flatten its rich_message
+        # blocks to plaintext and dispatch through the normal text pipeline.
+        app.add_handler(TypeHandler(Update, self._handle_rich_only_message), group=100)
         # Inline command picker (@botname <query>) — searchable, uncapped
         # access to every command/skill. Inert until the bot owner enables
         # inline mode via BotFather /setinline (Telegram never delivers
@@ -9841,6 +9846,42 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        await self._cache_replied_media(msg, event)
+        event = self._apply_telegram_group_observe_attribution(event)
+        self._enqueue_text_event(event)
+
+    async def _handle_rich_only_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Catch rich-only messages (group 100) that no group-0 handler claimed.
+
+        Bot API 10.1 rich messages carry their content in ``rich_message``
+        blocks instead of ``text``/``caption``. PTB 22.x does not model the
+        field, so ``filters.TEXT`` and every media filter miss them and the
+        update would be silently dropped. Flatten the blocks to plaintext
+        (formatting loss is acceptable — the content survives) and dispatch
+        through the normal text pipeline.
+        """
+        msg = self._effective_update_message(update)
+        if not msg:
+            return
+        if getattr(msg, "text", None) or getattr(msg, "caption", None):
+            return  # already claimed by a group-0 handler
+        rich_text = self._extract_rich_reply_text(msg)
+        if not rich_text:
+            return  # not a rich message (or empty) — nothing to recover
+        if not self._is_user_authorized_from_message(msg):
+            logger.warning(
+                "[Telegram] Blocked unauthorized user %s in chat %s",
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
+            )
+            return
+        if not self._should_process_message(msg):
+            return
+        await self._ensure_forum_commands(update.message)
+
+        logger.info("[%s] Recovered rich-only message as plaintext (%d chars)", self.name, len(rich_text))
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = self._clean_bot_trigger_text(rich_text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)

--- a/tests/gateway/test_telegram_rich_only.py
+++ b/tests/gateway/test_telegram_rich_only.py
@@ -1,0 +1,78 @@
+"""Rich-only Telegram messages (Bot API 10.1 rich_message blocks) must not be
+silently dropped — they are flattened to plaintext and dispatched as TEXT."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="test-token")
+    adapter._running = True
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._media_group_events = {}
+    adapter._media_group_tasks = {}
+    adapter._text_batch_delay_seconds = 0.1
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._held_inbound_events = []
+    adapter.HELD_INBOUND_MAX = 64
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _rich_update(text: str = "富文本内容", *, with_text: bool = False):
+    blocks = [{"type": "paragraph", "text": [{"type": "plain", "text": text}]}]
+    api_kwargs = {"rich_message": {"blocks": blocks}}
+    msg = SimpleNamespace(
+        text=text if with_text else None,
+        caption=None,
+        api_kwargs=api_kwargs,
+        chat=SimpleNamespace(id=1, type="private", title=None),
+        from_user=SimpleNamespace(id=1, full_name="T", is_bot=False),
+        message_id=10,
+        date=None,
+    )
+    return SimpleNamespace(update_id=1, message=msg)
+
+
+@pytest.mark.asyncio
+async def test_rich_only_message_recovered_as_text(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_is_user_authorized_from_message", lambda m: True)
+    monkeypatch.setattr(adapter, "_should_process_message", lambda m, **k: True)
+    monkeypatch.setattr(adapter, "_ensure_forum_commands", AsyncMock())
+    monkeypatch.setattr(adapter, "_cache_replied_media", AsyncMock())
+    monkeypatch.setattr(adapter, "_apply_telegram_group_observe_attribution", lambda e: e)
+    monkeypatch.setattr(adapter, "_clean_bot_trigger_text", lambda t: t)
+    monkeypatch.setattr(adapter, "_build_message_event", lambda m, t, update_id=None: SimpleNamespace(text=""))
+    enqueued = []
+    monkeypatch.setattr(adapter, "_enqueue_text_event", enqueued.append)
+
+    await adapter._handle_rich_only_message(_rich_update(), context=None)
+
+    assert len(enqueued) == 1
+    assert "富文本内容" in enqueued[0].text
+
+
+@pytest.mark.asyncio
+async def test_plain_message_not_touched(monkeypatch):
+    """A message with text is owned by the group-0 TEXT handler — never enqueue here."""
+    adapter = _make_adapter()
+    enqueued = []
+    monkeypatch.setattr(adapter, "_enqueue_text_event", enqueued.append)
+
+    await adapter._handle_rich_only_message(_rich_update(with_text=True), context=None)
+
+    assert enqueued == []


### PR DESCRIPTION
## Symptom

A user sending a **rich-formatted message** (Bot API 10.1 `rich_message` blocks — e.g. Telegram Premium / long formatted sends) gets **no response at all**: no inbound log line, no error, nothing. The message silently vanishes before reaching the agent.

Verified on a live gateway: plain text, photos and commands all produce `inbound message` log lines; a rich-only message produces none.

## Root cause

Bot API 10.1 rich messages carry their content in `message.rich_message` blocks **with no plain `text`/`caption` field**. PTB 22.x does not model `rich_message`, so it lands untouched in `Message.api_kwargs`:

- `_register_handlers` registers `filters.TEXT & ~filters.COMMAND`, media filters, etc. — **none match** `text=None`
- The gateway polls with `allowed_updates=Update.ALL_TYPES`, so the update *is* delivered to PTB — it just matches no handler and is dropped without any log

## Fix

A late catch-all handler registered at `group=100` (after every group-0 handler):

- Only fires when the message has **no** `text`/`caption` (i.e. no group-0 handler claimed it) **and** carries flatten-able `rich_message` blocks — every already-handled update returns immediately
- Flattens the rich blocks to plaintext via the **existing** `_flatten_rich_blocks`/`_extract_rich_reply_text` helpers (already used for rich reply-quote recovery)
- Dispatches through the **unchanged** text pipeline: `_is_user_authorized_from_message` → `_should_process_message` → `_build_message_event` → `_clean_bot_trigger_text` → text batching. Auth, gating and reply-context all apply as-is.

Formatting is deliberately dropped (plaintext recovery); keeping formatting would require PTB upstream support for the field.

## Verification

- New `tests/gateway/test_telegram_rich_only.py`: rich-only update → recovered & enqueued as TEXT; normal text message → **never** double-enqueued. `2 passed`.
- Existing suites on origin/main: `test_telegram_text_batching.py` + `test_telegram_auth_check.py` — `36 passed` total.
- Live-reproduced the drop on a production gateway before the fix.

## Relation to #95292

Same root cause as #95292 (found it after writing this fix). This is the **minimal variant** — 36 lines in the adapter, zero new abstractions, reusing the existing flattener and the existing text pipeline verbatim — offered as an alternative for maintainers to choose from. Happy to close in favor of either.