### PR TITLE
fix(state): auto-resume interrupted CJK FTS backfill, surface it in doctor/stats (#98743)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -474,6 +474,43 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "optimize-storage' with the gateway stopped)",
         ))
 
+    # #98743: an interrupted CJK-bigram backfill freezes its markers
+    # forever (only the optimize-storage loop ever advances them), leaving
+    # CJK search silently on trigram/LIKE. Surface it at ANY database
+    # size — the stuck state is invisible otherwise.
+    cjk_pending = stats.get("fts_cjk_rebuild_pending")
+    if cjk_pending:
+        cjk_hw = stats.get("fts_cjk_rebuild_high_water")
+        cjk_done = stats.get("fts_cjk_rebuild_progress")
+        cjk_detail = (
+            "(resumes automatically on the next writable open with the "
+            "CJK extension, or run 'hermes sessions optimize-storage')"
+        )
+        if isinstance(cjk_hw, int) and isinstance(cjk_done, int) and cjk_hw > 0:
+            pct = min(100, int(100 * cjk_done / cjk_hw))
+            lines.append((
+                "warn",
+                f"CJK FTS backfill interrupted at {pct}% "
+                f"({cjk_done:,}/{cjk_hw:,} rows) — CJK search is falling "
+                f"back to trigram/LIKE",
+                cjk_detail,
+            ))
+        else:
+            lines.append((
+                "warn",
+                "CJK FTS backfill interrupted — CJK search is falling back "
+                "to trigram/LIKE",
+                cjk_detail,
+            ))
+    if stats.get("fts_cjk_stale"):
+        lines.append((
+            "warn",
+            "CJK FTS index is marked stale (a process without the CJK "
+            "extension dropped its triggers)",
+            "(run 'hermes sessions optimize-storage' on a host with the "
+            "CJK extension to rebuild it from scratch)",
+        ))
+
     # Advisory: oversized database. Suggest auto_prune, and — when the v23
     # FTS rebuild is pending OR the DB still carries the legacy inline
     # trigram layout (fts_storage_version marker absent) — the offline

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1448,6 +1448,35 @@ def cmd_sessions(args, sessions_parser=None):
         if db_path.exists():
             size_mb = os.path.getsize(db_path) / (1024 * 1024)
             print(f"Database size: {size_mb:.1f} MB")
+        # #98743: surface an interrupted CJK FTS backfill here too — the
+        # markers freeze forever otherwise and CJK search quietly stays on
+        # trigram/LIKE. Same read-only probe doctor uses; never raises.
+        try:
+            from hermes_state import collect_state_db_stats
+
+            state_stats = collect_state_db_stats(db_path)
+            if state_stats.get("fts_cjk_rebuild_pending"):
+                cjk_hw = state_stats.get("fts_cjk_rebuild_high_water")
+                cjk_done = state_stats.get("fts_cjk_rebuild_progress")
+                pct = (
+                    min(100, int(100 * cjk_done / cjk_hw))
+                    if isinstance(cjk_hw, int) and cjk_hw > 0
+                    and isinstance(cjk_done, int)
+                    else None
+                )
+                progress = (
+                    f" at {pct}% ({cjk_done:,}/{cjk_hw:,} rows)"
+                    if pct is not None
+                    else ""
+                )
+                print(
+                    f"Note: CJK FTS backfill interrupted{progress} — CJK "
+                    "search falls back to trigram/LIKE; it resumes on the "
+                    "next writable open with the CJK extension (or run "
+                    "'hermes sessions optimize-storage')."
+                )
+        except Exception:
+            pass
 
     else:
         sessions_parser.print_help()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4109,6 +4109,12 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
       finished (high_water present and progress < high_water)
     - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
     - ``fts_rebuild_deferral`` — durable blocked-repair diagnostic, when present
