### PR TITLE
fix(api-server): resolve MEDIA: tags to inline images when streaming

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1208,6 +1208,83 @@ def _resolve_media_to_data_urls(text: str) -> str:
         return text
 
 
+class _StreamingMediaResolver:
+    """Buffers SSE ``delta.content`` text so a ``MEDIA:<path>`` tag split
+    across chunk boundaries still gets resolved to an inline base64 image
+    before reaching the client, matching what the non-streaming dispatch
+    path already does via :func:`_resolve_media_to_data_urls`.
+
+    Without this, ``/v1/chat/completions`` with ``stream: true`` forwards
+    the model's raw text deltas as they're generated — the literal
+    ``MEDIA:/path/to/plot.png`` string reaches the client untouched, since
+    the non-streaming branch's post-hoc resolve step never runs on
+    already-sent chunks (#see api-server MEDIA streaming bug).
+    """
+
+    _MAX_PREFIX = len("MEDIA:")
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def feed(self, chunk: str) -> str:
+        """Feed a chunk of streamed text; returns text now safe to emit."""
+        if not chunk:
+            return ""
+        self._buf += chunk
+        return self._drain(final=False)
+
+    def flush(self) -> str:
+        """Call once at end of stream to emit any remaining buffered text."""
+        out = self._drain(final=True)
+        self._buf = ""
+        return out
+
+    def _drain(self, *, final: bool) -> str:
+        out_parts: list[str] = []
+        while True:
+            match = None
+            # Only resolve matches that end strictly before the end of the
+            # buffer (unless this is the final flush) — a match ending
+            # exactly at the buffer's end could still be extended by the
+            # next chunk (e.g. a longer path continues past what's known
+            # so far), so it stays buffered until we're sure it's complete.
+            for m in MEDIA_TAG_CLEANUP_RE.finditer(self._buf):
+                if final or m.end() < len(self._buf):
+                    match = m
+            if match is None:
+                break
+            out_parts.append(self._buf[: match.start()])
+            out_parts.append(_resolve_media_to_data_urls(match.group(0)))
+            self._buf = self._buf[match.end() :]
+
+        if final:
+            out_parts.append(self._buf)
+            self._buf = ""
+        else:
+            safe_len = self._safe_flush_length(self._buf)
+            out_parts.append(self._buf[:safe_len])
+            self._buf = self._buf[safe_len:]
+        return "".join(out_parts)
+
+    @classmethod
+    def _safe_flush_length(cls, buf: str) -> int:
+        """Return how much of ``buf`` is safe to emit now — i.e. excludes
+        any trailing text that could still turn into (or extend) a
+        ``MEDIA:`` tag once more chunks arrive."""
+        idx = buf.find("MEDIA:")
+        if idx != -1:
+            # An in-progress tag (incomplete path, no resolved extension
+            # yet) — hold back everything from its start.
+            return idx
+        # No full "MEDIA:" yet, but the tail might be the start of one
+        # split across the next chunk boundary (e.g. buffer ends "...MED").
+        tail = buf[-cls._MAX_PREFIX :]
+        for k in range(min(len(tail), cls._MAX_PREFIX), 0, -1):
+            if tail.endswith("MEDIA:"[:k]):
+                return len(buf) - k
+        return len(buf)
+
+
 def _redact_api_error_text(value: Any, *, limit: int | None = None) -> str:
     """Redact API-bound error text before it crosses the HTTP boundary."""
     redacted = redact_sensitive_text(str(value), force=True)
@@ -5440,11 +5517,17 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(_sse_frame(role_chunk))
             last_activity = time.monotonic()
 
+            # Buffers plain-text deltas so a ``MEDIA:<path>`` tag split
+            # across SSE chunks still resolves to an inline base64 image
+            # instead of reaching the client as literal, unrendered text.
+            media_resolver = _StreamingMediaResolver()
+
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
-                Plain strings are sent as normal ``delta.content`` chunks.
+                Plain strings are sent as normal ``delta.content`` chunks
+                (after passing through ``media_resolver`` — see above).
                 Tagged tuples ``("__tool_progress__", payload)`` are sent
                 as a custom ``event: hermes.tool.progress`` SSE event so
                 frontends can display them without storing the markers in
@@ -5454,12 +5537,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
                 else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(_sse_frame(content_chunk))
+                    resolved = media_resolver.feed(item)
+                    if resolved:
+                        content_chunk = {
+                            "id": completion_id, "object": "chat.completion.chunk",
+                            "created": created, "model": model,
+                            "choices": [{"index": 0, "delta": {"content": resolved}, "finish_reason": None}],
+                        }
+                        await response.write(_sse_frame(content_chunk))
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent. Woken
@@ -5490,6 +5575,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
 
                 last_activity = await _emit(delta)
+
+            # Flush any text still held back by media_resolver (e.g. a
+            # MEDIA: tag that only completed in the very last chunk) so it
+            # reaches the client instead of being silently dropped.
+            trailing = media_resolver.flush()
+            if trailing:
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": trailing}, "finish_reason": None}],
+                }
+                await response.write(_sse_frame(content_chunk))
 
             # Get usage from completed agent. The agent can fail two ways
             # after the content queue terminates cleanly: (1) ``agent_task``

