### PR TITLE
fix(doctor): surface interrupted CJK index rebuilds

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -474,6 +474,39 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "optimize-storage' with the gateway stopped)",
         ))
 
+    cjk_pending = stats.get("fts_cjk_rebuild_pending") is True
+    cjk_stale = stats.get("fts_cjk_stale") is True
+    if cjk_pending or cjk_stale:
+        indexed = stats.get("fts_cjk_rebuild_progress")
+        total = stats.get("fts_cjk_rebuild_high_water")
+        has_progress = (
+            isinstance(indexed, int)
+            and isinstance(total, int)
+            and total > 0
+        )
+        progress = ""
+        if has_progress:
+            percent = min(100, max(0, int(100 * indexed / total)))
+            progress = (
+                f"; backfill progress is {percent}% "
+                f"({indexed:,}/{total:,})"
+            )
+
+        if cjk_stale:
+            lines.append((
+                "warn",
+                "CJK search index is stale" + progress,
+                "(run 'hermes sessions optimize-storage' to rebuild it; "
+                "stale recovery restarts the CJK index from scratch)",
+            ))
+        else:
+            lines.append((
+                "warn",
+                "CJK search-index rebuild is incomplete" + progress,
+                "(run 'hermes sessions optimize-storage' to resume; CJK "
+                "search uses the fallback path until it completes)",
+            ))
+
     # Advisory: oversized database. Suggest auto_prune, and — when the v23
     # FTS rebuild is pending OR the DB still carries the legacy inline
     # trigram layout (fts_storage_version marker absent) — the offline

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4108,6 +4108,10 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
     - ``fts_rebuild_pending`` — True when the deferred v23 backfill has not
       finished (high_water present and progress < high_water)
     - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