+    - ``fts_cjk_rebuild_pending`` / ``fts_cjk_rebuild_high_water`` /
+      ``fts_cjk_rebuild_progress`` — same triple for the CJK-bigram index
+      (#98743: an interrupted cjk backfill leaves these markers frozen
+      forever; stats/doctor make the stuck state visible)
+    - ``fts_cjk_stale`` — True when the tokenizer-less-process breadcrumb
+      is present (cjk index needs a from-scratch rebuild)
     """
     stats: Dict[str, Any] = {
         "page_count": None,
@@ -4125,6 +4131,10 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
         "fts_rebuild_deferral": None,
+        "fts_cjk_rebuild_pending": None,
+        "fts_cjk_rebuild_high_water": None,
+        "fts_cjk_rebuild_progress": None,
+        "fts_cjk_stale": None,
     }
 
     # WAL sidecar size needs no connection at all.
@@ -4215,6 +4225,27 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
             stats["fts_rebuild_pending"] = False
         else:
             stats["fts_rebuild_pending"] = (progress or 0) < high_water
+
+        # CJK-bigram backfill markers (#98743) — same shape as the base
+        # rebuild triple so doctor renders both identically.
+        cjk_hw = _meta_int("fts_cjk_rebuild_high_water")
+        cjk_progress = _meta_int("fts_cjk_rebuild_progress")
+        stats["fts_cjk_rebuild_high_water"] = cjk_hw
+        stats["fts_cjk_rebuild_progress"] = cjk_progress
+        if cjk_hw is None:
+            stats["fts_cjk_rebuild_pending"] = False
+        else:
+            stats["fts_cjk_rebuild_pending"] = (cjk_progress or 0) < cjk_hw
+        try:
+            stats["fts_cjk_stale"] = (
+                conn.execute(
+                    "SELECT 1 FROM state_meta WHERE key = ? LIMIT 1",
+                    (FTS_CJK_STALE_KEY,),
+                ).fetchone()
+                is not None
+            )
+        except Exception:
+            pass
         try:
             row = conn.execute(
                 "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
@@ -4591,6 +4622,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # _init_schema / _probe_fts_cjk.
         self._fts_cjk_loaded = False
         self._fts_cjk_available = False
+        # Background auto-resume of an interrupted cjk backfill (#98743).
+        # The lock guards thread/stop creation; the thread is daemon so an
+        # interpreter exit never waits on it (progress markers are durable).
+        self._cjk_resume_lock = threading.Lock()
+        self._cjk_resume_thread: Optional[threading.Thread] = None
+        self._cjk_resume_stop: Optional[threading.Event] = None
         self._fts_unavailable_warned = False
         self._conn = None
         # Async token accounting (see queue_token_counts). The condition
@@ -4787,6 +4824,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # racing session lifecycle and the surprise disk/latency cost on
             # an unattended open. (An interrupted optimize resumes when the
             # user re-runs the command.)
+            # #98743 — an interrupted *cjk backfill* (the incremental phase
+            # of an ALREADY-demoted v23 DB) is the one piece that does
+            # auto-resume: the demote opt-in already happened, and the
+            # markers freeze forever otherwise. Throttled background loop,
+            # never DDL — see _maybe_start_cjk_backfill_resume.
+            self._maybe_start_cjk_backfill_resume()
             initialization_complete = True
         except Exception as exc:
             # Capture the cause so /resume and friends can surface WHY the
@@ -5790,6 +5833,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         races the gateway's live writer and tears B-tree pages — issue
         #45383). Read-only connections never request a checkpoint.
         """
+        # Stop the #98743 background cjk backfill resume BEFORE draining
+        # anything — its loop shares self._lock/self._conn with this closer.
+        self._stop_cjk_backfill_resume(join_timeout_s=2.0)
         self._stop_token_writer()
         hook, self._token_atexit_hook = self._token_atexit_hook, None
         if hook is not None:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import sqlite3
+import threading
 import time
 from typing import Any, Callable, Collection, Dict, List, Optional, Tuple
 
@@ -433,6 +434,123 @@ class SessionSearchMixin:
         self._fts_cjk_available = True
         logger.info("CJK FTS index backfill complete — serving CJK search.")
 
