### PR TITLE
feat: add safe pre-agent turn routing middleware

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3297,13 +3297,21 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         return True
 
     def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
-        from hermes_cli.plugins import get_plugin_command_handler, resolve_plugin_command_result
+        from hermes_cli.plugins import get_plugin_command_handler, invoke_plugin_command, resolve_plugin_command_result
 
         plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
         if not plugin_handler:
             return
         try:
-            result = resolve_plugin_command_result(plugin_handler(user_args))
+            result = resolve_plugin_command_result(
+                invoke_plugin_command(
+                    plugin_handler,
+                    user_args,
+                    session_id=getattr(self, "session_id", None),
+                    session_key=getattr(self, "session_id", None),
+                    platform="cli",
+                )
+            )
             if result:
                 _cprint(str(result))
         except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -3296,27 +3296,6 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
             self._console_print(f"[bold red]Quick command error: {e}[/]")
         return True
 
-    def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
-        from hermes_cli.plugins import get_plugin_command_handler, invoke_plugin_command, resolve_plugin_command_result
-
-        plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
-        if not plugin_handler:
-            return
-        try:
-            result = resolve_plugin_command_result(
-                invoke_plugin_command(
-                    plugin_handler,
-                    user_args,
-                    session_id=getattr(self, "session_id", None),
-                    session_key=getattr(self, "session_id", None),
-                    platform="cli",
-                )
-            )
-            if result:
-                _cprint(str(result))
-        except Exception as e:
-            _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
-
     def _queue_skill_message(self, msg) -> None:
         if hasattr(self, '_pending_input'):
             self._pending_input.put(msg)

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -30,13 +30,14 @@ def register(ctx):
     ctx.register_middleware("llm_execution", on_llm_execution)
     ctx.register_middleware("tool_request", on_tool_request)
     ctx.register_middleware("tool_execution", on_tool_execution)
