### PR TITLE
fix(worktree): give every worktree-add call site the measured budget

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7721,6 +7721,14 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
+# Budget for materializing a worktree. A dispatcher runs several workers at
+# once, so a checkout competes with sibling agents for the same disk: a
+# 100k-file monorepo measured 34s wall warm-cache while otherwise idle, and
+# `hermes -w` measured 113s under load versus 1.2s idle (#90602). Anything
+# tighter kills a create that is progressing normally and burns a retry.
+_WORKTREE_ADD_TIMEOUT = 300
+
+
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
@@ -7741,7 +7749,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         cmd,
         capture_output=True,
         text=True, encoding='utf-8', errors='replace',
-        timeout=60,
+        timeout=_WORKTREE_ADD_TIMEOUT,
         check=False,
     )
     if result.returncode != 0:

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -22,6 +22,10 @@ from pathlib import Path
 from hermes_cli._subprocess_compat import noninteractive_git_env
 
 _GIT_TIMEOUT = 30
+# Materializing a worktree scales with repo size and disk contention, unlike
+# the other git calls here, so it gets its own budget (#90602 measured 113s
+# under load for a 10k-file checkout; a 100k-file monorepo takes 34s warm).
+_WORKTREE_ADD_TIMEOUT = 300
 _GH_TIMEOUT = 30
 _MAX_BUFFER = 32 * 1024 * 1024
 _UNTRACKED_LINE_MAX_BYTES = 1024 * 1024
@@ -61,9 +65,9 @@ def _git_out(cwd: str, args: list[str]) -> str:
     return out if code == 0 else ""
 
 
