### PR TITLE
fix(model): honor persist default for provider switches

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -744,15 +744,16 @@ def resolve_persist_behavior(
     1. ``--once`` explicitly opts out → ``False`` (next turn only).
     2. ``--session`` explicitly opts out → ``False`` (this session only).
     3. ``--global`` explicitly opts in → ``True``.
-    4. ``--provider`` given without an explicit persist flag → ``False``
-       (session only).  Provider switches are typically exploratory — the
-       user is trying a different backend for this conversation, not
-       reconfiguring the default.  ``--global`` can still force persist.
-    5. Otherwise defer to ``model.persist_switch_by_default`` in
+    4. Otherwise defer to ``model.persist_switch_by_default`` in
        ``config.yaml`` (defaults to ``False``: a plain ``/model <name>``
-       affects only the current session).  Users who want the old
-       persist-by-default behavior can set the key to ``true``; a one-off
-       ``--global`` always persists.
+       affects only the current session).  Users who want picker/menu choices
+       to behave like a persistent preference can set the key to ``true``;
+       a one-off ``--global`` always persists.
+
+    ``--provider`` is intentionally *not* an automatic session-only opt-out
+    when the config default is true.  Gateway/model-picker choices for named
+    custom providers necessarily carry a provider slug; those menu choices
+    should still persist for users who enabled ``persist_switch_by_default``.
 
     The config read is defensive: on a fresh install ``model`` may be a
     flat string rather than a dict, in which case the built-in default
@@ -764,8 +765,6 @@ def resolve_persist_behavior(
         return False
     if is_global:
         return True
-    if explicit_provider:
-        return False
     try:
         from hermes_cli.config import load_config
 

--- a/tests/hermes_cli/test_model_switch_persist_default.py
+++ b/tests/hermes_cli/test_model_switch_persist_default.py
@@ -4,9 +4,9 @@ Covers:
 - ``parse_model_flags`` recognises ``--session`` (and keeps ``--global``).
 - ``resolve_persist_behavior`` applies the config-gated default and the
   ``--session`` / ``--global`` overrides.
-- The default (no flags) is session-only, which is the user-facing fix: a
-  plain ``/model <name>`` affects only the current session unless the user
-  passes ``--global`` or sets ``model.persist_switch_by_default: true``.
+- the default (no flags) is session-only unless the user sets
+  ``model.persist_switch_by_default: true``; when that setting is true,
+  model-picker/provider choices persist too unless ``--session``/``--once`` is used.
 """
 
 from unittest.mock import patch
@@ -51,6 +51,16 @@ class TestResolvePersistBehavior:
         # No --provider → respects config default (True).
         with _config({"model": {"persist_switch_by_default": True}}):
             assert resolve_persist_behavior(False, False, explicit_provider="") is True
+
+    def test_provider_flag_respects_persist_default_when_true(self):
+        # Picker selections for named custom providers carry --provider internally,
+        # but users with persist_switch_by_default=True expect menu choices to stick.
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, False, explicit_provider="custom:pgx") is True
+
+    def test_provider_flag_session_only_when_persist_default_false(self):
+        with _config({"model": {"persist_switch_by_default": False}}):
+            assert resolve_persist_behavior(False, False, explicit_provider="anthropic") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make provider-bearing `/model` switches honor `model.persist_switch_by_default`
- preserve explicit `--once` and `--session` opt-outs and the `--global` opt-in
- add regression coverage for both enabled and disabled persistence defaults

## Problem

Model-picker and named custom-provider selections carry an explicit provider slug internally. `resolve_persist_behavior()` currently treats every explicit provider as session-only before consulting `model.persist_switch_by_default`. As a result, users who enable persistent model switching still see provider-bearing picker selections revert after the session.

The explicit `--session` and `--once` flags already provide clear temporary-switch semantics, so an implicit provider slug should not override the configured persistence preference.

## Verification

- `6 passed` — `tests/hermes_cli/test_model_switch_persist_default.py`
- broader model-switch selection: `143 passed, 2 failed`
- clean `origin/main` baseline for the same selection: `141 passed, the same 2 failed`
- `ruff check` passed for both changed files
- `git diff --check` passed
- independent review found no security concerns or logic errors