+    - ``fts_cjk_rebuild_pending`` — True when the optional CJK index backfill
+      has not finished
+    - ``fts_cjk_rebuild_high_water`` / ``fts_cjk_rebuild_progress`` — raw ints
+    - ``fts_cjk_stale`` — True when the CJK index requires a clean rebuild
     - ``fts_rebuild_deferral`` — durable blocked-repair diagnostic, when present
     """
     stats: Dict[str, Any] = {
@@ -4124,6 +4128,10 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         "fts_rebuild_pending": None,
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
+        "fts_cjk_rebuild_pending": None,
+        "fts_cjk_rebuild_high_water": None,
+        "fts_cjk_rebuild_progress": None,
+        "fts_cjk_stale": None,
         "fts_rebuild_deferral": None,
     }
 
@@ -4215,6 +4223,26 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
             stats["fts_rebuild_pending"] = False
         else:
             stats["fts_rebuild_pending"] = (progress or 0) < high_water
+
+        cjk_high_water = _meta_int("fts_cjk_rebuild_high_water")
+        cjk_progress = _meta_int("fts_cjk_rebuild_progress")
+        stats["fts_cjk_rebuild_high_water"] = cjk_high_water
+        stats["fts_cjk_rebuild_progress"] = cjk_progress
+        if cjk_high_water is None:
+            stats["fts_cjk_rebuild_pending"] = False
+        else:
+            stats["fts_cjk_rebuild_pending"] = (
+                (cjk_progress or 0) < cjk_high_water
+            )
+        try:
+            stats["fts_cjk_stale"] = bool(
+                conn.execute(
+                    "SELECT 1 FROM state_meta WHERE key = ? LIMIT 1",
+                    (FTS_CJK_STALE_KEY,),
+                ).fetchone()
+            )
+        except Exception:
+            pass
         try:
             row = conn.execute(
                 "SELECT value FROM state_meta WHERE key = ? LIMIT 1",

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -3,7 +3,7 @@
 Covers:
 - ``hermes_state.collect_state_db_stats``: read-only, best-effort stats
   (page_count, freelist, WAL size, journal mode, row counts, FTS presence,
-  pending v23 FTS-rebuild bookkeeping).
+  pending v23/CJK FTS-rebuild bookkeeping).
 - ``hermes_state.count_db_holders``: /proc-based best-effort probe for how
   many processes hold the DB file open (Linux only; None elsewhere/on error).
 - ``hermes_cli.doctor._render_state_db_stats``: formatting/threshold helper
@@ -62,6 +62,8 @@ def test_collect_stats_sane_values(populated_db):
 
     # No rebuild pending on a fresh DB.
     assert stats["fts_rebuild_pending"] in (False, None)
+    assert stats["fts_cjk_rebuild_pending"] in (False, None)
+    assert stats["fts_cjk_stale"] in (False, None)
 
 
 def test_collect_stats_is_read_only(populated_db):
@@ -132,6 +134,27 @@ def test_collect_stats_rebuild_pending_flag(populated_db):
     assert stats["fts_rebuild_progress"] == 40
 
 
+def test_collect_stats_cjk_rebuild_and_stale_state(populated_db):
+    conn = sqlite3.connect(str(populated_db))
+    conn.executemany(
+        "INSERT OR REPLACE INTO state_meta(key, value) VALUES (?, ?)",
+        (
+            ("fts_cjk_rebuild_high_water", "290407"),
+            ("fts_cjk_rebuild_progress", "148500"),
+            ("fts_cjk_stale", "1"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+
+    assert stats["fts_cjk_rebuild_pending"] is True
+    assert stats["fts_cjk_rebuild_high_water"] == 290407
+    assert stats["fts_cjk_rebuild_progress"] == 148500
+    assert stats["fts_cjk_stale"] is True
+
+
 # ── count_db_holders ────────────────────────────────────────────────────
 
 
@@ -175,6 +198,10 @@ def _base_stats(**overrides):
         "fts_rebuild_pending": False,
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
+        "fts_cjk_rebuild_pending": False,
+        "fts_cjk_rebuild_high_water": None,
+        "fts_cjk_rebuild_progress": None,
+        "fts_cjk_stale": False,
     }
     stats.update(overrides)
     return stats
@@ -234,6 +261,41 @@ def test_render_large_db_legacy_trigram_suggests_optimize():
     )
     blob = " ".join(" ".join(str(p) for p in line) for line in lines)
     assert "optimize-storage" in blob
+
+
+def test_render_warns_on_interrupted_cjk_rebuild_regardless_of_db_size():
+    from hermes_cli.doctor import _render_state_db_stats
+
+    lines = _render_state_db_stats(_base_stats(
+        fts_cjk_rebuild_pending=True,
+        fts_cjk_rebuild_high_water=290407,
+        fts_cjk_rebuild_progress=148500,
+    ))
+
+    warnings = [line for line in lines if line[0] == "warn"]
+    blob = " ".join(" ".join(str(part) for part in line) for line in warnings)
+    assert "51%" in blob
+    assert "148,500/290,407" in blob
+    assert "optimize-storage" in blob
+    assert "resume" in blob
+
+
+def test_render_stale_cjk_rebuild_warns_progress_will_be_discarded():
+    from hermes_cli.doctor import _render_state_db_stats
+
+    lines = _render_state_db_stats(_base_stats(
+        fts_cjk_rebuild_pending=True,
+        fts_cjk_rebuild_high_water=290407,
+        fts_cjk_rebuild_progress=148500,
+        fts_cjk_stale=True,
+    ))
+
+    warnings = [line for line in lines if line[0] == "warn"]
+    assert len(warnings) == 1
+    blob = " ".join(str(part) for part in warnings[0])
+    assert "stale" in blob
+    assert "51%" in blob
+    assert "from scratch" in blob
 
 
 def test_render_does_not_duplicate_legacy_wal_warning():


### PR DESCRIPTION
## Summary

Addresses the diagnostics/visibility part of #98743 without starting database work in the background.

- expose CJK rebuild progress and stale state through the existing read-only state.db stats snapshot
- make hermes doctor warn about an incomplete CJK backfill at any database size, including its exact progress and the resume command
- when the stale marker is also present, say explicitly that optimize-storage will rebuild from scratch instead of implying that the partial progress will resume

The probe still opens state.db in read-only mode and never instantiates SessionDB, so doctor remains safe against a live gateway. The actual rebuild remains the existing explicit foreground optimize-storage operation.

## Validation

- 25 focused state-db/CJK tests passed
- 131 adjacent doctor tests passed
- Ruff and git diff checks passed
- the broader state suite reached 244 passes with one unrelated current-main failure in test_search_projection_skips_context_enrichment_queries; the same test fails unchanged on exact upstream 4f225435

## Scope

This does not change stale-index recovery or add automatic backfill scheduling. It makes the frozen state visible and gives the operator the existing safe recovery command while those policy choices remain separate.