+    ctx.register_middleware("turn_route", on_turn_route)
 ```
 
 Every middleware callback receives:
 
 - `telemetry_schema_version`: currently `hermes.observer.v1`
 - `middleware_schema_version`: currently `hermes.middleware.v1`
-- Runtime context such as `session_id`, `task_id`, `turn_id`,
+- Runtime context such as `session_id`, durable `session_key`, `task_id`, `turn_id`,
   `api_request_id`, `provider`, `model`, `api_mode`, `tool_name`, and
   `tool_call_id` when applicable.
 
@@ -48,6 +49,20 @@ Supported middleware kinds:
 | `tool_request` | `tool_name`, `args`, `original_args` | `{"args": {...}}` | Replace effective tool args before hooks, guardrails, approvals, and execution. |
 | `llm_execution` | `request`, `original_request`, `next_call` | Any provider response | Wrap or replace the actual provider call. |
 | `tool_execution` | `tool_name`, `args`, `original_args`, `next_call` | Any tool result | Wrap or replace the actual tool call. |
+| `turn_route` | `route`, `original_route`, `user_message`, `session_id`, `session_key` | `{"route": {...}}` | Select public model/provider metadata before agent construction. |
+
+`turn_route` is called once for an external user turn before Hermes constructs
+the provider client or agent. The callback receives no credentials, API keys,
+or provider clients. Its public runtime DTO is limited to `provider`,
+`requested_provider`, and host-derived `api_mode`; command paths and argument
+vectors are never exposed. `requested_provider` is the selector passed through
+Hermes' normal resolver, while `provider` and `api_mode` remain host-derived
+diagnostic fields. Middleware may replace `model` and `requested_provider`, but
+must not use the informational runtime fields to select credentials or a
+transport. Hermes resolves or refreshes credentials for the selected provider
+through its normal resolver after this decision. Internal events and tool
+continuations must set `internal` or `tool_continuation` and bypass this phase.
+Routing failures are fail-open and retain the host route.
 
 Request middleware can return optional trace fields:
 
@@ -87,6 +102,10 @@ For each provider request, Hermes applies middleware in this order:
 3. Emit `pre_api_request` observer hooks with the effective request.
 4. Run provider execution through `llm_execution` middleware.
 5. Emit `post_api_request` or `api_request_error` observer hooks.
+
+For each external user turn, `turn_route` runs before agent/provider-client
+construction. It is not part of the provider request middleware chain and must
+never issue a provider call itself.
 
 Request middleware sees the full provider kwargs, including `messages` or
 Responses API `input`, model settings, tool definitions, stream options, and

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -981,10 +981,23 @@ class GatewayInboundMixin:
         # underscored autocomplete form matches plugin commands registered with hyphens.
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import get_plugin_command_handler, invoke_plugin_command
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
+                    quick_key = self._session_key_for_source(source)
+                    physical_session_id = None
+                    session_store = getattr(self, "session_store", None)
+                    peek_session_id = getattr(session_store, "peek_session_id", None)
+                    if callable(peek_session_id):
+                        with suppress(Exception):
+                            physical_session_id = peek_session_id(quick_key)
+                    result = invoke_plugin_command(
+                        plugin_handler,
+                        event.get_command_args().strip(),
+                        session_id=physical_session_id,
+                        session_key=quick_key,
+                        platform=source.platform.value if source.platform else None,
+                    )
                     if asyncio.iscoroutine(result):
                         result = await result
                     return True, str(result) if result else None, command

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -179,7 +179,8 @@ class GatewayTurnMixin:
     def _resolve_turn_agent_config(
         self, user_message: str, model: str, runtime_kwargs: dict,
         *, session_id: Optional[str] = None, session_key: Optional[str] = None,
-        source: Optional[SessionSource] = None, internal: bool = False,
+        source: Optional[SessionSource] = None, conversation_history: Optional[list] = None,
+        internal: bool = False,
     ) -> dict:
         """Effective model/runtime config for one turn. With `/fast` priority on, fast-mode
         ``request_overrides`` are deep-merged OVER the per-provider ones so both reach the model."""
@@ -205,7 +206,7 @@ class GatewayTurnMixin:
                     session_key=session_key,
                     source=source.platform.value if source and source.platform else "gateway",
                     is_user_turn=True,
-                    is_first_turn=False,
+                    is_first_turn=not bool(conversation_history),
                     internal=False,
                     tool_continuation=False,
                 )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -158,7 +158,11 @@ class GatewayTurnMixin:
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self, user_message: str, model: str, runtime_kwargs: dict,
+        *, session_id: Optional[str] = None, session_key: Optional[str] = None,
+        source: Optional[SessionSource] = None, internal: bool = False,
+    ) -> dict:
         """Effective model/runtime config for one turn. With `/fast` priority on, fast-mode
         ``request_overrides`` are deep-merged OVER the per-provider ones so both reach the model."""
         from gateway.run import _deep_merge_request_overrides
@@ -181,6 +185,43 @@ class GatewayTurnMixin:
                 runtime["api_mode"], runtime["command"], tuple(runtime["args"]),
             ),
         }
+        if not internal:
+            try:
+                from hermes_cli.middleware import apply_turn_route_middleware, public_turn_route
+                result = apply_turn_route_middleware(
+                    public_turn_route(route["model"], runtime),
+                    user_message=user_message,
+                    session_id=session_id,
+                    session_key=session_key,
+                    source=source.platform.value if source and source.platform else "gateway",
+                    is_user_turn=True,
+                    is_first_turn=False,
+                    internal=False,
+                    tool_continuation=False,
+                )
+                if result.changed and isinstance(result.payload, dict):
+                    selected_model = result.payload.get("model")
+                    public_runtime = result.payload.get("runtime")
+                    public_runtime = public_runtime if isinstance(public_runtime, dict) else {}
+                    current_requested = runtime.get("requested_provider") or runtime.get("provider")
+                    current_canonical = runtime.get("provider")
+                    top_requested = result.payload.get("requested_provider")
+                    nested_requested = public_runtime.get("requested_provider")
+                    requested = nested_requested if nested_requested and nested_requested != current_requested else (top_requested or nested_requested)
+                    canonical = result.payload.get("provider") or public_runtime.get("provider")
+                    selected_provider = requested if requested and requested != current_requested else (canonical if canonical and canonical != current_canonical else (requested or canonical or current_requested))
+                    if isinstance(selected_model, str) and selected_model.strip() and isinstance(selected_provider, str) and selected_provider.strip():
+                        selected_model = selected_model.strip()
+                        selected_provider = selected_provider.strip()
+                        if selected_provider != current_requested:
+                            from gateway.run import _resolve_runtime_agent_kwargs_for_provider
+                            runtime = _resolve_runtime_agent_kwargs_for_provider(selected_provider)
+                        runtime["requested_provider"] = selected_provider
+                        route["model"] = selected_model
+                        route["runtime"] = runtime
+                        route["middleware_trace"] = result.trace
+            except Exception as exc:
+                logger.warning("Turn-route middleware failed open: %s", exc)
         if getattr(self, "_service_tier", None) != "priority":
             # None / auto / cold: the bounded window is applied per request by agent.fast_mode.
             route["request_overrides"] = base_request_overrides
@@ -2138,7 +2179,7 @@ class GatewayTurnMixin:
             reasoning_config = self._resolve_session_reasoning_config(source=source, model=model)
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs, internal=True)
 
             # Enrich the prompt with image descriptions (same as the main flow).
             enriched_prompt = prompt

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -43,6 +43,24 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 logger = logging.getLogger("gateway.run")
 
 
+def _project_runtime_agent_kwargs(runtime_kwargs: dict) -> tuple[dict, dict]:
+    """Split provider resolution output into public agent runtime and request overrides.
+
+    Provider resolvers return constructor kwargs, including ``request_overrides``.  Turn routes
+    pass request overrides separately so fast-mode overlays can be applied without expanding the
+    same keyword twice at the AIAgent call site.
+    """
+    runtime = {
+        key: runtime_kwargs.get(key) for key in (
+            "api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args",
+            "credential_pool", "max_tokens", "capabilities",
+        )
+    }
+    runtime["args"] = list(runtime["args"] or [])
+    runtime["capabilities"] = dict(runtime["capabilities"] or {})
+    return runtime, dict(runtime_kwargs.get("request_overrides") or {})
+
+
 class GatewayTurnMixin:
     """Agent-turn execution for GatewayRunner (see module docstring)."""
 
@@ -168,15 +186,7 @@ class GatewayTurnMixin:
         from gateway.run import _deep_merge_request_overrides
         from hermes_cli.models import resolve_fast_mode_overrides
         # Tests bind this method onto bare namespaces, so no class-level tables here.
-        runtime = {
-            k: runtime_kwargs.get(k) for k in (
-                "api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args",
-                "credential_pool", "max_tokens", "capabilities",
-            )
-        }
-        runtime["args"] = list(runtime["args"] or [])
-        runtime["capabilities"] = dict(runtime["capabilities"] or {})
-        base_request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
+        runtime, base_request_overrides = _project_runtime_agent_kwargs(runtime_kwargs)
         route = {
             "model": model,
             "runtime": runtime,
@@ -215,7 +225,9 @@ class GatewayTurnMixin:
                         selected_provider = selected_provider.strip()
                         if selected_provider != current_requested:
                             from gateway.run import _resolve_runtime_agent_kwargs_for_provider
-                            runtime = _resolve_runtime_agent_kwargs_for_provider(selected_provider)
+                            runtime, base_request_overrides = _project_runtime_agent_kwargs(
+                                _resolve_runtime_agent_kwargs_for_provider(selected_provider)
+                            )
                         runtime["requested_provider"] = selected_provider
                         route["model"] = selected_model
                         route["runtime"] = runtime

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -30,6 +30,7 @@ from gateway.session import (
 from gateway.session_transcript import TranscriptReadError
 from gateway.turn_context import TurnContext
 from gateway.turn_lease import DEFAULT_LEASE_WAIT, TurnLeaseTimeoutError
+from gateway.run_turn_routing import GatewayTurnRoutingMixin
 from hermes_constants import get_hermes_home_override
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -43,25 +44,7 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 logger = logging.getLogger("gateway.run")
 
 
-def _project_runtime_agent_kwargs(runtime_kwargs: dict) -> tuple[dict, dict]:
-    """Split provider resolution output into public agent runtime and request overrides.
-
-    Provider resolvers return constructor kwargs, including ``request_overrides``.  Turn routes
-    pass request overrides separately so fast-mode overlays can be applied without expanding the
-    same keyword twice at the AIAgent call site.
-    """
-    runtime = {
-        key: runtime_kwargs.get(key) for key in (
-            "api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args",
-            "credential_pool", "max_tokens", "capabilities",
-        )
-    }
-    runtime["args"] = list(runtime["args"] or [])
-    runtime["capabilities"] = dict(runtime["capabilities"] or {})
-    return runtime, dict(runtime_kwargs.get("request_overrides") or {})
-
-
-class GatewayTurnMixin:
+class GatewayTurnMixin(GatewayTurnRoutingMixin):
     """Agent-turn execution for GatewayRunner (see module docstring)."""
 
     def _resolve_session_agent_runtime(
@@ -175,79 +158,6 @@ class GatewayTurnMixin:
             self._session_state("*").conversation.last_resolved_model = model
 
         return model, runtime_kwargs
-
-    def _resolve_turn_agent_config(
-        self, user_message: str, model: str, runtime_kwargs: dict,
-        *, session_id: Optional[str] = None, session_key: Optional[str] = None,
-        source: Optional[SessionSource] = None, conversation_history: Optional[list] = None,
-        internal: bool = False,
-    ) -> dict:
-        """Effective model/runtime config for one turn. With `/fast` priority on, fast-mode
-        ``request_overrides`` are deep-merged OVER the per-provider ones so both reach the model."""
-        from gateway.run import _deep_merge_request_overrides
-        from hermes_cli.models import resolve_fast_mode_overrides
-        # Tests bind this method onto bare namespaces, so no class-level tables here.
-        runtime, base_request_overrides = _project_runtime_agent_kwargs(runtime_kwargs)
-        route = {
-            "model": model,
-            "runtime": runtime,
-            "signature": (
-                model, runtime["provider"], runtime["requested_provider"], runtime["base_url"],
-                runtime["api_mode"], runtime["command"], tuple(runtime["args"]),
-            ),
-        }
-        if not internal:
-            try:
-                from hermes_cli.middleware import apply_turn_route_middleware, public_turn_route
-                result = apply_turn_route_middleware(
-                    public_turn_route(route["model"], runtime),
-                    user_message=user_message,
-                    session_id=session_id,
-                    session_key=session_key,
-                    source=source.platform.value if source and source.platform else "gateway",
-                    is_user_turn=True,
-                    is_first_turn=not bool(conversation_history),
-                    internal=False,
-                    tool_continuation=False,
-                )
-                if result.changed and isinstance(result.payload, dict):
-                    selected_model = result.payload.get("model")
-                    public_runtime = result.payload.get("runtime")
-                    public_runtime = public_runtime if isinstance(public_runtime, dict) else {}
-                    current_requested = runtime.get("requested_provider") or runtime.get("provider")
-                    current_canonical = runtime.get("provider")
-                    top_requested = result.payload.get("requested_provider")
-                    nested_requested = public_runtime.get("requested_provider")
-                    requested = nested_requested if nested_requested and nested_requested != current_requested else (top_requested or nested_requested)
-                    canonical = result.payload.get("provider") or public_runtime.get("provider")
-                    selected_provider = requested if requested and requested != current_requested else (canonical if canonical and canonical != current_canonical else (requested or canonical or current_requested))
-                    if isinstance(selected_model, str) and selected_model.strip() and isinstance(selected_provider, str) and selected_provider.strip():
-                        selected_model = selected_model.strip()
-                        selected_provider = selected_provider.strip()
-                        if selected_provider != current_requested:
-                            from gateway.run import _resolve_runtime_agent_kwargs_for_provider
-                            runtime, base_request_overrides = _project_runtime_agent_kwargs(
-                                _resolve_runtime_agent_kwargs_for_provider(selected_provider)
-                            )
-                        runtime["requested_provider"] = selected_provider
-                        route["model"] = selected_model
-                        route["runtime"] = runtime
-                        route["middleware_trace"] = result.trace
-            except Exception as exc:
-                logger.warning("Turn-route middleware failed open: %s", exc)
-        if getattr(self, "_service_tier", None) != "priority":
-            # None / auto / cold: the bounded window is applied per request by agent.fast_mode.
-            route["request_overrides"] = base_request_overrides
-            return route
-        try:
-            overrides = resolve_fast_mode_overrides(
-                route["model"], provider=runtime["provider"], base_url=runtime["base_url"],
-            )
-        except Exception:
-            overrides = None
-        # Fast-mode keys (service_tier / speed) are top-level and don't collide with extra_body.
-        route["request_overrides"] = _deep_merge_request_overrides(base_request_overrides, overrides or {})
-        return route
 
     def _sync_session_model_from_agent(self, session_id: str, agent: Any) -> None:
         """Persist the runtime model/provider a gateway turn actually used (provider fallback can
@@ -2192,7 +2102,7 @@ class GatewayTurnMixin:
             reasoning_config = self._resolve_session_reasoning_config(source=source, model=model)
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs, internal=True)
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
             # Enrich the prompt with image descriptions (same as the main flow).
             enriched_prompt = prompt

--- a/gateway/run_turn_routing.py
+++ b/gateway/run_turn_routing.py
@@ -1,0 +1,125 @@
+"""Turn-route selection for the Gateway runner.
+
+The route is resolved before agent construction.  Hermes keeps credentials and transport
+ownership; middleware only selects a public model/provider identity for this turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from gateway.session import SessionSource
+
+logger = logging.getLogger("gateway.run")
+
+
+def _project_runtime_agent_kwargs(runtime_kwargs: dict) -> tuple[dict, dict]:
+    """Split provider resolution output into public agent runtime and request overrides."""
+    runtime = {
+        key: runtime_kwargs.get(key) for key in (
+            "api_key", "base_url", "provider", "requested_provider", "api_mode", "command", "args",
+            "credential_pool", "max_tokens", "capabilities",
+        )
+    }
+    runtime["args"] = list(runtime["args"] or [])
+    runtime["capabilities"] = dict(runtime["capabilities"] or {})
+    return runtime, dict(runtime_kwargs.get("request_overrides") or {})
+
+
+class GatewayTurnRoutingMixin:
+    """Resolve the effective public route and host-owned runtime for one Gateway turn."""
+
+    def _resolve_turn_agent_config(
+        self, user_message: str, model: str, runtime_kwargs: dict,
+        *, session_id: Optional[str] = None, session_key: Optional[str] = None,
+        source: Optional[SessionSource] = None, conversation_history: Optional[list] = None,
+        # Legacy/background callers are internal unless the external TurnRunner opts in explicitly.
+        internal: bool = True,
+    ) -> dict:
+        """Build one turn route; middleware is fail-open and never owns credentials.
+
+        The default keeps internal/background turns out of user-turn middleware. The external
+        TurnRunner passes ``internal=False`` after loading the persisted turn history.
+        """
+        from gateway.run import _deep_merge_request_overrides
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        runtime, base_request_overrides = _project_runtime_agent_kwargs(runtime_kwargs)
+        route = {
+            "model": model,
+            "runtime": runtime,
+            "signature": (
+                model, runtime["provider"], runtime["requested_provider"], runtime["base_url"],
+                runtime["api_mode"], runtime["command"], tuple(runtime["args"]),
+            ),
+        }
+        if not internal:
+            try:
+                from hermes_cli.middleware import apply_turn_route_middleware, public_turn_route
+
+                result = apply_turn_route_middleware(
+                    public_turn_route(route["model"], runtime),
+                    user_message=user_message,
+                    session_id=session_id,
+                    session_key=session_key,
+                    source=source.platform.value if source and source.platform else "gateway",
+                    is_user_turn=True,
+                    is_first_turn=not bool(conversation_history),
+                    internal=False,
+                    tool_continuation=False,
+                )
+                if result.changed and isinstance(result.payload, dict):
+                    selected_model = result.payload.get("model")
+                    public_runtime = result.payload.get("runtime")
+                    public_runtime = public_runtime if isinstance(public_runtime, dict) else {}
+                    current_requested = runtime.get("requested_provider") or runtime.get("provider")
+                    current_canonical = runtime.get("provider")
+                    top_requested = result.payload.get("requested_provider")
+                    nested_requested = public_runtime.get("requested_provider")
+                    requested = (
+                        nested_requested
+                        if nested_requested and nested_requested != current_requested
+                        else (top_requested or nested_requested)
+                    )
+                    canonical = result.payload.get("provider") or public_runtime.get("provider")
+                    selected_provider = (
+                        requested
+                        if requested and requested != current_requested
+                        else (
+                            canonical
+                            if canonical and canonical != current_canonical
+                            else (requested or canonical or current_requested)
+                        )
+                    )
+                    if (
+                        isinstance(selected_model, str)
+                        and selected_model.strip()
+                        and isinstance(selected_provider, str)
+                        and selected_provider.strip()
+                    ):
+                        selected_model = selected_model.strip()
+                        selected_provider = selected_provider.strip()
+                        if selected_provider != current_requested:
+                            from gateway.run import _resolve_runtime_agent_kwargs_for_provider
+
+                            runtime, base_request_overrides = _project_runtime_agent_kwargs(
+                                _resolve_runtime_agent_kwargs_for_provider(selected_provider)
+                            )
+                        runtime["requested_provider"] = selected_provider
+                        route["model"] = selected_model
+                        route["runtime"] = runtime
+                        route["middleware_trace"] = result.trace
+            except Exception as exc:
+                logger.warning("Turn-route middleware failed open: %s", exc)
+        if getattr(self, "_service_tier", None) != "priority":
+            route["request_overrides"] = base_request_overrides
+            return route
+        try:
+            overrides = resolve_fast_mode_overrides(
+                route["model"], provider=runtime["provider"], base_url=runtime["base_url"],
+            )
+        except Exception:
+            overrides = None
+        route["request_overrides"] = _deep_merge_request_overrides(base_request_overrides, overrides or {})
+        return route

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1726,7 +1726,11 @@ class TurnRunner:
         runner._reasoning_config = reasoning_config
         runner._service_tier = runner._resolve_session_service_tier(source=ctx.source, session_key=ctx.session_key)
         stream_consumer, stream_delta_cb, interim_cb, want_interim = self._setup_stream_consumer(platform_key)
-        turn_route = runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
+        turn_route = runner._resolve_turn_agent_config(
+            ctx.message, model, runtime_kwargs,
+            session_id=ctx.session_id, session_key=ctx.session_key,
+            source=ctx.source,
+        )
         agent, reused_cached_agent = self._resolve_turn_agent(
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,
         )

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1729,7 +1729,7 @@ class TurnRunner:
         turn_route = runner._resolve_turn_agent_config(
             ctx.message, model, runtime_kwargs,
             session_id=ctx.session_id, session_key=ctx.session_key,
-            source=ctx.source, conversation_history=ctx.history,
+            source=ctx.source, conversation_history=ctx.history, internal=False,
         )
         agent, reused_cached_agent = self._resolve_turn_agent(
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1729,7 +1729,7 @@ class TurnRunner:
         turn_route = runner._resolve_turn_agent_config(
             ctx.message, model, runtime_kwargs,
             session_id=ctx.session_id, session_key=ctx.session_key,
-            source=ctx.source,
+            source=ctx.source, conversation_history=ctx.history,
         )
         agent, reused_cached_agent = self._resolve_turn_agent(
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -388,7 +388,7 @@ class CLIAgentSetupMixin:
                     session_key=getattr(self, "session_id", None),
                     source="cli",
                     is_user_turn=True,
-                    is_first_turn=self.agent is None,
+                    is_first_turn=not bool(getattr(self, "conversation_history", None)),
                     internal=False,
                     tool_continuation=False,
                 )

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -432,6 +432,7 @@ class CLIAgentSetupMixin:
             except Exception:
                 pass
         route["request_overrides"] = overrides
+        route["signature"] = _route_signature(route["model"], route["runtime"])
         return route
 
     def _follow_compression_chain(self, session_meta, announce):

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -378,6 +378,52 @@ class CLIAgentSetupMixin:
         from hermes_cli.models import resolve_fast_mode_overrides
         runtime = _current_runtime(self)
         route = {"model": self.model, "runtime": runtime, "signature": _route_signature(self.model, runtime)}
+        if not getattr(self, "_skip_turn_routing", False):
+            try:
+                from hermes_cli.middleware import apply_turn_route_middleware, public_turn_route
+                result = apply_turn_route_middleware(
+                    public_turn_route(route["model"], runtime),
+                    user_message=user_message,
+                    session_id=getattr(self, "session_id", None),
+                    session_key=getattr(self, "session_id", None),
+                    source="cli",
+                    is_user_turn=True,
+                    is_first_turn=self.agent is None,
+                    internal=False,
+                    tool_continuation=False,
+                )
+                if result.changed and isinstance(result.payload, dict):
+                    selected_model = result.payload.get("model")
+                    selected_runtime = result.payload.get("runtime")
+                    selected_runtime = selected_runtime if isinstance(selected_runtime, dict) else {}
+                    current_requested = runtime.get("requested_provider") or runtime.get("provider")
+                    current_canonical = runtime.get("provider")
+                    top_requested = result.payload.get("requested_provider")
+                    nested_requested = selected_runtime.get("requested_provider")
+                    requested = nested_requested if nested_requested and nested_requested != current_requested else (top_requested or nested_requested)
+                    canonical = result.payload.get("provider") or selected_runtime.get("provider")
+                    selected_provider = requested if requested and requested != current_requested else (canonical if canonical and canonical != current_canonical else (requested or canonical or current_requested))
+                    if isinstance(selected_model, str) and selected_model.strip() and isinstance(selected_provider, str) and selected_provider.strip():
+                        selected_model = selected_model.strip()
+                        selected_provider = selected_provider.strip()
+                        if selected_provider != current_requested:
+                            from hermes_cli.runtime_provider import resolve_runtime_provider
+                            resolved = resolve_runtime_provider(requested=selected_provider, target_model=selected_model)
+                            runtime = {
+                                "api_key": resolved.get("api_key"), "base_url": resolved.get("base_url"),
+                                "provider": resolved.get("provider", selected_provider),
+                                "requested_provider": selected_provider,
+                                "api_mode": resolved.get("api_mode", self.api_mode),
+                                "command": resolved.get("command"), "args": list(resolved.get("args") or []),
+                                "credential_pool": resolved.get("credential_pool"),
+                            }
+                        runtime["requested_provider"] = selected_provider
+                        route["model"] = selected_model
+                        route["runtime"] = runtime
+                        route["middleware_trace"] = result.trace
+            except Exception as exc:
+                from cli import logger
+                logger.warning("Turn-route middleware failed open: %s", exc)
         overrides = None
         if getattr(self, "service_tier", None) == "priority":
             try:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1917,7 +1917,12 @@ class CLICommandsMixin:
         preview = _ellipsize(prompt, 60)
         _cp(f"  🔄 Background task #{task_num} started: \"{preview}\"", f"  Task ID: {task_id}",
             "  You can continue chatting — results will appear when done.\n")
-        turn_route = self._resolve_turn_agent_config(prompt)
+        previous_skip = getattr(self, "_skip_turn_routing", False)
+        self._skip_turn_routing = True
+        try:
+            turn_route = self._resolve_turn_agent_config(prompt)
+        finally:
+            self._skip_turn_routing = previous_skip
         runtime = turn_route["runtime"]
 
         def produce():
@@ -2013,7 +2018,12 @@ class CLICommandsMixin:
         history_snapshot = list(self.conversation_history or [])
         # Live agent → cache-parity fork (full context, warm cache reads).
         parent_agent = self.agent
-        turn_route = self._resolve_turn_agent_config(question)
+        previous_skip = getattr(self, "_skip_turn_routing", False)
+        self._skip_turn_routing = True
+        try:
+            turn_route = self._resolve_turn_agent_config(question)
+        finally:
+            self._skip_turn_routing = previous_skip
         runtime = turn_route["runtime"]
         main_runtime = {
             "model": turn_route["model"],

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -602,6 +602,29 @@ def _browser_status() -> None:
 class CLICommandsMixin:
     """Mixin holding the interactive-CLI slash-command handlers."""
 
+    def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
+        """Run a discovered plugin slash command with the current CLI session context."""
+        from cli import _RST, _cprint
+        from hermes_cli.plugins import get_plugin_command_handler, invoke_plugin_command, resolve_plugin_command_result
+
+        plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
+        if not plugin_handler:
+            return
+        try:
+            result = resolve_plugin_command_result(
+                invoke_plugin_command(
+                    plugin_handler,
+                    user_args,
+                    session_id=getattr(self, "session_id", None),
+                    session_key=getattr(self, "session_id", None),
+                    platform="cli",
+                )
+            )
+            if result:
+                _cprint(str(result))
+        except Exception as exc:
+            _cprint(f"\033[1;31mPlugin command error: {exc}{_RST}")
+
     # ---- /rollback ------------------------------------------------------------------------
     def _checkpoint_manager(self, disabled_lines):
         """The agent's checkpoint manager, or None after printing why it is unavailable."""

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -20,9 +20,28 @@ TOOL_REQUEST_MIDDLEWARE = "tool_request"
 TOOL_EXECUTION_MIDDLEWARE = "tool_execution"
 LLM_REQUEST_MIDDLEWARE = "llm_request"
 LLM_EXECUTION_MIDDLEWARE = "llm_execution"
+# Turn-route middleware runs once before Hermes constructs a provider client or
+# agent; it is separate from request middleware for an already selected route.
+TURN_ROUTE_MIDDLEWARE = "turn_route"
+PUBLIC_TURN_RUNTIME_KEYS = ("provider", "requested_provider", "api_mode")
+
+
+def public_turn_route(model: str, runtime: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the redacted route DTO exposed to turn-route middleware."""
+    return {
+        "model": model,
+        "provider": runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider"),
+        "runtime": {
+            key: runtime.get(key)
+            for key in PUBLIC_TURN_RUNTIME_KEYS
+            if runtime.get(key) not in (None, "")
+        },
+    }
 
 VALID_MIDDLEWARE: set[str] = {
     TOOL_REQUEST_MIDDLEWARE, TOOL_EXECUTION_MIDDLEWARE, LLM_REQUEST_MIDDLEWARE, LLM_EXECUTION_MIDDLEWARE,
+    TURN_ROUTE_MIDDLEWARE,
 }
 
 
@@ -96,6 +115,40 @@ def apply_llm_request_middleware(request: Dict[str, Any], **context: Any) -> Req
     return _apply_request_chain(
         LLM_REQUEST_MIDDLEWARE, "request", [], original_request,
         request=_safe_copy(original_request), original_request=original_request, **context,
+    )
+
+
+def apply_turn_route_middleware(route: Dict[str, Any], **context: Any) -> RequestMiddlewareResult:
+    """Apply pre-agent turn routing middleware to a public, credential-free route."""
+    from hermes_cli.plugins import has_middleware
+
+    if not has_middleware(TURN_ROUTE_MIDDLEWARE):
+        return RequestMiddlewareResult(payload=route, original_payload=route)
+    original_route = _safe_copy(route)
+    current_route = _safe_copy(original_route)
+    trace: List[Dict[str, Any]] = []
+    from hermes_cli.plugins import invoke_middleware
+
+    for result in invoke_middleware(
+        TURN_ROUTE_MIDDLEWARE,
+        route=current_route,
+        original_route=original_route,
+        **middleware_payload(**context),
+    ):
+        if not isinstance(result, dict) or not isinstance(result.get("route"), dict):
+            continue
+        current_route = _safe_copy(result["route"])
+        entry = {
+            key: value
+            for key in ("source", "reason", "name")
+            if isinstance(value := result.get(key), str) and value
+        }
+        trace.append(entry or {"source": "plugin"})
+    return RequestMiddlewareResult(
+        payload=current_route,
+        original_payload=original_route,
+        changed=current_route != original_route,
+        trace=trace,
     )
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -653,9 +653,12 @@ class PluginContext:
         self, name: str, handler: Callable, description: str = "", args_hint: str = "",
         argument_mode: str | None = None,
     ) -> Optional[PluginRegistration]:
-        """Register an in-session slash command (``/name``); handler ``fn(raw_args: str) -> str | None``
-        (sync or async). ``args_hint`` (e.g. ``"<file>"``) lets adapters like Discord surface an argument
-        field; without it the command registers parameterless there but still accepts trailing text."""
+        """Register an in-session slash command (``/name``).
+
+        Handlers may accept keyword context such as ``session_id`` (the
+        persisted physical id, or ``None`` before creation), durable
+        ``session_key``, and ``platform``; one-argument handlers remain valid.
+        """
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning("Plugin '%s' tried to register a command with an empty name.", self.manifest.name)
@@ -1975,6 +1978,25 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def invoke_plugin_command(handler: Callable, raw_args: str, **context: Any) -> Any:
+    """Invoke a slash-command handler with only the context it declares."""
+    try:
+        parameters = inspect.signature(handler).parameters.values()
+    except (TypeError, ValueError):
+        return handler(raw_args)
+    parameter_list = list(parameters)
+    accepts_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameter_list)
+    accepted_names = {
+        p.name for p in parameter_list
+        if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+    if not accepts_kwargs and not accepted_names.intersection(context):
+        return handler(raw_args)
+    if accepts_kwargs:
+        return handler(raw_args, **context)
+    return handler(raw_args, **{name: value for name, value in context.items() if name in accepted_names})
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -458,11 +458,21 @@ class PluginDispatchMixin:
     def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
         """Call middleware callbacks for *kind* (each isolated); return non-``None`` results."""
         results: List[Any] = []
+        route_chain = kind == "turn_route" and isinstance(kwargs.get("route"), dict)
+        current_route = copy.deepcopy(kwargs["route"]) if route_chain else None
+        original_route = copy.deepcopy(kwargs.get("original_route")) if route_chain else None
         for cb in self._middleware.get(kind, []):
+            callback_kwargs = kwargs
+            if route_chain:
+                callback_kwargs = dict(kwargs)
+                callback_kwargs["route"] = copy.deepcopy(current_route)
+                callback_kwargs["original_route"] = copy.deepcopy(original_route)
             try:
-                ret = cb(**kwargs)
+                ret = cb(**callback_kwargs)
                 if ret is not None:
                     results.append(ret)
+                    if route_chain and isinstance(ret, dict) and isinstance(ret.get("route"), dict):
+                        current_route = copy.deepcopy(ret["route"])
             except Exception as exc:
                 logger.warning(
                     "Middleware '%s' callback %s raised: %s", kind, getattr(cb, "__name__", repr(cb)), exc)

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -200,6 +200,37 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
+    def test_turn_route_resolves_requested_provider_alias(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="primary", api_key="alpha-key", base_url="https://alpha.example/v1",
+            provider="custom", requested_provider="custom:alpha", api_mode="chat_completions",
+            acp_command=None, acp_args=[], _credential_pool=None, service_tier=None,
+            agent=None, session_id="session-1",
+        )
+
+        def fake_apply(route, **_context):
+            return SimpleNamespace(
+                changed=True,
+                payload={**route, "model": "target", "provider": "custom",
+                         "requested_provider": "custom:beta",
+                         "runtime": {**route["runtime"], "requested_provider": "custom:beta", "api_mode": "invalid"}},
+                trace=[],
+            )
+
+        with patch("hermes_cli.middleware.apply_turn_route_middleware", fake_apply), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={"provider": "custom", "requested_provider": "custom:beta",
+                          "api_key": "beta-key", "base_url": "https://beta.example/v1",
+                          "api_mode": "responses"},
+        ) as resolve:
+            route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "route")
+
+        resolve.assert_called_once_with(requested="custom:beta", target_model="target")
+        assert route["runtime"]["api_key"] == "beta-key"
+        assert route["runtime"]["provider"] == "custom"
+        assert route["runtime"]["api_mode"] == "responses"
+
 
 class TestAnthropicFastMode(unittest.TestCase):
     """Verify Anthropic Fast Mode model support and override resolution."""

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -200,6 +200,29 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
+    def test_turn_route_first_turn_uses_history_not_agent_construction_state(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="primary", api_key="primary-key", base_url="https://api.example/v1",
+            provider="custom", requested_provider="custom", api_mode="chat_completions",
+            acp_command=None, acp_args=[], _credential_pool=None, service_tier=None,
+            session_id="session-1", agent=object(), conversation_history=[],
+        )
+        seen = []
+
+        def fake_apply(route, **context):
+            seen.append(context["is_first_turn"])
+            return SimpleNamespace(changed=False, payload=route, trace=[])
+
+        with patch("hermes_cli.middleware.apply_turn_route_middleware", fake_apply):
+            cli_mod.HermesCLI._resolve_turn_agent_config(stub, "first")
+            # A route change can rebuild the agent without starting a new turn.
+            stub.agent = None
+            stub.conversation_history = [{"role": "user", "content": "first"}]
+            cli_mod.HermesCLI._resolve_turn_agent_config(stub, "later")
+
+        assert seen == [True, False]
+
     def test_turn_route_resolves_requested_provider_alias(self):
         cli_mod = _import_cli()
         stub = SimpleNamespace(

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -230,6 +230,76 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["api_key"] == "beta-key"
         assert route["runtime"]["provider"] == "custom"
         assert route["runtime"]["api_mode"] == "responses"
+        from hermes_cli.cli_agent_setup_mixin import _route_signature
+        assert route["signature"] == _route_signature(route["model"], route["runtime"])
+
+    def test_warm_turn_route_switch_rebuilds_then_reuses_selected_agent(self):
+        cli_mod = _import_cli()
+        shell = cli_mod.HermesCLI(model="alpha", compact=True, max_turns=1)
+        shell.provider = "custom"
+        shell.requested_provider = "custom"
+        shell.api_mode = "chat_completions"
+        shell.base_url = "https://alpha.example/v1"
+        shell.api_key = "alpha-key"
+        shell.acp_command = None
+        shell.acp_args = []
+        shell._credential_pool = None
+        shell.service_tier = None
+        shell._skip_turn_routing = False
+        shell._active_agent_route_signature = None
+        shell.agent = None
+
+        selected = {"model": "alpha"}
+        shell._ensure_runtime_credentials = lambda: True
+        shell.finalize_preloaded_skills = lambda: None
+        shell._install_tool_callbacks = lambda: None
+        shell._ensure_tirith_security = lambda: None
+
+        class CapturingAgent:
+            instances = []
+
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+                self._print_fn = None
+                type(self).instances.append(self)
+
+        def fake_apply(route, **_context):
+            return SimpleNamespace(
+                changed=selected["model"] != route["model"],
+                payload={**route, "model": selected["model"]},
+                trace=[],
+            )
+
+        with (
+            patch.object(cli_mod, "_prepare_deferred_agent_startup", lambda: None),
+            patch(
+                "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+                lambda **_kwargs: None,
+            ),
+            patch("run_agent.AIAgent", CapturingAgent),
+            patch("hermes_cli.middleware.apply_turn_route_middleware", fake_apply),
+        ):
+            def begin_turn():
+                route = shell._resolve_turn_agent_config("route")
+                if route["signature"] != shell._active_agent_route_signature:
+                    shell.agent = None
+                assert shell._init_agent(
+                    model_override=route["model"],
+                    runtime_override=route["runtime"],
+                    request_overrides=route.get("request_overrides"),
+                )
+                return shell.agent
+
+            alpha = begin_turn()
+            selected["model"] = "beta"
+            beta = begin_turn()
+            beta_again = begin_turn()
+            selected["model"] = "alpha"
+            alpha_again = begin_turn()
+
+        assert [agent.model for agent in CapturingAgent.instances] == ["alpha", "beta", "alpha"]
+        assert beta_again is beta
+        assert alpha_again is not alpha
 
 
 class TestAnthropicFastMode(unittest.TestCase):

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -117,7 +117,7 @@ def _runner(session_store):
         {"provider": "openai-codex", "api_mode": "codex_responses", "base_url": "https://chatgpt.com/backend-api/codex", "api_key": "token"},
     )
     runner._resolve_session_reasoning_config = lambda **_kwargs: None
-    runner._resolve_turn_agent_config = lambda message, model, runtime: {"model": model, "runtime": runtime}
+    runner._resolve_turn_agent_config = lambda message, model, runtime, **_kwargs: {"model": model, "runtime": runtime}
     runner._load_service_tier = lambda: None
     runner._agent_config_signature = lambda *_args, **_kwargs: ("sig",)
     runner._extract_cache_busting_config = lambda _config: ()
@@ -281,5 +281,4 @@ class _ProviderSwitchAgent(_CompressionThenFailureAgent):
             ],
             "api_calls": 1,
         }
-
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -129,6 +129,39 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_resolves_requested_provider_alias(monkeypatch):
+    runner = _make_runner()
+
+    def fake_apply(route, **_context):
+        return SimpleNamespace(
+            changed=True,
+            payload={**route, "model": "target", "provider": "custom",
+                     "requested_provider": "custom:beta",
+                     "runtime": {**route["runtime"], "requested_provider": "custom:beta", "api_mode": "invalid"}},
+            trace=[],
+        )
+
+    monkeypatch.setattr("hermes_cli.middleware.apply_turn_route_middleware", fake_apply)
+    resolver = MagicMock(return_value={
+        "provider": "custom", "requested_provider": "custom:beta",
+        "api_key": "beta-key", "base_url": "https://beta.example/v1", "api_mode": "responses",
+    })
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs_for_provider", resolver)
+    route = runner._resolve_turn_agent_config(
+        "route", "primary", {
+            "provider": "custom", "requested_provider": "custom:alpha",
+            "api_key": "alpha-key", "base_url": "https://alpha.example/v1",
+            "api_mode": "chat_completions",
+        }, session_id="session-1", session_key="chat-1", source=_make_source(),
+    )
+
+    resolver.assert_called_once_with("custom:beta")
+    assert route["runtime"]["provider"] == "custom"
+    assert route["runtime"]["requested_provider"] == "custom:beta"
+    assert route["runtime"]["api_key"] == "beta-key"
+    assert route["runtime"]["api_mode"] == "responses"
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_global_flag_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
@@ -173,5 +206,3 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     assert runner._resolve_session_service_tier(session_key=session_key) is None
     # A different session still gets the config default.
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
-
-

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -145,6 +145,7 @@ def test_turn_route_resolves_requested_provider_alias(monkeypatch):
     resolver = MagicMock(return_value={
         "provider": "custom", "requested_provider": "custom:beta",
         "api_key": "beta-key", "base_url": "https://beta.example/v1", "api_mode": "responses",
+        "request_overrides": {"extra_body": {"route_owner": "beta"}},
     })
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs_for_provider", resolver)
     route = runner._resolve_turn_agent_config(
@@ -160,6 +161,50 @@ def test_turn_route_resolves_requested_provider_alias(monkeypatch):
     assert route["runtime"]["requested_provider"] == "custom:beta"
     assert route["runtime"]["api_key"] == "beta-key"
     assert route["runtime"]["api_mode"] == "responses"
+    assert "request_overrides" not in route["runtime"]
+    assert route["request_overrides"] == {"extra_body": {"route_owner": "beta"}}
+
+
+def test_build_fresh_agent_receives_projected_route_overrides(monkeypatch):
+    from gateway.run_turn_runner import TurnRunner
+
+    runner = _make_runner()
+    runner._refresh_fallback_model = lambda: None
+    source = _make_source()
+    ctx = SimpleNamespace(
+        AIAgent=_CapturingAgent,
+        source=source,
+        user_config={},
+        enabled_toolsets=[],
+        disabled_toolsets=[],
+        session_id="session-1",
+        session_key="chat-1",
+    )
+    turn_runner = TurnRunner(runner, ctx)
+    route = {
+        "model": "target",
+        "runtime": {
+            "api_key": "beta-key",
+            "base_url": "https://beta.example/v1",
+            "provider": "custom",
+            "requested_provider": "custom:beta",
+            "api_mode": "responses",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "max_tokens": None,
+            "capabilities": {},
+        },
+        "request_overrides": {"extra_body": {"route_owner": "beta"}},
+    }
+
+    monkeypatch.setattr(gateway_run, "_checkpoint_agent_kwargs", lambda _config: {})
+    turn_runner._build_fresh_agent(route, "telegram", "", 3, None, {}, False)
+
+    assert _CapturingAgent.last_init["request_overrides"] == {
+        "extra_body": {"route_owner": "beta"}
+    }
+    assert _CapturingAgent.last_init["requested_provider"] == "custom:beta"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -144,11 +144,11 @@ def test_turn_route_reports_history_derived_first_turn(monkeypatch):
     }
 
     gateway_run.GatewayRunner._resolve_turn_agent_config(
-        runner, "first", "gpt-5.4", runtime_kwargs, source=_make_source(), conversation_history=[]
+        runner, "first", "gpt-5.4", runtime_kwargs, source=_make_source(), conversation_history=[], internal=False
     )
     gateway_run.GatewayRunner._resolve_turn_agent_config(
         runner, "later", "gpt-5.4", runtime_kwargs, source=_make_source(),
-        conversation_history=[{"role": "user", "content": "first"}],
+        conversation_history=[{"role": "user", "content": "first"}], internal=False,
     )
 
     assert seen == [True, False]
@@ -179,6 +179,7 @@ def test_turn_route_resolves_requested_provider_alias(monkeypatch):
             "api_key": "alpha-key", "base_url": "https://alpha.example/v1",
             "api_mode": "chat_completions",
         }, session_id="session-1", session_key="chat-1", source=_make_source(),
+        internal=False,
     )
 
     resolver.assert_called_once_with("custom:beta")

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -129,6 +129,31 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_reports_history_derived_first_turn(monkeypatch):
+    runner = _make_runner()
+    seen = []
+
+    def fake_apply(route, **context):
+        seen.append(context["is_first_turn"])
+        return SimpleNamespace(changed=False, payload=route, trace=[])
+
+    monkeypatch.setattr("hermes_cli.middleware.apply_turn_route_middleware", fake_apply)
+    runtime_kwargs = {
+        "api_key": "***", "base_url": "https://api.openai.com/v1", "provider": "openai",
+        "api_mode": "chat_completions", "command": None, "args": [], "credential_pool": None,
+    }
+
+    gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "first", "gpt-5.4", runtime_kwargs, source=_make_source(), conversation_history=[]
+    )
+    gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "later", "gpt-5.4", runtime_kwargs, source=_make_source(),
+        conversation_history=[{"role": "user", "content": "first"}],
+    )
+
+    assert seen == [True, False]
+
+
 def test_turn_route_resolves_requested_provider_alias(monkeypatch):
     runner = _make_runner()
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -47,6 +47,45 @@ def test_portable_skill_namespace_is_ascii_safe():
     assert is_valid_namespace(namespace)
 
 
+def test_turn_route_middleware_discards_mutation_from_failed_callback():
+    manager = PluginManager()
+    original = {"model": "alpha", "runtime": {"provider": "custom"}}
+
+    def broken(route, **_kwargs):
+        route["model"] = "uncommitted-target"
+        raise RuntimeError("decision unavailable")
+
+    manager._middleware["turn_route"] = [broken]
+
+    assert manager.invoke_middleware(
+        "turn_route", route=original, original_route=original,
+    ) == []
+    assert original == {"model": "alpha", "runtime": {"provider": "custom"}}
+
+
+def test_turn_route_failed_callback_does_not_poison_next_callback():
+    manager = PluginManager()
+    original = {"model": "alpha", "runtime": {"provider": "custom"}}
+    seen = []
+
+    def broken(route, **_kwargs):
+        route["model"] = "uncommitted-target"
+        raise RuntimeError("decision unavailable")
+
+    def noop(route, **_kwargs):
+        seen.append(route)
+        return {"route": route}
+
+    manager._middleware["turn_route"] = [broken, noop]
+
+    results = manager.invoke_middleware(
+        "turn_route", route=original, original_route=original,
+    )
+
+    assert seen == [original]
+    assert results == [{"route": original}]
+
+
 def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
                      manifest_extra: dict | None = None,
                      auto_enable: bool = True,


### PR DESCRIPTION
## Summary
- add a versioned `turn_route` middleware phase before Hermes agent construction
- allow plugins to select public model/provider metadata while Hermes resolves credentials and clients
- provide durable `session_key` plus physical `session_id` context while preserving legacy one-argument plugins
- wire Veto automatic routing with fail-open behavior, per-session disable/pin controls, and decision traces

## P1 review fixes
- gateway commands and turn routing share durable `session_key`; physical `session_id` remains diagnostic
- public route runtime is explicitly limited to `provider`, `requested_provider`, and `api_mode`; ACP command/argv are never exposed
- CLI route selections are ephemeral and do not mutate configured runtime state across turns
- Veto consumer identity fix is merged in [veto#60](https://github.com/oleg-koval/veto/pull/60) at `f1df7e8`

## Safety
- no credentials, API keys, or provider clients are exposed to middleware
- internal events and tool continuations bypass automatic routing
- middleware executes once; provider execution remains owned by Hermes
- Veto failures and incompatible routes fail open to the configured route

## Verification
- rebased onto exact upstream `main` at `1cf3639`
- 177 affected Hermes/plugin compatibility tests pass
- isolated `hermes plugins doctor --ci` passes for the Veto plugin (6 tools)
- Ruff and Python compilation clean
- Veto PR #60 CI green: build, race, vet, onboarding, OpenCode/Hermes contracts, packaging, governance, and security

Veto remains a standalone plugin; this PR only widens the generic host contract.
