### PR TITLE
fix(update): dismiss stale receipt after catch-up fleet restart

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -43,7 +43,8 @@ from hermes_cli.update_cmd_windows import (  # noqa: F401
 from hermes_cli.update_cmd_fleet import (  # noqa: F401
     _FLEET_RESTART_PENDING_NAME, _FRESH_RESTART_SUPERVISORS, _GatewayRestartOutcome,
     _apply_pending_fleet_restart_catchup, _clear_fleet_restart_pending_marker,
-    _current_checkout_sha, _drain_or_signal_gateway_for_update, _fleet_probe_expected_runtimes,
+    _current_checkout_sha, _dismiss_stale_receipt_trigger, _drain_or_signal_gateway_for_update,
+    _fleet_probe_expected_runtimes,
     _fleet_restart_pending_marker_path, _for_each_systemd_gateway_unit,
     _gateway_recovery_partition, _gateway_service_matches_profile, _pending_fleet_restart_needed,
     _receipt_looks_unfinished, _receipt_reports_stale_runtime, _resolve_manage_cmd,

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -344,6 +344,30 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
+def _dismiss_stale_receipt_trigger() -> None:
+    """Rename a stale unfinished ``latest.json`` so it stops re-triggering.
+
+    An interrupted-update receipt whose ``plan.runtimes[].code_sha`` values
+    are permanently behind the current checkout HEAD would retrigger
+    ``_receipt_reports_stale_runtime()`` on every invocation, driving an
+    idempotent but noisy fleet restart on every ``hermes update`` — the
+    catch-up restart already ran, the obligation is discharged, only the
+    receipt is still pointing at the pre-update state (#98022).
+    """
+    try:
+        from hermes_cli.update_receipt import _receipt_dir, read_latest_receipt
+
+        receipt = read_latest_receipt()
+        if isinstance(receipt, dict) and _receipt_looks_unfinished(receipt):
+            path = _receipt_dir() / "latest.json"
+            try:
+                path.rename(path.with_name("latest.json.bak"))
+            except OSError:
+                path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
@@ -358,6 +382,7 @@ def _apply_pending_fleet_restart_catchup() -> None:
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
+        _dismiss_stale_receipt_trigger()
         return
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -609,3 +609,43 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+def test_stale_unfinished_receipt_dismissed_after_catchup(monkeypatch):
+    """An interrupted-update receipt re-triggers pending infinitely.
+    _dismiss_stale_receipt_trigger must rename it so the next check
+    sees nothing pending (#98022)."""
+    disk_sha = "e" * 40
+    stale_sha = "7" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    receipt_json = json.dumps(
+        {
+            "exit_code": 1,
+            "stop_reason": "KeyboardInterrupt: ",
+            "outcome": "failed",
+            "plan": {
+                "expected_sha": disk_sha,
+                "runtimes": [
+                    {
+                        "kind": "gateway",
+                        "profile": "default",
+                        "pid": 42,
+                        "code_sha": stale_sha,
+                    }
+                ],
+            },
+        }
+    )
+    receipt_path = receipt_dir / "latest.json"
+    receipt_path.write_text(receipt_json, encoding="utf-8")
+
+    assert update_cmd._pending_fleet_restart_needed() is True
+
+    update_cmd._dismiss_stale_receipt_trigger()
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+    assert not receipt_path.exists()
+    assert receipt_dir.joinpath("latest.json.bak").read_text(encoding="utf-8") == receipt_json


### PR DESCRIPTION
Fixes #98022

## Problem

An interrupted-update receipt (`outcome=failed`, `stop_reason=KeyboardInterrupt`) whose `plan.runtimes[].code_sha` values are permanently behind the current checkout HEAD retriggered `_receipt_reports_stale_runtime()` on **every `hermes update`** — driving a redundant fleet restart on every invocation, even when the live fleet was already verified current (the run's own fleet check printed `up to date`).

The catch-up restart succeeded, the marker file was cleared, but the receipt was never touched — so the next invocation saw no marker but a stale receipt and restarted again.

## Timeline (verified by reporter @laoli-no1)

1. interrupted update writes `latest.json` with pre-update runtime SHAs
2. subsequent successful updates never write a new receipt (no receipt was written on this install since the interrupt)
3. every later `hermes update` restarts the fleet and prints the obsolete warning — 4 consecutive runs each restarted the gateway

## Fix

After a successful catch-up fleet restart (`_run_pending_fleet_restart()` returns `True`), `_dismiss_stale_receipt_trigger()` renames the unfinished `latest.json` to `latest.json.bak` (with `unlink` fallback). The marker file is still cleared first; two separate triggers, two separate guards. A live fleet probe is left as a follow-up hardening for the full self-healing chain the reporter suggested.

## Verification

New test `test_stale_unfinished_receipt_dismissed_after_catchup`:
- unfinished stale receipt → `_pending_fleet_restart_needed()` is `True`
- `_dismiss_stale_receipt_trigger()` → receipt renamed to `.bak`
- `_pending_fleet_restart_needed()` is `False`

`tests/hermes_cli/test_update_fleet_restart_pending.py`: 14/14 pass.