### PR TITLE
fix(gateway): resolve user systemd units against the account home, not profile HOME

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2717,7 +2717,7 @@ def _systemd_user_unit_dir() -> Path:
     try:
         import pwd  # windows-footgun: ok — POSIX-only module inside try/except
 
-        pw_dir = pwd.getpwuid(os.getuid()).pw_dir.strip()
+        pw_dir = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok — POSIX-only module inside try/except
     except Exception:
         pw_dir = ""
     if pw_dir:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2699,11 +2699,39 @@ def get_service_name() -> str:
     return f"{_SERVICE_BASE}-{suffix}"
 
 
+def _systemd_user_unit_dir() -> Path:
+    """The account home that owns the systemd user session (#98699).
+
+    ``Path.home()`` trusts the process ``HOME``, which profile isolation may
+    point at ``{HERMES_HOME}/home`` — the *active* profile's, not even the one
+    selected with ``-p``. A unit written there is invisible to
+    ``systemctl --user``: ``gateway install`` reports success while the
+    service never exists. ``systemctl --user`` targets the login user's
+    session, so resolve the account home explicitly: the recorded real home
+    first, then the passwd entry, and only fall back to ``HOME``-derived
+    resolution when neither resolves (non-POSIX).
+    """
+    explicit = os.environ.get("HERMES_REAL_HOME", "").strip()
+    if explicit:
+        return Path(explicit) / ".config" / "systemd" / "user"
+    try:
+        import pwd  # windows-footgun: ok — POSIX-only module inside try/except
+
+        pw_dir = pwd.getpwuid(os.getuid()).pw_dir.strip()
+    except Exception:
+        pw_dir = ""
+    if pw_dir:
+        return Path(pw_dir) / ".config" / "systemd" / "user"
+    from hermes_constants import get_real_home
+
+    return Path(get_real_home()) / ".config" / "systemd" / "user"
+
+
 def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
-    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+    return _systemd_user_unit_dir() / f"{name}.service"
 
 
 class UserSystemdUnavailableError(RuntimeError):
