### PR TITLE
fix(tools): never write a host cwd onto a live container env

### DIFF
--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -13,8 +13,17 @@ working directory before it reaches ``docker run -w``:
      host prefixes but only ever ran against ``config["cwd"]``, so the override
      bypassed the one guard that would have caught it.
 
-Both paths now share ``_is_unusable_container_cwd()``; these tests pin its
-behaviour so neither path can regress.
+  3. ``register_task_env_overrides()`` writes a freshly registered ``cwd``
+     onto the ALREADY-LIVE environment. That write was raw too, and it is the
+     one that breaks file tools rather than container startup:
+     ``ShellFileOperations`` reads ``env.cwd`` for every operation and the
+     command wrapper emits ``builtin cd -- <cwd> || exit 126``, so a host cwd
+     made ``read_file``/``patch``/``search_files`` fail with "File not found"
+     and "rg is not installed" for files that plainly exist — intermittently,
+     because the next terminal command rewrote the cwd back to a usable one.
+
+All three paths now share ``_is_unusable_container_cwd()``; these tests pin
+their behaviour so none can regress.
 """
 
 import tools.terminal_tool as tt
@@ -212,3 +221,79 @@ class TestFileOpsCwdSanitizedAtCallSite:
         cwd = self._run_and_capture_cwd(
             monkeypatch, "/Users/me/workspace", env_type="modal")
         assert cwd == "/workspace"
+
+
+class TestLiveEnvCwdSanitizedOnRegistration:
+    """E2E pin for path #3: registering a host cwd must not poison the cwd of
+    an environment that is already running on a container backend.
+    """
+
+    class _FakeDockerEnvironment:
+        """Stands in for a live container env (recognized by class name)."""
+
+        def __init__(self, cwd="/root"):
+            self.cwd = cwd
+
+    class _FakeLocalEnvironment:
+        def __init__(self, cwd="/root"):
+            self.cwd = cwd
+
+    def _register(self, monkeypatch, env, cwd, task_id="sess-live-cwd"):
+        monkeypatch.setattr(tt, "_active_environments", {task_id: env})
+        monkeypatch.setattr(tt, "_session_cwd", {})
+        tt.register_task_env_overrides(task_id, {"cwd": cwd})
+        try:
+            return tt.get_session_cwd(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+
+    def test_host_cwd_does_not_reach_live_container_env(self, monkeypatch):
+        env = self._FakeDockerEnvironment(cwd="/root")
+        recorded = self._register(monkeypatch, env, "/Users/me")
+        assert env.cwd == "/root", (
+            f"Host cwd leaked onto the live container env: {env.cwd!r}. Every "
+            "file operation would then run `cd /Users/me` inside the sandbox "
+            "and fail with a phantom 'File not found'."
+        )
+        # The session RECORD still keeps the host path — its readers guard it,
+        # and host-side surfaces need to know where the user actually is.
+        assert recorded == "/Users/me"
+
+    def test_windows_host_cwd_does_not_reach_live_container_env(self, monkeypatch):
+        env = self._FakeDockerEnvironment(cwd="/workspace")
+        self._register(monkeypatch, env, r"C:\Users\someuser")
+        assert env.cwd == "/workspace"
+
+    def test_container_cwd_still_applies_immediately(self, monkeypatch):
+        # An in-sandbox path is the case the assignment exists for (an ACP
+        # client switching project root mid-session); it must still take
+        # effect on the live env.
+        env = self._FakeDockerEnvironment(cwd="/root")
+        self._register(monkeypatch, env, "/workspace/task42")
+        assert env.cwd == "/workspace/task42"
+
+    def test_local_backend_keeps_host_cwd(self, monkeypatch):
+        # On a local backend a host path IS the working directory.
+        env = self._FakeLocalEnvironment(cwd="/tmp")
+        self._register(monkeypatch, env, "/Users/me")
+        assert env.cwd == "/Users/me"
+
+
+class TestEnvInstanceBackendName:
+    def test_docker_class(self):
+        class DockerEnvironment:
+            pass
+
+        assert tt._env_instance_backend_name(DockerEnvironment()) == "docker"
+
+    def test_stamp_wins_over_class_name(self):
+        class SomePluginEnv:
+            _hermes_backend_name = "e2b"
+
+        assert tt._env_instance_backend_name(SomePluginEnv()) == "e2b"
+
+    def test_unrecognized_returns_empty(self):
+        class Mystery:
+            pass
+
+        assert tt._env_instance_backend_name(Mystery()) == ""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1005,10 +1005,56 @@ class ShellFileOperations(FileOperations):
             exit_code=exit_code
         )
     
+    def _unusable_cwd_error(self, result: ExecuteResult) -> Optional[str]:
+        """Explain a failure that happened BEFORE the command ran, else None.
+
+        Every command goes out wrapped as ``builtin cd -- <cwd> || exit 126``
+        (BaseEnvironment._wrap_command), and container backends additionally
+        chdir via ``docker exec -w``. When that cwd doesn't exist inside the
+        sandbox — a host workspace path registered onto a container env, or a
+        directory deleted underneath a live session — the wrapper exits
+        126/127 and the real command never executes. Every probe in this
+        class reads that as "the path isn't there", which is how a working
+        directory problem gets reported as "File not found: <file>" for files
+        that plainly exist, and as "rg is not installed" for a sandbox that
+        has ripgrep. Callers use this to report what actually happened
+        instead, and to skip caching the bogus answer.
+        """
+        if result.exit_code not in (126, 127):
+            return None
+        output = result.stdout or ""
+        if not any(m in output for m in ("cd:", "chdir to cwd")):
+            return None
+        cwd = getattr(self.env, "cwd", None) or self.cwd
+        return (
+            f"Cannot run file operations: the session's working directory "
+            f"{cwd!r} does not exist in the execution environment, so the "
+            f"command never ran and the path was never checked. Run any "
+            f"terminal command first (the terminal tool resets an unusable "
+            f"working directory), then retry."
+        )
+
+    def _cwd_failure_error(self) -> Optional[str]:
+        """Re-probe the environment and explain an unusable cwd, else None.
+
+        For error paths that only know "the command didn't work" (a tool
+        that reports as missing, say): one no-op exec distinguishes a real
+        absence from a session whose working directory no longer exists, so
+        the caller can name the actual problem.
+        """
+        return self._unusable_cwd_error(self._exec("true"))
+
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
         if cmd not in self._command_cache:
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
+            # Never cache a "missing" verdict the probe could not establish:
+            # a wrapper-level failure (unusable cwd) answers nothing, and the
+            # cache lives as long as the file_ops instance — one poisoned
+            # probe would keep claiming rg/find are absent for the rest of
+            # the session, long after the cwd was repaired.
+            if self._unusable_cwd_error(result) is not None:
+                return False
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
@@ -1525,6 +1571,9 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(self._size_probe_cmd(path))
 
         if stat_result.exit_code != 0:
+            cwd_error = self._unusable_cwd_error(stat_result)
+            if cwd_error:
+                return ReadResult(error=cwd_error)
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
             # render identically in a terminal, so the model retyping a
@@ -1809,6 +1858,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
+            cwd_error = self._unusable_cwd_error(stat_result)
+            if cwd_error:
+                return ReadResult(error=cwd_error)
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:
@@ -1851,6 +1903,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
+            cwd_error = self._unusable_cwd_error(stat_result)
+            if cwd_error:
+                return ReadResult(error=cwd_error)
             return ReadResult(error=f"File not found: {path}")
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:
@@ -2260,6 +2315,9 @@ class ShellFileOperations(FileOperations):
         read_result = self._exec(read_cmd)
         
         if read_result.exit_code != 0:
+            cwd_error = self._unusable_cwd_error(read_result)
+            if cwd_error:
+                return PatchResult(error=cwd_error)
             return PatchResult(error=f"Failed to read file: {path}")
         
         content = read_result.stdout
@@ -3057,6 +3115,9 @@ class ShellFileOperations(FileOperations):
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
+            cwd_error = self._cwd_failure_error()
+            if cwd_error:
+                return SearchResult(error=cwd_error)
             return SearchResult(
                 error="File search requires 'rg' (ripgrep) or 'find'. "
                       "Install ripgrep for best results: "
@@ -3201,6 +3262,9 @@ class ShellFileOperations(FileOperations):
                                             output_mode, context)
         else:
             # Neither rg nor grep available (Windows without Git Bash, etc.)
+            cwd_error = self._cwd_failure_error()
+            if cwd_error:
+                return SearchResult(error=cwd_error)
             return SearchResult(
                 error="Content search requires ripgrep (rg) or grep. "
                       "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1320,7 +1320,37 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         with _env_lock:
             env = _active_environments.get(task_id) or _active_environments.get(container_id)
         if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            # Third site of the container-cwd guard, alongside env creation
+            # (#54447) and per-command resolution (#50636). A surface that
+            # registers its HOST workspace (a Desktop/TUI session posting
+            # /Users/<me> on every turn) must not have that path written onto
+            # a live container env: ShellFileOperations reads ``env.cwd`` for
+            # EVERY file operation and the command wrapper prefixes
+            # ``builtin cd -- <cwd> || exit 126``, so an unusable value turns
+            # read_file/patch/search_files into "File not found" and "rg is
+            # not installed" until the next terminal command happens to
+            # rewrite the cwd. The session record above keeps the host path
+            # (its readers guard it); the live env keeps the cwd it can
+            # actually chdir into.
+            # Fall back to the configured backend when the instance is
+            # unrecognized (a plugin env created before stamping, a test
+            # double): on a container-configured process that is the better
+            # guess, and guessing "container" only ever declines to write a
+            # cwd the sandbox could not have used anyway.
+            env_type = _env_instance_backend_name(env)
+            if not env_type:
+                try:
+                    env_type = str(_get_env_config().get("env_type") or "").lower()
+                except Exception:
+                    env_type = ""
+            if _is_container_backend(env_type) and _is_unusable_container_cwd(new_cwd):
+                logger.info(
+                    "Not applying registered cwd %r to the live %s environment "
+                    "(host/relative path won't exist in the sandbox). Keeping %r.",
+                    new_cwd, env_type, env.cwd,
+                )
+            else:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):
@@ -1701,6 +1731,40 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     if not os.path.isabs(cwd):
         return True
     return False
+
+
+_ENV_CLASS_BACKEND_HINTS = (
+    ("docker", "docker"),
+    ("singularity", "singularity"),
+    ("managedmodal", "managed_modal"),
+    ("modal", "modal"),
+    ("daytona", "daytona"),
+    ("vercel", "vercel_sandbox"),
+    ("ssh", "ssh"),
+    ("local", "local"),
+)
+
+
+def _env_instance_backend_name(env) -> str:
+    """Best-effort backend name for a LIVE environment object.
+
+    ``_is_container_backend`` answers questions about a configured backend
+    *type*; callers holding an already-created environment need the same
+    answer about the instance in hand (the process config may have changed,
+    and plugin backends have no built-in class). Prefer the stamp written by
+    ``_create_environment`` for plugin providers, then fall back to the class
+    name. Returns "" when the instance is unrecognizable; callers decide what
+    an unknown backend means (the cwd guard below falls back to the configured
+    ``env_type``).
+    """
+    stamped = getattr(env, "_hermes_backend_name", None)
+    if isinstance(stamped, str) and stamped.strip():
+        return stamped.strip().lower()
+    name = env.__class__.__name__.lower()
+    for needle, backend in _ENV_CLASS_BACKEND_HINTS:
+        if needle in name:
+            return backend
+    return ""
 
 
 # One-shot guard for the config-fallback bridge below.  Purely an


### PR DESCRIPTION
Fixes #98723.

## The bug

`register_task_env_overrides()` applied a freshly registered `cwd` **raw** to an already-live environment:

```python
        if env is not None and getattr(env, "cwd", None) is not None:
            env.cwd = new_cwd          # no container-path guard
```

On a container backend that value is routinely a **host** path — the desktop/TUI surface registers its host workspace (`/Users/<me>`, `C:\Users\<me>`) on every turn via `_register_session_cwd` (`tui_gateway/server.py:3781`).

`ShellFileOperations._exec()` resolves `env.cwd` live for **every** operation, and `BaseEnvironment._wrap_command()` prefixes every command with `builtin cd -- <cwd> || exit 126`. So after any registration, each file-tool exec died at exit 126 inside the sandbox before the real command ran:

```
bash: line 4: cd: /Users/<me>: No such file or directory
```

and the probes reported that as a missing path:

| Tool | Reported | Reality |
|---|---|---|
| `read_file` | `File not found: /root/<file>.md` | file exists; never opened |
| `patch` | `Failed to read file: <path>` | same |
| `search_files` | `File search requires 'rg' (ripgrep) or 'find'` | rg installed; `command -v rg` hit the same bad cwd |

It presents as **intermittent** because `terminal_tool` recomputes a safe workdir per command and each completed command re-learns the cwd from the pwd marker: poisoned at turn start → repaired by the next terminal command → poisoned again next turn. In the reporting session one existing file failed ~10 times across five sessions while other reads seconds apart succeeded, purely by position in that cycle.

## The fix

This is the **third site** of the container-cwd guard. Env creation (#54447) and per-command resolution (#50636) already sanitize through `_is_unusable_container_cwd`; a host cwd there breaks container *startup*, which is loud. This site corrupts a *live* env's cwd instead, which fails quietly and blames the wrong thing.

- `tools/terminal_tool.py` — apply the same guard, keyed on the **live** environment via a new `_env_instance_backend_name()` helper (stamp first, then class name, falling back to the configured `env_type` for unrecognized instances). The session *record* still keeps the host path: its readers already guard it and host-side surfaces need it.

Defence in depth, so this failure class can never masquerade as a missing file again:

- `tools/file_operations.py` — `_unusable_cwd_error()` recognizes the wrapper failure (exit 126/127 with `cd:` / `chdir to cwd`) and the size probes, `read_file_raw`, `read_file_bytes`, the patch pre-image read and both search "tool missing" paths now report *"the session's working directory does not exist in the execution environment … the path was never checked"* instead of accusing the file.
- Two caches stop recording verdicts the probe never established: `_has_command` no longer pins `rg`/`find` as missing for the life of the file_ops instance, and a transport failure no longer populates the 60s negative read cache — whose "was it created since?" recheck calls `os.path.exists` on the **host** and therefore can never clear a `/root/...` entry.

## Tests

`tests/tools/test_container_cwd_sanitize.py` gains 7 tests pinning the third site: a POSIX and a Windows host cwd must not reach a live container env, an in-sandbox path must still apply immediately (the ACP project-root switch this assignment exists for), a local backend must still take the host path, plus the helper's stamp/class-name/unknown paths. The file's module docstring is extended to document all three sites.

Verified against a real Docker backend before and after — with the guard, the registration that used to break everything leaves `env.cwd=/root` and reads/patches keep working across turns:

```
Not applying registered cwd '/Users/<me>' to the live docker environment
  (host/relative path won't exist in the sandbox). Keeping '/root'.
read #1: OK (16031 chars)
read #2: OK (15995 chars)
read #3: OK (15920 chars)
```

Suites run green on this branch: `test_container_cwd_sanitize`, `test_file_ops_cwd_tracking`, `test_file_tools_cwd_resolution`, `test_terminal_task_cwd` (36 passed), plus `test_file_operations`, `test_file_operations_edge_cases`, `test_session_cwd_store`, `test_gateway_cwd_contract`, the `test_patch_*` and `test_read_*` families and `tests/gateway` cwd tests on the reporting checkout (319 passed).

## Notes for review

- Behaviour change worth a look: on a container backend, an ACP/desktop client switching its project root to a **host** path no longer moves the live env's cwd. Remapping it to `/workspace` was considered and rejected — the live env may not mount that host path there, so it would silently point file ops at a different directory. Keeping the last usable cwd matches what the per-command resolver already does.
- Related, not fixed here: #62169 (deleted cwd, same wrapper failure from a different trigger — the new error message covers its file-tool symptom) and #90679 / #60962 (Windows drive letters escaping `_HOST_CWD_PREFIXES` — guard *coverage* rather than a missing guard *site*; on Windows both can fire at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFnjwiUQtkoonFiRa186GR
