### PR TITLE
fix(telegram): report the clipped stream preview instead of a bare success (#98552)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2080,6 +2080,24 @@ class GatewayStreamConsumer:
             logger.error("Stream send chunk error: %s", e)
             return reply_to_id
 
+    @staticmethod
+    def _delivered_text_for(result: Any, sent_text: str) -> str:
+        """Return the text the adapter reports the platform actually stored.
+
+        Adapters that clip an oversized progressive edit instead of splitting
+        it (Telegram's saturated stream preview) still report success, and
+        surface what landed as ``raw_response["delivered_prefix"]`` — the same
+        field the ``partial_overflow`` contract uses on the failure branch.
+        Adapters that deliver exactly what they were given report nothing and
+        keep ``sent_text``.
+        """
+        raw = getattr(result, "raw_response", None)
+        if isinstance(raw, dict):
+            delivered = raw.get("delivered_prefix")
+            if isinstance(delivered, str) and delivered:
+                return delivered
+        return sent_text
+
     def _visible_prefix(self) -> str:
         """Return the visible text already shown in the streamed message."""
         prefix = self._last_sent_text or ""
@@ -3362,7 +3380,17 @@ class GatewayStreamConsumer:
                             self._last_sent_text = ""
                             self._notify_new_message()
                         else:
-                            self._last_sent_text = text
+                            # Track what the platform actually STORED, not what
+                            # we asked it to store.  An adapter may accept an
+                            # oversized progressive edit and keep only a
+                            # truncated preview (Telegram, #48648); advancing
+                            # from ``text`` then makes every "already seen"
+                            # derivation — _visible_prefix, _continuation_text,
+                            # the turn-final payload record — describe text no
+                            # API call ever carried (#98552).
+                            self._last_sent_text = self._delivered_text_for(
+                                result, text,
+                            )
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -230,6 +230,33 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
 
 
+def _stream_preview_truncated_result(
+    message_id: str, delivered_prefix: str
+) -> "SendResult":
+    """Success result for a mid-stream edit Telegram stored only in part.
+
+    A progressive edit that overflows the 4,096 UTF-16 cap is truncated to one
+    message instead of being split (#48648), so the text that reaches Telegram
+    is SHORTER than the text the caller passed.  Reporting a bare success made
+    that invisible: the stream consumer advanced ``_last_sent_text`` — and
+    every "what has the user already seen" derivation built on it
+    (``_visible_prefix``, ``_continuation_text``, the turn-final payload
+    record) — to text no API call ever carried, so a later fallback skipped
+    the un-stored middle and the gateway suppressed its corrective send
+    (#98552).  ``delivered_prefix`` states what Telegram actually holds; the
+    existing ``partial_overflow`` contract carries the same field on the
+    failure branch.
+    """
+    return SendResult(
+        success=True,
+        message_id=message_id,
+        raw_response={
+            "stream_preview_truncated": True,
+            "delivered_prefix": delivered_prefix,
+        },
+    )
+
+
 def _flood_cap_result(wait: float) -> "SendResult":
     """The shared fail-closed SendResult for an over-cap flood wait."""
     return SendResult(
@@ -5744,7 +5771,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return _stream_preview_truncated_result(message_id, content)
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -5760,6 +5787,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
+                    return _stream_preview_truncated_result(message_id, content)
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
@@ -5809,14 +5837,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 truncated = self._truncate_stream_overflow_preview(content)
                 if self._last_overflow_preview.get(_preview_key) == truncated:
                     # Saturated-preview dedup (see pre-flight path above).
-                    return SendResult(success=True, message_id=message_id)
+                    return _stream_preview_truncated_result(message_id, truncated)
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return _stream_preview_truncated_result(message_id, truncated)
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.

--- a/tests/gateway/test_truncated_preview_ack.py
+++ b/tests/gateway/test_truncated_preview_ack.py
@@ -1,0 +1,275 @@
+"""Regression coverage for #98552 — a truncated preview must not ACK as delivered.
+
+Telegram refuses to split an oversized *progressive* edit: splitting mid-stream
+moves the editable message id and the next accumulated-token edit re-splits,
+producing the #48648 duplication loop.  Instead the adapter clips the payload
+to one message and edits with the clipped text.  That call succeeded, so it
+returned a bare ``SendResult(success=True)`` — and the stream consumer advanced
+``_last_sent_text`` to the text it *sent*, not the shorter text Telegram
+*stored*.
+
+Everything the consumer knows about "what the user has already seen" is derived
+from that field:
+
+* ``_visible_prefix()`` — the on-screen text;
+* ``_continuation_text()`` — the tail a fallback send still owes the user;
+* ``_mark_skip_redundant_finalize()`` / the failed-final-edit guard — the
+  turn-final payload the gateway reconciles against ``final_response``.
+
+With an over-long ``_last_sent_text`` all three describe text no API call ever
+carried: the fallback skips the un-stored middle, and
+``delivered_final_matches`` reports a match, so ``gateway/run.py`` suppresses
+its corrective send ("final delivery already confirmed ... content_delivered=
+True") over a frozen, clipped preview.
+
+These tests pin the contract at both layers: the adapter must report what it
+actually stored, and the consumer must believe the report over its own request.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+CURSOR = " ▉"
+CAP = 4096
+
+
+# ---------------------------------------------------------------------------
+# Adapter layer — the truncation must be reported, not hidden behind success
+# ---------------------------------------------------------------------------
+
+
+def _telegram_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock()
+    adapter._bot.send_message = AsyncMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_saturated_preview_edit_reports_what_telegram_stored():
+    """The first oversized progressive edit clips; the result must say so."""
+    adapter = _telegram_adapter()
+
+    result = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
+
+    assert result.success is True
+    assert result.message_id == "456"
+    stored = adapter._bot.edit_message_text.call_args.kwargs["text"]
+    assert len(stored) <= CAP
+    assert isinstance(result.raw_response, dict)
+    assert result.raw_response.get("stream_preview_truncated") is True
+    assert result.raw_response.get("delivered_prefix") == stored
+
+
+@pytest.mark.asyncio
+async def test_deduped_saturated_preview_still_reports_the_stored_text():
+    """The no-API-call dedup path must not look like a full delivery either."""
+    adapter = _telegram_adapter()
+
+    first = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
+    second = await adapter.edit_message("123", "456", "x" * 7000, finalize=False)
+
+    # Dedup held: the growing stream truncates to the same preview.
+    assert adapter._bot.edit_message_text.await_count == 1
+    assert second.success is True
+    assert second.raw_response.get("delivered_prefix") == first.raw_response.get(
+        "delivered_prefix"
+    )
+
+
+@pytest.mark.asyncio
+async def test_under_cap_edit_reports_no_truncation():
+    """Ordinary edits keep the bare success contract (no false positives)."""
+    adapter = _telegram_adapter()
+
+    result = await adapter.edit_message("123", "456", "short reply", finalize=False)
+
+    assert result.success is True
+    assert not (
+        isinstance(result.raw_response, dict)
+        and result.raw_response.get("delivered_prefix")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consumer layer — believe the adapter's report, not our own request
+# ---------------------------------------------------------------------------
+
+
+class ClippingAdapter(BasePlatformAdapter):
+    """Telegram-shaped double: progressive edits are clipped to ``CAP``.
+
+    Records only what a user could actually see, so the assertions below
+    compare the consumer's claims against the rendered screen rather than
+    against the calls it made.
+    """
+
+    REQUIRES_EDIT_FINALIZE = True
+    FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    MAX_MESSAGE_LENGTH = CAP
+
+    def __init__(self, *, fail_finalize_edit: bool = False):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._fail_finalize_edit = fail_finalize_edit
+        self.screen = {}
+        self.order = []
+        self._next_id = 0
+
+    def prefers_fresh_final_streaming(self, content, metadata=None) -> bool:
+        return False
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._next_id += 1
+        mid = f"m{self._next_id}"
+        # Telegram's send() chunks oversized content rather than clipping it,
+        # so a fresh send always lands whole; only progressive EDITS clip.
+        self.screen[mid] = content
+        self.order.append(mid)
+        return SendResult(success=True, message_id=mid)
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        if finalize:
+            if self._fail_finalize_edit:
+                return SendResult(
+                    success=False, error="Flood control exceeded. Retry in 30 seconds"
+                )
+            self.screen[message_id] = content
+            return SendResult(success=True, message_id=message_id)
+        if len(content) <= CAP:
+            self.screen[message_id] = content
+            return SendResult(success=True, message_id=message_id)
+        clipped = content[:CAP]
+        self.screen[message_id] = clipped
+        return SendResult(
+            success=True,
+            message_id=message_id,
+            raw_response={
+                "stream_preview_truncated": True,
+                "delivered_prefix": clipped,
+            },
+        )
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.screen.pop(message_id, None)
+        if message_id in self.order:
+            self.order.remove(message_id)
+        return True
+
+    def rendered(self) -> str:
+        return "".join(self.screen[m] for m in self.order)
+
+
+def _consumer_claims_final_delivery(consumer, final_text: str) -> bool:
+    """Mirror of the suppression decision in ``gateway/run.py``."""
+    if consumer.delivered_final_matches(final_text) is False:
+        return False
+    return bool(consumer.final_response_sent or consumer.final_content_delivered)
+
+
+async def _drive(adapter, deltas, final_text):
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(cursor=CURSOR, edit_interval=0.0),
+    )
+    # Keep the whole reply in one preview so the adapter (not the consumer)
+    # owns the overflow, which is what Telegram's rich-message cap does via
+    # ``streaming_overflow_limit``.
+    consumer._raw_message_limit = lambda: 32768
+    task = asyncio.create_task(consumer.run())
+    for delta in deltas:
+        consumer.on_delta(delta)
+        await asyncio.sleep(0.02)
+    consumer.finish(final_text)
+    try:
+        await asyncio.wait_for(task, timeout=3.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        task.cancel()
+    return consumer
+
+
+def _oversized_deltas():
+    # First delta creates the preview message (well under the cap); the second
+    # grows it past the cap so the clip happens on a progressive EDIT, which is
+    # the path Telegram takes for a rich-capable bot (streaming_overflow_limit
+    # raises the consumer's own split threshold to 32,768).
+    opening = "报告开头。"
+    body = "内容" * 2600
+    tail = "最后一句：过去 4 天又发了 135 条）"
+    return [opening, body, tail], opening + body + tail
+
+
+@pytest.mark.asyncio
+async def test_clipped_preview_never_claims_delivery_it_cannot_back_up():
+    """The #98552 shape: clipped preview + a turn-final edit that fails.
+
+    Whatever recovery path the consumer takes, it may only claim the turn
+    final was delivered if the complete answer is actually on screen.
+    """
+    deltas, final_text = _oversized_deltas()
+    adapter = ClippingAdapter(fail_finalize_edit=True)
+
+    consumer = await _drive(adapter, deltas, final_text)
+
+    if _consumer_claims_final_delivery(consumer, final_text):
+        rendered = adapter.rendered()
+        assert final_text.strip() in rendered, (
+            "consumer claims the turn final was delivered, but the platform "
+            "only stored a clipped preview — the gateway would suppress its "
+            "corrective send and the answer would be lost. "
+            f"flags=(response_sent={consumer.final_response_sent}, "
+            f"content_delivered={consumer.final_content_delivered}) "
+            f"verdict={consumer.delivered_final_matches(final_text)!r} "
+            f"rendered_len={len(rendered)} final_len={len(final_text)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clipped_preview_leaves_a_reconcilable_record():
+    """A clipped preview must never reconcile as the complete final answer."""
+    deltas, final_text = _oversized_deltas()
+    adapter = ClippingAdapter(fail_finalize_edit=True)
+
+    consumer = await _drive(adapter, deltas, final_text)
+
+    if final_text.strip() not in adapter.rendered():
+        assert consumer.delivered_final_matches(final_text) is not True, (
+            "a clipped preview reconciled as the completed response"
+        )
+
+
+@pytest.mark.asyncio
+async def test_delivered_text_for_prefers_the_adapter_report():
+    """Unit contract for the helper the success path now goes through."""
+    plain = SimpleNamespace(raw_response=None)
+    reported = SimpleNamespace(
+        raw_response={"stream_preview_truncated": True, "delivered_prefix": "abc"}
+    )
+    empty = SimpleNamespace(raw_response={"delivered_prefix": ""})
+
+    assert GatewayStreamConsumer._delivered_text_for(plain, "abcdef") == "abcdef"
+    assert GatewayStreamConsumer._delivered_text_for(reported, "abcdef") == "abc"
+    assert GatewayStreamConsumer._delivered_text_for(empty, "abcdef") == "abcdef"


### PR DESCRIPTION
## Problem
Fixes #98552.

`gateway/run.py` suppresses its own final send when the stream consumer claims the turn final already reached the user:

```text
Suppressing normal final send for session ...: final delivery already confirmed (streamed=True previewed=False content_delivered=True).
```

That claim is only as good as the consumer's model of what is on screen — and on Telegram that model can be wrong by design.

Telegram refuses to **split** an oversized *progressive* edit: splitting mid-stream moves the editable message id, so the next accumulated-token edit re-splits and the reply duplicates (#48648). The adapter therefore **clips** the payload to one message and edits with the clipped text. The call succeeded, so `edit_message()` returned a bare `SendResult(success=True)` — with no way for the caller to learn that Telegram stored *less* than it was handed.

`GatewayStreamConsumer._send_or_edit()` then advanced `_last_sent_text` from the text it **sent**. Every "what has the user already seen" derivation is built on that one field:

| Derivation | What it is used for | Effect when `_last_sent_text` is too long |
|---|---|---|
| `_visible_prefix()` | on-screen text | over-reports the preview |
| `_continuation_text()` | the tail a fallback send still owes | fallback starts past the visible end — the middle of the answer is dropped |
| `_mark_skip_redundant_finalize()` / failed-final-edit guard | turn-final payload the gateway reconciles | a clipped preview reconciles as the completed `final_response` |

So `delivered_final_matches()` returns `True` for a message that only holds the first 4,096 units, the gateway suppresses its corrective send, and the user is left with a frozen preview and a stuck streaming cursor. This is the same failure family as #71643 / #78541 / #82656, and it is the one member of it whose "ACK for text the platform never stored" is produced **inside Hermes**, not by the network.

This path is not exotic: `TelegramAdapter.streaming_overflow_limit()` deliberately raises the consumer's own split threshold to the 32,768 rich-message cap, so any streamed reply over 4,096 characters on a rich-capable bot relies on the adapter's clip.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Streamed Deltas] -->|accumulated over 4096| B[Progressive Edit]
    B -->|clip to one message| C[Telegram Stores 4096]
    C -->|bare SendResult success=true| D[Consumer Records Full Text]
    D --> E[visible_prefix over-reports]
    D --> F[continuation_text skips the middle]
    D --> G[turn-final payload is un-stored text]
    G --> H[delivered_final_matches returns True]
    H --> I[Gateway Suppresses Final Send]
    I --> J[Frozen Preview and Stuck Cursor]
```

## Solution

Make the ACK honest, then let the existing recovery machinery do its job.

1. **`plugins/platforms/telegram/adapter.py`** — all three clipped-preview returns (pre-flight clip, saturated-preview dedup, and the reactive `message_too_long` retry) now go through `_stream_preview_truncated_result()`, returning `raw_response={"stream_preview_truncated": True, "delivered_prefix": <stored text>}`. `delivered_prefix` is the field the existing `partial_overflow` contract already carries on the failure branch, so no new vocabulary is introduced.
2. **`gateway/stream_consumer.py`** — the successful-edit path sets `_last_sent_text` through the new `_delivered_text_for()` helper, tracking what the platform **stored** rather than what was **requested**. Adapters that deliver exactly what they were given report nothing and keep the previous behaviour.

Nothing downstream changed: once `_visible_prefix()` is accurate, `_continuation_text()` computes the real missing tail and `delivered_final_matches()` reports the mismatch, so `gateway/run.py` takes its existing stale-finalize reconciliation / normal final-send path.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Progressive Edit] -->|clip to one message| B[Telegram Stores 4096]
    B -->|delivered_prefix reported| C[Consumer Tracks Stored Text]
    C --> D[visible_prefix matches the screen]
    D --> E[Fallback Sends the Real Tail]
    D --> F[delivered_final_matches returns False]
    F --> G[Gateway Delivers the Complete Answer]
```

## Notes on the report

Two details in #98552 did not survive verification, and they are worth recording so the next reader does not chase them:

- The quoted `[Telegram] Flushing text batch ... (333 chars)` line is **inbound** message aggregation (`TelegramAdapter._flush_text_batch` calling `handle_message`), i.e. the user's own message being debounced before dispatch. It is not the outbound reply, so "only 333 of 624 chars were flushed" is not what that log shows.
- The proposed cause (an interrupted stream leaving no record, `delivered_final_matches()` returning `None`, and the gateway keeping legacy trust) is not reachable from the consumer's own bookkeeping. Driving the real `GatewayStreamConsumer` against a Telegram-shaped adapter across 2,048 honest-transport scenarios (flood / timeout / permanent-error scripts on edit and send, tool boundaries, authoritative `finish(final_text)` adoption), 600 delta/boundary/commentary schedules, and 729 overflow-split scenarios produced **zero** states where the consumer claimed delivery it could not back up. The in-tree contract matrix (`tests/gateway/test_suppression_contract_matrix.py`) reaches the same conclusion for honest transports.

What *is* reachable is the clipped-preview ACK above, which is exactly the "edit ACKed but never rendered" residue that matrix documents as its single `xfail`.

## Verification

```bash
pytest tests/gateway/test_truncated_preview_ack.py \
       tests/gateway/test_suppression_contract_matrix.py \
       tests/gateway/test_stale_finalize_suppression.py \
       tests/gateway/test_stream_final_contract.py \
       tests/gateway/test_telegram_format.py \
       tests/gateway/test_stream_consumer.py \
       tests/gateway/test_telegram_final_delivery.py \
       tests/gateway/test_split_final_suffix_reconcile.py
```

`185 passed, 1 xfailed`. The six new tests in `tests/gateway/test_truncated_preview_ack.py` were confirmed non-vacuous: five of them fail on the unpatched tree, including the end-to-end one that reproduces the loss (`rendered_len=4117` vs `final_len=5226`, with `verdict=True` and both suppression flags set).

Also ran `tests/gateway/test_stream_consumer_draft.py`, `test_stream_consumer_fresh_final.py`, `test_stream_consumer_wecom_native.py`, `test_duplicate_reply_suppression.py`, `test_stream_consumer_tool_progress.py`, `test_stream_final_adoption_gate.py` and `test_discord_edit_message_overflow.py` — all green. One unrelated pre-existing failure on this machine (`test_update_streaming.py::TestUpdateCommandGatewayFlag::test_spawns_with_gateway_flag`) reproduces on a clean tree.

## Relationship to #98583

#98583 targets the same issue from the reconciliation side, changing `delivered_final_matches()` to compare `_visible_prefix()` against the target when `_delivered_final_text is None`. Its regression test reaches that state by subclassing `GatewayStreamConsumer.run()` and assigning the flags after the run returns — the state the fuzzing above could not produce from the real consumer. The two changes do not conflict; this one removes the source of the bad prefix rather than reinterpreting it.
