### PR TITLE
fix(buzz): secondary multiplex profiles must not inherit the default profile's env

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -69,6 +69,26 @@ def _auth_env(name: str, default: str = "") -> str:
     return _platform_gate_env(name, default)
 
 
+def _platform_declares_allowed_users_env(platform) -> bool:
+    """Whether a plugin platform's registry entry declares ``allowed_users_env``.
+
+    Such platforms (Buzz, DingTalk, …) document ``PlatformConfig.extra
+    .allowed_users`` as the config-file spelling of that env allowlist, so
+    the live adapter's extra is a valid authorization source when the env
+    var is absent (#98738 / #82871). Built-in platforms and unknown entries
+    return False.
+    """
+    if platform is None:
+        return False
+    try:
+        from gateway.platform_registry import platform_registry
+
+        entry = platform_registry.get(platform.value)
+        return bool(entry and entry.allowed_users_env)
+    except Exception:
+        return False
+
+
 def _coerce_allow_set(raw) -> set[str]:
     """Parse allowlist values from config or env var into a set of strings.
 
@@ -692,8 +712,26 @@ class GatewayAuthorizationMixin:
                     adapter_allow = extra.get("group_allow_from")
                 else:
                     adapter_allow = extra.get("allow_from")
+                if not adapter_allow and _platform_declares_allowed_users_env(source.platform):
+                    # Plugin platforms whose registry entry declares
+                    # ``allowed_users_env`` (e.g. Buzz) carry the same
+                    # operator-configured allowlist in
+                    # ``PlatformConfig.extra.allowed_users``. Under multiplex
+                    # the YAML→env bridge is first-writer-wins, so only the
+                    # default profile's list ever reaches the env var read
+                    # above; consult the live (profile-routed) adapter's own
+                    # config so a secondary profile's allowlist authorizes its
+                    # users (#98738 / #82871). An absent/empty entry changes
+                    # nothing here — the default-deny below still applies.
+                    adapter_allow = extra.get("allowed_users")
                 if adapter_allow:
                     allowed = _coerce_allow_set(adapter_allow)
+                    normalize = getattr(adapter, "normalize_user_id", None)
+                    if callable(normalize):
+                        # Ids and allowlist entries may use different
+                        # spellings of the same principal (e.g. Buzz hex
+                        # pubkeys vs npubs) — normalize the entries.
+                        allowed = {normalize(entry) or entry for entry in allowed}
                     if user_id in allowed or "*" in allowed:
                         return True
             # No allowlists configured -- check global allow-all flag

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -830,11 +830,17 @@ class BuzzAdapter(BasePlatformAdapter):
         message = json.loads(raw)
         if not isinstance(message, list) or len(message) < 2 or message[0] != "AUTH":
             raise ConnectionError("Buzz relay did not send a NIP-42 AUTH challenge")
+        # BUZZ_AUTH_TAG is per-identity NIP-OA owner attestation, so it must
+        # resolve through the profile secret scope (#98738): inside a scoped
+        # multiplex profile a missing tag fails closed to "" instead of
+        # attaching the default profile's tag from os.environ, while
+        # single-profile and unscoped default-profile reads keep the legacy
+        # env behavior (the wrapper falls back to os.environ there).
         event = build_auth_event(
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=os.getenv("BUZZ_AUTH_TAG", ""),
+            auth_tag_json=_get_scoped_secret("BUZZ_AUTH_TAG", "") or "",
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -73,6 +73,41 @@ def _get_scoped_secret(name, default=None):
     return val if val is not None else default
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed, connected, and reloaded
+    inside ``_profile_runtime_scope`` (secret scope installed + multiplex
+    active) — the same discriminator as the Discord adapter's
+    ``_profile_scoped_config_load`` (#72348). The DEFAULT profile under
+    multiplexing runs unscoped: ``os.environ`` holds its own bridge output
+    there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _scoped_platform_setting(env_name, extra, key):
+    """Raw read of a non-secret Buzz setting, multiplex-profile-correct.
+
+    Inside a secondary profile scope ``os.environ`` holds the DEFAULT
+    profile's YAML-to-env bridge output (#98738), so the profile's
+    ``PlatformConfig.extra`` is authoritative and env is not consulted: a
+    missing key yields ``None`` and callers fail closed to their default
+    instead of silently borrowing the default profile's relay, channels, or
+    allowlist. Everywhere else — single-profile gateways, the default
+    profile under multiplexing — the legacy ``os.getenv`` read is returned
+    unchanged, so env-over-config precedence is preserved.
+    """
+    if _profile_scoped():
+        return (extra or {}).get(key)
+    return os.getenv(env_name)
+
+
 logger = logging.getLogger(__name__)
 
 from gateway.platforms.base import (
@@ -253,7 +288,8 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
     key = _get_scoped_secret("BUZZ_PRIVATE_KEY", "").strip()
     if key:
         return key
-    configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")
+    _creds_raw = _scoped_platform_setting("BUZZ_CREDENTIALS_FILE", extra, "credentials_file")
+    configured = str(_creds_raw or "").strip() or (extra or {}).get("credentials_file", "")
     if configured:
         candidates = [Path(configured).expanduser()]
     else:
@@ -361,22 +397,30 @@ class BuzzAdapter(BasePlatformAdapter):
         extra = getattr(config, "extra", {}) or {}
         self._extra = extra
 
-        # Connection settings (env vars override config.yaml)
-        self.relay_url = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
+        # Connection settings (env vars override config.yaml; under a
+        # secondary multiplex profile scope the profile's extra wins and
+        # env — the default profile's bridge output — is not consulted)
+        _relay_raw = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+        self.relay_url = (_relay_raw or extra.get("relay_url", "")).strip()
+        _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
         self.cli_path = _resolve_cli_path(
-            os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
+            str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
         )
 
         # Channels to watch: env csv > extra list/csv; empty = all joined channels
-        raw_channels = os.getenv("BUZZ_CHANNELS") or extra.get("channels", [])
+        raw_channels = _scoped_platform_setting("BUZZ_CHANNELS", extra, "channels")
+        if raw_channels is None:
+            raw_channels = extra.get("channels", [])
         if isinstance(raw_channels, str):
             raw_channels = raw_channels.split(",")
         self.channels: List[str] = [c.strip() for c in raw_channels if isinstance(c, str) and c.strip()]
 
-        self.home_channel = (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+        _home_raw = _scoped_platform_setting("BUZZ_HOME_CHANNEL", extra, "home_channel")
+        self.home_channel = (_home_raw or str(extra.get("home_channel", "") or "")).strip()
 
+        _pi_raw = _scoped_platform_setting("BUZZ_POLL_INTERVAL", extra, "poll_interval")
         try:
-            interval = float(os.getenv("BUZZ_POLL_INTERVAL") or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
+            interval = float(_pi_raw or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
         except (TypeError, ValueError):
             interval = _DEFAULT_POLL_INTERVAL
         self.poll_interval = max(_MIN_POLL_INTERVAL, interval)
@@ -385,7 +429,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # Defaults to True (respond only when addressed). Set False to make the
         # agent respond to every message in a watched channel. DMs always
         # dispatch regardless. Env (BUZZ_REQUIRE_MENTION) overrides config.yaml.
-        _rm_raw = os.getenv("BUZZ_REQUIRE_MENTION")
+        _rm_raw = _scoped_platform_setting("BUZZ_REQUIRE_MENTION", extra, "require_mention")
         if _rm_raw is None:
             _rm_cfg = extra.get("require_mention", True)
         else:
@@ -396,13 +440,16 @@ class BuzzAdapter(BasePlatformAdapter):
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
         # config.yaml.
+        _transport_raw = _scoped_platform_setting("BUZZ_TRANSPORT", extra, "transport")
         _transport = (
-            os.getenv("BUZZ_TRANSPORT") or str(extra.get("transport", "auto") or "auto")
+            _transport_raw or str(extra.get("transport", "auto") or "auto")
         ).strip().lower()
         self.transport = _transport if _transport in ("auto", "websocket", "poll") else "auto"
 
         # Auth: entries may be hex pubkeys or npubs; normalized to hex
-        raw_allowed = os.getenv("BUZZ_ALLOWED_USERS") or extra.get("allowed_users", [])
+        raw_allowed = _scoped_platform_setting("BUZZ_ALLOWED_USERS", extra, "allowed_users")
+        if raw_allowed is None:
+            raw_allowed = extra.get("allowed_users", [])
         if isinstance(raw_allowed, str):
             raw_allowed = raw_allowed.split(",")
         self._allowed_pubkeys: set = {
@@ -440,6 +487,17 @@ class BuzzAdapter(BasePlatformAdapter):
     @property
     def name(self) -> str:
         return "Buzz"
+
+    @staticmethod
+    def normalize_user_id(user_id: str) -> Optional[str]:
+        """Normalize a Buzz user reference (hex pubkey or npub) to hex.
+
+        Optional hook consumed by ``gateway/authz_mixin`` when matching the
+        profile allowlist carried in ``config.extra.allowed_users`` (#98738):
+        entries may be npubs while inbound ``user_id`` is always the hex
+        pubkey, so a plain string compare would deny listed users.
+        """
+        return _normalize_user_ref(user_id)
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
@@ -1256,8 +1314,44 @@ class BuzzAdapter(BasePlatformAdapter):
 # Plugin registration
 # ---------------------------------------------------------------------------
 
+def _profile_buzz_extra() -> dict:
+    """Read ``buzz.extra`` from the active profile's config.yaml (scoped path).
+
+    Only meaningful inside a secondary profile scope, where the hermes-home
+    override points at that profile's home. Used by ``check_requirements``
+    (which has no PlatformConfig argument) so the multiplex gate consults the
+    profile's own configuration instead of the process env. Best-effort: any
+    failure yields an empty mapping and the caller fails closed.
+    """
+    if not _profile_scoped():
+        return {}
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(Path(get_hermes_home()) / "config.yaml")
+    except Exception:
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    buzz = ((cfg.get("gateway") or {}).get("platforms") or {}).get("buzz")
+    if not isinstance(buzz, dict):
+        return {}
+    extra = buzz.get("extra", buzz)
+    return extra if isinstance(extra, dict) else {}
+
+
 def check_requirements() -> bool:
     """Check if Buzz is configured: a relay URL plus a resolvable key."""
+    if _profile_scoped():
+        # Multiplexed secondary profile (#98738): os.environ's BUZZ_* values
+        # are the default profile's bridge output and must not satisfy this
+        # gate for another profile. Consult the profile's own config.yaml
+        # (via the scoped home override) and its secret scope instead; an
+        # unconfigured profile fails closed.
+        extra = _profile_buzz_extra()
+        relay = str(extra.get("relay_url") or "").strip()
+        return bool(relay and _resolve_private_key(extra))
     if not os.getenv("BUZZ_RELAY_URL", "").strip():
         return False
     return bool(_resolve_private_key())
@@ -1266,7 +1360,8 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    relay = os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")
+    relay = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+    relay = relay if relay is not None else extra.get("relay_url", "")
     return bool(relay and _resolve_private_key(extra))
 
 
@@ -1291,6 +1386,12 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     extra = buzz_cfg.get("extra", buzz_cfg) or {}
     if not isinstance(extra, dict):
         return None
+    # Under multiplex, a secondary profile's config loads inside its runtime
+    # scope; its values must NOT be written to the process-global env, where
+    # first-writer-wins would pin them for every other profile (issue #72348
+    # Telegram/Discord mirror, Buzz side of #98738). Its adapter reads the
+    # profile's PlatformConfig.extra directly instead.
+    _skip_env_bridge = _profile_scoped()
     _str_keys = {
         "relay_url": "BUZZ_RELAY_URL",
         "cli_path": "BUZZ_CLI_PATH",
@@ -1299,24 +1400,24 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     }
     for src, env in _str_keys.items():
         val = extra.get(src)
-        if val and not os.getenv(env):
+        if val and not _skip_env_bridge and not os.getenv(env):
             os.environ[env] = str(val)
     interval = extra.get("poll_interval")
-    if interval is not None and not os.getenv("BUZZ_POLL_INTERVAL"):
+    if interval is not None and not _skip_env_bridge and not os.getenv("BUZZ_POLL_INTERVAL"):
         os.environ["BUZZ_POLL_INTERVAL"] = str(interval)
     channels = extra.get("channels")
-    if channels is not None and not os.getenv("BUZZ_CHANNELS"):
+    if channels is not None and not _skip_env_bridge and not os.getenv("BUZZ_CHANNELS"):
         if isinstance(channels, (list, tuple)):
             channels = ",".join(str(c) for c in channels)
         os.environ["BUZZ_CHANNELS"] = str(channels)
     allowed = extra.get("allowed_users")
-    if allowed is not None and not os.getenv("BUZZ_ALLOWED_USERS"):
+    if allowed is not None and not _skip_env_bridge and not os.getenv("BUZZ_ALLOWED_USERS"):
         if isinstance(allowed, (list, tuple)):
             allowed = ",".join(str(a) for a in allowed)
         os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
-    if "allow_all_users" in extra and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
+    if "allow_all_users" in extra and not _skip_env_bridge and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
-    if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
+    if "require_mention" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
     return None
 
@@ -1331,6 +1432,12 @@ def _env_enablement() -> Optional[dict]:
     The special ``home_channel`` key is handled by the core hook — it becomes
     a proper ``HomeChannel`` on the ``PlatformConfig``.
     """
+    if _profile_scoped():
+        # Secondary profile scope (#98738): the process env's BUZZ_* values
+        # are the default profile's configuration, not this profile's — env
+        # enablement must not fabricate a Buzz platform for a profile that
+        # did not configure one.
+        return None
     relay = os.getenv("BUZZ_RELAY_URL", "").strip()
     if not relay or not _resolve_private_key():
         return None
@@ -1374,16 +1481,19 @@ async def _standalone_send(
     fail with ``No live adapter for platform 'buzz'``.
     """
     extra = getattr(pconfig, "extra", {}) or {}
-    relay = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
+    _relay_raw = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+    relay = (_relay_raw or extra.get("relay_url", "")).strip()
     private_key = _resolve_private_key(extra)
+    _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
     cli_path = _resolve_cli_path(
-        os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
+        str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
     )
     if not relay or not private_key:
         return {"error": "Buzz standalone send: BUZZ_RELAY_URL and BUZZ_PRIVATE_KEY must be configured"}
     if not cli_path:
         return {"error": "Buzz standalone send: buzz CLI binary not found"}
-    target = (chat_id or "").strip() or (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+    _home_raw = _scoped_platform_setting("BUZZ_HOME_CHANNEL", extra, "home_channel")
+    target = (chat_id or "").strip() or (_home_raw or str(extra.get("home_channel", "") or "")).strip()
     if not target:
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -143,6 +143,234 @@ class TestBuzzAdapterInit:
         assert adapter.relay_url == "https://env.relay"
 
 
+# ── Multiplex secondary-profile scope (#98738) ─────────────────────────────
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("BUZZ_RELAY_URL", "https://default.relay")
+    monkeypatch.setenv("BUZZ_CHANNELS", "chan-a,chan-b,chan-c")
+    monkeypatch.setenv("BUZZ_HOME_CHANNEL", "chan-a")
+    monkeypatch.setenv("BUZZ_POLL_INTERVAL", "9")
+    monkeypatch.setenv("BUZZ_CLI_PATH", "/default/bin/buzz")
+    monkeypatch.setenv("BUZZ_TRANSPORT", "poll")
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", "default-user-npub")
+    monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", "/default/creds.json")
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1default")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """The secondary profile's PlatformConfig is authoritative (#98738)."""
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "relay_url": "https://profile.relay",
+                "channels": ["pchan"],
+                "home_channel": "pchan",
+                "poll_interval": 2,
+                "cli_path": str(cli),
+                "transport": "websocket",
+                "allowed_users": [SELF_NPUB],
+            },
+        )
+        adapter = BuzzAdapter(cfg)
+        assert adapter.relay_url == "https://profile.relay"
+        assert adapter.channels == ["pchan"]
+        assert adapter.home_channel == "pchan"
+        assert adapter.poll_interval == 2.0
+        assert adapter.cli_path == str(cli)
+        assert adapter.transport == "websocket"
+        assert adapter._allowed_pubkeys == {SELF_PUBKEY}
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's config must NOT borrow the default
+        profile's bridged env values — that would connect this adapter to the
+        default profile's relay and watch its channels."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = BuzzAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.relay_url == ""
+        assert adapter.channels == []
+        assert adapter.home_channel == ""
+        assert adapter.poll_interval == _buzz_mod._DEFAULT_POLL_INTERVAL
+        assert adapter.transport == "auto"
+        assert adapter._allowed_pubkeys == set()
+
+    def test_secondary_credentials_file_not_borrowed(
+        self, multiplex_scope, default_profile_env, tmp_path, monkeypatch
+    ):
+        """BUZZ_CREDENTIALS_FILE in env points at the DEFAULT profile's key
+        file; the scoped adapter must not read the default identity's key."""
+        default_creds = tmp_path / "default-creds.json"
+        default_creds.write_text(
+            json.dumps({"nsec": "nsec1default-identity"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(default_creds))
+        multiplex_scope()
+        # Scope has no key: the profile is unconfigured and must fail closed
+        # to "" rather than resolving the default profile's credentials.
+        assert _buzz_mod._resolve_private_key({}) == ""
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = BuzzAdapter(
+                PlatformConfig(enabled=True, extra={"relay_url": "https://cfg.relay"})
+            )
+        finally:
+            set_multiplex_active(False)
+        assert adapter.relay_url == "https://default.relay"
+
+    def test_check_requirements_scoped_reads_profile_config(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """The gate must consult the profile's own config.yaml + secret scope,
+        not the default profile's env values."""
+        import yaml
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        creds = tmp_path / "creds.json"
+        creds.write_text(json.dumps({"nsec": "nsec1profile"}), encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "gateway": {
+                        "platforms": {
+                            "buzz": {
+                                "enabled": True,
+                                "extra": {
+                                    "relay_url": "https://profile.relay",
+                                    "credentials_file": str(creds),
+                                },
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        multiplex_scope()
+        token = set_hermes_home_override(str(tmp_path))
+        try:
+            # The default profile's env relay+key must NOT pass the gate on
+            # their own for a profile without a buzz config...
+            assert check_requirements() is True  # profile config passes
+        finally:
+            reset_hermes_home_override(token)
+
+        # A profile whose config.yaml has no buzz entry fails closed even
+        # though the default profile's env values are present.
+        empty_home = tmp_path / "empty-profile"
+        empty_home.mkdir()
+        multiplex_scope()
+        token = set_hermes_home_override(str(empty_home))
+        try:
+            assert check_requirements() is False
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_env_enablement_scoped_returns_none(self, multiplex_scope, default_profile_env):
+        """Scoped env enablement must not fabricate Buzz for a profile from
+        the default profile's env values."""
+        multiplex_scope()
+        assert _env_enablement() is None
+
+    def test_apply_yaml_config_scoped_skips_env_bridge(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """A secondary profile's YAML values must not be pinned into the
+        process env for every other profile (first-writer-wins)."""
+        for var in ("BUZZ_RELAY_URL", "BUZZ_HOME_CHANNEL", "BUZZ_CHANNELS"):
+            monkeypatch.delenv(var, raising=False)
+        multiplex_scope()
+        _buzz_mod._apply_yaml_config(
+            {},
+            {"extra": {"relay_url": "https://profile.relay", "home_channel": "pchan"}},
+        )
+        import os as _os
+
+        assert "BUZZ_RELAY_URL" not in _os.environ
+        assert "BUZZ_HOME_CHANNEL" not in _os.environ
+        assert "BUZZ_CHANNELS" not in _os.environ
+
+    def test_standalone_send_scoped_uses_profile_extra(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        calls = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            calls["relay"] = relay_url
+            return 0, '{"event_id": "e1"}', ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={"relay_url": "https://profile.relay", "cli_path": str(cli)},
+                ),
+                "chan-x",
+                "hello",
+            )
+        )
+        assert result.get("success") is True
+        assert calls["relay"] == "https://profile.relay"
+
+
 # ── CLI error contract ────────────────────────────────────────────────────
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -43,6 +43,7 @@ _ENV_VARS = (
     "BUZZ_ALLOWED_USERS",
     "BUZZ_ALLOW_ALL_USERS",
     "BUZZ_POLL_INTERVAL",
+    "BUZZ_AUTH_TAG",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
 )
@@ -180,6 +181,7 @@ def default_profile_env(monkeypatch):
     monkeypatch.setenv("BUZZ_ALLOWED_USERS", "default-user-npub")
     monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", "/default/creds.json")
     monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1default")
+    monkeypatch.setenv("BUZZ_AUTH_TAG", '["auth","default-profile-tag","","x"]')
 
 
 class TestMultiplexProfileScope:
@@ -369,6 +371,221 @@ class TestMultiplexProfileScope:
         )
         assert result.get("success") is True
         assert calls["relay"] == "https://profile.relay"
+
+    def test_secondary_partial_extra_fills_missing_keys_from_defaults(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Partial config: configured keys win, unconfigured keys fall back to
+        their own defaults — never to the default profile's env values."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = BuzzAdapter(
+            PlatformConfig(enabled=True, extra={"relay_url": "https://profile.relay"})
+        )
+        assert adapter.relay_url == "https://profile.relay"
+        assert adapter.channels == []
+        assert adapter.home_channel == ""
+        assert adapter.poll_interval == _buzz_mod._DEFAULT_POLL_INTERVAL
+        assert adapter.transport == "auto"
+        assert adapter._allowed_pubkeys == set()
+
+    def test_ws_auth_tag_not_borrowed_from_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """BUZZ_AUTH_TAG is per-identity NIP-OA owner attestation: a scoped
+        secondary profile without one must not sign its NIP-42 auth event
+        with the default profile's tag from os.environ (#98738)."""
+        import asyncio as _asyncio
+
+        multiplex_scope()
+        adapter = BuzzAdapter.__new__(BuzzAdapter)
+        adapter._private_key = "00" * 31 + "03"
+        adapter._websocket_url = lambda: "wss://relay.example"
+
+        class _FakeWS:
+            def __init__(self):
+                self.sent = []
+
+            async def recv(self):
+                if self.sent:
+                    return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                return json.dumps(["AUTH", "challenge-1"])
+
+            async def send(self, raw):
+                self.sent.append(json.loads(raw))
+
+        ws = _FakeWS()
+        _asyncio.run(adapter._authenticate_websocket(ws))
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == []
+
+    def test_ws_auth_tag_scoped_profile_uses_its_own_tag(
+        self, multiplex_scope
+    ):
+        """Positive control: a tag present in the profile's own secret scope
+        IS attached to the NIP-42 auth event."""
+        import asyncio as _asyncio
+
+        profile_tag = json.dumps(["auth", "p" * 64, "", "q" * 128])
+        multiplex_scope({"BUZZ_AUTH_TAG": profile_tag})
+        adapter = BuzzAdapter.__new__(BuzzAdapter)
+        adapter._private_key = "00" * 31 + "03"
+        adapter._websocket_url = lambda: "wss://relay.example"
+
+        class _FakeWS:
+            def __init__(self):
+                self.sent = []
+
+            async def recv(self):
+                if self.sent:
+                    return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                return json.dumps(["AUTH", "challenge-1"])
+
+            async def send(self, raw):
+                self.sent.append(json.loads(raw))
+
+        ws = _FakeWS()
+        _asyncio.run(adapter._authenticate_websocket(ws))
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == [json.loads(profile_tag)]
+
+    def test_ws_auth_tag_unscoped_default_profile_keeps_env(
+        self, default_profile_env
+    ):
+        """The default profile constructs unscoped even under multiplex, so
+        its env-provided auth tag still applies (legacy behavior kept)."""
+        import asyncio as _asyncio
+
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            adapter = BuzzAdapter.__new__(BuzzAdapter)
+            adapter._private_key = "00" * 31 + "03"
+            adapter._websocket_url = lambda: "wss://relay.example"
+
+            class _FakeWS:
+                def __init__(self):
+                    self.sent = []
+
+                async def recv(self):
+                    if self.sent:
+                        return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                    return json.dumps(["AUTH", "challenge-1"])
+
+                async def send(self, raw):
+                    self.sent.append(json.loads(raw))
+
+            ws = _FakeWS()
+            _asyncio.run(adapter._authenticate_websocket(ws))
+        finally:
+            set_multiplex_active(False)
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == [["auth", "default-profile-tag", "", "x"]]
+
+    def test_validate_config_scoped_extra_is_authoritative(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """Scoped validation reads the profile's extra, not the default
+        profile's env relay/key: unconfigured fails closed, configured
+        passes via its own credentials file."""
+        creds = tmp_path / "creds.json"
+        creds.write_text(json.dumps({"nsec": "nsec1profile"}), encoding="utf-8")
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        assert validate_config(PlatformConfig(enabled=True, extra={})) is False
+        assert (
+            validate_config(
+                PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "relay_url": "https://profile.relay",
+                        "credentials_file": str(creds),
+                    },
+                )
+            )
+            is True
+        )
+
+    def test_validate_config_unscoped_keeps_env_precedence(
+        self, default_profile_env
+    ):
+        """Single-profile/unscoped: env relay + env key still validate even
+        with an empty extra mapping."""
+        from gateway.config import PlatformConfig
+
+        assert validate_config(PlatformConfig(enabled=True, extra={})) is True
+
+    def test_standalone_send_scoped_target_falls_back_to_profile_home(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        """With no explicit chat_id, the scoped standalone send targets the
+        profile's own home_channel — never the default profile's env one."""
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        calls = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            calls["args"] = args
+            return 0, '{"event_id": "e1"}', ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "relay_url": "https://profile.relay",
+                        "cli_path": str(cli),
+                        "home_channel": "pchan",
+                    },
+                ),
+                "",
+                "hello",
+            )
+        )
+        assert result.get("success") is True
+        assert calls["args"][calls["args"].index("--channel") + 1] == "pchan"
+
+    def test_standalone_send_scoped_without_target_fails_closed(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        """No chat_id and no profile home_channel: the error is returned —
+        the default profile's env BUZZ_HOME_CHANNEL must not be borrowed."""
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            raise AssertionError("CLI must not run without a resolved target")
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={"relay_url": "https://profile.relay", "cli_path": str(cli)},
+                ),
+                "",
+                "hello",
+            )
+        )
+        assert result == {
+            "error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"
+        }
 
 
 # ── CLI error contract ────────────────────────────────────────────────────

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -174,6 +174,12 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
 # Plugin-platform extra.allowed_users fallback (#98738 / #82871)
 # ─────────────────────────────────────────────────────────────────────
 
