### PR TITLE
fix(desktop): stop hidden panes from flashing composer focus

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -4,6 +4,7 @@ import { $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 
 import {
   blurComposerInput,
+  focusComposerInput,
   getActiveComposer,
   markActiveComposer,
   onComposerFocusRequest,
@@ -50,6 +51,29 @@ afterEach(() => {
   // would otherwise decide the next one.
   markActiveComposer('main')
   $hoveredTreeGroup.set(null)
+})
+
+describe('focusComposerInput', () => {
+  it('does not steal the caret from another live composer', () => {
+    const foreground = mountInput()
+    const background = mountInput()
+
+    foreground.focus()
+    focusComposerInput(background)
+
+    expect(document.activeElement).toBe(foreground)
+  })
+
+  it('still focuses when the caret is not already in a composer', () => {
+    const input = mountInput()
+    const outside = document.createElement('button')
+
+    document.body.append(outside)
+    outside.focus()
+    focusComposerInput(input)
+
+    expect(document.activeElement).toBe(input)
+  })
 })
 
 describe('blurComposerInput', () => {

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -396,10 +396,21 @@ export const focusComposerInput = (el: HTMLElement | null) => {
   // Skip when already focused: focus() runs the full focusing steps (forcing
   // layout) even on the active element, and during a session switch the DOM is
   // large and dirty — the redundant retries were measurably expensive there.
+  // Also skip when another composer already holds the caret: keep-alive tabs
+  // remount on 30s transcript/status backstops and would otherwise yank typing
+  // out of the visible box.
   const focus = () => {
-    if (document.activeElement !== el) {
-      el.focus({ preventScroll: true })
+    if (document.activeElement === el) {
+      return
     }
+
+    const active = document.activeElement
+
+    if (active instanceof HTMLElement && active.dataset.slot === RICH_INPUT_SLOT) {
+      return
+    }
+
+    el.focus({ preventScroll: true })
   }
 
   focus()

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react'
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
-import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
+import { usePaneLifecycle, usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
@@ -25,8 +25,8 @@ import {
   onScrollToBottomRequest,
   onThreadEditClose,
   onThreadEditOpen,
-  resetThreadScroll,
-  setThreadAtBottom
+  publishThreadAtBottom,
+  resetPublishedThreadScroll
 } from '@/store/thread-scroll'
 import { isSecondaryWindow } from '@/store/windows'
 
@@ -421,6 +421,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   const mountedPanes = useStore($mountedTranscriptPanes)
   const paneLifecycle = usePaneLifecycle()
+  const paneVisible = usePaneVisible()
   // Hidden panes retain only a live-tail budget. Visible panes share the normal
   // screen budget; a reveal backfills older rows in bounded transition steps.
   const paneBudget = transcriptPaneBudget(mountedPanes, paneLifecycle === 'hot-hidden')
@@ -575,8 +576,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
-  useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
-  useEffect(() => () => resetThreadScroll(), [])
+  useEffect(() => publishThreadAtBottom(isAtBottom, { paneVisible }), [isAtBottom, paneVisible])
+  useEffect(() => () => resetPublishedThreadScroll({ paneVisible }), [paneVisible])
 
   // Floating jump button (outside this subtree) → return to the bottom.
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])

--- a/apps/desktop/src/store/thread-scroll.test.ts
+++ b/apps/desktop/src/store/thread-scroll.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  $threadJumpButtonVisible,
+  $threadScrolledUp,
+  publishThreadAtBottom,
+  resetPublishedThreadScroll,
+  resetThreadScroll,
+  setThreadAtBottom
+} from './thread-scroll'
+
+afterEach(() => {
+  resetThreadScroll()
+})
+
+describe('publishThreadAtBottom', () => {
+  it('lets the visible pane flash the jump pill when the thread leaves the bottom', () => {
+    publishThreadAtBottom(false, { paneVisible: true })
+
+    expect($threadJumpButtonVisible.get()).toBe(true)
+    expect($threadScrolledUp.get()).toBe(true)
+  })
+
+  it('ignores stick-to-bottom misses from a hidden keep-alive pane', () => {
+    setThreadAtBottom(true)
+
+    publishThreadAtBottom(false, { paneVisible: false })
+
+    expect($threadJumpButtonVisible.get()).toBe(false)
+    expect($threadScrolledUp.get()).toBe(false)
+  })
+})
+
+describe('resetPublishedThreadScroll', () => {
+  it('clears the jump pill when the visible pane unmounts', () => {
+    setThreadAtBottom(false)
+
+    resetPublishedThreadScroll({ paneVisible: true })
+
+    expect($threadJumpButtonVisible.get()).toBe(false)
+    expect($threadScrolledUp.get()).toBe(false)
+  })
+
+  it('does not clear the visible pane when a hidden list unmounts', () => {
+    setThreadAtBottom(false)
+
+    resetPublishedThreadScroll({ paneVisible: false })
+
+    expect($threadJumpButtonVisible.get()).toBe(true)
+    expect($threadScrolledUp.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -28,6 +28,25 @@ export const setThreadAtBottom = (isAtBottom: boolean) => {
 
 export const resetThreadScroll = () => setThreadAtBottom(true)
 
+/** Keep-alive tabs stay mounted with a real layout box, so their stick-to-bottom
+ *  misses (and unmount resets) would flash the visible jump pill and dim the
+ *  composer. Only the on-screen pane may publish the composer-facing mirror. */
+export const publishThreadAtBottom = (isAtBottom: boolean, publisher: { paneVisible: boolean }): void => {
+  if (!publisher.paneVisible) {
+    return
+  }
+
+  setThreadAtBottom(isAtBottom)
+}
+
+export const resetPublishedThreadScroll = (publisher: { paneVisible: boolean }): void => {
+  if (!publisher.paneVisible) {
+    return
+  }
+
+  resetThreadScroll()
+}
+
 // Cross-component bridge: the jump button lives by the composer, the viewport's
 // `scrollToBottom` lives inside the thread. The bridge registers a handler; the
 // button fires it. Mirrors the composer focus/insert emitter pattern.


### PR DESCRIPTION
Fixes #98680

## Bug Description

While typing in the primary Desktop composer, a keep-alive tab's 30s transcript/status backstop flashes the jump-to-bottom pill, dims the composer, and steals the caret. It reads as the chat "refreshing".

## Root Cause

`$threadScrolledUp` / `$threadJumpButtonVisible` are window-global. Every mounted `ThreadMessageList` (including `visibility: hidden` keep-alive tabs, which still have a layout box) publishes stick-to-bottom into them. A buried pane's backstop remount/reconcile therefore flashes chrome on the visible surface. Separately, `focusComposerInput` will `focus()` a remounted composer even when another composer already holds the caret.

Related but not this PR: #98316 scopes scroll *requests* per session but still writes the global visibility atoms; #98554 / #98434 are the dead-runtime 4001 storm; #95227 unmounts the composer on `loadingSession`.

## Fix

- Gate publishes/resets behind pane visibility (`publishThreadAtBottom` / `resetPublishedThreadScroll`).
- `focusComposerInput` is a no-op while another `[data-slot=composer-rich-input]` already has focus.

## How to Verify

1. Open two sessions as tabs. Type in the front composer.
2. Confirm a buried tab's transcript reconcile no longer flashes the jump pill or blurs the input.
3. `npx vitest run src/store/thread-scroll.test.ts src/app/chat/composer/focus.test.ts src/app/chat/scroll-to-bottom-button.test.tsx` (from `apps/desktop`)

## Test Plan

- [x] Added regression tests (hidden pane must not flip the jump pill; focusing a second composer must not steal the caret)
- [x] Sabotage run: both tests fail on the pre-fix bodies and pass on the fix
- [x] Existing focus + scroll-to-bottom tests still pass (25 tests)
- [x] `tsc -p . --noEmit` clean for the renderer

## Risk Assessment

Low — publisher no-ops when `paneVisible` is false; visible pane behavior is unchanged. Focus guard only skips when the active element is already a composer input, so type-to-focus and session-switch focus still work.
