### PR TITLE
fix(desktop): show configured provider after fallback

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -8,6 +8,8 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 import os
 from unittest.mock import MagicMock, patch
 
+from hermes_cli.auth import AuthError
+
 
 def test_make_agent_passes_resolved_provider():
     """_make_agent forwards provider/base_url/api_key/api_mode from
@@ -58,6 +60,51 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+
+
+def test_make_agent_preserves_named_custom_provider_on_auth_fallback():
+    """Setup-time fallback keeps the configured provider identity for billing."""
+    fallback_runtime = {
+        "provider": "custom",
+        "requested_provider": "my-custom-provider",
+        "base_url": "https://example.com/v1",
+        "api_key": "sk-fallback",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "model": {"default": "primary-model", "provider": "xiaomi"},
+        "agent": {"system_prompt": "test"},
+    }
+    fallback_chain = [
+        {"provider": "my-custom-provider", "model": "some-model"},
+    ]
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch("tui_gateway.server._load_fallback_model", return_value=fallback_chain),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=[
+                AuthError("primary unavailable", provider="xiaomi"),
+                fallback_runtime,
+            ],
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-fallback", "key-fallback")
+
+    call_kwargs = mock_agent.call_args.kwargs
+    assert call_kwargs["model"] == "some-model"
+    assert call_kwargs["provider"] == "my-custom-provider"
 
 
 def test_probe_config_health_flags_null_sections():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8310,11 +8310,22 @@ def _make_agent(
             if not resolution.selected_model:
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
+    # Runtime resolution deliberately separates the transport/billing class
+    # (``custom``) from the configured provider identity. Setup-time fallback
+    # must expose the selected identity just like in-loop fallback and /model;
+    # otherwise Desktop UI and token accounting collapse every named custom
+    # fallback to the generic ``custom`` bucket (#98739).
+    active_provider = (
+        runtime.get("requested_provider")
+        if resolution.used_fallback
+        else runtime.get("provider")
+    )
     _pr = _load_provider_routing()
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
-        provider=runtime.get("provider"),
+        provider=active_provider,
+        requested_provider=runtime.get("requested_provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8316,7 +8316,7 @@ def _make_agent(
     # otherwise Desktop UI and token accounting collapse every named custom
     # fallback to the generic ``custom`` bucket (#98739).
     active_provider = (
-        runtime.get("requested_provider")
+        runtime.get("requested_provider") or runtime.get("provider")
         if resolution.used_fallback
         else runtime.get("provider")
     )


### PR DESCRIPTION
## What does this PR do?

Named custom providers selected during Desktop/TUI setup-time fallback now retain their configured provider ID instead of being reported as the generic `custom` class. This keeps the provider indicator and session billing attribution consistent with in-loop fallback and manual model switching.

### Symptom

When primary runtime authentication fails and fallback selects a user-defined `providers:` entry, Desktop displays `custom` rather than the configured provider name.

### Impact

Users with named custom fallback providers cannot tell which configured endpoint served the turn, and `session_model_usage.billing_provider` records the generic class instead of the configured provider ID.

### Bug Cause

**Trigger:** `tui_gateway/server.py:8119` / `_resolve_runtime_with_fallback` followed by `_make_agent`

**Causal chain:**
1. Primary runtime resolution raises `AuthError`, so the TUI/Desktop setup path resolves a configured fallback provider.
2. Runtime resolution returns both the generic transport class (`custom`) and the requested provider identity, but `_make_agent` forwarded only the generic class to `AIAgent`.
3. UI state and token accounting read `agent.provider`, so both reported `custom`.

**Why it is wrong:** The setup-time fallback path discarded the provider identity after successfully selecting a named configuration entry.

**Working sibling / contrast:** In-loop fallback and manual `/model` switching assign the selected provider ID to the live agent, so those paths preserve the identity.

**Ruled out:** The renderer is not relabeling the provider; the wrong value is already present in backend agent state before UI and accounting consume it.

### Fix

Use the resolved requested provider identity when setup-time fallback constructs `AIAgent`, while leaving normal primary runtime construction on the resolved provider class. Also forward `requested_provider` explicitly and add a regression test for the named custom fallback path.

## Related Issue

Closes #98739

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - preserve the configured provider identity when auth fallback selects a named custom provider.
- `tests/tui_gateway/test_make_agent_provider.py` - reproduce the identity collapse and verify the selected ID reaches `AIAgent`.

## How to Test

1. Run the focused provider-construction regression tests.
2. Run the adjacent custom-provider session persistence tests.

```bash
scripts/run_tests.sh tests/tui_gateway/test_make_agent_provider.py -q
scripts/run_tests.sh tests/tui_gateway/test_custom_provider_session_persistence.py -q
```

Result: 4 provider-construction tests and 11 custom-provider persistence tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: provider identity selection is platform-independent
- [x] Tool description/schema update: N/A

## Screenshots / Logs

N/A - the regression is covered at the backend construction boundary before UI and accounting consume the provider value.
