### PR TITLE
fix(skills): don't report persisted skill bodies as loaded

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -280,7 +280,17 @@ SKILLS_GUIDANCE = (
     "context compression and is inaccessible — reload it with "
     "skill_view(name='...') before acting on anything that depends on it. "
     "After reloading, ignore any remaining `[SKILL_PRUNED]` markers for that "
-    "same skill; they are historical artifacts of earlier compactions."
+    "same skill; they are historical artifacts of earlier compactions.\n"
+    "A skill result containing `[SKILL_INCOMPLETE]` was NOT loaded: its body "
+    "was removed to protect the context window and only a heading index came "
+    "back, so do not treat it as loaded and do not act on it. Retrieve the "
+    "headings you need one at a time with skill_view(name='...', "
+    "section='...') and read them before acting. If the result names a linked "
+    "file (it carries a `file` key), keep that same path on every follow-up — "
+    "skill_view(name='...', file_path='...', section='...') — because the "
+    "headings and `#n` selectors are positions inside that file; dropping "
+    "`file_path` answers out of SKILL.md instead, and says nothing about "
+    "having done so."
 )
 
 KANBAN_GUIDANCE = (

--- a/tests/agent/test_skill_incomplete_guidance.py
+++ b/tests/agent/test_skill_incomplete_guidance.py
@@ -1,0 +1,48 @@
+"""The Skill Safety Rule must cover a load that did not arrive.
+
+The existing rule covers a skill whose content was lost to COMPRESSION
+([SKILL_PRUNED]). A skill whose body was removed at the persistence boundary
+never arrived in the first place, and the receipt for it says so with
+[SKILL_INCOMPLETE]. Without guidance naming that marker the model has no
+instruction telling it the index receipt is not a loaded skill.
+"""
+
+from agent.prompt_builder import SKILLS_GUIDANCE
+
+
+class TestIncompleteLoadSafetyRule:
+    def test_the_guidance_names_the_incomplete_marker(self):
+        assert "## Skill Safety Rule" in SKILLS_GUIDANCE
+        assert "[SKILL_INCOMPLETE]" in SKILLS_GUIDANCE
+
+    def test_the_guidance_says_an_incomplete_result_is_not_loaded(self):
+        assert "NOT loaded" in SKILLS_GUIDANCE
+
+    def test_the_guidance_names_section_as_the_way_back(self):
+        assert "section=" in SKILLS_GUIDANCE
+
+    def test_the_pruned_rule_survives_alongside_it(self):
+        assert "[SKILL_PRUNED]" in SKILLS_GUIDANCE
+        assert "context compression" in SKILLS_GUIDANCE
+
+
+class TestLinkedFileGuidance:
+    """A linked file is a different document from SKILL.md with its own
+    heading index, so a continuation that drops file_path silently resolves
+    against SKILL.md. Every surface that tells the model how to continue must
+    say to keep it."""
+
+    def test_the_guidance_tells_the_model_to_keep_file_path(self):
+        assert "file_path" in SKILLS_GUIDANCE
+        marker_at = SKILLS_GUIDANCE.index("[SKILL_INCOMPLETE]")
+        tail = SKILLS_GUIDANCE[marker_at:]
+        assert "file_path=" in tail
+        assert "SKILL.md" in tail
+
+    def test_the_section_parameter_description_tells_the_model_the_same(self):
+        from tools.skills_tool import SKILL_VIEW_SCHEMA
+
+        described = SKILL_VIEW_SCHEMA["parameters"]["properties"]["section"][
+            "description"
+        ]
+        assert "file_path" in described

--- a/tests/tools/test_oversized_result_formatters.py
+++ b/tests/tools/test_oversized_result_formatters.py
@@ -1,0 +1,306 @@
+"""The formatter hook must not change generic persistence in any way.
+
+The hook is consulted only AFTER tools/tool_result_storage.py has already
+decided to persist a result. Thresholds, previews, persist decisions, aggregate
+candidate order and the storage write are none of its business, and with an
+empty registry the storage layer must behave exactly as it did before this
+module existed.
+
+The invariance checks are written as with-registry vs without-registry
+comparisons rather than against a literal receipt, because the receipt names
+the path the result was persisted to and that path is backend-dependent. What
+must hold is that registering a formatter for one tool changes nothing for any
+other tool, byte for byte.
+"""
+
+import json
+
+import pytest
+
+from tools import oversized_result_formatters as orf
+from tools.budget_config import (
+    DEFAULT_BUDGET,
+    DEFAULT_PREVIEW_SIZE_CHARS,
+    DEFAULT_RESULT_SIZE_CHARS,
+    PINNED_THRESHOLDS,
+)
+from tools.tool_result_storage import (
+    PERSISTED_OUTPUT_CLOSING_TAG,
+    PERSISTED_OUTPUT_TAG,
+    _BUDGET_TOOL_NAME,
+    enforce_turn_budget,
+    generate_preview,
+    maybe_persist_tool_result,
+)
+
+
+@pytest.fixture
+def empty_registry(monkeypatch):
+    """No formatters at all -- the shipping default for every tool but one."""
+    monkeypatch.setattr(orf, "_FORMATTERS", {})
+    return orf
+
+
+def _persist(tool, content, tool_use_id, env=None):
+    return maybe_persist_tool_result(
+        content=content,
+        tool_name=tool,
+        tool_use_id=tool_use_id,
+        env=env,
+        config=DEFAULT_BUDGET,
+    )
+
+
+def _without_registry(monkeypatch, fn):
+    """Run *fn* with the registry emptied, then restore it."""
+    saved = dict(orf._FORMATTERS)
+    monkeypatch.setattr(orf, "_FORMATTERS", {})
+    try:
+        return fn()
+    finally:
+        monkeypatch.setattr(orf, "_FORMATTERS", saved)
+
+
+class _SandboxEnv:
+    """A remote-looking env whose sandbox write and readability probe succeed."""
+
+    def get_temp_dir(self):
+        return "/tmp"
+
+    def execute(self, cmd, timeout=30, stdin_data=None):
+        return {"returncode": 0}
+
+
+class TestGenericPersistenceIsUnchanged:
+    def test_non_skill_oversized_result_gets_the_generic_receipt(self, empty_registry):
+        content = "x" * 100_001
+        delivered = _persist("search_files", content, "tu_generic")
+        preview, has_more = generate_preview(
+            content, max_chars=DEFAULT_PREVIEW_SIZE_CHARS
+        )
+        assert len(preview) == 1_500 and has_more is True
+        assert delivered != content
+        assert "[SKILL_INCOMPLETE:" not in delivered
+
+    def test_a_registered_formatter_leaves_a_non_skill_receipt_byte_identical(
+        self, monkeypatch
+    ):
+        import tools.skills_tool  # noqa: F401  (registers skill_view's formatter)
+
+        content = "x" * 100_001
+        with_registry = _persist("search_files", content, "tu_generic")
+        without = _without_registry(
+            monkeypatch, lambda: _persist("search_files", content, "tu_generic")
+        )
+        assert with_registry == without
+
+    def test_a_registered_formatter_leaves_a_sandbox_receipt_byte_identical(
+        self, monkeypatch
+    ):
+        import tools.skills_tool  # noqa: F401  (registers skill_view's formatter)
+
+        content = "y" * 100_001
+        with_registry = _persist(
+            "search_files", content, "tu_sandbox_generic", env=_SandboxEnv()
+        )
+        without = _without_registry(
+            monkeypatch,
+            lambda: _persist(
+                "search_files", content, "tu_sandbox_generic", env=_SandboxEnv()
+            ),
+        )
+        assert with_registry == without
+        assert with_registry.startswith(PERSISTED_OUTPUT_TAG)
+        assert with_registry.endswith(PERSISTED_OUTPUT_CLOSING_TAG)
+
+    def test_a_result_at_the_threshold_is_still_returned_untouched(self, empty_registry):
+        content = "z" * 100_000
+        assert _persist("search_files", content, "tu_at_cap") == content
+
+
+class TestAggregateSelectionIsUnchanged:
+    def _messages(self):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        sizes = [("search_files", 90_000), ("terminal", 70_000), ("web_search", 55_000)]
+        return [
+            make_tool_result_message(n, "q" * s, f"tu_{i}")
+            for i, (n, s) in enumerate(sizes)
+        ]
+
+    def test_empty_registry_selects_the_same_candidates_in_the_same_order(
+        self, empty_registry
+    ):
+        messages = self._messages()
+        before = [m["content"] for m in messages]
+        enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+        after = [m["content"] for m in messages]
+
+        # Largest-first until under budget: 215,000 total, 200,000 budget, so
+        # exactly the single largest result is spilled and nothing else moves.
+        assert after[0] != before[0]
+        assert after[1] == before[1]
+        assert after[2] == before[2]
+        assert "[SKILL_INCOMPLETE:" not in after[0]
+
+    def test_a_registered_formatter_changes_no_non_skill_aggregate_spill(
+        self, monkeypatch
+    ):
+        import tools.skills_tool  # noqa: F401  (registers skill_view's formatter)
+
+        def _run():
+            messages = self._messages()
+            enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+            return [m["content"] for m in messages]
+
+        with_registry = _run()
+        without = _without_registry(monkeypatch, _run)
+        assert with_registry == without
+
+    def test_under_budget_turns_are_never_touched(self, empty_registry):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        messages = [make_tool_result_message("search_files", "q" * 10, "tu_small")]
+        before = [m["content"] for m in messages]
+        enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+        assert [m["content"] for m in messages] == before
+
+    def test_aggregate_enforcement_still_forces_threshold_zero(
+        self, empty_registry, monkeypatch
+    ):
+        """The synthetic tool name and threshold=0 are what decide an aggregate
+        spill. The real tool name is passed for the formatter lookup ONLY."""
+        import tools.tool_result_storage as trs
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        seen = []
+        real = trs.maybe_persist_tool_result
+
+        def _spy(**kw):
+            seen.append(kw)
+            return real(**kw)
+
+        monkeypatch.setattr(trs, "maybe_persist_tool_result", _spy)
+        messages = [
+            make_tool_result_message("skill_view", "a" * 150_000, "tu_x"),
+            make_tool_result_message("search_files", "b" * 60_000, "tu_y"),
+        ]
+        trs.enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+
+        assert seen, "no candidate was persisted"
+        for call in seen:
+            assert call["threshold"] == 0
+            assert call["tool_name"] == _BUDGET_TOOL_NAME
+        assert seen[0]["formatter_name"] == "skill_view"
+
+
+class TestThresholdsAreUnchanged:
+    def test_skill_view_threshold_is_still_the_default(self):
+        import tools.skills_tool  # noqa: F401  (registers the tool)
+        from tools.registry import registry
+
+        assert DEFAULT_BUDGET.resolve_threshold("skill_view") == 100_000
+        assert DEFAULT_RESULT_SIZE_CHARS == 100_000
+        assert registry.get_entry("skill_view").max_result_size_chars is None
+        assert "skill_view" not in PINNED_THRESHOLDS
+        assert "skill_view" not in DEFAULT_BUDGET.tool_overrides
+
+
+class TestRegistryContract:
+    def test_registry_is_empty_apart_from_skill_view(self):
+        import tools.skills_tool  # noqa: F401  (registers on import)
+
+        assert set(orf._FORMATTERS) == {"skill_view"}
+
+    def test_no_formatter_means_no_opinion(self, empty_registry):
+        assert orf.format_oversized_result("anything", "search_files") is None
+        assert orf.format_oversized_result("anything", "") is None
+        assert orf.has_formatter("search_files") is False
+
+    def test_a_formatter_that_raises_degrades_to_the_generic_receipt(
+        self, empty_registry, monkeypatch
+    ):
+        content = "x" * 100_001
+        baseline = _persist("search_files", content, "tu_boom")
+
+        def _boom(content, *, tool_name):
+            raise RuntimeError("formatter is broken")
+
+        orf.register_formatter("search_files", _boom)
+        assert orf.format_oversized_result("anything", "search_files") is None
+        assert _persist("search_files", content, "tu_boom") == baseline
+
+    def test_a_formatter_that_declines_falls_through(self, empty_registry):
+        orf.register_formatter("search_files", lambda content, *, tool_name: None)
+        assert orf.format_oversized_result("anything", "search_files") is None
+        orf.register_formatter("search_files", lambda content, *, tool_name: "")
+        assert orf.format_oversized_result("anything", "search_files") is None
+
+    def test_register_rejects_nonsense(self, empty_registry):
+        with pytest.raises(ValueError):
+            orf.register_formatter("", lambda c, *, tool_name: None)
+        with pytest.raises(ValueError):
+            orf.register_formatter("x", "not callable")
+
+
+class TestRegisteredFormatterDoesNotLeakToOtherTools:
+    """Run against the REAL registry, with skill_view's formatter registered.
+    A lookup that falls back to "some formatter" instead of "this tool's
+    formatter" would rewrite every other tool's receipt, so the byte-identity
+    checks above must also hold while a formatter exists.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _real_registry(self):
+        import tools.skills_tool  # noqa: F401  (registers skill_view)
+
+        assert orf.has_formatter("skill_view")
+
+    @pytest.mark.parametrize(
+        "tool", ["search_files", "terminal", "web_search", "memory"]
+    )
+    def test_other_tools_still_get_the_generic_receipt(self, tool, monkeypatch):
+        content = "x" * 100_001
+        delivered = _persist(tool, content, f"tu_{tool}")
+        without = _without_registry(
+            monkeypatch, lambda: _persist(tool, content, f"tu_{tool}")
+        )
+        assert delivered == without
+        assert "[SKILL_INCOMPLETE:" not in delivered
+        assert orf.has_formatter(tool) is False
+
+    def test_a_skill_shaped_payload_from_another_tool_is_not_rewritten(
+        self, monkeypatch
+    ):
+        """Same bytes, different tool name: the lookup is by name, not shape."""
+        payload = json.dumps(
+            {
+                "success": True,
+                "name": "looks-like-a-skill",
+                "content": "# H\n" + "b" * 100_001,
+            }
+        )
+        delivered = _persist("read_file_alt", payload, "tu_shape")
+        without = _without_registry(
+            monkeypatch, lambda: _persist("read_file_alt", payload, "tu_shape")
+        )
+        assert "[SKILL_INCOMPLETE:" not in delivered
+        assert delivered == without
+
+    def test_aggregate_spill_of_a_non_skill_result_is_the_generic_block(
+        self, monkeypatch
+    ):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        def _run():
+            messages = [
+                make_tool_result_message("search_files", "q" * 150_000, "tu_ns1"),
+                make_tool_result_message("terminal", "r" * 60_000, "tu_ns2"),
+            ]
+            enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+            return messages[0]["content"]
+
+        delivered = _run()
+        without = _without_registry(monkeypatch, _run)
+        assert "[SKILL_INCOMPLETE:" not in delivered
+        assert delivered == without

--- a/tests/tools/test_skill_incomplete_direct_consumers.py
+++ b/tests/tools/test_skill_incomplete_direct_consumers.py
@@ -1,0 +1,98 @@
+"""Consumers that never cross the model-facing persistence boundary keep the
+full skill body.
+
+The incomplete-load receipt exists because a tool result was truncated on its
+way to the model. Four callers of skill_view() have no tool-result budget at
+all -- preloaded/slash-command skills and cron skill injection put the content
+into a prompt block, and the MCP/codex surface dispatches through
+model_tools.handle_function_call, which never persists. Implementing the
+truthful receipt INSIDE skill_view() would silently strip all four. This file
+is the guard against that.
+"""
+
+import json
+
+import pytest
+
+FINAL_RULE = "ALWAYS run the migration before restarting the service."
+BODY_LINE = "Some ordinary instruction prose that fills the body of the skill file."
+
+
+def _write_skill(skills_dir, name, target_chars):
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    head = (
+        f"---\nname: {name}\ndescription: A skill used by the incomplete-load tests\n"
+        f"---\n\n# {name}\n\n## Procedure\n\n"
+    )
+    tail = f"\n## Final Governing Rule\n\n{FINAL_RULE}\n"
+    filler = BODY_LINE + "\n"
+    n = max(0, (target_chars - len(head) - len(tail)) // len(filler))
+    (d / "SKILL.md").write_text(head + (filler * n) + tail, encoding="utf-8")
+
+
+@pytest.fixture
+def oversized_home(tmp_path, monkeypatch):
+    from tools.skills_tool import reset_skill_view_dedup
+
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    _write_skill(skills, "oversized-skill", 120_000)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    reset_skill_view_dedup()
+    yield home
+    reset_skill_view_dedup()
+
+
+class TestDirectConsumersGetTheFullBody:
+    def test_skill_view_itself_is_unchanged(self, oversized_home):
+        from tools.skills_tool import skill_view
+
+        payload = json.loads(skill_view("oversized-skill"))
+        assert payload["success"] is True
+        assert len(payload["content"]) > 100_000
+        assert FINAL_RULE in payload["content"]
+        assert "load_status" not in payload
+
+    def test_preloaded_slash_command_path_gets_the_full_body(self, oversized_home):
+        from agent.skill_commands import _load_skill_payload, build_preloaded_skills_prompt
+
+        payload, _skill_dir, name = _load_skill_payload(
+            "oversized-skill", task_id="t-preload"
+        )
+        assert name == "oversized-skill"
+        assert FINAL_RULE in payload["content"]
+
+        prompt, names, missing = build_preloaded_skills_prompt(["oversized-skill"])
+        assert names == ["oversized-skill"] and missing == []
+        assert FINAL_RULE in prompt
+        assert "[SKILL_INCOMPLETE:" not in prompt
+
+    def test_cron_skill_injection_gets_the_full_body(self, oversized_home):
+        """Both cron/scheduler.py call sites do json.loads(skill_view(name))."""
+        from tools.skills_tool import skill_view
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        loaded = json.loads(skill_view(normalize_skill_lookup_name("oversized-skill")))
+        assert loaded["success"] is True
+        assert FINAL_RULE in loaded["content"]
+
+        readiness = json.loads(skill_view("oversized-skill"))
+        assert readiness.get("readiness_status") == "available"
+        assert FINAL_RULE in readiness["content"]
+
+    def test_mcp_codex_surface_gets_the_full_body(self, oversized_home):
+        """skill_view over MCP dispatches through model_tools.handle_function_call,
+        which never calls maybe_persist_tool_result."""
+        import model_tools
+        from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
+        assert "skill_view" in EXPOSED_TOOLS
+        raw = model_tools.handle_function_call(
+            "skill_view", {"name": "oversized-skill"}, task_id="t-mcp"
+        )
+        payload = json.loads(raw)
+        assert payload["success"] is True
+        assert FINAL_RULE in payload["content"]
+        assert "load_status" not in payload

--- a/tests/tools/test_skill_incomplete_load.py
+++ b/tests/tools/test_skill_incomplete_load.py
@@ -1,0 +1,1112 @@
+"""A mandatory skill that did not reach the model is never reported as loaded.
+
+`skill_view` can have its body removed by two independent context-protection
+decisions in `tools/tool_result_storage.py`: the per-result threshold (layer 2)
+and aggregate turn-budget enforcement (layer 3). Both used to leave a generic
+preview that still opened with `"success": true` plus a truncated fragment of
+the skill body, and the repeat-view dedup cache then told a retry the earlier
+load was "current and complete". These tests pin the honest receipt instead.
+"""
+
+import json
+import re
+
+import pytest
+
+from tools.budget_config import DEFAULT_BUDGET
+from tools.registry import registry
+from tools.skills_tool import reset_skill_view_dedup
+from tools.tool_result_storage import maybe_persist_tool_result
+
+FINAL_RULE = "ALWAYS run the migration before restarting the service."
+BODY_LINE = "Some ordinary instruction prose that fills the body of the skill file."
+
+
+def _write_skill(skills_dir, name, target_chars):
+    """Write a SKILL.md of roughly *target_chars* with a known final rule."""
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    head = (
+        f"---\nname: {name}\ndescription: A skill used by the incomplete-load tests\n"
+        f"---\n\n# {name}\n\n## Overview\n\nWhat this skill is for.\n\n## Procedure\n\n"
+    )
+    tail = f"\n## Final Governing Rule\n\n{FINAL_RULE}\n"
+    filler = BODY_LINE + "\n"
+    n = max(0, (target_chars - len(head) - len(tail)) // len(filler))
+    (d / "SKILL.md").write_text(head + (filler * n) + tail, encoding="utf-8")
+    return d / "SKILL.md"
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    _write_skill(skills, "oversized-skill", 120_000)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    reset_skill_view_dedup()
+    yield home
+    reset_skill_view_dedup()
+
+
+def _view_through_executor(name, task_id, **kw):
+    """Exactly what agent/tool_executor.py does: registered handler, then layer 2."""
+    handler = registry.get_entry("skill_view").handler
+    raw = handler({"name": name, **kw}, task_id=task_id)
+    return raw, maybe_persist_tool_result(
+        content=raw,
+        tool_name="skill_view",
+        tool_use_id=f"tu_{task_id}",
+        env=None,
+        config=DEFAULT_BUDGET,
+    )
+
+
+class TestPerResultSpill:
+    def test_oversized_skill_view_returns_index_only_receipt(self, skills_home):
+        raw, delivered = _view_through_executor("oversized-skill", "t-per-result")
+
+        assert len(raw) > DEFAULT_BUDGET.resolve_threshold("skill_view")
+        assert delivered != raw, "layer 2 must still remove the oversized body"
+
+        payload = json.loads(delivered)
+        assert "[SKILL_INCOMPLETE:" in payload["notice"]
+        assert payload["load_status"] == "incomplete"
+        assert payload["content_returned"] is False
+        assert "content" not in payload
+
+        headings = [s["heading"] for s in payload["sections"]]
+        assert "Final Governing Rule" in headings
+        assert 0 < len(payload["sections"]) <= 40
+
+        # No skill body reaches the model -- not one line of it.
+        assert BODY_LINE not in delivered
+        assert FINAL_RULE not in delivered
+
+
+class _FakeEnv:
+    """Minimal remote sandbox env: records the write and reports success.
+
+    *probe_readable* False makes the readability probe on the host-side
+    spillover copy fail, which is what drives layer 2 down to the in-sandbox
+    write fallback.
+    """
+
+    def __init__(self, probe_readable=True):
+        self.written = None
+        self.probe_readable = probe_readable
+
+    def get_temp_dir(self):
+        return "/tmp"
+
+    def execute(self, cmd, timeout=30, stdin_data=None):
+        if cmd.startswith("test -r "):
+            return {"returncode": 0 if self.probe_readable else 1}
+        self.written = stdin_data
+        return {"returncode": 0}
+
+
+class TestPerResultSpillWithSandbox:
+    """Layer 2 has more than one return path once a sandbox env is present.
+    None of them may emit the generic block for a skill_view result."""
+
+    def _spill(self, env, tool_use_id):
+        handler = registry.get_entry("skill_view").handler
+        raw = handler({"name": "oversized-skill"}, task_id="t-sandbox")
+        return raw, maybe_persist_tool_result(
+            content=raw,
+            tool_name="skill_view",
+            tool_use_id=tool_use_id,
+            env=env,
+            config=DEFAULT_BUDGET,
+        )
+
+    def _assert_index_only(self, delivered):
+        payload = json.loads(delivered)
+        assert "[SKILL_INCOMPLETE:" in payload["notice"]
+        assert payload["load_status"] == "incomplete"
+        assert "content" not in payload
+        assert "<persisted-output>" not in delivered
+        assert BODY_LINE not in delivered
+        assert FINAL_RULE not in delivered
+
+    def test_visible_spillover_copy_still_yields_index_only_receipt(self, skills_home):
+        """Remote backend, spillover dir readable from inside the sandbox."""
+        env = _FakeEnv(probe_readable=True)
+        raw, delivered = self._spill(env, "tu_sandbox_visible")
+
+        # The full result still reaches disk unchanged -- nothing is lost --
+        # and the readable host-side copy is enough, so no second write.
+        spilled = skills_home / "cache" / "spillover" / "tu_sandbox_visible.txt"
+        assert spilled.read_text(encoding="utf-8") == raw
+        assert env.written is None
+
+        self._assert_index_only(delivered)
+
+    def test_in_sandbox_write_still_yields_index_only_receipt(self, skills_home):
+        """Remote backend whose sandbox cannot read the spillover copy, so
+        layer 2 falls back to writing into the sandbox temp dir."""
+        env = _FakeEnv(probe_readable=False)
+        raw, delivered = self._spill(env, "tu_sandbox_write")
+
+        # The full result still reaches disk unchanged -- nothing is lost.
+        assert env.written == raw
+
+        self._assert_index_only(delivered)
+
+
+class TestAggregateSpill:
+    """A skill_view result that is legal under every per-result cap can still be
+    removed later, by aggregate turn-budget enforcement. That decision is made
+    after skill_view has returned, and it used to discard the tool identity --
+    so the skill was replaced by the generic preview and no marker was possible.
+    """
+
+    def test_legal_size_skill_view_spilled_by_turn_budget_gets_the_marker(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.tool_result_storage import PERSISTED_OUTPUT_TAG, enforce_turn_budget
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        home = tmp_path / ".hermes"
+        skills = home / "skills"
+        skills.mkdir(parents=True)
+        _write_skill(skills, "legal-skill", 90_000)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        reset_skill_view_dedup()
+
+        handler = registry.get_entry("skill_view").handler
+        raw = handler({"name": "legal-skill"}, task_id="t-aggregate")
+
+        # Legal at layer 2: it survives the per-result threshold untouched.
+        assert len(raw) < DEFAULT_BUDGET.resolve_threshold("skill_view")
+        assert maybe_persist_tool_result(
+            content=raw, tool_name="skill_view", tool_use_id="tu_a",
+            env=None, config=DEFAULT_BUDGET,
+        ) == raw
+
+        messages = [
+            make_tool_result_message("skill_view", raw, "tu_a"),
+            make_tool_result_message("search_files", "x" * 60_000, "tu_b"),
+            make_tool_result_message("read_file", "y" * 60_000, "tu_c"),
+        ]
+        assert sum(len(m["content"]) for m in messages) > DEFAULT_BUDGET.turn_budget
+
+        enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+        delivered = messages[0]["content"]
+
+        assert delivered != raw, "the turn budget must still have spilled it"
+        payload = json.loads(delivered)
+        assert "[SKILL_INCOMPLETE:" in payload["notice"]
+        assert payload["load_status"] == "incomplete"
+        assert payload["content_returned"] is False
+        assert "content" not in payload
+        assert "Final Governing Rule" in [s["heading"] for s in payload["sections"]]
+        assert PERSISTED_OUTPUT_TAG not in delivered
+        assert BODY_LINE not in delivered
+        assert FINAL_RULE not in delivered
+
+
+class TestDedupTruthfulness:
+    """The repeat-view dedup cache records what skill_view RETURNED, which is
+    not what the model RECEIVED. After a spill it told a retry the earlier load
+    was "current and complete" -- about a body the model never saw.
+    """
+
+    def test_retry_after_per_result_spill_does_not_claim_completeness(self, skills_home):
+        raw, delivered = _view_through_executor("oversized-skill", "t-dedup-l2")
+        assert "[SKILL_INCOMPLETE:" in json.loads(delivered)["notice"]
+
+        raw2, delivered2 = _view_through_executor("oversized-skill", "t-dedup-l2")
+        retry = json.loads(raw2)
+        assert retry.get("dedup") is not True
+        assert "current and complete" not in raw2
+        # The retry executed a real load: the body was actually re-read.
+        assert FINAL_RULE in raw2
+
+    def test_retry_after_aggregate_spill_does_not_claim_completeness(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.tool_result_storage import enforce_turn_budget
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        home = tmp_path / ".hermes"
+        skills = home / "skills"
+        skills.mkdir(parents=True)
+        _write_skill(skills, "legal-skill", 90_000)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        reset_skill_view_dedup()
+
+        handler = registry.get_entry("skill_view").handler
+        raw = handler({"name": "legal-skill"}, task_id="t-dedup-l3")
+        messages = [
+            make_tool_result_message("skill_view", raw, "tu_a"),
+            make_tool_result_message("search_files", "x" * 60_000, "tu_b"),
+            make_tool_result_message("read_file", "y" * 60_000, "tu_c"),
+        ]
+        enforce_turn_budget(messages, env=None, config=DEFAULT_BUDGET)
+        assert "[SKILL_INCOMPLETE:" in json.loads(messages[0]["content"])["notice"]
+
+        raw2 = handler({"name": "legal-skill"}, task_id="t-dedup-l3")
+        retry = json.loads(raw2)
+        assert retry.get("dedup") is not True
+        assert "current and complete" not in raw2
+        assert FINAL_RULE in raw2
+
+
+class TestMarkerCannotDrift:
+    """PR #44166 shipped a marker whose emit side said "[SKILL_PRUNED:" while
+    its check side matched "[SKILL_PRUNED]"; the re-injection then fired even
+    when the marker had survived. Mirrors tests/agent/test_ghost_skill_pruning.py
+    for the incomplete-load marker: one constant, both sides.
+    """
+
+    def test_emit_and_detect_share_one_constant(self):
+        import tools.skills_tool as st
+
+        marker = st._skill_incomplete_marker("some-skill")
+        assert marker.startswith(st.SKILL_INCOMPLETE_MARKER_PREFIX)
+        assert st.has_skill_incomplete_marker(marker)
+        assert st.extract_incomplete_skill_names(marker) == ["some-skill"]
+        # The detector is BUILT from the prefix, not from a copy of it.
+        import re as _re
+        assert _re.escape(st.SKILL_INCOMPLETE_MARKER_PREFIX) in \
+            st._SKILL_INCOMPLETE_MARKER_RE.pattern
+
+    def test_the_marker_the_model_receives_is_the_one_we_detect(self, skills_home):
+        _raw, delivered = _view_through_executor("oversized-skill", "t-marker")
+        import tools.skills_tool as st
+
+        assert st.has_skill_incomplete_marker(delivered)
+        assert st.extract_incomplete_skill_names(delivered) == ["oversized-skill"]
+        assert json.loads(delivered)["notice"] == st._skill_incomplete_marker(
+            "oversized-skill"
+        )
+
+
+class TestSectionRetrieval:
+    """The index receipt is only useful if a named heading can be fetched."""
+
+    def test_named_section_returns_exactly_that_section(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        r = json.loads(
+            handler(
+                {"name": "oversized-skill", "section": "Final Governing Rule"},
+                task_id="t-section",
+            )
+        )
+        assert r["success"] is True
+        assert r["section"] == "Final Governing Rule"
+        assert r["section_found"] is True
+        assert FINAL_RULE in r["content"]
+        assert r["content"].lstrip().startswith("## Final Governing Rule")
+        # Exactly that section: none of the preceding body comes with it.
+        assert BODY_LINE not in r["content"]
+
+    def test_unknown_heading_returns_the_index_and_a_plain_notice(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        r = json.loads(
+            handler(
+                {"name": "oversized-skill", "section": "No Such Heading"},
+                task_id="t-section-miss",
+            )
+        )
+        assert r["success"] is True
+        assert r["section_found"] is False
+        assert "content" not in r
+        assert "not found" in r["notice"].lower()
+        assert "error" not in r
+        assert "Final Governing Rule" in [s["heading"] for s in r["sections"]]
+
+    def test_section_request_is_not_answered_from_the_dedup_stub(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        # A full, fitting view first, so a dedup record exists for this skill.
+        _write_skill(skills_home / "skills", "small-skill", 400)
+        handler({"name": "small-skill"}, task_id="t-section-dedup")
+        r = json.loads(
+            handler(
+                {"name": "small-skill", "section": "Final Governing Rule"},
+                task_id="t-section-dedup",
+            )
+        )
+        assert r.get("dedup") is not True
+        assert FINAL_RULE in r["content"]
+
+    def test_omitting_section_preserves_current_behaviour(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        _write_skill(skills_home / "skills", "small-skill", 400)
+        r = json.loads(handler({"name": "small-skill"}, task_id="t-section-none"))
+        assert "section" not in r
+        assert "section_found" not in r
+        assert FINAL_RULE in r["content"]
+        assert BODY_LINE in r["content"]
+
+
+class TestGuardrailSuffixAndBadInput:
+    """run_agent.append_toolguard_guidance can append text AFTER the JSON before
+    persistence. That guidance is a live instruction to the model, so the
+    receipt must carry it; and anything that does not parse must fall through to
+    the generic block rather than raise inside the storage layer."""
+
+    def test_trailing_guardrail_guidance_survives(self, skills_home):
+        from agent.tool_guardrails import ToolGuardrailDecision, append_toolguard_guidance
+        import tools.skills_tool as st
+
+        handler = registry.get_entry("skill_view").handler
+        raw = handler({"name": "oversized-skill"}, task_id="t-guard")
+        decision = ToolGuardrailDecision(
+            action="warn",
+            code="repeat_tool_calls",
+            count=4,
+            message="Vary the arguments or change approach.",
+        )
+        with_guidance = append_toolguard_guidance(raw, decision)
+        assert with_guidance != raw
+
+        delivered = maybe_persist_tool_result(
+            content=with_guidance, tool_name="skill_view", tool_use_id="tu_guard",
+            env=None, config=DEFAULT_BUDGET,
+        )
+        assert "Vary the arguments or change approach." in delivered
+        assert delivered.rstrip().endswith("]")
+        assert st.has_skill_incomplete_marker(delivered)
+        assert BODY_LINE not in delivered
+
+        payload, end = json.JSONDecoder().raw_decode(delivered)
+        assert payload["load_status"] == "incomplete"
+        assert "Tool loop warning" in delivered[end:]
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "not json at all",
+            "",
+            "[1, 2, 3]",
+            '{"success": false, "error": "nope"}',
+            '{"success": true, "name": "x"}',                 # no content key
+            '{"success": true, "name": "x", "content": null}',
+            '{"success": true, "status": "unchanged", "dedup": true, '
+            '"content_returned": false, "message": "..."}',   # the dedup stub
+        ],
+    )
+    def test_unparseable_or_bodyless_input_falls_through_without_raising(
+        self, content, tmp_path, monkeypatch
+    ):
+        """A payload the formatter declines gets exactly the generic receipt --
+        byte for byte the same string the storage layer produces with no
+        formatter registered at all."""
+        import tools.oversized_result_formatters as orf
+        import tools.skills_tool as st
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        assert st._skill_view_incomplete_result(content) is None
+
+        padded = content + "p" * 100_001
+
+        def _persist():
+            return maybe_persist_tool_result(
+                content=padded, tool_name="skill_view", tool_use_id="tu_fall",
+                env=None, config=DEFAULT_BUDGET,
+            )
+
+        delivered = _persist()
+        saved = dict(orf._FORMATTERS)
+        monkeypatch.setattr(orf, "_FORMATTERS", {})
+        try:
+            generic = _persist()
+        finally:
+            monkeypatch.setattr(orf, "_FORMATTERS", saved)
+
+        assert delivered == generic
+        assert "[SKILL_INCOMPLETE:" not in delivered
+
+
+class TestUseAccounting:
+    """A skill_view call counts as a USE because the agent is loading the skill
+    to act on it. When the body never arrives, nothing was used -- it was at
+    most viewed. The curator's stale timer keys off last_used_at, so an
+    incomplete load must not refresh it.
+    """
+
+    def test_incomplete_delivery_counts_as_a_view_not_a_use(self, skills_home):
+        from tools.skill_usage import get_record
+
+        before = get_record("oversized-skill")
+        _raw, delivered = _view_through_executor("oversized-skill", "t-accounting")
+        assert "[SKILL_INCOMPLETE:" in json.loads(delivered)["notice"]
+
+        after = get_record("oversized-skill")
+        assert after["view_count"] == before["view_count"] + 1
+        assert after["use_count"] == before["use_count"]
+        assert after["last_used_at"] == before["last_used_at"]
+        assert after["last_viewed_at"] != before["last_viewed_at"]
+
+    def test_complete_delivery_keeps_current_accounting(self, skills_home):
+        from tools.skill_usage import get_record
+
+        _write_skill(skills_home / "skills", "small-skill", 400)
+        before = get_record("small-skill")
+        raw, delivered = _view_through_executor("small-skill", "t-accounting-ok")
+        assert delivered == raw and FINAL_RULE in delivered
+
+        after = get_record("small-skill")
+        assert after["view_count"] == before["view_count"] + 1
+        assert after["use_count"] == before["use_count"] + 1
+        assert after["last_used_at"] is not None
+
+
+# ── Batched-correction coverage (review findings B1-B4) ─────────────────────
+# Each class below reproduces one blocking finding from the exact-commit review
+# of 5e2c4dd988 and pins the corrected behaviour.
+
+def _write_raw_skill(skills_dir, name, body):
+    """Write a SKILL.md whose body is *body* verbatim, after frontmatter."""
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "SKILL.md"
+    path.write_text(
+        f"---\nname: {name}\ndescription: A skill used by the incomplete-load "
+        f"tests\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _entries(payload):
+    """Leaf navigation targets a response offered, in order."""
+    return list(payload.get("sections") or [])
+
+
+def _groups(payload):
+    """Group navigation targets a response offered, in order."""
+    return list(payload.get("section_groups") or [])
+
+
+def _crawl_navigation(handler, name, task_id, payload, budget=4000):
+    """Follow ONLY selectors the tool returned; never construct one.
+
+    Returns (leaf entries reached, largest response seen, number of calls).
+    """
+    leaves, seen, calls, biggest = {}, set(), 0, len(json.dumps(payload))
+    queue = [("leaf", e) for e in _entries(payload)]
+    queue += [("group", g) for g in _groups(payload)]
+    while queue:
+        kind, entry = queue.pop(0)
+        selector = entry["selector"]
+        if kind == "leaf":
+            leaves[selector] = entry
+            continue
+        if selector in seen:
+            continue
+        seen.add(selector)
+        calls += 1
+        assert calls <= budget, "navigation did not converge"
+        raw = handler({"name": name, "section": selector}, task_id=task_id)
+        biggest = max(biggest, len(raw))
+        sub = json.loads(raw)
+        # A group selector is navigation only -- never an instruction body.
+        assert "content" not in sub, f"group selector {selector} returned a body"
+        queue += [("leaf", e) for e in _entries(sub)]
+        queue += [("group", g) for g in _groups(sub)]
+    return leaves, biggest, calls
+
+
+class TestCrossTaskRevocation:
+    """B1: identical payloads from two tasks share one delivery digest. A spill
+    of either one must never leave the other holding a 'current and complete'
+    claim, and the use counters must land back on the earliest pre-bump state.
+    """
+
+    def test_spill_revokes_every_claim_for_that_exact_payload(self, skills_home):
+        from tools.skill_usage import get_record
+
+        handler = registry.get_entry("skill_view").handler
+        before = dict(get_record("oversized-skill"))
+
+        raw_a = handler({"name": "oversized-skill"}, task_id="task-A")
+        raw_b = handler({"name": "oversized-skill"}, task_id="task-B")
+        assert raw_a == raw_b, "the two tasks must share one delivery digest"
+
+        # The EARLIER task's result is the one the budget spills.
+        delivered = maybe_persist_tool_result(
+            content=raw_a,
+            tool_name="skill_view",
+            tool_use_id="tu_task_a",
+            env=None,
+            config=DEFAULT_BUDGET,
+        )
+        assert "[SKILL_INCOMPLETE:" in json.loads(delivered)["notice"]
+
+        # Neither task may retain a false-complete cache claim.
+        for task in ("task-A", "task-B"):
+            retry = json.loads(handler({"name": "oversized-skill"}, task_id=task))
+            assert retry.get("dedup") is not True, f"{task} kept a stale claim"
+            assert "current and complete" not in json.dumps(retry)
+
+    def test_use_counters_return_to_the_earliest_pre_bump_state(self, skills_home):
+        from tools.skill_usage import get_record
+
+        handler = registry.get_entry("skill_view").handler
+        before = dict(get_record("oversized-skill"))
+
+        raw_a = handler({"name": "oversized-skill"}, task_id="task-A")
+        raw_b = handler({"name": "oversized-skill"}, task_id="task-B")
+        assert raw_a == raw_b
+        bumped = dict(get_record("oversized-skill"))
+        assert bumped["use_count"] == before["use_count"] + 2
+
+        maybe_persist_tool_result(
+            content=raw_a,
+            tool_name="skill_view",
+            tool_use_id="tu_task_a",
+            env=None,
+            config=DEFAULT_BUDGET,
+        )
+
+        after = dict(get_record("oversized-skill"))
+        # Reverse-order restoration: the OLDEST snapshot is applied last.
+        assert after["use_count"] == before["use_count"]
+        assert after["last_used_at"] == before["last_used_at"]
+        # View accounting is untouched: both views really happened.
+        assert after["view_count"] == before["view_count"] + 2
+
+    def test_resetting_one_task_leaves_the_other_claim_revocable(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        raw = handler({"name": "oversized-skill"}, task_id="task-A")
+        assert raw == handler({"name": "oversized-skill"}, task_id="task-B")
+
+        reset_skill_view_dedup("task-A")  # e.g. task A's context was compressed
+        maybe_persist_tool_result(
+            content=raw,
+            tool_name="skill_view",
+            tool_use_id="tu_reset",
+            env=None,
+            config=DEFAULT_BUDGET,
+        )
+        retry = json.loads(handler({"name": "oversized-skill"}, task_id="task-B"))
+        assert retry.get("dedup") is not True
+
+    def test_a_newer_changed_view_is_never_revoked_by_an_older_spill(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        stale = handler({"name": "oversized-skill"}, task_id="task-A")
+
+        # The skill changes on disk and is loaded again: different bytes, so a
+        # different digest and a different dedup fingerprint.
+        _write_skill(skills_home / "skills", "oversized-skill", 121_000)
+        fresh = handler({"name": "oversized-skill"}, task_id="task-A")
+        assert fresh != stale
+
+        # Spilling the STALE payload must not withdraw the fresh claim.
+        maybe_persist_tool_result(
+            content=stale,
+            tool_name="skill_view",
+            tool_use_id="tu_stale",
+            env=None,
+            config=DEFAULT_BUDGET,
+        )
+        again = json.loads(handler({"name": "oversized-skill"}, task_id="task-A"))
+        assert again.get("dedup") is True
+
+
+class TestEveryHeadingIsReachable:
+    """B2: more than 40 headings. Every occurrence must be reachable by
+    recursively following selectors the tool itself returned, and every
+    response must stay bounded.
+    """
+
+    HEADINGS = 120
+
+    def _skill(self, skills_home):
+        body = "".join(
+            f"## Heading {i:03d}\n\nprose for {i:03d}\n" + ("x" * 900) + "\n\n"
+            for i in range(1, self.HEADINGS + 1)
+        )
+        _write_raw_skill(skills_home / "skills", "many-headings", body)
+        return "many-headings"
+
+    def test_recursive_navigation_reaches_every_heading(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        raw, delivered = _view_through_executor(name, "t-many")
+        assert len(raw) > 100_000, "fixture must trip the per-result threshold"
+        receipt = json.loads(delivered)
+        assert receipt["load_status"] == "incomplete"
+        assert "content" not in receipt
+
+        leaves, biggest, _calls = _crawl_navigation(
+            handler, name, "t-many-nav", receipt
+        )
+        found = {e["heading"] for e in leaves.values()}
+        expected = {f"Heading {i:03d}" for i in range(1, self.HEADINGS + 1)}
+        assert expected <= found, sorted(expected - found)[:10]
+        assert biggest <= 100_000, "a navigation response became a spill candidate"
+
+    def test_no_omitted_count_without_a_route(self, skills_home):
+        name = self._skill(skills_home)
+        _raw, delivered = _view_through_executor(name, "t-many-omit")
+        receipt = json.loads(delivered)
+        assert "sections_omitted" not in receipt
+        assert _entries(receipt) or _groups(receipt)
+
+    def test_every_returned_selector_resolves_to_its_own_heading(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        _raw, delivered = _view_through_executor(name, "t-many-resolve")
+        leaves, _b, _c = _crawl_navigation(
+            handler, name, "t-many-resolve", json.loads(delivered)
+        )
+        for selector, entry in sorted(leaves.items()):
+            if not entry["heading"].startswith("Heading "):
+                continue
+            got = json.loads(
+                handler({"name": name, "section": selector}, task_id="t-many-resolve")
+            )
+            assert got["section_found"] is True, selector
+            assert got["content"].lstrip().startswith(f"## {entry['heading']}")
+
+
+class TestOversizedSectionHasNoPartialBody:
+    """B3: a section too large to return must return NO body fragment, and its
+    part selectors must reconstruct the original span byte-for-byte.
+    """
+
+    def _skill(self, skills_home):
+        body = "## Big Leaf\n\n" + ("y" * 79 + "\n") * 1_700
+        path = _write_raw_skill(skills_home / "skills", "big-leaf", body)
+        return "big-leaf", path
+
+    def test_oversized_leaf_returns_a_marker_and_no_fragment(self, skills_home):
+        name, _path = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": name, "section": "Big Leaf"}, task_id="t-leaf")
+        )
+        assert "content" not in got, "an oversized section returned a body fragment"
+        assert got["load_status"] == "incomplete"
+        assert "[SKILL_INCOMPLETE:" in got["notice"]
+        assert got.get("section_found") is not True
+        assert _entries(got) or _groups(got)
+
+    def test_part_selectors_reconstruct_the_span_exactly(self, skills_home):
+        name, path = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        full = path.read_text(encoding="utf-8")
+        span = full[full.index("## Big Leaf") :]
+
+        got = json.loads(
+            handler({"name": name, "section": "Big Leaf"}, task_id="t-leaf-parts")
+        )
+        leaves, biggest, _calls = _crawl_navigation(handler, name, "t-leaf-parts", got)
+        assert biggest <= 100_000
+
+        rebuilt = ""
+        parts = [s for s in leaves if ".part" in s]
+        assert len(parts) > 1, "an oversized leaf must be split into parts"
+        for selector in sorted(parts, key=lambda s: int(s.split(".part")[1])):
+            piece = json.loads(
+                handler({"name": name, "section": selector}, task_id="t-leaf-parts")
+            )
+            assert piece["section_found"] is True, selector
+            assert piece["section_part_count"] == len(parts)
+            assert piece["section_part"] == int(selector.split(".part")[1])
+            assert "[SKILL_INCOMPLETE:" not in json.dumps(piece)
+            assert len(piece["content"]) <= 60_000
+            rebuilt += piece["content"]
+        assert rebuilt == span, "parts must tile the span with no gap or overlap"
+
+
+class TestPreambleIsReachable:
+    """Skills routinely open with prose before the first heading -- and always
+    with frontmatter. Without an entry of its own that text has no selector, so
+    an index that names only headings still strands it.
+    """
+
+    def test_the_text_before_the_first_heading_has_its_own_selector(self, skills_home):
+        _write_raw_skill(
+            skills_home / "skills",
+            "with-preamble",
+            "Read this before anything else.\n\n## Later\n\nlater prose\n",
+        )
+        handler = registry.get_entry("skill_view").handler
+        index = json.loads(
+            handler(
+                {"name": "with-preamble", "section": "No Such Heading"},
+                task_id="t-preamble",
+            )
+        )
+        preamble = [e for e in _entries(index) if e["selector"] == "#0"]
+        assert preamble, [e["selector"] for e in _entries(index)]
+
+        got = json.loads(
+            handler({"name": "with-preamble", "section": "#0"}, task_id="t-preamble")
+        )
+        assert got["section_found"] is True
+        assert "Read this before anything else." in got["content"]
+        assert "later prose" not in got["content"]
+
+
+class TestSectionsAreHierarchical:
+    """B3's root cause: a section that ended at the next heading of ANY level
+    could only overflow the ceiling by containing no headings at all, which is
+    exactly why "request its sub-headings" was unsatisfiable. A section runs to
+    the next heading of the SAME OR A HIGHER level, so sub-sections come with
+    their parent -- and an oversized parent has real children to hand back.
+    """
+
+    def test_a_parent_section_carries_its_sub_sections(self, skills_home):
+        body = (
+            "# Parent\n\nparent prose\n\n"
+            "## Child One\n\nchild one prose\n\n"
+            "### Grandchild\n\ngrandchild prose\n\n"
+            "# Sibling\n\nsibling prose\n"
+        )
+        _write_raw_skill(skills_home / "skills", "nested", body)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": "nested", "section": "Parent"}, task_id="t-nest")
+        )
+        assert got["section_found"] is True
+        for expected in ("parent prose", "child one prose", "grandchild prose"):
+            assert expected in got["content"], expected
+        # ...and stops at the next heading of the same level.
+        assert "sibling prose" not in got["content"]
+
+    def test_an_oversized_parent_hands_back_its_children(self, skills_home):
+        filler = ("k" * 99 + "\n") * 350  # 35,000 chars per child
+        body = (
+            "# Parent\n\nparent prose\n\n"
+            + "".join(f"## Child {i}\n\n{filler}\n" for i in range(1, 4))
+        )
+        _write_raw_skill(skills_home / "skills", "big-parent", body)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": "big-parent", "section": "Parent"}, task_id="t-bigparent")
+        )
+        assert "content" not in got
+        assert got["load_status"] == "incomplete"
+        assert got["section_chars"] > 60_000
+        offered = [e["heading"] for e in _entries(got)]
+        for i in range(1, 4):
+            assert f"Child {i}" in offered, offered
+        # Its own prose is reachable too, as a part -- nothing is stranded.
+        assert any(".part" in e["selector"] for e in _entries(got))
+        own = json.loads(
+            handler(
+                {"name": "big-parent", "section": [e for e in _entries(got)
+                                                   if ".part" in e["selector"]][0]["selector"]},
+                task_id="t-bigparent",
+            )
+        )
+        assert "parent prose" in own["content"]
+
+
+class TestDuplicateHeadingsAreHonest:
+    """B4: a repeated heading is ambiguous, not silently the first match."""
+
+    def _skill(self, skills_home):
+        body = (
+            "## Alpha\n\nfirst alpha body\n\n"
+            "## Beta\n\nbeta body\n\n"
+            "## Alpha\n\nsecond alpha body\n"
+        )
+        _write_raw_skill(skills_home / "skills", "dupe-headings", body)
+        return "dupe-headings"
+
+    def test_exact_name_reports_ambiguity_and_returns_no_body(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": name, "section": "Alpha"}, task_id="t-dupe")
+        )
+        assert got.get("section_found") is not True
+        assert "content" not in got
+        assert got["section_ambiguous"] is True
+        assert got["load_status"] == "incomplete"
+        assert "[SKILL_INCOMPLETE:" in got["notice"]
+        selectors = [e["selector"] for e in _entries(got)]
+        assert len(selectors) == 2, selectors
+
+    def test_each_occurrence_selector_returns_its_own_content(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": name, "section": "Alpha"}, task_id="t-dupe-each")
+        )
+        bodies = []
+        for entry in _entries(got):
+            one = json.loads(
+                handler(
+                    {"name": name, "section": entry["selector"]},
+                    task_id="t-dupe-each",
+                )
+            )
+            assert one["section_found"] is True
+            bodies.append(one["content"])
+        assert "first alpha body" in bodies[0]
+        assert "second alpha body" in bodies[1]
+        assert "second alpha body" not in bodies[0]
+        assert "first alpha body" not in bodies[1]
+
+    def test_a_unique_heading_still_answers_to_its_exact_text(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": name, "section": "Beta"}, task_id="t-dupe-unique")
+        )
+        assert got["section_found"] is True
+        assert "beta body" in got["content"]
+        assert "[SKILL_INCOMPLETE:" not in json.dumps(got)
+
+    def test_the_index_keeps_duplicate_occurrences_separate(self, skills_home):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler({"name": name, "section": "No Such Heading"}, task_id="t-dupe-idx")
+        )
+        headings = [e["heading"] for e in _entries(got)]
+        assert headings.count("Alpha") == 2
+        selectors = [e["selector"] for e in _entries(got)]
+        assert len(selectors) == len(set(selectors))
+
+
+# ── Linked-file continuation (terminal review, 2026-08-23) ──────────────
+# A linked file is a DIFFERENT document from SKILL.md with its own heading
+# index. A receipt for one that does not carry file_path sends the model back
+# to SKILL.md, where the same heading text and the same #n both resolve -- so
+# the answer is a confident, unmarked section of the WRONG file. These tests
+# follow only the call literal the receipt itself hands the model.
+
+_FOLLOW_RE = re.compile(
+    r'skill_view\(name="([^"]+)"(?:,\s*file_path="([^"]+)")?,\s*section='
+)
+
+MAIN_OVERVIEW = "MAIN-OVERVIEW-BODY"
+MAIN_PROCEDURE = "MAIN-PROCEDURE-BODY"
+LINKED_OVERVIEW = "LINKED-OVERVIEW-BODY"
+LINKED_OMEGA = "LINKED-OMEGA-BODY"
+BIG_FILE = "references/big.md"
+
+
+def _follow_the_notice(payload):
+    """The call the receipt literally tells the model to make next.
+
+    Reads ONLY the actionable call literal out of ``notice``: that string is
+    all the model has, so anything this helper infers from elsewhere in the
+    payload would be evidence the model never gets.
+    """
+    notice = payload.get("notice") or ""
+    match = _FOLLOW_RE.search(notice)
+    assert match, f"no actionable skill_view call in notice: {notice!r}"
+    args = {"name": match.group(1)}
+    if match.group(2):
+        args["file_path"] = match.group(2)
+    return args
+
+
+def _selector_for(payload, heading):
+    """The selector this payload's own index gives for *heading*."""
+    hits = [e for e in _entries(payload) if e["heading"] == heading]
+    assert len(hits) == 1, f"{heading!r} not uniquely advertised: {_entries(payload)}"
+    return hits[0]["selector"]
+
+
+class TestLinkedFileContinuation:
+    """Requirements 1-4: a linked-file continuation stays on the linked file."""
+
+    def _skill(self, skills_home):
+        """SKILL.md and references/big.md that collide on BOTH grammars.
+
+        Heading text: 'Overview' is a heading in each file.
+        Numeric: '#3' is 'Procedure' in SKILL.md and 'Omega' in the linked
+        file -- unrelated positions, which is the normal case for two
+        different documents, not a contrived one.
+        """
+        skills = skills_home / "skills"
+        _write_raw_skill(
+            skills,
+            "linked-skill",
+            f"# linked-skill\n\n## Overview\n\n{MAIN_OVERVIEW}\n\n"
+            f"## Procedure\n\n{MAIN_PROCEDURE}\n",
+        )
+        big = skills / "linked-skill" / BIG_FILE
+        big.parent.mkdir(parents=True, exist_ok=True)
+        big.write_text(
+            f"# Reference\n\nreference intro\n\n"
+            f"## Overview\n\n{LINKED_OVERVIEW}\n\n"
+            f"## Omega\n\n{LINKED_OMEGA}\n\n"
+            f"## Bulk\n\n" + ("filler line for the linked reference file\n" * 3000),
+            encoding="utf-8",
+        )
+        return "linked-skill"
+
+    def _receipt(self, skills_home, task_id):
+        name = self._skill(skills_home)
+        raw, delivered = _view_through_executor(
+            name, task_id, file_path=BIG_FILE
+        )
+        assert len(raw) > DEFAULT_BUDGET.resolve_threshold("skill_view"), (
+            "fixture must trip the per-result threshold"
+        )
+        receipt = json.loads(delivered)
+        assert receipt["load_status"] == "incomplete"
+        assert receipt["file"] == BIG_FILE
+        return name, receipt
+
+    def test_the_receipt_instructs_a_continuation_that_keeps_file_path(
+        self, skills_home
+    ):
+        _name, receipt = self._receipt(skills_home, "t-linked-marker")
+        assert f'file_path="{BIG_FILE}"' in receipt["notice"], (
+            "the only actionable instruction in the receipt drops file_path"
+        )
+        assert _follow_the_notice(receipt).get("file_path") == BIG_FILE
+
+    def test_a_colliding_heading_returns_the_linked_file_not_the_main_skill(
+        self, skills_home
+    ):
+        """Terminal-review failure 1: 'Overview' is in both files."""
+        _name, receipt = self._receipt(skills_home, "t-linked-collide")
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {**_follow_the_notice(receipt), "section": "Overview"},
+                task_id="t-linked-collide",
+            )
+        )
+        assert got["section_found"] is True
+        assert LINKED_OVERVIEW in got["content"]
+        assert MAIN_OVERVIEW not in got["content"], (
+            "the receipt's own instruction resolved against SKILL.md"
+        )
+        assert got["file"] == BIG_FILE
+
+    def test_a_numeric_selector_is_scoped_to_the_linked_files_own_index(
+        self, skills_home
+    ):
+        """Terminal-review failure 2: #3 means different sections per file."""
+        _name, receipt = self._receipt(skills_home, "t-linked-numeric")
+        selector = _selector_for(receipt, "Omega")
+        assert selector == "#3", f"fixture must collide on #3, got {selector}"
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {**_follow_the_notice(receipt), "section": selector},
+                task_id="t-linked-numeric",
+            )
+        )
+        assert got["section_found"] is True
+        assert LINKED_OMEGA in got["content"]
+        for sentinel in (MAIN_OVERVIEW, MAIN_PROCEDURE):
+            assert sentinel not in got["content"], (
+                f"advertised {selector} as 'Omega' and answered out of SKILL.md, "
+                f"whose {selector} is an unrelated section"
+            )
+
+    def test_every_advertised_selector_resolves_inside_the_linked_file(
+        self, skills_home
+    ):
+        _name, receipt = self._receipt(skills_home, "t-linked-all")
+        handler = registry.get_entry("skill_view").handler
+        follow = _follow_the_notice(receipt)
+        for entry in _entries(receipt):
+            got = json.loads(
+                handler(
+                    {**follow, "section": entry["selector"]},
+                    task_id="t-linked-all",
+                )
+            )
+            assert got["file"] == BIG_FILE, entry
+            assert MAIN_OVERVIEW not in json.dumps(got), entry
+            assert MAIN_PROCEDURE not in json.dumps(got), entry
+
+    def test_a_section_answer_keeps_file_path_in_its_continuation(
+        self, skills_home
+    ):
+        """Requirement 2: the hop AFTER a successful section stays on the file."""
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {"name": name, "file_path": BIG_FILE, "section": "Omega"},
+                task_id="t-linked-answer",
+            )
+        )
+        assert got["section_found"] is True
+        assert LINKED_OMEGA in got["content"]
+        assert f'file_path="{BIG_FILE}"' in got["notice"]
+        assert _follow_the_notice(got)["file_path"] == BIG_FILE
+
+    def test_a_navigation_answer_keeps_file_path_in_its_continuation(
+        self, skills_home
+    ):
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {"name": name, "file_path": BIG_FILE, "section": "No Such Heading"},
+                task_id="t-linked-nav",
+            )
+        )
+        assert got["section_found"] is False
+        assert f'file_path="{BIG_FILE}"' in got["notice"]
+        assert _follow_the_notice(got)["file_path"] == BIG_FILE
+
+    def test_an_oversized_linked_section_keeps_file_path_in_its_continuation(
+        self, skills_home
+    ):
+        """The no-fragment path for a section too large to return whole."""
+        name = self._skill(skills_home)
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {"name": name, "file_path": BIG_FILE, "section": "Bulk"},
+                task_id="t-linked-oversized",
+            )
+        )
+        assert got.get("section_found") is not True
+        assert "content" not in got
+        assert f'file_path="{BIG_FILE}"' in got["notice"]
+        follow = _follow_the_notice(got)
+        assert follow["file_path"] == BIG_FILE
+        part = json.loads(
+            handler(
+                {**follow, "section": _entries(got)[0]["selector"]},
+                task_id="t-linked-oversized",
+            )
+        )
+        assert part["file"] == BIG_FILE
+        assert f'file_path="{BIG_FILE}"' in part["notice"]
+
+    def test_the_marker_still_reports_the_skill_name_it_always_did(
+        self, skills_home
+    ):
+        """Requirement 5: marker detection and name extraction do not drift."""
+        import tools.skills_tool as st
+
+        name, receipt = self._receipt(skills_home, "t-linked-detect")
+        rendered = json.dumps(receipt)
+        assert st.has_skill_incomplete_marker(rendered)
+        assert st.extract_incomplete_skill_names(rendered) == [name]
+
+
+class TestMainSkillContinuationIsUnchanged:
+    """Requirement 5: nothing above may alter the main-SKILL.md path."""
+
+    def test_a_main_skill_receipt_instructs_a_call_with_no_file_path(
+        self, skills_home
+    ):
+        _raw, delivered = _view_through_executor("oversized-skill", "t-main-shape")
+        receipt = json.loads(delivered)
+        assert "file_path=" not in receipt["notice"]
+        assert _follow_the_notice(receipt) == {"name": "oversized-skill"}
+
+    def test_a_main_skill_section_answer_instructs_no_file_path(self, skills_home):
+        handler = registry.get_entry("skill_view").handler
+        got = json.loads(
+            handler(
+                {"name": "oversized-skill", "section": "Final Governing Rule"},
+                task_id="t-main-answer",
+            )
+        )
+        assert got["section_found"] is True
+        assert "file_path=" not in got["notice"]