+    # ── Background auto-resume of an interrupted cjk backfill (#98743) ──
+
+    def cjk_backfill_resume_active(self) -> bool:
+        """True while this instance's background cjk backfill resume runs."""
+        thread = getattr(self, "_cjk_resume_thread", None)
+        stop = getattr(self, "_cjk_resume_stop", None)
+        return bool(thread and thread.is_alive() and not (stop and stop.is_set()))
+
+    def _maybe_start_cjk_backfill_resume(self) -> None:
+        """Auto-resume a pending (interrupted) cjk backfill, in the background.
+
+        Before #98743 the cjk markers were advanced ONLY by the foreground
+        loop inside ``optimize_fts_storage()``; a run interrupted by Ctrl-C,
+        a crash, or shutdown left ``fts_cjk_rebuild_progress`` frozen
+        forever with ``_fts_cjk_available=False`` — CJK search permanently
+        fell back to trigram/LIKE and no surface showed why.
+
+        Deliberately narrower than the opt-in v23 storage optimize: this
+        only resumes an ALREADY-CLAIMED incremental backfill (chunked
+        INSERTs under the same duty-cycle throttle); it never demotes
+        legacy tables, tears down trash, or vacuums. Skipped for read-only
+        connections, tokenizer-less hosts, stale indexes (an unknown-gap
+        from-scratch rebuild stays with ``optimize-storage``), and when a
+        resume is already running for this instance. Best-effort: any
+        failure to start leaves the pre-fix behavior (resume on the next
+        `hermes sessions optimize-storage`) intact.
+        """
+        try:
+            if (
+                self.read_only
+                or not self._fts_enabled
+                or not self._fts_cjk_loaded
+                or self.cjk_backfill_resume_active()
+            ):
+                return
+            if self.get_meta(FTS_CJK_STALE_KEY) is not None:
+                return
+            if self.fts_cjk_rebuild_status() is None:
+                return
+            with self._cjk_resume_lock:
+                if self.cjk_backfill_resume_active():
+                    return
+                stop = threading.Event()
+                thread = threading.Thread(
+                    target=self._cjk_backfill_resume_loop,
+                    args=(stop,),
+                    name="session-db-cjk-backfill",
+                    daemon=True,
+                )
+                self._cjk_resume_stop = stop
+                self._cjk_resume_thread = thread
+                thread.start()
+            logger.info(
+                "Interrupted CJK FTS backfill detected — resuming it in the "
+                "background (throttled). `hermes sessions optimize-storage` "
+                "remains the full foreground optimize."
+            )
+        except Exception:
+            logger.debug("cjk backfill resume failed to start", exc_info=True)
+
+    def _cjk_backfill_resume_loop(self, stop: threading.Event) -> None:
+        """Throttled chunk loop mirroring optimize_fts_storage's Phase 1b.
+
+        Chunk claiming lives inside ``fts_cjk_rebuild_step``'s BEGIN
+        IMMEDIATE (progress re-read per chunk), so this loop can interleave
+        safely with the foreground optimize and with other processes. The
+        duty-cycle pause keeps a live gateway sharing the DB responsive.
+
+        A short initial grace lets short-lived opens (CLI one-shots,
+        ``doctor``-style probes, test fixtures that assert the pending
+        state right after construction) observe the markers before any
+        chunk is claimed.
+        """
+        if stop.wait(self._FTS_REBUILD_MIN_PAUSE):
+            return
+        while not stop.is_set():
+            _t0 = time.monotonic()
+            try:
+                more = self.fts_cjk_rebuild_step()
+            except Exception:
+                # Connection closed under us, or an unexpected engine error:
+                # stop silently — the durable progress marker keeps whatever
+                # completed, and the next writable open resumes again.
+                logger.debug("cjk backfill resume chunk failed", exc_info=True)
+                return
+            if not more:
+                return
+            if self.get_meta(FTS_CJK_STALE_KEY) is not None:
+                # A tokenizer-less process staled the index mid-resume. The
+                # gap's extent is unknown; incremental INSERTs are no longer
+                # safe. Leave the markers for optimize-storage's reset path.
+                logger.warning(
+                    "CJK index went stale during the background backfill "
+                    "resume — stopping; run `hermes sessions "
+                    "optimize-storage` on a host with the CJK extension "
+                    "to rebuild it from scratch."
+                )
+                return
+            stop.wait(max(
+                self._FTS_REBUILD_MIN_PAUSE,
+                (time.monotonic() - _t0) * self._FTS_REBUILD_DUTY_FACTOR,
+            ))
+
+    def _stop_cjk_backfill_resume(self, *, join_timeout_s: float = 5.0) -> None:
+        """Signal the background resume loop to stop (close()/optimize).
+
+        Bounded join so a foreground ``optimize_fts_storage`` takeover (E8)
+        and ``close()`` both wait for the in-flight chunk — its transaction
+        commits in milliseconds — without ever hanging on a stuck loop.
+        """
+        stop = getattr(self, "_cjk_resume_stop", None)
+        thread = getattr(self, "_cjk_resume_thread", None)
+        if stop is not None:
+            stop.set()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=join_timeout_s)
+
     def _fts_cjk_reset_if_stale(self) -> None:
         """Rebuild path for a stale cjk index (triggers were dropped).
 
@@ -441,6 +559,10 @@ class SessionSearchMixin:
         recreate via ``_ensure_fts_cjk_schema`` (which sets fresh backfill
         markers on a populated DB). Called from ``optimize_fts_storage`` on
         a tokenizer-capable host; no-op when not stale.
+
+        When the reset discards completed backfill work (markers present,
+        progress > 0), a warning names the discarded percentage so an
+        interrupted-then-staled index never loses progress silently (#98743).
         """
         if not self._fts_cjk_loaded:
             return
