### PR TITLE
fix(state): surface interrupted CJK FTS backfill in doctor and on open

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -474,6 +474,29 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "optimize-storage' with the gateway stopped)",
         ))
 
+    # An interrupted optimize-storage run leaves the CJK backfill markers
+    # frozen — nothing but that command's loop ever advances them, so CJK
+    # search quietly stays on trigram/LIKE forever. Surface the stuck
+    # progress (and the stale-index case, which forces a full rebuild).
+    cjk = stats.get("fts_cjk_backfill")
+    if isinstance(cjk, dict):
+        lines.append((
+            "warn",
+            "CJK FTS index backfill is interrupted "
+            f"({cjk.get('indexed', 0):,}/{cjk.get('total', 0):,} rows, "
+            f"{cjk.get('percent', 0)}% indexed)",
+            "(CJK search falls back to trigram/LIKE; run 'hermes sessions "
+            "optimize-storage' to finish the backfill)",
+        ))
+    if stats.get("fts_cjk_stale"):
+        lines.append((
+            "warn",
+            "CJK FTS index is stale (its triggers were dropped by a "
+            "tokenizer-less process)",
+            "(the next 'hermes sessions optimize-storage' run rebuilds it "
+            "from scratch)",
+        ))
+
     # Advisory: oversized database. Suggest auto_prune, and — when the v23
     # FTS rebuild is pending OR the DB still carries the legacy inline
     # trigram layout (fts_storage_version marker absent) — the offline

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4109,6 +4109,13 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
       finished (high_water present and progress < high_water)
     - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
     - ``fts_rebuild_deferral`` — durable blocked-repair diagnostic, when present