+# Buzz has no static Platform member: plugin platforms get a dynamic
+# member created on demand by Platform._missing_ (value lookup). Resolve
+# it that way — attribute access only works after an earlier lookup in
+# the same process, which a fresh CI shard cannot rely on.
+_BUZZ = Platform("buzz")
+
 
 def _make_buzz_multiplex_runner(monkeypatch, extra):
     """Runner whose secondary 'coder' profile runs a live Buzz adapter."""
@@ -198,7 +204,7 @@ def _make_buzz_multiplex_runner(monkeypatch, extra):
         normalize_user_id=_normalize_user_ref,
     )
     runner.adapters = {}
-    runner._profile_adapters = {"coder": {Platform.BUZZ: adapter}}
+    runner._profile_adapters = {"coder": {_BUZZ: adapter}}
     runner.pairing_store = MagicMock()
     runner.pairing_store.is_approved.return_value = False
     return runner
@@ -206,7 +212,7 @@ def _make_buzz_multiplex_runner(monkeypatch, extra):
 
 def _buzz_source(user_id):
     return SessionSource(
-        platform=Platform.BUZZ,
+        platform=_BUZZ,
         user_id=user_id,
         chat_id="chat-1",
         user_name="member",

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -284,3 +284,83 @@ def test_extra_allowed_users_not_consulted_without_registry_declaration(monkeypa
     _patch_buzz_registry(monkeypatch, allowed_users_env="")
 
     assert runner._is_user_authorized(_buzz_source("someone")) is False
+
+
+def test_extra_allowed_users_wildcard_authorizes_any_sender(monkeypatch):
+    """\"*\" in the profile's extra.allowed_users keeps the env-var wildcard
+    semantics: any sender is authorized (still gated on the registry
+    declaration)."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra={"allowed_users": ["*"]})
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_extra_allowed_users_blank_entries_are_dropped_not_denials(monkeypatch):
+    """Blank/whitespace entries are dropped at parse; an otherwise-empty
+    list behaves like the absent case (default-deny), not like a wildcard."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["", "   ", ","]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_extra_allowed_users_case_insensitive_hex_and_uppercase_npub(monkeypatch):
+    """Entry spellings normalize to the same principal: upper-case hex and
+    upper-case npub entries both match the hex user id Buzz dispatches
+    (entries are normalized; the inbound id is already hex)."""
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": [SELF_PUBKEY.upper(), SELF_NPUB.upper()]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_adapter_intake_and_central_authz_agree_on_the_same_list(monkeypatch):
+    """Policy-layer agreement (#98738): a sender admitted by the adapter's
+    construction-time intake allowlist (extra.allowed_users normalized to
+    hex) is exactly the sender the central check authorizes, and an
+    unlisted sender is rejected at BOTH layers."""
+    from gateway.session import SessionSource as _SessionSource
+
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    monkeypatch.delenv("BUZZ_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("BUZZ_ALLOW_ALL_USERS", raising=False)
+
+    other_hex = "b" * 64
+    adapter_extra = {"allowed_users": [SELF_NPUB]}
+
+    # Layer 1 — adapter intake: construction normalizes npub entries to hex.
+    from tests.gateway.test_buzz_adapter import _make_adapter as _base_adapter
+
+    adapter = _base_adapter(adapter_extra)
+    assert adapter._allowed_pubkeys == {SELF_PUBKEY}
+
+    # Layer 2 — central authz over the same adapter config.
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra=adapter_extra)
+    _patch_buzz_registry(monkeypatch)
+
+    for sender, admitted in ((SELF_PUBKEY, True), (other_hex, False)):
+        # Adapter layer: intake filter admits/denies...
+        assert (sender in adapter._allowed_pubkeys) is admitted
+        # ...and central authz returns the SAME verdict for that sender.
+        assert runner._is_user_authorized(
+            _SessionSource(
+                platform=_BUZZ,
+                user_id=sender,
+                chat_id="chat-1",
+                user_name="member",
+                chat_type="dm",
+                profile="coder",
+            )
+        ) is admitted

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -168,3 +168,113 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Plugin-platform extra.allowed_users fallback (#98738 / #82871)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_buzz_multiplex_runner(monkeypatch, extra):
+    """Runner whose secondary 'coder' profile runs a live Buzz adapter."""
+    from gateway.run import GatewayRunner
+    from tests.gateway.test_buzz_adapter import _normalize_user_ref
+
+    for key in (
+        "BUZZ_ALLOWED_USERS",
+        "BUZZ_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    adapter = SimpleNamespace(
+        config=PlatformConfig(enabled=True, extra=extra),
+        # The Buzz adapter exposes this hook so npub allowlist entries match
+        # the hex-pubkey user ids the gateway authorizes.
+        normalize_user_id=_normalize_user_ref,
+    )
+    runner.adapters = {}
+    runner._profile_adapters = {"coder": {Platform.BUZZ: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _buzz_source(user_id):
+    return SessionSource(
+        platform=Platform.BUZZ,
+        user_id=user_id,
+        chat_id="chat-1",
+        user_name="member",
+        chat_type="dm",
+        profile="coder",
+    )
+
+
+def _patch_buzz_registry(monkeypatch, allowed_users_env="BUZZ_ALLOWED_USERS"):
+    from gateway.platform_registry import platform_registry
+
+    real_get = platform_registry.get
+
+    def _get(key):
+        if key == "buzz":
+            return SimpleNamespace(allowed_users_env=allowed_users_env)
+        return real_get(key)
+
+    monkeypatch.setattr(platform_registry, "get", _get)
+
+
+def test_secondary_buzz_extra_allowed_users_authorizes_listed_user(monkeypatch):
+    """A secondary profile's extra.allowed_users must authorize its users when
+    the env var only ever carried the default profile's list (#98738/#82871)."""
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": [SELF_NPUB]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    # user_id arrives as the hex pubkey while the allowlist entry is an npub.
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_secondary_buzz_extra_allowed_users_denies_unlisted_sender(monkeypatch):
+    """Default-deny is preserved: a sender not in the profile's allowlist
+    stays denied even though the adapter-level list admitted the message."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["npub1" + "b" * 56]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_secondary_buzz_without_extra_allowlist_stays_default_deny(monkeypatch):
+    """No extra.allowed_users configured: nothing changes, the default-deny
+    path applies (no fail-open via an empty list)."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra={})
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_extra_allowed_users_not_consulted_without_registry_declaration(monkeypatch):
+    """The fallback is gated on the platform's registry entry declaring
+    allowed_users_env — a platform without that contract keeps the previous
+    behavior even if its extra happens to hold an allowed_users key."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["someone"]}
+    )
+    _patch_buzz_registry(monkeypatch, allowed_users_env="")
+
+    assert runner._is_user_authorized(_buzz_source("someone")) is False


### PR DESCRIPTION
## What does this PR do?

Fixes cross-profile configuration and authorization leakage in the Buzz adapter under `gateway.multiplex_profiles` (#98738), plus the central-authorization gap it exposes (#82871).

**Root cause 1 — env inheritance.** The default profile's YAML-to-env bridge writes `BUZZ_*` values into `os.environ`, and every Buzz read (`os.getenv(...) or extra.get(...)`) gave that env precedence over the secondary profile's `PlatformConfig`. Since secondary adapters are constructed inside `_profile_runtime_scope`, each one connected as the default identity, watched the default profile's channels, and resolved the default profile's credentials file. The fix adds a `_profile_scoped()` discriminator (the same `is_multiplex_active() and current_secret_scope() is not None` test the Discord/Telegram adapters already use for #72348) and a `_scoped_platform_setting()` read: inside a secondary profile scope the profile's `extra` is authoritative and env is not consulted — a missing key fails closed to its default instead of silently borrowing the default profile's relay/channels/allowlist. Single-profile gateways and the unscoped default profile keep the legacy env-over-config precedence byte-for-byte.

**Root cause 2 — central authorization never saw `extra.allowed_users` (#82871).** `_is_user_authorized` consults the `{PLATFORM}_ALLOWED_USERS` env var (scope-isolated since #72348), but a secondary profile's allowlist lives in its own `config.yaml` and, under first-writer-wins bridging, only the default profile's list ever reaches that env var — so listed users were default-denied. The existing `extra.allow_from` live-adapter fallback is extended: for plugin platforms whose registry entry declares `allowed_users_env`, `extra.allowed_users` is consulted on the live (profile-routed) adapter, with an optional `normalize_user_id` hook so Buzz npub entries match the hex-pubkey user ids. An absent/empty entry changes nothing — default-deny is preserved.

## Related Issue

Fixes #98738
Fixes #82871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - Added `_profile_scoped()` / `_scoped_platform_setting()` helpers (multiplex-profile-correct raw reads; fail-closed on scoped misses).
  - `BuzzAdapter.__init__`: relay, CLI path, channels, home channel, poll interval, require_mention, transport, and allowed users now resolve via the scoped read.
  - `_resolve_private_key`: `BUZZ_CREDENTIALS_FILE` no longer borrows the default profile's key file inside a profile scope.
  - `validate_config` / `_standalone_send`: relay, CLI path, and home-channel target use the scoped read.
  - `check_requirements`: inside a profile scope it consults the profile's own `config.yaml` (via the scoped home override) + secret scope instead of the process env.
  - `_env_enablement()` returns `None` inside a profile scope (env values are the default profile's, not this profile's configuration).
  - `_apply_yaml_config()` skips the process-env bridge inside a profile scope (Telegram/Discord #72348 mirror) so a secondary profile's YAML can't be pinned into `os.environ` for every other profile.
  - `BuzzAdapter.normalize_user_id`: optional authz hook normalizing hex/npub spellings.
- `gateway/authz_mixin.py`
  - `_platform_declares_allowed_users_env()` helper; the live-adapter allowlist fallback now also honors `config.extra.allowed_users` for platforms whose registry entry declares `allowed_users_env`, normalizing entries via the adapter hook when present.
- `tests/gateway/test_buzz_adapter.py`: new `TestMultiplexProfileScope` — extra-wins, fail-closed missing keys, credentials isolation, unscoped default-profile precedence unchanged, scoped `check_requirements` (profile config passes / empty profile fails closed), scoped env-enablement, scoped YAML-bridge skip, scoped standalone send.
- `tests/gateway/test_multiplex_profile_authz.py`: four tests for the `extra.allowed_users` fallback — listed npub authorizes hex user, unlisted sender stays denied, absent list stays default-deny, and no consultation without the registry declaration.

## How to Test

1. `pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_multiplex_profile_authz.py -q` → observed result: **41 passed**.
2. `pytest tests/gateway/ -q -k "multiplex"` → observed result: **196 passed, 2 skipped**.
3. `pytest tests/gateway/ -q -k "authz or auth_fallback or authorized or authorization"` → observed result: **156 passed, 2 skipped**.
4. `pytest tests/gateway/test_config.py tests/test_secret_scope_plugin_families.py -q` → observed result: **72 passed**.
5. Before the fix, the first regression test fails with `assert "https://default.relay" == "https://profile.relay"` (secondary adapter reads the default profile's env); the authz test fails with `assert False is True` for a listed secondary-profile user.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites for the touched modules: buzz adapter/websocket, multiplex, authz, config, secret-scope families — all green as listed under How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior now matches the documented per-profile isolation; docstrings updated in-code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python env/scope reads, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
