### PR TITLE
fix(config): prove env-template provenance via runtime secret authorities

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2785,6 +2785,53 @@ def _env_ref_var_name(ref: str) -> Optional[str]:
     return ref
 
 
+def _runtime_env_ref_value(name: str) -> Optional[str]:
+    """Resolve one env-ref name through the runtime secret authorities.
+
+    ``os.environ`` first (same as ``_env_expand_match``), then the scope-aware
+    ``agent.secret_scope.get_secret`` and ``~/.hermes/.env``. Those two can
+    supply a live credential that never passes through ``os.environ`` — e.g.
+    a value resolved under an installed profile scope during a multiplexed
+    gateway turn, or one that only lives in the dotenv file. Used solely by
+    the save-side template-preservation proof; load-side expansion stays
+    environment-only (#98717).
+    """
+    val = os.environ.get(name)
+    if val is not None:
+        return val
+    try:
+        from agent.secret_scope import get_secret
+
+        val = get_secret(name)
+    except Exception:
+        val = None
+    if val is not None:
+        return val
+    try:
+        return load_env().get(name)
+    except Exception:
+        return None
+
+
+def _expand_env_refs_via_runtime(raw: str) -> str:
+    """Expand ``${VAR}`` / ``${env:VAR}`` in one string via runtime authorities.
+
+    Mirrors ``_env_expand_match``'s ref grammar but resolves each name with
+    ``_runtime_env_ref_value``; unresolved refs stay verbatim. Non-env
+    SecretRef sources (``file:``, ``vault:``, ...) stay verbatim exactly as
+    the load-side expander leaves them.
+    """
+
+    def _match(m: "re.Match[str]") -> str:
+        name = _env_ref_var_name(m.group(1))
+        if name is None:
+            return m.group(0)
+        val = _runtime_env_ref_value(name)
+        return val if val is not None else m.group(0)
+
+    return re.sub(r"\${([^}]+)}", _match, raw)
+
+
 def _expand_env_vars(obj):
     """Recursively expand ``${VAR}`` / ``${env:VAR}`` references in config
     values.
@@ -2861,6 +2908,14 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
     the current environment expansion of ``raw``. This handles env-var
     rotation between load and save while still treating mixed literal/template
     string edits as caller-owned once their rendered value diverges.
+
+    The provenance proof also consults the runtime secret authorities
+    (profile scope via ``get_secret``, then ``~/.hermes/.env``): a live
+    credential can reach the config object through those without ever
+    appearing in ``os.environ``, and value equality against the bare
+    environment alone cannot prove the template is its origin (#98717).
+    A caller-typed literal that no authority can recompute stays
+    caller-owned, so intentional replacement semantics are unchanged.
     """
     if isinstance(current, str) and isinstance(raw, str) and re.search(r"\${[^}]+}", raw):
         if current == raw:
@@ -2868,6 +2923,8 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
         if isinstance(loaded_expanded, str) and current == loaded_expanded:
             return raw
         if _expand_env_vars(raw) == current:
+            return raw
+        if _expand_env_refs_via_runtime(raw) == current:
             return raw
         return current
 

