### PR TITLE
fix(bedrock): strip the inference-profile prefix from the status bar model name

### DIFF
--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -178,8 +178,15 @@ class CLIStatusBarMixin:
         if model_short == model_name:
             model_short = model_name.split("/")[-1] if "/" in model_name else model_name
             # Shared RID-prefix stripper so this and ModelSwitchResult can't drift.
-            from hermes_cli.model_switch import format_model_for_display
+            from hermes_cli.model_switch import (
+                format_model_for_display,
+                strip_bedrock_profile_prefix_for_display,
+            )
             model_short = format_model_for_display(model_short)
+            # Status bar only: the geography token spends 3-7 of the 23 visible
+            # characters at the front, where the model identity is. Not applied in
+            # ``cli_model_switch_mixin``, where it would read "switched from X to X".
+            model_short = strip_bedrock_profile_prefix_for_display(model_short)
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
         if len(model_short) > 26:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -123,6 +123,66 @@ def format_model_for_display(model_name: str) -> str:
     return model_name
 
 
+# Bedrock cross-region inference profiles prefix the foundation-model ID with a
+# geography token:
+#
+#   us.anthropic.claude-sonnet-4-5-20250929-v1:0
+#
+# The token identifies the routing profile, not the model, so in the
+# width-constrained status bar (26 chars, truncated to 23 plus an ellipsis) it is
+# 3-7 characters of pure overhead -- and it spends them at the FRONT, where the
+# model identity lives:
+#
+#   before   us.anthropic.claude-son...
+#   after    anthropic.claude-sonnet...
+#
+# Wire-side copies of this prefix list already exist in agent/bedrock_adapter.py
+# (``is_anthropic_bedrock_model``) and agent/usage_pricing.py. They are
+# deliberately not imported here: importing agent.bedrock_adapter costs ~1.2s of
+# module init, which is not something to put on a status-bar refresh path. All
+# three lists were checked to hold the same eleven prefixes; if they ever need to
+# become one constant it has to land in a module that is cheap to import.
+#
+# Attested by ListInferenceProfiles: "global." and "us." (us-east-1), "eu."
+# (eu-west-1, eu-central-1), "apac." (ap-southeast-1), "jp." (ap-northeast-1),
+# "au." (ap-southeast-2), "ca." (ca-central-1).
+#
+# "ap.", "sa.", "me." and "af." are NOT attested -- no profile using them turned
+# up in any region checked, and the AWS docs enumerate no complete list ("tied to
+# a geography (such as US, EU, or APAC)" is as specific as they get). They are
+# kept because the strip is display-only and only fires when a dotted vendor
+# component survives, so a prefix AWS never ships costs nothing; if it does ship
+# one, the status bar gets the shortening for free.
+_BEDROCK_INFERENCE_PROFILE_PREFIXES: tuple[str, ...] = (
+    "global.", "us.", "eu.", "apac.", "au.", "jp.", "ca.",   # attested
+    "ap.", "sa.", "me.", "af.",                              # not attested
+)
+
+
+def strip_bedrock_profile_prefix_for_display(model_name: str) -> str:
+    """Drop a Bedrock inference-profile geography prefix, for display only.
+
+    Separate from :func:`format_model_for_display` on purpose. That function also
+    feeds the model-switch note (``cli_model_switch_mixin``), where collapsing
+    ``us.X`` to ``X`` would render as "switched from X to X". Only the status bar
+    is width-constrained enough to want this, so only the status bar calls it.
+
+    The guard is the dotted tail: a prefix is removed only when a
+    ``vendor.model`` component survives it, because a real profile ID always has
+    one. That is what keeps ``me.some-model`` -- a plain name whose first token
+    happens to collide with a geography token -- from losing it.
+    """
+    if not model_name:
+        return model_name
+    for prefix in _BEDROCK_INFERENCE_PROFILE_PREFIXES:
+        if model_name.startswith(prefix):
+            rest = model_name[len(prefix):]
+            if "." in rest:
+                return rest
+            break
+    return model_name
+
+
 def is_nous_hermes_non_agentic(model_name: str) -> bool:
     """True if *model_name* is a real Nous Hermes 3/4 chat model (single owner; cli.py uses it too)."""
     return bool(model_name and _NOUS_HERMES_NON_AGENTIC_RE.search(model_name))

