### PR TITLE
fix(approval): make unattended exclusion transport-scoped so /v1/runs approval works

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -862,6 +862,204 @@ class TestWebhookApprovalExclusion:
         assert "approvals.unattended_mode" in result["message"]
 
 
+class TestUnattendedApprovalTransport:
+    """A registered per-session approval transport makes an unattended
+    platform session resolvable (#98728).
+
+    ``/v1/runs`` binds a run-scoped session key and registers a gateway
+    notify callback resolvable via ``POST /v1/runs/{run_id}/approval``, so
+    its guarded actions must go through the interactive gateway approval
+    flow instead of the instant unattended deny/approve. Listener-less
+    sessions (no registered callback) keep the fail-closed behavior from
+    #87509.
+    """
+
+    SESSION_KEY = "test-runs-approval-transport"
+
+    def setup_method(self):
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in (
+                "HERMES_CRON_SESSION",
+                "HERMES_GATEWAY_SESSION",
+                "HERMES_INTERACTIVE",
+                "HERMES_EXEC_ASK",
+                "HERMES_SESSION_PLATFORM",
+                "HERMES_SESSION_KEY",
+            )
+        }
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ.pop("HERMES_GATEWAY_SESSION", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_EXEC_ASK", None)
+        os.environ["HERMES_SESSION_PLATFORM"] = "api_server"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _isolate(self, monkeypatch):
+        """Manual mode, no frozen yolo, short approval timeout for guards."""
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"mode": "manual", "timeout": 2},
+        )
+
+    def test_registered_transport_is_interactive(self, monkeypatch):
+        """A registered notify callback flips both context checks; unregistering restores."""
+        from tools.approval import (
+            _is_gateway_approval_context,
+            _is_unattended_platform_approval_context,
+        )
+
+        assert _is_unattended_platform_approval_context() is True
+        assert _is_gateway_approval_context() is False
+
+        approval_module.register_gateway_notify(
+            self.SESSION_KEY, lambda data: None
+        )
+        try:
+            assert _is_unattended_platform_approval_context() is False
+            assert _is_gateway_approval_context() is True
+        finally:
+            approval_module.unregister_gateway_notify(self.SESSION_KEY)
+
+        assert _is_unattended_platform_approval_context() is True
+        assert _is_gateway_approval_context() is False
+
+    def test_listenerless_execute_code_still_denies(self, monkeypatch):
+        """No registered callback: instant deny, no pending approval (#87509 kept)."""
+        from tools.approval import check_execute_code_guard
+
+        self._isolate(monkeypatch)
+        result = check_execute_code_guard("import os", "local")
+        assert result["approved"] is False
+        assert "approvals.unattended_mode" in result["message"]
+        assert not approval_module._gateway_queues.get(self.SESSION_KEY)
+
+    def test_transport_execute_code_resolves_once(self, monkeypatch):
+        """With a run-scoped callback, execute_code emits approval.request and
+        continues on an exact ``once`` resolution."""
+        from tools.approval import check_execute_code_guard
+
+        self._isolate(monkeypatch)
+        notified = []
+        approval_module.register_gateway_notify(
+            self.SESSION_KEY, lambda data: notified.append(dict(data))
+        )
+
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = check_execute_code_guard("import os", "local")
+
+        t = threading.Thread(target=_check)
+        t.start()
+        try:
+            for _ in range(400):
+                if approval_module._gateway_queues.get(self.SESSION_KEY):
+                    break
+                time.sleep(0.005)
+            assert approval_module._gateway_queues.get(self.SESSION_KEY), (
+                "approval.request never became pending for the transport session"
+            )
+            assert approval_module.resolve_gateway_approval(
+                self.SESSION_KEY, "once"
+            ) == 1
+        finally:
+            t.join(timeout=5)
+
+        assert "r" in result_holder, "approval wait did not return after resolve"
+        r = result_holder["r"]
+        assert r["approved"] is True
+        assert r.get("user_approved") is True
+        assert len(notified) == 1, "notify callback should have fired exactly once"
+
+    def test_transport_execute_code_honors_deny(self, monkeypatch):
+        """An exact ``deny`` resolution through the transport blocks the action."""
+        from tools.approval import check_execute_code_guard
+
+        self._isolate(monkeypatch)
+        approval_module.register_gateway_notify(
+            self.SESSION_KEY, lambda data: None
+        )
+
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = check_execute_code_guard("import os", "local")
+
+        t = threading.Thread(target=_check)
+        t.start()
+        try:
+            for _ in range(400):
+                if approval_module._gateway_queues.get(self.SESSION_KEY):
+                    break
+                time.sleep(0.005)
+            assert approval_module.resolve_gateway_approval(
+                self.SESSION_KEY, "deny"
+            ) == 1
+        finally:
+            t.join(timeout=5)
+
+        assert "r" in result_holder, "approval wait did not return after deny"
+        r = result_holder["r"]
+        assert r["approved"] is False
+        assert r.get("user_consent") is False
+        assert r.get("outcome") == "denied"
+
+    def test_transport_dangerous_command_resolves_once(self, monkeypatch):
+        """Dangerous commands on a transport session emit approval.request and
+        resolve through the gateway wait instead of the instant unattended
+        deny."""
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        notified = []
+        approval_module.register_gateway_notify(
+            self.SESSION_KEY, lambda data: notified.append(dict(data))
+        )
+
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = check_all_command_guards(
+                "sudo systemctl restart nginx", "local"
+            )
+
+        t = threading.Thread(target=_check)
+        t.start()
+        try:
+            for _ in range(400):
+                if approval_module._gateway_queues.get(self.SESSION_KEY):
+                    break
+                time.sleep(0.005)
+            assert approval_module._gateway_queues.get(self.SESSION_KEY), (
+                "approval.request never became pending for the transport session"
+            )
+            assert approval_module.resolve_gateway_approval(
+                self.SESSION_KEY, "once"
+            ) == 1
+        finally:
+            t.join(timeout=5)
+
+        assert "r" in result_holder, "approval wait did not return after resolve"
+        r = result_holder["r"]
+        assert r["approved"] is True
+        assert r.get("user_approved") is True
+        assert len(notified) == 1
+        assert "unattended platform" not in (r.get("message") or "")
+
+
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -287,8 +287,21 @@ def _is_unattended_platform_approval_context() -> bool:
     who can resolve a pending approval. Treating them as gateway approval
     contexts blocks the session for the full approval timeout (60-300s) and
     then fails closed anyway — the deadlock in #37284/#87509.