--- a/tests/gateway/test_api_server_media_data_urls.py
+++ b/tests/gateway/test_api_server_media_data_urls.py
@@ -12,7 +12,10 @@ import pytest
 
 pytest.importorskip("aiohttp")
 
-from gateway.platforms.api_server import _resolve_media_to_data_urls  # noqa: E402
+from gateway.platforms.api_server import (  # noqa: E402
+    _resolve_media_to_data_urls,
+    _StreamingMediaResolver,
+)
 
 # 1x1 transparent PNG
 _PNG_BYTES = base64.b64decode(
@@ -49,6 +52,81 @@ class TestResolveMediaToDataUrls(unittest.TestCase):
     def test_non_image_left_untouched(self):
         text = "MEDIA:/tmp/archive.zip"
         self.assertEqual(_resolve_media_to_data_urls(text), text)
+
+
+class TestStreamingMediaResolver(unittest.TestCase):
+    """``/v1/chat/completions`` with ``stream: true`` forwards the model's
+    raw text deltas as they're generated, bypassing the non-streaming
+    path's post-hoc ``_resolve_media_to_data_urls`` call entirely — a
+    ``MEDIA:<path>`` tag reached streaming clients as literal, unrendered
+    text. ``_StreamingMediaResolver`` buffers deltas so a tag split across
+    chunk boundaries (the normal case under token-by-token streaming)
+    still resolves before reaching the client.
+    """
+
+    def _write_png(self, tmpdir_name="hermes_media_stream_test"):
+        import tempfile
+        from pathlib import Path
+
+        d = Path(tempfile.mkdtemp(prefix=tmpdir_name))
+        p = d / "shot.png"
+        p.write_bytes(_PNG_BYTES)
+        return p
+
+    def test_tag_split_across_many_small_chunks(self):
+        p = self._write_png()
+        full = f"Here is the plot: MEDIA:{p} enjoy!"
+        chunks = [full[i : i + 3] for i in range(0, len(full), 3)]
+        r = _StreamingMediaResolver()
+        out = "".join(r.feed(c) for c in chunks) + r.flush()
+        self.assertIn("data:image/png;base64,", out)
+        self.assertNotIn("MEDIA:", out)
+        self.assertIn("Here is the plot:", out)
+        self.assertIn("enjoy!", out)
+
+    def test_tag_ends_exactly_at_stream_end_needs_flush(self):
+        """A tag with nothing streamed after it must still resolve — the
+        buffer can only know it's complete once ``flush()`` is called,
+        since more path characters could otherwise still be coming."""
+        p = self._write_png()
+        full = f"Done: MEDIA:{p}"
+        chunks = [full[i : i + 2] for i in range(0, len(full), 2)]
+        r = _StreamingMediaResolver()
+        out = "".join(r.feed(c) for c in chunks)
+        # Nothing after the tag yet arrived, so it must still be withheld
+        # pending flush() — this is what the bug looked like: a stream
+        # that ends right after the tag with no data delivered at all.
+        self.assertNotIn("data:image/png;base64,", out)
+        out += r.flush()
+        self.assertIn("data:image/png;base64,", out)
+        self.assertNotIn("MEDIA:", out)
+
+    def test_plain_text_streams_immediately_without_media_tag(self):
+        """Text that never contains a MEDIA: tag must not be held back
+        waiting for more chunks — that would add latency to the common
+        case (a reply with no image) for no reason."""
+        r = _StreamingMediaResolver()
+        self.assertEqual(r.feed("Generating the plot now"), "Generating the plot now")
+        self.assertEqual(r.feed(", please wait"), ", please wait")
+        self.assertEqual(r.flush(), "")
+
+    def test_partial_prefix_at_chunk_boundary_is_held_back(self):
+        """A chunk ending in a partial ``MEDIA:`` prefix (e.g. the word
+        got split as ``...MED`` + ``IA:/path...``) must not flush that
+        partial prefix as literal text before the tag is known."""
+        r = _StreamingMediaResolver()
+        held = r.feed("some text MED")
+        self.assertEqual(held, "some text ")
+        p = self._write_png()
+        out = r.feed(f"IA:{p} done") + r.flush()
+        self.assertIn("data:image/png;base64,", out)
+        self.assertIn("done", out)
+
+    def test_missing_file_left_as_literal_text_after_flush(self):
+        text = "MEDIA:/nonexistent/path/shot.png"
+        r = _StreamingMediaResolver()
+        out = "".join(r.feed(c) for c in [text[:10], text[10:]]) + r.flush()
+        self.assertEqual(out, text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `/v1/chat/completions` with `stream: true` forwarded the model's raw text deltas straight to the client as they were generated, never running `_resolve_media_to_data_urls()` on them — only the non-streaming branch called it. Any `MEDIA:<path>` tag reached a streaming client (e.g. Open WebUI, which defaults to streaming) as literal, unrendered text instead of an inline base64 image.
- Adds `_StreamingMediaResolver`, which buffers streamed text so a tag split across SSE chunk boundaries still resolves before reaching the client.

## Test plan
- [x] pytest tests/gateway/test_api_server_media_data_urls.py — 9 passed
