### PR TITLE
fix(mcp): park stdio servers that crash before the handshake

### DIFF
--- a/tests/tools/test_mcp_stdio_startup_crash.py
+++ b/tests/tools/test_mcp_stdio_startup_crash.py
@@ -1,0 +1,305 @@
+"""Regression tests for stdio MCP servers that crash at startup (#98763).
+
+A stdio server whose child process exits before the MCP handshake completes
+(e.g. ``ModuleNotFoundError`` under the shebang-resolved interpreter, any
+import-time error) used to be classified ``transient``: the crash happens in
+a separate process, so the parent only observes a closed stdio pipe, and
+``run()`` burned the full initial retry ladder, parked, then repeated on
+every parked self-probe — flooding logs for days (#98763: 1,982 park events
+across two servers in ~12 days).
+
+The fix detects the dead child when the ``stdio_client`` context unwinds and
+raises :class:`StdioStartupCrashError`, which ``_classify_mcp_failure``
+treats as permanent: park immediately with one clear log line (root cause +
+the child's stderr tail), while staying revivable via the self-probe.
+
+These tests drive the *real* ``MCPServerTask._run_stdio`` / ``run()`` with
+fake transports — no real subprocess, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("mcp")
+pytest.importorskip("psutil")
+
+DEAD_PID = 4194304  # > typical pid_max; only ever consulted via mocked psutil
+
+
+class _FakeAsyncCM:
+    """Minimal async context manager yielding a fixed value; spawns nothing."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _CrashingAtHandshakeSession:
+    """Stand-in ClientSession: the child dies before ``initialize()`` answers."""
+
+    async def initialize(self):
+        raise EOFError("stream closed before initialize response")
+
+
+class _HealthyThenDroppingSession:
+    """Handshake completes, then the transport drops while serving."""
+
+    async def initialize(self):
+        return object()
+
+
+def _drive_run_stdio(task, config, **patches):
+    async def drive():
+        return await task._run_stdio(config)
+
+    # Caller-supplied patches plus the hermetic baseline every _run_stdio
+    # drive needs (spawn-adjacent helpers would touch the real process
+    # table / stderr log).
+    defaults = {
+        "stdio_client": lambda *a, **k: _FakeAsyncCM((object(), object())),
+        "ClientSession": lambda *a, **k: _FakeAsyncCM(_CrashingAtHandshakeSession()),
+        "_resolve_stdio_command": lambda c, e: (c, e),
+        "_write_stderr_log_header": lambda *_a, **_k: None,
+        "_get_mcp_stderr_log": lambda: None,
+        "_kill_orphaned_mcp_children": lambda: None,
+    }
+    defaults.update(patches)
+    with patch("tools.osv_check.check_package_for_malware", lambda *_a, **_k: None):
+        with patch.multiple("tools.mcp_tool", **defaults):
+            return asyncio.run(drive())
+
+
+def _spawn_snapshot_mock():
+    """``_snapshot_child_pids`` that sees no children before the spawn and
+    exactly one (DEAD_PID) after it — as if the SDK spawned a child that has
+    since exited."""
+    calls = {"n": 0}
+
+    def _snapshot():
+        calls["n"] += 1
+        return set() if calls["n"] == 1 else {DEAD_PID}
+
+    return _snapshot
+
+
+class TestRunStdioStartupCrashDetection:
+    def test_dead_child_crash_is_wrapped_as_permanent(self, monkeypatch):
+        """A child that dies before the handshake must surface as
+        ``StdioStartupCrashError`` carrying the unwrapped root cause."""
+        from tools import mcp_tool
+
+        task = mcp_tool.MCPServerTask("xapi-bearer")
+        monkeypatch.setattr("psutil.pid_exists", lambda pid: False)
+
+        with pytest.raises(mcp_tool.StdioStartupCrashError) as excinfo:
+            _drive_run_stdio(
+                task,
+                {"command": "python", "args": ["-m", "xapi_bearer"]},
+                _snapshot_child_pids=_spawn_snapshot_mock(),
+                _filter_mcp_children=lambda pids: set(pids),
+            )
+
+        assert isinstance(excinfo.value.__cause__, EOFError)
+        assert "before the MCP handshake" in str(excinfo.value)
+        assert "EOFError" in str(excinfo.value)
+
+    def test_live_child_drop_is_not_wrapped(self, monkeypatch):
+        """The same EOF with the child still alive (e.g. a server that
+        answers garbage then hangs) must keep today's transient behaviour —
+        only a dead child proves a deterministic startup crash."""
+        from tools import mcp_tool
+
+        task = mcp_tool.MCPServerTask("hangy")
+        monkeypatch.setattr("psutil.pid_exists", lambda pid: True)
+
+        with pytest.raises(EOFError):
+            _drive_run_stdio(
+                task,
+                {"command": "python", "args": []},
+                _snapshot_child_pids=_spawn_snapshot_mock(),
+                _filter_mcp_children=lambda pids: set(pids),
+            )
+
+    def test_spawn_failure_is_not_wrapped(self, monkeypatch):
+        """When no child PID was captured this round (e.g. ``stdio_client``
+        entry itself failed), stale PIDs from a previous attempt must not
+        reclassify the failure — the raw error propagates as before."""
+        from tools import mcp_tool
+
+        task = mcp_tool.MCPServerTask("gone-cmd")
+        monkeypatch.setattr("psutil.pid_exists", lambda pid: False)
+
+        with pytest.raises(EOFError):
+            _drive_run_stdio(
+                task,
+                {"command": "python", "args": []},
+                _snapshot_child_pids=lambda: set(),
+                _filter_mcp_children=lambda pids: set(pids),
+            )
+
+    def test_runtime_drop_after_handshake_is_not_wrapped(self, monkeypatch):
+        """A server that handshakes fine and drops later may still recover on
+        reconnect — ``_ever_connected`` must keep it out of the startup-crash
+        bucket."""
+        from tools import mcp_tool
+
+        task = mcp_tool.MCPServerTask("flapper")
+        monkeypatch.setattr("psutil.pid_exists", lambda pid: False)
+
+        async def _drop(_self):
+            raise EOFError("stream closed mid-session")
+
+        with (
+            patch.object(mcp_tool.MCPServerTask, "_wait_for_lifecycle_event", _drop),
+            patch.object(mcp_tool.MCPServerTask, "_discover_tools", _noop_async),
+        ):
+            with pytest.raises(EOFError):
+                _drive_run_stdio(
+                    task,
+                    {"command": "python", "args": []},
+                    ClientSession=lambda *a, **k: _FakeAsyncCM(
+                        _HealthyThenDroppingSession()
+                    ),
+                    _snapshot_child_pids=_spawn_snapshot_mock(),
+                    _filter_mcp_children=lambda pids: set(pids),
+                )
+
+
+async def _noop_async(*_a, **_k):
+    return None
+
+
+class TestClassifyStdioStartupCrash:
+    def test_direct_and_taskgroup_wrapped_are_permanent(self):
+        from tools.mcp_tool import (
+            StdioStartupCrashError,
+            _classify_mcp_failure,
+        )
+
+        direct = StdioStartupCrashError("stdio process exited early")
+        grouped = BaseExceptionGroup(
+            "unhandled errors in a TaskGroup (1 sub-exception)", [direct]
+        )
+        assert _classify_mcp_failure(direct) == "permanent"
+        assert _classify_mcp_failure(grouped) == "permanent"
+
+
+class TestStderrTail:
+    def test_tail_returns_last_lines_after_offset(self, monkeypatch, tmp_path):
+        from tools import mcp_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        header = "===== starting MCP server 'xapi-bearer' =====\n"
+        crash = (
+            "Traceback (most recent call last):\n"
+            '  File "xapi-bearer", line 1, in <module>\n'
+            "    import yaml\n"
+            "ModuleNotFoundError: No module named 'yaml'\n"
+            "\n"
+        )
+        (log_dir / "mcp-stderr.log").write_text(header + crash, encoding="utf-8")
+
+        tail = mcp_tool._read_mcp_stderr_tail(len(header.encode()))
+        assert "ModuleNotFoundError: No module named 'yaml'" in tail
+        assert "starting MCP server" not in tail
+
+    def test_tail_no_offset_or_missing_file_is_empty(self, monkeypatch, tmp_path):
+        from tools import mcp_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # No logs directory at all — must degrade to "".
+        assert mcp_tool._read_mcp_stderr_tail(0) == ""
+        assert mcp_tool._read_mcp_stderr_tail(None) == ""
+
+
+# ── run() parks startup crashes without the retry ladder ────────────────────
+
+
+class TestStartupCrashParksImmediately:
+    def test_startup_crash_parks_without_retry_ladder(
+        self,
+        monkeypatch,
+        tmp_path,
+        caplog,
+    ):
+        """A StdioStartupCrashError must park after ONE attempt with the
+        stderr diagnostic in the log — not burn _MAX_INITIAL_CONNECT_RETRIES
+        identical warnings (#98763)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools import mcp_tool
+
+        _real_sleep = asyncio.sleep
+
+        async def _fast_sleep(_delay, *a, **kw):
+            await _real_sleep(0)
+
+        monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+        state = {"transport_calls": 0, "parked": False}
+
+        async def _scenario():
+            class _Task(mcp_tool.MCPServerTask):
+                def _is_http(self):
+                    return False
+
+                def _deregister_tools(self):
+                    state["parked"] = True
+                    self._registered_tool_names = []
+
+                async def _run_stdio(self, config):
+                    state["transport_calls"] += 1
+                    raise mcp_tool.StdioStartupCrashError(
+                        "stdio process exited before the MCP handshake "
+                        "completed (caused by EOFError); recent stderr:\n"
+                        "ModuleNotFoundError: No module named 'yaml'"
+                    )
+
+            task = _Task("xapi-bearer")
+
+            with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+                run_task = asyncio.ensure_future(task.run({"command": "x"}))
+                for _ in range(500):
+                    await _real_sleep(0)
+                    if state["parked"]:
+                        break
+
+            assert state["parked"], "startup crash never parked"
+            assert state["transport_calls"] == 1, (
+                f"startup crash burned {state['transport_calls']} attempts — "
+                "should park immediately"
+            )
+            assert not run_task.done(), (
+                "run task exited on a startup crash — the server is now unrevivable"
+            )
+
+            task._shutdown_event.set()
+            task._reconnect_event.set()
+            try:
+                await asyncio.wait_for(run_task, timeout=15)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                run_task.cancel()
+
+        asyncio.run(_scenario())
+
+        park_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "permanent error" in r.getMessage()
+        ]
+        assert len(park_warnings) == 1
+        message = park_warnings[0].getMessage()
+        assert "StdioStartupCrashError" in message
+        assert "ModuleNotFoundError: No module named 'yaml'" in message

--- a/tests/tools/test_mcp_stdio_startup_crash.py
+++ b/tests/tools/test_mcp_stdio_startup_crash.py
@@ -223,6 +223,19 @@ class TestStderrTail:
         assert mcp_tool._read_mcp_stderr_tail(0) == ""
         assert mcp_tool._read_mcp_stderr_tail(None) == ""
 
+    def test_tail_read_failure_emits_debug_signal(self, monkeypatch, tmp_path, caplog):
+        from tools import mcp_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # The empty-string return is pinned above; the read failure must also
+        # leave a debug breadcrumb so a missing stderr tail is explainable.
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            assert mcp_tool._read_mcp_stderr_tail(0) == ""
+        assert any(
+            "mcp stderr tail unavailable" in record.message
+            for record in caplog.records
+        )
+
 
 # ── run() parks startup crashes without the retry ladder ────────────────────
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -224,20 +224,56 @@ def _get_mcp_stderr_log() -> Any:
         return _mcp_stderr_log_fh
 
 
-def _write_stderr_log_header(server_name: str) -> None:
+def _write_stderr_log_header(server_name: str) -> Optional[int]:
     """Write a human-readable session marker before launching a server.
 
     Gives operators a way to find each server's output in the shared
     ``mcp-stderr.log`` file without needing per-line prefixes (which would
     require a pipe + reader thread and complicate shutdown).