--- a/tools/oversized_result_formatters.py
+++ b/tools/oversized_result_formatters.py
@@ -1,0 +1,86 @@
+"""Optional per-tool replacement formatters for results that got persisted.
+
+`tools/tool_result_storage.py` protects the context window by writing an
+oversized tool result to the sandbox and putting a generic
+``<persisted-output>`` preview in its place. That preview is the right answer
+for a search or a file read -- the model is told where the rest lives and can
+go and get it.
+
+It is the wrong answer for a result whose whole point is that the model read
+all of it. A `skill_view` preview still opens with ``"success": true`` and a
+fragment of the skill body, so the model believes a mandatory skill is loaded
+when most of it was dropped.
+
+This registry lets exactly those tools say what their receipt should look like
+when their content did NOT reach the model:
+
+    register_formatter("skill_view", _skill_view_incomplete_result)
+
+The contract is deliberately narrow:
+
+* A formatter is consulted ONLY after the storage layer has already decided,
+  on its own, to persist a result. It cannot change a threshold, a persistence
+  decision, the aggregate candidate order, or what is written to disk -- the
+  full result is on disk unchanged either way. It only changes the rendered
+  receipt.
+* ``formatter(content, *, tool_name) -> str | None``. Returning ``None`` (or
+  anything that is not a non-empty string) means "no opinion": the caller
+  emits its normal generic block.
+* A formatter that raises is treated as ``None`` and logged. A broken
+  formatter degrades to today's behaviour; it never fails a tool call.
+* The registry is EMPTY by default. With nothing registered, every lookup is
+  one ``dict.get`` returning ``None`` and the storage layer is byte-identical
+  to what it was before this module existed.
+"""
+
+import logging
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# fn(content, *, tool_name) -> replacement receipt, or None to fall through.
+OversizedResultFormatter = Callable[..., Optional[str]]
+
+_FORMATTERS: Dict[str, OversizedResultFormatter] = {}
+
+
+def register_formatter(tool_name: str, formatter: OversizedResultFormatter) -> None:
+    """Register *formatter* as the persisted-result receipt for *tool_name*."""
+    if not tool_name or not callable(formatter):
+        raise ValueError("register_formatter needs a tool name and a callable")
+    _FORMATTERS[str(tool_name)] = formatter
+
+
+def unregister_formatter(tool_name: str) -> None:
+    """Remove any formatter for *tool_name* (no-op when none is registered)."""
+    _FORMATTERS.pop(str(tool_name), None)
+
+
+def has_formatter(tool_name: str) -> bool:
+    """True when *tool_name* has a replacement formatter registered."""
+    return bool(tool_name) and str(tool_name) in _FORMATTERS
+
+
+def format_oversized_result(content: str, tool_name: str) -> Optional[str]:
+    """Return a tool-specific receipt for persisted *content*, or None.
+
+    None means the caller keeps its generic ``<persisted-output>`` block. That
+    is the answer for every tool without a formatter, for a formatter that
+    declines, and for a formatter that raises.
+    """
+    if not tool_name:
+        return None
+    formatter = _FORMATTERS.get(str(tool_name))
+    if formatter is None:
+        return None
+    try:
+        replacement = formatter(content, tool_name=str(tool_name))
+    except Exception as exc:
+        logger.warning(
+            "Oversized-result formatter for %s failed, using generic receipt: %s",
+            tool_name, exc,
+        )
+        return None
+    if isinstance(replacement, str) and replacement:
+        return replacement
+    return None

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -860,6 +860,42 @@ def bump_view(skill_name: str) -> None:
     _mutate(skill_name, _apply)
 
 
+# Fields bump_use() owns. use_snapshot()/revert_use() capture and restore
+# exactly these, so a use that turned out never to have happened leaves no
+# trace -- including in last_used_at, which agent/curator.py reads as the
+# staleness clock.
+_USE_FIELDS = (
+    "use_count",
+    "last_used_at",
+    "patch_generation",
+    "last_reused_patch_generation",
+)
+
+
+def use_snapshot(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Capture the bump_use()-owned fields of *record* for a later revert."""
+    return {k: record.get(k) for k in _USE_FIELDS}
+
+
+def revert_use(skill_name: str, snapshot: Dict[str, Any]) -> None:
+    """Undo a bump_use() whose skill body never reached the model.
+
+    Called from the persisted-result formatter when the skill_view result that
+    triggered the bump was replaced by an incomplete-load receipt: the agent
+    viewed the skill, it did not use it. Restores the exact pre-bump values
+    rather than decrementing, so a concurrent patch cannot be lost.
+    """
+    if not isinstance(snapshot, dict) or not snapshot:
+        return
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        for key in _USE_FIELDS:
+            if key in snapshot:
+                rec[key] = snapshot[key]
+
+    _mutate(skill_name, _apply)
+
+
 def bump_use(
     skill_name: str,
     *,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -66,6 +66,7 @@ Usage:
     content = skill_view("axolotl", "references/dataset-formats.md")
 """
 
+import hashlib
 import json
 import logging
 import time
@@ -79,6 +80,9 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, Any, List, Optional, Set, Tuple
 
 from tools.registry import registry, tool_error
+from tools.oversized_result_formatters import (
+    register_formatter as register_oversized_result_formatter,
+)
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
@@ -1088,6 +1092,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    section: str = None,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -1100,6 +1105,12 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        section: Optional exact heading to return instead of the whole body.
+            Used to retrieve a skill one named section at a time after a load
+            came back [SKILL_INCOMPLETE]. An unknown heading returns the
+            bounded heading index and a notice, not an error. Selectors are
+            scoped to the document actually served, so a section of a linked
+            file must be requested with that file's file_path.
 
     Returns:
         JSON string with skill content or error message
@@ -1619,19 +1630,19 @@ def skill_view(
                     exc_info=True,
                 )
 
-            return json.dumps(
-                {
-                    "success": True,
-                    "name": name,
-                    "file": file_path,
-                    "content": content,
-                    "file_type": target_file.suffix,
-                    # Internal: absolute source path for the repeat-view dedup
-                    # fingerprint (mtime+size change detection).
-                    "_source_path": str(target_file),
-                },
-                ensure_ascii=False,
-            )
+            linked_result = {
+                "success": True,
+                "name": name,
+                "file": file_path,
+                "content": content,
+                "file_type": target_file.suffix,
+                # Internal: absolute source path for the repeat-view dedup
+                # fingerprint (mtime+size change detection).
+                "_source_path": str(target_file),
+            }
+            if section:
+                _apply_section_selection(linked_result, section)
+            return json.dumps(linked_result, ensure_ascii=False)
 
         # Reuse the parse from the platform check above
         frontmatter = parsed_frontmatter
@@ -1929,6 +1940,9 @@ def skill_view(
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        if section:
+            _apply_section_selection(result, section)
+
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:
@@ -2013,6 +2027,10 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+            "section": {
+                "type": "string",
+                "description": "OPTIONAL: Exact heading to return instead of the whole body (e.g. 'Final Governing Rule'). Use this after a load came back with a [SKILL_INCOMPLETE] notice, retrieving one named heading from its 'sections' index at a time. An unknown heading returns the heading index, not an error. If the notice was for a linked file (the result carries a 'file' key), pass the SAME file_path alongside section: headings and #n selectors are positions within that file, and omitting file_path silently answers out of SKILL.md instead.",
+            },
         },
         "required": ["name"],
     },