@@ -452,6 +574,27 @@ class SessionSearchMixin:
             ).fetchone()
             if not stale:
                 return False
+            hw_row = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_cjk_rebuild_high_water'"
+            ).fetchone()
+            progress_row = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_cjk_rebuild_progress'"
+            ).fetchone()
+            if hw_row is not None and progress_row is not None:
+                try:
+                    hw = int(hw_row[0])
+                    done = int(progress_row[0])
+                except (TypeError, ValueError):
+                    hw, done = 0, 0
+                if hw > 0 and done > 0:
+                    logger.warning(
+                        "Stale cjk index reset is discarding a %d%%-complete "
+                        "backfill (%d/%d rows) — the rebuild restarts from "
+                        "zero because the trigger gap's extent is unknown.",
+                        min(100, int(100 * done / hw)), done, hw,
+                    )
             for trig in _FTS_CJK_TRIGGERS:
                 conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
             conn.execute("DROP TABLE IF EXISTS messages_fts_cjk")
@@ -765,6 +908,13 @@ class SessionSearchMixin:
             return {"ok": False, "reason": "fts5_unavailable"}
         if self.read_only:
             return {"ok": False, "reason": "read_only"}
+
+        # #98743: the foreground optimize owns the cjk backfill from here —
+        # stop this instance's background auto-resume loop so the two never
+        # interleave (chunk claims would still be correct — disjoint ranges
+        # under BEGIN IMMEDIATE — but the progress bar and the Phase-1b
+        # completion bookkeeping must be single-writer).
+        self._stop_cjk_backfill_resume()
 
         # Heal empty-index / orphan-marker bookkeeping from an interrupted
         # demote *before* deciding whether to demote again. This re-seeds