+    - ``fts_cjk_backfill`` — {"total", "indexed", "percent"} for the CJK
+      bigram index when its backfill markers are present (an interrupted
+      `optimize-storage` run freezes them; CJK search falls back to
+      trigram/LIKE until the backfill is re-run), None otherwise
+    - ``fts_cjk_stale`` — True when the ``fts_cjk_stale`` breadcrumb is set
+      (a tokenizer-less process dropped the cjk triggers; the next
+      optimize-storage run rebuilds the index from scratch)
     """
     stats: Dict[str, Any] = {
         "page_count": None,
@@ -4125,6 +4132,8 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
         "fts_rebuild_deferral": None,
+        "fts_cjk_backfill": None,
+        "fts_cjk_stale": None,
     }
 
     # WAL sidecar size needs no connection at all.
@@ -4226,6 +4235,25 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
                     stats["fts_rebuild_deferral"] = parsed
         except Exception:
             pass
+
+        # CJK-bigram backfill markers — same pending/high_water/progress
+        # shape as the base index, kept as a nested dict because the two
+        # backfills are independent phases of optimize-storage.
+        cjk_hw = _meta_int("fts_cjk_rebuild_high_water")
+        if cjk_hw is not None and cjk_hw > 0:
+            cjk_progress = _meta_int("fts_cjk_rebuild_progress") or 0
+            stats["fts_cjk_backfill"] = {
+                "total": cjk_hw,
+                "indexed": min(cjk_progress, cjk_hw),
+                "percent": min(100, int(100 * cjk_progress / cjk_hw)),
+            }
+        stats["fts_cjk_stale"] = (
+            conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ? LIMIT 1",
+                (FTS_CJK_STALE_KEY,),
+            ).fetchone()
+            is not None
+        )
     finally:
         try:
             conn.close()
@@ -4779,6 +4807,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if not report.get("repaired"):
                     raise
                 _connect_and_init_with_lock_patience()
+
+            # An interrupted CJK backfill freezes silently: the marker pair
+            # sits in state_meta forever because only the explicit
+            # optimize-storage loop ever advances it. Say so once per open,
+            # so weeks of trigram/LIKE fallback don't go unnoticed (#98743).
+            if self._fts_cjk_loaded:
+                _st = self.fts_cjk_rebuild_status()
+                if _st is not None:
+                    logger.warning(
+                        "CJK FTS index backfill is pending (%d/%d rows, %d%%) — "
+                        "CJK search falls back to trigram/LIKE until "
+                        "'hermes sessions optimize-storage' completes it.",
+                        _st["indexed"], _st["total"], _st["percent"],
+                    )
 
             # NOTE: the v23 FTS optimization is OPT-IN (`hermes db optimize`),
             # never auto-started on open. Legacy installs keep their working

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -242,3 +242,45 @@ def test_integrity_after_lifecycle(db):
             "INSERT INTO messages_fts_cjk(messages_fts_cjk) "
             "VALUES('integrity-check')"
         )
+
+
+def test_pending_backfill_warns_on_open_and_stats(cjk_so, tmp_path, monkeypatch, caplog):
+    """An interrupted cjk backfill must not stay silent (#98743).
+
+    A DB left with the marker pair frozen mid-way (only optimize-storage's
+    loop ever advances it) warns on the next capable writable open, and the
+    read-only doctor probe reports the same stuck progress."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+    db_path = tmp_path / "state.db"
+    d1 = SessionDB(db_path=db_path)
+    d1.create_session(session_id="s1", source="cli", model="m")
+    for i in range(10):
+        d1.append_message("s1", role="user", content=f"중단된 백필 {i}")
+    d1.close()
+
+    # Reopen capable: table gets created on the populated DB with the
+    # backfill markers pending.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d2 = SessionDB(db_path=db_path)
+    assert d2._fts_cjk_loaded
+    assert not d2._fts_cjk_available
+    st = d2.fts_cjk_rebuild_status()
+    assert st is not None and st["pending"]
+    d2.close()
+
+    from hermes_state import collect_state_db_stats
+    stats = collect_state_db_stats(db_path)
+    cjk = stats["fts_cjk_backfill"]
+    assert cjk is not None and cjk["total"] > 0
+
+    import logging as _logging
+    with caplog.at_level(_logging.WARNING, logger="hermes_state"):
+        d3 = SessionDB(db_path=db_path)
+        try:
+            assert not d3._fts_cjk_available  # still not served
+        finally:
+            d3.close()
+    assert any(
+        "CJK FTS index backfill is pending" in r.message
+        for r in caplog.records
+    ), caplog.text

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -38,6 +38,68 @@ def populated_db(tmp_path):
 # ── collect_state_db_stats ──────────────────────────────────────────────
 
 
+def test_collect_stats_cjk_backfill_markers(populated_db):
+    # Simulate the interrupted CJK backfill directly: markers set, progress
+    # frozen mid-way. The probe must surface it without opening a SessionDB.
+    conn = sqlite3.connect(str(populated_db))
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta(key, value) "
+        "VALUES ('fts_cjk_rebuild_high_water', '290407')"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta(key, value) "
+        "VALUES ('fts_cjk_rebuild_progress', '148500')"
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+    cjk = stats["fts_cjk_backfill"]
+    assert cjk is not None
+    assert cjk["total"] == 290407
+    assert cjk["indexed"] == 148500
+    assert cjk["percent"] == 51
+    assert stats["fts_cjk_stale"] is False
+
+    from hermes_cli.doctor import _render_state_db_stats
+
+    rendered = _render_state_db_stats(stats)
+    warnings = [
+        " ".join((text, detail))
+        for kind, text, detail in rendered
+        if kind == "warn"
+    ]
+    assert any(
+        "CJK FTS index backfill is interrupted" in w
+        and "148,500/290,407" in w
+        and "optimize-storage" in w
+        for w in warnings
+    )
+
+
+def test_collect_stats_cjk_stale_flag(populated_db):
+    conn = sqlite3.connect(str(populated_db))
+    conn.execute(
+        "INSERT OR REPLACE INTO state_meta(key, value) VALUES ('fts_cjk_stale', '1')"
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+    assert stats["fts_cjk_stale"] is True
+    assert stats["fts_cjk_backfill"] is None
+
+    from hermes_cli.doctor import _render_state_db_stats
+
+    rendered = _render_state_db_stats(stats)
+    warnings = [
+        " ".join((text, detail))
+        for kind, text, detail in rendered
+        if kind == "warn"
+    ]
+    assert any("CJK FTS index is stale" in w for w in warnings)
+
+
 def test_collect_stats_sane_values(populated_db):
     stats = collect_state_db_stats(populated_db)
 


### PR DESCRIPTION
## Summary

Fixes #98743 (visibility half).

An interrupted `optimize-storage` run leaves the CJK-bigram backfill markers (`fts_cjk_rebuild_high_water` / `fts_cjk_rebuild_progress`) frozen in `state_meta` forever — only that command's own loop ever advances them, so CJK search quietly stays on trigram/LIKE for weeks with nothing pointing at the stuck state, and `_fts_cjk_reset_if_stale` later discards the 51%-complete index instead of resuming.

This PR makes the frozen state visible in the two places an operator already looks:

1. **`hermes doctor`** — `collect_state_db_stats()` now reports `fts_cjk_backfill` (`total`/`indexed`/`percent` from the marker pair) and `fts_cjk_stale` (the breadcrumb a tokenizer-less process leaves after dropping the cjk triggers). `_render_state_db_stats()` renders both as warns with the `optimize-storage` repair hint. Read-only probe — no `SessionDB` instantiation, no DDL.
2. **Writable open** — when the tokenizer is loaded and the backfill is pending, `SessionDB.__init__` logs a `WARNING` with the stuck progress and the repair command, so the silent weeks-long fallback can't go unnoticed.

## Testing

- `tests/test_state_db_stats.py`: marker-pair probe → `fts_cjk_backfill` dict (290407/148500 → 51%) + doctor render assert; stale-flag probe → warn assert.
- `tests/test_fts_cjk_bigram.py::test_pending_backfill_warns_on_open_and_stats`: real DB built tokenizer-less, reopened capable → markers pending, stats report the backfill, reopen emits the WARNING.

```
tests/test_state_db_stats.py  15 passed

tests/test_fts_cjk_bigram.py  10 passed
```

Both files verified green on the full suites; the wider `state_db or fts or doctor` selection is also green apart from pre-existing local-venv gaps (missing `pytest_asyncio`) unrelated to this change.