### PR TITLE
feat(delegate): action='stream' returns typed events from a running child's transcript

### DIFF
--- a/tests/tools/test_delegate_stream_action.py
+++ b/tests/tools/test_delegate_stream_action.py
@@ -1,0 +1,191 @@
+"""Tests for delegate_task(action='stream') — typed-event peek of a running child."""
+
+import json
+import weakref
+
+from tools.delegate_tool import (
+    _handle_control_action,
+    _register_subagent,
+)
+
+
+class _StubChild:
+    """Weakref-able stand-in for a live child AIAgent with a transcript file."""
+
+    def __init__(self, parent=None, accept_steer: bool = True, transcript_path: str | None = None):
+        self.steered: list[str] = []
+        self.accept_steer = accept_steer
+        self._live_transcript_path = transcript_path
+        if parent is not None:
+            self._delegate_parent_ref = weakref.ref(parent)
+
+
+class _StubParent:
+    pass
+
+
+def _register(sid: str, child, **extra) -> None:
+    record = {
+        "subagent_id": sid,
+        "parent_id": None,
+        "depth": 0,
+        "goal": "test goal",
+        "model": "test-model",
+        "started_at": 1000.0,
+        "status": "running",
+        "tool_count": 0,
+        "agent": child,
+    }
+    record.update(extra)
+    _register_subagent(record)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_stream_requires_subagent_id():
+    payload = json.loads(_handle_control_action("stream", None, None, _StubParent()))
+    assert "error" in payload
+
+
+def test_stream_with_blank_subagent_id_errors():
+    payload = json.loads(_handle_control_action("stream", "", None, _StubParent()))
+    assert "error" in payload
+
+
+def test_stream_unknown_subagent_id_errors():
+    payload = json.loads(_handle_control_action("stream", "no-such-child", None, _StubParent()))
+    assert "error" in payload
+
+
+def test_stream_child_with_no_transcript_path():
+    parent = _StubParent()
+    child = _StubChild(parent=parent, transcript_path=None)
+    _register("c1", child)
+    payload = json.loads(_handle_control_action("stream", "c1", None, parent))
+    assert payload["action"] == "stream"
+    assert payload["status"] == "no_transcript"
+
+
+# ---------------------------------------------------------------------------
+# Real transcript parsing
+# ---------------------------------------------------------------------------
+
+
+def _write_transcript(tmp_path, lines: list[str]) -> str:
+    p = tmp_path / "task-0.log"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+def test_stream_returns_typed_events_with_summary(tmp_path):
+    parent = _StubParent()
+    path = _write_transcript(tmp_path, [
+        "14:22:08 start    | goal",
+        "14:22:08 user     | kickoff",
+        "14:22:09 assistant| planning",
+        "14:22:10 tool     | -> terminal({\"command\": \"ls\"})",
+        "14:22:11 result   | terminal ok 0.42s: done",
+        "14:22:12 tool     | -> web_extract({\"urls\": []})",
+        "14:22:13 result   | web_extract ERROR 1.20s: 404",
+    ])
+    child = _StubChild(parent=parent, transcript_path=path)
+    _register("c2", child)
+
+    payload = json.loads(_handle_control_action("stream", "c2", None, parent))
+    assert payload["action"] == "stream"
+    assert payload["subagent_id"] == "c2"
+    assert payload["transcript_path"] == path
+    assert payload["event_count"] == len(payload["events"])
+    # 2 tool_start + 2 tool_result = 4 tool events in default (all-kinds) mode.
+    assert payload["event_count"] == 7
+    assert payload["summary"]["tool_call_count"] == 2
+    assert payload["summary"]["tool_error_count"] == 1
+
+
+def test_stream_filters_by_kinds(tmp_path):
+    parent = _StubParent()
+    path = _write_transcript(tmp_path, [
+        "14:22:10 tool     | -> terminal({\"command\": \"ls\"})",
+        "14:22:11 result   | terminal ok 0.10s: ok",
+        "14:22:12 tool     | -> web_extract({\"urls\": []})",
+        "14:22:13 result   | web_extract ERROR 1.20s: 404",
+    ])
+    child = _StubChild(parent=parent, transcript_path=path)
+    _register("c3", child)
+
+    payload = json.loads(_handle_control_action(
+        "stream", "c3", None, parent,
+        args={"kinds": ["tool_result"]},
+    ))
+    kinds = [e["kind"] for e in payload["events"]]
+    assert all(k == "tool_result" for k in kinds)
+    assert payload["event_count"] == 2
+
+
+def test_stream_filters_by_tool_name(tmp_path):
+    parent = _StubParent()
+    path = _write_transcript(tmp_path, [
+        "14:22:10 tool     | -> terminal({\"command\": \"ls\"})",
+        "14:22:11 result   | terminal ok 0.10s: ok",
+        "14:22:12 tool     | -> web_extract({\"urls\": []})",
+        "14:22:13 result   | web_extract ERROR 1.20s: 404",
+    ])
+    child = _StubChild(parent=parent, transcript_path=path)
+    _register("c4", child)
+
+    payload = json.loads(_handle_control_action(
+        "stream", "c4", None, parent,
+        args={"tool_name": "terminal"},
+    ))
+    names = {e.get("tool_name") for e in payload["events"]}
+    assert names == {"terminal"}
+
+
+def test_stream_errors_only(tmp_path):
+    parent = _StubParent()
+    path = _write_transcript(tmp_path, [
+        "14:22:10 tool     | -> terminal({\"command\": \"ls\"})",
+        "14:22:11 result   | terminal ok 0.10s: ok",
+        "14:22:12 tool     | -> web_extract({\"urls\": []})",
+        "14:22:13 result   | web_extract ERROR 1.20s: 404",
+    ])
+    child = _StubChild(parent=parent, transcript_path=path)
+    _register("c5", child)
+
+    payload = json.loads(_handle_control_action(
+        "stream", "c5", None, parent,
+        args={"errors_only": True},
+    ))
+    assert payload["event_count"] == 1
+    assert payload["events"][0]["is_error"] is True
+    assert payload["events"][0]["tool_name"] == "web_extract"
+
+
+def test_stream_caps_oversized_lines_param(tmp_path):
+    parent = _StubParent()
+    path = _write_transcript(tmp_path, ["x"] * 5)
+    child = _StubChild(parent=parent, transcript_path=path)
+    _register("c6", child)
+
+    payload = json.loads(_handle_control_action(
+        "stream", "c6", None, parent,
+        lines=99999,   # way over the 1000 cap
+    ))
+    assert payload["lines_requested"] == 1000
+    # But the file only had 5 lines.
+    assert payload["lines_returned"] == 5
+    assert payload["event_count"] == 5
+
+
+def test_stream_reports_missing_transcript_file(tmp_path):
+    parent = _StubParent()
+    missing = str(tmp_path / "does-not-exist.log")
+    child = _StubChild(parent=parent, transcript_path=missing)
+    _register("c7", child)
+
+    payload = json.loads(_handle_control_action("stream", "c7", None, parent))
+    assert payload["status"] == "transcript_missing"
+    assert payload["transcript_path"] == missing

