### PR TITLE
fix(tts): resolve default output dir from the active profile

### DIFF
--- a/tests/tools/test_tts_output_dir_profile_scope.py
+++ b/tests/tools/test_tts_output_dir_profile_scope.py
@@ -1,0 +1,76 @@
+"""Regression tests for profile-scoped TTS default output dir (#98749).
+
+``DEFAULT_OUTPUT_DIR`` was resolved once at import time, so long-lived
+multi-profile runtimes (dashboard console, TUI/Desktop backend, cron, kanban
+workers) kept writing synthesized audio into the launch profile's
+``cache/audio`` even while the request was scoped to a different profile via
+``HERMES_HOME`` or ``set_hermes_home_override()``. The call-time accessor
+``_default_output_dir()`` re-resolves from the live profile-scoped home;
+these pins keep the synthesis paths from re-freezing the launch profile.
+"""
+
+import importlib
+from pathlib import Path
+
+
+def _reload_tts_tool(import_home: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(import_home))
+    import tools.tts_tool as tts_tool
+
+    return importlib.reload(tts_tool)
+
+
+def test_default_output_dir_follows_live_hermes_home(tmp_path, monkeypatch):
+    """Synthesized audio must land in the active profile's cache, not the
+    HERMES_HOME snapshot captured when the module was first imported."""
+    default_home = tmp_path / "default-home"
+    profile_home = tmp_path / "profiles" / "doc"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+
+    tts_tool = _reload_tts_tool(default_home, monkeypatch)
+    assert tts_tool.DEFAULT_OUTPUT_DIR == str(default_home / "cache" / "audio")
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert tts_tool._default_output_dir() == str(profile_home / "cache" / "audio")
+
+
+def test_default_output_dir_follows_contextvar_profile_override(tmp_path, monkeypatch):
+    """The web server scopes profiles via set_hermes_home_override() rather
+    than mutating the process env; the accessor must follow that override."""
+    default_home = tmp_path / "default-home"
+    profile_home = tmp_path / "profiles" / "ramona"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+
+    tts_tool = _reload_tts_tool(default_home, monkeypatch)
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert tts_tool._default_output_dir() == str(
+            profile_home / "cache" / "audio"
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    # Outside the override scope the launch home applies again.
+    assert tts_tool._default_output_dir() == str(default_home / "cache" / "audio")
+
+
+def test_explicit_default_output_dir_monkeypatch_still_wins(tmp_path, monkeypatch):
+    """Existing tests and external patchers can still override
+    tools.tts_tool.DEFAULT_OUTPUT_DIR directly."""
+    default_home = tmp_path / "default-home"
+    default_home.mkdir(parents=True)
+
+    tts_tool = _reload_tts_tool(default_home, monkeypatch)
+
+    monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", "/custom/audio")
+
+    assert tts_tool._default_output_dir() == "/custom/audio"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -266,6 +266,26 @@ def _get_default_output_dir() -> str:
     return str(get_hermes_dir("cache/audio", "audio_cache"))
 
 DEFAULT_OUTPUT_DIR = _get_default_output_dir()
+_DEFAULT_OUTPUT_DIR_AT_IMPORT = DEFAULT_OUTPUT_DIR
+
+def _default_output_dir() -> str:
+    """Return the active profile's audio output dir at call time.
+
+    Same bug class as skills_tool (f8723c478) and skills_sync (#65828):
+    long-lived multi-profile runtimes (dashboard console, TUI/Desktop backend,
+    cron, kanban workers) import this module once under the launch
+    HERMES_HOME and later scope requests to a different profile via
+    ``hermes_constants.set_hermes_home_override()`` — a frozen module
+    constant keeps writing synthesized audio into the launch profile's
+    cache instead of the active profile's (#98749). Keep the legacy
+    ``DEFAULT_OUTPUT_DIR`` module attribute for tests and external patchers;
+    when it has not been patched, re-resolve from the live profile-scoped
+    HERMES_HOME on every call.
+    """
+    configured = DEFAULT_OUTPUT_DIR
+    if configured != _DEFAULT_OUTPUT_DIR_AT_IMPORT:
+        return configured
+    return _get_default_output_dir()
 
 # ---------------------------------------------------------------------------
 # Per-provider input-character limits (from official provider docs).
@@ -3243,7 +3263,7 @@ def _text_to_speech_single(
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir = Path(_default_output_dir())
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
@@ -3601,7 +3621,7 @@ def text_to_speech_tool(
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir = Path(_default_output_dir())
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
@@ -4484,7 +4504,7 @@ if __name__ == "__main__":
     print(f"  MiniMax:    {minimax_status}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
-    print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
+    print(f"\n  Output dir: {_default_output_dir()}")
 
     provider = _get_provider(config)
     print(f"  Configured provider: {provider}")


### PR DESCRIPTION
## What does this PR do?

`text_to_speech` resolved its default audio output directory (`DEFAULT_OUTPUT_DIR`) once at module import time. Long-lived multi-profile runtimes — dashboard console, TUI/Desktop backend, cron, kanban workers — import the module once under the launch `HERMES_HOME` and later scope individual requests to a different profile via `set_hermes_home_override()`. The provider/voice config chain re-reads the live profile's config on every call, but the frozen constant kept writing synthesized audio into the **launch** profile's `cache/audio` instead of the requesting profile's. #98749 reports exactly this cross-profile leak: audio from a session under one profile landed in `~/.hermes/profiles/<other>/cache/audio/`.

This PR makes the output dir resolve from the live profile-scoped home at call time, following the same pattern already established for this bug class by skills_tool (f8723c478) and skills_sync (#65828): keep the legacy module attribute for tests and external patchers, but re-resolve on every synthesis call.

Scope note: this fixes the **cache-path leak** component of #98749. The reported voice-selection component stems from requests reaching the backend without a profile scope — that request-side gap is tracked in #97515 and already has PRs (#97563, #97530).

## Related Issue

Fixes #98749
Fixes #99634 — same frozen-DEFAULT_OUTPUT_DIR root cause, reported independently from the multiplex-gateway side (follow-up to #18594)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py`: added `_default_output_dir()` call-time accessor next to the frozen `DEFAULT_OUTPUT_DIR` (import-time snapshot kept; a directly patched module attribute still wins, as tests rely on).
- `tools/tts_tool.py`: both synthesis fallback paths (`_text_to_speech_single` and the long-form wrapper) now use `Path(_default_output_dir())` instead of the frozen constant.
- `tools/tts_tool.py`: the `hermes tools` provider-status print now shows the live output dir.
- `tests/tools/test_tts_output_dir_profile_scope.py`: regression tests pinning env-var profile switch, contextvar override (the web-server scoping mechanism), and patch-priority behavior.

## How to Test

1. Run the new regression tests: `.venv/bin/python -m pytest tests/tools/test_tts_output_dir_profile_scope.py -q` — Observed result: 3 passed.
2. Run the existing TTS suite: `.venv/bin/python -m pytest tests/tools/ -k tts -q` — Observed result: 253 passed, 7 skipped (unchanged vs. pre-fix baseline).
3. Manual equivalent of the regression test: import `tools.tts_tool` under `HERMES_HOME=A`, then set `HERMES_HOME=B` (or wrap a call in `set_hermes_home_override(B)`) — `_default_output_dir()` should return `B/cache/audio`; before the fix it stayed pinned to A.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (TTS suite + new tests; audio/voice web endpoints: 31 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the issue reporter's Windows 11 repro is covered logically by the profile-scope tests (path resolution is platform-independent `pathlib`)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (accessor docstring documents the contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (schema text was already made profile-neutral by #95700)