--- a/tests/test_fts_cjk_backfill_resume.py
+++ b/tests/test_fts_cjk_backfill_resume.py
@@ -1,0 +1,304 @@
+"""Regression tests for #98743: interrupted CJK FTS backfill.
+
+Covers the three layers from the issue:
+  L1 — a writable open on a tokenizer-capable host auto-resumes a pending
+        cjk backfill in the background (throttled), instead of freezing
+        the markers forever with the index unservable.
+  L2 — the pending state is VISIBLE: collect_state_db_stats exposes cjk
+        backfill markers, doctor renders them, and the doctor advisory
+        points at the resume path.
+  L3 — an INCOMPLETE (mid-backfill, non-stale) index keeps its progress on
+        a stale-reset check; only a genuinely stale index (breadcrumb set)
+        is reset from scratch — and THAT reset logs how much progress is
+        discarded.
+
+Builds the loadable tokenizer from native/fts5_cjk/fts5_cjk.c on the fly;
+skips when no C toolchain / extension loading is available (same pattern as
+tests/test_fts_cjk_bigram.py).
+"""
+
+import logging
+import shutil
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import FTS_CJK_STALE_KEY, SessionDB, collect_state_db_stats
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
+VENDOR = REPO / "native" / "fts5_cjk" / "vendor"
+
+# Auto-resume must finish a small backfill well inside this budget; generous
+# enough for a contended CI host, tight enough to fail if nothing advances.
+RESUME_TIMEOUT_S = 30.0
+
+
+@pytest.fixture(scope="session")
+def cjk_so(tmp_path_factory):
+    if shutil.which("gcc") is None or not SRC.exists():
+        pytest.skip("no C toolchain / tokenizer source")
+    out = tmp_path_factory.mktemp("fts5cjk98743") / "libfts5_cjk.so"
+    try:
+        subprocess.run(
+            ["gcc", "-shared", "-fPIC", "-O2", f"-I{VENDOR}", str(SRC),
+             "-o", str(out)],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.skip(f"tokenizer build failed: {e.stderr[:200]}")
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(out))
+    except Exception as e:
+        pytest.skip(f"extension loading unavailable: {e}")
+    finally:
+        probe.close()
+    return out
+
+
+def _populate(db, n=60, session_id="s1"):
+    db.create_session(session_id=session_id, source="cli", model="m")
+    for i in range(n):
+        db.append_message(
+            session_id, role="user", content=f"기존 메시지 {i} 일본 프로젝트"
+        )
+
+
+def _pending_db(cjk_so, tmp_path, monkeypatch, *, chunk_override=None):
+    """A v23 DB with a PENDING (interrupted) cjk backfill: markers set,
+    index absent. Mirrors the state an interrupted optimize leaves behind."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "state.db"
+
+    # Phase 1: create the DB WITHOUT the tokenizer → v23 layout, no cjk table.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+    d1 = SessionDB(db_path=db_path)
+    _populate(d1)
+    d1.close()
+
+    # Phase 2: open WITH the tokenizer. _ensure_fts_cjk_schema creates the
+    # table + markers (backfill pending, index not served)…
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d2 = SessionDB(db_path=db_path)
+    assert d2._fts_cjk_loaded
+    assert d2.fts_cjk_rebuild_status() is not None
+    # …and simulate the interruption by NOT running optimize, just closing.
+    d2.close()
+    return db_path
+
+
+def _wait_for_resume(db, timeout_s=RESUME_TIMEOUT_S):
+    """Block until the background auto-resume finishes the backfill."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if db.fts_cjk_rebuild_status() is None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+# ── L1: auto-resume on writable open ───────────────────────────────────
+
+
+def test_writable_open_auto_resumes_pending_cjk_backfill(
+    cjk_so, tmp_path, monkeypatch
+):
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    d3 = SessionDB(db_path=db_path)
+    try:
+        assert d3._fts_cjk_loaded
+        st = d3.fts_cjk_rebuild_status()
+        assert st is not None and st["pending"], "backfill must start pending"
+
+        # The writable open must resume the backfill without any manual
+        # command — the frozen-forever state from the issue.
+        assert _wait_for_resume(d3), (
+            "background auto-resume did not finish the cjk backfill within "
+            f"{RESUME_TIMEOUT_S}s"
+        )
+        assert d3._fts_cjk_available, "index must become servable after resume"
+        # The whole corpus is searchable through the cjk index afterwards.
+        assert d3._describe_search_path("일본") == "fts_cjk"
+        rows = d3.search_messages("일본", limit=100)
+        assert len(rows) == 60
+    finally:
+        d3.close()
+
+
+def test_auto_resume_survives_reopen_without_duplicates(cjk_so, tmp_path, monkeypatch):
+    """An auto-resumed-and-completed index must not re-backfill or double-
+    index on a later open (markers gone, triggers cover new rows)."""
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    d3 = SessionDB(db_path=db_path)
+    try:
+        assert _wait_for_resume(d3)
+    finally:
+        d3.close()
+
+    d4 = SessionDB(db_path=db_path)
+    try:
+        assert d4.fts_cjk_rebuild_status() is None
+        assert d4._fts_cjk_available
+        with d4._lock:
+            idx = d4._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_cjk"
+            ).fetchone()[0]
+            non_tool = d4._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE role <> 'tool'"
+            ).fetchone()[0]
+        assert idx == non_tool, "resume must index each row exactly once"
+    finally:
+        d4.close()
+
+
+def test_read_only_open_does_not_spawn_resume(cjk_so, tmp_path, monkeypatch):
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    d3 = SessionDB(db_path=db_path, read_only=True)
+    try:
+        st = d3.fts_cjk_rebuild_status()
+        assert st is not None, "read-only open must leave markers untouched"
+        # Give any (forbidden) background worker a chance to misbehave.
+        time.sleep(1.0)
+        st2 = d3.fts_cjk_rebuild_status()
+        assert st2 == st, "read-only open must not advance the backfill"
+    finally:
+        d3.close()
+
+
+def test_stale_breadcrumb_blocks_auto_resume(cjk_so, tmp_path, monkeypatch):
+    """A stale index (triggers dropped by a tokenizer-less process) must NOT
+    be auto-resumed: the gap extent is unknown, so incremental INSERTs would
+    corrupt the external-content index. It stays for optimize-storage."""
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+    # Mark it stale the way a tokenizer-less process would.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+        (FTS_CJK_STALE_KEY,),
+    )
+    conn.commit()
+    conn.close()
+
+    d3 = SessionDB(db_path=db_path)
+    try:
+        time.sleep(1.5)
+        st = d3.fts_cjk_rebuild_status()
+        assert st is not None, "stale index must keep its markers (no resume)"
+        assert not d3._fts_cjk_available
+    finally:
+        d3.close()
+
+
+# ── L3: stale-reset keeps mid-backfill progress ────────────────────────
+
+
+def test_incomplete_index_survives_stale_check_with_progress(cjk_so, tmp_path, monkeypatch):
+    """_fts_cjk_reset_if_stale on a mid-backfill (non-stale) index must keep
+    the completed progress — the '51% discarded' complaint from the issue."""
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    d3 = SessionDB(db_path=db_path)
+    # Advance the backfill partway by hand (chunk-by-chunk, exactly like
+    # the optimize loop does), then drop the connection mid-flight. The
+    # chunk is shrunk so 60 rows span several steps (the class default of
+    # 500 would finish in one).
+    monkeypatch.setattr(d3, "_FTS_REBUILD_CHUNK_ROWS", 10)
+    for _ in range(3):
+        if not d3.fts_cjk_rebuild_step():
+            break
+    partial = d3.fts_cjk_rebuild_status()
+    assert partial is not None and partial["indexed"] > 0
+    d3.close()
+
+    d4 = SessionDB(db_path=db_path)
+    try:
+        st = d4.fts_cjk_rebuild_status()
+        assert st is not None, "progress markers must survive reopen"
+        assert st["indexed"] >= partial["indexed"], (
+            "reopen must not discard completed backfill progress"
+        )
+    finally:
+        d4.close()
+
+
+def test_stale_reset_discard_is_logged(cjk_so, tmp_path, monkeypatch, caplog):
+    """When a genuinely stale reset DOES discard completed backfill work, the
+    issue asks for at least a warning naming the discarded percentage."""
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    d3 = SessionDB(db_path=db_path)
+    # Shrink the chunk so 60 rows span several steps (the class default of
+    # 500 would finish in one).
+    monkeypatch.setattr(d3, "_FTS_REBUILD_CHUNK_ROWS", 10)
+    for _ in range(3):
+        if not d3.fts_cjk_rebuild_step():
+            break
+    partial = d3.fts_cjk_rebuild_status()
+    assert partial is not None and partial["indexed"] > 0
+    d3.close()
+
+    # Now make it genuinely stale.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+        (FTS_CJK_STALE_KEY,),
+    )
+    conn.commit()
+    conn.close()
+
+    d4 = SessionDB(db_path=db_path)
+    try:
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            d4._fts_cjk_reset_if_stale()
+        assert any(
+            "discarding" in r.message.lower() or "discard" in r.message.lower()
+            for r in caplog.records
+        ), "stale reset that throws away progress must warn"
+    finally:
+        d4.close()
+
+
+# ── L2: visibility ─────────────────────────────────────────────────────
+
+
+def test_collect_stats_exposes_cjk_backfill(cjk_so, tmp_path, monkeypatch):
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+
+    stats = collect_state_db_stats(db_path)
+    assert stats["fts_cjk_rebuild_pending"] is True
+    assert isinstance(stats["fts_cjk_rebuild_progress"], int)
+    assert isinstance(stats["fts_cjk_rebuild_high_water"], int)
+    assert (
+        stats["fts_cjk_rebuild_progress"] < stats["fts_cjk_rebuild_high_water"]
+    )
+
+    # Fresh DB: nothing pending.
+    fresh = tmp_path / "fresh.db"
+    d = SessionDB(db_path=fresh)
+    d.close()
+    stats2 = collect_state_db_stats(fresh)
+    assert stats2["fts_cjk_rebuild_pending"] in (False, None)
+
+
+def test_doctor_renders_cjk_backfill_pending(cjk_so, tmp_path, monkeypatch):
+    from hermes_cli.doctor import _render_state_db_stats
+
+    db_path = _pending_db(cjk_so, tmp_path, monkeypatch)
+    stats = collect_state_db_stats(db_path)
+
+    lines = _render_state_db_stats(stats)
+    text = " ".join(t for _, t, _ in lines)
+    assert "cjk" in text.lower(), "doctor must surface a pending cjk backfill"
+    assert any(kind == "warn" for kind, _, _ in lines), (
+        "pending cjk backfill must render as a warning, not info-only"
+    )