--- a/tests/tools/test_delegation_live_stream.py
+++ b/tests/tools/test_delegation_live_stream.py
@@ -1,0 +1,177 @@
+"""Tests for tools/delegation_live_stream.py — transcript parser + filter."""
+
+import pytest
+
+from tools.delegation_live_stream import (
+    filter_events,
+    parse_event,
+    parse_lines,
+    summarise,
+)
+
+
+# Sample transcript lines (mirrors the format written by tools/delegation_live_log.py).
+SAMPLE_LINES = [
+    "14:22:08 start    | child goal: verify CLI flag",
+    "14:22:08 user     | kickoff: verify --json flag",
+    "14:22:09 assistant| planning to run a few probes",
+    "14:22:10 think    | considering timeout defaults",
+    "14:22:10 tool     | -> terminal({\"command\": \"cli --json\"})",
+    "14:22:11 result   | terminal ok 0.42s: {\"ok\": true, \"returncode\": 0}",
+    "14:22:12 tool     | -> web_extract({\"urls\": [\"https://example.com\"]})",
+    "14:22:13 result   | web_extract ERROR 1.20s: 404 Not Found",
+    "14:22:14 final    | child complete",
+    "unparseable line that the parser must not crash on",
+    "",
+]
+
+
+# ----------------------------- parse_event -----------------------------
+
+
+def test_parse_event_tool_start_extracts_name_and_args():
+    ev = parse_event(0, "14:22:10 tool     | -> terminal({\"command\": \"ls\"})")
+    assert ev.kind == "tool_start"
+    assert ev.ts == "14:22:10"
+    assert ev.tool_name == "terminal"
+    assert ev.tool_args is not None and "command" in ev.tool_args
+    assert ev.is_error is False
+
+
+def test_parse_event_tool_result_success_extracts_status_and_duration():
+    ev = parse_event(0, "14:22:11 result   | terminal ok 0.42s: done")
+    assert ev.kind == "tool_result"
+    assert ev.tool_name == "terminal"
+    assert ev.tool_status == "ok"
+    assert ev.tool_duration_seconds == 0.42
+    assert ev.is_error is False
+    assert ev.tool_result_preview == "done"
+
+
+def test_parse_event_tool_result_error_sets_is_error_true():
+    ev = parse_event(0, "14:22:13 result   | web_extract ERROR 1.20s: 404")
+    assert ev.kind == "tool_result"
+    assert ev.tool_name == "web_extract"
+    assert ev.tool_status == "ERROR"
+    assert ev.is_error is True
+    assert ev.tool_duration_seconds == 1.20
+
+
+def test_parse_event_assistant_and_thinking_become_typed_kinds():
+    a = parse_event(0, "14:22:09 assistant| hi there")
+    t = parse_event(0, "14:22:10 think    | reasoning about it")
+    assert a.kind == "assistant"
+    assert t.kind == "thinking"
+
+
+def test_parse_event_user_becomes_kickoff():
+    u = parse_event(0, "14:22:08 user     | kickoff: do thing")
+    assert u.kind == "kickoff"
+    assert u.text == "kickoff: do thing"
+
+
+def test_parse_event_unparseable_line_returns_raw_kind_no_crash():
+    ev = parse_event(0, "## header line ##")
+    assert ev.kind == "raw"
+    assert ev.ts is None
+    assert ev.role == ""
+
+
+def test_parse_event_index_is_preserved():
+    ev = parse_event(7, "14:22:08 start | x")
+    assert ev.index == 7
+
+
+# ----------------------------- parse_lines -----------------------------
+
+
+def test_parse_lines_returns_one_event_per_input_line():
+    events = parse_lines(SAMPLE_LINES)
+    assert len(events) == len(SAMPLE_LINES)
+    assert [e.kind for e in events] == [
+        "marker",      # start
+        "kickoff",     # user
+        "assistant",
+        "thinking",
+        "tool_start",  # terminal
+        "tool_result", # terminal ok
+        "tool_start",  # web_extract
+        "tool_result", # web_extract ERROR
+        "marker",      # final
+        "raw",         # unparseable
+        "raw",         # blank
+    ]
+
+
+def test_parse_lines_preserves_indexes_in_order():
+    events = parse_lines(SAMPLE_LINES)
+    assert [e.index for e in events] == list(range(len(SAMPLE_LINES)))
+
+
+# ----------------------------- filter_events ---------------------------
+
+
+def test_filter_events_by_kinds_returns_only_matching():
+    events = parse_lines(SAMPLE_LINES)
+    tool_events = filter_events(events, kinds=["tool_start", "tool_result"])
+    assert all(e.kind in {"tool_start", "tool_result"} for e in tool_events)
+    assert len(tool_events) == 4
+
+
+def test_filter_events_by_tool_name():
+    events = parse_lines(SAMPLE_LINES)
+    only_terminal = filter_events(events, tool_name="terminal")
+    names = [e.tool_name for e in only_terminal]
+    assert names == ["terminal", "terminal"]
+
+
+def test_filter_events_errors_only():
+    events = parse_lines(SAMPLE_LINES)
+    errors = filter_events(events, errors_only=True)
+    assert len(errors) == 1
+    assert errors[0].is_error is True
+    assert errors[0].tool_name == "web_extract"
+
+
+def test_filter_events_combined_kinds_and_errors_only():
+    events = parse_lines(SAMPLE_LINES)
+    # Combine kinds + errors_only — both must apply.
+    out = filter_events(events, kinds=["tool_result"], errors_only=True)
+    assert len(out) == 1
+    assert out[0].is_error is True
+
+
+def test_filter_events_no_filters_returns_all():
+    events = parse_lines(SAMPLE_LINES)
+    assert len(filter_events(events)) == len(events)
+
+
+# ----------------------------- summarise -------------------------------
+
+
+def test_summarise_counts_tool_calls_and_errors():
+    events = parse_lines(SAMPLE_LINES)
+    s = summarise(events)
+    assert s["event_count"] == len(events)
+    assert s["tool_call_count"] == 2
+    assert s["tool_error_count"] == 1
+    assert s["tool_call_breakdown"] == {"terminal": 1, "web_extract": 1}
+    assert s["tool_error_breakdown"] == {"web_extract": 1}
+    assert s["total_tool_duration_seconds"] == pytest.approx(1.62, abs=1e-3)
+
+
+def test_summarise_handles_empty_event_list():
+    s = summarise([])
+    assert s["event_count"] == 0
+    assert s["tool_call_count"] == 0
+    assert s["tool_error_count"] == 0
+    assert s["tool_call_breakdown"] == {}
+    assert s["tool_error_breakdown"] == {}
+    assert s["total_tool_duration_seconds"] == 0
+
+
+def test_summarise_ignores_events_without_tool_name():
+    # No tool_start/tool_result events → zero tool activity.
+    s = summarise(parse_lines(["14:22:09 assistant| hi"]))
+    assert s["tool_call_count"] == 0
+    assert s["total_tool_duration_seconds"] == 0

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -26,6 +26,7 @@ import re
 logger = logging.getLogger(__name__)
 import os
 import threading
