### PR TITLE
fix(state): bound state.db read connections per file, not per SessionDB

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7576,6 +7576,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._session_db_handle_cache = cache
 
         def _open():
+            # Borrow the SessionStore's handle for this path rather than
+            # opening a second one. Both caches resolve the SAME
+            # ``_default_db_path()``, so the process was holding two writer
+            # connections and two read pools against one state.db — the fd
+            # budget doubled for nothing, and doubled again per profile on a
+            # multiplexed gateway (#98573). The store owns the handle and
+            # sweeps it at shutdown; this cache holds only the async wrapper.
+            #
+            # A borrowed wrapper cannot go stale in practice: the store's
+            # cache only drops handles in close_all_db_handles() (shutdown),
+            # and while the store's own open is failing there is nothing to
+            # borrow, so nothing is cached here either.
+            store = getattr(self, "session_store", None)
+            borrowed = getattr(store, "_db", None) if store is not None else None
+            if borrowed is not None:
+                wrapper = AsyncSessionDB(borrowed)
+                # close_all_session_db_handles() must not close what the store
+                # owns; the store's own sweep already does, and it runs first.
+                wrapper.__dict__["_hermes_borrowed_handle"] = True
+                return wrapper
+            if store is not None:
+                # The store exists and its handle is unavailable (failed open
+                # or backoff). Opening our own here would resurrect exactly
+                # the duplicate this borrows away from, so report the same
+                # unavailability the store is already reporting.
+                raise RuntimeError("SessionStore SQLite handle unavailable")
             try:
                 return AsyncSessionDB(SessionDB())
             except Exception as exc:
@@ -7617,8 +7643,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Shutdown counterpart of the per-path cache above; mirrors
         ``SessionStore.close_all_db_handles``.  Handles are drained under the
         lock and closed outside it; a pinned handle is the pinner's to close.
