### PR TITLE
fix(tools): use typing.Any instead of builtin any in get_distribution return type

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -214,7 +214,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## What

`get_distribution()` in `toolset_distributions.py` annotated its return type as `Optional[Dict[str, any]]`, using Python's builtin `any()` callable instead of `typing.Any`. `Any` was never imported from `typing` — only `Dict`, `List`, `Optional` were.

## Why

The annotation silently references the builtin predicate function rather than a type, so static type checkers either flag it as invalid or treat the value as effectively untyped instead of properly permissive.

## Fix

1. Added `Any` to the `typing` import.
2. Changed the return annotation from `Dict[str, any]` to `Dict[str, Any]`.

No behavior change — pure type-annotation correction.

## Testing

- `python -m pytest tests/test_toolset_distributions.py -q` → 7 passed
- `ruff check toolset_distributions.py` → All checks passed
- `ty check toolset_distributions.py` → All checks passed
- Manual smoke test: `get_distribution('balanced')` returns the expected dict unchanged

Fixes #2139