### PR DESCRIPTION
## Summary

An interrupted `optimize-storage` run left the CJK-bigram backfill markers (`fts_cjk_rebuild_high_water` / `fts_cjk_rebuild_progress`) frozen forever: only that command's own loop ever advanced them, so `_fts_cjk_available` stayed False and CJK search permanently fell back to trigram/LIKE with nothing surfacing the stuck state (#98743).

Fixes all three layers from the issue:

1. **Auto-resume** — a writable `SessionDB` open on a tokenizer-capable host now resumes a pending (non-stale) cjk backfill in a throttled daemon loop reusing `fts_cjk_rebuild_step`'s chunk claims (BEGIN IMMEDIATE, durable per-chunk progress markers, same duty-cycle throttle as the foreground optimize). Skipped for read-only opens, tokenizer-less hosts, and stale indexes; stopped on `close()` and when a foreground `optimize_fts_storage` takes over. The v23 *demote* stays opt-in — this only resumes an already-demoted DB's incremental phase.
2. **Visibility** — `collect_state_db_stats` exposes `fts_cjk_rebuild_pending`/`high_water`/`progress` + `fts_cjk_stale`; `hermes doctor` renders both as warnings at any DB size (read-only probe, no `SessionDB` instantiation); `hermes sessions stats` prints the same note.
3. **Discard accounting** — `_fts_cjk_reset_if_stale` logs how much completed backfill work a from-scratch stale reset discards ("discarding a 51%-complete backfill (148500/290407 rows)").

