### PR TITLE
fix(gateway): sessions.changed broadcast ignores heartbeat-only db writes

### DIFF
--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -262,3 +262,48 @@ def test_broken_probe_never_kills_the_pass(watcher_home, monkeypatch):
 
     # The broken cron probe is skipped; sessions still broadcasts.
     assert ("sessions.changed", {}) in events
+
+
+def test_heartbeat_only_write_does_not_broadcast_sessions_changed(watcher_home):
+    """A gateway_heartbeats write bumps state.db mtime but no session row —
+    the new table-based signature must NOT broadcast on that ghost write
+    (#98005)."""
+    home, events = watcher_home
+    import sqlite3
+
+    db_path = home / "state.db"
+
+    # Bootstrap a real SQLite db with the two tables the signal
+    # probes — no session rows yet, so MAX(last_activity_at) is NULL
+    # and the fallback handles it.
+    db = sqlite3.connect(str(db_path))
+    db.execute("CREATE TABLE sessions (last_activity_at TEXT)")
+    db.execute("CREATE TABLE gateway_heartbeats (profile TEXT)")
+    db.execute("INSERT INTO gateway_heartbeats VALUES ('default')")
+    db.commit()
+    db.close()
+
+    server._broadcast_watched_changes(now=0.0)
+
+    # Bump only the heartbeat table — no session row touched.
+    db2 = sqlite3.connect(str(db_path))
+    db2.execute(
+        "UPDATE gateway_heartbeats SET profile='default' WHERE profile='default'"
+    )
+    db2.commit()
+    db2.close()
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("sessions.changed", {}) not in events
+
+    # A real session activity must still fire.
+    db3 = sqlite3.connect(str(db_path))
+    db3.execute(
+        "INSERT INTO sessions (last_activity_at) "
+        "VALUES ('2026-08-29T12:00:00Z')"
+    )
+    db3.commit()
+    db3.close()
+    server._broadcast_watched_changes(now=20.0)
+
+    assert ("sessions.changed", {}) in events

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4898,11 +4898,40 @@ def _cron_sig():
 
 
 def _sessions_sig():
-    """Newest mtime across state.db and its WAL — the cross-process change
-    signal. Messaging-gateway turns and cron runs are written by OTHER
-    processes that never touch this gateway's transports; the shared SQLite
-    file is the one thing they all move (#58671)."""
+    """Highest ``last_activity_at`` across the sessions table.
+
+    The ``state.db`` file mtime used previously flipped on EVERY db write,
+    including the cross-backend heartbeat that refreshes
+    ``gateway_heartbeats`` every 60 s (#94895).  Those ghost writes
+    produced a ``sessions.changed`` broadcast with no real session change,
+    and the desktop remounted the chat on every one of them — yanking the
+    transcript scroll back to the bottom on a 60 s idle beat (#38015
+    gateway half, #98005).
+
+    Querying the sessions table instead filters out heartbeat-only writes:
+    they don't touch any ``last_activity_at`` column so the signature
+    remains stable between real changes.  Fall back to the mtime-based
+    signature when the table read is unavailable (first startup before the
+    table exists or a corrupt DB in recovery).
+    """
     home = _watcher_home()
+    try:
+        import sqlite3
+
+        db = sqlite3.connect(
+            f"file:{home / 'state.db'}?mode=ro", uri=True, timeout=5
+        )
+        try:
+            row = db.execute(
+                "SELECT COALESCE(MAX(last_activity_at), '') FROM sessions"
+            ).fetchone()
+        finally:
+            db.close()
+        if row and row[0]:
+            return row[0]
+    except Exception:
+        pass
+    # Graceful fallback — same mtime-based signal as before.
     sig = None
     for name in ("state.db", "state.db-wal"):
         try:


### PR DESCRIPTION
Fixes #98005

## Problem

`_sessions_sig()` compared the raw `state.db` file mtime, which flips on **every** database write — including the cross-backend heartbeat that refreshes `gateway_heartbeats` every 60s (#94895). That ghost write moves no session row, but the mtime change triggers `sessions.changed` broadcast on the exact 60s beat, and the Desktop remounts the chat on every one — yanking the transcript scroll back to bottom every minute of idle use (#38015 gateway half, previously only the renderer side was fixed by #40433).

The reporter (@stevenzepol) traced the full chain with server log evidence: empty-payload `sessions.changed` events arrive at exactly +60s intervals, matching the heartbeat cadence exactly.

## Fix

`_sessions_sig()` now queries `SELECT COALESCE(MAX(last_activity_at), '') FROM sessions` on a read-only URI connection. Heartbeat writes touch only `gateway_heartbeats` — no session column is updated — so the signature stays stable between real session changes. The existing mtime-based probe is preserved as a graceful fallback for first-startup (before the table exists) or corrupt-DB-in-recovery paths.

## Verification

New test `test_heartbeat_only_write_does_not_broadcast_sessions_changed`:
- bootstrap a real SQLite db with `sessions` + `gateway_heartbeats` tables
- heartbeat-only UPDATE on `gateway_heartbeats` → **no broadcast** (was: broadcast)
- real INSERT on `sessions.last_activity_at` → broadcast fires

Existing 15 change-watcher tests also pass (the fallback path still handles plain-byte writes).