### PR TITLE
fix(desktop): rest every browser overlay at turn end

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-mind.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-mind.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const target = (url: string) => ({ kind: 'url' as const, label: url, source: url, url })
+
+describe('preview mind', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(async () => {
+    const { setBusy } = await import('@/store/session')
+    const { closeRightRail } = await import('@/store/preview')
+
+    setBusy(false)
+    closeRightRail()
+  })
+
+  it('rests the overlay that started thinking when another browser tab becomes active', async () => {
+    const { $rightRailActiveTabId, selectRightRailTab } = await import('@/store/layout')
+    const { newBrowserTab, openPreview } = await import('@/store/preview')
+    const { setBusy } = await import('@/store/session')
+    const { registerPreviewScriptRunner } = await import('./preview-script-runner')
+
+    openPreview(target('https://example.com'))
+
+    const firstTabId = $rightRailActiveTabId.get()!
+    const firstRunner = vi.fn(async (_code: string) => 'ok')
+    const unregisterFirst = registerPreviewScriptRunner(firstTabId, firstRunner)
+
+    newBrowserTab()
+
+    const secondTabId = $rightRailActiveTabId.get()!
+    const secondRunner = vi.fn(async (_code: string) => 'ok')
+    const unregisterSecond = registerPreviewScriptRunner(secondTabId, secondRunner)
+
+    selectRightRailTab(firstTabId)
+    await import('./preview-mind')
+    setBusy(true)
+
+    expect(firstRunner.mock.calls.at(-1)?.[0]).toContain('"think"')
+    expect(secondRunner).not.toHaveBeenCalled()
+
+    selectRightRailTab(secondTabId)
+    setBusy(false)
+
+    expect(secondRunner.mock.calls.at(-1)?.[0]).toContain('"rest"')
+    expect(firstRunner.mock.calls.at(-1)?.[0]).toContain('"rest"')
+
+    unregisterSecond()
+    unregisterFirst()
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-mind.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-mind.ts
@@ -7,13 +7,14 @@
  * read. A page that stops responding the moment the agent is thinking hardest
  * reads as the agent having wandered off.
  *
- * This is deliberately NOT part of the act pipeline: a turn boundary only has
- * to poke the overlay the last action left behind. See preview-nudge.ts.
+ * This is deliberately NOT part of the act pipeline: starting a turn only has
+ * to poke the active overlay, while ending one hushes every mounted overlay so
+ * a tab switch cannot strand the old page's pulse. See preview-nudge.ts.
  */
 
 import { $busy } from '@/store/session'
 
-import { nudgeOverlay } from './preview-nudge'
+import { nudgeOverlay, restOverlays } from './preview-nudge'
 
 // Module-level, matching how review.ts and coding-status.ts watch this edge. It
 // is inert without a live pane, so there is nothing to mount or tear down.
@@ -25,5 +26,10 @@ $busy.subscribe(busy => {
   }
 
   running = busy
-  nudgeOverlay(busy ? 'think' : 'rest')
+
+  if (busy) {
+    nudgeOverlay('think')
+  } else {
+    restOverlays()
+  }
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-nudge.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-nudge.ts
@@ -16,16 +16,9 @@
 
 import type { WatchStage } from '@/lib/preview-act/watch-in-page'
 
-import { activePreviewScriptRunner } from './preview-script-runner'
+import { activePreviewScriptRunner, type PreviewScriptRunner, previewScriptRunners } from './preview-script-runner'
 
-/** Run one stage against the active pane's overlay, if it has one. */
-export function nudgeOverlay(stage: WatchStage): void {
-  const run = activePreviewScriptRunner()
-
-  if (!run) {
-    return
-  }
-
+function nudgeRunner(run: PreviewScriptRunner, stage: WatchStage): void {
   void run(`(function () {
   var w = window;
   var fn = w.__hermesWatch_fn;
@@ -35,4 +28,23 @@ export function nudgeOverlay(stage: WatchStage): void {
 })()`).catch(() => {
     // The page navigated out from under us. The next action re-injects.
   })
+}
+
+/** Run one stage against the active pane's overlay, if it has one. */
+export function nudgeOverlay(stage: WatchStage): void {
+  const run = activePreviewScriptRunner()
+
+  if (!run) {
+    return
+  }
+
+  nudgeRunner(run, stage)
+}
+
+/** Stop the idle pulse everywhere it could still be running. `think` belongs to
+ * the active page; `rest` is cleanup and must survive a tab switch. */
+export function restOverlays(): void {
+  for (const run of previewScriptRunners()) {
+    nudgeRunner(run, 'rest')
+  }
 }

--- a/apps/desktop/src/app/chat/right-rail/preview-script-runner.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-script-runner.ts
@@ -36,3 +36,9 @@ export function activePreviewScriptRunner(): PreviewScriptRunner | null {
 
   return (tab && runners.get(tab.id)) || null
 }
+
+/** Every mounted guest-page runner. Idle cleanup is a renderer-wide invariant:
+ * a tab switch must not strand the pulse that another tab started. */
+export function previewScriptRunners(): readonly PreviewScriptRunner[] {
+  return [...runners.values()]
+}


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop in-app Browser's element overlay from continuing to pulse after a turn becomes idle when the active Browser tab changed during that turn.

A page could keep flashing/scanning elements even though Hermes was idle. The trigger looked random because it depended on which Browser tab was active at the start and end of the turn.

### Root cause

`preview-mind.ts` sent both busy-edge stages through `activePreviewScriptRunner()`:

1. Tab A was active when `$busy` became true, so A received `think` and started its pulse interval.
2. The user selected tab B while the turn was running.
3. When `$busy` became false, only the now-active tab B received `rest`.
4. Tab A never received cleanup, so its pulse interval continued while the session was idle.

The fix keeps `think` scoped to the active page but broadcasts the idle `rest` cleanup to every mounted preview script runner.

## Related Issue

No matching issue or PR was found for the idle pulse/tab-switch lifecycle; the bug was reported directly.

The separate workspace-edit refresh symptom is already tracked by #81487 and has the authorship-preserving open fix #88877 (salvaged from #81503), so this PR intentionally does not duplicate it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-mind.ts` — keep active-page `think`, but rest all mounted preview overlays when the turn ends.
- `apps/desktop/src/app/chat/right-rail/preview-nudge.ts` — share nudge dispatch and add renderer-wide idle cleanup.
- `apps/desktop/src/app/chat/right-rail/preview-script-runner.ts` — expose the mounted runner set to idle cleanup.
- `apps/desktop/src/app/chat/right-rail/preview-mind.test.ts` — reproduce tab A thinking, tab B becoming active, and the busy→idle edge.

## How to Test

1. On current `origin/main`, the regression test fails because tab A's last overlay stage remains `"think"`:
   ```bash
   cd apps/desktop
   npx vitest run src/app/chat/right-rail/preview-mind.test.ts
   ```
2. Apply this patch and rerun the focused test; it passes.
3. Run the complete Desktop gate:
   ```bash
   npm run check
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide and Desktop `AGENTS.md`
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed issues/PRs to avoid duplicates
- [x] This PR contains only the idle overlay lifecycle fix
- [x] The focused regression test was observed red before implementation and now passes
- [x] `npm run check` passes
- [x] Tested on Ubuntu 26.04

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing API or setting changed
- [x] `cli-config.yaml.example` update — N/A; no config changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow changed
- [x] Cross-platform impact considered — renderer-only state and guest-page script dispatch
- [x] Tool descriptions/schemas update — N/A; no model tool contract changed