## Verification

```
tests/test_fts_cjk_backfill_resume.py   8 passed  (RED on main: 5 failed / 3 passed)
tests/test_fts_cjk_bigram.py           10 passed
tests/test_state_db_stats.py           15 passed
tests/hermes_cli/test_doctor.py        65 passed
state-db repair/durability suites      94 passed
hermes_state + session-db suites       317 passed (1 pre-existing failure on exact upstream 4f225435:
                                            test_search_projection_skips_context_enrichment_queries —
                                            fails identically without this patch)
ruff + git diff --check                clean
```

The 8 new tests exercise real production paths against a real on-the-fly-built `libfts5_cjk.so`: writable-open resume to servable index, reopen without double-indexing, read-only no-resume, stale-breadcrumb no-resume, mid-backfill progress survives reopen, stale-discard warning, stats exposure, doctor rendering.

## Relationship to open PRs

- #98751 (ayushnangia) covers the doctor-visibility half; this PR includes that surface and adds the actual auto-resume + discard accounting. Credit to that PR for the read-only-probe framing.
- #98758 (kokhlo) likewise covers doctor + an open-warning; same subset relationship.

Both were evaluated at ~6/10 against the full issue (visibility-only); neither implements the resume. Happy to coordinate on splitting scope if maintainers prefer the smaller PRs.

Auto-published by Moonsong via Path B automated pipeline.