### PR TITLE
fix(bedrock): correct Llama 4 context windows (128K -> measured 1M/3.5M), add six measured rows

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1887,6 +1887,15 @@ def classify_bedrock_error(error_message: str) -> str:
 # Static fallback table for models where the Bedrock API doesn't expose
 # context window sizes.  Used by agent/model_metadata.py when dynamic
 # detection is unavailable.
+#
+# Rows marked "measured" were obtained by sending Converse a prompt padded
+# just past the suspected window and reading the maximum out of the resulting
+# ValidationException.  Length validation runs before inference, so a rejected
+# probe costs nothing.  This matters because several vendors return a length
+# error with no number in it at all — Nova ("Input Tokens Exceeded: Number of
+# input tokens exceeds maximum length.") and DeepSeek R1 ("Input is too long
+# for requested model.") both do — which means probe_bedrock_context_length()
+# returns None for them and this table is their only source of truth.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
@@ -1921,13 +1930,36 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "amazon.nova-lite":              300_000,
     "amazon.nova-micro":             128_000,
     # Meta Llama
-    "meta.llama4-maverick":          128_000,
-    "meta.llama4-scout":             128_000,
+    # Llama 4 is long-context, not 128K. Both rows were capping it at an
+    # eighth (Maverick) and a twenty-seventh (Scout) of the real window, so a
+    # Llama 4 session compacted almost immediately.
+    # Maverick measured against Converse in us-east-1 and us-east-2 — both
+    # reject at the same value: "This model's maximum context length is
+    # 1048576 tokens". The model card rounds that to "1M"; the API enforces
+    # the exact binary multiple, so use the enforced number.
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-4-maverick-17b-instruct.html
+    "meta.llama4-maverick":          1_048_576,
+    # Scout measured at 3,500,000: "This model's maximum context length is
+    # 3500000 tokens". Deliberately *not* the 10M its Bedrock model card
+    # states — that is Meta's native window, and Bedrock serves less. Taking
+    # the documented figure here would overshoot by 3x and turn premature
+    # compaction into hard ValidationExceptions, so the measured value wins.
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-4-scout-17b-instruct.html
+    "meta.llama4-scout":             3_500_000,
     "meta.llama3-3-70b-instruct":    128_000,
     # Mistral
     "mistral.mistral-large":         128_000,
+    "mistral.pixtral-large":         131_072,   # measured
     # DeepSeek
     "deepseek.v3":                   128_000,
+    "deepseek.v3.2":                 163_840,   # measured; longest-match beats "deepseek.v3"
+    # MiniMax — measured identically on minimax-m2, m2.1 and m2.5.
+    "minimax.minimax-m2":            196_608,
+    # Moonshot Kimi K2. Bedrock ships this family under two different vendor
+    # prefixes ("moonshot." and "moonshotai."), so the key deliberately omits
+    # the prefix to match both. Measured identically on kimi-k2-thinking and
+    # kimi-k2.5.
+    "kimi-k2":                       262_144,
     # OpenAI on Bedrock (Mantle/Responses route)
     # https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html
     "openai.gpt-5.5":                272_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1709,6 +1709,13 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
       - "Maximum context size 32768 exceeded"
       - "model's max context length is 65536"
       - "input token count is 32825 but model only supports up to 32768"