@@ -2039,6 +2057,17 @@ _skill_view_tracker: Dict[str, Dict[tuple, tuple]] = {}
 _skill_view_tracker_lock = threading.Lock()
 _SKILL_VIEW_DEDUP_CAP = 200
 
+# ── Delivery index ──────────────────────────────────────────────────────
+# Two things are decided when skill_view returns: a dedup record is written,
+# and the skill is counted as USED. Both are claims about a body the model has
+# not received yet -- delivery is only settled later, at the persistence
+# boundary in tools/tool_result_storage.py. This index is the seam between the
+# two moments: digest of the exact JSON that was served -> what was claimed for
+# it, newest last. The persisted-result formatter looks itself up here and
+# withdraws both claims when the body did not survive. Same lock, same
+# lifetime and same reset hook as the dedup cache; bounded by the same cap.
+_skill_view_delivery_index: Dict[str, list] = {}
+
 _SKILL_VIEW_DEDUP_MESSAGE = (
     "Skill content unchanged since it was loaded earlier in this "
     "conversation — refer to the earlier skill_view result; it is still "
@@ -2059,18 +2088,27 @@ def _skill_view_fingerprint(payload: dict) -> tuple | None:
         return None
 
 
-def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
-    """Record a served skill_view so an identical repeat can be deduped."""
+def _skill_view_delivery_digest(delivered: str) -> str:
+    """Digest of the exact JSON text a skill_view served."""
+    return hashlib.sha256(delivered.encode("utf-8", "replace")).hexdigest()
+
+
+def _record_skill_view(task_id, name, file_path, payload: dict) -> tuple | None:
+    """Record a served skill_view so an identical repeat can be deduped.
+
+    Returns ``(key, fingerprint)`` when a record was written, else None, so the
+    caller can note it in the delivery index for possible revocation.
+    """
     if not task_id:
-        return
+        return None
     # Never dedup setup-needed views: readiness depends on config/env state
     # that can change without the skill file changing, and the model must
     # see the refreshed setup status on a re-view.
     if payload.get("setup_needed") or payload.get("readiness_status") == "setup_needed":
-        return
+        return None
     fp = _skill_view_fingerprint(payload)
     if fp is None:
-        return
+        return None
     key = (str(payload.get("name") or name), file_path or "")
     with _skill_view_tracker_lock:
         cache = _skill_view_tracker.setdefault(str(task_id), {})
@@ -2080,6 +2118,79 @@ def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
                 cache.pop(next(iter(cache)))
             except (StopIteration, KeyError):
                 break
+    return key, fp
+
+
+def _note_skill_view_delivery(delivered, task_id, recorded, skill_name, use_snapshot) -> None:
+    """Index what was claimed for the exact JSON *delivered*."""
+    if not delivered or (recorded is None and not use_snapshot):
+        return
+    with _skill_view_tracker_lock:
+        entries = _skill_view_delivery_index.setdefault(
+            _skill_view_delivery_digest(delivered), []
+        )
+        entries.append((str(task_id) if task_id else None, recorded, skill_name, use_snapshot))
+        while len(_skill_view_delivery_index) > _SKILL_VIEW_DEDUP_CAP:
+            try:
+                _skill_view_delivery_index.pop(next(iter(_skill_view_delivery_index)))
+            except (StopIteration, KeyError):
+                break
+
+
+def _revoke_skill_view_delivery(delivered: str) -> bool:
+    """Withdraw the claims made for *delivered*, which never reached the model.
+
+    A digest identifies the exact JSON that was served, NOT the call that served
+    it: two tasks viewing the same unchanged skill produce byte-identical
+    payloads and therefore share one digest. The formatter contract carries no
+    call identity, so there is no honest way to tell which of them is the one
+    being spilled -- and guessing (popping the newest) revokes the wrong task,
+    leaving the spilled one holding a "current and complete" claim for a body it
+    never received. So we withdraw EVERY outstanding claim for the digest.
+
+    Over-revoking is the safe direction. A skill that really was delivered may
+    be forced to reload, and its use count may be rolled back further than it
+    strictly had to be; both are cheap. Telling a task a mandatory skill is
+    loaded when it is not is the failure this whole path exists to prevent.
+
+    Drops each task's dedup record only while its cached fingerprint still
+    matches what was recorded, so a NEWER view of the same skill (different
+    bytes, different digest) is never touched. Use snapshots are restored in
+    reverse registration order, oldest applied last, so repeated bumps of one
+    skill land back on the earliest pre-bump state. View accounting is left
+    alone: the agent really did view this skill.
+
+    Returns True when anything was withdrawn.
+    """
+    if not delivered:
+        return False
+    digest = _skill_view_delivery_digest(delivered)
+    withdrew = False
+    with _skill_view_tracker_lock:
+        entries = _skill_view_delivery_index.pop(digest, None)
+        if not entries:
+            return False
+        for task_id, recorded, _skill_name, _snapshot in entries:
+            if recorded is None or task_id is None:
+                continue
+            key, fp = recorded
+            cache = _skill_view_tracker.get(task_id)
+            if cache is not None and cache.get(key) == fp:
+                cache.pop(key, None)
+                if not cache:
+                    _skill_view_tracker.pop(task_id, None)
+                withdrew = True
+    for _task_id, _recorded, skill_name, use_snapshot in reversed(entries):
+        if not skill_name or not use_snapshot:
+            continue
+        try:
+            from tools.skill_usage import revert_use
+
+            revert_use(skill_name, use_snapshot)
+            withdrew = True
+        except Exception:
+            logger.debug("Could not revert use bump for %s", skill_name, exc_info=True)
+    return withdrew
 
 
 def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
@@ -2133,8 +2244,698 @@ def reset_skill_view_dedup(task_id: str | None = None) -> None:
     with _skill_view_tracker_lock:
         if task_id is None:
             _skill_view_tracker.clear()
+            _skill_view_delivery_index.clear()
         else:
             _skill_view_tracker.pop(str(task_id), None)
+            for digest in list(_skill_view_delivery_index):
+                kept = [
+                    e for e in _skill_view_delivery_index[digest] if e[0] != str(task_id)
+                ]
+                if kept:
+                    _skill_view_delivery_index[digest] = kept
+                else:
+                    _skill_view_delivery_index.pop(digest, None)
+
+
+# ── Incomplete-load receipt (mandatory skills that did NOT reach the model) ──
+# A skill_view result can have its body removed by either context-protection
+# layer in tools/tool_result_storage.py: the per-result threshold, or aggregate
+# turn-budget enforcement. The generic <persisted-output> receipt is wrong for a
+# skill -- it still opens with `"success": true` and a fragment of the body, so
+# the model acts as if a mandatory skill were loaded. We replace it with an
+# index-only receipt carrying NO body at all.
+#
+# The marker below is the ONE canonical incomplete-load signal:
+# _skill_incomplete_marker() builds it and every presence check matches the same
+# prefix constant, so emit and check cannot drift apart. (That drift is a real
+# upstream bug, not a hypothetical: PR #44166 emitted "[SKILL_PRUNED:" while
+# presence-checking "[SKILL_PRUNED]" -- see agent/context_compressor.py.)
+SKILL_INCOMPLETE_MARKER_PREFIX = "[SKILL_INCOMPLETE:"
+# Bounds on the receipt. It is itself a tool result, so it must be small enough
+# that it never becomes a spill candidate in its own right.
+_MAX_INCOMPLETE_SECTIONS = 40
+_MAX_SECTION_HEADING_CHARS = 200
+_MAX_INCOMPLETE_RECEIPT_CHARS = 20_000
+# Ceiling on a single retrieved section, well under the per-result
+# threshold so a section answer is not itself a spill candidate. A section
+# whose full content exceeds this is NOT truncated -- it is answered with
+# navigation only (see _apply_section_selection).
+_MAX_SECTION_CHARS = 60_000
+# Label for the entry covering everything before the first heading. Skills
+# routinely open with prose (and always with frontmatter); without an entry of
+# its own that text would have no retrieval route at all.
+_PREAMBLE_HEADING = "(document preamble)"
+# Metadata worth carrying into an incomplete receipt: what the skill is, whether
+# it is usable, and what setup it still needs. Copied verbatim when present.
+_INCOMPLETE_RECEIPT_METADATA_KEYS = (
+    "description",
+    "file",
+    "path",
+    "skill_dir",
+    "readiness_status",
+    "setup_needed",
+    "setup_skipped",
+    "setup_help",
+    "setup_note",
+    "gateway_setup_hint",
+    "missing_required_environment_variables",
+    "missing_credential_files",
+    "missing_required_commands",
+    "required_environment_variables",
+    "required_commands",
+    "usage_hint",
+    "org_provenance",
+    "compatibility",
+    "tags",
+    "related_skills",
+    "linked_files",
+    "metadata",
+)
+# Dropped first, in this order, if the receipt still exceeds its cap.
+_INCOMPLETE_RECEIPT_DROPPABLE_KEYS = (
+    "metadata",
+    "linked_files",
+    "related_skills",
+    "tags",
+    "required_environment_variables",
+    "org_provenance",
+)
+
+
+def _skill_incomplete_marker(skill_name: str, file_path: str | None = None) -> str:
+    """Return the canonical incomplete-load marker for *skill_name*.
+
+    *file_path* names the LINKED FILE this receipt is about, when it is about
+    one. It must then appear in the continuation call, because a linked file is
+    a different document from SKILL.md with its own heading index: a follow-up
+    that drops file_path resolves against SKILL.md instead, where the same
+    heading text and the same ``#n`` both exist, and answers out of the wrong
+    file with section_found true and no marker. The instruction the model is
+    handed is the only thing standing between it and that answer.
+
+    Used verbatim by the emit site (the persisted-result formatter) and matched
+    by _SKILL_INCOMPLETE_MARKER_RE below -- one string, no drift. The tool-call
+    literal is quoted the same way the JSON receipt carrying it is, so what the
+    model reads back is what the detector matches.
+    """
+    subject = f'file "{file_path}" of this skill' if file_path else "this skill"
+    target = f'name="{skill_name}"'
+    if file_path:
+        target += f', file_path="{file_path}"'
+    return (
+        f"{SKILL_INCOMPLETE_MARKER_PREFIX} {subject} is NOT loaded. Its body was "
+        f"removed to protect the context window, so none of its instructions were "
+        f"delivered. Do not act on it. Retrieve what you need one section at a "
+        f'time with skill_view({target}, section="<heading>")]'
+    )
+
+
+def _payload_file(payload: dict) -> str | None:
+    """The linked file a skill_view payload is about, or None for SKILL.md.
+
+    Only the linked-file branches set "file"; a main-skill payload carries
+    "path" instead. That difference is the whole discriminator -- nothing here
+    infers a file from a name.
+    """
+    file_path = payload.get("file")
+    return file_path if isinstance(file_path, str) and file_path else None
+
+
+def _continuation_hint(payload: dict) -> str:
+    """Sentence keeping a linked-file continuation on the same linked file.
+
+    Empty for SKILL.md, where the bare call shape is already correct. A section
+    that WAS delivered carries no incomplete marker, so on that path this is the
+    only place the next call's shape is stated at all.
+    """
+    file_path = _payload_file(payload)
+    if not file_path:
+        return ""
+    return (
+        f' These selectors are positions in file "{file_path}", not in '
+        f"SKILL.md, so keep file_path on every follow-up: "
+        f'skill_view(name="{payload.get("name") or ""}", '
+        f'file_path="{file_path}", section="<heading>").'
+    )
+
+
+# Matches the canonical marker and captures the skill name. Anchored on the
+# shared prefix constant so a wording change updates the emit helper and this
+# extractor together. The quotes are optionally backslash-escaped because the
+# marker is normally read back out of the JSON receipt that carries it, where
+# json.dumps has escaped every double quote inside the string.
+_SKILL_INCOMPLETE_MARKER_RE = re.compile(
+    re.escape(SKILL_INCOMPLETE_MARKER_PREFIX)
+    + r'[^\]]*?skill_view\(name=\\?"([^"\\]+)\\?"'
+    + r'(?:, file_path=\\?"[^"\\]*\\?")?, section='
+)
+
+
+def has_skill_incomplete_marker(text: str) -> bool:
+    """True when *text* carries a canonical incomplete-load marker."""
+    return bool(text) and bool(_SKILL_INCOMPLETE_MARKER_RE.search(text))
+
+
+def extract_incomplete_skill_names(text: str) -> list[str]:
+    """Return skill names referenced by incomplete-load markers in *text*."""
+    names: list[str] = []
+    for match in _SKILL_INCOMPLETE_MARKER_RE.finditer(text or ""):
+        name = match.group(1)
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def _skill_entries(body: str) -> list[dict]:
+    """Ordered navigation entries for markdown *body*.
+
+    Entry 0 is the document preamble -- everything before the first heading,
+    frontmatter included -- and exists only when that text is not blank. Entries
+    1..N are the ATX heading occurrences in document order. A repeated heading
+    is two DIFFERENT places in the file, so it gets two entries; nothing here is
+    deduplicated by text.
+
+    Each entry carries two spans:
+
+    ``own_start``/``own_end``
+        the heading line plus its own prose, ending at the next heading of ANY
+        level. Parts tile this span.
+    ``start``/``end``
+        the logical section: down to the next heading of the SAME OR A HIGHER
+        level, so descendants are included. This is what a section request
+        returns when it fits.
+
+    An entry's own span plus its children's logical spans tile its logical span
+    exactly -- that is what makes retrieval lossless: whatever is too large to
+    return is always reachable as parts (own text) plus child sections.
+
+    Fenced code blocks are skipped so a shell comment inside an example is not
+    mistaken for a heading. Single source of truth for the index, for named
+    retrieval and for every selector.
+    """
+    text = body or ""
+    heads: list[tuple[int, str, int]] = []  # (level, heading, start offset)
+    offset = 0
+    in_fence = False
+    fence_marker = ""
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped[:3] in ("```", "~~~"):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence, fence_marker = True, marker
+            elif marker == fence_marker:
+                in_fence, fence_marker = False, ""
+            offset += len(line)
+            continue
+        if not in_fence and stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            heading = stripped[level:].strip().rstrip("#").strip()
+            if 1 <= level <= 6 and heading:
+                heads.append((level, heading, offset))
+        offset += len(line)
+
+    # Logical end of each heading: the next heading at the same or a higher
+    # level closes it. One pass with a stack -- an O(n^2) scan is noticeable on
+    # the 400-heading scraped reference dumps this feature exists for.
+    ends = [len(text)] * len(heads)
+    open_stack: list[int] = []
+    for i, (level, _heading, start) in enumerate(heads):
+        while open_stack and heads[open_stack[-1]][0] >= level:
+            ends[open_stack.pop()] = start
+        open_stack.append(i)
+
+    entries: list[dict] = []
+    first = heads[0][2] if heads else len(text)
+    if text[:first].strip():
+        entries.append(
+            {
+                "number": 0,
+                "heading": _PREAMBLE_HEADING,
+                "level": 0,
+                "start": 0,
+                "end": first,
+                "own_start": 0,
+                "own_end": first,
+                "parent": None,
+            }
+        )
+    for i, (level, heading, start) in enumerate(heads):
+        entries.append(
+            {
+                "number": i + 1,
+                "heading": heading,
+                "level": level,
+                "start": start,
+                "end": ends[i],
+                "own_start": start,
+                "own_end": heads[i + 1][2] if i + 1 < len(heads) else len(text),
+                "parent": None,
+            }
+        )
+
+    # Immediate parent = nearest preceding heading of a strictly smaller level.
+    parent_stack: list[dict] = []
+    for entry in entries:
+        if entry["number"] == 0:
+            continue
+        while parent_stack and parent_stack[-1]["level"] >= entry["level"]:
+            parent_stack.pop()
+        entry["parent"] = parent_stack[-1]["number"] if parent_stack else None
+        parent_stack.append(entry)
+    return entries
+
+
+def _section_part_spans(text: str, start: int, end: int) -> list[tuple[int, int]]:
+    """Deterministic part offsets tiling ``text[start:end]``.
+
+    Parts break on line boundaries so each one reads as prose; a single line
+    longer than the ceiling is chunked at fixed offsets rather than dropped.
+    Concatenating the parts in order reproduces ``text[start:end]`` exactly --
+    no gap, no overlap, no character unreachable.
+    """
+    limit = _MAX_SECTION_CHARS
+    if end - start <= limit:
+        return [(start, end)]
+    spans: list[tuple[int, int]] = []
+    cursor = pos = start
+    while pos < end:
+        newline = text.find("\n", pos, end)
+        line_end = end if newline == -1 else newline + 1
+        if line_end - cursor > limit:
+            if cursor < pos:
+                spans.append((cursor, pos))
+                cursor = pos
+            while line_end - cursor > limit:  # one line longer than the ceiling
+                spans.append((cursor, cursor + limit))
+                cursor += limit
+        pos = line_end
+    if cursor < end:
+        spans.append((cursor, end))
+    return spans
+
+
+def _selector_of(entry: dict) -> str:
+    """Stable selector for *entry*, unique within this exact skill body."""
+    return f"#{entry['number']}"
+
+
+def _leaf_target(entry: dict) -> dict:
+    """One retrievable navigation target, as the model sees it."""
+    return {
+        "selector": _selector_of(entry),
+        "heading": entry["heading"][:_MAX_SECTION_HEADING_CHARS],
+        "level": entry["level"],
+        "chars": entry["end"] - entry["start"],
+    }
+
+
+def _group_span(count: int) -> int:
+    """Entries per group so that at most _MAX_INCOMPLETE_SECTIONS groups fit.
+
+    Always strictly smaller than *count* when *count* overflows the cap, so
+    expanding a group makes progress and the recursion terminates.
+    """
+    span = _MAX_INCOMPLETE_SECTIONS
+    while span * _MAX_INCOMPLETE_SECTIONS < count:
+        span *= _MAX_INCOMPLETE_SECTIONS
+    return span
+
+
+def _chunk_groups(items: list, span: int, selector_of, covers_of) -> list[dict]:
+    """Split *items* into bounded groups, each with its own selector."""
+    groups = []
+    for at in range(0, len(items), span):
+        chunk = items[at : at + span]
+        groups.append(
+            {
+                "selector": selector_of(chunk[0], chunk[-1]),
+                "covers": covers_of(chunk[0], chunk[-1], at, len(chunk)),
+            }
+        )
+    return groups
+
+
+def _entry_range_groups(entries: list[dict], total: int, span: int | None = None) -> list[dict]:
+    """Group selectors over a run of entries, expressed as ``#first-last``."""
+    return _chunk_groups(
+        entries,
+        span or _group_span(len(entries)),
+        lambda lo, hi: f"#{lo['number']}-{hi['number']}",
+        lambda lo, hi, _at, n: (
+            f"{n} entries, headings {lo['number']}-{hi['number']} of {total}"
+            f" — starts at {lo['heading'][:60]!r}"
+        ),
+    )
+
+
+def _entry_navigation(entries: list[dict], total: int) -> tuple[list, list]:
+    """(leaf targets, group targets) for *entries* -- whichever stays bounded.
+
+    Never both, and never neither while *entries* is non-empty: every entry is
+    reachable either directly or by expanding exactly one returned group.
+    """
+    if len(entries) <= _MAX_INCOMPLETE_SECTIONS:
+        return [_leaf_target(e) for e in entries], []
+    return [], _entry_range_groups(entries, total)
+
+
+def _part_navigation(entry: dict, numbered: list, total_parts: int) -> tuple[list, list]:
+    """(leaf targets, group targets) for parts of *entry*'s own span.
+
+    *numbered* is ``[(real part number, (start, end)), ...]`` -- the real number
+    travels with each span so that expanding a part range keeps naming parts by
+    their true position, not by their offset inside the page being expanded.
+    """
+    selector = _selector_of(entry)
+    heading = entry["heading"][:_MAX_SECTION_HEADING_CHARS]
+    if len(numbered) <= _MAX_INCOMPLETE_SECTIONS:
+        return (
+            [
+                {
+                    "selector": f"{selector}.part{n}",
+                    "heading": f"part {n} of {total_parts} of {heading!r}",
+                    "level": entry["level"],
+                    "chars": hi - lo,
+                }
+                for n, (lo, hi) in numbered
+            ],
+            [],
+        )
+    return [], _chunk_groups(
+        numbered,
+        _group_span(len(numbered)),
+        lambda lo, hi: f"{selector}.part{lo[0]}-{hi[0]}",
+        lambda lo, hi, _at, n: (
+            f"{n} parts, parts {lo[0]}-{hi[0]} of {total_parts} of {heading!r}"
+        ),
+    )
+
+
+# Selector grammar. These are the ONLY shapes the model ever needs, and it
+# never has to construct one -- every selector it can use was returned to it by
+# a previous result. A heading whose literal text looks like a selector is
+# still reachable through its own numeric selector, so nothing becomes
+# unretrievable; the selector reading simply wins.
+_SELECTOR_ONE_RE = re.compile(r"^#(\d+)$")
+_SELECTOR_RANGE_RE = re.compile(r"^#(\d+)-(\d+)$")
+_SELECTOR_PART_RE = re.compile(r"^#(\d+)\.part(\d+)$")
+_SELECTOR_PART_RANGE_RE = re.compile(r"^#(\d+)\.part(\d+)-(\d+)$")
+
+
+def _skill_section_navigation(body: str) -> tuple[list, list, int]:
+    """Bounded, fully routed index of *body*: (leaves, groups, total entries)."""
+    entries = _skill_entries(body)
+    leaves, groups = _entry_navigation(entries, len(entries))
+    return leaves, groups, len(entries)
+
+
+def _set_navigation(payload: dict, notice: str, leaves: list, groups: list, total: int) -> None:
+    """Answer with navigation only: no body, canonical marker, honest status.
+
+    Every response that withholds content goes through here, so "content is
+    absent" and "the incomplete marker is present" cannot come apart.
+    """
+    payload.pop("content", None)
+    payload["load_status"] = "incomplete"
+    payload["content_returned"] = False
+    payload["notice"] = (
+        f"{notice} "
+        f"{_skill_incomplete_marker(str(payload.get('name') or ''), _payload_file(payload))}"
+    )
+    if leaves:
+        payload["sections"] = leaves
+    else:
+        payload.pop("sections", None)
+    if groups:
+        payload["section_groups"] = groups
+    else:
+        payload.pop("section_groups", None)
+    payload["sections_total"] = total
+
+
+def _apply_section_selection(payload: dict, section: str) -> None:
+    """Narrow *payload*'s content to the requested *section*, in place.
+
+    Three kinds of request, one rule: content comes back only when the WHOLE of
+    what was asked for fits. Otherwise the answer is navigation -- selectors
+    that between them cover every character of the thing that did not fit --
+    and no fragment of the body at all.
+
+    * an exact heading, when it occurs exactly once;
+    * ``#n`` / ``#n.partK`` -- a heading occurrence or one part of its own text;
+    * ``#a-b`` / ``#n.partA-B`` -- an index page, navigation only.
+
+    A miss, an ambiguous heading and an oversized section are all navigation
+    answers rather than tool errors: the model's next move is another
+    ``section=`` call either way.
+    """
+    wanted = str(section).strip()
+    body = payload.get("content")
+    if not isinstance(body, str):
+        return
+    payload["section"] = wanted
+    entries = _skill_entries(body)
+    total = len(entries)
+    by_number = {e["number"]: e for e in entries}
+
+    def index_answer(notice: str) -> None:
+        """Nothing here answers to what was asked: whole index, no body.
+
+        This is the ONLY path that reports section_found False. An ambiguous
+        heading and an oversized section both exist -- they just cannot be
+        returned as asked -- so they leave the key off rather than deny them.
+        """
+        leaves, groups = _entry_navigation(entries, total)
+        _set_navigation(payload, notice, leaves, groups, total)
+        payload["section_found"] = False
+
+    # ── index pages: navigation only, never an instruction body ──────────
+    match = _SELECTOR_RANGE_RE.match(wanted)
+    if match:
+        lo, hi = int(match.group(1)), int(match.group(2))
+        chosen = [e for e in entries if lo <= e["number"] <= hi]
+        if not chosen:
+            return index_answer(
+                f"Selector {wanted!r} covers no headings in this skill."
+            )
+        leaves, groups = _entry_navigation(chosen, total)
+        return _set_navigation(
+            payload,
+            f"Headings {lo}-{hi} of {total} in this skill. This is an index, "
+            f"not skill content — request an entry by its selector.",
+            leaves,
+            groups,
+            total,
+        )
+
+    match = _SELECTOR_PART_RANGE_RE.match(wanted)
+    if match:
+        number, lo, hi = (int(g) for g in match.groups())
+        entry = by_number.get(number)
+        if entry is None:
+            return index_answer(f"Selector {wanted!r} names no section here.")
+        spans = _section_part_spans(body, entry["own_start"], entry["own_end"])
+        numbered = [(n, s) for n, s in enumerate(spans, start=1) if lo <= n <= hi]
+        if not numbered:
+            return index_answer(f"Selector {wanted!r} covers no parts here.")
+        leaves, groups = _part_navigation(entry, numbered, len(spans))
+        return _set_navigation(
+            payload,
+            f"Parts {lo}-{hi} of {len(spans)} of section "
+            f"{entry['heading']!r}. This is an index, not skill content.",
+            leaves,
+            groups,
+            total,
+        )
+
+    # ── one part of a section's own text ─────────────────────────────────
+    match = _SELECTOR_PART_RE.match(wanted)
+    if match:
+        number, wanted_part = int(match.group(1)), int(match.group(2))
+        entry = by_number.get(number)
+        if entry is None:
+            return index_answer(f"Selector {wanted!r} names no section here.")
+        spans = _section_part_spans(body, entry["own_start"], entry["own_end"])
+        if not 1 <= wanted_part <= len(spans):
+            return index_answer(
+                f"Section {_selector_of(entry)} has {len(spans)} part(s); "
+                f"{wanted!r} is out of range."
+            )
+        lo, hi = spans[wanted_part - 1]
+        leaves, groups = _part_navigation(
+            entry, list(enumerate(spans, start=1)), len(spans)
+        )
+        payload["section_found"] = True
+        payload["content"] = body[lo:hi]
+        payload["section_part"] = wanted_part
+        payload["section_part_count"] = len(spans)
+        payload["part_of"] = {
+            "selector": _selector_of(entry),
+            "heading": entry["heading"][:_MAX_SECTION_HEADING_CHARS],
+            "level": entry["level"],
+        }
+        payload["notice"] = (
+            f"This is part {wanted_part} of {len(spans)} of the text of section "
+            f"{entry['heading']!r} ({_selector_of(entry)}). This part is "
+            f"complete; the section is NOT. The remaining parts are listed in "
+            f'"sections".' + _continuation_hint(payload)
+        )
+        payload["sections"] = leaves
+        if groups:
+            payload["section_groups"] = groups
+        payload["sections_total"] = total
+        return
+
+    # ── a single heading occurrence ──────────────────────────────────────
+    entry = None
+    match = _SELECTOR_ONE_RE.match(wanted)
+    if match:
+        entry = by_number.get(int(match.group(1)))
+        if entry is None:
+            return index_answer(f"Selector {wanted!r} names no section here.")
+    else:
+        hits = [e for e in entries if e["heading"].strip() == wanted]
+        if not hits:
+            return index_answer(
+                f"Section {wanted!r} was not found in this skill. The headings "
+                f'that do exist are listed in "sections"; request one of those '
+                f"exactly, or by its selector."
+            )
+        if len(hits) > 1:
+            leaves, groups = _entry_navigation(hits, total)
+            payload["section_ambiguous"] = True
+            return _set_navigation(
+                payload,
+                f"Heading {wanted!r} occurs {len(hits)} times in this skill, so "
+                f"an exact-heading request is ambiguous and no body was "
+                f'returned. Each occurrence has its own selector in "sections" '
+                f"— request the one you want.",
+                leaves,
+                groups,
+                total,
+            )
+        entry = hits[0]
+
+    # Both arms above either returned or bound a real entry.
+    size = entry["end"] - entry["start"]
+    if size <= _MAX_SECTION_CHARS:
+        leaves, groups = _entry_navigation(entries, total)
+        payload["section_found"] = True
+        payload["section_selector"] = _selector_of(entry)
+        payload["content"] = body[entry["start"] : entry["end"]]
+        payload["notice"] = (
+            f"Section {entry['heading']!r} ({_selector_of(entry)}) is returned "
+            f"in full. It is one entry of {total} in this skill; the rest of "
+            f'the skill is NOT loaded. The others are listed in "sections".'
+            + _continuation_hint(payload)
+        )
+        payload["sections"] = leaves
+        if groups:
+            payload["section_groups"] = groups
+        payload["sections_total"] = total
+        return
+
+    # Too large to return whole. NO fragment: the own text becomes parts and
+    # the child headings become their own targets, and between them they cover
+    # every character of the section.
+    own_parts = _section_part_spans(body, entry["own_start"], entry["own_end"])
+    part_leaves, part_groups = _part_navigation(
+        entry, list(enumerate(own_parts, start=1)), len(own_parts)
+    )
+    children = [e for e in entries if e["parent"] == entry["number"]]
+    child_leaves, child_groups = _entry_navigation(children, total)
+    payload["section_selector"] = _selector_of(entry)
+    payload["section_chars"] = size
+    _set_navigation(
+        payload,
+        f"Section {entry['heading']!r} ({_selector_of(entry)}) is {size:,} "
+        f"characters, larger than the {_MAX_SECTION_CHARS:,}-character result "
+        f"ceiling, so NO part of it was returned. Its own text is available as "
+        f'parts and its sub-sections as their own selectors, listed in '
+        f'"sections"; together they cover the whole section.',
+        part_leaves + child_leaves,
+        part_groups + child_groups,
+        total,
+    )
+
+
+def _skill_view_incomplete_result(content: str, *, tool_name: str = "skill_view") -> str | None:
+    """Replacement receipt for a skill_view result whose body was NOT delivered.
+
+    Called by tools/tool_result_storage.py only after that module has already
+    decided, on its own, to persist this result -- i.e. the body is gone from
+    the model's view no matter what we return. Emits an index-only receipt:
+    typed marker, honest status, bounded heading index, availability metadata,
+    and no fragment of the skill body.
+
+    Returns None (meaning "use the generic receipt") for anything that is not a
+    successful skill_view payload carrying content. Never raises.
+    """
+    try:
+        payload, end = json.JSONDecoder().raw_decode(content)
+    except ValueError:
+        # Not a JSON payload at all (already-truncated text, a synthetic error
+        # string, ...). The generic receipt is the honest answer.
+        return None
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    body = payload.get("content")
+    if not isinstance(body, str):
+        # Nothing was going to be delivered anyway (dedup stub, error shape).
+        return None
+
+    # run_agent.append_toolguard_guidance can append text AFTER the JSON before
+    # persistence. That guidance is a live instruction to the model; carry it.
+    trailing = content[end:]
+
+    # The dedup record for this exact payload is a promise the delivery just
+    # broke. Revoke it BEFORE returning, so a retry re-loads for real instead
+    # of being told the earlier result "is still current and complete".
+    _revoke_skill_view_delivery(content[:end])
+
+    name = str(payload.get("name") or "")
+    leaves, groups, total = _skill_section_navigation(body)
+    receipt = {
+        "success": True,
+        "name": name,
+        "load_status": "incomplete",
+        "content_returned": False,
+        "notice": _skill_incomplete_marker(name, _payload_file(payload)),
+        "sections_total": total,
+    }
+    if leaves:
+        receipt["sections"] = leaves
+    if groups:
+        receipt["section_groups"] = groups
+    for key in _INCOMPLETE_RECEIPT_METADATA_KEYS:
+        if key in payload and payload[key] is not None:
+            receipt[key] = payload[key]
+
+    rendered = json.dumps(receipt, ensure_ascii=False)
+    for key in _INCOMPLETE_RECEIPT_DROPPABLE_KEYS:
+        if len(rendered) <= _MAX_INCOMPLETE_RECEIPT_CHARS:
+            break
+        if receipt.pop(key, None) is not None:
+            rendered = json.dumps(receipt, ensure_ascii=False)
+
+    # Still over the cap: coarsen the index into fewer, wider groups rather
+    # than dropping entries off the end. A dropped entry is a heading the model
+    # is told exists and given no way to reach; a wider group is one extra hop.
+    entries = _skill_entries(body)
+    span = None
+    while len(rendered) > _MAX_INCOMPLETE_RECEIPT_CHARS and entries:
+        span = _group_span(total) if span is None else span * _MAX_INCOMPLETE_SECTIONS
+        receipt.pop("sections", None)
+        receipt["section_groups"] = _entry_range_groups(entries, total, span)
+        rendered = json.dumps(receipt, ensure_ascii=False)
+        if len(receipt["section_groups"]) <= 1:
+            break  # one group already covers everything; nothing left to merge
+
+    return rendered + trailing
+
+
+register_oversized_result_formatter("skill_view", _skill_view_incomplete_result)
 
 
 def _skill_view_with_bump(args, **kw):
@@ -2152,21 +2953,33 @@ def _skill_view_with_bump(args, **kw):
     # "skills must be loaded fully" rule is preserved — and the cache is
     # cleared on context compression (same hook as read_file's dedup)
     # so a post-compression re-view returns full content again.
-    stub = _check_skill_view_dedup(task_id, name, args.get("file_path"))
-    if stub is not None:
-        return stub
+    # A section request asks for content the earlier result may not have
+    # carried, so it is never answered from the unchanged-stub.
+    section = args.get("section")
+    if not section:
+        stub = _check_skill_view_dedup(task_id, name, args.get("file_path"))
+        if stub is not None:
+            return stub
     result = skill_view(
-        name, file_path=args.get("file_path"), task_id=task_id
+        name, file_path=args.get("file_path"), task_id=task_id, section=section
     )
     try:
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
-            _record_skill_view(task_id, name, args.get("file_path"), parsed)
+            recorded = None
+            if not section:
+                recorded = _record_skill_view(task_id, name, args.get("file_path"), parsed)
             # Use the resolved skill name from the payload when present —
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name
+            snapshot = None
             if resolved:
-                from tools.skill_usage import bump_use, bump_view
+                from tools.skill_usage import bump_use, bump_view, get_record, use_snapshot
+                # Both the dedup record above and the use bump below are claims
+                # about a body the model has not received yet. Capture what the
+                # use bump is about to overwrite so the persistence boundary can
+                # put it back if the body never arrives.
+                snapshot = use_snapshot(get_record(str(resolved)))
                 bump_view(str(resolved))
                 # A skill_view tool call is the agent actively loading the skill
                 # to act on it — that counts as use, not just a browse/view.
@@ -2176,6 +2989,9 @@ def _skill_view_with_bump(args, **kw):
                     task_id=kw.get("task_id"),
                     session_id=kw.get("session_id"),
                 )