+
+    A session is NOT unattended once its exact session key registered a
+    gateway approval transport via ``register_gateway_notify``: ``/v1/runs``
+    binds a run-scoped callback resolvable through
+    ``POST /v1/runs/{run_id}/approval``, so a pending approval there has a
+    live listener (#98728). Listener-less routes never register one and keep
+    the instant deny/approve behavior below.
     """
-    return _get_session_platform() in _UNATTENDED_APPROVAL_PLATFORMS
+    if _get_session_platform() not in _UNATTENDED_APPROVAL_PLATFORMS:
+        return False
+    session_key = get_current_session_key(default="")
+    if not session_key:
+        return True
+    with _lock:
+        return session_key not in _gateway_notify_cbs
 
 
 def _is_single_query_approval_context() -> bool:
@@ -337,6 +350,10 @@ def _is_gateway_approval_context() -> bool:
     approval timeout (60-300 s) with no human who can resolve it (#37284,
     #87509). Their dangerous-command handling is governed by
     ``approvals.unattended_mode`` config (default deny), mirroring cron.
+    The exclusion is transport-scoped, not platform-wide: once a session
+    registers a gateway approval transport (``register_gateway_notify``,
+    e.g. a ``/v1/runs`` run with its run-scoped callback), it is treated
+    as an interactive gateway context again (#98728).
     """
     if _is_cron_approval_context():
         return False


### PR DESCRIPTION
## What does this PR do?

`/v1/runs` has had a run-scoped human approval transport since #21899 (`_handle_runs` registers a gateway notify callback resolvable via `POST /v1/runs/{run_id}/approval`), but #98558 classified the whole `api_server` platform as unattended to fix the listener-less deadlock in #87509. As a result, with the safe defaults (`approvals.mode: manual`, `approvals.unattended_mode: deny`), guarded `execute_code` calls were denied instantly — no `approval.request` was ever emitted, and the approval endpoint had nothing pending to resolve. Setting `unattended_mode: approve` auto-approves every guarded API-server action, which is not a safe workaround.

This PR scopes the unattended exclusion to sessions **without** a registered approval transport: `_is_unattended_platform_approval_context()` now returns `False` once the current session key has registered a callback via `register_gateway_notify`. So:

- `/v1/runs` (run-scoped callback registered) → interactive gateway approval flow again: emit `approval.request`, wait, resolve via `POST /v1/runs/{run_id}/approval` with the exact `once`/`session`/`always`/`deny` decision.
- Listener-less routes (`/v1/chat/completions`, `/v1/responses`, webhook, msgraph_webhook — none of them ever register a callback) → keep the instant deny/approve behavior from #87509, no indefinite blocking regression.

This is the transport-scoped shape proposed in the issue, and it is the minimal change: one predicate, no per-route plumbing in `api_server.py`.

## Related Issue

Fixes #98728

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` — `_is_unattended_platform_approval_context()`: after the platform-set check, a session whose exact session key has a registered gateway notify callback is no longer unattended; empty/missing session keys and unregistered keys keep the unattended classification. Docstring of `_is_gateway_approval_context()` updated to document the transport-scoped exception.
- `tests/tools/test_approval.py` — new `TestUnattendedApprovalTransport` class: predicate flip on register/unregister, listener-less `execute_code` still instant-denies (fail-closed, #87509 kept), transport-resolved `execute_code` continues on an exact `once` and honors an explicit `deny`, and a guarded dangerous command resolves through the gateway wait instead of the instant unattended deny.

## How to Test

1. Run the new regression tests: `pytest tests/tools/test_approval.py::TestUnattendedApprovalTransport -q` — Observed result: 5 passed.
2. Run the existing approval suites: `pytest tests/tools/test_approval.py tests/gateway/test_api_server_runs.py tests/gateway/test_approval_boundary.py -q` — Observed result: 155 passed, 1 pre-existing failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) that reproduces identically on a clean `upstream/main` checkout (verified via `git stash` on this branch), i.e. unrelated to this change.
3. Behavior check per the issue: bind an `api_server` session key and call `register_gateway_notify` before `check_execute_code_guard` — the guard now emits an approval request and blocks for a decision instead of returning the unattended BLOCKED message; without the registration it still returns the instant unattended deny.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the approval/gateway suites relevant to this change (see How to Test); the single failure is pre-existing on clean main
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both predicates updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A