### PR TITLE
fix(bedrock): stop deepseek.v3.2 leaking tool-call scaffolding into the text channel

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -615,6 +615,171 @@ def _tool_call_ns(tool_use_id: str, name: str, input_dict) -> SimpleNamespace:
     )
 
 
+# ---------------------------------------------------------------------------
+# Chat-template tool-call scaffolding leaking into the text channel (#54283)
+# ---------------------------------------------------------------------------
+#
+# Some Bedrock models emit a fragment of their own chat-template tool-call
+# scaffolding into the assistant TEXT channel, *alongside* -- not instead of --
+# a well-formed ``toolUse`` block. Tool calling still works; the user just sees
+# template garbage glued to the end of the prose.
+#
+# Measured with a single ``get_weather`` tool, "What is the weather in Tokyo?":
+#
+#   deepseek.v3.2   text: "I'll get the current weather in Tokyo for you.\n\n"
+#                         "<｜DSML｜function_calls"
+#                   toolUse: name=get_weather input={"city": "Tokyo"}   <- fine
+#
+# 20 streaming runs leaked 20 times, 10 in us-east-1 and 10 in us-west-2; the
+# non-streaming path leaks too. Sometimes there is no prose at all -- one
+# measured non-streaming response was exactly "\n\n<｜DSML｜function_calls" --
+# which is why the cut has to be able to reduce the content to nothing. Of the
+# seven non-Claude models tried (deepseek.v3.2, minimax-m2.5, kimi-k2-thinking,
+# kimi-k2.5, llama4-maverick, nova-pro, deepseek-r1) only deepseek.v3.2 leaks.
+#
+# Two properties of the real leak decide the shape of this code, and both
+# contradict the description in #54283:
+#
+# 1. The fragment is TRUNCATED and UNTERMINATED. Bedrock cuts the model off
+#    part-way through, so there is no closing tag and no inner
+#    ``invoke``/``parameter`` element -- measured: ``"invoke" in leaked`` is
+#    False, ``"parameter" in leaked`` is False, ``"</" in leaked`` is False. A
+#    regex matching a balanced DSML block therefore matches nothing and does
+#    nothing. Cutting from the opening marker to end-of-text is what works.
+#
+# 2. The delimiter is U+FF5C FULLWIDTH VERTICAL LINE, not ASCII "|".
+#    ``"|" in "<｜DSML｜function_calls"`` is False. It renders
+#    near-identically on an issue page, so it is written as an escape here to
+#    keep a later editor from "fixing" it into an ASCII pipe.
+#
+# Only the marker measured above is listed. The tuple leaves room because
+# DeepSeek's template has sibling tool-call tokens and which one survives the
+# truncation is not ours to choose -- but nothing else has been OBSERVED, and
+# unobserved markers are deliberately not guessed at.
+_TOOL_CALL_SCAFFOLDING_MARKERS: Tuple[str, ...] = (
+    "<\uff5cDSML\uff5c",   # renders as <｜DSML｜ ; U+FF5C, not ASCII "|"
+)
+
+
+def strip_tool_call_scaffolding(text: str) -> str:
+    """Cut leaked chat-template tool-call scaffolding off the end of *text*.
+
+    Truncates from the first marker to end-of-string, then drops the whitespace
+    the model put in front of it. Text with no marker is returned unchanged,
+    byte for byte -- including trailing whitespace -- so this is a provable
+    no-op for every model that does not leak.
+    """
+    if not text:
+        return text
+    cut = len(text)
+    for marker in _TOOL_CALL_SCAFFOLDING_MARKERS:
+        index = text.find(marker)
+        if index != -1:
+            cut = min(cut, index)
+    if cut == len(text):
+        return text
+    return text[:cut].rstrip()
+
+
+def _assemble_assistant_text(text_parts: List[str]) -> Optional[str]:
+    """Join assistant text blocks, minus any leaked tool-call scaffolding.
+
+    Reached by both normalizers through :meth:`_ResponseParts.build`, which is
+    the point: the leak was measured on the streaming AND the non-streaming
+    path, and one cut serves both. Applied to the joined string rather than
+    per-block, because everything after the marker is scaffolding including any
+    later block.
+    """
+    if not text_parts:
+        return None
+    text = "\n".join(text_parts)
+    if not any(marker in text for marker in _TOOL_CALL_SCAFFOLDING_MARKERS):
+        return text
+    return strip_tool_call_scaffolding(text) or None
+
+
+class _ScaffoldingDeltaFilter:
+    """Hold-back filter that keeps leaked scaffolding out of live output.
+
+    Cleaning the assembled text is not enough. ``on_text_delta`` fires while
+    ``has_tool_use`` is still False -- the measured event order is text deltas
+    first, ``contentBlockStart(toolUse)`` after -- so by the time anything knows
+    a tool call is coming, the fragment has already been printed to the CLI and
+    pushed out as a progressive gateway update.
+
+    The mechanism: withhold the longest tail of the stream that is still a
+    proper prefix of a marker, release it as soon as the next delta proves it
+    was ordinary text, and suppress everything from a completed marker onward.
+
+    Why hold back rather than test each delta alone? Bedrock chunks the fragment
+    differently between runs -- three consecutive runs of the same prompt gave
+    ``"...for you.\n\n<｜DSML｜function"`` + ``"_calls"``, then the whole
+    marker in one delta, then ``"...for you.\n\n"`` + the whole marker. But to
+    be straight about the evidence: the marker itself arrived WHOLE in every run
+    measured, 23 for 23, so a stateless matcher would have caught all of them.
+    This class is defence, not a reproduction. It is kept because delta
+    boundaries are the service's to place and form no part of the Converse
+    contract, the boundaries around the marker demonstrably do move, and the
+    first time one lands inside the marker a stateless matcher ships the raw
+    fragment to the screen. The price is ~30 lines that provably cannot lose
+    text -- :meth:`flush` releases a partial marker rather than eating it. The
+    test covering a split marker is therefore synthetic, and says so.
+
+    One asymmetry is unavoidable: the live stream keeps the whitespace that
+    preceded the marker because it was already on screen, while the assembled
+    content has it rstripped. Nothing compares the two, and the persisted text
+    is the one worth having tidy.
+    """
+
+    def __init__(self) -> None:
+        self._pending = ""
+        self._suppressing = False
+
+    def feed(self, text: str) -> str:
+        """Return the portion of *text* that is safe to emit right now."""
+        if self._suppressing:
+            return ""
+        buffered = self._pending + text
+        self._pending = ""
+        cut = len(buffered)
+        for marker in _TOOL_CALL_SCAFFOLDING_MARKERS:
+            index = buffered.find(marker)
+            if index != -1:
+                cut = min(cut, index)
+        if cut != len(buffered):
+            self._suppressing = True
+            return buffered[:cut]
+        held = self._partial_marker_suffix_length(buffered)
+        if held:
+            self._pending = buffered[len(buffered) - held:]
+            return buffered[:len(buffered) - held]
+        return buffered
+
+    def flush(self) -> str:
+        """Release any still-ambiguous tail at end of stream.
+
+        A tail that is only a PARTIAL marker is emitted rather than dropped.
+        Bedrock was never observed to truncate mid-marker, so this fires when
+        the stream ends early (interrupt, ``max_tokens``) and the choice is
+        between showing a few stray characters and silently eating real output.
+        Showing them is the lesser failure, and it keeps this filter unable to
+        lose text.
+        """
+        if self._suppressing:
+            return ""
+        pending, self._pending = self._pending, ""
+        return pending
+
+    @staticmethod
+    def _partial_marker_suffix_length(buffered: str) -> int:
+        longest = max(len(marker) for marker in _TOOL_CALL_SCAFFOLDING_MARKERS)
+        for length in range(min(longest - 1, len(buffered)), 0, -1):
+            tail = buffered[-length:]
+            if any(marker.startswith(tail) for marker in _TOOL_CALL_SCAFFOLDING_MARKERS):
+                return length
+        return 0
+
+
 class _ResponseParts:
     """Accumulator shared by the sync and streaming normalizers."""
 
