### PR TITLE
test: add tests for hermes_cli/memory_oauth.py and web_deps.py

### DIFF
--- a/tests/hermes_cli/test_memory_oauth.py
+++ b/tests/hermes_cli/test_memory_oauth.py
@@ -1,0 +1,25 @@
+"""Tests for hermes_cli/memory_oauth.py — _resolve_flow provider validation."""
+
+import pytest
+from fastapi import HTTPException
+
+
+def test_resolve_flow_valid_provider():
+    from hermes_cli.memory_oauth import _resolve_flow
+    # honcho is a known memory provider
+    flow = _resolve_flow("honcho")
+    assert flow is not None
+
+
+def test_resolve_flow_invalid_provider_name():
+    from hermes_cli.memory_oauth import _resolve_flow
+    with pytest.raises(HTTPException) as exc:
+        _resolve_flow("not-a-valid!provider")
+    assert exc.value.status_code == 404
+
+
+def test_resolve_flow_nonexistent_provider():
+    from hermes_cli.memory_oauth import _resolve_flow
+    with pytest.raises(HTTPException) as exc:
+        _resolve_flow("nonexistentproviderxyz")
+    assert exc.value.status_code == 404

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tests/hermes_cli/test_web_deps.py
+++ b/tests/hermes_cli/test_web_deps.py
@@ -1,0 +1,34 @@
+"""Tests for hermes_cli/web_deps.py — late-binding helpers."""
+
+
+def test_late_attr_returns_actual_value():
+    from hermes_cli.web_deps import late_attr
+
+    class FakeServer:
+        token = "abc123"
+    server = FakeServer()
+    assert late_attr("token")(server) == "abc123"
+
+
+def test_late_attr_missing_returns_none():
+    from hermes_cli.web_deps import late_attr
+    assert late_attr("missing")(None) is None
+
+
+def test_late_delegates_to_late_attr_without_args():
+    from hermes_cli.web_deps import late, late_attr
+    # late(name) returns the same thing as late_attr(name)
+    assert late("x").func == late_attr("x").func
+
+
+def test_get_session_token_returns_string():
+    from hermes_cli.web_deps import get_session_token
+    # Without a running server, returns None
+    result = get_session_token()
+    assert result is None or isinstance(result, str)
+
+
+def test_get_dashboard_health_returns_dict():
+    from hermes_cli.web_deps import get_dashboard_health
+    result = get_dashboard_health()
+    assert result is None or isinstance(result, (dict, bool))


### PR DESCRIPTION
﻿Tests for hermes_cli/memory_oauth.py (_resolve_flow provider validation) and
web_deps.py (late/late_attr delegation, session token, dashboard health).