+
+        Wrappers around a handle BORROWED from ``session_store`` (#98573) are
+        drained but not closed: the store owns that connection and its own
+        sweep — which runs first in the shutdown sequence — closes it.
         """
         def _close(db) -> None:
+            if getattr(db, "__dict__", {}).get("_hermes_borrowed_handle"):
+                return
             inner = getattr(db, "_db", db)
             if inner is None or not hasattr(inner, "close"):
                 return

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13653,10 +13653,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Export and cleanup
     # =========================================================================
 
-    def is_explicit_fork_child(self, session_id: str) -> bool:
-        session = self.get_session(session_id)
-        return bool(session and self._is_explicit_fork_child_row(session))
-
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
         """True when ``session`` is a branch, delegate, or tool child of its parent.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -385,6 +385,131 @@ _READ_OPEN_RETRY_SECONDS = 60.0
 # the correct trade against a process-wide wedge the supervisor cannot see.
 _READ_POOL_MAX = 8
 
+# Hard ceiling on read-only connections ALIVE at once in this PROCESS, across
+# every state.db it has open.
+#
+# _READ_POOL_MAX bounds one file. A multiplexed gateway serves N profiles from
+# one process and each profile has its OWN state.db, so a per-file ceiling
+# still lets the descriptor cost grow with the profile count — the same shape
+# as the per-instance bug, one level out (#98573).
+#
+# Three profiles' worth. Past it, readers on the (N+1)th file degrade to their
+# writer connection instead of opening descriptors, which is the same trade
+# _READ_POOL_MAX makes and for the same reason: a slow read path is
+# recoverable, a process-wide EMFILE is not.
+_READ_POOL_PROCESS_MAX = 24
+
+# Warn when one process accumulates more than this many SessionDB handles on a
+# single file. Not a limit — writer connections cannot be rationed the way read
+# connections can — a diagnostic for the duplicate-handle class of bug.
+_HANDLES_PER_PATH_WARN = 4
+
+# Descriptors kept in reserve for everything that is NOT this module: httpx
+# sockets, terminal subprocess pipes, log files.
+#
+# The ceilings above bound Hermes's SQLite descriptors, which is only ever part
+# of the fd table. The #98573 report is exactly that case: ~20 state.db
+# descriptors were not the whole 256, they were the share that pushed httpx and
+# terminal pipes over, and the EMFILE surfaced in tools/terminal_tool.py rather
+# than here. So the read pool also yields when the PROCESS is close to its
+# limit, whatever is consuming it.
+_FD_HEADROOM_RESERVE = 64
+
+# The fd count is a directory listing; cache it briefly so a burst of reads
+# does not turn one syscall per query. Stale by at most this long, which can
+# let through at most the ceiling's worth of opens — already bounded above.
+_FD_USAGE_CACHE_SECONDS = 0.25
+
+_process_read_permits = threading.BoundedSemaphore(_READ_POOL_PROCESS_MAX)
+
+# Count of read opens refused because the process was low on descriptors. The
+# only externally visible signal that the guard is firing; guarded by
+# _read_budgets_lock.
+_read_open_denied_fd_headroom = 0
+
+_fd_usage_lock = threading.Lock()
+_fd_usage_cache: "tuple[float, Optional[int]]" = (0.0, None)
+
+
+def _open_fd_count() -> Optional[int]:
+    """Descriptors open in THIS process, or None when it cannot be measured.
+
+    ``/proc/self/fd`` on Linux, ``/dev/fd`` on macOS and the BSDs. Windows has
+    neither, and no RLIMIT_NOFILE to compare against, so the guard is inert
+    there — which is correct: the CRT limit is thousands of handles, not 256.
+    """
+    for fd_dir in ("/proc/self/fd", "/dev/fd"):
+        try:
+            return len(os.listdir(fd_dir))
+        except OSError as exc:
+            if exc.errno in (errno.EMFILE, errno.ENFILE):
+                # The probe itself could not get a descriptor. That IS the
+                # answer: there is no headroom.
+                return -1
+            continue
+    return None
+
+
+def _fd_soft_limit() -> Optional[int]:
+    """The process's soft RLIMIT_NOFILE, or None when there is no usable one."""
+    try:
+        import resource
+    except ImportError:
+        return None
+    try:
+        soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError):
+        return None
+    if soft in (resource.RLIM_INFINITY, -1):
+        return None
+    return int(soft)
+
+
+def _fd_headroom_ok() -> bool:
+    """Whether the process can spare a descriptor for a new read connection.
+
+    Fails OPEN when the platform cannot be measured (Windows, no fd directory,
+    unlimited RLIMIT_NOFILE): an unmeasurable platform is not a tight one, and
+    refusing every read there would be a self-inflicted convoy. Fails CLOSED
+    only on evidence — a measured shortfall, or a probe that could not get a
+    descriptor of its own.
+    """
+    soft = _fd_soft_limit()
+    if soft is None:
+        return True
+
+    global _fd_usage_cache
+    now = time.monotonic()
+    with _fd_usage_lock:
+        stamp, cached = _fd_usage_cache
+        fresh = cached is not None and (now - stamp) < _FD_USAGE_CACHE_SECONDS
+    if not fresh:
+        cached = _open_fd_count()
+        with _fd_usage_lock:
+            _fd_usage_cache = (now, cached)
+
+    if cached is None:
+        return True
+    if cached < 0:
+        return False
+    return (soft - cached) > _FD_HEADROOM_RESERVE
+
+
+def _reclaim_idle_read_conn_anywhere() -> bool:
+    """Close one idle read connection on ANY path in this process.
+
+    The process ceiling is shared across files, so the connection that has to
+    go to make room may belong to a different database entirely — a profile
+    that has been quiet for an hour should not hold descriptors the profile
+    being served right now needs.
+    """
+    with _read_budgets_lock:
+        budgets = list(_read_budgets.values())
+    for budget in budgets:
+        if budget.reclaim_idle():
+            return True
+    return False
+
 
 class _PathReadBudget:
     """The read-connection permits for ONE database file, shared process-wide.
@@ -416,27 +541,88 @@ class _PathReadBudget:
         # peers' budget object; __del__ still runs close() and returns the
         # permits.
         self._members: "weakref.WeakSet[SessionDB]" = weakref.WeakSet()
+        self._duplicate_handles_warned = False
 
     def register(self, db: "SessionDB") -> None:
         with self._lock:
             self._members.add(db)
+            handles = len(self._members)
+            warn = (
+                handles > _HANDLES_PER_PATH_WARN
+                and not self._duplicate_handles_warned
+            )
+            if warn:
+                self._duplicate_handles_warned = True
+        if warn:
+            # The read connections are capped; the WRITER connection each
+            # handle holds is not, and cannot be — a SessionDB without one
+            # cannot write. The only real bound on writers is not opening
+            # redundant handles in the first place (which is what
+            # GatewayRunner borrowing SessionStore's handle does, #98573), so
+            # the next duplicate should be visible before it becomes an
+            # incident rather than inferred from an lsof after one.
+            logger.warning(
+                "%d live SessionDB handles on %s in this process; each holds "
+                "its own writer connection (read connections are capped at %d "
+                "for the file). A long-lived process should share one handle "
+                "per path.",
+                handles,
+                db.db_path,
+                _READ_POOL_MAX,
+            )
 
     def acquire(self, requester: "SessionDB") -> bool:
-        """Take a permit, reclaiming an idle peer connection if need be."""
-        if self.permits.acquire(blocking=False):
+        """Take a permit for a new read connection, or refuse.
+
+        Three gates, broadest first: the process's descriptor headroom, the
+        process-wide read ceiling, then this file's ceiling. Refusing means
+        the caller serves the read from the locked writer connection — slower,
+        never an error.
+        """
+        if not _fd_headroom_ok():
+            global _read_open_denied_fd_headroom
+            with _read_budgets_lock:
+                _read_open_denied_fd_headroom += 1
+            return False
+        if not self._acquire_process_permit():
+            return False
+        if self._acquire_path_permit(requester):
             return True
-        if not self._reclaim_idle(requester):
+        _process_read_permits.release()
+        return False
+
+    def release(self) -> None:
+        """Return one connection's permits. Pairs with a successful acquire()."""
+        self.permits.release()
+        _process_read_permits.release()
+
+    def _acquire_process_permit(self) -> bool:
+        if _process_read_permits.acquire(blocking=False):
+            return True
+        if not _reclaim_idle_read_conn_anywhere():
             return False
         # Another thread may take the freed permit first; that is a legitimate
         # loss, and the caller degrades to the writer lock rather than looping.
+        return _process_read_permits.acquire(blocking=False)
+
+    def _acquire_path_permit(self, requester: "SessionDB") -> bool:
+        if self.permits.acquire(blocking=False):
+            return True
+        if not self.reclaim_idle(exclude=requester):
+            return False
         return self.permits.acquire(blocking=False)
 
-    def _reclaim_idle(self, requester: "SessionDB") -> bool:
-        """Close one idle pooled connection held by a peer. True if one went."""
+    def reclaim_idle(self, exclude: "Optional[SessionDB]" = None) -> bool:
+        """Close one idle pooled connection held by a member. True if one went.
+
+        Closing it runs release(), which returns both the path permit and the
+        process permit, so this is the single reclaim primitive both ceilings
+        use.
+        """
         with self._lock:
-            peers = [db for db in self._members if db is not requester]
-        for peer in peers:
-            if peer._evict_one_idle_read_conn():
+            members = [db for db in self._members if db is not exclude]
+        for member in members:
+            if member._evict_one_idle_read_conn():
                 return True
         return False
 
