### PR TITLE
fix(tools): sanitize live-env cwd override on container backends (#98723)

### DIFF
--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -212,3 +212,53 @@ class TestFileOpsCwdSanitizedAtCallSite:
         cwd = self._run_and_capture_cwd(
             monkeypatch, "/Users/me/workspace", env_type="modal")
         assert cwd == "/workspace"
+
+
+class TestLiveEnvCwdSanitizedOnReRegister(object):
+    """E2E pin: re-registering a cwd override against an ALREADY-LIVE container
+    env must not poison ``env.cwd`` with a host path (#98723) — the third site
+    of the container-cwd guard, alongside env-creation (#50636/#54447) and
+    per-command resolution. The desktop/TUI calls
+    ``register_task_env_overrides()`` with the session's HOST workspace on
+    every turn; without this guard the live env's cwd is overwritten raw, and
+    every subsequent file-tool call inside the container dies at exit 126
+    (``cd: /Users/<user>: No such file or directory``) before the real command
+    runs — misreported by callers as "file not found" / "rg missing".
+    """
+
+    def _register_against_live_env(self, monkeypatch, override_cwd, initial_cwd="/root"):
+        import tools.terminal_tool as tt
+
+        class _DummyEnv:
+            def __init__(self, cwd):
+                self.cwd = cwd
+
+        env = _DummyEnv(initial_cwd)
+        task_id = "sess-live-env-reregister"
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setattr(tt, "_active_environments", {task_id: env})
+        monkeypatch.setattr(tt, "_session_cwd", {})
+
+        try:
+            tt.register_task_env_overrides(task_id, {"cwd": override_cwd})
+        finally:
+            tt.clear_task_env_overrides(task_id)
+        return env.cwd
+
+    def test_host_cwd_override_does_not_poison_live_env(self, monkeypatch):
+        cwd = self._register_against_live_env(monkeypatch, "/Users/me/workspace")
+        assert cwd == "/root", (
+            f"A host-path cwd override poisoned the live container env: {cwd!r}. "
+            "It must be rejected, keeping the env's existing (usable) cwd."
+        )
+
+    def test_windows_host_cwd_override_does_not_poison_live_env(self, monkeypatch):
+        cwd = self._register_against_live_env(monkeypatch, r"C:\Users\someuser")
+        assert cwd == "/root"
+
+    def test_valid_container_cwd_override_still_applies_live(self, monkeypatch):
+        # In-sandbox path (e.g. ACP client switching project root) must still
+        # take effect immediately on the live env.
+        cwd = self._register_against_live_env(monkeypatch, "/workspace/task42")
+        assert cwd == "/workspace/task42"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1320,7 +1320,27 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         with _env_lock:
             env = _active_environments.get(task_id) or _active_environments.get(container_id)
         if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            # Third site of the container-cwd guard (see #50636, #54447 for the
+            # sibling env-creation and per-command sites). A host/relative path
+            # here is routinely the desktop/TUI's `_register_session_cwd()`
+            # registering the session's HOST workspace on every turn — applying
+            # it raw to a live container env poisons `env.cwd`, and every
+            # subsequent command's `cd -- '<host path>'` wrapper prefix then
+            # dies with exit 126 before the real command runs. Callers read
+            # that as "file not found" / "rg missing" instead of what it is
+            # (issue #98723). The session *record* above intentionally still
+            # gets the raw host path — host-side surfaces need it and
+            # ``get_session_cwd()`` readers already guard container use.
+            env_type = os.getenv("TERMINAL_ENV", "local")
+            if _is_container_backend(env_type) and _is_unusable_container_cwd(new_cwd):
+                logger.info(
+                    "Not applying registered cwd %r to the live %s environment "
+                    "for task %s (host/relative path won't exist in the "
+                    "sandbox). Keeping %r.",
+                    new_cwd, env_type, task_id, env.cwd,
+                )
+            else:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):


### PR DESCRIPTION
## Summary

Fixes #98723 — `register_task_env_overrides()` applied a freshly registered
`cwd` override raw to an already-live container env's `env.cwd`, with no
guard against a host or relative path.

The desktop/TUI surface calls `_register_session_cwd()` on every turn with
the session's HOST workspace (e.g. `/Users/<user>`, `C:\Users\<user>`), which
does not exist inside the sandbox. This is the third site of the
container-cwd guard — the other two (env creation #54447, per-command
resolution #50636) already sanitize via `_is_unusable_container_cwd()`; this
site never did.

## Why it broke file tools

`ShellFileOperations._exec()` resolves the cwd live from `self.env.cwd` on
every call, and every command is wrapped with `cd -- '<cwd>' || exit 126`.
Once `env.cwd` is poisoned with a host path, every subsequent file-tool exec
inside the container dies at exit 126 before the real command runs —
misreported by callers as "File not found" / "rg missing" instead of what it
actually is. An unrelated terminal command later re-learns `cwd=/root` from
its pwd marker, which is why the failure presented as intermittent (works,
then breaks, then works again).

## Fix

Reuse the existing `_is_container_backend()` / `_is_unusable_container_cwd()`
guard at this third site: a host/relative cwd is rejected and the live env
keeps its existing (usable) cwd. The session *record* (`record_session_cwd`)
intentionally still gets the raw host path — host-side surfaces need it, and
its readers (`get_session_cwd()` callers) already guard container use.

## Testing

- Added 3 regression tests to `tests/tools/test_container_cwd_sanitize.py`
  pinning this third site:
  - host path rejected, live env cwd unchanged
  - Windows host path rejected
  - valid in-container override still applies immediately (ACP client
    switching project root must keep working)
- Confirmed the new tests fail without the fix (`AssertionError:
  'C:\Users\someuser' == '/root'`) and pass with it.
- Full run: `pytest tests/tools/test_container_cwd_sanitize.py
  tests/tools/test_file_ops_cwd_tracking.py
  tests/tools/test_file_tools_cwd_resolution.py
  tests/tools/test_gateway_cwd_contract.py
  tests/tools/test_init_session_cwd_respect.py
  tests/tools/test_session_cwd_store.py tests/tools/test_terminal_task_cwd.py
  tests/tools/test_terminal_tool.py` — 60 passed.
- `ruff check tools/terminal_tool.py tests/tools/test_container_cwd_sanitize.py`
  — clean.

## Platforms tested

macOS (Darwin), local dev environment; logic is platform-agnostic (guards
both POSIX and Windows host-path prefixes via the existing
`_is_unusable_container_cwd()`).

## Related

- #50636 / #54447 — the two sibling sites that already sanitize; this is the
  missing third.
- #62169 — deleted CWD breaks subsequent commands (exit 126); same wrapper
  failure, different trigger.

Closes #98723.