+from pathlib import Path
 import time
 import weakref
 from concurrent.futures import (
@@ -400,7 +401,7 @@ def _is_descendant_of(child_agent: Any, parent_agent: Any, max_hops: int = 8) ->
 
 # Model-facing control actions accepted by delegate_task(action=...).
 # "spawn" (or omitted) keeps the historical spawn semantics.
-_CONTROL_ACTIONS = frozenset({"list", "steer", "stop"})
+_CONTROL_ACTIONS = frozenset({"list", "steer", "stop", "tail", "stream"})
 
 
 def _resolve_session_lineage(session_id: Optional[str], parent_agent: Any) -> str:
@@ -468,8 +469,11 @@ def _handle_control_action(
     subagent_id: Optional[str],
     message: Optional[str],
     parent_agent: Any,
+    *,
+    lines: Optional[int] = None,
+    args: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """Synchronous control plane for delegate_task: list/steer/stop.
+    """Synchronous control plane for delegate_task: list/steer/stop/tail/stream.
 
     Runs in-turn (never backgrounded) and only over subagents descended from
     *parent_agent* — the same registry the TUI overlay drives, but scoped so
@@ -579,7 +583,21 @@ def _handle_control_action(
             "message; re-delegate a follow-up task if more work is needed."
         )
 
-    return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, or stop.")
+    if action == "tail":
+        return _handle_tail_action(subagent_id, parent_agent, lines)
+
+    if action == "stream":
+        a = args or {}
+        return _handle_stream_action(
+            subagent_id,
+            parent_agent,
+            lines=lines,
+            kinds=a.get("kinds") if isinstance(a.get("kinds"), list) else None,
+            tool_name=a.get("tool_name") if isinstance(a.get("tool_name"), str) else None,
+            errors_only=bool(a.get("errors_only", False)),
+        )
+
+    return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, stop, tail, or stream.")
 
 
 def _extract_output_tail(
@@ -3667,7 +3685,7 @@ def delegate_task(
     normalized_action = (action or "").strip().lower()
     if normalized_action in _CONTROL_ACTIONS:
         return _handle_control_action(
-            normalized_action, subagent_id, message, parent_agent
+            normalized_action, subagent_id, message, parent_agent,
         )
     if normalized_action and normalized_action != "spawn":
         return tool_error(
@@ -4690,8 +4708,10 @@ def _build_top_level_description() -> str:
         "transcript paths, and the completed result (one consolidated message, "
         "results in task order) re-enters the conversation on its own. Do NOT "
         "wait or poll; continue other work. While children run, `action` "
-        "(list/steer/stop) controls them live — steer when a transcript shows "
-        "a child drifting.\n\n"
+        "(list/steer/stop/tail/stream) controls them live — steer when a transcript shows "
+        "a child drifting; tail to peek at one child's recent lines without "
+        "waiting on its completion message; stream for the same data parsed into "
+        "typed events you can grep or count.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
@@ -4848,13 +4868,19 @@ DELEGATE_TASK_SCHEMA = {
             # re-add to the schema.
             "action": {
                 "type": "string",
-                "enum": ["spawn", "list", "steer", "stop"],
+                "enum": ["spawn", "list", "steer", "stop", "tail", "stream"],
                 "description": (
                     "Default 'spawn'. Live control of running children: "
                     "'list' = ids/goals/status/transcripts; 'steer' = queue "
                     "course-correction text into one child (subagent_id + "
                     "message) without stopping it; 'stop' = end one child "
-                    "early (subagent_id; partial result still returns). "
+                    "early (subagent_id; partial result still returns); "
+                    "'tail' = return the last N lines (default 40) of one "
+                    "child's live transcript (subagent_id + lines) for "
+                    "in-flight visibility without waiting on completion; "
+                    "'stream' = same target, but the lines are parsed into "
+                    "typed events (kickoff/assistant/thinking/tool_start/"
+                    "tool_result/marker) for machine consumption. "
                     "Control actions return immediately; goal/tasks are "
                     "ignored unless spawning."
                 ),
@@ -4872,6 +4898,41 @@ DELEGATE_TASK_SCHEMA = {
                     "For action='steer': the course correction, appended to "
                     "the child's next tool result mid-run. Be directive and "
                     "specific."
+                ),
+            },
+            "lines": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000,
+                "default": 40,
+                "description": (
+                    "For action='tail'/'stream': how many of the most-recent lines "
+                    "to return from the child's live transcript. Defaults to "
+                    "40; capped at 1000. Ignored for other actions."
+                ),
+            },
+            "kinds": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "For action='stream': optional list of event kinds to "
+                    "include (kickoff, assistant, thinking, tool_start, "
+                    "tool_result, marker, raw). Defaults to all."
+                ),
+            },
+            "tool_name": {
+                "type": "string",
+                "description": (
+                    "For action='stream': optional filter; only events for "
+                    "this tool name are returned. Ignored for other actions."
+                ),
+            },
+            "errors_only": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "For action='stream': if true, only events with is_error=true "
+                    "are returned (tool results that failed). Ignored otherwise."
                 ),
             },
         },