--- a/tests/hermes_cli/test_provider_section3_grouping.py
+++ b/tests/hermes_cli/test_provider_section3_grouping.py
@@ -8,9 +8,12 @@ tests — grouping identity, header-routed separation, list-of-dict model
 declarations, and display-only RID stripping.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import (
     format_model_for_display,
+    strip_bedrock_profile_prefix_for_display,
     list_authenticated_providers,
 )
 
@@ -86,3 +89,61 @@ class TestFormatModelForDisplay:
         assert format_model_for_display(rid) == "anthropic-claude-4-7-opus"
 
 
+class TestStripBedrockProfilePrefixForDisplay:
+    """Every profile ID below is a real one, confirmed against
+    ``ListInferenceProfiles``. That matters more than it looks: a string
+    transform passes just as happily on an ID no region serves, so an invented
+    one would quietly stop being evidence that the helper handles the shapes
+    Bedrock actually returns."""
+
+    @pytest.mark.parametrize("profile,expected", [
+        ("us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+         "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        ("eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+         "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        ("global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+         "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+        ("apac.anthropic.claude-sonnet-4-20250514-v1:0",
+         "anthropic.claude-sonnet-4-20250514-v1:0"),
+        ("us.meta.llama4-scout-17b-instruct-v1:0",
+         "meta.llama4-scout-17b-instruct-v1:0"),
+        ("us.deepseek.r1-v1:0", "deepseek.r1-v1:0"),
+    ])
+    def test_geo_prefix_stripped(self, profile, expected):
+        assert strip_bedrock_profile_prefix_for_display(profile) == expected
+
+    @pytest.mark.parametrize("model_id", [
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "meta.llama4-scout-17b-instruct-v1:0",
+        "mistral.pixtral-large-2502-v1:0",
+        "deepseek.v3.2",
+        "moonshotai.kimi-k2.5",
+        "amazon.nova-pro-v1:0",
+        "claude-sonnet-4-20250514",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "gpt-5-4",
+    ])
+    def test_non_profile_ids_are_untouched(self, model_id):
+        assert strip_bedrock_profile_prefix_for_display(model_id) == model_id
+
+    def test_vendor_is_never_eaten_when_no_dotted_tail_remains(self):
+        """The guard that matters: a name whose first dotted token collides with
+        a geography token must not lose it, because a real profile ID always has
+        a ``vendor.model`` tail left over and this one does not."""
+        assert strip_bedrock_profile_prefix_for_display("me.some-model") == "me.some-model"
+        assert strip_bedrock_profile_prefix_for_display("ca.thing-v1:0") == "ca.thing-v1:0"
+
+    def test_empty_and_prefix_only_are_safe(self):
+        assert strip_bedrock_profile_prefix_for_display("") == ""
+        assert strip_bedrock_profile_prefix_for_display("us.") == "us."
+
+    def test_only_the_leading_prefix_goes(self):
+        """Strip once, not repeatedly -- the second token is the vendor."""
+        assert strip_bedrock_profile_prefix_for_display(
+            "us.us.anthropic.claude-sonnet-4-5") == "us.anthropic.claude-sonnet-4-5"
+
+    def test_the_switch_note_path_is_deliberately_untouched(self):
+        """``format_model_for_display`` also feeds the model-switch note, where
+        collapsing ``us.X`` to ``X`` would render as "switched from X to X"."""
+        profile = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        assert format_model_for_display(profile) == profile


### PR DESCRIPTION
## What you see today

The status bar truncates the model name to 23 characters plus an ellipsis. Bedrock cross-region inference profiles put a geography token in front of the foundation-model ID, so that budget gets spent at the front — on the one part of the string that tells you nothing about which model you are talking to:

| model | status bar today | with this change |
|---|---|---|
| `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `us.anthropic.claude-son...` | `anthropic.claude-sonnet...` |
| `us.meta.llama4-scout-17b-instruct-v1:0` | `us.meta.llama4-scout-17...` | `meta.llama4-scout-17b-i...` |
| `us.deepseek.v3.2` | `us.deepseek.v3.2` | `deepseek.v3.2` |

`us.` costs 3 of 23, `global.` costs 7. The profile prefix is routing metadata — it selects which geography Bedrock may serve the request from. Useful, but not the thing you are squinting at the status bar to check.

That first row is the one that motivated this: `us.anthropic.claude-son...` truncates one character before the model family becomes unambiguous.

## Two things I decided against, both on purpose

**1. Not folded into `format_model_for_display()`.**

That was my first instinct, since it is already the shared display formatter and the status bar calls it. But its other two callers (`cli.py:11647`, `cli.py:12039`) don't print to the user — they build the `_pending_model_switch_note` that gets injected into the *model's own* context ("Adjust your self-identification accordingly"). Collapsing `us.X` to `X` there would render a switch between a bare foundation ID and its own US profile as:

> `[Note: model was just switched from anthropic.claude-sonnet-4-5 to anthropic.claude-sonnet-4-5 ...]`

Rare, but actively confusing to the model when it happens, and a strictly worse failure than the cosmetic one being fixed. So: separate helper, one call site, and a test asserting `format_model_for_display` leaves the prefix alone so nobody "simplifies" the two together later.

**2. Not sharing the prefix tuple with the wire-side copies.**

The same list already exists twice, in `agent/bedrock_adapter.py` (`is_anthropic_bedrock_model`) and `agent/usage_pricing.py`. Importing it would be the obvious de-duplication, and I measured it before rejecting it:

```
$ python -X importtime -c "import agent.bedrock_adapter"
import time:    145767 |    1156613 | agent.bedrock_adapter
```

~1.2s of cumulative module init, on a path that repaints. There is no cheap module for the constant to live in today, so this is a third copy — which I'd rather state plainly in a comment, along with what would have to be true to consolidate, than hide. Happy to hoist all three into a tiny `agent/bedrock_ids.py` in this PR if you'd prefer that shape; I left it out because it turns a display fix into a refactor of two wire-side call sites.

## The guard, and why not a regex

The strip only fires when a dotted vendor component remains after the prefix. That is what stops `me.some-model` from losing its first segment — every real Bedrock ID is `vendor.model`, so the tail always has a dot, and anything that doesn't is not a profile ID.

A regex on prefix *shape* would be shorter and would be wrong. Something like `^[a-z]{2,5}\.(?=[a-z0-9-]+\.)` matches a hypothetical `xai.grok-4.1-fast` — three-letter vendor, dotted version — and eats the vendor. The explicit allow-list can only be wrong about a geography AWS adds later, which is a much smaller and more obvious failure.

## Display-only

`snapshot["model_name"]` still carries the full profile ID; only `model_short` is rewritten. Bedrock requires the complete profile ID on the wire, and anything that compares, persists, or re-sends the name reads `model_name`. Tested.

## Tests

- `TestStripBedrockProfilePrefixForDisplay` — each geography prefix; real Bedrock foundation IDs and non-Bedrock names left untouched; the vendor-eating guard; empty and prefix-only input; strip-once-not-repeatedly.
- `TestFormatModelForDisplay::test_bedrock_profile_prefix_is_not_stripped_here` — pins decision (1) above.
- `TestBedrockProfilePrefixInStatusBar` — end to end through `_get_status_bar_snapshot()`, including that `model_name` keeps the full ID.

**Mutation check:** reverting only the `cli.py` wiring fails 2 tests; neutering only the helper to `return model_name` fails 9. Un-mutated, `ruff` is clean and the two touched test files are 74 passed.

`tests/hermes_cli/test_mcp_helper_ledger.py` fails to import locally for want of `psutil` — pre-existing on a clean checkout of this base, unrelated to this change.
