### PR TITLE
fix(env): include custom provider key_env values in BWS/secret-injection allowlist

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -57,13 +57,34 @@ def _known_hermes_env_keys() -> set[str]:
 
     Includes both ``OPTIONAL_ENV_VARS`` (setup-flow vars with metadata) and
     ``_EXTRA_ENV_KEYS`` (provider/platform keys managed outside the setup
-    wizard).  Lazy-imported to avoid circular-dependency during early-bootstrap
+    wizard).  Also includes ``key_env`` values from any custom providers the
+    user has configured under ``providers:`` in config.yaml — so that BWS /
+    Bitwarden secret injection respects user-defined provider credentials
+    without requiring a source-level edit to ``_EXTRA_ENV_KEYS`` after every
+    upgrade (#97596).
+
+    Lazy-imported to avoid circular-dependency during early-bootstrap
     ``load_hermes_dotenv()`` calls.
     """
     from hermes_cli.config import _EXTRA_ENV_KEYS
     from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
 
-    return set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
+    base = set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
+
+    # Augment with key_env values from user-configured custom providers.
+    # Fail open: if config loading fails, return the base set unchanged.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        for _pname, _pcfg in (cfg.get("providers") or {}).items():
+            if isinstance(_pcfg, dict):
+                _key_env = (_pcfg.get("key_env") or "").strip()
+                if _key_env:
+                    base.add(_key_env)
+    except Exception:  # noqa: BLE001 — discovery is best-effort
+        pass
+
+    return base
 
 
 # Behavioral routing keys a parent Hermes process injects into child env and

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
## Problem (#97596)

`_EXTRA_ENV_KEYS` in `hermes_cli/config.py` is a hardcoded frozenset. Custom providers configured under `providers:` in `config.yaml` with their own `key_env` (e.g. `SENSENOVA_API_KEY`, `AGNES_API_KEY`, `STEPFUN_API_KEY`) were not in the allowlist. BWS/Bitwarden Secrets Manager injection skipped them with a warning, leaving the provider with no API key at runtime.

Users had to patch the Hermes source after every upgrade to add their custom keys — exactly the kind of per-deployment maintenance burden that `providers:` key_env was supposed to avoid.

## Fix

Extend `_known_env_keys()` in `hermes_cli/env_loader.py` — the function that builds the allowlist used by `reload_env()` and `_clear_known_keys_missing_from_dotenv()` — to also derive `key_env` values from the user's `providers:` section in `config.yaml`.

Any provider a user explicitly configured is by definition one whose API key they want injected. Derivation is best-effort (`try/except`) so a broken config file does not prevent startup.

Fixes #97596