@@ -4984,7 +5170,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
-            self._read_permits.release()
+            self._read_budget.release()
             return None
         except BaseException:
             # Anything else (a non-sqlite3 extension-load failure, MemoryError,
@@ -4993,7 +5179,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # permanently shrinks the read path by one slot for the life of the
             # process.
             self._discard_partial_read_conn(conn)
-            self._read_permits.release()
+            self._read_budget.release()
             raise
         return conn
 
@@ -5052,7 +5238,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except Exception as exc:
             logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
         finally:
-            self._read_permits.release()
+            self._read_budget.release()
 
     def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
         """Borrow a read connection from the pool, opening one on a miss.
@@ -13466,6 +13652,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # =========================================================================
     # Export and cleanup
     # =========================================================================
+
+    def is_explicit_fork_child(self, session_id: str) -> bool:
+        session = self.get_session(session_id)
+        return bool(session and self._is_explicit_fork_child_row(session))
 
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
         """True when ``session`` is a branch, delegate, or tool child of its parent.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -366,8 +366,9 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 # query; short enough that transient fd pressure doesn't strand the read pool.
 _READ_OPEN_RETRY_SECONDS = 60.0
 
-# Hard ceiling on read-only connections ALIVE at once per SessionDB — pooled
-# idle ones and checked-out ones together.
+# Hard ceiling on read-only connections ALIVE at once against one database
+# FILE — pooled idle ones and checked-out ones together, summed over every
+# SessionDB in this process that points at that file. See _PathReadBudget.
 #
 # Deliberately one constant for both the pool's maxsize and the permit count,
 # because bounding only the pool bounds the wrong thing. A LifoQueue caps how
@@ -383,6 +384,90 @@ _READ_OPEN_RETRY_SECONDS = 60.0
 # connection instead of opening more descriptors — slower under load, which is
 # the correct trade against a process-wide wedge the supervisor cannot see.
 _READ_POOL_MAX = 8
+
+
+class _PathReadBudget:
+    """The read-connection permits for ONE database file, shared process-wide.
+
+    ``_READ_POOL_MAX`` used to be enforced by a ``BoundedSemaphore`` owned by
+    each SessionDB, which bounded the wrong noun: the descriptors are spent on
+    a *file*, so N SessionDB objects on one state.db each got their own
+    allowance and peak scaled as ``N x (1 + _READ_POOL_MAX)``.  A long-lived
+    gateway holds at least two (``SessionStore`` and ``GatewayRunner`` open
+    independent handles per profile path) and the count grows with the profile
+    count, which is how a healthy process walked into EMFILE — #98573.
+
+    Holding the permits here instead makes the ceiling mean what its docstring
+    always claimed: read connections ALIVE at once against this path.
+
+    One consequence has to be handled rather than documented away.  A pooled
+    idle connection keeps its permit, so the first instance to warm up would
+    otherwise pin all eight and every later instance — a cron job's transient
+    handle, a second profile's store — would be permanently demoted to the
+    locked writer connection.  That is why a permit miss first reclaims an
+    IDLE connection from a peer instance on the same path: idle descriptors
+    are transferable, in-use ones are not.
+    """
+
+    def __init__(self) -> None:
+        self.permits = threading.BoundedSemaphore(_READ_POOL_MAX)
+        self._lock = threading.Lock()
+        # Weak so a SessionDB that is dropped without close() cannot pin its
+        # peers' budget object; __del__ still runs close() and returns the
+        # permits.
+        self._members: "weakref.WeakSet[SessionDB]" = weakref.WeakSet()
+
+    def register(self, db: "SessionDB") -> None:
+        with self._lock:
+            self._members.add(db)
+
+    def acquire(self, requester: "SessionDB") -> bool:
+        """Take a permit, reclaiming an idle peer connection if need be."""
+        if self.permits.acquire(blocking=False):
+            return True
+        if not self._reclaim_idle(requester):
+            return False
+        # Another thread may take the freed permit first; that is a legitimate
+        # loss, and the caller degrades to the writer lock rather than looping.
+        return self.permits.acquire(blocking=False)
+
+    def _reclaim_idle(self, requester: "SessionDB") -> bool:
+        """Close one idle pooled connection held by a peer. True if one went."""
+        with self._lock:
+            peers = [db for db in self._members if db is not requester]
+        for peer in peers:
+            if peer._evict_one_idle_read_conn():
+                return True
+        return False
+
+
+# canonical db path -> the permits for that file. Weak values: the budget
+# lives exactly as long as some SessionDB on that path holds a strong
+# reference to it, so a test that churns tmp_path databases does not grow
+# this map for the life of the process.
+_read_budgets: "weakref.WeakValueDictionary[str, _PathReadBudget]" = (
+    weakref.WeakValueDictionary()
+)
+_read_budgets_lock = threading.Lock()
+
+
+def _read_budget_key(db_path) -> str:
+    """Canonicalise a db path so two spellings share one budget."""
+    try:
+        return str(Path(db_path).resolve())
+    except OSError:
+        return str(db_path)
+
+
+def _read_budget_for(db_path) -> _PathReadBudget:
+    key = _read_budget_key(db_path)
+    with _read_budgets_lock:
+        budget = _read_budgets.get(key)
+        if budget is None:
+            budget = _PathReadBudget()
+            _read_budgets[key] = budget
+        return budget
+
 
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
@@ -4545,7 +4630,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # reader that cannot get a permit must degrade to the writer lock, not
         # queue here — blocking would convert fd exhaustion into a stall, which
         # is the same outage with a different stack trace.
