### PR TITLE
fix(dashboard): stop latest-descendant resume hijack onto reset/branch/delegate children

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12158,6 +12158,15 @@ def _session_latest_descendant(session_id: str, db):
 
     /model may create child sessions. Dashboard refresh should continue the
     newest child instead of reopening the old parent.
+
+    Only compression continuations (and model-rotation children) are
+    followed. Children that start a NEW user-visible conversation — /branch
+    forks, /new-reset / idle-daily boundary children, delegate subagents and
+    tool workers — must never hijack a resume of the session the user
+    actually clicked. This mirrors the guard set used by
+    ``SessionDB.resolve_resume_session_id`` / ``get_compression_tip``
+    (#84284 family; the missing reset guard here made the dashboard rewrite
+    ``?resume=<parent>`` onto the empty post-/new session).
     """
     def row_get(row, key, index):
         if isinstance(row, dict):
@@ -12174,6 +12183,11 @@ def _session_latest_descendant(session_id: str, db):
     if not sid or not db.get_session(sid):
         return None, []
 
+    # Reuse the canonical child-classification predicates from
+    # hermes_state_common so this walk cannot drift from the guard sets used
+    # by resolve_resume_session_id / get_compression_tip.
+    from hermes_state_common import _BRANCH_CHILD_SQL, _RESET_CHILD_SQL
+
     conn = (
         getattr(db, "conn", None)
         or getattr(db, "_conn", None)
@@ -12184,15 +12198,19 @@ def _session_latest_descendant(session_id: str, db):
     rows = []
     if conn is not None:
         raw_rows = conn.execute(
-            """
-            WITH RECURSIVE descendants(id, parent_session_id, started_at) AS (
-                SELECT id, parent_session_id, started_at FROM sessions WHERE id = ?
+            f"""
+            WITH RECURSIVE descendants(id, parent_session_id, started_at, model_config) AS (
+                SELECT id, parent_session_id, started_at, model_config FROM sessions WHERE id = ?
                 UNION
-                SELECT s.id, s.parent_session_id, s.started_at
+                SELECT s.id, s.parent_session_id, s.started_at, s.model_config
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
+                WHERE NOT ({_BRANCH_CHILD_SQL.format(a='s')})
+                  AND NOT ({_RESET_CHILD_SQL.format(a='s')})
+                  AND json_extract(COALESCE(s.model_config, '{{}}'), '$._delegate_from') IS NULL
+                  AND COALESCE(s.source, '') != 'tool'
             )
-            SELECT id, parent_session_id, started_at FROM descendants
+            SELECT id, parent_session_id, started_at, model_config FROM descendants
             """,
             (sid,),
         ).fetchall()
@@ -12201,9 +12219,47 @@ def _session_latest_descendant(session_id: str, db):
                 "id": row_get(row, "id", 0),
                 "parent_session_id": row_get(row, "parent_session_id", 1),
                 "started_at": row_get(row, "started_at", 2),
+                "model_config": row_get(row, "model_config", 3),
             })
     else:
         rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
+
+    # Same exclusion set as the SQL branch above, applied to the
+    # compact-rows fallback. Filter on BOTH the source label AND the durable
+    # markers: the source column can be polluted by the parent session's
+    # HERMES_SESSION_SOURCE ContextVar leaking into a delegation worker
+    # thread (mislabeling the child as tui/desktop), so source alone is not a
+    # reliable signal. The legacy reset heuristic recovers pre-marker rows:
+    # same exact non-empty routing key as a parent that ended at a reset
+    # boundary (session_reset / session_switch / idle / daily / ...).
+    from hermes_state_common import _RESET_END_REASONS
+
+    _parents = {r.get("id"): r for r in rows}
+
+    def _is_continuation_skip(row):
+        if row_get(row, "source", 3) == "subagent":
+            return True
+        try:
+            cfg = row_get(row, "model_config", 3) or "{}"
+            if isinstance(cfg, str):
+                cfg = json.loads(cfg)
+        except Exception:
+            cfg = {}
+        if cfg.get("_delegate_from") or cfg.get("_branched_from") or cfg.get("_reset_from"):
+            return True
+        if (row_get(row, "source", 3) or "") == "tool":
+            return True
+        parent = _parents.get(row.get("parent_session_id"))
+        if (
+            parent
+            and (parent.get("end_reason") or "") in _RESET_END_REASONS
+            and row.get("session_key")
+            and row.get("session_key") == parent.get("session_key")
+        ):
+            return True
+        return False
+
+    rows = [r for r in rows if not _is_continuation_skip(r)]
 
     children = {}
     for row in rows:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1147,6 +1147,90 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["session_id"] == "cyc-b"
 
