### PR TITLE
fix(delegation): close split-brain where live batch is invisible to action=list and persistence failure kills dispatch

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tests/tools/test_delegate_split_brain.py
+++ b/tests/tools/test_delegate_split_brain.py
@@ -1,0 +1,144 @@
+"""Regression tests for #98713: delegate_task split-brain.
+
+Background batch dispatched, persistence fails → tool used to return a generic
+error while workers kept running; action=list returned count:0. Two fixes:
+
+1. _persist_dispatch failure must not abort the dispatch (fail-open so the
+   accepted batch's tool result says 'dispatched', not 'Error executing tool').
+2. action=list reconciles async_delegation._records so live batches are visible
+   even after a parent-agent rebuild breaks the weakref chain.
+"""
+
+import time
+import threading
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestPersistDispatchFailOpen(unittest.TestCase):
+    """_persist_dispatch failure must not kill an already-accepted dispatch."""
+
+    def test_persistence_failure_does_not_revert_in_memory_record(self):
+        """When _persist_dispatch raises, _records still has the delegation."""
+        from tools import async_delegation as ad
+
+        # Reset state
+        with ad._records_lock:
+            ad._records.clear()
+
+        called = []
+
+        def _boom(_record):
+            called.append(True)
+            raise OSError("disk I/O error")
+
+        def _runner():
+            return {"results": [], "total_duration_seconds": 0.1}
+
+        deleg_id = "test-persist-fail-" + str(int(time.time() * 1000))
+
+        with patch.object(ad, "_persist_dispatch", side_effect=_boom):
+            result = ad.dispatch_async_delegation_batch(
+                goals=["task A"],
+                context=None,
+                toolsets=None,
+                role="leaf",
+                model="test-model",
+                session_key="sess-test-123",
+                runner=_runner,
+                delegation_id=deleg_id,
+            )
+
+        # Despite persistence failure, dispatch must succeed
+        self.assertEqual(result.get("status"), "dispatched",
+                         f"Expected dispatched, got: {result}")
+        self.assertEqual(result.get("delegation_id"), deleg_id)
+        self.assertTrue(called, "_persist_dispatch was not called")
+
+        # Clean up background thread
+        time.sleep(0.2)
+        with ad._records_lock:
+            ad._records.pop(deleg_id, None)
+
+
+class TestGetRunningRecords(unittest.TestCase):
+    """get_running_records surfaces live batch records by session_key."""
+
+    def test_empty_when_no_matching_session(self):
+        from tools.async_delegation import get_running_records
+        result = get_running_records(session_key="no-such-session")
+        self.assertEqual(result, [])
+
+    def test_empty_session_key_returns_empty(self):
+        from tools.async_delegation import get_running_records
+        self.assertEqual(get_running_records(session_key=""), [])
+
+    def test_returns_live_record_for_session(self):
+        from tools import async_delegation as ad
+
+        deleg_id = "test-get-running-" + str(int(time.time() * 1000))
+        record = {
+            "delegation_id": deleg_id,
+            "goal": "test goal",
+            "goals": ["test goal"],
+            "model": "m",
+            "session_key": "sess-abc",
+            "status": "running",
+            "is_batch": True,
+            "dispatched_at": time.time(),
+            "origin_ui_session_id": "",
+            "origin_session_id": "",
+            "parent_session_id": None,
+            "context": None,
+            "toolsets": None,
+            "role": "leaf",
+            "completed_at": None,
+            "interrupt_fn": None,
+            "progress_fn": None,
+            "_progress_token": None,
+            "_progress_ts": time.time(),
+            "_interrupted_at": None,
+        }
+        with ad._records_lock:
+            ad._records[deleg_id] = record
+
+        try:
+            result = ad.get_running_records(session_key="sess-abc")
+            ids = [r["delegation_id"] for r in result]
+            self.assertIn(deleg_id, ids)
+            match = next(r for r in result if r["delegation_id"] == deleg_id)
+            self.assertEqual(match["goal"], "test goal")
+            self.assertEqual(match["status"], "running")
+            self.assertTrue(match["is_batch"])
+        finally:
+            with ad._records_lock:
+                ad._records.pop(deleg_id, None)
+
+    def test_does_not_return_finished_records(self):
+        from tools import async_delegation as ad
+
+        deleg_id = "test-finished-" + str(int(time.time() * 1000))
+        record = {
+            "delegation_id": deleg_id,
+            "goal": "done",
+            "goals": ["done"],
+            "model": "m",
+            "session_key": "sess-done",
+            "status": "completed",  # finished
+            "is_batch": True,
+            "dispatched_at": time.time(),
+        }
+        with ad._records_lock:
+            ad._records[deleg_id] = record
+
+        try:
+            result = ad.get_running_records(session_key="sess-done")
+            self.assertEqual(result, [],
+                             "Completed records must not appear in running list")
+        finally:
+            with ad._records_lock:
+                ad._records.pop(deleg_id, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -616,6 +616,40 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
         return _executor
 
 
+def get_running_records(*, session_key: str) -> List[Dict[str, Any]]:
+    """Return live async delegation records owned by *session_key*.
+
+    Used by ``delegate_task(action='list')`` to reconcile the async-batch
+    registry (``_records``) with the synchronous subagent registry
+    (``_active_subagents`` in ``delegate_tool``), which are two separate
+    in-memory dicts.  Without this reconciliation a live background batch is
+    invisible to ``action=list`` — the caller sees ``{"count": 0}`` while
+    detached workers run with real side effects (#98713).
+
+    Matches on ``session_key`` (== the durable session-id the delivery path
+    uses) so the batch remains visible even after a parent-agent rebuild
+    (credential refresh, ``/model`` switch) that breaks the weakref chain.
+    """
+    if not session_key:
+        return []
+    live_statuses = {"running", "stalling", "finalizing"}
+    with _records_lock:
+        return [
+            {
+                "delegation_id": r.get("delegation_id"),
+                "goal": r.get("goal"),
+                "goals": r.get("goals"),
+                "model": r.get("model"),
+                "status": r.get("status"),
+                "is_batch": r.get("is_batch", False),
+                "dispatched_at": r.get("dispatched_at"),
+            }
+            for r in _records.values()
+            if r.get("status") in live_statuses
+            and str(r.get("session_key") or "") == session_key
+        ]
+
+
 def active_count() -> int:
     """Number of async delegation UNITS currently running.
 
@@ -1104,7 +1138,23 @@ def dispatch_async_delegation_batch(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    # Persist to durable storage.  A failure here (e.g. disk I/O error on a
+    # degraded state.db) must NOT abort the dispatch: the batch is already
+    # registered in the in-memory _records dict and the executor submission
+    # below is the point of no return.  Propagating the exception causes the
+    # tool to return a generic "Error executing tool" while workers continue
+    # running with real side effects — the split-brain in #98713.
+    #
+    # Fail open: log the error and continue.  The batch remains visible via
+    # get_running_records() / action=list for the life of this process.
+    try:
+        _persist_dispatch(record)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "async_delegation: failed to persist dispatch record for %s "
+            "(batch is live in memory — dispatch continues)",
+            delegation_id,
+        )
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -500,6 +500,57 @@ def _handle_control_action(
                     "live_transcript": getattr(agent, "_live_transcript_path", None),
                 }
             )
+
+        # Also surface background batch records from async_delegation._records
+        # that belong to this conversation.  These are registered in a SEPARATE
+        # in-memory dict (async_delegation._records) and are never added to
+        # _active_subagents, so without this reconciliation a live background
+        # batch is invisible to action=list — the split-brain that produced a
+        # verified production incident where the caller was told "count:0" while
+        # 10 detached workers were running with real side effects (#98713).
+        #
+        # Match on session_key (== parent agent session_id, the durable spine
+        # used by the delivery path) rather than object identity so the batch
+        # remains visible even after a parent-agent rebuild (credential refresh,
+        # /model switch) that breaks the weakref chain.
+        try:
+            from tools.async_delegation import (
+                get_running_records as _get_async_records,
+            )
+            parent_sid = str(getattr(parent_agent, "session_id", "") or "")
+            if parent_sid:
+                async_records = _get_async_records(session_key=parent_sid)
+                seen_deleg_ids = {r.get("delegation_id") for r in entries}
+                for ar in async_records:
+                    deleg_id = ar.get("delegation_id")
+                    if deleg_id in seen_deleg_ids:
+                        continue
+                    dispatched = ar.get("dispatched_at")
+                    entries.append(
+                        {
+                            "delegation_id": deleg_id,
+                            "goal": ar.get("goal"),
+                            "goals": ar.get("goals"),
+                            "model": ar.get("model"),
+                            "status": ar.get("status", "running"),
+                            "is_batch": True,
+                            "running_seconds": (
+                                round(time.time() - dispatched, 1)
+                                if isinstance(dispatched, (int, float))
+                                else None
+                            ),
+                            "accepting_steer": False,
+                            "note": (
+                                "Background batch — use action='stop' with "
+                                "delegation_id to interrupt."
+                            ),
+                        }
+                    )
+        except Exception:  # noqa: BLE001 — reconciliation is best-effort
+            logger.debug(
+                "action=list: async_delegation reconciliation failed", exc_info=True
+            )
+
         payload: Dict[str, Any] = {
             "action": "list",
             "count": len(entries),


### PR DESCRIPTION
## Problem (#98713)

A background `delegate_task(tasks=[...])` fan-out can leave the caller in a split-brain state: workers run with real side effects while the tool reports failure and `action=list` returns `{"count":0}`.

**Verified in production** (v0.20.6, 10-task batch, Telegram gateway, 1.4 GB state.db):
- 10-task batch dispatched, manifest + transcripts created, workers started
- Tool returned `Error executing tool: disk I/O error`
- 5s later `action=list` → `{"count": 0, "subagents": []}`
- Caller had no handle, blind retry risked duplicate spawn
- Workers kept running for 10 minutes, produced real outputs
- Stale monitor force-finalized at 622s; `async_delegations` table has no row

## Root cause (two independent bugs)

**Bug 1 — two separate in-memory registries (the main culprit):**

`dispatch_async_delegation_batch` registers the batch in `async_delegation._records`. `action=list` reads only `delegate_tool._active_subagents`. These are **different dicts**. Background batches are **never added** to `_active_subagents`, so `action=list` returns `count:0` for every live background batch regardless of health.

**Bug 2 — `_persist_dispatch` failure kills an accepted dispatch:**

`_persist_dispatch` is called after `_records[delegation_id] = record` but before `executor.submit()`. A disk I/O error propagates through `dispatch_async_delegation_batch`, the tool returns `"Error executing tool: ..."`, and the executor is never reached — but `_records` has the entry. Invitation to a blind retry that risks duplicate fan-outs on DB recovery.

## Fix

**Fix 1 — `action=list` reconciliation (`delegate_tool.py`):**

`_handle_control_action` now calls `async_delegation.get_running_records(session_key=parent_agent.session_id)` and merges live batch records into the list response. Matched on `session_key` (the durable spine the delivery path already uses) so batches survive parent-agent rebuilds that break the weakref chain (credential refresh, `/model` switch).

**Fix 2 — fail-open `_persist_dispatch` (`async_delegation.py`):**

Wrap `_persist_dispatch` in `try/except` so a DB failure no longer aborts a dispatch whose in-memory registration already happened. Log the error and continue to `executor.submit()` — tool returns `"dispatched"` with the delegation ID. The batch is visible via `get_running_records()` for the life of the process; the durable row can be reconstructed from the live manifest directory.

**New API — `get_running_records(session_key)` (`async_delegation.py`):**

Returns live `_records` entries filtered by `session_key`. Used by the `action=list` reconciliation path; also useful for observability/debugging.

## Tests (`tests/tools/test_delegate_split_brain.py`)

5 tests, all pass:
- persistence failure does not revert in-memory record; dispatch returns `"dispatched"` — regression witness for bug 2
- `get_running_records` returns live records for matching `session_key`
- `get_running_records` ignores completed records
- `get_running_records` returns empty for non-matching session
- `get_running_records` returns empty for empty `session_key`

Fixes #98713