### PR TITLE
fix(tirith): honour fail_open for analysis_incomplete findings

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -852,6 +852,20 @@ def check_command_security(command: str) -> dict:
             findings = []
             summary = ""
 
+    # When the only finding is analysis_incomplete (tirith's threat-intel
+    # lookups exceeded their per-lookup deadline), the scan completed but
+    # could not verify the command.  In a non-interactive context (cron)
+    # this becomes a hard denial with no user to approve it.  Honouring
+    # tirith_fail_open for this case gives operators the same escape hatch
+    # for incomplete scans that they already have for outright tirith
+    # process failures (#97949).
+    if action == "warn" and fail_open and findings:
+        incomplete_only = all(
+            f.get("rule_id") == "analysis_incomplete" for f in findings
+        )
+        if incomplete_only:
+            action = "allow"
+
     return {"action": action, "findings": findings, "summary": summary}
 
 


### PR DESCRIPTION
Fixes #97949

## Problem

When tirith's runtime threat-intel lookups (OSV/ecosyste.ms/deps.dev) exhaust their per-lookup deadline, the one-shot `tirith check` returns `analysis_incomplete` at MEDIUM severity — not a security finding, but a statement that verification couldn't complete. In a non-interactive cron context with `approvals.cron_mode: deny` (the safe default), even benign commands like `npx skills update` are blocked — not because anything was found, but because the lookup timed out.

The reporter traced the full chain: ~0.75s scan, cold cache, MEDIUM finding → cron blocks it. Same command with the tirith daemon running completes and returns `allow`. Hermes has no config to start/manage the daemon, and `tirith_fail_open` only applied to outright tirith process failures (exit code ≠ 0/1/2).

## Fix

When the **only** findings are `analysis_incomplete` (no actual security issue) and `tirith_fail_open` is true, the scan now treats the incomplete-verification scan like a process failure: allow the command. Operators who need complete verification can keep the default (`fail_open: false`); the escape hatch is the one already documented, now applying consistently to scans that couldn't complete.

## Verification

Existing tirith test suite: 24 passed, 17 failures all pre-existing on this Windows host (reproduced with the change stashed — the `TestMkdtempOSErrorNoSpace` and `TestAppTldSuppression` failures are environment-dependent and unchanged). No new failures introduced.