+
+    Returns the byte offset just past the header so callers can later read
+    back what THIS launch wrote (see :func:`_read_mcp_stderr_tail`), or
+    ``None`` when the marker could not be written.
     """
     fh = _get_mcp_stderr_log()
     try:
         ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         fh.write(f"\n===== [{ts}] starting MCP server '{server_name}' =====\n")
         fh.flush()
+        return fh.tell()
     except Exception:
-        pass
+        return None
+
+
+def _read_mcp_stderr_tail(
+    start_offset: Optional[int],
+    max_bytes: int = 2048,
+    max_lines: int = 5,
+) -> str:
+    """Return the last non-empty stderr lines a server launch wrote (#98763).
+
+    Reads ``~/.hermes/logs/mcp-stderr.log`` from ``start_offset`` (the value
+    :func:`_write_stderr_log_header` handed back before the spawn) and keeps
+    at most ``max_lines`` trailing non-empty lines within ``max_bytes``. When
+    a stdio server crashes at startup, its traceback (e.g.
+    ``ModuleNotFoundError``) lands here — the actionable diagnostic a bare
+    "unhandled errors in a TaskGroup" park log otherwise hides.
+
+    Best-effort: any failure (offset ``None``, file rotated away, decode
+    error, ...) returns ``""`` — diagnostics must never break error handling.
+    """
+    if start_offset is None:
+        return ""
+    try:
+        from hermes_constants import get_hermes_home
+        log_path = get_hermes_home() / "logs" / "mcp-stderr.log"
+        with open(log_path, "r", encoding="utf-8", errors="replace") as fh:
+            fh.seek(start_offset)
+            chunk = fh.read(max_bytes)
+        lines = [line.strip() for line in chunk.splitlines() if line.strip()]
+        return "\n".join(lines[-max_lines:])
+    except Exception:
+        return ""
 
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
@@ -1377,6 +1413,27 @@ class NonMcpEndpointError(ConnectionError):
     """
 
 
+class StdioStartupCrashError(Exception):
+    """Raised when a stdio MCP subprocess dies before the handshake (#98763).
+
+    A server that exits non-zero at startup (missing module under the
+    shebang-resolved interpreter, any import-time error, bad wrapper script)
+    is deterministic: every retry respawns a child that dies the same way.
+    The crash happens in a separate process, so the parent only observes a
+    closed stdio pipe — an EOF/TaskGroup drop that exception-type
+    classification would call "transient". :meth:`MCPServerTask._run_stdio`
+    detects the dead child at teardown time and raises this instead, so
+    :func:`_classify_mcp_failure` parks the server immediately (like the
+    existing ``FileNotFoundError``/ENOENT handling) instead of burning the
+    retry ladder.
+
+    The message carries the unwrapped root cause and, best-effort, the tail
+    of the child's stderr (where e.g. ``ModuleNotFoundError`` lands) — the
+    actionable diagnostic the raw TaskGroup wrapper hides. The server stays
+    revivable via the parked self-probe once the operator fixes the command.
+    """
+
+
 def _unwrap_exception_group(exc: BaseException) -> BaseException:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -1432,7 +1489,9 @@ def _classify_mcp_failure(exc: BaseException) -> str:
     - auth failures (401/403) — need new credentials, not a retry;
     - :class:`NonMcpEndpointError` — the URL serves a web page, not MCP;
     - :class:`InvalidMcpUrlError` — unusable config;
-    - ``FileNotFoundError`` / ``ENOENT`` — the stdio command doesn't exist.
+    - ``FileNotFoundError`` / ``ENOENT`` — the stdio command doesn't exist;
+    - :class:`StdioStartupCrashError` — the stdio subprocess died before the
+      MCP handshake completed (deterministic crash-at-startup).
 
     Everything else (network blips, EOF, ``ClosedResourceError``, transport
     TaskGroup drops, timeouts) is transient and keeps the normal
@@ -1445,6 +1504,8 @@ def _classify_mcp_failure(exc: BaseException) -> str:
         return "permanent"
     # Stdio command missing: FileNotFoundError, or an OSError carrying ENOENT.
     if isinstance(root, FileNotFoundError):
+        return "permanent"
+    if isinstance(root, StdioStartupCrashError):
         return "permanent"
     if isinstance(root, OSError) and getattr(root, "errno", None) == errno.ENOENT:
         return "permanent"
@@ -3284,7 +3345,7 @@ class MCPServerTask:
         # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
         # the user's TTY and corrupt the TUI.  Preserves debuggability via
         # ~/.hermes/logs/mcp-stderr.log.
-        _write_stderr_log_header(self.name)
+        stderr_log_offset = _write_stderr_log_header(self.name)
         _errlog = _get_mcp_stderr_log()
         try:
             async with stdio_client(server_params, errlog=_errlog) as (
@@ -3378,6 +3439,37 @@ class MCPServerTask:
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
                     return await self._wait_for_lifecycle_event()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Startup-crash detection (#98763): the child exited before the
+            # MCP handshake ever completed. Checked here — after the
+            # ``stdio_client`` context has unwound and reaped the process —
+            # so a dead PID is reliable evidence. ``new_pids`` gates on a
+            # successful spawn this round (a failed ``stdio_client`` entry
+            # would leave ``_stdio_child_pids`` holding stale PIDs from the
+            # previous attempt). ``_ever_connected`` is set only after a
+            # completed handshake and never cleared, so it separates
+            # "crashed at startup" (retrying respawns the same dying child)
+            # from "ran fine, then dropped" (a reconnect may still recover).
+            # Everything else (child alive, PIDs unknown, psutil missing)
+            # falls through as before.
+            if (
+                new_pids
+                and not self._ever_connected
+                and self._stdio_children_dead()
+            ):
+                root = _unwrap_exception_group(exc)
+                detail = f"{type(root).__name__}: {root}".rstrip(": ")
+                tail = _read_mcp_stderr_tail(stderr_log_offset)
+                message = (
+                    "stdio process exited before the MCP handshake "
+                    f"completed (caused by {detail})"
+                )
+                if tail:
+                    message += f"; recent stderr:\n{tail}"
+                raise StdioStartupCrashError(message) from exc
+            raise
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -273,6 +273,9 @@ def _read_mcp_stderr_tail(
         lines = [line.strip() for line in chunk.splitlines() if line.strip()]
         return "\n".join(lines[-max_lines:])
     except Exception:
+        logger.debug(
+            "mcp stderr tail unavailable (offset=%s)", start_offset, exc_info=True
+        )
         return ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

A stdio MCP server whose child process exits non-zero **at startup** (missing module under the shebang-resolved `python3`, any import-time error, bad wrapper script) is deterministic — but the crash happens in a separate process, so the parent only observes a closed stdio pipe. `_classify_mcp_failure` therefore called it `transient`, and `run()` burned the full initial retry ladder, parked, then repeated the whole cycle on every 300s parked self-probe. For the reporter this meant 1,982 park events across two servers in ~12 days, each preceded by `unhandled errors in a TaskGroup` noise.

This PR detects the dead child when the `stdio_client` context unwinds — spawn succeeded, handshake never completed — and raises a new `StdioStartupCrashError` instead, which `_classify_mcp_failure` treats as **permanent**: the server parks immediately with a single clear log line, mirroring the existing `FileNotFoundError`/ENOENT handling for a missing stdio command. The park log carries the unwrapped root cause plus the tail of the child's stderr read back from `mcp-stderr.log` (where the `ModuleNotFoundError` traceback actually lands) — the actionable diagnostic the bare TaskGroup wrapper hides. The server stays revivable via the parked self-probe once the operator fixes the command.

Guard rails so nothing regresses:
- A **live** child (server started, e.g. answers garbage then hangs) keeps today's transient behaviour — only a dead child proves a deterministic startup crash.
- A **failed spawn** (`stdio_client` entry itself fails, no PIDs captured this round) is never reclassified — the raw error propagates as before.
- A drop **after a completed handshake** (`_ever_connected`) keeps the reconnect ladder — a flapping-but-recoverable server must not be parked.
- psutil missing / PIDs unknown ⇒ unchanged (transient) behaviour.

## Related Issue

Fixes #98763

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`
  - New `StdioStartupCrashError` — raised when a stdio child dies before the MCP handshake completes; classified permanent.
  - `MCPServerTask._run_stdio`: wrap the transport body; on exception, if PIDs were captured this round, the handshake never completed, and every tracked child has exited, re-raise as `StdioStartupCrashError` with root cause + stderr tail (checked after the SDK context unwound and reaped the process, so a dead PID is reliable evidence).
  - `_classify_mcp_failure`: classify `StdioStartupCrashError` as permanent (docstring updated).
  - `_write_stderr_log_header` now returns the post-header byte offset; new `_read_mcp_stderr_tail(offset)` reads back what this launch wrote (best-effort, never raises).
- `tests/tools/test_mcp_stdio_startup_crash.py` (new) — 8 regression tests: dead-child crash wrapped + classified permanent (also through a TaskGroup), live-child drop not wrapped, failed-spawn not wrapped, runtime drop after handshake not wrapped, stderr-tail extraction, and a `run()`-level test asserting one attempt → park with the stderr diagnostic in the log, task stays revivable.

## How to Test

1. `python -m pytest tests/tools/test_mcp_stdio_startup_crash.py -q` → `8 passed`.
2. `python -m pytest tests/tools/ -k mcp -q` → `662 passed, 3 skipped` (no regressions).
3. Manual repro from the issue: configure a stdio server as a script whose import fails (`#!/usr/bin/env python3` + `import yaml` without PyYAML installed for that interpreter) and start Hermes.
   - Observed result before: three initial-connect retries + park, then the same ladder again on every 300s self-probe, logging `unhandled errors in a TaskGroup (1 sub-exception)` each time.
   - Observed result after: one warning (`failed initial connection with a permanent error … StdioStartupCrashError: stdio process exited before the MCP handshake completed (caused by …); recent stderr: ModuleNotFoundError: No module named 'yaml'`), park, no retry ladder. A `/mcp` refresh (or the parked self-probe) still revives it once the script is fixed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A