### PR TITLE
feat(skills): add onload hook and HERMES_HOME template var for environment-triggered skill loading

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1593,7 +1593,7 @@ _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 # v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
 # org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1729,6 +1729,8 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "onload": str(frontmatter.get("onload", "") or ""),
+        "rel_path": str(rel_path),
     }
     if org_id:
         entry["org_id"] = org_id
@@ -1830,7 +1832,7 @@ def build_skills_system_prompt(
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
     skills_dir_override: "Path | None" = None,
-) -> str:
+) -> tuple[str, list[dict]]:
     """Build a compact skill index for the system prompt.
 
     Two-layer cache:
@@ -1896,7 +1898,7 @@ def _build_skills_system_prompt_inner(
     available_toolsets: "set[str] | None",
     compact_categories: "frozenset[str] | None",
     project_dirs: "list[Path] | None" = None,
-) -> str:
+) -> tuple[str, list[dict]]:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
@@ -1916,6 +1918,11 @@ def _build_skills_system_prompt_inner(
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
         if cached is not None:
             _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
+            # Old-format cached strings (v2 snapshots) get wrapped to
+            # maintain the new (index, onload_entries) contract.
+            if isinstance(cached, str):
+                cached = (cached, [])
+                _SKILLS_PROMPT_CACHE[cache_key] = cached
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
@@ -2196,14 +2203,35 @@ def _build_skills_system_prompt_inner(
             + hidden_note
         )
 
+    # ── Collect onload entries ──────────────────────────────────────────
+    # Skills with an `onload:` frontmatter field register a script that the
+    # system-prompt builder runs at session init. If it returns "INJECT",
+    # the skill body is pre-loaded into the system prompt volatile tier.
+    onload_entries: list[dict] = []
+    for entry in visible_entries:
+        ol_raw = entry.get("onload", "") or ""
+        ol = str(ol_raw).strip()
+        if not ol:
+            continue
+        rp = entry.get("rel_path", "") or ""
+        if not rp:
+            continue
+        rp_obj = Path(rp)
+        onload_entries.append({
+            "onload": ol,
+            "skill_dir": str(skills_dir / rp_obj.parent),
+            "skill_md_path": str(skills_dir / rp),
+            "skill_name": entry.get("skill_name", "?"),
+        })
+
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
-        _SKILLS_PROMPT_CACHE[cache_key] = result
+        _SKILLS_PROMPT_CACHE[cache_key] = (result, onload_entries)
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
         while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
             _SKILLS_PROMPT_CACHE.popitem(last=False)
 
-    return result
+    return result, onload_entries
 
 
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -1,18 +1,20 @@
 """Shared SKILL.md preprocessing helpers."""
 
 import logging
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 
 logger = logging.getLogger(__name__)
 
-# Matches ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} tokens in SKILL.md.
+# Matches ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} / ${HERMES_HOME} tokens in SKILL.md.
 # Tokens that don't resolve (e.g. ${HERMES_SESSION_ID} with no session) are
 # left as-is so the user can debug them.
-_SKILL_TEMPLATE_RE = re.compile(r"\$\{(HERMES_SKILL_DIR|HERMES_SESSION_ID)\}")
+_SKILL_TEMPLATE_RE = re.compile(r"\$\{(HERMES_SKILL_DIR|HERMES_SESSION_ID|HERMES_HOME)\}")
 
 # Matches inline shell snippets like:  !`date +%Y-%m-%d`
 # Non-greedy, single-line only -- no newlines inside the backticks.
@@ -41,7 +43,7 @@ def substitute_template_vars(
     skill_dir: Path | None,
     session_id: str | None,
 ) -> str:
-    """Replace ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} in skill content.
+    """Replace ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} / ${HERMES_HOME} in skill content.
 
     Only substitutes tokens for which a concrete value is available --
     unresolved tokens are left in place so the author can spot them.
@@ -50,6 +52,7 @@ def substitute_template_vars(
         return content
 
     skill_dir_str = str(skill_dir) if skill_dir else None
+    hermes_home = os.environ.get("HERMES_HOME")
 
     def _replace(match: re.Match) -> str:
         token = match.group(1)
@@ -57,6 +60,8 @@ def substitute_template_vars(
             return skill_dir_str
         if token == "HERMES_SESSION_ID" and session_id:
             return str(session_id)
+        if token == "HERMES_HOME" and hermes_home:
+            return hermes_home
         return match.group(0)
 
     return _SKILL_TEMPLATE_RE.sub(_replace, content)
@@ -142,3 +147,72 @@ def preprocess_skill_content(
         timeout = int(cfg.get("inline_shell_timeout", 10) or 10)
         content = expand_inline_shell(content, skill_dir, timeout)
     return content
+
+
+def run_onload_script(
+    script_rel_path: str,
+    skill_dir: Path,
+    extra_env: dict | None = None,
+    timeout: int = 30,
+) -> str:
+    """Run a skill's onload script and return its stdout (stripped).
+
+    The script is expected to print ``INJECT`` (case-insensitive, trimmed)
+    to signal that the skill body should be pre-loaded into the system
+    prompt.  Any other output (or an empty string) means "skip".
+
+    Supports ``.sh`` (bash) and ``.py`` (python) scripts.  Falls back to
+    running the command directly via bash for unrecognised extensions.
+
+    Reuses the same subprocess machinery as ``run_inline_shell`` so any
+    platform quirks (Windows hide-console flags) are already handled.
+    """
+    script_path = skill_dir / script_rel_path
+    if not script_path.exists():
+        logger.warning(
+            "onload script %s not found for skill at %s",
+            script_rel_path, skill_dir,
+        )
+        return ""
+
+    # Normalise to forward slashes so bash doesn't interpret backslashes
+    # as escape characters on Windows.
+    script_path_str = str(script_path).replace("\\", "/")
+
+    ext = script_path.suffix.lower()
+    if ext == ".py":
+        # Run Python scripts via python directly to avoid bash PATH
+        # resolution issues on Windows (git-bash vs WSL relay).
+        _python = sys.executable or "python"
+        args = [_python, script_path_str]
+    elif ext == ".sh":
+        args = ["bash", script_path_str]
+    else:
+        args = ["bash", script_path_str]  # default fallback
+
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(skill_dir).replace("\\", "/"),
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=max(1, int(timeout)),
+            check=False,
+            stdin=subprocess.DEVNULL,
+            env=env,
+            **_popen_kwargs,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("onload script %s timed out after %ss", script_path, timeout)
+        return "[TIMEOUT]"
+    except Exception as exc:
+        logger.warning("onload script %s failed: %s", script_path, exc)
+        return ""
+
+    output = (completed.stdout or "").strip()
+    return output

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -55,6 +55,8 @@ from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_default_hermes_root, get_hermes_home
 from pathlib import Path
 from utils import is_truthy_value
+from agent.skill_preprocessing import run_onload_script
+from agent.skill_utils import parse_frontmatter
 
 logger = logging.getLogger(__name__)
 _PLUGIN_SECTION_FRAME_RE = re.compile(
@@ -551,8 +553,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
         )
+        # Unpack onload entries (new-style tuple) with backward compat for
+        # cached strings from v2 snapshots.
+        onload_entries: list[dict] = []
+        if isinstance(skills_prompt, tuple):
+            skills_prompt, onload_entries = skills_prompt
     else:
         skills_prompt = ""
+        onload_entries = []
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -816,6 +824,55 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # system message is one cache unit regardless of internal order.)
     if skills_prompt:
         volatile_parts.append(skills_prompt)
+
+    # ── Onload skill body injection ──────────────────────────────────────
+    # Skills with an ``onload:`` frontmatter field register a script that
+    # runs at session init.  If it returns ``INJECT``, the skill body is
+    # pre-loaded into the system prompt volatile tier — before the model
+    # sees any user message.  This lets environment-triggered skills
+    # (e.g. model-specific behavior mandates) fire without depending on
+    # conversational keyword matching.
+    if onload_entries:
+        _onload_env: dict[str, str] = {}
+        _model = getattr(agent, "model", "") or ""
+        _provider = getattr(agent, "provider", "") or ""
+        if _model:
+            _onload_env["HERMES_MODEL"] = _model
+        if _provider:
+            _onload_env["HERMES_PROVIDER"] = _provider
+        for _entry in onload_entries:
+            _script = (_entry.get("onload") or "").strip()
+            _skill_dir = (_entry.get("skill_dir") or "")
+            _skill_md = (_entry.get("skill_md_path") or "")
+            _name = (_entry.get("skill_name") or "?")
+            if not _script or not _skill_dir or not _skill_md:
+                continue
+            _dir_path = Path(_skill_dir)
+            if not _dir_path.exists():
+                continue
+            try:
+                _output = run_onload_script(
+                    _script, _dir_path,
+                    extra_env=_onload_env or None,
+                )
+            except Exception as _exc:
+                logger.warning("onload script error for %s: %s", _name, _exc)
+                continue
+            if not _output or _output.strip().upper() != "INJECT":
+                continue
+            # Load skill body, strip frontmatter, inject into volatile tier
+            try:
+                _raw = Path(_skill_md).read_text(encoding="utf-8")
+                _fm, _body = parse_frontmatter(_raw)
+                _body = _body.strip()
+                if _body:
+                    volatile_parts.append(
+                        f"## Onload: {_name}\n\n{_body}"
+                    )
+            except Exception as _exc:
+                logger.warning(
+                    "Failed to load onload skill body %s: %s", _name, _exc
+                )
 
     if agent._memory_store:
         if agent._memory_enabled:


### PR DESCRIPTION
## Summary

Two additive changes to the skill system that extend it without breaking existing behaviour.

### 1. Onload hook

Skills can now declare an `onload:` frontmatter field pointing to a script ( or ). At session init the script runs with the resolved model/provider in env; if it prints `INJECT` the skill body is pre-loaded into the system prompt volatile tier as `## Onload: <name>` — before the model sees any user message.

This lets **environment-triggered skills** fire without depending on conversational keyword matching:
- Model-specific behavior mandates (e.g. a DeepSeek mandate that constrains tool-use patterns)
- Safety rules that must load early
- Platform-specific protocols
- Compliance guardrails

### 2. `HERMES_HOME` template variable

`${HERMES_HOME}` now resolves in SKILL.md content alongside the existing `${HERMES_SKILL_DIR}` and `${HERMES_SESSION_ID}` vars. This lets cross-skill references use an absolute anchor (e.g. `${HERMES_HOME}/skref/<skill>/file`) instead of fragile relative paths.

## Changes

| File | Δ | Description |
|------|---|---|
| `agent/skill_preprocessing.py` | +80/-2 | Added `run_onload_script()`, `HERMES_HOME` template var support |
| `agent/system_prompt.py` | +57/-0 | Onload runner: iterates entries, runs scripts, injects bodies on `INJECT` |
| `agent/prompt_builder.py` | +38/-8 | Extracts `onload` + `rel_path` from frontmatter, v3 snapshot bump, returns `(index, onload_entries)` tuple |

## Design

Both changes are purely **additive** — no existing skill breaks, no existing reference breaks. The session init path gains only a new injector stage in the volatile tier builder:



## Testing

- `onload` hook verified: check_model.py runs at session init, detects DeepSeek provider, returns `INJECT`, mandate body lands in system prompt
- `HERMES_HOME` var verified: `${HERMES_HOME}/skref/<skill>/file` resolves and loads correctly
- Backward compat: skills without `onload:` field load identically, old v2 snapshot cache entries are auto-wrapped to the new tuple contract

Co-authored-by: CaptainGimpy <captaingimpy@users.noreply.github.com>