@@ -3015,7 +3043,7 @@ def _legacy_unit_search_paths() -> list[tuple[bool, Path]]:
     real filesystem paths.
     """
     return [
-        (False, Path.home() / ".config" / "systemd" / "user"),
+        (False, _systemd_user_unit_dir()),
         (True, Path("/etc/systemd/system")),
     ]
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -42,6 +42,88 @@ class TestUserSystemdPrivateSocketPreflight:
         assert calls == ["env"]
 
 
+class TestUserUnitDirResolvesAccountHome:
+    """User-scope unit paths must resolve to the login account home (#98699).
+
+    Profile isolation can point the process ``HOME`` at
+    ``{HERMES_HOME}/home`` — the *active* profile's, not even the one
+    selected with ``-p``. A unit written under a profile home is invisible
+    to ``systemctl --user``: ``gateway install`` reports success while the
+    service never exists.
+    """
+
+    def _profile_homes(self, tmp_path):
+        real = tmp_path / "account-home"
+        amelia = tmp_path / "dot-hermes" / "profiles" / "amelia" / "home"
+        nick = tmp_path / "dot-hermes" / "profiles" / "nick-white" / "home"
+        for d in (real, amelia, nick):
+            d.mkdir(parents=True)
+        return real, amelia, nick
+
+    def test_unit_path_ignores_profile_home(self, tmp_path, monkeypatch):
+        real, amelia, _nick = self._profile_homes(tmp_path)
+        monkeypatch.setenv("HOME", str(amelia))
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / "dot-hermes" / "profiles" / "amelia")
+        )
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(real)))
+
+        unit = gateway_cli.get_systemd_unit_path()
+
+        expected = (
+            real / ".config" / "systemd" / "user" / f"{gateway_cli.get_service_name()}.service"
+        )
+        assert unit == expected
+        assert str(amelia) not in str(unit)
+
+    def test_unit_path_ignores_sibling_profile_home(self, tmp_path, monkeypatch):
+        # Issue #98699: HOME points at the *active* profile's home while -p
+        # selected a different profile — neither is the account home.
+        real, amelia, _nick = self._profile_homes(tmp_path)
+        monkeypatch.setenv("HOME", str(amelia))
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / "dot-hermes" / "profiles" / "nick-white")
+        )
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(real)))
+
+        unit = gateway_cli.get_systemd_unit_path()
+
+        expected = (
+            real / ".config" / "systemd" / "user" / f"{gateway_cli.get_service_name()}.service"
+        )
+        assert unit == expected
+
+    def test_recorded_real_home_wins(self, tmp_path, monkeypatch):
+        real, amelia, _nick = self._profile_homes(tmp_path)
+        monkeypatch.setenv("HOME", str(amelia))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real))
+        monkeypatch.setattr(
+            pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir="/etc/passwd-fallback")
+        )
+
+        unit = gateway_cli.get_systemd_unit_path()
+
+        expected = (
+            real / ".config" / "systemd" / "user" / f"{gateway_cli.get_service_name()}.service"
+        )
+        assert unit == expected
+
+    def test_legacy_search_paths_use_account_home(self, tmp_path, monkeypatch):
+        real, amelia, _nick = self._profile_homes(tmp_path)
+        monkeypatch.setenv("HOME", str(amelia))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(real)))
+
+        paths = gateway_cli._legacy_unit_search_paths()
+
+        assert paths == [
+            (False, real / ".config" / "systemd" / "user"),
+            (True, Path("/etc/systemd/system")),
+        ]
+
+
 class TestSystemdServiceRefresh:
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes -p <profile> gateway install` derives the user-scope systemd unit path from `Path.home()`, which trusts a process `HOME` that profile isolation may point at `{HERMES_HOME}/home` — the **active** profile's, not even the one selected with `-p`. The unit then lands in `~/.hermes/profiles/<active>/home/.config/systemd/user/`, `systemctl --user` never sees it, and `gateway start` fails with `Unit hermes-gateway-<profile>.service does not exist` (#98699).

`systemctl --user` targets the login user's session, so the unit directory must resolve to the account home. This PR adds `_systemd_user_unit_dir()`, which resolves the account home explicitly: `HERMES_REAL_HOME` when recorded, else the passwd entry for the current uid, falling back to `get_real_home()` only when neither resolves (non-POSIX). `get_systemd_unit_path()` and the legacy-unit scan root `_legacy_unit_search_paths()` now both use it, so old units are still found under the real `~/.config/systemd/user` and refreshed units are written back there.

## Related Issue

Fixes #98699

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — added `_systemd_user_unit_dir()` (HERMES_REAL_HOME → `pwd.getpwuid` → `get_real_home()`); `get_systemd_unit_path()` user branch and `_legacy_unit_search_paths()` now use it instead of `Path.home()`
- `tests/hermes_cli/test_gateway_service.py` — `TestUserUnitDirResolvesAccountHome`: unit path ignores the current profile's home, ignores a sibling profile's home (the exact #98699 topology: `HOME` on the active profile, `-p` selecting another), honors `HERMES_REAL_HOME`, and the legacy scan root follows the account home

## How to Test

1. `pytest tests/hermes_cli/test_gateway_service.py::TestUserUnitDirResolvesAccountHome -q` → 4 passed
2. `pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_gateway.py -q` → 150 passed, 4 skipped (no regressions around the unit-path consumers)
3. Manual equivalent on Linux: with `HOME=$HOME/.hermes/profiles/amelia/home` and `HERMES_HOME=$HOME/.hermes/profiles/nick-white` exported, `python -c "from hermes_cli.gateway import get_systemd_unit_path; print(get_systemd_unit_path())"` should print the real account home path (`/home/<user>/.config/systemd/user/hermes-gateway-nick-white.service`), not the amelia profile path. Observed result: unit path resolves under the passwd home; before this change it resolved under `Path.home()` (the profile dir).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the changed code path is POSIX/Linux, exercised via the unit tests above

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_gateway_service.py::TestUserUnitDirResolvesAccountHome -q
4 passed in 0.61s
```