--- a/tests/hermes_cli/test_config_env_refs.py
+++ b/tests/hermes_cli/test_config_env_refs.py
@@ -59,6 +59,146 @@ def test_save_config_allows_intentional_secret_value_change(monkeypatch, tmp_pat
     assert "${TU_ZI_API_KEY}" not in saved
 
 
+# --- Runtime-authority provenance proof (#98717) ---------------------------
+#
+# A live credential can reach the config object through a runtime authority
+# (profile scope via agent.secret_scope.get_secret, or ~/.hermes/.env) that
+# never exposes the value through os.environ. The save-side template guard
+# must still recognize the raw ${VAR} template as the value's origin instead
+# of persisting the live secret as plaintext, while a caller-typed literal no
+# authority can recompute stays an intentional replacement.
+
+
+def _patch_scope_secrets(monkeypatch, secrets: dict):
+    import agent.secret_scope as secret_scope
+
+    monkeypatch.setattr(
+        secret_scope,
+        "get_secret",
+        lambda name, default=None: secrets.get(name, default),
+    )
+
+
+def test_save_config_preserves_template_when_scope_supplies_live_secret(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_BEARER_TOKEN", raising=False)
+    _patch_scope_secrets(monkeypatch, {"TEST_BEARER_TOKEN": "opaque-live-secret-value"})
+    _write_config(
+        tmp_path,
+        """\
+        gateway:
+          authorization: Bearer ${TEST_BEARER_TOKEN}
+        """,
+    )
+
+    config = load_config()
+    # Runtime authority resolved the live bearer into the config object;
+    # an unrelated setting is then persisted by a whole-document save.
+    config["gateway"]["authorization"] = "Bearer opaque-live-secret-value"
+    config["display"]["compact"] = True
+    save_config(config)
+
+    saved = _read_config(tmp_path)
+    assert "authorization: Bearer ${TEST_BEARER_TOKEN}" in saved
+    assert "opaque-live-secret-value" not in saved
+
+
+def test_save_config_preserves_template_when_dotenv_supplies_value(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_DOTENV_BEARER", raising=False)
+    _patch_scope_secrets(monkeypatch, {})
+    (tmp_path / ".env").write_text(
+        "TEST_DOTENV_BEARER=dotenv-live-secret\n", encoding="utf-8"
+    )
+    _write_config(
+        tmp_path,
+        """\
+        gateway:
+          authorization: Bearer ${TEST_DOTENV_BEARER}
+        """,
+    )
+
+    config = load_config()
+    config["gateway"]["authorization"] = "Bearer dotenv-live-secret"
+    config["display"]["compact"] = True
+    save_config(config)
+
+    saved = _read_config(tmp_path)
+    assert "authorization: Bearer ${TEST_DOTENV_BEARER}" in saved
+    assert "dotenv-live-secret" not in saved
+
+
+def test_save_config_still_allows_intentional_replacement_under_scope(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_BEARER_TOKEN", raising=False)
+    _patch_scope_secrets(monkeypatch, {"TEST_BEARER_TOKEN": "opaque-live-secret-value"})
+    _write_config(
+        tmp_path,
+        """\
+        gateway:
+          authorization: Bearer ${TEST_BEARER_TOKEN}
+        """,
+    )
+
+    config = load_config()
+    # Positive control: a user-owned edit that no authority can recompute
+    # from the template must survive as a literal replacement.
+    config["gateway"]["authorization"] = "Bearer user-typed-rotation"
+    save_config(config)
+
+    saved = _read_config(tmp_path)
+    assert "authorization: Bearer user-typed-rotation" in saved
+    assert "${TEST_BEARER_TOKEN}" not in saved
+
+
+def test_save_config_preserves_non_secret_env_ref_from_scope(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_MODEL_ALIAS", raising=False)
+    _patch_scope_secrets(monkeypatch, {"TEST_MODEL_ALIAS": "claude-opus-4-6"})
+    _write_config(
+        tmp_path,
+        """\
+        model:
+          default: ${TEST_MODEL_ALIAS}
+        """,
+    )
+
+    config = load_config()
+    config["model"]["default"] = "claude-opus-4-6"
+    config["display"]["compact"] = True
+    save_config(config)
+
+    saved = _read_config(tmp_path)
+    assert "default: ${TEST_MODEL_ALIAS}" in saved
+
+
+def test_save_config_allows_clearing_templated_value(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_BEARER_TOKEN", raising=False)
+    _patch_scope_secrets(monkeypatch, {"TEST_BEARER_TOKEN": "opaque-live-secret-value"})
+    _write_config(
+        tmp_path,
+        """\
+        gateway:
+          authorization: Bearer ${TEST_BEARER_TOKEN}
+        """,
+    )
+
+    config = load_config()
+    config["gateway"]["authorization"] = ""
+    save_config(config)
+
+    saved = _read_config(tmp_path)
+    assert "${TEST_BEARER_TOKEN}" not in saved
+    assert "opaque-live-secret-value" not in saved
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`save_config()`'s env-template preservation guard proved that a live value originated from the raw `${VAR}` template only when `os.environ` could recompute the expansion. When the variable is absent from `os.environ` at save time but the resolved credential reached the config object through another runtime authority, none of the three existing comparisons could prove provenance and the helper fell through to the caller-provided literal — persisting the live secret as plaintext in place of the on-disk template (#98717).

This PR extends the provenance proof with a save-side expansion that resolves each `${VAR}` / `${env:VAR}` name through the runtime secret authorities, in order:

1. `os.environ` (unchanged, fast path),
2. the scope-aware `agent.secret_scope.get_secret` — under a multiplexed gateway turn the profile scope supplies a live credential that never appears in `os.environ`,
3. `~/.hermes/.env` via `load_env()`.

A value any of those authorities can recompute from the raw template keeps the template on disk. A caller-typed literal that no authority can recompute remains an intentional replacement, so replacement semantics are unchanged — the decision is bound to recomputable provenance, not to secret-looking strings or ambient equality. Defect provenance for this boundary: @dizhaky's closed-unmerged #98029 reproduction ("var UNSET, token came from elsewhere -> template preserved? False").

## Related Issue

Fixes #98717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/config.py`: added `_runtime_env_ref_value()` (resolve one env-ref name via os.environ → `get_secret` → `.env`, exceptions treated as a miss) and `_expand_env_refs_via_runtime()` (same `${VAR}`/`${env:VAR}` grammar as `_env_expand_match`, unresolved/non-env refs stay verbatim).
- `hermes_cli/config.py`: `_preserve_env_ref_templates()` gains a fourth preservation rule after the existing environment-expansion check: runtime-authority expansion equality → keep the raw template.
- `tests/hermes_cli/test_config_env_refs.py`: regression matrix — scope-supplied live secret preserved, dotenv-supplied value preserved, intentional replacement under scope still lands as literal (positive control), non-secret `${VAR}` template preserved, clearing a templated value stays cleared.

## How to Test

1. `python -m pytest tests/hermes_cli/test_config_env_refs.py -v` — Observed result: 7 passed (2 pre-existing + 5 new).
2. `python -m pytest tests/hermes_cli/test_config_env_expansion.py tests/hermes_cli/test_config_env_ref_parity.py tests/hermes_cli/test_config_loader_e2e.py tests/hermes_cli/test_config_set_coercion.py tests/hermes_cli/test_config_set_list_values.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_read_guard.py` — Observed result: 49 passed.
3. Wider save_config surface (`tests/test_secret_scope_plugin_families.py`, `tests/hermes_cli/test_model_switch_custom_providers.py`, `tests/hermes_cli/test_setup.py` and others) — Observed result: 179 passed.
4. `python -m ruff check hermes_cli/config.py tests/hermes_cli/test_config_env_refs.py` and `python scripts/check-windows-footguns.py hermes_cli/config.py` — Observed result: all clean.
5. The fail-closed regression mirrors the issue's minimal shape: raw `authorization: Bearer ${TEST_BEARER_TOKEN}`, variable absent from `os.environ`, live value supplied through the scope authority, unrelated setting persisted → the written `config.yaml` still contains `Bearer ${TEST_BEARER_TOKEN}` byte-for-byte and never the live secret.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated on the guard and new helpers
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python env/dict logic, no OS-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A