@@ -643,7 +808,7 @@ class _ResponseParts:
         """Assemble the OpenAI-shaped response. Converse's inputTokens EXCLUDES cache read/write tokens
         (OpenAI's prompt_tokens includes them), so they are added back."""
         msg = SimpleNamespace(
-            role="assistant", content="\n".join(self.text_parts) if self.text_parts else None,
+            role="assistant", content=_assemble_assistant_text(self.text_parts),
             tool_calls=self.tool_calls or None, reasoning_details=self.reasoning_details or None,
             reasoning_content="\n\n".join(self.reasoning_parts) if self.reasoning_parts else None,
             bedrock_content_blocks=ordered_blocks or None,
@@ -707,6 +872,10 @@ def stream_converse_with_callbacks(
     current_block_index: Optional[int] = None
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
+    # Guards the LIVE output only. ``current_text_buffer`` keeps the raw text and
+    # the assembled result is cleaned once, in ``build``, so there is a single
+    # place that decides where the cut goes.
+    scaffolding_filter = _ScaffoldingDeltaFilter()
     has_tool_use = False
     stop_reason = "end_turn"
     usage_data: Dict[str, int] = {}
@@ -744,8 +913,12 @@ def stream_converse_with_callbacks(
                 block = current_block({"text": ""})
                 block["text"] = block.get("text", "") + text
                 current_text_buffer.append(text)
+                # Fires while has_tool_use is still False: the measured event
+                # order is text deltas first, toolUse block after, which is
+                # exactly why leaked scaffolding reaches the screen (#54283).
                 if on_text_delta and not has_tool_use:
-                    on_text_delta(text)
+                    if visible := scaffolding_filter.feed(text):
+                        on_text_delta(visible)
             elif "toolUse" in delta and current_tool is not None:
                 current_tool["input_json"] += delta["toolUse"].get("input", "")
             elif "reasoningContent" in delta:
@@ -768,6 +941,12 @@ def stream_converse_with_callbacks(
             meta_usage = event["metadata"].get("usage", {})
             usage_data = {key: meta_usage.get(key, 0) for key in ("inputTokens", "outputTokens", "cacheReadInputTokens", "cacheWriteInputTokens")}
     flush_text()
+    # Release any tail the scaffolding filter is still holding back. Skipped once
+    # a toolUse block has been seen, because at that point a held partial marker
+    # is the leak itself rather than ordinary text cut short.
+    if on_text_delta and not has_tool_use:
+        if held := scaffolding_filter.flush():
+            on_text_delta(held)
     return parts.build([stream_blocks[i] for i in sorted(stream_blocks)], usage_data, stop_reason, "")
 
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1421,3 +1421,168 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+DSML_MARKER = "<\uff5cDSML\uff5c"
+
+# Measured verbatim against deepseek.v3.2 on Converse with a single
+# ``get_weather`` tool, "What is the weather in Tokyo?".
+MEASURED_LEAK = ("I'll get the current weather in Tokyo for you.\n\n"
+                 + DSML_MARKER + "function_calls")
+MEASURED_CLEAN = "I'll get the current weather in Tokyo for you."
+
+# Also measured on the non-streaming path: sometimes there is no prose at all
+# and the text block is nothing but whitespace plus the fragment. The cut has to
+# be able to empty the content out.
+MEASURED_LEAK_WITHOUT_PROSE = "\n\n" + DSML_MARKER + "function_calls"
+
+# Three consecutive runs of the same prompt. The marker arrived WHOLE in every
+# one; only the boundaries around it moved.
+MEASURED_DELTA_SPLITS = [
+    ["I'll get the current weather in Tokyo for you.\n\n" + DSML_MARKER + "function",
+     "_calls"],
+    ["I'll get the current weather in Tokyo for you.\n\n" + DSML_MARKER + "function_calls"],
+    ["I'll get the current weather in Tokyo for you.\n\n",
+     DSML_MARKER + "function_calls"],
+]
+
+
+def _leaky_tool_call_stream(text_deltas):
+    """Text deltas first, THEN the toolUse block -- the measured event order."""
+    stream = [{"contentBlockStart": {"contentBlockIndex": 0, "start": {}}}]
+    stream += [{"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": d}}}
+               for d in text_deltas]
+    stream += [
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+            "toolUse": {"toolUseId": "t1", "name": "get_weather"}}}},
+        {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+            "toolUse": {"input": '{"city":"Tokyo"}'}}}},
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+    return {"stream": stream}
+
+
+class TestStripToolCallScaffolding:
+    def test_the_delimiter_is_fullwidth_not_an_ascii_pipe(self):
+        """``"|" in "<｜DSML｜function_calls"`` is False. The two render almost
+        identically, so this pins the codepoint rather than the glyph."""
+        assert ord(DSML_MARKER[1]) == 0xFF5C
+        assert "|" not in DSML_MARKER
+
+    def test_the_measured_leak_is_cut_back_to_the_prose(self):
+        from agent.bedrock_adapter import strip_tool_call_scaffolding
+        assert strip_tool_call_scaffolding(MEASURED_LEAK) == MEASURED_CLEAN
+
+    def test_the_leaked_fragment_is_unterminated(self):
+        """Why the cut runs to end-of-text instead of matching a block: Bedrock
+        truncates the scaffolding, so there is no closing tag and no inner
+        element for a balanced-block regex to match."""
+        assert "invoke" not in MEASURED_LEAK
+        assert "parameter" not in MEASURED_LEAK
+        assert "</" not in MEASURED_LEAK
+
+    @pytest.mark.parametrize("text", [
+        "", "plain answer", "a pipe | is fine", "trailing space kept   ",
+        "code: a <b> c </b>",
+    ])
+    def test_text_without_a_marker_is_returned_unchanged(self, text):
+        from agent.bedrock_adapter import strip_tool_call_scaffolding
+        assert strip_tool_call_scaffolding(text) == text
+
+    def test_everything_after_the_marker_goes_not_just_the_marker(self):
+        from agent.bedrock_adapter import strip_tool_call_scaffolding
+        assert strip_tool_call_scaffolding(
+            "answer" + DSML_MARKER + "function_calls trailing junk") == "answer"
+
+    def test_only_the_first_marker_matters(self):
+        from agent.bedrock_adapter import strip_tool_call_scaffolding
+        assert strip_tool_call_scaffolding(
+            "a" + DSML_MARKER + "x" + DSML_MARKER + "y") == "a"
+
+
+class TestScaffoldingDeltaFilter:
+    @pytest.mark.parametrize("deltas", MEASURED_DELTA_SPLITS)
+    def test_every_measured_split_is_caught(self, deltas):
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        shown = "".join(f.feed(d) for d in deltas) + f.flush()
+        assert DSML_MARKER not in shown
+        assert shown.startswith(MEASURED_CLEAN)
+
+    def test_marker_split_one_character_per_delta(self):
+        """SYNTHETIC. Bedrock delivered the marker whole in all 23 runs measured,
+        so this is the defence the hold-back exists for, not a reproduction."""
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        shown = "".join(f.feed(c) for c in ("hi" + DSML_MARKER + "fn")) + f.flush()
+        assert shown == "hi"
+
+    def test_a_partial_marker_that_turns_out_to_be_prose_is_released(self):
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        shown = f.feed("cost is <") + f.feed(DSML_MARKER[1] + " lower") + f.flush()
+        assert shown == "cost is <" + DSML_MARKER[1] + " lower"
+
+    def test_partial_marker_at_end_of_stream_is_emitted_not_eaten(self):
+        """An interrupt or max_tokens can end a stream mid-marker. Showing a few
+        stray characters beats silently losing real output."""
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        assert f.feed("answer" + DSML_MARKER[:4]) + f.flush() == "answer" + DSML_MARKER[:4]
+
+    def test_suppression_persists_across_later_deltas(self):
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        f.feed("a" + DSML_MARKER + "fn")
+        assert f.feed("more junk") == ""
+        assert f.flush() == ""
+
+    def test_a_clean_stream_is_passed_through_verbatim(self):
+        from agent.bedrock_adapter import _ScaffoldingDeltaFilter
+        f = _ScaffoldingDeltaFilter()
+        deltas = ["The ", "weather ", "in Tokyo ", "is fine."]
+        assert "".join(f.feed(d) for d in deltas) + f.flush() == "".join(deltas)
+
+
+class TestScaffoldingLeakThroughPublicEntryPoints:
+    def test_non_streaming_is_cleaned_and_keeps_the_tool_call(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {"output": {"message": {"role": "assistant", "content": [
+            {"text": MEASURED_LEAK},
+            {"toolUse": {"toolUseId": "t1", "name": "get_weather",
+                         "input": {"city": "Tokyo"}}}]}},
+            "stopReason": "tool_use", "usage": {}}
+        msg = normalize_converse_response(response).choices[0].message
+        assert msg.content == MEASURED_CLEAN
+        assert msg.tool_calls[0].function.name == "get_weather"
+
+    def test_text_that_is_nothing_but_scaffolding_becomes_none(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {"output": {"message": {"role": "assistant", "content": [
+            {"text": MEASURED_LEAK_WITHOUT_PROSE},
+            {"toolUse": {"toolUseId": "t1", "name": "get_weather", "input": {}}}]}},
+            "stopReason": "tool_use", "usage": {}}
+        msg = normalize_converse_response(response).choices[0].message
+        assert msg.content is None
+        assert msg.tool_calls
+
+    @pytest.mark.parametrize("deltas", MEASURED_DELTA_SPLITS)
+    def test_streaming_leak_never_reaches_the_display(self, deltas):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        shown = []
+        result = stream_converse_with_callbacks(
+            _leaky_tool_call_stream(deltas), on_text_delta=shown.append)
+        assert DSML_MARKER not in "".join(shown)
+        assert result.choices[0].message.content == MEASURED_CLEAN
+        assert result.choices[0].message.tool_calls
+
+    def test_a_model_that_does_not_leak_streams_identically(self):
+        """The no-op guarantee: a clean stream reaches the display byte for byte."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        shown = []
+        deltas = ["The weather ", "in Tokyo ", "is fine."]
+        stream_converse_with_callbacks(
+            _leaky_tool_call_stream(deltas), on_text_delta=shown.append)
+        assert "".join(shown) == "".join(deltas)


### PR DESCRIPTION
Fixes #54283.

## What happens

`deepseek.v3.2` on Bedrock emits a fragment of its own chat-template tool-call scaffolding into the assistant **text** channel, *alongside* — not instead of — a perfectly well-formed `toolUse` block. Tool calling is not broken. The user just sees template garbage glued to the model's prose.

Measured against Converse with one `get_weather` tool and *"What is the weather in Tokyo?"*:

```
text     "I'll check the weather in Tokyo for you.\n\n<｜DSML｜function_calls"
toolUse  name=get_weather  input={"city": "Tokyo"}            <- always correct
```

| | |
|---|---|
| Leak rate | **20/20** streaming runs (10 × us-east-1, 10 × us-west-2) |
| Non-streaming | also leaks |
| Other models | 0/6 leak — minimax-m2.5, kimi-k2-thinking, kimi-k2.5, llama4-maverick, nova-pro, deepseek-r1 |
| Repo handling of DSML before this PR | none (`grep` finds 0 files) |

## Two things the issue gets wrong, and why they matter

I could not fix this from the issue text. Both corrections change what a working fix looks like.

**1. The leaked fragment is truncated and unterminated.** The issue describes a balanced block with `invoke`/`parameter` elements and closing tags. Measured on the real string:

```python
"invoke"    in leaked   # False
"parameter" in leaked   # False
"</"        in leaked   # False
```

Bedrock cuts the model off part-way through the scaffolding. A regex matching a balanced DSML block therefore matches **nothing** — it would pass review, ship, and silently do nothing. Cutting from the opening marker to end-of-text is what works.

**2. The delimiter is U+FF5C FULLWIDTH VERTICAL LINE, not ASCII `|`.**

```python
"|" in "<｜DSML｜function_calls"   # False
```

The two render near-identically on a GitHub issue page, so a matcher copy-typed from the rendered issue never fires. The marker is written as `"<｜DSML｜"` in the source so it cannot be "corrected" into a pipe later, and a test pins `ord(marker[1]) == 0xFF5C`.

## The fix

Placed in `agent/bedrock_adapter.py` — the single choke point closest to the wire — rather than in `agent_runtime_helpers.py` as the issue suggests, so the CLI, the messaging gateway's progressive updates and the TUI/WebUI gateway are all covered by one change.

**`strip_tool_call_scaffolding()`** cuts assembled assistant text from the first marker onward. Text containing no marker is returned byte for byte, including trailing whitespace, so this is a provable no-op for every model that does not leak.

**`_ScaffoldingDeltaFilter`** guards live output. Sanitizing only the assembled text is **not sufficient**: `on_text_delta` fires while `has_tool_use` is still `False`, and the measured event order is text deltas first, `contentBlockStart(toolUse)` after. By the time anything knows a tool call is coming, the fragment is already on screen and already pushed as a gateway update.

One measured non-streaming response had no prose at all — its text block was exactly `"\n\n<｜DSML｜function_calls"` — so the cut has to be able to empty the content out. It yields `None` rather than `""`, since `""` is a content block the agent loop would go on to render.

## Being straight about the hold-back filter

The delta filter withholds any tail that is still a proper prefix of the marker. **The marker arrived whole in all 23 runs I measured** (3 earlier + 20 above), so a stateless per-delta matcher would have caught every single one. This class is defence, not a reproduction, and the code comment says exactly that.

I kept it because delta boundaries are the service's to place and form no part of the Converse contract, the boundaries *around* the marker demonstrably move between runs:

```
run 1:  "...for you.\n\n<｜DSML｜function"  +  "_calls"
run 2:  "...for you.\n\n<｜DSML｜function_calls"
run 3:  "...for you.\n\n"  +  "<｜DSML｜function_calls"
```

and the first time one lands *inside* the marker, a stateless matcher ships the raw fragment to the screen for that turn. The price is ~30 lines that provably cannot lose text — `flush()` releases a partial marker rather than eating it. The test covering a split marker is synthetic by necessity and is labelled as such.

Happy to drop the filter and keep only the stateless cut if you would rather not carry unmeasured defence; the two parts are independent.

## Verification

Live, against Bedrock, replaying captured events through the patched adapter:

```
NON-STREAMING
  raw wire text     : '\n\n<｜DSML｜function_calls'
  leaks marker      : True
  after fix .content: None
  tool_calls        : [('get_weather', '{"city": "Tokyo"}')]
  finish_reason     : tool_calls

STREAMING (3 of 3 runs identical in shape)
  raw joined leaks  : True
  what user SEES    : "I'll check the weather in Tokyo for you.\n\n"
  shown leaks       : False
  after fix .content: "I'll check the weather in Tokyo for you."
  tool_calls        : [('get_weather', '{"city": "Tokyo"}')]
```

Mutation testing — revert one piece of the fix, keep all tests, count reds. Six mutations, six caught:

| Mutation | Red |
|---|---|
| Unwire the stream filter (emit raw delta) | 3 |
| `strip_tool_call_scaffolding` → identity | 8 |
| ASCII `\|` in the marker instead of U+FF5C | 14 |
| Remove the hold-back (stateless filtering) | 1 |
| Unwire the assembled-text cut | 5 |
| `flush()` drops the pending tail instead of emitting it | 1 |

Tests: `tests/agent/test_bedrock_adapter.py` 100 passed. `tests/agent/ -k "bedrock or converse"` 165 passed, 5 skipped. `ruff check` clean.

Three failures in `tests/run_agent/test_streaming.py::TestAnthropicStreamCallbacks` reproduce identically on the pristine base — they are a local env artefact (missing `anthropic` package), not from this change.

## Incidental behaviour change

Empty text deltas no longer invoke `on_text_delta`. Bedrock does emit `""` deltas at the start and end of a text block; they produce no output either way, and the filter's `if visible:` guard skips them.

## Relationship to #46537 and #27834

Triage marks #54283 a duplicate of #27834 and points at **#46537** (@magic524) as the in-flight fix, which adds `agent/tool_call_scrubber.py` and wires it into `run_agent.py`, `gateway/run.py` and `gateway/stream_consumer.py`. That PR gets the hard parts right — full-width markers, stateful hold-back across deltas — and I would rather defer to it than duplicate it.

It does not close #54283. Running its scrubber, unmodified at `61b7ffd87`, against the string Bedrock actually returns:

```
in : "I'll check the weather in Tokyo for you.\n\n<｜DSML｜function_calls"
out: "I'll check the weather in Tokyo for you.\n\n<｜DSML｜function_calls"   <- unchanged
```

All three measured delta splits pass through untouched too, as does the no-prose variant. Its own target shape scrubs correctly, so this is not a broken scrubber:

```
in : 'Sure.\n\n<｜DSML｜tool_calls> <｜DSML｜invoke name="write_file"> x </tool_calls>'
out: 'Sure.\n\n'
```

Two reasons it misses:

1. Its `_OPEN_MARKERS` are `<｜DSML｜tool_calls>` — the leak says **`function_calls`**, a different word.
2. Both open markers require a trailing `>`, and the truncated fragment has none.

So the two changes are complementary rather than competing: #46537 is a display-boundary scrubber for balanced spans arriving over the gateway, this one is a wire-boundary cut in the Bedrock adapter that also covers the non-streaming `converse()` path and the CLI. **Happy to close this in favour of #46537 if @magic524 would rather add `function_calls` and drop the required `>` there** — the measurements above are posted on #46537 either way, and closing #54283 correctly matters more than which PR does it.