+            _note_skill_view_delivery(
+                result, task_id, recorded, str(resolved or ""), snapshot
+            )
     except Exception:
         pass
     return result

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -56,6 +56,7 @@ from tools.budget_config import (
     BudgetConfig,
     DEFAULT_BUDGET,
 )
+from tools.oversized_result_formatters import format_oversized_result
 
 logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
@@ -318,6 +319,7 @@ def maybe_persist_tool_result(
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
+    formatter_name: str | None = None,
 ) -> str:
     """Layer 2: persist oversized result into the sandbox, return preview + path.
 
@@ -332,6 +334,10 @@ def maybe_persist_tool_result(
         env: The active BaseEnvironment instance, or None.
         config: BudgetConfig controlling thresholds and preview size.
         threshold: Explicit override; takes precedence over config resolution.
+        formatter_name: Tool name used for the replacement-formatter lookup
+            only, when it differs from ``tool_name``. Layer 3 passes the real
+            tool name here because it must keep forcing ``threshold=0`` under
+            the synthetic ``tool_name``. Never consulted for thresholds.
 
     Returns:
         Original content if small, or <persisted-output> replacement.
@@ -347,6 +353,14 @@ def maybe_persist_tool_result(
     filename = _safe_result_filename(tool_use_id)
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
+    # The persist decision is already taken above; a registered formatter only
+    # changes how the removal is REPORTED, and every return below this point is
+    # a report of the same removal. `formatter_name` exists so layer 3 can hand
+    # us the real tool name for the lookup while still forcing threshold=0
+    # through `tool_name`. None (the shipping default for every tool but one)
+    # leaves each receipt exactly as it was.
+    custom = format_oversized_result(content, formatter_name or tool_name)
+
     # Always persist host-side first: $HERMES_HOME/cache/spillover is the
     # single canonical home for spilled results (with the other Hermes-owned
     # caches, pruned by gateway housekeeping) regardless of backend.
@@ -358,6 +372,8 @@ def maybe_persist_tool_result(
                 "Persisted large tool result: %s (%s, %d chars -> %s)",
                 tool_name, tool_use_id, len(content), host_path,
             )
+            if custom is not None:
+                return custom
             return _build_persisted_message(preview, has_more, len(content), host_path)
     elif env is not None:
         # Remote backend: the spillover dir is auto-mounted (docker) or
@@ -370,6 +386,8 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s [host: %s])",
                     tool_name, tool_use_id, len(content), visible, host_path,
                 )
+                if custom is not None:
+                    return custom
                 return _build_persisted_message(preview, has_more, len(content), visible)
         # Fallback: write into the sandbox temp dir (pre-existing containers
         # without the spillover mount, translation/probe failures).
@@ -381,6 +399,8 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,
                 )
+                if custom is not None:
+                    return custom
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
@@ -389,6 +409,8 @@ def maybe_persist_tool_result(
         "Inline-truncating large tool result: %s (%d chars, no sandbox write)",
         tool_name, len(content),
     )
+    if custom is not None:
+        return custom
     return (
         f"{preview}\n\n"
         f"[Truncated: tool response was {len(content):,} chars. "
@@ -430,6 +452,11 @@ def enforce_turn_budget(
         content = msg["content"]
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
+        # `tool_name` stays synthetic so `threshold=0` is what decides the
+        # spill, exactly as before. The REAL tool name goes to formatter_name,
+        # which is consulted only after that decision, purely to choose how the
+        # removal is reported. It was already on the message and simply thrown
+        # away (make_tool_result_message sets both keys).
         replacement = maybe_persist_tool_result(
             content=content,
             tool_name=_BUDGET_TOOL_NAME,
@@ -437,6 +464,7 @@ def enforce_turn_budget(
             env=env,
             config=config,
             threshold=0,
+            formatter_name=msg.get("tool_name") or msg.get("name") or None,
         )
         if replacement != content:
             total_size -= size


### PR DESCRIPTION
## What does this PR do?

`skill_view` can currently report a mandatory skill as loaded even when Hermes removed most of its body to protect the context window.

The failure has two parts:

1. Per-result or aggregate persistence can replace the JSON payload with a generic `<persisted-output>` preview that still begins with `{"success": true, ...}` and a partial instruction body.
2. `skill_view` records the load before that later replacement, so a retry can say the earlier body is “still current and complete” even though it never reached the model.

There is a second correctness issue for linked files: the recovery guidance omitted `file_path`. Following the suggested call therefore resolves headings and `#n` selectors against `SKILL.md`, not the linked document that produced the index.

This PR makes incomplete delivery explicit and gives the model a complete route back without increasing thresholds or weakening persistence.

## Related Issue

No dedicated issue currently tracks this exact persistence-ordering and linked-file continuation bug. I searched open and closed issues/PRs before submitting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a small per-tool formatter registry that is consulted only after the existing storage layer has independently decided to persist a result. The registry is empty by default; `skill_view` is its only consumer.
- Replaced an omitted skill body with a bounded `[SKILL_INCOMPLETE: ...]` index instead of a partial instruction preview.
- Added hierarchical section retrieval with stable selectors, duplicate-heading disambiguation, complete-part retrieval for oversized sections, and grouped navigation when an index itself would overflow.
- Revoked premature `skill_view` dedup records and restored use accounting when the body did not reach the model.
- Preserved the real tool name for formatter lookup during aggregate enforcement while leaving `threshold=0`, candidate order, persistence decisions, previews, and writes unchanged.
- Kept `file_path` in every recovery surface so linked-file selectors remain scoped to the document that produced them.
- Updated the system-prompt guidance and the `skill_view` schema for incomplete loads and linked-file continuation.
- Added fail-first coverage for both persistence layers, dedup truthfulness, direct consumers, section navigation, non-skill invariants, and linked-file heading collisions.

## How to Test

1. Create a skill whose `SKILL.md` and `references/big.md` both contain `## Overview` and `## Omega`, with different content, and make the linked file exceed the result threshold.
2. Call `skill_view(name="...", file_path="references/big.md")`. It should return an incomplete marker and a heading index, with no partial body.
3. Call the advertised selector while keeping the same `file_path`. It should return the linked file’s complete section, never the same-named section from `SKILL.md`.
4. Run the affected suite:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 4 \
  tests/tools/test_skill_incomplete_load.py \
  tests/tools/test_oversized_result_formatters.py \
  tests/tools/test_skill_incomplete_direct_consumers.py \
  tests/agent/test_skill_incomplete_guidance.py \
  tests/tools/test_tool_result_storage.py \
  tests/tools/test_budget_config.py \
  tests/tools/test_skills_tool.py \
  tests/tools/test_skill_usage.py \
  tests/tools/test_skill_view_dedup.py \
  tests/tools/test_skill_view_path_check.py \
  tests/tools/test_skill_view_traversal.py \
  tests/tools/test_skill_improvements.py \
  tests/tools/test_skill_ledger.py \
  tests/tools/test_skills_tool_discovery_cache.py \
  tests/tools/test_skills_tool_profile_scope.py \
  tests/tools/test_skill_size_limits.py \
  tests/tools/test_skill_manager_tool.py \
  tests/agent/test_prompt_builder.py \
  tests/agent/test_system_prompt.py \
  tests/agent/test_ghost_skill_pruning.py \
  tests/agent/test_skills_guidance_content_filter.py \
  tests/agent/test_skill_commands.py \
  tests/agent/test_skill_invocation_description.py \
  tests/agent/test_skill_utils.py -q
```

Local result: **538 passed, 2 skipped, 0 failed** across 24 files. The focused new modules are 78/78 green. `ruff check` passes on all changed files, and `scripts/check-windows-footguns.py --diff HEAD^` reports no findings.

The same real two-call sequence fails on current `main`: the first result is a partial `<persisted-output>` preview and the second claims that omitted body is complete. It passes on this branch with all 11 acceptance checks true.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, arm64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; user-facing behavior is described in the tool schema and system guidance changed here
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific code; Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `skill_view` schema updated

## Compatibility / non-goals

- Generic tool-result persistence remains byte-identical when no formatter is registered.
- Preloaded/slash-command skills, both cron consumers, and the direct MCP surface still receive the full body because they do not pass through result persistence.
- Plugin-sourced skills still ignore `section=`; that pre-existing limitation is not widened into this fix. An incomplete plugin skill now fails visibly instead of being falsely reported as complete.
- I ran the affected CI-parity suite locally rather than the repository-wide suite; full cross-platform coverage is left to CI.
