### PR TITLE
fix(terminal): skip live-env cwd override for host paths on container backends

### DIFF
--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -248,3 +248,57 @@ def test_safe_getcwd_falls_back_to_home_when_no_terminal_cwd(monkeypatch):
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.setattr(terminal_tool.os.path, "expanduser", lambda p: "/home/me")
     assert terminal_tool._safe_getcwd() == "/home/me"
+
+
+def test_live_env_cwd_override_skipped_for_host_path_on_container_backend(monkeypatch):
+    """A host workspace registered onto a LIVE container env must not poison env.cwd.
+
+    Desktop/TUI surfaces call register_task_env_overrides with their host
+    workspace (/Users/<user>) on every turn. Written raw onto a container
+    env, every exec dies at `cd <host path>` (exit 126) and file tools
+    misreport existing files as missing.
+    """
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_container_aliases", {})
+    monkeypatch.setattr(
+        terminal_tool, "_resolve_container_task_id", lambda value: value or "default"
+    )
+    monkeypatch.setattr(terminal_tool, "record_session_cwd", lambda session_key, cwd: None)
+    monkeypatch.setattr(
+        terminal_tool, "_get_env_config",
+        lambda: _minimal_terminal_config(cwd="/workspace"),
+    )
+    # make the local env config claim a container backend
+    config = _minimal_terminal_config(cwd="/workspace")
+    config["env_type"] = "docker"
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace"
+
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"desktop-session": FakeEnv()})
+
+    terminal_tool.register_task_env_overrides(
+        "desktop-session", {"cwd": "/Users/kokhlo/Projects"}
+    )
+
+    live_env = terminal_tool._active_environments["desktop-session"]
+    assert live_env.cwd == "/workspace", "host path must not overwrite the live env cwd"
+
+    # in-sandbox absolute paths still propagate to the live env
+    terminal_tool.register_task_env_overrides(
+        "desktop-session", {"cwd": "/root/project"}
+    )
+    assert live_env.cwd == "/root/project"
+
+    # local backend keeps accepting host paths (no container guard)
+    local_config = _minimal_terminal_config(cwd="/home/user/proj")
+    local_config["env_type"] = "local"
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: local_config)
+    terminal_tool.register_task_env_overrides(
+        "desktop-session", {"cwd": "/home/user/proj/newroot"}
+    )
+    assert live_env.cwd == "/home/user/proj/newroot"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1320,7 +1320,22 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         with _env_lock:
             env = _active_environments.get(task_id) or _active_environments.get(container_id)
         if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            # A live container's cwd must stay a path that exists inside the
+            # sandbox. Desktop/TUI surfaces register their HOST workspace
+            # (/Users/<user>, C:\Users\<user>) on every turn; written raw onto
+            # the env it makes every exec fail at `cd <host path>` (exit 126)
+            # while file tools misreport it as "File not found". Same guard
+            # class as the env-creation and per-command sites — skip the
+            # override instead of poisoning the live environment.
+            env_type = overrides.get("env_type") or _get_env_config().get("env_type", "local")
+            if not (_is_container_backend(env_type) and _is_unusable_container_cwd(new_cwd)):
+                env.cwd = new_cwd
+            else:
+                logger.info(
+                    "Skipping live-env cwd override %r for %s backend "
+                    "(host/relative path won't work in sandbox).",
+                    new_cwd, env_type,
+                )
 
 
 def clear_task_env_overrides(task_id: str):


### PR DESCRIPTION
## Problem (issue #98723)

`register_task_env_overrides()` wrote a freshly registered `cwd` **raw** onto a live container environment (`tools/terminal_tool.py`):

```python
if env is not None and getattr(env, "cwd", None) is not None:
    env.cwd = new_cwd
```

Desktop/TUI surfaces call `_register_session_cwd()` on every turn with the session's **host** workspace (`/Users/<user>`, `C:\Users\<user>`), which does not exist inside the sandbox. Every file-tool exec is prefixed with `builtin cd -- '<cwd>' || exit 126`, so after the registration `read_file` / `patch` / `search_files` die at exit 126 before the real command runs — and callers read that as "File not found" for files that exist. The negative-read cache (`_NOT_FOUND_TTL_SECONDS = 60`) and `_has_command` cache then serve the phantom miss long after the cwd is repaired, which produces the "intermittent" failure pattern described in the issue.

## Fix

This is the third cwd write site; the other two — env creation (#54447) and per-command resolution (#50636) — already sanitize with `_is_unusable_container_cwd()`. This PR applies the same guard to the live-env write:

- On a **container backend**, a host/relative cwd override is **skipped** (with an info log) instead of poisoning the live env; other overrides still apply.
- **Local** backends and in-sandbox absolute paths (`/workspace`, `/root`, …) keep propagating unchanged — the ACP editor-switch and RL/benchmark cwd overrides are unaffected.

## Testing

New regression test in `tests/tools/test_terminal_task_cwd.py`:

- docker backend + live env + host-path override → `env.cwd` unchanged;
- docker backend + in-sandbox absolute path → propagates;
- local backend + host path → propagates (no guard).

```
tests/tools/test_terminal_task_cwd.py  7 passed
```

Fixes #98723