+      - "This model's maximum context length is 1048576 tokens" (Bedrock Llama 4)
+
+    Some do not, and there is nothing to extract: Bedrock's Nova models say
+    "Input Tokens Exceeded: Number of input tokens exceeds maximum length."
+    and DeepSeek R1 says "Input is too long for requested model.", neither of
+    which names a number.  ``None`` is the correct answer there — callers fall
+    back to their static table rather than inventing a window.
     """
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1112,6 +1112,119 @@ class TestBedrockContextProbe:
                 region="eu-central-1") == 1_000_000
 
 
+class TestMeasuredBedrockContextWindows:
+    """Pin context windows that were measured against live Bedrock Converse.
+
+    Each value here came from padding a Converse request just past the
+    suspected window and reading the maximum out of the ValidationException.
+    The tests assert against the real model IDs Bedrock serves — including the
+    ``us.`` inference-profile forms the picker actually offers — because the
+    lookup is substring-based and it is the *resolution* that regressed, not
+    the literal dict entry.
+    """
+
+    # (model_id, expected_window)
+    MEASURED = [
+        # Llama 4 was the actual bug: both rows read 128_000, capping Maverick
+        # at 1/8 and Scout at 1/27 of their real windows.
+        ("meta.llama4-maverick-17b-instruct-v1:0", 1_048_576),
+        ("us.meta.llama4-maverick-17b-instruct-v1:0", 1_048_576),
+        ("meta.llama4-scout-17b-instruct-v1:0", 3_500_000),
+        ("us.meta.llama4-scout-17b-instruct-v1:0", 3_500_000),
+        ("us.mistral.pixtral-large-2502-v1:0", 131_072),
+        ("deepseek.v3.2", 163_840),
+        ("minimax.minimax-m2", 196_608),
+        ("minimax.minimax-m2.1", 196_608),
+        ("minimax.minimax-m2.5", 196_608),
+        # Bedrock ships Kimi K2 under two vendor prefixes.
+        ("moonshot.kimi-k2-thinking", 262_144),
+        ("moonshotai.kimi-k2.5", 262_144),
+    ]
+
+    @pytest.mark.parametrize("model_id,expected", MEASURED)
+    def test_measured_window_resolves(self, model_id, expected):
+        from agent.bedrock_adapter import _static_bedrock_context_length
+        assert _static_bedrock_context_length(model_id) == expected
+
+    @pytest.mark.parametrize("model_id,expected", MEASURED)
+    def test_measured_window_is_not_the_default(self, model_id, expected):
+        """The regression these rows fix: every one of these models silently
+        took the 128K default (or, for Llama 4, an explicit wrong 128K), so the
+        agent compacted long before it had to."""
+        from agent.bedrock_adapter import (
+            BEDROCK_DEFAULT_CONTEXT_LENGTH,
+            _static_bedrock_context_length,
+        )
+        assert _static_bedrock_context_length(model_id) != BEDROCK_DEFAULT_CONTEXT_LENGTH
+        assert expected > BEDROCK_DEFAULT_CONTEXT_LENGTH
+
+    def test_deepseek_v3_2_longest_match_beats_v3(self):
+        """``deepseek.v3`` is a substring of ``deepseek.v3.2``; longest-match
+        must pick the more specific row or v3.2 silently reads 128K."""
+        from agent.bedrock_adapter import _static_bedrock_context_length
+        assert _static_bedrock_context_length("deepseek.v3.2") == 163_840
+        assert _static_bedrock_context_length("deepseek.v3-v1:0") == 128_000
+
+    def test_llama4_rows_do_not_shadow_each_other(self):
+        from agent.bedrock_adapter import _static_bedrock_context_length
+        assert _static_bedrock_context_length(
+            "meta.llama4-scout-17b-instruct-v1:0"
+        ) != _static_bedrock_context_length(
+            "meta.llama4-maverick-17b-instruct-v1:0"
+        )
+
+    def test_llama3_is_untouched(self):
+        """Only Llama 4 is long-context; the Llama 3 rows must stay 128K."""
+        from agent.bedrock_adapter import _static_bedrock_context_length
+        assert _static_bedrock_context_length(
+            "meta.llama3-3-70b-instruct-v1:0") == 128_000
+
+
+class TestBedrockLengthErrorDialects:
+    """``parse_context_limit_from_error`` against verbatim Bedrock errors.
+
+    These strings were captured from real ValidationExceptions during the
+    measurement above.  Bedrock has several length-error dialects and two of
+    them carry no number at all, which is why the static table remains the
+    only source of truth for those models.
+    """
+
+    def test_llama4_dialect_parses(self):
+        from agent.model_metadata import parse_context_limit_from_error
+        msg = (
+            "An error occurred (ValidationException) when calling the Converse "
+            "operation: The model returned the following errors: This model's "
+            "maximum context length is 1048576 tokens. Please reduce the "
+            "length of the prompt"
+        )
+        assert parse_context_limit_from_error(msg) == 1_048_576
+
+    def test_scout_3_5m_is_within_the_sanity_ceiling(self):
+        """The largest window Bedrock actually serves must survive the
+        1024..10_000_000 sanity check rather than being discarded."""
+        from agent.model_metadata import parse_context_limit_from_error
+        msg = (
+            "The model returned the following errors: This model's maximum "
+            "context length is 3500000 tokens. Please reduce the length of "
+            "the prompt"
+        )
+        assert parse_context_limit_from_error(msg) == 3_500_000
+
+    @pytest.mark.parametrize("msg", [
+        # Nova: no number anywhere in the message.
+        "The model returned the following errors: Input Tokens Exceeded: "
+        "Number of input tokens exceeds maximum length. Please update the "
+        "input to try again.",
+        # DeepSeek R1: likewise.
+        "The model returned the following errors: Input is too long for "
+        "requested model.",
+    ])
+    def test_numberless_dialects_return_none(self, msg):
+        """None is the right answer — the caller must fall back to the static
+        table rather than invent a window."""
+        from agent.model_metadata import parse_context_limit_from_error
+        assert parse_context_limit_from_error(msg) is None
+
 
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection


### PR DESCRIPTION
## The bug

`BEDROCK_CONTEXT_LENGTHS` lists both Llama 4 models at `128_000`. Neither is 128K. Measured against Converse, **Maverick enforces 1,048,576** and **Scout enforces 3,500,000** — the table was capping them at 1/8 and 1/27 of the real window.

These numbers feed `get_bedrock_context_length()`, which feeds the compaction threshold. The user-visible effect is that a Llama 4 session starts summarising away context almost immediately and keeps doing it, while the model could have held the whole conversation. Silent, and it looks like the agent is just forgetful.

Four more models were absent from the table entirely and silently inherited the 128K default:

| model | table before | measured | ratio |
|---|---|---|---|
| `meta.llama4-maverick` | 128,000 | **1,048,576** | 8.2× under |
| `meta.llama4-scout` | 128,000 | **3,500,000** | 27.3× under |
| `mistral.pixtral-large` | *(default)* 128,000 | **131,072** | 1.02× |
| `deepseek.v3.2` | *(default)* 128,000 | **163,840** | 1.28× |
| `minimax.minimax-m2` | *(default)* 128,000 | **196,608** | 1.54× |
| `kimi-k2` | *(default)* 128,000 | **262,144** | 2.05× |

## How the numbers were obtained

Send Converse a prompt padded just past the suspected window and read the maximum out of the resulting `ValidationException`. Bedrock validates request length *before* inference, so a rejected probe is not billed — which is what makes this cheap enough to do exhaustively.

Verbatim, for Scout:

```
An error occurred (ValidationException) when calling the Converse operation:
The model returned the following errors: This model's maximum context length
is 3500000 tokens. Please reduce the length of the prompt
```

Cross-checks, because a single probe proves very little:

- **Maverick rejects at the same 1,048,576 in `us-east-1` and `us-east-2`** — not a regional quota artefact.
- **MiniMax is identical on `minimax-m2`, `minimax-m2.1` and `minimax-m2.5`** (196,608), so one key covers the family.
- **Kimi K2 is identical on `moonshot.kimi-k2-thinking` and `moonshotai.kimi-k2.5`** (262,144).
- **Negative results were kept too.** Nova Pro rejected at 345,000 and DeepSeek R1 at 147,200, both consistent with their existing rows — so I changed nothing there. Only rows I could show were wrong were touched.

## Two judgement calls I want to flag explicitly

**1. Scout is not 10M on Bedrock, whatever its model card says.**

The [Bedrock model card for Llama 4 Scout](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-4-scout-17b-instruct.html) states 10M. The API rejects at exactly 3,500,000. The card describes Meta's native model; Bedrock serves less. I went with the measurement, because trusting the doc here would overshoot by ~3× and that failure mode is strictly worse than the one being fixed — it converts *premature compaction* (annoying) into *hard `ValidationException`s* (broken). I had 3.5M in mind before measuring, then found the doc contradicting me, and did not write either number down until a probe settled it.

**2. Maverick's card rounds to "1M"; I used 1,048,576.**

The API reports the exact binary multiple, so that is what it enforces. Writing 1,000,000 would be safe but leaves 48K on the table for no reason.

## The Kimi key deliberately has no vendor prefix

Bedrock ships this family as both `moonshot.kimi-k2-thinking` and `moonshotai.kimi-k2.5`. `_static_bedrock_context_length()` does longest-substring matching, so the prefix-less key `"kimi-k2"` covers both without duplicating the row. That is load-bearing and easy to "tidy up" into a break, hence the comment on it.

Relatedly: **every key in this change was checked against `list-foundation-models` output in `us-east-1`/`us-east-2`/`us-west-2`**, because a table key that matches no real model ID is a silent no-op that a unit test written against the key itself will happily pass. `deepseek.v3.2`, `minimax.minimax-m2`, `moonshot.kimi-k2-thinking` and `moonshotai.kimi-k2.5` are literal Bedrock model IDs with no `-v1:0` suffix; the tests use the real IDs.

## A parser note, no behaviour change

Several Bedrock vendors report a length error with **no number in it at all**:

- Nova: `Input Tokens Exceeded: Number of input tokens exceeds maximum length.`
- DeepSeek R1: `Input is too long for requested model.`

`parse_context_limit_from_error()` returns `None` for these, which is correct — and it is exactly *why* this static table is those models' only source of truth, since `probe_bedrock_context_length()` can never learn their window. I added that to the docstring so the next person doesn't read the `None` as a parser gap and "fix" it into a guess. **The parser code is untouched.**

I did briefly raise the parser's sanity ceiling from `10_000_000` to `10_485_760`, on the theory that a 10Mi Scout limit would be discarded. Measuring Scout at 3,500,000 disproved the premise, so I reverted it rather than ship a change whose only justification I had just refuted.

## Tests

29 new tests in `tests/agent/test_bedrock_adapter.py`:

- each measured window resolves from the **real** model ID, including the `us.` inference-profile forms the picker actually offers;
- the regression form — none of these models may resolve to `BEDROCK_DEFAULT_CONTEXT_LENGTH`;
- both shadowing hazards: `deepseek.v3.2` must beat the `deepseek.v3` substring, and the Scout/Maverick rows must not collapse into each other;
- Llama 3 stays at 128K (only Llama 4 is long-context);
- the verbatim captured error dialects against `parse_context_limit_from_error`, including the two numberless ones.

**Mutation check:** reverting only the table, keeping the tests, turns **24 of the 29 red**. The 5 that stay green are the Llama-3 row and the four parser-dialect tests — which is right, since those document existing behaviour rather than guarding this change.

`ruff` clean. `tests/agent/test_bedrock_adapter.py` 105 passed; the three `model_metadata` suites 150 passed.
