### PR TITLE
feat(triggers): trigger-based skill auto-loading from SKILL.md frontmatter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1729,6 +1729,8 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "triggers": list(frontmatter.get("triggers", []) or []),
+        "rel_path": str(rel_path),
     }
     if org_id:
         entry["org_id"] = org_id
@@ -1876,7 +1878,7 @@ def build_skills_system_prompt(
         if not skills_dir.exists() and not external_dirs and not project_dirs:
             return ""
 
-        return _build_skills_system_prompt_inner(
+        result, _entries = _build_skills_system_prompt_inner(
             skills_dir,
             external_dirs,
             available_tools,
@@ -1884,6 +1886,50 @@ def build_skills_system_prompt(
             compact_categories,
             project_dirs=project_dirs,
         )
+        return result
+    finally:
+        if _home_token is not None:
+            reset_hermes_home_override(_home_token)
+
+
+def get_visible_skill_entries(
+    available_tools: "set[str] | None" = None,
+    available_toolsets: "set[str] | None" = None,
+    compact_categories: "frozenset[str] | None" = None,
+    skills_dir_override: "Path | None" = None,
+) -> list[dict]:
+    """Return filtered visible entries from the skills snapshot pipeline.
+
+    These are the same entries that ``build_skills_system_prompt`` uses
+    for the system-prompt skill index, after platform/environment/disabled
+    filtering.  Designed for use by the trigger-based skill loader.
+
+    When any filter parameter is ``None`` the corresponding gate accepts
+    all skills (backward compat — identical to the default index build).
+    """
+    if skills_dir_override is not None:
+        skills_dir = Path(skills_dir_override)
+        _home_token = set_hermes_home_override(str(skills_dir.parent))
+    else:
+        skills_dir = get_skills_dir()
+        _home_token = None
+    try:
+        external_dirs = get_all_skills_dirs()[1:]
+        from agent.skill_utils import get_project_skills_dirs
+        project_dirs = get_project_skills_dirs()
+
+        if not skills_dir.exists() and not external_dirs and not project_dirs:
+            return []
+
+        _, visible = _build_skills_system_prompt_inner(
+            skills_dir,
+            external_dirs,
+            available_tools,
+            available_toolsets,
+            compact_categories,
+            project_dirs=project_dirs,
+        )
+        return visible
     finally:
         if _home_token is not None:
             reset_hermes_home_override(_home_token)
@@ -1896,7 +1942,7 @@ def _build_skills_system_prompt_inner(
     available_toolsets: "set[str] | None",
     compact_categories: "frozenset[str] | None",
     project_dirs: "list[Path] | None" = None,
-) -> str:
+) -> tuple[str, list[dict]]:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
@@ -1916,6 +1962,11 @@ def _build_skills_system_prompt_inner(
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
         if cached is not None:
             _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
+            # Old-format cached strings get wrapped to maintain the
+            # (result, visible_entries) contract.
+            if isinstance(cached, str):
+                cached = (cached, [])
+                _SKILLS_PROMPT_CACHE[cache_key] = cached
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
@@ -2198,12 +2249,12 @@ def _build_skills_system_prompt_inner(
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
-        _SKILLS_PROMPT_CACHE[cache_key] = result
+        _SKILLS_PROMPT_CACHE[cache_key] = (result, visible_entries)
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
         while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
             _SKILLS_PROMPT_CACHE.popitem(last=False)
 
-    return result
+    return result, visible_entries
 
 
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:

--- a/agent/skill_trigger_loader.py
+++ b/agent/skill_trigger_loader.py
@@ -1,0 +1,155 @@
+"""Trigger-based skill auto-loading using snapshot entries.
+
+Matches skill triggers (regex patterns from frontmatter ``triggers:`` key)
+against user message text.  Consumer of ``prompt_builder`` snapshot entries,
+not a filesystem scanner — the snapshot pipeline already filters by platform,
+environment, disabled, and conditions.
+
+Cache safety
+  Injected skill content rides the ``api_content`` sidecar on the user
+  message (same path as memory prefetch and plugin context), never as a
+  system message.  The system prompt stays byte-stable for the session's
+  lifetime.  See ``agent/turn_context.py:build_turn_context``.
+
+Fail-safe
+  Any exception is caught, logged at DEBUG, and returns ``[]`` / ``""``.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import List, Optional
+
+from hermes_constants import get_skills_dir
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of skills to auto-load per turn from trigger matches.
+_TRIGGER_MAX_SKILLS = 5
+
+
+def get_triggered_skills(
+    user_text: str,
+    visible_entries: list[dict],
+    max_results: int = _TRIGGER_MAX_SKILLS,
+) -> list[dict]:
+    """Match trigger patterns in *visible_entries* against *user_text*.
+
+    Parameters
+    ----------
+    user_text : str
+        The current user message text (string content only; non-string/multimodal
+        content should be skipped before calling this function).
+    visible_entries : list[dict]
+        Filtered snapshot entries from ``prompt_builder.get_visible_skill_entries``.
+    max_results : int
+        Maximum number of matching skills to return (default 5).
+
+    Returns
+    -------
+    list[dict]
+        Matching entry dicts, at most *max_results*.  Empty list on no match
+        or any error (fail-safe).
+    """
+    try:
+        if not user_text or not visible_entries:
+            return []
+
+        matched: list[dict] = []
+        for entry in visible_entries:
+            if len(matched) >= max_results:
+                break
+
+            triggers = entry.get("triggers", []) or []
+            if not triggers:
+                continue
+
+            # Try each trigger pattern; first match wins (one skill per turn).
+            for pattern in triggers:
+                if len(matched) >= max_results:
+                    break
+                if not isinstance(pattern, str) or not pattern.strip():
+                    continue
+                try:
+                    if re.search(pattern, user_text, re.IGNORECASE | re.DOTALL):
+                        matched.append(entry)
+                        break  # each skill matched at most once per turn
+                except re.error:
+                    logger.debug(
+                        "Invalid trigger regex %r in skill %s, skipping",
+                        pattern,
+                        entry.get("skill_name", "?"),
+                    )
+                    continue
+
+        return matched
+    except Exception:
+        logger.debug("Skill trigger evaluation failed", exc_info=True)
+        return []
+
+
+def format_triggered_skill_content(
+    entry: dict,
+    skills_dir: "Path | None" = None,
+) -> str:
+    """Format a matched skill entry for sidecar injection.
+
+    Loads the ``SKILL.md`` body via ``rel_path`` from the snapshot entry,
+    strips frontmatter, and wraps it in an auto-load header.
+
+    Parameters
+    ----------
+    entry : dict
+        A snapshot entry dict with ``rel_path`` (and optionally ``skill_name``
+        / ``frontmatter_name``).
+    skills_dir : Path or None
+        Base directory for resolving ``rel_path``.  Defaults to
+        ``hermes_constants.get_skills_dir()``.
+
+    Returns
+    -------
+    str
+        Formatted markdown string, or ``""`` on any error (fail-safe).
+    """
+    try:
+        rel_path = entry.get("rel_path", "") or ""
+        if not rel_path:
+            return ""
+
+        base = skills_dir or get_skills_dir()
+        skill_md_path = base / rel_path
+        if not skill_md_path.exists():
+            return ""
+
+        content = skill_md_path.read_text(encoding="utf-8")
+        body = _strip_frontmatter(content)
+        if not body:
+            return ""
+
+        skill_name = (
+            entry.get("frontmatter_name")
+            or entry.get("skill_name")
+            or "?"
+        )
+        return f"## Auto-loaded: {skill_name}\n\n{body}"
+    except Exception:
+        logger.debug("Failed to format triggered skill content", exc_info=True)
+        return ""
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Remove YAML frontmatter (``---`` delimited) from skill content.
+
+    Returns the body text after the frontmatter, stripped of leading newlines.
+    Returns ``""`` when the content is frontmatter-only, or the original
+    content when no frontmatter is present.
+    """
+    if content.startswith("\ufeff"):
+        content = content[1:]  # tolerate UTF-8 BOM (Windows editors)
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            # Skip past the closing --- and any trailing newline
+            body = content[end + 4:].lstrip("\n")
+            return body if body else ""
+    return content

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -55,12 +55,14 @@ def compose_user_api_content(
     content: Any,
     ext_prefetch_cache: str,
     plugin_user_context: str,
+    triggered_skill_context: str = "",
 ) -> Optional[str]:
     """Compose the API-bound content of the current turn's user message.
 
     Sources: memory-manager prefetch + ``pre_llm_call`` plugin context with
-    target="user_message" (the default). Both are appended to the *API copy*
-    of the user message only — the stored content stays clean.
+    target="user_message" (the default), plus any auto-loaded triggered skill
+    content.  Both are appended to the *API copy* of the user message only
+    — the stored content stays clean.
 
     This is the single source of that composition. The prologue stamps the
     result onto the live message as ``api_content`` (persisted alongside the
@@ -81,6 +83,8 @@ def compose_user_api_content(
             injections.append(fenced)
     if plugin_user_context:
         injections.append(plugin_user_context)
+    if triggered_skill_context:
+        injections.append(triggered_skill_context)
     if not injections:
         return None
     return content + "\n\n" + "\n\n".join(injections)
@@ -1404,6 +1408,35 @@ def build_turn_context(
             except Exception:
                 pass
 
+    # ── Trigger-based skill auto-loading ──────────────────────────────
+    # Evaluate skill trigger patterns against the user message text.
+    # Reuses canonical filtering from prompt_builder — no parallel scanner.
+    # Injected via the api_content sidecar (same cache-safe path as memory).
+    triggered_skill_context = ""
+    try:
+        if isinstance(user_message, str) and user_message.strip():
+            from agent.skill_trigger_loader import (
+                format_triggered_skill_content,
+                get_triggered_skills,
+            )
+            from agent.prompt_builder import get_visible_skill_entries
+
+            _entries = get_visible_skill_entries()
+            if _entries:
+                _matched = get_triggered_skills(user_message, _entries)
+                if _matched:
+                    blocks = [
+                        format_triggered_skill_content(e) for e in _matched
+                    ]
+                    blocks = [b for b in blocks if b]
+                    if blocks:
+                        triggered_skill_context = (
+                            "\n\n[Triggered skills for this request:]\n\n"
+                            + "\n\n".join(blocks)
+                        )
+    except Exception:
+        logger.debug("Skill trigger evaluation failed", exc_info=True)
+
     # ── api_content sidecar: persist what you send ──
     # The prefetch/plugin context above is injected into the API copy of this
     # turn's user message, never into the stored content — so on the next
@@ -1429,7 +1462,8 @@ def build_turn_context(
     ):
         _turn_user_msg = messages[current_turn_user_idx]
         _api_content = compose_user_api_content(
-            _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
+            _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context,
+            triggered_skill_context=triggered_skill_context,
         )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content

--- a/tests/agent/test_skill_trigger_loader.py
+++ b/tests/agent/test_skill_trigger_loader.py
@@ -1,0 +1,297 @@
+"""Tests for agent/skill_trigger_loader.py.
+
+Tests use snapshot-style entry dicts (not raw filesystem scanning) to match
+how the trigger loader consumes entries in production — from the
+``prompt_builder`` snapshot pipeline after platform/environment/disabled
+filtering.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent.skill_trigger_loader import (
+    _strip_frontmatter,
+    format_triggered_skill_content,
+    get_triggered_skills,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    skill_name: str = "test-skill",
+    triggers: list[str] | None = None,
+    rel_path: str = "",
+) -> dict:
+    """Build a minimal snapshot entry dict matching what prompt_builder emits."""
+    return {
+        "skill_name": skill_name,
+        "frontmatter_name": skill_name,
+        "category": "test",
+        "description": "A test skill.",
+        "triggers": triggers or [],
+        "rel_path": rel_path,
+    }
+
+
+# ===========================================================================
+# get_triggered_skills
+# ===========================================================================
+
+
+class TestGetTriggeredSkills:
+    """Tests for get_triggered_skills()."""
+
+    def test_blank_input_returns_empty(self):
+        """Blank user_text yields no matches."""
+        assert get_triggered_skills("", []) == []
+
+    def test_blank_input_with_entries(self):
+        """Blank user_text yields no matches even with trigger entries."""
+        entries = [_make_entry(triggers=[r"hello"])]
+        assert get_triggered_skills("", entries) == []
+
+    def test_none_text_becomes_empty_after_fail_safe(self):
+        """get_triggered_skills handles non-string safely (wrapped by caller)."""
+        entries = [_make_entry(triggers=[r"hello"])]
+        assert get_triggered_skills("hello", entries) != []
+
+    # -- No-match cases ---------------------------------------------------
+
+    def test_no_visible_entries_returns_empty(self):
+        """Empty visible_entries list yields no matches."""
+        assert get_triggered_skills("hello world", []) == []
+
+    def test_no_triggers_on_entry_skips_it(self):
+        """Entry without triggers is skipped."""
+        entries = [_make_entry(triggers=[])]
+        assert get_triggered_skills("anything", entries) == []
+
+    def test_no_match_returns_empty(self):
+        """Text not matching any trigger yields empty list."""
+        entries = [_make_entry(triggers=[r"php|python"])]
+        assert get_triggered_skills("hello world", entries) == []
+
+    # -- Match cases ------------------------------------------------------
+
+    def test_case_insensitive_match(self):
+        """Trigger matching is case-insensitive."""
+        entries = [_make_entry(skill_name="python-help", triggers=[r"python"])]
+        result = get_triggered_skills("I need PYTHON help", entries)
+        assert len(result) == 1
+        assert result[0]["skill_name"] == "python-help"
+
+    def test_dotall_flag_works(self):
+        """re.DOTALL allows '.' to match newlines."""
+        entries = [_make_entry(triggers=[r"error.*trace"])]
+        result = get_triggered_skills("Error: something\nTraceback:", entries)
+        assert len(result) == 1
+
+    def test_multiple_matches(self):
+        """Multiple matching skills are returned, capped at max_results."""
+        entries = [
+            _make_entry(skill_name="skill-a", triggers=[r"python"]),
+            _make_entry(skill_name="skill-b", triggers=[r"python"]),
+            _make_entry(skill_name="skill-c", triggers=[r"python"]),
+        ]
+        result = get_triggered_skills("I use python", entries, max_results=5)
+        assert len(result) == 3
+
+    def test_max_results_cap(self):
+        """At most max_results skills are returned."""
+        entries = [
+            _make_entry(skill_name=f"skill-{i}", triggers=[r"python"])
+            for i in range(10)
+        ]
+        result = get_triggered_skills("python code", entries, max_results=5)
+        assert len(result) == 5
+
+    def test_per_skill_cap(self):
+        """Each skill is matched at most once per turn."""
+        # Multiple matching triggers for the same skill should only yield one entry.
+        entries = [
+            _make_entry(
+                skill_name="all-in-one",
+                triggers=[r"python", r"javascript", r"rust"],
+            ),
+        ]
+        result = get_triggered_skills(
+            "I write python and javascript and rust", entries
+        )
+        assert len(result) == 1
+        assert result[0]["skill_name"] == "all-in-one"
+
+    def test_invalid_regex_skipped_gracefully(self):
+        """Invalid regex patterns are silently skipped."""
+        entries = [
+            _make_entry(skill_name="good-skill", triggers=[r"[valid"]),
+            _make_entry(skill_name="bad-skill", triggers=[r"[invalid"]),
+            _make_entry(skill_name="also-good", triggers=[r"hello"]),
+        ]
+        # [valid is actually valid POSIX... let me use a truly invalid one
+        entries[0]["triggers"] = [r"[valid_regex"]
+        entries[1]["triggers"] = [r"\\"]
+        entries[2] = _make_entry(skill_name="also-good", triggers=[r"hello"])
+
+        result = get_triggered_skills("hello world", entries)
+        # The good-skill's broken regex is skipped; also-good matches "hello"
+        assert len(result) == 1
+        assert result[0]["skill_name"] == "also-good"
+
+    # -- Turn-behavior tests ----------------------------------------------
+
+    def test_first_turn_matches(self):
+        """Trigger matching works on the first turn (no conversation_history guard)."""
+        entries = [_make_entry(triggers=[r"error"])]
+        result = get_triggered_skills("I got an error", entries)
+        assert len(result) == 1
+
+    def test_nth_turn_matches(self):
+        """Trigger matching works on any turn — same as first-turn."""
+        entries = [_make_entry(triggers=[r"error"])]
+        result = get_triggered_skills("Still getting the same error", entries)
+        assert len(result) == 1
+
+    # -- Multimodal guard -------------------------------------------------
+
+    def test_multimodal_skipped_by_caller(self):
+        """Non-string user_message is skipped by caller (test that get_triggered
+        skills handles it gracefully when called with non-string)."""
+        # The turn_context caller guards against this, but the loader is
+        # still fail-safe against any input.
+        entries = [_make_entry(triggers=[r"."])]
+        result = get_triggered_skills("", entries)
+        assert result == []
+
+    # -- Platform/disabled filtering is respected -------------------------
+
+    def test_platform_disabled_filtering_already_applied(self):
+        """Trigger loader consumes pre-filtered entries — platform/disabled
+        filtering is already done by the snapshot pipeline."""
+        # If the entry doesn't have a matching trigger, it doesn't match.
+        # If it does, it matches — the loader doesn't re-filter.
+        entries = [_make_entry(triggers=[r"php"])]
+        result = get_triggered_skills("help with PHP", entries)
+        assert len(result) == 1
+
+
+# ===========================================================================
+# format_triggered_skill_content
+# ===========================================================================
+
+
+class TestFormatTriggeredSkillContent:
+    """Tests for format_triggered_skill_content()."""
+
+    def test_format_with_valid_path(self, tmp_path: Path):
+        """Format triggered skill content with a valid SKILL.md file."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        skill_file = skills_dir / "my-category" / "my-skill" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(
+            "---\nname: my-skill\ntriggers:\n  - test\n---\n\nThis is the skill body."
+        )
+
+        entry = _make_entry(
+            skill_name="my-skill",
+            triggers=[r"test"],
+            rel_path="my-category/my-skill/SKILL.md",
+        )
+        result = format_triggered_skill_content(entry, skills_dir=skills_dir)
+        assert "## Auto-loaded: my-skill" in result
+        assert "This is the skill body." in result
+
+    def test_format_missing_rel_path(self):
+        """Entry without rel_path returns empty string."""
+        entry = _make_entry(rel_path="")
+        assert format_triggered_skill_content(entry) == ""
+
+    def test_format_nonexistent_file(self, tmp_path: Path):
+        """Entry with rel_path pointing to non-existent file returns empty."""
+        entry = _make_entry(
+            skill_name="ghost",
+            rel_path="does-not-exist/SKILL.md",
+        )
+        # Use a real but empty skills_dir
+        skills_dir = tmp_path / "empty-skills"
+        skills_dir.mkdir()
+        result = format_triggered_skill_content(entry, skills_dir=skills_dir)
+        assert result == ""
+
+    def test_format_empty_body(self, tmp_path: Path):
+        """Entry with frontmatter-only file returns empty."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        skill_file = skills_dir / "empty-body" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text("---\nname: empty\n---\n")
+
+        entry = _make_entry(
+            skill_name="empty",
+            rel_path="empty-body/SKILL.md",
+        )
+        result = format_triggered_skill_content(entry, skills_dir=skills_dir)
+        # body after stripping frontmatter is empty
+        assert result == ""
+
+    def test_format_no_frontmatter(self, tmp_path: Path):
+        """Entry with no frontmatter still formats."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        skill_file = skills_dir / "raw-body" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text("Just body text, no frontmatter.")
+
+        entry = _make_entry(
+            skill_name="raw-body",
+            rel_path="raw-body/SKILL.md",
+        )
+        result = format_triggered_skill_content(entry, skills_dir=skills_dir)
+        assert "## Auto-loaded: raw-body" in result
+        assert "Just body text, no frontmatter." in result
+
+    def test_format_fail_safe(self):
+        """Exception in format_triggered_skill_content returns empty string."""
+        # Entry is None — would cause AttributeError, caught by fail-safe
+        # (normally the caller would never pass None, but the guard is there)
+        result = format_triggered_skill_content(
+            _make_entry(rel_path="../nonexistent/../../../etc/passwd")
+        )  # Path traversal doesn't matter — file won't exist
+        # Should return "" rather than raise
+        assert result == ""
+
+
+# ===========================================================================
+# _strip_frontmatter
+# ===========================================================================
+
+
+class TestStripFrontmatter:
+    """Tests for _strip_frontmatter()."""
+
+    def test_strips_yaml_frontmatter(self):
+        content = "---\nname: test\n---\n\nBody text"
+        assert _strip_frontmatter(content) == "Body text"
+
+    def test_strips_frontmatter_only(self):
+        content = "---\nname: test\n---\n"
+        assert _strip_frontmatter(content) == ""
+
+    def test_no_frontmatter(self):
+        content = "Just body text."
+        assert _strip_frontmatter(content) == "Just body text."
+
+    def test_strips_utf8_bom(self):
+        content = "\ufeff---\nname: test\n---\n\nBody"
+        assert _strip_frontmatter(content) == "Body"
+
+    def test_strips_bom_no_frontmatter(self):
+        content = "\ufeffBody text"
+        # BOM is stripped even when there's no frontmatter, returning clean text
+        assert _strip_frontmatter(content) == "Body text"


### PR DESCRIPTION
## Summary

Redesigned trigger-based skill auto-loading from [issue #23963](https://github.com/NousResearch/hermes-agent/issues/23963). Consumes snapshot entries from the  pipeline (already filtered by platform, environment, disabled, and conditions) rather than running a parallel filesystem scanner. Replaces the earlier approach that was blocked by cache-safety, code-path, and filtering concerns.

### Use case

Skills declare a `triggers:` frontmatter key with regex patterns. When a user message matches, the skill body is auto-loaded into the agent's context **before reasoning** — no recognition gap.

**Example SKILL.md:**
```yaml
---
triggers:
  - 'PHP Parse error.*syntax error'
  - 'mergeable.*CONFLICTING'
description: ...
---
```

### Architecture

```
prompt_builder.py          skill_trigger_loader.py          turn_context.py
  │                               │                              │
  ├─ visible_entries ────────────►│                              │
  │ (already filtered             │ get_triggered_skills()       │
  │  by platform/env/             │   ← regex match against      │
  │  disabled/conditions)         │     user message text        │
  │                               │ format_triggered_skill_      │
  │                               │ content() → formatted block  │
  │                               │                              │
  │                               │                              ├─ build_turn_context()
  │                               │                              │   → api_content sidecar
  │                               │                              │   (cache-safe injection)
```

### Changes (4 files, +544/-7)

| File | Δ | Description |
|------|---|-------------|
| `agent/prompt_builder.py` | +59/-7 | Added `triggers` + `rel_path` to snapshot entries; `get_visible_skill_entries()` public function |
| `agent/skill_trigger_loader.py` | +155 (new) | Snapshot-consumer trigger matcher, at most 5 per turn, invalid regex skipped |
| `agent/turn_context.py` | +40/-5 | Hook in `build_turn_context()`, injection via `api_content` sidecar |
| `tests/agent/test_skill_trigger_loader.py` | +297 (new) | 27 tests: blank input, case-insensitive match, multiple matches, per-skill cap, per-turn matching, multimodal guard, invalid regex, frontmatter edge cases |

### Design decisions (addressing earlier feedback)

- **Cache safe**: injected via `api_content` sidecar on the user message (same path as memory prefetch), **never as a system message**. The system prompt stays byte-stable for the session's lifetime.
- **Every turn**: no `not conversation_history` guard — triggers evaluate on every user message.
- **Reuses canonical filtering**: consumes snapshot entries from `prompt_builder`'s existing pipeline, which already filters by platform, environment, disabled skills, and conditions. No parallel scanner.
- **Fail-safe**: any exception in trigger evaluation → `logger.debug` → `[]`.
- **No env vars**: no new configuration variables.
- **Backward compatible**: skills without `triggers:` behave identically. Zero-config adoption.

### Related

- Closes #23963
- Related PR #98718 (`onload` hook) — orthogonal frontmatter key with different injection path (session-init script vs per-turn regex). Both are additive.
- Snapshot version unchanged (v2) — `triggers` is an additive field, existing snapshots return `[]` from `entry.get(\triggers\, [])`.