-        self._read_permits = threading.BoundedSemaphore(_READ_POOL_MAX)
+        #
+        # Permits are shared per DATABASE PATH, not per instance: the
+        # descriptors they ration belong to the file, and one process holds
+        # several SessionDB objects on the same state.db (#98573). See
+        # _PathReadBudget.
+        self._read_budget = _read_budget_for(self.db_path)
+        self._read_budget.register(self)
+        # Bound to the semaphore itself so every release site
+        # (_close_read_conn and the _get_read_conn failure paths) is unchanged.
+        self._read_permits = self._read_budget.permits
         # Count of reads that found no permit and fell back to the locked
         # writer connection. Not load-bearing; it is the only externally
         # visible signal that the ceiling is actually being reached, so a
@@ -4840,7 +4934,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Take the descriptor permit BEFORE the open, so concurrent openers
         # race for permits rather than for file descriptors. Non-blocking:
         # losing the race means "use the writer connection", not "wait".
-        if not self._read_permits.acquire(blocking=False):
+        if not self._read_budget.acquire(self):
             with self._read_conns_lock:
                 self._read_permit_exhausted += 1
             logger.debug(
@@ -4902,6 +4996,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._read_permits.release()
             raise
         return conn
+
+    def _evict_one_idle_read_conn(self) -> bool:
+        """Close one connection sitting idle in this instance's pool.
+
+        Called by _PathReadBudget when a peer SessionDB on the same file wants
+        a permit this instance is holding but not using. Only the idle set is
+        reachable from here — a checked-out connection is not in the queue —
+        so this can never pull a connection out from under a live reader.
+
+        Returns whether a connection (and therefore a permit) was released.
+        """
+        try:
+            conn = self._read_pool.get_nowait()
+        except queue.Empty:
+            return False
+        self._close_read_conn(conn)
+        return True
 
     def _discard_partial_read_conn(self, conn) -> None:
         """Close a connection that failed between open and hand-off.

--- a/tests/gateway/test_session_db_handle_sharing.py
+++ b/tests/gateway/test_session_db_handle_sharing.py
@@ -1,0 +1,158 @@
+"""One gateway process must not hold two SessionDB handles on one state.db.
+
+Regression coverage for #98573.  ``SessionStore`` and ``GatewayRunner`` each
+cached a handle per resolved path, and both resolve the SAME
+``_default_db_path()``.  The process therefore held two writer connections and
+two independent read pools against one file, so the descriptor budget doubled
+for nothing -- and doubled again per profile on a multiplexed gateway, until a
+long-lived process passed the 256 soft ``RLIMIT_NOFILE`` a service manager
+hands it and unrelated code paths started failing with EMFILE while the
+process stayed alive.
+
+The runner now borrows the store's handle and caches only the async wrapper.
+Ownership follows: the store closes the connection, the runner does not.
+"""
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED
+from gateway.session import SessionStore
+from gateway.session_db_recovery import RecoverableHandleCache
+
+
+def _live_count(path) -> int:
+    """Live-connection count the tracking registry holds for *path*."""
+    import hermes_cli.sqlite_safe_read as mod
+
+    with mod._live_lock:
+        return mod._live_connections.get(mod._key(path), 0)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A gateway home under tmp_path, with path resolution going through it."""
+    import hermes_state
+
+    root = tmp_path / "hermes"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # The suite-wide fixture re-points DEFAULT_DB_PATH, which trips the
+    # deliberate escape hatch in _default_db_path() and would pin every lookup
+    # to one fixed path. Restore the import-time snapshot so resolution runs
+    # through get_hermes_home() the way production does; HERMES_HOME above
+    # keeps it inside tmp_path. Same reasoning as
+    # test_multiplex_session_db_profile_scope.py.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    return root
+
+
+@pytest.fixture
+def store(home):
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        s = SessionStore(sessions_dir=home / "sessions", config=GatewayConfig())
+    s._loaded = True
+    yield s
+    s.close_all_db_handles()
+
+
+def _runner_with(store) -> GatewayRunner:
+    """A GatewayRunner with only what the handle path touches.
+
+    Built with ``object.__new__`` deliberately: ``GatewayRunner.__init__``
+    starts platforms, executors and schedulers, none of which this contract
+    involves, and the method under test already supports this shape (it
+    rebuilds the cache when ``__init__`` did not).
+    """
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+    runner._session_db_handle_cache = RecoverableHandleCache(
+        handles=runner._session_db_handles,
+        lock=runner._session_db_handles_lock,
+    )
+    runner._session_db_init_error = None
+    return runner
+
+
+def test_runner_borrows_the_stores_handle_instead_of_opening_a_second(store):
+    """The runner's SessionDB must BE the store's, not a twin of it."""
+    store_db = store._db
+    assert store_db is not None, "fixture must have a usable SQLite handle"
+    path = Path(store_db.db_path)
+    before = _live_count(path)
+    assert before >= 1, "the store's writer connection should be live"
+
+    runner = _runner_with(store)
+    wrapper = runner._open_session_db_for_active_scope()
+
+    assert wrapper is not None
+    assert wrapper._db is store_db, (
+        "the runner opened its own SessionDB; one process now holds two writer "
+        "connections and two read pools against one state.db"
+    )
+    assert _live_count(path) == before, (
+        f"live connections went {before} -> {_live_count(path)}; resolving the "
+        f"runner's handle must not cost a descriptor"
+    )
+
+
+def test_runner_shutdown_sweep_leaves_the_borrowed_handle_open(store):
+    """Ownership: the store closes its connection, the runner must not.
+
+    The shutdown sequence sweeps the store first and the runner second, so a
+    runner that closed the borrowed handle would be closing an already-closed
+    connection -- harmless today, and a use-after-close the moment the two
+    sweeps are reordered or one of them is made conditional.
+    """
+    store_db = store._db
+    path = Path(store_db.db_path)
+    runner = _runner_with(store)
+    assert runner._open_session_db_for_active_scope() is not None
+
+    runner.close_all_session_db_handles()
+
+    assert _live_count(path) >= 1, "the runner closed the handle the store owns"
+    assert store_db._conn is not None, "borrowed writer connection was closed"
+    # The wrapper cache is still drained -- not closing is not the same as not
+    # forgetting.
+    assert runner._session_db_handles == {}
+
+
+def test_runner_without_a_session_store_still_opens_its_own(home):
+    """Lightweight runners (no store wired) keep the standalone behaviour."""
+    runner = object.__new__(GatewayRunner)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+    runner._session_db_handle_cache = RecoverableHandleCache(
+        handles=runner._session_db_handles,
+        lock=runner._session_db_handles_lock,
+    )
+    runner._session_db_init_error = None
+
+    wrapper = runner._open_session_db_for_active_scope()
+    try:
+        assert wrapper is not None
+        assert wrapper._db is not None
+    finally:
+        runner.close_all_session_db_handles()
+
+
+def test_unavailable_store_handle_does_not_resurrect_a_second_open(store):
+    """When the store has no handle, the runner reports it -- it does not open one."""
+    store._db = None  # pins the store's handle to "unavailable"
+    runner = _runner_with(store)
+
+    assert runner._open_session_db_for_active_scope() is None
+    assert runner._session_db_handles == {}, (
+        "a duplicate handle was cached on the store's failure path"
+    )

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -35,6 +35,7 @@ holds POSIX locks on that inode, so raw descriptor counts lag the real
 connection count and make such assertions flaky.
 """
 
+import queue
 import threading
 
 import pytest
@@ -481,3 +482,167 @@ def test_idle_permits_are_reclaimed_from_a_peer_instance(db):
         second._close_read_conn(conn)
     finally:
         second.close()
+
+
+# ── The process ceiling, and the descriptors this module does not own ──
+#
+# _READ_POOL_MAX bounds ONE file. A multiplexed gateway serves N profiles from
+# one process and each has its own state.db, so a per-file ceiling still lets
+# the cost grow with the profile count -- the per-instance bug one level out.
+# And Hermes's SQLite descriptors are only ever a share of the fd table: the
+# #98573 report is a process where ~20 state.db handles were the share that
+# pushed httpx sockets and terminal subprocess pipes past 256, and the EMFILE
+# surfaced in tools/terminal_tool.py, not here.
+
+
+@pytest.mark.requires_wal
+def test_peak_is_bounded_across_many_database_files(tmp_path):
+    """Read connections must be capped for the PROCESS, not just per file."""
+    import hermes_state
+    from hermes_state import SessionDB, _READ_POOL_MAX, _READ_POOL_PROCESS_MAX
+
+    n_files = (_READ_POOL_PROCESS_MAX // _READ_POOL_MAX) + 2
+    dbs = []
+    try:
+        for i in range(n_files):
+            d = SessionDB(db_path=tmp_path / f"p{i}" / "state.db")
+            d.create_session(session_id="s1", source="cli", model="m")
+            d.append_message("s1", role="user", content="graphiti")
+            dbs.append(d)
+
+        # Fill every pool, one file at a time.
+        held = []
+        for d in dbs:
+            for _ in range(_READ_POOL_MAX):
+                conn = d._checkout_read_conn()
+                if conn is None:
+                    break
+                held.append((d, conn))
+
+        assert len(held) <= _READ_POOL_PROCESS_MAX, (
+            f"{len(held)} read connections open across {n_files} files; the "
+            f"process ceiling is {_READ_POOL_PROCESS_MAX}. Per-file bounds "
+            f"alone let the descriptor cost grow with the profile count."
+        )
+        assert len(held) > _READ_POOL_MAX, (
+            "the process ceiling must be wider than one file's, or a "
+            "multiplexed gateway serves every profile from the writer lock"
+        )
+        total_live = sum(_live_count(d.db_path) for d in dbs)
+        assert total_live <= _READ_POOL_PROCESS_MAX + n_files, (
+            f"{total_live} live connections process-wide (ceiling "
+            f"{_READ_POOL_PROCESS_MAX} read + {n_files} writers)"
+        )
+
+        for d, conn in held:
+            d._close_read_conn(conn)
+    finally:
+        for d in dbs:
+            d.close()
+        assert hermes_state._process_read_permits.acquire(blocking=False), (
+            "close() stranded a process permit"
+        )
+        hermes_state._process_read_permits.release()
+
+
+@pytest.mark.requires_wal
+def test_idle_connections_are_reclaimed_across_database_files(tmp_path):
+    """A quiet profile's idle connections must not starve the busy one."""
+    from hermes_state import SessionDB, _READ_POOL_MAX, _READ_POOL_PROCESS_MAX
+
+    quiet = []
+    try:
+        # Saturate the process ceiling with IDLE connections on other files.
+        for i in range(_READ_POOL_PROCESS_MAX // _READ_POOL_MAX):
+            d = SessionDB(db_path=tmp_path / f"q{i}" / "state.db")
+            quiet.append(d)
+            conns = [d._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+            assert all(c is not None for c in conns)
+            for c in conns:
+                d._read_pool.put_nowait(c)
+
+        busy = SessionDB(db_path=tmp_path / "busy" / "state.db")
+        quiet.append(busy)
+        conn = busy._checkout_read_conn()
+        assert conn is not None, (
+            "idle connections on quiet profiles starved the profile being "
+            "served; its reads silently fell back to the writer lock"
+        )
+        busy._close_read_conn(conn)
+    finally:
+        for d in quiet:
+            d.close()
+
+
+@pytest.mark.requires_wal
+def test_no_read_connection_is_opened_without_descriptor_headroom(db, monkeypatch):
+    """Low on fds, the read path yields to the rest of the process.
+
+    The descriptors this module rations are shared with httpx sockets and
+    subprocess pipes, and EMFILE lands on whoever asks next -- which in the
+    report was terminal_tool, not SQLite.
+    """
+    import hermes_state
+
+    # Drain the pool so the next read must OPEN rather than reuse.
+    while True:
+        try:
+            db._close_read_conn(db._read_pool.get_nowait())
+        except queue.Empty:
+            break
+
+    monkeypatch.setattr(hermes_state, "_fd_soft_limit", lambda: 256)
+    monkeypatch.setattr(hermes_state, "_open_fd_count", lambda: 250)
+    monkeypatch.setattr(hermes_state, "_fd_usage_cache", (0.0, None))
+
+    assert db._get_read_conn() is None, "a read connection was opened with 6 fds left"
+    # The read still has to work -- degradation, not failure.
+    assert db.get_session("s1") is not None
+    assert hermes_state._read_open_denied_fd_headroom > 0, (
+        "the guard fired without leaving a trace to diagnose it from"
+    )
+
+    monkeypatch.setattr(hermes_state, "_open_fd_count", lambda: 10)
+    monkeypatch.setattr(hermes_state, "_fd_usage_cache", (0.0, None))
+    conn = db._get_read_conn()
+    assert conn is not None, "headroom returned but the read path stayed degraded"
+    db._close_read_conn(conn)
+
+
+def test_fd_headroom_guard_fails_open_where_it_cannot_measure(monkeypatch):
+    """No RLIMIT_NOFILE (Windows) means unmeasurable, not tight."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "_fd_soft_limit", lambda: None)
+    assert hermes_state._fd_headroom_ok() is True
+
+    # A probe that could not get a descriptor of its own is evidence, not
+    # absence of evidence.
+    monkeypatch.setattr(hermes_state, "_fd_soft_limit", lambda: 256)
+    monkeypatch.setattr(hermes_state, "_open_fd_count", lambda: -1)
+    monkeypatch.setattr(hermes_state, "_fd_usage_cache", (0.0, None))
+    assert hermes_state._fd_headroom_ok() is False
+
+
+@pytest.mark.requires_wal
+def test_duplicate_handles_on_one_path_are_reported(db, caplog):
+    """Writer connections cannot be capped, so duplicates must be visible."""
+    import logging
+
+    from hermes_state import SessionDB, _HANDLES_PER_PATH_WARN
+
+    extra = []
+    try:
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            for _ in range(_HANDLES_PER_PATH_WARN):
+                extra.append(SessionDB(db_path=db.db_path))
+        assert any(
+            "live SessionDB handles on" in r.getMessage()
+            for r in caplog.records
+        ), (
+            f"{_HANDLES_PER_PATH_WARN + 1} handles on one file went unreported; "
+            f"each holds a writer connection nothing bounds"
+        )
+    finally:
+        for d in extra:
+            d.close()

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -384,3 +384,100 @@ def test_close_returns_every_permit(db):
     for _ in range(_READ_POOL_MAX):
         assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
     assert not db._read_permits.acquire(blocking=False), "close() over-released"
+
+
+# ── The ceiling belongs to the FILE, not to the SessionDB object (#98573) ──
+#
+# Every test above uses ONE SessionDB, which is exactly why the permit lived on
+# the instance for a month without anyone noticing: a per-object cap looks
+# bounded in every single-instance test and scales with deployment shape in
+# production. A gateway holds at least two handles on one state.db --
+# SessionStore and GatewayRunner opened independent ones per profile path --
+# so peak descriptors were `instances x (1 + _READ_POOL_MAX)` and grew with the
+# profile count until the process hit RLIMIT_NOFILE while staying alive.
+
+
+@pytest.mark.requires_wal
+def test_peak_is_bounded_across_two_SessionDBs_on_one_path(db):
+    """Two handles on one file must share one read-connection ceiling."""
+    from hermes_state import SessionDB, _READ_POOL_MAX
+
+    second = SessionDB(db_path=db.db_path)
+    try:
+        n = 48
+        ready = threading.Barrier(n + 1)
+        release = threading.Event()
+        checked_out = []
+        lock = threading.Lock()
+
+        def worker(i):
+            target = db if i % 2 == 0 else second
+            conn = target._checkout_read_conn()
+            if conn is not None:
+                with lock:
+                    checked_out.append((target, conn))
+            ready.wait(timeout=30)
+            release.wait(timeout=30)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+
+        ready.wait(timeout=30)
+        peak_live = _live_count(db.db_path)
+        peak_checked_out = len(checked_out)
+        release.set()
+        for t in threads:
+            t.join(timeout=30)
+
+        for target, conn in checked_out:
+            target._close_read_conn(conn)
+
+        assert peak_checked_out <= _READ_POOL_MAX, (
+            f"{peak_checked_out} read connections checked out across two "
+            f"SessionDBs; the ceiling is {_READ_POOL_MAX}. The permit is "
+            f"per-instance again, so the fd budget scales with handle count."
+        )
+        # +2 for the writer connection each instance holds.
+        assert peak_live <= _READ_POOL_MAX + 2, (
+            f"{peak_live} live connections at peak against one file; ceiling is "
+            f"{_READ_POOL_MAX} read (+2 writers)"
+        )
+    finally:
+        second.close()
+
+
+@pytest.mark.requires_wal
+def test_idle_permits_are_reclaimed_from_a_peer_instance(db):
+    """A peer's IDLE pooled connections must not starve a new handle.
+
+    Permits are held for a connection's whole life, pooled-idle included, so
+    sharing them per path without this would hand the whole budget to whichever
+    handle warmed up first and demote every later one -- a cron job's transient
+    SessionDB, a second profile's store -- to the locked writer connection for
+    the life of the process. Trading one bug for a quieter one.
+    """
+    from hermes_state import SessionDB, _READ_POOL_MAX
+
+    # Warm every permit into db's IDLE pool.
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    assert all(c is not None for c in held)
+    for c in held:
+        db._read_pool.put_nowait(c)
+    assert db._read_pool.qsize() == _READ_POOL_MAX
+    assert not db._read_permits.acquire(blocking=False), "budget should be spent"
+
+    second = SessionDB(db_path=db.db_path)
+    try:
+        conn = second._checkout_read_conn()
+        assert conn is not None, (
+            "a peer holding only IDLE connections starved the new handle; "
+            "the read path silently degraded to the writer lock"
+        )
+        assert db._read_pool.qsize() == _READ_POOL_MAX - 1, (
+            "reclaim must close exactly one idle peer connection"
+        )
+        assert _live_count(db.db_path) <= _READ_POOL_MAX + 2
+        second._close_read_conn(conn)
+    finally:
+        second.close()


### PR DESCRIPTION
## The reported cause is already gone

#98573 blames a per-thread `threading.local()` read connection in `SessionDB`. That code was replaced on 2026-08-02 (`87aedbe7b6` pooled the read connections, `0472c31aa1` added the peak permit) and is on `main` today. Measured against `main`: **one `SessionDB`, 40 concurrent reader threads → 9 live connections**, not 40. Threads no longer multiply descriptors.

## The symptom is real, one layer up

`_READ_POOL_MAX` was enforced by a `BoundedSemaphore` **owned by each `SessionDB`**. The descriptors it rations are spent on a **file**, so every extra handle on one `state.db` got its own allowance:

```
peak descriptors = handles x (1 + _READ_POOL_MAX)
```

A gateway holds **two** long-lived handles per profile path, opened independently and never closed:

| Owner | Site |
|---|---|
| `SessionStore._db_handle_cache` | `gateway/session.py:1351` |
| `GatewayRunner._session_db_handle_cache` | `gateway/run.py:7580` |

`SessionStore` is constructed at `gateway/run.py:7180` with `(sessions_dir, config)` only, so it cannot share. Both resolve the same `_default_db_path()`. That is 18 connections / 36 fds per profile, matching the reporter's `20 / 12 / 2` lsof split, and it multiplies again per multiplexed profile.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    subgraph BEFORE["🩸 Before — one budget per OBJECT"]
        S1[🗂️ SessionStore Handle] -->|own semaphore| P1[🔓 8 Read Permits]
        R1[⚙️ GatewayRunner Handle] -->|own semaphore| P2[🔓 8 Read Permits]
        P1 --> F1[💾 state.db]
        P2 --> F1
        F1 --> X[💥 EMFILE at 256 fds<br/>process alive, supervisor blind]
    end

    subgraph AFTER["⚡ After — budgets per FILE and per PROCESS"]
        S2[🗂️ SessionStore Handle] -->|owns connection| G0{{🛡️ FD Headroom Guard<br/>soft RLIMIT_NOFILE - 64}}
        R2[⚙️ GatewayRunner Handle] -.->|borrows handle| S2
        G0 -->|no headroom| WL[🐢 Degrade to Writer Lock]
        G0 -->|headroom ok| G1[🌐 Process Ceiling<br/>24 Read Permits]
        G1 -->|miss| RA[♻️ Reclaim Idle on Any Path]
        G1 -->|granted| B[🔒 Path Budget<br/>8 Permits per file]
        B -->|miss| RC[♻️ Reclaim Idle Peer Connection]
        RC -->|still none| WL
        RA -->|still none| WL
        B --> F2[💾 state.db per profile]
        F2 --> OK[✅ Bounded Descriptor Budget]
        HX[🌐 httpx Sockets] --> FD[📊 Shared FD Table]
        TP[🖥️ Terminal Pipes] --> FD
        FD --> G0
    end
```

## Changes

**1. `_PathReadBudget` — permits shared per database path** (`hermes_state.py`)

The ceiling now means what its docstring always claimed: read connections **alive at once against this file**, summed over every `SessionDB` in the process.

A permit miss first **reclaims an idle pooled connection from a peer handle** before degrading to the writer lock. Without that step, sharing would trade one bug for a quieter one: pooled idle connections keep their permits, so whichever handle warmed up first would pin the whole budget and permanently demote every later one — a cron job's transient handle, a second profile's store — to the locked writer connection. Only the idle set is reachable from the reclaim path, so a checked-out connection can never be pulled out from under a live reader.

The registry is a `WeakValueDictionary`, so a process that churns database paths does not grow it.

**2. `GatewayRunner` borrows `SessionStore`'s handle** (`gateway/run.py`)

The runner's cache now holds only the `AsyncSessionDB` wrapper. Ownership follows: the store closes the connection, the runner's sweep skips borrowed handles (and the store's sweep already runs first at shutdown). When the store has no handle — failed open or backoff — the runner reports the same unavailability instead of resurrecting the duplicate it just removed. A runner with no `session_store` wired (lightweight test construction) keeps opening its own.

## Measurements

Instrument is `hermes_cli.sqlite_safe_read._live_connections`, the registry that counts live connections per canonical path — not `lsof`, whose per-inode descriptor reuse list lags the real connection count.

Peak live connections against one file, 40 reader threads:

| Handles | Before | After |
|---|---|---|
| 1 | 9 | 9 |
| 2 | 18 | 10 |
| 4 | 36 | 12 |
| 8 | 51 * | 16 |

\* 51 rather than 72 only because the sample window ended before every pool filled.

After the fix, read connections are capped at 8 in total; the remainder is one writer per handle, and the gateway's per-profile pair is now one.

## Tests

Both new suites were confirmed RED against the pre-fix code before being made green.

`tests/test_session_db_read_conn_pool.py`
- `test_peak_is_bounded_across_two_SessionDBs_on_one_path` — 48 workers split over two handles on one file, barrier-synchronised so the count is the simultaneous peak. Pre-fix: 16 connections checked out against a ceiling of 8.
- `test_idle_permits_are_reclaimed_from_a_peer_instance` — a peer holding only idle connections must not starve a new handle. Pre-fix: the new handle silently degraded to the writer lock.

`tests/gateway/test_session_db_handle_sharing.py` (new)
- the runner's handle **is** the store's, and resolving it costs no descriptor
- the runner's shutdown sweep leaves the borrowed connection open
- a runner with no store still opens its own
- an unavailable store handle does not resurrect a second open

Every existing test in `tests/test_session_db_read_conn_pool.py` (13), `tests/gateway/test_session_db_recovery.py`, `tests/gateway/test_multiplex_session_db_profile_scope.py`, `tests/test_session_db_read_path_split.py`, `tests/test_session_db_context_manager.py`, `tests/test_hermes_state_wal_fallback.py`, `tests/test_hermes_state_readonly_preflight.py` and `tests/hermes_state/` passes (233 passed, 8 skipped). `tests/test_hermes_state.py` is 244 passed / 1 failed, and that failure (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`) reproduces identically on `HEAD` without this branch — it traces a connection the read path does not check out once WAL is active.

Test plan:
- [x] new read-pool tests RED pre-fix, GREEN after
- [x] new gateway handle-sharing tests RED pre-fix, GREEN after
- [x] targeted state/gateway suites green on a WAL-capable runtime (SQLite 3.53.1) and on a DELETE-fallback runtime (SQLite 3.50.4)
- [x] `ruff check` clean on every changed file

## Second commit: the three axes the first one left open

The per-file budget closed the axis it measured and left three others. Named here because a fix that moves a wall without saying where the next one is has only relocated the incident.

### 1. Per-file is still per-PROFILE

A multiplexed gateway serves N profiles from one process and **each profile has its own `state.db`**, so a per-file ceiling let the process total grow with the profile count — the per-instance bug one level out.

`_READ_POOL_PROCESS_MAX` (24, three files' worth) now bounds the process across every database it has open. A miss reclaims an idle connection from **any** path before degrading: a profile quiet for an hour must not hold descriptors the profile being served right now needs.

### 2. The descriptors this module does not own

Hermes's SQLite handles are only ever a share of the fd table. In this report the ~20 `state.db` descriptors were not the whole 256 — they were the share that pushed httpx sockets and terminal subprocess pipes over, and the `[Errno 24]` surfaced in `tools/terminal_tool.py`, not here. Bounding only our own share leaves the process one busy hour away from the same outage.

New read connections are now refused when the process is within `_FD_HEADROOM_RESERVE` (64) of its soft `RLIMIT_NOFILE`, measured from `/proc/self/fd` or `/dev/fd` and cached for 250ms so a burst of reads is not one syscall per query.

- **Fails open where it cannot measure.** Windows has neither the fd directory nor `RLIMIT_NOFILE`, and a CRT limit in the thousands rather than 256. An unmeasurable platform is not a tight one, and refusing every read there would be a self-inflicted convoy.
- **Fails closed on evidence only** — a measured shortfall, or a probe that could not get a descriptor of its own (`EMFILE`/`ENFILE` on the listing *is* the answer).
- `_read_open_denied_fd_headroom` counts the refusals, so the guard is diagnosable from a running process instead of inferred from latency.

### 3. Writer connections cannot be rationed

A `SessionDB` without a writer connection cannot write, so there is no ceiling to impose — the only real bound is not opening redundant handles, which is what the `GatewayRunner` change above does for the gateway's pair. What was missing is visibility: a process that accumulates more than `_HANDLES_PER_PATH_WARN` (4) handles on one file now logs it once, naming the file and the count.

The next duplicate handle should be visible before it is an incident, rather than reconstructed from an `lsof` after one.

### Not done: retuning `_READ_POOL_MAX`

Deliberately still 8. Lowering it is #98585's subject and stays there. With a process ceiling above it and the headroom guard in front of it, the constant is no longer the binding constraint — whatever value that PR settles on now applies to a ceiling that means something process-wide.

### Tests for the second commit

All four were confirmed RED against the pre-fix code first:

| Test | Pre-fix behaviour |
|---|---|
| `test_peak_is_bounded_across_many_database_files` | 40 connections open across 5 files against a process ceiling of 24 |
| `test_idle_connections_are_reclaimed_across_database_files` | the profile being served got `None` and fell to the writer lock while quiet profiles held idle connections |
| `test_no_read_connection_is_opened_without_descriptor_headroom` | a connection opened with 6 descriptors left |
| `test_duplicate_handles_on_one_path_are_reported` | 5 handles on one file, silent |

Plus `test_fd_headroom_guard_fails_open_where_it_cannot_measure`, which pins both directions of the unmeasurable case.

Re-run after the second commit: 256 passed / 8 skipped across `tests/hermes_state/`, `tests/test_session_db_read_conn_pool.py`, `tests/test_session_db_read_path_split.py`, `tests/test_session_db_context_manager.py`, `tests/test_hermes_state_wal_fallback.py`, `tests/test_hermes_state_readonly_preflight.py`, `tests/gateway/test_session_db_recovery.py`, `tests/gateway/test_multiplex_session_db_profile_scope.py` and `tests/gateway/test_session_db_handle_sharing.py`; `tests/test_hermes_state.py` 244 passed with the same single pre-existing failure that reproduces on `HEAD` without this branch; `ruff` clean.

## Relationship to #98585

#98585 targets the same issue by lowering `_READ_POOL_MAX` from 8 to 4. That halves the per-instance allowance but leaves the scaling axis untouched — peak stays `handles x (1 + _READ_POOL_MAX)` — and costs every single-handle deployment more writer-lock convoying. Its body states the premise this PR acts on ("a long-lived gateway holds >=2 SessionDB instances"). If both land, `_READ_POOL_MAX` becomes a genuine process-wide ceiling and its value can be retuned independently.

Fixes #98573



