### PR TITLE
fix(desktop): idle-stop the primary backend when a named profile is active

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -287,6 +287,7 @@ import {
   runPrimaryBackendStartup
 } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
+import { resolveApiRouteProfile, shouldIdleStopPrimary } from './primary-idle'
 import {
   assertLocalProfileCanStart,
   decideProfileDeleteAction,
@@ -1391,6 +1392,11 @@ const backendDialClaims = new BackendDialClaims()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
+let primaryIdleStopChild = null
+let primaryBackendReady = false
+let lastReportedActiveProfile = null
+let lastReportedKeepProfiles = []
+let primaryIdleStopTimer = null
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
 // (the desktop's launch profile) stays managed by backendConnectionState +
 // startHermes(); this pool only holds EXTRA profile
@@ -10838,6 +10844,7 @@ function stopBackendChild(child) {
 // (so skeletons retrigger) and re-dials. Distinct from hard re-home (profile
 // switch / crash recovery), which still resets boot progress + reloads.
 function resetHermesConnection({ soft = false } = {}) {
+  primaryBackendReady = false
   backendStartFailure = null
   remoteReauthFailure = null
   remoteLiveness.clear()
@@ -10948,6 +10955,89 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
   // Await the escalation as well; do not let shutdown or failed adoption race
   // a still-running backend.
   await wait(1000)
+}
+
+function primaryModeNow() {
+  const hermesProcess = backendConnectionState.getProcess()
+
+  if (hermesProcess && !hermesProcess.killed) {
+    return 'local-child'
+  }
+
+  // Promise set with no child = remote / still connecting
+  if (backendConnectionState.getPromise() && !hermesProcess) {
+    return 'remote'
+  }
+
+  return 'down'
+}
+
+function schedulePrimaryIdleStop() {
+  if (primaryIdleStopTimer) {
+    return
+  }
+
+  primaryIdleStopTimer = setTimeout(() => {
+    primaryIdleStopTimer = null
+    void idleStopPrimaryIfStillSafe()
+  }, 3_000)
+
+  if (typeof primaryIdleStopTimer.unref === 'function') {
+    primaryIdleStopTimer.unref()
+  }
+}
+
+function cancelPrimaryIdleStop() {
+  if (!primaryIdleStopTimer) {
+    return
+  }
+
+  clearTimeout(primaryIdleStopTimer)
+  primaryIdleStopTimer = null
+}
+
+function livePoolKeys() {
+  return [...backendPool.entries()]
+    .filter(([, entry]) => Boolean(entry && entry.process))
+    .map(([profile]) => profile)
+}
+
+function primaryIsReachable() {
+  return Boolean(backendConnectionState.getProcess()) || Boolean(backendConnectionState.getPromise())
+}
+
+async function idleStopPrimaryIfStillSafe() {
+  if (
+    !shouldIdleStopPrimary({
+      activeProfile: lastReportedActiveProfile,
+      primaryKey: primaryProfileKey(),
+      keepProfiles: lastReportedKeepProfiles || [],
+      primaryMode: primaryModeNow()
+    })
+  ) {
+    return
+  }
+
+  if (!primaryBackendReady) {
+    // Child is still booting — retry after another debounce. SIGTERM here
+    // would reject startHermes and latch backendStartFailure.
+    schedulePrimaryIdleStop()
+
+    return
+  }
+
+  const hermesProcess = backendConnectionState.getProcess()
+  const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
+
+  if (!dying) {
+    return
+  }
+
+  primaryIdleStopChild = dying
+  rememberLog(
+    `Idle-stopping primary backend "${primaryProfileKey()}" (active profile "${lastReportedActiveProfile}")`
+  )
+  await teardownPrimaryBackendAndWait({ soft: true })
 }
 
 // The profile the primary (window) backend runs as. readActiveDesktopProfile()
@@ -12523,9 +12613,15 @@ async function startHermes() {
       }
 
       rememberLog(`Hermes backend exited (${signal || code})`)
-      sendBackendExit({ code, signal })
+      const reason = primaryIdleStopChild === hermesProcess ? 'idle-stop' : undefined
 
-      if (!backendReady) {
+      if (primaryIdleStopChild === hermesProcess) {
+        primaryIdleStopChild = null
+      }
+
+      sendBackendExit({ code, signal, ...(reason ? { reason } : {}) })
+
+      if (!backendReady && reason !== 'idle-stop') {
         const message = `Hermes backend exited before it became ready (${signal || code}).${primaryOutputTail.describe()}`
         updateBootProgress(
           {
@@ -12563,6 +12659,7 @@ async function startHermes() {
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)
     await Promise.race([waitForHermes(baseUrl, token), backendStartFailed])
     backendReady = true
+    primaryBackendReady = true
     backendStartFailure = null
 
     const authToken = await adoptServedDashboardToken(baseUrl, token, {
@@ -12610,6 +12707,7 @@ async function startHermes() {
       throw error
     }
 
+    primaryBackendReady = false
     const failedProcess = backendConnectionState.invalidate()
     stopBackendChild(failedProcess)
     await waitForBackendExit(failedProcess)
@@ -14344,6 +14442,33 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
 
   return { ok: true }
 })
+ipcMain.handle('hermes:backend:usage', async (_event, payload) => {
+  const activeProfile = payload && payload.activeProfile != null ? String(payload.activeProfile) : ''
+  const keepProfiles = Array.isArray(payload?.keepProfiles) ? payload.keepProfiles.map(String) : []
+  lastReportedActiveProfile = activeProfile
+  lastReportedKeepProfiles = keepProfiles
+
+  const ping = [activeProfile, ...keepProfiles]
+
+  for (const name of ping) {
+    touchPoolBackend(name)
+  }
+
+  const shouldStop = shouldIdleStopPrimary({
+    activeProfile,
+    primaryKey: primaryProfileKey(),
+    keepProfiles,
+    primaryMode: primaryModeNow()
+  })
+
+  if (shouldStop) {
+    schedulePrimaryIdleStop()
+  } else {
+    cancelPrimaryIdleStop()
+  }
+
+  return { ok: true, idleStopScheduled: shouldStop }
+})
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))
 })
@@ -15746,7 +15871,18 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const base = (await fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)) as any
+  const aggregatorProfile = resolveApiRouteProfile({
+    requestProfile: null,
+    tornDownProfile: null,
+    primaryRunning: primaryIsReachable(),
+    livePoolKeys: livePoolKeys(),
+    lastActiveProfile: lastReportedActiveProfile,
+    method: 'GET',
+    pathname: '/api/profiles/sessions'
+  })
+  const base = (await fetchPrimaryProfileSessions(searchParams, (profile, path) =>
+    fetchJsonForProfile(profile ?? aggregatorProfile, path)
+  )) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.
@@ -15947,9 +16083,27 @@ async function handleHermesApiRequest(request) {
   // primary until the PATCH settles, so the request routes there.
   const apiRoute = resolveProfileApiRequest(profile, request.path, profileRouteOptions(profile, request))
 
-  const routeProfile = profileRename
+  let parsedPath = null
+
+  try {
+    parsedPath = new URL(request?.path || '/', 'http://x')
+  } catch {
+    parsedPath = null
+  }
+
+  const routed = profileRename
     ? profileRename.routeProfile
     : resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)
+
+  const routeProfile = resolveApiRouteProfile({
+    requestProfile: routed,
+    tornDownProfile,
+    primaryRunning: primaryIsReachable(),
+    livePoolKeys: livePoolKeys(),
+    lastActiveProfile: lastReportedActiveProfile,
+    method: request?.method,
+    pathname: parsedPath ? parsedPath.pathname : ''
+  })
 
   let response
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  reportBackendUsage: payload => ipcRenderer.invoke('hermes:backend:usage', payload),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.

--- a/apps/desktop/electron/primary-idle-wiring.test.ts
+++ b/apps/desktop/electron/primary-idle-wiring.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+const ELECTRON_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+function read(name: string) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+test('main idle-stop uses quiet/soft teardown and does not write active-profile.json', () => {
+  const source = read('main.ts')
+  assert.match(source, /from '\.\/primary-idle'/)
+  assert.match(source, /hermes:backend:usage/)
+  assert.match(source, /teardownPrimaryBackendAndWait\(\{\s*soft:\s*true\s*\}\)/)
+  assert.match(source, /reason: 'idle-stop'|['"]idle-stop['"]/)
+
+  const idleFnStart = source.indexOf('async function idleStopPrimaryIfStillSafe')
+  assert.notEqual(idleFnStart, -1)
+  const idleFn = source.slice(idleFnStart, idleFnStart + 1800)
+  assert.doesNotMatch(idleFn, /writeActiveDesktopProfile/)
+  assert.doesNotMatch(idleFn, /prepareProfileDeleteRequest/)
+  assert.doesNotMatch(idleFn, /mainWindow\?\.reload\(\)/)
+  // Latch must survive waitForBackendExit (which can resolve before 'exit'
+  // when SIGKILL times out). Clearing here races the later exit toast.
+  assert.doesNotMatch(idleFn, /primaryIdleStopChild = null/)
+})
+
+test('preload exposes reportBackendUsage', () => {
+  const source = read('preload.ts')
+  assert.match(source, /reportBackendUsage:\s*payload\s*=>\s*ipcRenderer\.invoke\('hermes:backend:usage'/)
+})

--- a/apps/desktop/electron/primary-idle.test.ts
+++ b/apps/desktop/electron/primary-idle.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { isMultiplexProfileRead, resolveApiRouteProfile, shouldIdleStopPrimary } from './primary-idle'
+
+test('idle-stop when UI is on a named profile, primary is a local child, keep excludes primary', () => {
+  assert.equal(
+    shouldIdleStopPrimary({
+      activeProfile: 'repro91050',
+      primaryKey: 'default',
+      keepProfiles: ['repro91050'],
+      primaryMode: 'local-child'
+    }),
+    true
+  )
+})
+
+test('do not idle-stop when the UI is still on the primary', () => {
+  assert.equal(
+    shouldIdleStopPrimary({
+      activeProfile: 'default',
+      primaryKey: 'default',
+      keepProfiles: [],
+      primaryMode: 'local-child'
+    }),
+    false
+  )
+})
+
+test('do not idle-stop when a working/attention session belongs to primary', () => {
+  assert.equal(
+    shouldIdleStopPrimary({
+      activeProfile: 'repro91050',
+      primaryKey: 'default',
+      keepProfiles: ['default', 'repro91050'],
+      primaryMode: 'local-child'
+    }),
+    false
+  )
+})
+
+test('treat empty activeProfile as default (legacy)', () => {
+  assert.equal(
+    shouldIdleStopPrimary({
+      activeProfile: '',
+      primaryKey: 'default',
+      keepProfiles: [],
+      primaryMode: 'local-child'
+    }),
+    false
+  )
+})
+
+test('do not idle-stop a remote primary or a primary that is already down', () => {
+  for (const primaryMode of ['remote', 'down']) {
+    assert.equal(
+      shouldIdleStopPrimary({
+        activeProfile: 'repro91050',
+        primaryKey: 'default',
+        keepProfiles: [],
+        primaryMode
+      }),
+      false
+    )
+  }
+})
+
+test('isMultiplexProfileRead covers only cross-profile GET list/active', () => {
+  assert.equal(isMultiplexProfileRead('GET', '/api/profiles/sessions'), true)
+  assert.equal(isMultiplexProfileRead('GET', '/api/profiles'), true)
+  assert.equal(isMultiplexProfileRead('GET', '/api/profiles/active'), true)
+  assert.equal(isMultiplexProfileRead('DELETE', '/api/profiles/sessions'), false)
+  assert.equal(isMultiplexProfileRead('GET', '/api/status'), false)
+  assert.equal(isMultiplexProfileRead('GET', '/api/sessions'), false)
+})
+
+test('resolveApiRouteProfile keeps stamped profile (named or default)', () => {
+  assert.equal(
+    resolveApiRouteProfile({
+      requestProfile: 'repro91050',
+      tornDownProfile: null,
+      primaryRunning: false,
+      livePoolKeys: ['repro91050'],
+      lastActiveProfile: 'repro91050',
+      method: 'GET',
+      pathname: '/api/profiles/sessions'
+    }),
+    'repro91050'
+  )
+  assert.equal(
+    resolveApiRouteProfile({
+      requestProfile: 'default',
+      tornDownProfile: null,
+      primaryRunning: true,
+      livePoolKeys: [],
+      lastActiveProfile: 'default',
+      method: 'GET',
+      pathname: '/api/profiles/sessions'
+    }),
+    'default'
+  )
+})
+
+test('unscoped multiplex GET falls back to a live pool key when primary is down', () => {
+  assert.equal(
+    resolveApiRouteProfile({
+      requestProfile: null,
+      tornDownProfile: null,
+      primaryRunning: false,
+      livePoolKeys: ['repro91050'],
+      lastActiveProfile: 'repro91050',
+      method: 'GET',
+      pathname: '/api/profiles/sessions'
+    }),
+    'repro91050'
+  )
+})
+
+test('unscoped non-multiplex still routes to primary (null) even if primary is down', () => {
+  assert.equal(
+    resolveApiRouteProfile({
+      requestProfile: null,
+      tornDownProfile: null,
+      primaryRunning: false,
+      livePoolKeys: ['repro91050'],
+      lastActiveProfile: 'repro91050',
+      method: 'GET',
+      pathname: '/api/status'
+    }),
+    null
+  )
+})
+
+test('profile-delete tornDownProfile still forces primary (null) — do not change that contract', () => {
+  assert.equal(
+    resolveApiRouteProfile({
+      requestProfile: 'doomed',
+      tornDownProfile: 'doomed',
+      primaryRunning: true,
+      livePoolKeys: [],
+      lastActiveProfile: 'default',
+      method: 'DELETE',
+      pathname: '/api/profiles/doomed'
+    }),
+    null
+  )
+})

--- a/apps/desktop/electron/primary-idle.ts
+++ b/apps/desktop/electron/primary-idle.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure policy for desktop primary-backend idle-stop (#91050).
+ * Kept out of main.ts so unit tests can load it without Electron.
+ */
+
+export type PrimaryMode = 'local-child' | 'remote' | 'down'
+
+export function normalizeProfileKey(name: unknown): string {
+  const value = name == null ? '' : String(name).trim()
+
+  return value || 'default'
+}
+
+export function shouldIdleStopPrimary({
+  activeProfile,
+  primaryKey,
+  keepProfiles,
+  primaryMode
+}: {
+  activeProfile?: null | string
+  keepProfiles?: unknown[]
+  primaryKey?: null | string
+  primaryMode?: string
+}): boolean {
+  if (primaryMode !== 'local-child') {
+    return false
+  }
+
+  const active = normalizeProfileKey(activeProfile)
+  const primary = normalizeProfileKey(primaryKey)
+
+  if (active === primary) {
+    return false
+  }
+
+  const keep = new Set((keepProfiles || []).map(normalizeProfileKey))
+
+  if (keep.has(primary)) {
+    return false
+  }
+
+  return true
+}
+
+export function isMultiplexProfileRead(method: unknown, pathname: unknown): boolean {
+  if (String(method || 'GET').toUpperCase() !== 'GET') {
+    return false
+  }
+
+  return (
+    pathname === '/api/profiles' || pathname === '/api/profiles/sessions' || pathname === '/api/profiles/active'
+  )
+}
+
+/**
+ * Which profile key to pass to ensureBackend().
+ * `null` means "primary" (same as today's unscoped hermes:api).
+ * When primary is down, unscoped multiplex GETs must not call startHermes()
+ * — return a live pool key instead.
+ */
+export function resolveApiRouteProfile({
+  requestProfile,
+  tornDownProfile,
+  primaryRunning,
+  livePoolKeys,
+  lastActiveProfile,
+  method,
+  pathname
+}: {
+  lastActiveProfile?: null | string
+  livePoolKeys?: unknown[]
+  method?: unknown
+  pathname?: unknown
+  primaryRunning?: boolean
+  requestProfile?: null | string
+  tornDownProfile?: null | string
+}): null | string {
+  if (tornDownProfile) {
+    return null
+  }
+
+  const stamped = requestProfile && String(requestProfile).trim() ? String(requestProfile).trim() : null
+
+  if (stamped) {
+    return stamped
+  }
+
+  if (primaryRunning || !isMultiplexProfileRead(method, pathname)) {
+    return null
+  }
+
+  const pool = Array.isArray(livePoolKeys) ? livePoolKeys.filter(Boolean).map(String) : []
+  const preferred = lastActiveProfile && pool.includes(lastActiveProfile) ? lastActiveProfile : pool[0]
+
+  return preferred || null
+}

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -238,6 +238,7 @@ function fakeDesktop() {
     revalidateConnection: vi.fn(async () => ({ ok: true, rebuilt: false })),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
+    reportBackendUsage: vi.fn(async () => ({ ok: true })),
     profile: { get: vi.fn(async () => ({ profile: 'default' })) }
   }
 }
@@ -1511,14 +1512,17 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     await advanceBackoff()
 
     const reconnectCalls = desktop.getConnection.mock.calls.slice(callsBeforeDrop)
+    // Must never retarget the primary socket at the named profile (#46651).
     expect(reconnectCalls.some(args => (args[0] ?? '').trim() === 'coder')).toBe(false)
-    expect(reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '')).toBe(true)
+    // #91050: while the UI is on a named profile, do not respawn the idle
+    // primary via getConnection(). Switching back to default reconnects it.
+    expect(reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '')).toBe(false)
 
     const primaryReconnectSockets = FakeWebSocket.instances
       .slice(socketsBeforeDrop)
       .filter(socket => socket.url === primaryConn.wsUrl)
 
-    expect(primaryReconnectSockets.length).toBeGreaterThan(0)
+    expect(primaryReconnectSockets).toHaveLength(0)
     expect($connection.get()?.profile).toBe('coder')
     expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -9,6 +9,7 @@ import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+import { collectKeptProfileKeys } from '@/store/backend-usage'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -27,6 +28,7 @@ import {
   disposeSecondariesForConnection,
   ensureGatewayForProfile,
   gatewayActivationEpoch,
+  getPrimaryProfileKey,
   isActivePrimary,
   liveSecondaryConnectionIds,
   pruneSecondaryGateways,
@@ -298,7 +300,7 @@ export function useGatewayBoot({
     }
 
     const attemptReconnect = async () => {
-      if (cancelled || reconnecting || gatewayOpen() || $gatewaySwitching.get()) {
+      if (cancelled || reconnecting || gatewayOpen() || $gatewaySwitching.get() || !isActivePrimary()) {
         return
       }
 
@@ -318,6 +320,10 @@ export function useGatewayBoot({
           'Timed out revalidating the gateway connection'
         ).catch(() => undefined)
 
+        if (cancelled || !isActivePrimary()) {
+          return
+        }
+
         // Primary sleep/wake reconnect must dial the WINDOW-owned primary backend
         // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget
         // this primary socket at a secondary profile's backend after a live swap.
@@ -330,7 +336,7 @@ export function useGatewayBoot({
 
         setPrimaryGatewayConnection(conn)
 
-        if (cancelled) {
+        if (cancelled || !isActivePrimary()) {
           return
         }
 
@@ -357,7 +363,7 @@ export function useGatewayBoot({
 
         await gateway.connect(wsUrl)
 
-        if (cancelled) {
+        if (cancelled || !isActivePrimary()) {
           return
         }
 
@@ -391,7 +397,7 @@ export function useGatewayBoot({
         // against a ticket that can never succeed. Transport failures fall
         // through to the backoff in the finally block below — they must NOT
         // take the full-screen "couldn't start" path (locks reading/drafting).
-        if (!cancelled && isGatewayReauthRequired(err) && !reauthNotified) {
+        if (!cancelled && isActivePrimary() && isGatewayReauthRequired(err) && !reauthNotified) {
           reauthNotified = true
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
@@ -400,7 +406,7 @@ export function useGatewayBoot({
       } finally {
         reconnecting = false
 
-        if (!cancelled && !gatewayOpen() && !$gatewaySwitching.get()) {
+        if (!cancelled && !gatewayOpen() && !$gatewaySwitching.get() && isActivePrimary()) {
           if (reconnectFailingSince === null) {
             reconnectFailingSince = Date.now()
           }
@@ -423,7 +429,14 @@ export function useGatewayBoot({
     }
 
     function scheduleReconnect() {
-      if (cancelled || reconnecting || reconnectTimer !== null || gatewayOpen() || $gatewaySwitching.get()) {
+      if (
+        cancelled ||
+        reconnecting ||
+        reconnectTimer !== null ||
+        gatewayOpen() ||
+        $gatewaySwitching.get() ||
+        !isActivePrimary()
+      ) {
         return
       }
 
@@ -820,9 +833,16 @@ export function useGatewayBoot({
         if (bootCompleted) {
           completeDesktopBoot()
         }
-      } else if (bootCompleted && !$gatewaySwitching.get() && (st === 'closed' || st === 'error')) {
+      } else if (
+        bootCompleted &&
+        !$gatewaySwitching.get() &&
+        isActivePrimary() &&
+        (st === 'closed' || st === 'error')
+      ) {
         // The socket dropped after a healthy boot (typically sleep/wake). Try
         // to bring it back instead of leaving the composer stuck disabled.
+        // Idle-stop closes primary while the user is on a named profile —
+        // reconnecting here would respawn it onto the wrong backend.
         scheduleReconnect()
       }
     })
@@ -893,13 +913,6 @@ export function useGatewayBoot({
     // this a socket dropped during sleep sits closed until the user clicks.
     window.addEventListener('focus', onFocus)
 
-    // Keep live pool backends alive while this window is open (the main process
-    // can't observe the direct renderer↔backend WS). No-op for the primary.
-    const keepaliveTimer = setInterval(() => {
-      touchActiveGatewayBackend()
-      touchSecondaryGateways()
-    }, 60_000)
-
     // Bound concurrency cost to consumers: keep a background socket while its
     // profile has a running (working) or blocked (needs-input) session, OR an
     // open owner-routed tile (Bot chats stay on a secondary while chrome stays
@@ -907,6 +920,8 @@ export function useGatewayBoot({
     // and its backend is free to idle-reap. The active profile is always spared.
     // Do not key this off `entry.retained` — that flag only skips dispose-after-
     // RPC; idle prune is what reclaims hover-warmed sockets after you leave.
+    // Also reports keep set + active profile to main so idle-stop can spare/stop
+    // the primary.
     const recomputeKeptGateways = () => {
       const live = new Set([...$workingSessionIds.get(), ...$attentionSessionIds.get()])
       // Registry-scoped (connectionId, profile) scopes with live work. Two
@@ -931,13 +946,55 @@ export function useGatewayBoot({
       // releases agree with this pruner. This recompute only has to RUN when
       // they change — see the tile / selected session / hold subscriptions.
       pruneSecondaryGateways(keep)
+
+      const idleKeep = new Set(
+        collectKeptProfileKeys(
+          $sessions.get(),
+          $workingSessionIds.get(),
+          $attentionSessionIds.get(),
+          getPrimaryProfileKey()
+        )
+      )
+      const primaryKey = getPrimaryProfileKey()
+
+      for (const scope of keep) {
+        const value = String(scope)
+
+        if (value === primaryKey || value.endsWith(`::${primaryKey}`)) {
+          idleKeep.add(primaryKey)
+        }
+      }
+
+      void window.hermesDesktop
+        ?.reportBackendUsage?.({
+          activeProfile: normalizeProfileKey($activeGatewayProfile.get()),
+          keepProfiles: [...idleKeep]
+        })
+        ?.catch(() => undefined)
     }
+
+    // Keep live pool backends alive while this window is open (the main process
+    // can't observe the direct renderer↔backend WS). No-op for the primary.
+    // Also refresh keep + report so main's idle-stop sees current usage.
+    const keepaliveTimer = setInterval(() => {
+      touchActiveGatewayBackend()
+      touchSecondaryGateways()
+      recomputeKeptGateways()
+    }, 60_000)
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
     const offActiveSession = $activeSessionId.subscribe(() => recomputeKeptGateways())
     const offSessionTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
-    const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
+    const offActiveProfile = $activeGatewayProfile.subscribe(() => {
+      recomputeKeptGateways()
+      // Switching back to the launch profile: ensureGatewayForProfile is a
+      // no-op for primary, so a socket idle-stopped while we were on a named
+      // profile stays closed unless we reconnect here.
+      if (bootCompleted && isActivePrimary() && !gatewayOpen()) {
+        void attemptReconnect()
+      }
+    })
     const offTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
     const offSelectedSession = $selectedStoredSessionId.subscribe(() => recomputeKeptGateways())
     const offSessionOwnerHolds = $sessionOwnerHoldRevision.subscribe(() => recomputeKeptGateways())
@@ -950,8 +1007,8 @@ export function useGatewayBoot({
       }
     })
 
-    const offExit = desktop.onBackendExit(() => {
-      if ($gatewaySwitching.get()) {
+    const offExit = desktop.onBackendExit(payload => {
+      if (payload?.reason === 'idle-stop' || $gatewaySwitching.get()) {
         return
       }
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -36,7 +36,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
-import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+import { $attentionSessionIds, $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
 import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
 
@@ -76,6 +76,7 @@ function dropTombstoned(sessions: SessionInfo[]): SessionInfo[] {
 function sessionsToKeep(scope?: string): Set<string> {
   const keep = new Set<string>([
     ...$workingSessionIds.get(),
+    ...$attentionSessionIds.get(),
     ...$pinnedSessionIds.get(),
     ...getRecentlySettledSessionIds()
   ])

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,13 @@ declare global {
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      // Renderer reports which profile is active in the UI and which profiles
+      // have live work (working ∪ attention). Main uses this to idle-stop the
+      // primary local child when it is not needed (#91050).
+      reportBackendUsage: (payload: {
+        activeProfile?: string | null
+        keepProfiles?: string[]
+      }) => Promise<{ ok: boolean; idleStopScheduled?: boolean }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false
@@ -1416,4 +1423,6 @@ export interface HermesSelectPathsOptions {
 export interface BackendExit {
   code: number | null
   signal: string | null
+  /** Present when main intentionally stopped the primary (idle-stop). */
+  reason?: string
 }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -84,6 +84,27 @@ describe('Hermes REST helpers', () => {
     )
   })
 
+  it('forwards the active profile on multiplex session list reads', async () => {
+    setApiRequestProfile('coder')
+
+    await listAllProfileSessions(50, 1)
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: 'coder'
+      })
+    )
+  })
+
+  it('omits profile on multiplex session list reads when none is active', async () => {
+    setApiRequestProfile(null)
+
+    await listAllProfileSessions(50, 1)
+
+    const call = api.mock.calls[0]?.[0] as { profile?: string }
+    expect(call.profile).toBeUndefined()
+  })
+
   it('batches the sidebar slices into a single request with per-slice limits + excludes', async () => {
     api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
 

--- a/apps/desktop/src/store/backend-usage.test.ts
+++ b/apps/desktop/src/store/backend-usage.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { collectKeptProfileKeys } from './backend-usage'
+
+describe('collectKeptProfileKeys', () => {
+  it('includes profiles of working or attention sessions', () => {
+    const sessions = [
+      { id: 'a', profile: 'default' },
+      { id: 'b', profile: 'repro91050' },
+      { id: 'c', profile: 'other' }
+    ]
+    expect(collectKeptProfileKeys(sessions, ['b'], ['a'])).toEqual(['default', 'repro91050'])
+  })
+
+  it('treats a missing profile as default', () => {
+    const sessions = [{ id: 'a' }, { id: 'b', profile: '  ' }]
+    expect(collectKeptProfileKeys(sessions, ['a', 'b'], [])).toEqual(['default'])
+  })
+
+  it('returns empty when nothing is live', () => {
+    const sessions = [{ id: 'a', profile: 'default' }]
+    expect(collectKeptProfileKeys(sessions, [], [])).toEqual([])
+  })
+
+  it('spares default when a live session id is missing from the list', () => {
+    expect(collectKeptProfileKeys([{ id: 'named', profile: 'repro91050' }], [], ['orphan'])).toEqual(['default'])
+  })
+
+  it('spares the launch profile when a live id is missing and a primary key is passed', () => {
+    expect(collectKeptProfileKeys([], [], ['orphan'], 'coder')).toEqual(['coder'])
+  })
+})

--- a/apps/desktop/src/store/backend-usage.ts
+++ b/apps/desktop/src/store/backend-usage.ts
@@ -1,0 +1,26 @@
+import { normalizeProfileKey } from '@/store/profile'
+
+export function collectKeptProfileKeys(
+  sessions: Array<{ id: string; profile?: null | string }>,
+  workingIds: readonly string[],
+  attentionIds: readonly string[],
+  unknownOwnerProfile = 'default'
+): string[] {
+  const live = new Set([...workingIds, ...attentionIds])
+  const known = new Set(sessions.map(session => session.id))
+  const keep = new Set<string>()
+
+  for (const session of sessions) {
+    if (live.has(session.id)) {
+      keep.add(normalizeProfileKey(session.profile))
+    }
+  }
+
+  for (const id of live) {
+    if (!known.has(id)) {
+      keep.add(normalizeProfileKey(unknownOwnerProfile))
+    }
+  }
+
+  return [...keep]
+}

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -300,6 +300,10 @@ export function isActivePrimary(): boolean {
   return g.activeKey === g.primaryProfile
 }
 
+export function getPrimaryProfileKey(): string {
+  return g.primaryProfile
+}
+
 /** Changes on every active route selection, including same-profile source swaps. */
 export function gatewayActivationEpoch(): number {
   return Number.isFinite(g.activationEpoch) ? g.activationEpoch : 0

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -201,6 +201,9 @@ export async function refreshActiveProfile(): Promise<void> {
 
   try {
     const res = await hermesApi<ActiveProfileResponse>({
+      ...($activeGatewayProfile.get()
+        ? { profile: normalizeProfileKey($activeGatewayProfile.get()) }
+        : {}),
       path: '/api/profiles/active',
       timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
     })


### PR DESCRIPTION
## What does this PR do?

When Desktop's rail selects a **named** profile, the launch/primary `hermes serve` stayed alive forever (`ensureBackend` → `startHermes()` for the primary key). The named profile got a **second** pooled process. Combined RSS on Linux was ~551 MB, with the idle primary still holding ~283 MB at 0% CPU ([#91050](https://github.com/NousResearch/hermes-agent/issues/91050)).

This idle-stops that primary local child after a 3s debounce when:

- the UI is on another profile, and
- no running or waiting (clarify) session belongs to the launch profile.

It does **not** re-home via `hermes:profile:set` / `writeActiveDesktopProfile` (that reloads the window and hits #85991). It does **not** delete profile dirs or session DBs. History lives in each profile's `state.db`; SIGTERM runs the existing `tui_gateway` finalize + WAL checkpoint.

The rail still only updates the UI/gateway profile. Switching back to default respawns primary via `startHermes()` and reconnects that socket.

## Related Issue

Fixes #91050

Related, not this PR: #89675 (sessions missing / spawn without `--profile`), #85991 (can't switch back to default once `active-profile.json` is set), #67605 (MCP/secrets from launch profile).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/primary-idle.ts` — pure policy: `shouldIdleStopPrimary`, `resolveApiRouteProfile` (no Electron).
- `apps/desktop/electron/main.ts` — `hermes:backend:usage` IPC, 3s debounce, soft SIGTERM teardown (`reason: 'idle-stop'`), multiplex GET fallback so `/api/profiles*` does not respawn primary.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` — report keep-set to main; ignore idle-stop as a crash; do not reconnect/respawn the primary WebSocket while a named profile is active.
- `apps/desktop/src/store/backend-usage.ts` — keep-set from working ∪ attention; unknown live ids spare the launch profile.
- Tests: vitest policy + wiring; keep-set; boot hook; session-list multiplex scope.

## How we reproduced (Linux, 2026-08-29)

Isolated `HERMES_HOME=/tmp/hermes-91050-home`, profiles `default` + `repro91050`, Electron from checkout with `HERMES_DESKTOP_USER_DATA_DIR=/tmp/hermes-91050-userdata`. The rail itself could not be clicked (Vite 500 on missing editor packages), so the switch used the **same IPC the rail uses**: `window.hermesDesktop.getConnection('repro91050')` → `hermes:connection` → `ensureBackend()`.

| Checkpoint | `# serve` | Primary | Named | `active-profile.json` |
|---|---|---|---|---|
| Boot | 1 | PID 1508127, `serve` **no `--profile`**, RSS **289 488 KB** (~283 MB), port 33733 | — | missing |
| After `getConnection('repro91050')` | **2** | same PID, **same RSS**, ~0.3% CPU | PID 1538518, `--profile repro91050 serve`, RSS **274 480 KB**, port 41495 | still missing |

Both children parented by Electron. Combined backend RSS ~551 MB. Primary `/api/profiles/active` → `current: default`. Named → `current: repro91050`.

## How to Test

### Unit (CI-shaped)

From `apps/desktop`:

```bash
npx vitest run --project electron electron/primary-idle.test.ts electron/primary-idle-wiring.test.ts
npx vitest run --project ui src/store/backend-usage.test.ts src/hermes.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx
```

### Manual process census (the #91050 symptom)

Throwaway home so this does not touch `~/.hermes`:

```bash
REPO=/path/to/hermes-agent
export HERMES_HOME=/tmp/hermes-91050-home
export HERMES_DESKTOP_USER_DATA_DIR=/tmp/hermes-91050-userdata
mkdir -p "$HERMES_HOME" "$HERMES_DESKTOP_USER_DATA_DIR"
"$REPO/.venv/bin/python" -m hermes_cli.main profile create repro91050 --no-skills

cd "$REPO/apps/desktop"
HERMES_HOME="$HERMES_HOME" HERMES_DESKTOP_USER_DATA_DIR="$HERMES_DESKTOP_USER_DATA_DIR" npm run dev
```

Census (before / after rail-select of `repro91050`, wait **>3s**, no running turn on default):

```bash
pgrep -af 'hermes_cli.main serve'
tr '\0' ' ' < /proc/<pid>/cmdline; echo
awk '/VmRSS:/ {print}' /proc/<pid>/status
```

**Before this PR:** two `serve` processes; primary has no `--profile` and keeps ~280 MB RSS.

**After this PR:** primary PID is gone (or RSS released); named `--profile repro91050 serve` remains. Default `state.db` / session list still intact. Switching the rail back to default respawns primary. A running or clarify turn on default must keep primary alive. No "backend stopped" toast on idle-stop.

Default-profile cron inside that `HERMES_DESKTOP=1` process pauses while primary is down and resumes when default is used again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.0-30-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal desktop process policy; no user-facing config)
- [x] `cli-config.yaml.example` — N/A (no new config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — POSIX SIGTERM + existing Windows `forceKillProcessTree` teardown; completed turns already on disk
- [x] Tool descriptions/schemas — N/A

## Out of scope / follow-ups

- Do not wire the rail to `profile.set` / window reload (#85991).
- Do not adopt an already-running atlas CLI gateway as the primary (reporter's dual-gateway topology; follow-up).
- Default-profile cron pausing while primary is idle-stopped (named-profile cron keeps running in the pool process).