@@ -4944,3 +5005,120 @@ registry.register(
     emoji="🔀",
     dynamic_schema_overrides=_build_dynamic_schema_overrides,
 )
+
+
+def _handle_tail_action(
+    subagent_id: Optional[str],
+    parent_agent: Any,
+    lines: Optional[int],
+) -> str:
+    "Return the last N lines of a live child's transcript (RFC #12)."
+    sid = (subagent_id or "").strip()
+    if not sid:
+        return tool_error(
+            "action='tail' requires subagent_id (from the spawn dispatch "
+            "response or action='list')."
+        )
+    with _active_subagents_lock:
+        record = _active_subagents.get(sid)
+    if record is None or not _owns_subagent_record(record, parent_agent):
+        return tool_error(
+            f"No live subagent '{sid}' in this conversation's spawn tree. It "
+            f"may have already finished (its result arrives as a normal "
+            f"completion message). Use action='list' to see live children."
+        )
+    agent = record.get("agent")
+    path_str = getattr(agent, "_live_transcript_path", None) if agent else None
+    if not path_str:
+        return json.dumps(
+            {
+                "action": "tail",
+                "subagent_id": sid,
+                "status": "no_transcript",
+                "note": (
+                    "This child has no live transcript (older dispatch or "
+                    "non-streaming backend). Tail is not available."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    path = Path(path_str)
+    if not path.exists():
+        return json.dumps(
+            {
+                "action": "tail",
+                "subagent_id": sid,
+                "status": "transcript_missing",
+                "transcript_path": path_str,
+            },
+            ensure_ascii=False,
+        )
+    try:
+        requested = int(lines) if lines is not None else 40
+    except (TypeError, ValueError):
+        requested = 40
+    requested = max(1, min(1000, requested))
+    try:
+        text_lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return tool_error(f"Could not read transcript: {exc}")
+    tail = text_lines[-requested:]
+    return json.dumps(
+        {
+            "action": "tail",
+            "subagent_id": sid,
+            "transcript_path": path_str,
+            "lines_returned": len(tail),
+            "lines_requested": requested,
+            "lines": tail,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _handle_stream_action(
+    subagent_id: Optional[str],
+    parent_agent: Any,
+    *,
+    lines: Optional[int],
+    kinds: Optional[List[str]],
+    tool_name: Optional[str],
+    errors_only: bool,
+) -> str:
+    "Return the last N lines of a child's transcript parsed into typed events (RFC #03)."
+    tail_payload = json.loads(
+        _handle_tail_action(subagent_id, parent_agent, lines) or "{}"
+    )
+    if tail_payload.get("status") in {"no_transcript", "transcript_missing"}:
+        payload = dict(tail_payload)
+        payload["action"] = "stream"
+        return json.dumps(payload, ensure_ascii=False)
+    if "error" in tail_payload or "lines" not in tail_payload:
+        return json.dumps(tail_payload, ensure_ascii=False)
+    from tools.delegation_live_stream import filter_events, parse_lines, summarise
+    events = parse_lines(tail_payload["lines"])
+    filtered = filter_events(
+        events,
+        kinds=kinds,
+        tool_name=tool_name,
+        errors_only=errors_only,
+    )
+    summary = summarise(filtered)
+    return json.dumps(
+        {
+            "action": "stream",
+            "subagent_id": subagent_id,
+            "transcript_path": tail_payload.get("transcript_path"),
+            "lines_requested": tail_payload.get("lines_requested"),
+            "lines_returned": tail_payload.get("lines_returned"),
+            "filters": {
+                "kinds": kinds,
+                "tool_name": tool_name,
+                "errors_only": errors_only,
+            },
+            "event_count": len(filtered),
+            "summary": summary,
+            "events": [e.to_dict() for e in filtered],
+        },
+        ensure_ascii=False,
+    )

--- a/tools/delegation_live_stream.py
+++ b/tools/delegation_live_stream.py
@@ -1,0 +1,173 @@
+"""Parse live subagent transcripts into structured event streams.
+
+The live transcript format (see tools/delegation_live_log.py) is one
+`HH:MM:SS role| content` line per event. ``action="tail"`` in
+``delegate_task`` returns the raw lines; ``action="stream"`` returns the
+same data parsed into typed event records the parent can dispatch on
+(grep "ERROR", filter by tool name, count iterations, etc.) without a
+regex.
+
+This module is intentionally pure:
+- No I/O. Pass an iterable of lines in, get a list of events back.
+- No state. Each call returns an independent list.
+- No reliance on agent internals — the parser only knows the live-log
+  format. Safe to import from CLI, tests, or any UI consumer.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+
+# Lines look like:  "14:22:08 tool    | -> terminal({\"command\": ...})"
+# The 9-char role field is left-padded to align the pipe.
+_LINE_RE = re.compile(
+    r"^(?P<ts>\d{2}:\d{2}:\d{2})\s+(?P<role>\S+)\s*\|\s*(?P<content>.*)$"
+)
+
+# Recognised roles (live-log vocabulary — keep in sync with delegation_live_log.py).
+_ROLES = frozenset({"user", "assistant", "think", "tool", "result", "final", "start"})
+
+# "-> name(args)"  — emitted by tool_start()
+_TOOL_START_RE = re.compile(r"^->\s*(?P<name>[^(\\s]+)(?:\((?P<args>.*)\))?\s*$")
+
+# "name status duration: preview"  — emitted by tool_result()
+# duration is optional; status is "ok" / "ERROR"
+_TOOL_RESULT_RE = re.compile(
+    r"^(?P<name>[^\s]+)\s+(?P<status>ok|ERROR)(?:\s+(?P<duration>[0-9.]+)s)?:\s*(?P<result>.*)$"
+)
+
+
+@dataclass
+class StreamEvent:
+    """One parsed event from the live transcript.
+
+    Fields are intentionally wide so every role can be represented; most
+    consumers will switch on ``kind`` and ignore the rest.
+    """
+
+    index: int                          # 0-based position from start of file
+    ts: Optional[str]                   # "HH:MM:SS" or None for unparseable
+    role: str                           # raw role label from the log
+    kind: str                           # normalised: kickoff/assistant/thinking/tool_start/tool_result/marker/raw
+    text: str                           # the raw line content (sans role prefix)
+    tool_name: Optional[str] = None     # for tool_start / tool_result
+    tool_args: Optional[str] = None     # for tool_start, args preview
+    tool_status: Optional[str] = None   # "ok" / "ERROR" for tool_result
+    tool_duration_seconds: Optional[float] = None
+    tool_result_preview: Optional[str] = None
+    is_error: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def parse_event(index: int, raw_line: str) -> StreamEvent:
+    """Parse one log line. Never raises; unparseable lines become kind='raw'."""
+    line = raw_line.rstrip("\n").rstrip("\r")
+    m = _LINE_RE.match(line)
+    if not m:
+        # Header line, blank line, or malformed input — keep the text but mark raw.
+        return StreamEvent(
+            index=index,
+            ts=None,
+            role="",
+            kind="raw",
+            text=line,
+        )
+    ts = m.group("ts")
+    role = m.group("role")
+    content = m.group("content")
+    kind = _normalise_role(role)
+    ev = StreamEvent(index=index, ts=ts, role=role, kind=kind, text=content)
+
+    if kind == "tool_start":
+        mm = _TOOL_START_RE.match(content)
+        if mm:
+            ev.tool_name = mm.group("name")
+            ev.tool_args = mm.group("args") or None
+    elif kind == "tool_result":
+        mm = _TOOL_RESULT_RE.match(content)
+        if mm:
+            ev.tool_name = mm.group("name")
+            ev.tool_status = mm.group("status")
+            ev.is_error = mm.group("status") == "ERROR"
+            dur = mm.group("duration")
+            if dur:
+                try:
+                    ev.tool_duration_seconds = float(dur)
+                except ValueError:
+                    pass
+            ev.tool_result_preview = mm.group("result")
+
+    return ev
+
+
+def _normalise_role(role: str) -> str:
+    """Map the live-log role to a stable ``kind`` for downstream switching."""
+    r = (role or "").strip().lower()
+    if r == "user":
+        return "kickoff"
+    if r == "assistant":
+        return "assistant"
+    if r == "think":
+        return "thinking"
+    if r == "tool":
+        return "tool_start"
+    if r == "result":
+        return "tool_result"
+    if r in {"final", "start"}:
+        return "marker"
+    return "raw"
+
+
+def parse_lines(lines: Iterable[str]) -> List[StreamEvent]:
+    """Parse an iterable of lines (typically the tail of a log file)."""
+    out: List[StreamEvent] = []
+    for i, ln in enumerate(lines):
+        out.append(parse_event(i, ln))
+    return out
+
+
+def filter_events(
+    events: List[StreamEvent],
+    *,
+    kinds: Optional[List[str]] = None,
+    tool_name: Optional[str] = None,
+    errors_only: bool = False,
+) -> List[StreamEvent]:
+    """Convenience: subset events by kind / tool / error filter."""
+    out = events
+    if kinds is not None:
+        wanted = set(kinds)
+        out = [e for e in out if e.kind in wanted]
+    if tool_name is not None:
+        out = [e for e in out if e.tool_name == tool_name]
+    if errors_only:
+        out = [e for e in out if e.is_error]
+    return out
+
+
+def summarise(events: List[StreamEvent]) -> Dict[str, Any]:
+    """Aggregate stats over an event stream."""
+    tool_calls: Dict[str, int] = {}
+    tool_errors: Dict[str, int] = {}
+    total_duration: float = 0.0
+    for e in events:
+        if e.kind == "tool_start" and e.tool_name:
+            tool_calls[e.tool_name] = tool_calls.get(e.tool_name, 0) + 1
+        if e.kind == "tool_result" and e.tool_name:
+            if e.is_error:
+                tool_errors[e.tool_name] = tool_errors.get(e.tool_name, 0) + 1
+            if e.tool_duration_seconds is not None:
+                total_duration += e.tool_duration_seconds
+    return {
+        "event_count": len(events),
+        "tool_call_count": sum(tool_calls.values()),
+        "tool_error_count": sum(tool_errors.values()),
+        "tool_call_breakdown": tool_calls,
+        "tool_error_breakdown": tool_errors,
+        "total_tool_duration_seconds": round(total_duration, 3),
+    }


### PR DESCRIPTION
## Summary

Adds `delegate_task(action='stream', subagent_id=..., lines=N, kinds=[...], tool_name=..., errors_only=...)` that returns the last N lines of a running child's live transcript **parsed into typed events**, not raw log lines.

## What ships

- New `tools/delegation_live_stream.py`: zero-dependency parser for the `LiveTranscriptWriter` format (HH:MM:SS role| content), classifies each line into `start/think/assistant/tool/result/final`, exposes `parse_lines`, `filter_events` (by kind, tool_name, errors_only), `summarise` (counts).
- New `action='stream'` in `delegate_task` schema enum.
- New optional params: `lines` (1-1000, default 50), `kinds` (list, e.g. ["tool","result"]), `tool_name` (str, exact match), `errors_only` (bool).
- New `tests/tools/test_delegation_live_stream.py` — 17 unit tests covering the parser, filter combinations, and edge cases.
- New `tests/tools/test_delegate_stream_action.py` — 10 integration tests covering the action dispatch (subagent_id requirement, ownership scoping, missing transcript, filter wiring, params caps).
- Caught + fixed 3 bugs along the way (literal-`\n` injection past the bad block, missing `args=None` guard at the dispatch boundary, unused `lines_arg` left over from an earlier draft).

## Why

- The live transcript (`list` action's `live_transcript` field) is currently raw text. Callers have to regex-parse it themselves to build a UI drawer, count tool calls, or detect errors.
- Structured events drop straight into a TUI drawer, a webhook, or a sub-task summariser — no parsing required downstream.
- Filters cut payload size and let callers focus on what matters (e.g. `errors_only=True` for failure alerts).

## Tests

```
tests/tools/test_delegation_live_stream.py     17 passed
tests/tools/test_delegate_stream_action.py     10 passed
tests/tools/test_delegate_control_actions.py  +136 existing tests still green
tests/tools/test_delegate.py                  (no regressions)
```

## Out of scope (deliberate)

- A UI drawer component. This is the data-plane change only.
- Replay mode for finished children. (The `list` action only exposes live transcripts.)
- Telemetry. No new metrics emitted; callers count events themselves via the summary block.

## Backwards compatibility

- Pure addition. Existing control actions (`list`/`steer`/`stop`) are unchanged.
- The new params are all optional; defaults match today's behaviour (last 50 lines, no filter).