+    def test_latest_descendant_skips_reset_branch_and_delegate_children(self):
+        """A dashboard resume of the session the user clicked must never be
+        hijacked onto a descendant that starts a NEW user-visible
+        conversation: /new-reset children (marker + legacy same-key
+        heuristic, #84284), /branch forks, and delegate subagents. Only
+        compression continuations may redirect the walk (same guard set as
+        resolve_resume_session_id)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="ln-a", source="telegram",
+                session_key="agent:main:telegram:dm:1", chat_id="1",
+            )
+            # modern /new-reset child (durable _reset_from marker)
+            db.create_session(
+                session_id="ln-b", source="telegram",
+                parent_session_id="ln-a", session_key="agent:main:telegram:dm:1",
+                chat_id="1", model_config={"_reset_from": "ln-a"},
+            )
+            # /branch fork
+            db.create_session(
+                session_id="ln-c", source="tui",
+                parent_session_id="ln-a", model_config={"_branched_from": "ln-a"},
+            )
+            # delegate subagent (worker child)
+            db.create_session(
+                session_id="ln-d", source="subagent",
+                parent_session_id="ln-a", model_config={"_delegate_from": "ln-a"},
+            )
+            # legacy pre-marker reset child: same routing key, parent ended at
+            # a reset boundary (session_reset / session_switch / idle / daily)
+            db.create_session(
+                session_id="ln-e", source="telegram",
+                parent_session_id="ln-a", session_key="agent:main:telegram:dm:1",
+                chat_id="1",
+            )
+            db._conn.execute(
+                "UPDATE sessions SET end_reason='session_reset',"
+                " ended_at=started_at + 1 WHERE id='ln-a'"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/ln-a/latest-descendant")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["session_id"] == "ln-a"
+        assert body["changed"] is False
+        assert body["path"] == ["ln-a"]
+
+    def test_latest_descendant_follows_compression_continuation(self):
+        """Auto-compression forks the continuation as a child of a parent
+        ended with end_reason='compression'; the dashboard refresh must keep
+        following that chain (that is what latest-descendant exists for)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="cc-a", source="telegram",
+                session_key="agent:main:telegram:dm:2", chat_id="1",
+            )
+            db.create_session(
+                session_id="cc-b", source="telegram",
+                parent_session_id="cc-a", session_key="agent:main:telegram:dm:2",
+                chat_id="1",
+            )
+            db._conn.execute(
+                "UPDATE sessions SET end_reason='compression',"
+                " ended_at=started_at + 1 WHERE id='cc-a'"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/cc-a/latest-descendant")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["session_id"] == "cc-b"
+        assert body["changed"] is True
+
 
 
 


### PR DESCRIPTION
## Summary

Resuming a session from the dashboard webui can silently switch to the **wrong session**: clicking a parent session (e.g. one that was later \`/new\`-reset) loads the empty post-reset descendant instead. Both the PTY startup path (\`_make_tui_argv\` → \`HERMES_TUI_RESUME\`) and \`GET /api/sessions/{id}/latest-descendant\` (which rewrites \`?resume=\` on the chat page) resolve through \`_session_latest_descendant\`, which walks \`parent_session_id\` to the newest child leaf.

## Root cause

\`_session_latest_descendant\` followed children of **any** kind. It only excluded delegate subagents, so:

- **/new-reset boundary children** (modern \`_reset_from\` marker, or the legacy same-key heuristic) hijacked the resume onto the new — usually empty — session. The state layer was already fenced for this (\`resolve_resume_session_id\`, fixed upstream in \`91c7a67f4\`, see #84284), but the web server walker was never touched.
- **/branch forks** and **tool children** were followed too (the exact gap #64618/#64620 describes).

## Fix

Reuse the canonical child-classification predicates from \`hermes_state_common\` (\`_BRANCH_CHILD_SQL\`, \`_RESET_CHILD_SQL\`, \`_RESET_END_REASONS\`) in both the recursive CTE and the compact-rows fallback so the walk matches \`resolve_resume_session_id\` exactly: only compression continuations (and model-rotation children) are followed.

## Tests

- \`test_latest_descendant_skips_reset_branch_and_delegate_children\` — modern \`_reset_from\` child, legacy same-key reset child, branch fork, and delegate subagent all excluded; the walk stays on the clicked parent.
- \`test_latest_descendant_follows_compression_continuation\` — compression chain still redirects to the continuation (the original purpose of the endpoint).
- Existing \`test_latest_descendant_survives_parent_cycle\` still passes.

Verified against a real state.db reproduction: clicking \`20260830_022311_2f4fd34a\` used to resolve to \`20260830_032428_e3372fd8\` (the /new fork, history=0); after the fix it resolves to itself.

Related: #84284 (state-layer fence, fixed upstream), #64618 / #64620 (same walker, delegate/branch/tool gap — this PR covers that scope too).