-def _git_ok(cwd: str, args: list[str]) -> None:
+def _git_ok(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> None:
     """Run a git mutation, raising RuntimeError with stderr on failure."""
-    code, _, err = _git(cwd, args)
+    code, _, err = _git(cwd, args, timeout=timeout)
     if code != 0:
         raise RuntimeError(err.strip() or f"git {' '.join(args)} failed")
 
@@ -720,9 +724,9 @@ def worktree_add(cwd: str, options: dict) -> dict:
             # user did not fetch recently. On failure (offline, branch gone)
             # the last known ref is still there to branch from.
             _git(root, ["fetch", remote, existing])
-            _git_ok(root, ["worktree", "add", "--track", "-b", existing, target, requested])
+            _git_ok(root, ["worktree", "add", "--track", "-b", existing, target, requested], timeout=_WORKTREE_ADD_TIMEOUT)
             return {"path": target, "branch": existing, "repoRoot": root}
-        _git_ok(root, ["worktree", "add", target, existing])
+        _git_ok(root, ["worktree", "add", target, existing], timeout=_WORKTREE_ADD_TIMEOUT)
         return {"path": target, "branch": existing, "repoRoot": root}
 
     slug = _slugify(options.get("name") or f"work-{os.urandom(4).hex()}")
@@ -744,10 +748,10 @@ def worktree_add(cwd: str, options: dict) -> dict:
             # checkout -b new` — so suppress it (parity with the Electron op).
             args.append("--no-track")
         args.append(base)
-    code, _, err = _git(root, args)
+    code, _, err = _git(root, args, timeout=_WORKTREE_ADD_TIMEOUT)
     if code != 0:
         if "already exists" in (err or "").lower():
-            _git_ok(root, ["worktree", "add", target, branch])
+            _git_ok(root, ["worktree", "add", target, branch], timeout=_WORKTREE_ADD_TIMEOUT)
         else:
             raise RuntimeError(err.strip() or "git worktree add failed")
     return {"path": target, "branch": branch, "repoRoot": root}

--- a/tests/hermes_cli/test_worktree_add_timeout.py
+++ b/tests/hermes_cli/test_worktree_add_timeout.py
@@ -1,0 +1,136 @@
+"""Worktree creation gets a budget that survives disk contention.
+
+``git worktree add`` is the one git call whose wall time scales with repo
+size and with how many sibling agents are hitting the same disk. Every
+other git call in these modules is a metadata operation that returns in
+well under a second.
+
+PR #90602 raised the budget in ``cli.py`` from 30s to 120s after measuring
+113s wall for a 10k-file checkout under load. The three sibling call sites
+that also materialize a worktree kept their original values: the Kanban
+dispatcher at 60s, and the subagent and web-dashboard helpers at 30s. A
+100k-file monorepo measures 34s warm-cache on an otherwise idle machine, so
+those budgets kill creates that are progressing normally — the dispatcher
+recorded three ``spawn_failed`` runs at 60-61s against one such repo.
+
+These tests assert the observable contract: the subprocess that runs
+``worktree add`` receives a budget of at least the measured-worst-case
+120s, whichever module issues it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import web_git
+from tools import subagent_worktree
+
+# The floor #90602 established from measurement. A budget at or above this
+# covers the 113s loaded checkout it observed.
+MIN_BUDGET_SECONDS = 120
+
+
+class _Recorder:
+    """Stand-in for ``subprocess.run`` that captures the timeout kwarg."""
+
+    def __init__(self, returncode: int = 0) -> None:
+        self.calls: list[tuple[list[str], float | None]] = []
+        self._returncode = returncode
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append((list(cmd), kwargs.get("timeout")))
+        return subprocess.CompletedProcess(cmd, self._returncode, "", "")
+
+    def timeout_for(self, needle: str) -> float:
+        """Budget given to the first recorded call containing ``needle``."""
+        for cmd, timeout in self.calls:
+            if needle in cmd:
+                assert timeout is not None, f"{needle!r} ran with no timeout at all"
+                return timeout
+        raise AssertionError(f"no recorded call contained {needle!r}: {self.calls}")
+
+
+def test_kanban_dispatcher_worktree_add_budget(tmp_path, monkeypatch):
+    """The dispatcher's worktree add survives a slow monorepo checkout."""
+    rec = _Recorder()
+    monkeypatch.setattr(kb.subprocess, "run", rec)
+    monkeypatch.setattr(kb, "_git_common_dir", lambda _p: None)
+    monkeypatch.setattr(kb, "_git_branch_exists", lambda _r, _b: False)
+
+    kb._ensure_git_worktree(tmp_path / "repo", tmp_path / "wt", "wt/t_abc123")
+
+    assert rec.timeout_for("worktree") >= MIN_BUDGET_SECONDS
+
+
+def test_subagent_worktree_add_budget(tmp_path, monkeypatch):
+    """The subagent helper's worktree add gets the same budget.
+
+    Drives ``create_subagent_worktree`` so the budget under test is the one
+    production picks, not one the test supplies.
+    """
+    rec = _Recorder()
+    monkeypatch.setattr(subagent_worktree.subprocess, "run", rec)
+    monkeypatch.setattr(subagent_worktree, "_ensure_gitignore_entry", lambda _r: None)
+    monkeypatch.setattr(subagent_worktree, "resolve_repo_root", lambda _p: str(tmp_path))
+
+    subagent_worktree.create_subagent_worktree(str(tmp_path), "sub-1")
+
+    assert rec.timeout_for("worktree") >= MIN_BUDGET_SECONDS
+
+
+def test_web_git_worktree_add_budget(tmp_path, monkeypatch):
+    """The dashboard's worktree add gets the same budget.
+
+    Drives ``worktree_add`` so the budget under test is production's own.
+    """
+    rec = _Recorder()
+    monkeypatch.setattr(web_git.subprocess, "run", rec)
+    monkeypatch.setattr(web_git, "_ensure_repo", lambda _c: None)
+    monkeypatch.setattr(web_git, "_main_root", lambda _c: str(tmp_path))
+
+    web_git.worktree_add(str(tmp_path), {"name": "scratch"})
+
+    assert rec.timeout_for("worktree") >= MIN_BUDGET_SECONDS
+
+
+@pytest.mark.parametrize(
+    "module",
+    [kb, subagent_worktree, web_git],
+    ids=["kanban_db", "subagent_worktree", "web_git"],
+)
+def test_budget_is_a_named_constant(module):
+    """The budget is a named constant, so all sites move together.
+
+    Three of the four worktree-creating call sites drifted apart because
+    each held its own literal; #90602 fixed ``cli.py`` alone and the others
+    stayed at 30s and 60s.
+    """
+    assert getattr(module, "_WORKTREE_ADD_TIMEOUT", 0) >= MIN_BUDGET_SECONDS
+
+
+def test_ordinary_git_calls_keep_the_short_budget():
+    """Widening the worktree budget must not slow failure on metadata calls.
+
+    A hung ``status``/``fetch`` should still fail fast; only the checkout
+    that legitimately takes minutes gets the long budget.
+    """
+    assert web_git._GIT_TIMEOUT <= 60
+    assert subagent_worktree._GIT_TIMEOUT <= 60
+
+
+def test_web_git_metadata_call_is_not_widened(tmp_path, monkeypatch):
+    """A sibling git call in the same module keeps the short budget.
+
+    Guards the real risk of this change: raising the module-wide
+    ``_GIT_TIMEOUT`` instead of giving ``worktree add`` its own budget would
+    make every dashboard git call hang five times longer before failing.
+    """
+    rec = _Recorder()
+    monkeypatch.setattr(web_git.subprocess, "run", rec)
+
+    web_git._git(str(tmp_path), ["status", "--porcelain"])
+
+    assert rec.timeout_for("status") <= 60

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -47,6 +47,10 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT = 30
+# Materializing a worktree is the one git call here that scales with repo
+# size and disk contention, so it gets its own budget (#90602 measured 113s
+# under load for a 10k-file checkout; a 100k-file monorepo takes 34s warm).
+_WORKTREE_ADD_TIMEOUT = 300
 _WORKTREES_DIRNAME = ".worktrees"
 _BRANCH_NAMESPACE = "hermes-subagent"
 
@@ -151,6 +155,7 @@ def create_subagent_worktree(
         result = _run_git(
             ["worktree", "add", str(wt_path), "-b", branch, "HEAD"],
             cwd=repo_root,
+            timeout=_WORKTREE_ADD_TIMEOUT,
         )
     except Exception as exc:
         logger.warning("subagent worktree: creation failed: %s", exc)


### PR DESCRIPTION
## Summary

`git worktree add` is the one git call whose wall time scales with repo size and disk contention. #90602 raised it from 30s to 120s in `cli.py` after measuring 113s for a 10k-file checkout under multi-agent load. Three sibling call sites that also materialize a worktree kept their original literals.

| Call site | Budget before | Fixed by #90602 |
|---|---|---|
| `cli.py:1907,1922` | 120s | yes |
| `hermes_cli/kanban_db.py:7744` | 60s | no |
| `tools/subagent_worktree.py:152` | 30s | no |
| `hermes_cli/web_git.py:723,725,748,754` | 30s | no |

## Symptom

A Kanban dispatcher spawning workers against a 100k-file monorepo recorded three `spawn_failed` runs, one per card, each dying at 60-61s:

```
workspace: Command '['git', '-C', '<repo>', 'worktree', 'add', '-b',
'wt/<task-id>', '<repo>/.worktrees/<task-id>', 'HEAD']'
timed out after 60 seconds
```

That checkout measures 34s wall warm-cache on an otherwise idle machine:

```
$ time git worktree add -b probe /tmp/probe HEAD
Updating files: 100% (100477/100477), done.
real  0m34.027s
```

34s against a 60s budget is a 1.8x margin before any contention. The dispatcher runs several workers concurrently by design, so the checkout competes with sibling agents for the same disk — which is precisely the condition #90602 measured at 113s. Each timeout also consumes one of the task's retries.

## Changes

- `kanban_db.py`, `subagent_worktree.py`, `web_git.py`: name the budget `_WORKTREE_ADD_TIMEOUT = 300` and apply it to worktree creation only.
- `web_git.py`: `_git_ok` takes a keyword-only `timeout` defaulting to `_GIT_TIMEOUT`. Its eleven other callers are unchanged.
- Ordinary git calls keep the 30s `_GIT_TIMEOUT`, so a hung `status`/`fetch` still fails fast. Widening the module-wide constant instead would have made every dashboard git call hang five times longer before failing; `test_web_git_metadata_call_is_not_widened` guards that.
- `tests/hermes_cli/test_worktree_add_timeout.py`: 8 tests. The three behavior tests drive the real production entry points (`_ensure_git_worktree`, `create_subagent_worktree`, `worktree_add`) and assert the budget the subprocess actually receives.

## Validation

```
ruff check <changed files>                        All checks passed!
pytest tests/hermes_cli/test_worktree_add_timeout.py   8 passed
```

Calibration — the same tests against the unmodified source, fix stashed:

```
6 failed, 2 passed
```

The two that still pass are the fast-failure guards, which correctly assert unchanged behavior. The six failures are the budget assertions, so the gate has teeth.

Regression radius, all worktree-touching suites:

```
tests/hermes_cli/test_worktree_add_timeout.py       8 passed
tests/hermes_cli/test_kanban_worktree_isolation.py  2 passed
tests/hermes_cli/test_worktree_command.py           9 passed
tests/tools/test_subagent_worktree.py              22 passed
tests/hermes_cli/test_kanban_worktree_teardown.py  11 passed
tests/hermes_cli/test_worktree_gc.py               16 passed
=== 6 files, 68 tests passed, 0 failed ===
```

## Known / out of scope

- **300s, not 120s.** #90602 measured 113s for a 10k-file checkout; the monorepo here is 10x that at 34s idle. 300s covers a large repo under the load that produced the 113s figure. The cost of an over-generous budget is a slow failure on a genuinely wedged create; the cost of a tight one is killing work in progress, which is what happened.
- **`worktree_remove` (`web_git.py:766`) keeps the 30s budget.** Removal also touches every file and could hit the same wall, but no failure has been observed there. Left alone rather than widened speculatively.
- **No config key.** The budget is a measured constant, not a user-facing knob. If a repo ever needs more than 300s that is a separate report with its own measurement.
