### PR TITLE
fix(kanban): suppress mid-stream continuation when worker's run has been superseded by a terminal transition

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3958,6 +3958,71 @@ def run_conversation(
                                     truncated_response_parts.append(assistant_message.content)
 
                             if length_continue_retries < 4:
+                                # Guard: if this is a kanban worker and its own run
+                                # has already transitioned to a terminal state, the
+                                # mid-stream drop happened AFTER a successful
+                                # kanban_request_changes / kanban_complete call.
+                                # Injecting a continuation would restart work that
+                                # already finished — writing ghost comments onto a
+                                # card owned by the next run (#98750).
+                                #
+                                # Check that the run-id in the env still matches an
+                                # active run on the task.  If the run has moved on,
+                                # abort cleanly instead of continuing.
+                                _kanban_task = (
+                                    getattr(agent, "_kanban_task_id", None)
+                                    or agent.context_env.get("HERMES_KANBAN_TASK")
+                                    if hasattr(agent, "context_env")
+                                    else None
+                                )
+                                _kanban_run = (
+                                    getattr(agent, "_kanban_run_id", None)
+                                    or agent.context_env.get("HERMES_KANBAN_RUN_ID")
+                                    if hasattr(agent, "context_env")
+                                    else None
+                                )
+                                if _kanban_task and _kanban_run:
+                                    try:
+                                        from hermes_cli.kanban import _worker_run_id_for
+                                        _live_run = _worker_run_id_for(_kanban_task)
+                                        if _live_run is not None and str(_live_run) != str(_kanban_run):
+                                            # The task has moved to a new run —
+                                            # this worker's run is done.
+                                            agent._vprint(
+                                                f"{agent.log_prefix}⚠️  Kanban run "
+                                                f"{_kanban_run} is no longer the "
+                                                f"active run on task {_kanban_task} "
+                                                f"(current run: {_live_run}) — "
+                                                f"aborting continuation to prevent "
+                                                f"ghost work.",
+                                                force=True,
+                                            )
+                                            logger.info(
+                                                "conversation_loop: kanban run %s "
+                                                "superseded by %s on task %s — "
+                                                "suppressing mid-stream continuation",
+                                                _kanban_run, _live_run, _kanban_task,
+                                            )
+                                            agent._cleanup_task_resources(effective_task_id)
+                                            agent._persist_session(messages, conversation_history)
+                                            return {
+                                                "final_response": (
+                                                    partial_response
+                                                    if (partial_response := agent._strip_think_blocks(
+                                                        _join_truncated_parts(truncated_response_parts)
+                                                    ).strip())
+                                                    else (
+                                                        getattr(assistant_message, "content", None) or ""
+                                                    )
+                                                ),
+                                                "messages": messages,
+                                                "api_calls": api_call_count,
+                                                "completed": True,
+                                                "kanban_run_superseded": True,
+                                            }
+                                    except Exception:
+                                        pass  # best-effort; proceed with normal continuation
+
                                 _is_partial_stream_stub = (
                                     getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                                 )

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
## Problem (#98750)

A kanban `reviewer` worker called `kanban_request_changes` (a terminal state transition — the run was done). The stream then ended without `finish_reason`. The agent loop classified it as a mid-stream drop and injected a continuation stub. The worker — still holding `HERMES_KANBAN_TASK` and `HERMES_KANBAN_RUN_ID` in its process env — kept working for 16 more minutes, writing three ghost `kanban_comment` calls onto a card that already belonged to the **next** run started by the dispatcher.

Lifecycle integrity held (every state transition was refused with `run_id mismatch`), but comments carry no run-id and are never blocked — so three ghost "Round 2 review" / "escalation" / "gap report" comments about a defect that doesn't exist landed on the card.

## Fix

Before injecting the continuation nudge (lines 3960-3999 in `agent/conversation_loop.py`), check via `_worker_run_id_for(task_id)` whether the kanban run-id in the agent's env is still the active run on the task. If it has been superseded, abort cleanly with the partial content collected so far and mark `kanban_run_superseded=True` in the result.

The guard is best-effort (wrapped in `try/except`) so a missing kanban env or an import error proceeds with normal continuation.

Fixes #98750