### PR TITLE
fix(agent): stop long sessions from re-entering compression after timeout

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1611,24 +1611,51 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     return _sig is True or isinstance(_sig, str)
 
 
+def _get_context_compression_timeout_state(
+    agent: Any,
+    *,
+    create: bool,
+) -> Optional[Tuple[Any, Optional[threading.local]]]:
+    """Return the stable lock and thread-local timeout state for an agent."""
+    try:
+        attributes = vars(agent)
+    except TypeError:
+        return None
+
+    lock = attributes.setdefault(
+        "_context_compression_timeout_state_lock",
+        threading.Lock(),
+    )
+    with lock:
+        state = attributes.get("_context_compression_timeout_state")
+        if create and not isinstance(state, threading.local):
+            state = threading.local()
+            attributes["_context_compression_timeout_state"] = state
+        return lock, state if isinstance(state, threading.local) else None
+
+
 def reset_context_compression_timeout_outcome(agent: Any) -> None:
     """Clear the current thread's owned-compression timeout outcome."""
-    state = vars(agent).get("_context_compression_timeout_state")
-    if not isinstance(state, threading.local):
-        state = threading.local()
-        vars(agent)["_context_compression_timeout_state"] = state
-    state.timed_out = False
-    agent._last_context_compression_timed_out = False
+    locked_state = _get_context_compression_timeout_state(agent, create=True)
+    if locked_state is None:
+        agent._last_context_compression_timed_out = False
+        return
+    lock, state = locked_state
+    with lock:
+        state.timed_out = False
+        agent._last_context_compression_timed_out = False
 
 
 def mark_context_compression_timed_out(agent: Any) -> None:
     """Mark the current owned compression as host-timed-out."""
-    state = vars(agent).get("_context_compression_timeout_state")
-    if not isinstance(state, threading.local):
-        state = threading.local()
-        vars(agent)["_context_compression_timeout_state"] = state
-    state.timed_out = True
-    agent._last_context_compression_timed_out = True
+    locked_state = _get_context_compression_timeout_state(agent, create=True)
+    if locked_state is None:
+        agent._last_context_compression_timed_out = True
+        return
+    lock, state = locked_state
+    with lock:
+        state.timed_out = True
+        agent._last_context_compression_timed_out = True
 
 
 def context_compression_timed_out(agent: Any) -> bool:
@@ -1639,12 +1666,12 @@ def context_compression_timed_out(agent: Any) -> bool:
     timeout. The attribute fallback supports older/minimal agent doubles.
     Every read is type-pinned to avoid MagicMock auto-attributes.
     """
-    try:
-        state = vars(agent).get("_context_compression_timeout_state")
-    except TypeError:
-        state = None
-    if isinstance(state, threading.local):
-        return getattr(state, "timed_out", None) is True
+    locked_state = _get_context_compression_timeout_state(agent, create=False)
+    if locked_state is not None:
+        lock, state = locked_state
+        with lock:
+            if isinstance(state, threading.local):
+                return getattr(state, "timed_out", None) is True
     return getattr(agent, "_last_context_compression_timed_out", None) is True
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1611,6 +1611,43 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     return _sig is True or isinstance(_sig, str)
 
 
+def reset_context_compression_timeout_outcome(agent: Any) -> None:
+    """Clear the current thread's owned-compression timeout outcome."""
+    state = vars(agent).get("_context_compression_timeout_state")
+    if not isinstance(state, threading.local):
+        state = threading.local()
+        vars(agent)["_context_compression_timeout_state"] = state
+    state.timed_out = False
+    agent._last_context_compression_timed_out = False
+
+
+def mark_context_compression_timed_out(agent: Any) -> None:
+    """Mark the current owned compression as host-timed-out."""
+    state = vars(agent).get("_context_compression_timeout_state")
+    if not isinstance(state, threading.local):
+        state = threading.local()
+        vars(agent)["_context_compression_timeout_state"] = state
+    state.timed_out = True
+    agent._last_context_compression_timed_out = True
+
+
+def context_compression_timed_out(agent: Any) -> bool:
+    """Return whether this thread's owned compression hit its host timeout.
+
+    A single agent may receive overlapping automatic/manual entrypoints. The
+    thread-local outcome prevents one entrypoint's reset from hiding another's
+    timeout. The attribute fallback supports older/minimal agent doubles.
+    Every read is type-pinned to avoid MagicMock auto-attributes.
+    """
+    try:
+        state = vars(agent).get("_context_compression_timeout_state")
+    except TypeError:
+        state = None
+    if isinstance(state, threading.local):
+        return getattr(state, "timed_out", None) is True
+    return getattr(agent, "_last_context_compression_timed_out", None) is True
+
+
 def _adopt_live_compression_child(
     agent: Any,
     session_db: Any,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,6 +34,7 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
     compression_skipped_due_to_lock,
+    context_compression_timed_out,
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
@@ -294,6 +295,12 @@ def _should_skip_model_call_for_reference_handoff(
 _HANDOFF_SKIP_FINAL_RESPONSE = (
     "Context was compacted. The previous response is complete — "
     "awaiting your next message."
+)
+
+_COMPRESSION_TIMEOUT_FINAL_RESPONSE = (
+    "Context compression timed out without reducing this conversation. "
+    "No messages were dropped. Start a fresh session with /new, or check "
+    "auxiliary.compression before retrying /compress."
 )
 
 
@@ -2026,6 +2033,10 @@ def run_conversation(
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
+    _preflight_compression_timed_out = (
+        _ctx.preflight_compression_timed_out is True
+    )
+    _compression_timeout_exhausted = False
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
@@ -2072,6 +2083,15 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        if _preflight_compression_timed_out:
+            # A turn-start threshold pass already exhausted the full host
+            # budget. Do not send the unchanged oversized request: a provider
+            # overflow would immediately invoke compression again.
+            final_response = _COMPRESSION_TIMEOUT_FINAL_RESPONSE
+            failed = True
+            _compression_timeout_exhausted = True
+            _turn_exit_reason = "context_compression_timeout"
+            break
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -2816,6 +2836,19 @@ def run_conversation(
                 approx_tokens=request_pressure_tokens,
                 task_id=effective_task_id,
             )
+            if context_compression_timed_out(agent):
+                # This preflight iteration never reached the provider. Refund
+                # its provisional call/budget exactly like a successful
+                # pre-API compaction, then stop before overflow recovery can
+                # invoke compression again on the unchanged transcript.
+                api_call_count -= 1
+                agent._api_call_count = api_call_count
+                agent.iteration_budget.refund()
+                final_response = _COMPRESSION_TIMEOUT_FINAL_RESPONSE
+                failed = True
+                _compression_timeout_exhausted = True
+                _turn_exit_reason = "context_compression_timeout"
+                break
             if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
                 # #69870 lock-skip: another path holds this session's
                 # compression lock, so this pass no-oped. That is a temporary
@@ -8738,7 +8771,7 @@ def run_conversation(
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
-    return finalize_turn(
+    result = finalize_turn(
         agent,
         final_response=final_response,
         api_call_count=api_call_count,
@@ -8755,6 +8788,14 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
+    if _compression_timeout_exhausted:
+        # Reuse the gateway's existing context-recovery contract. The bloated
+        # transcript remains intact while future input can move to a clean
+        # session instead of replaying the summarize timeout loop.
+        result["error"] = _COMPRESSION_TIMEOUT_FINAL_RESPONSE
+        result["partial"] = True
+        result["compression_exhausted"] = True
+    return result
 
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -35,6 +35,7 @@ from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
     compression_skipped_due_to_lock,
+    context_compression_timed_out,
     conversation_history_after_compression,
     recover_rotated_compression_session,
 )
@@ -503,6 +504,8 @@ class TurnContext:
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
     preflight_compression_blocked: bool = False
+    # The threshold preflight exhausted the host's progress-aware wait.
+    preflight_compression_timed_out: bool = False
 
 
 def build_turn_context(
@@ -959,6 +962,7 @@ def build_turn_context(
     # issue #27405 (a few very large messages slipping past the count gate).
     _preflight_compressed = False
     _preflight_compression_blocked = False
+    _preflight_compression_timed_out = False
     agent._turn_received_provider_response = False
     agent._turn_preflight_display_snapshot = None
     if (
@@ -1113,6 +1117,14 @@ def build_turn_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
+                if context_compression_timed_out(agent):
+                    # The host already spent the full progress-aware budget.
+                    # Preserve the transcript and tell run_conversation to end
+                    # before the unchanged over-limit request reaches provider
+                    # overflow recovery and invokes compression again.
+                    _preflight_compression_blocked = True
+                    _preflight_compression_timed_out = True
+                    break
                 if (
                     messages is _preflight_input
                     and compression_skipped_due_to_lock(agent)
@@ -1575,4 +1587,5 @@ def build_turn_context(
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
+        preflight_compression_timed_out=_preflight_compression_timed_out,
     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -8066,6 +8066,8 @@ class AIAgent:
         from agent.conversation_compression import (
             CompressionCommitFence,
             compress_context,
+            mark_context_compression_timed_out,
+            reset_context_compression_timeout_outcome,
             resolve_context_compression_timeouts,
             run_compress_context_with_progress_timeout,
         )
@@ -8096,6 +8098,10 @@ class AIAgent:
         # Every AIAgent compression has a fence, including ordinary in-turn and
         # manual paths. hard_interrupt() uses this exact instance to serialize
         # cancel admission against begin_commit().
+        # Automatic callers inspect this typed outcome immediately after the
+        # call. Clear it per invocation so a prior turn's timeout cannot leak
+        # through a later cooldown skip.
+        reset_context_compression_timeout_outcome(self)
         active_fence = commit_fence or CompressionCommitFence()
         # A single agent can receive overlapping automatic/manual entrypoints.
         # Serialize fence publication so a waiter cannot replace the fence of
@@ -8180,6 +8186,7 @@ class AIAgent:
                         return system_message or ""
 
                 def _on_timeout(idle, waited, since_progress):
+                    mark_context_compression_timed_out(self)
                     logger.warning(
                         "Context compression made no progress for %.1fs "
                         "(total wait %.1fs, ceiling %.1fs); continuing without "

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -423,6 +423,7 @@ class TestCompressContextForwarderOwnsTimeout:
         assert out_msgs is original
         assert out_prompt == "sys"
         assert calls["n"] == 1
+        assert agent._last_context_compression_timed_out is True
         agent._emit_warning.assert_called_once()
         assert agent.context_compressor._consecutive_timeout_failures == 1
         agent.context_compressor._record_compression_failure_cooldown.assert_called_once()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from agent.conversation_compression import (
     CompressionCommitFence,
+    context_compression_timed_out,
+    mark_context_compression_timed_out,
+    reset_context_compression_timeout_outcome,
     resolve_context_compression_timeouts,
     run_compress_context_with_progress_timeout,
 )
@@ -46,6 +50,31 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
+    def test_timeout_outcome_is_isolated_between_overlapping_entrypoints(self):
+        agent = SimpleNamespace()
+        worker_marked = threading.Event()
+        main_reset = threading.Event()
+        seen = {}
+
+        def worker():
+            reset_context_compression_timeout_outcome(agent)
+            mark_context_compression_timed_out(agent)
+            worker_marked.set()
+            assert main_reset.wait(timeout=2)
+            seen["worker"] = context_compression_timed_out(agent)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        assert worker_marked.wait(timeout=2)
+
+        reset_context_compression_timeout_outcome(agent)
+        seen["main"] = context_compression_timed_out(agent)
+        main_reset.set()
+        thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert seen == {"main": False, "worker": True}
+
     def test_silent_worker_times_out_and_preserves_messages(self):
         original = [{"role": "user", "content": "keep-me"}]
         started = threading.Event()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agent import conversation_compression as compression_module
 from agent.conversation_compression import (
     CompressionCommitFence,
     context_compression_timed_out,
@@ -50,6 +51,60 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
+    def test_timeout_state_first_use_is_atomic(self, monkeypatch):
+        agent = SimpleNamespace()
+        reset_constructor_entered = threading.Event()
+        marker_constructor_finished = threading.Event()
+        release_reset_constructor = threading.Event()
+        reset_finished = threading.Event()
+        marker_finished = threading.Event()
+        seen = {}
+        original_local = threading.local
+
+        class DelayedLocal(original_local):
+            def __new__(cls):
+                state = super().__new__(cls)
+                if threading.current_thread().name == "timeout-resetter":
+                    reset_constructor_entered.set()
+                    assert release_reset_constructor.wait(timeout=2)
+                else:
+                    marker_constructor_finished.set()
+                return state
+
+        monkeypatch.setattr(compression_module.threading, "local", DelayedLocal)
+
+        def resetter():
+            reset_context_compression_timeout_outcome(agent)
+            reset_finished.set()
+            assert marker_finished.wait(timeout=2)
+            seen["resetter"] = context_compression_timed_out(agent)
+
+        def marker():
+            mark_context_compression_timed_out(agent)
+            marker_finished.set()
+            assert reset_finished.wait(timeout=2)
+            seen["marker"] = context_compression_timed_out(agent)
+
+        reset_thread = threading.Thread(target=resetter, name="timeout-resetter")
+        mark_thread = threading.Thread(target=marker, name="timeout-marker")
+        reset_thread.start()
+        assert reset_constructor_entered.wait(timeout=2)
+        mark_thread.start()
+
+        # A fixed implementation publishes the initialization lock before
+        # constructing the state. The old implementation lets the marker
+        # publish a competing state while the resetter is paused here.
+        if "_context_compression_timeout_state_lock" not in vars(agent):
+            assert marker_constructor_finished.wait(timeout=2)
+        release_reset_constructor.set()
+
+        reset_thread.join(timeout=2)
+        mark_thread.join(timeout=2)
+
+        assert not reset_thread.is_alive()
+        assert not mark_thread.is_alive()
+        assert seen == {"resetter": False, "marker": True}
+
     def test_timeout_outcome_is_isolated_between_overlapping_entrypoints(self):
         agent = SimpleNamespace()
         worker_marked = threading.Event()

--- a/tests/agent/test_preflight_lock_defer.py
+++ b/tests/agent/test_preflight_lock_defer.py
@@ -73,6 +73,29 @@ def test_preflight_lock_skip_does_not_set_blocked_flag():
     assert ctx.preflight_compression_blocked is False
 
 
+def test_preflight_timeout_is_exposed_as_terminal_outcome():
+    """A host timeout must not look like an ordinary compressible no-op.
+
+    The conversation loop needs this typed outcome to stop before sending the
+    unchanged over-limit request and entering the provider overflow retry path.
+    """
+    agent = _make_agent()
+    calls = []
+
+    def _timed_out_compress(messages, _system_message, **_kwargs):
+        calls.append(1)
+        agent._last_context_compression_timed_out = True
+        return messages, "SYSTEM"
+
+    agent._compress_context = _timed_out_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    assert calls == [1]
+    assert ctx.preflight_compression_blocked is True
+    assert ctx.preflight_compression_timed_out is True
+
+
 
 
 

--- a/tests/run_agent/test_compression_timeout_terminal.py
+++ b/tests/run_agent/test_compression_timeout_terminal.py
@@ -1,0 +1,68 @@
+"""Host compression timeout terminates the turn before provider retry (#98722)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_turn_start_timeout_never_sends_unchanged_oversized_request():
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.compression_enabled = True
+    agent.context_compressor.protect_first_n = 0
+    agent.context_compressor.protect_last_n = 0
+    agent.context_compressor.threshold_tokens = 1
+    agent.context_compressor.should_compress = MagicMock(return_value=True)
+    agent.context_compressor.should_defer_preflight_to_real_usage = MagicMock(
+        return_value=False
+    )
+    agent.context_compressor.get_active_compression_failure_cooldown = MagicMock(
+        return_value=None
+    )
+
+    compression_calls = []
+
+    def _timed_out(messages, _system_message, **_kwargs):
+        compression_calls.append(1)
+        agent._last_context_compression_timed_out = True
+        return messages, agent._cached_system_prompt
+
+    agent._compress_context = _timed_out
+
+    history = [
+        {"role": "user", "content": "old request"},
+        {"role": "assistant", "content": "old response"},
+    ]
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("continue", conversation_history=history)
+
+    assert compression_calls == [1]
+    agent.client.chat.completions.create.assert_not_called()
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["compression_exhausted"] is True
+    assert result["turn_exit_reason"] == "context_compression_timeout"
+    assert "No messages were dropped" in result["final_response"]
+    assert result["error"] == result["final_response"]


### PR DESCRIPTION
## What does this PR do?

Long sessions whose automatic compression reaches the host timeout now end the current turn with an explicit recovery error instead of sending the unchanged oversized request and entering compression again through provider overflow recovery. The transcript remains intact, and the existing `compression_exhausted` gateway path can move future input to a clean session.

### Symptom

An over-limit session can spend the full compression ceiling in "Summarizing thread", continue unchanged, and immediately enter another automatic compression path.

### Impact

The affected session remains unusable while repeated compression attempts consume the full timeout budget. No messages need to be dropped to stop the loop.

### Bug Cause

**Trigger:** `run_agent.py` host-owned compression timeout combined with the turn-start or mid-turn pre-API threshold guard.

**Causal chain:**
1. Automatic compression reaches its progress-aware host ceiling and returns the original transcript unchanged.
2. The caller cannot distinguish that timeout from an ordinary no-op and continues toward the provider with the still-oversized request.
3. Provider overflow recovery is then allowed to invoke compression again in the same turn.

**Why it is wrong:** The timeout outcome is recorded only as a cooldown and warning, not as a typed result consumed by the automatic compression callers.

**Working sibling / contrast:** Compression lock contention already has a typed outcome and is handled as a defer without consuming retry budget. A host timeout needs a different terminal outcome because the full wait budget has already been exhausted.

**Ruled out:** Stale-lock reclaim is not the retry trigger. Holder-qualified lock release and reclaim already protect ownership; the loop occurs after compression returns unchanged.

### Fix

- Record a thread-local, type-pinned host-timeout outcome for each owned compression call.
- Propagate turn-start threshold timeouts through `TurnContext`.
- Stop turn-start and mid-turn pre-API execution before a provider call can re-enter compression.
- Return an actionable failed result with `compression_exhausted=True` while preserving the original transcript.

## Related Issue

Closes #98722

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` - expose a concurrency-safe typed timeout outcome.
- `run_agent.py` - reset and mark the timeout outcome around host-owned compression.
- `agent/turn_context.py` - propagate a threshold preflight timeout to the main loop.
- `agent/conversation_loop.py` - terminate timed-out turns before provider or overflow retries.
- `tests/agent/` and `tests/run_agent/` - cover timeout signaling, preflight propagation, transcript preservation, zero provider calls, and terminal recovery metadata.

## How to Test

1. Run a controlled over-threshold turn whose compression call returns unchanged with the host-timeout outcome.
2. Verify exactly one compression call occurs, no provider request is sent, messages remain intact, and the result is failed with `compression_exhausted=True`.
3. Run the related compression, turn-context, and gateway recovery tests:

```bash
scripts/run_tests.sh tests/run_agent/test_compression_timeout_terminal.py tests/agent/test_preflight_lock_defer.py tests/agent/test_compress_context_progress_timeout.py -q
scripts/run_tests.sh tests/agent/test_turn_context.py tests/run_agent/test_1630_context_overflow_loop.py tests/gateway/test_35809_auto_reset_clean_context.py tests/gateway/test_7100_transient_failure_transcript.py -q
```

Result: 55 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required; runtime behavior and docstrings are covered
- [x] Config example update is not required; no config keys changed
- [x] Contributor guide update is not required; no workflow changed
- [x] I've considered cross-platform impact; the outcome uses Python threading primitives on all supported platforms
- [x] Tool descriptions and schemas are not affected

## Screenshots / Logs

Not applicable. The regression is covered by controlled runtime tests.
