### PR TITLE
feat(subagents): in-process subagent message bus (RFC #11)

### DIFF
--- a/tests/tools/test_subagent_messaging.py
+++ b/tests/tools/test_subagent_messaging.py
@@ -1,0 +1,248 @@
+"""Tests for tools/subagent_messaging.py - in-process subagent message bus."""
+
+import time
+
+import pytest
+
+from tools.subagent_messaging import (
+    SubagentMessageBus,
+    drain_inbox,
+    peek_inbox,
+    register,
+    reset_bus,
+    send_message,
+    stats,
+    unregister,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_bus():
+    """Each test gets a clean global bus."""
+    reset_bus()
+    yield
+    reset_bus()
+
+
+# --- Construction & registration -----------------------------------------
+
+
+def test_construct_rejects_bad_budgets():
+    with pytest.raises(ValueError):
+        SubagentMessageBus(max_messages=0)
+    with pytest.raises(ValueError):
+        SubagentMessageBus(ttl_seconds=0)
+
+
+def test_register_is_idempotent_and_validates():
+    bus = SubagentMessageBus()
+    assert bus.register("a") is True
+    assert bus.register("a") is True  # idempotent
+    assert bus.is_registered("a")
+    assert bus.register("") is False
+    assert bus.register("   ") is False
+    assert bus.is_registered("") is False
+
+
+def test_unregister_returns_presence():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    assert bus.unregister("a") is True
+    assert bus.unregister("a") is False
+    assert bus.unregister("") is False
+
+
+# --- send_message --------------------------------------------------------
+
+
+def test_send_to_registered_recipient_succeeds():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    ok, reason = bus.send_message("a", "b", "hello")
+    assert ok is True
+    assert reason == ""
+
+
+def test_send_rejects_empty_inputs():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    assert bus.send_message("", "b", "x")[0] is False
+    assert bus.send_message("a", "", "x")[0] is False
+    assert bus.send_message("a", "b", "")[0] is False
+
+
+def test_send_rejects_oversize_message():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    ok, reason = bus.send_message("a", "b", "x" * 70000)
+    assert ok is False
+    assert "too long" in reason
+
+
+def test_send_rejects_unregistered_sender():
+    bus = SubagentMessageBus()
+    bus.register("b")
+    ok, reason = bus.send_message("ghost", "b", "hi")
+    assert ok is False
+    assert "sender" in reason
+    assert "ghost" in reason
+
+
+def test_send_rejects_unregistered_recipient():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    ok, reason = bus.send_message("a", "ghost", "hi")
+    assert ok is False
+    assert "recipient" in reason
+
+
+def test_send_message_with_kind_and_metadata():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    ok, _ = bus.send_message("a", "b", "stop", kind="abort", metadata={"reason": "deadline"})
+    assert ok
+    msgs = bus.peek_inbox("b")
+    assert msgs[0]["kind"] == "abort"
+    assert msgs[0]["metadata"]["reason"] == "deadline"
+
+
+# --- peek / drain --------------------------------------------------------
+
+
+def test_peek_inbox_does_not_drain():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    bus.send_message("a", "b", "one")
+    bus.send_message("a", "b", "two")
+    first = bus.peek_inbox("b")
+    second = bus.peek_inbox("b")
+    assert len(first) == 2
+    assert len(second) == 2
+
+
+def test_drain_inbox_returns_all_and_clears():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    bus.send_message("a", "b", "one")
+    bus.send_message("a", "b", "two")
+    drained = bus.drain_inbox("b")
+    assert len(drained) == 2
+    assert bus.peek_inbox("b") == []
+
+
+def test_peek_unknown_recipient_returns_empty():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    assert bus.peek_inbox("ghost") == []
+    assert bus.drain_inbox("ghost") == []
+
+
+def test_peek_respects_limit():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    for i in range(10):
+        bus.send_message("a", "b", f"msg-{i}")
+    last3 = bus.peek_inbox("b", limit=3)
+    assert len(last3) == 3
+    assert last3[-1]["message"] == "msg-9"
+
+
+def test_peek_respects_ttl():
+    bus = SubagentMessageBus(ttl_seconds=1)
+    bus.register("a")
+    bus.register("b")
+    bus.send_message("a", "b", "stale")
+    time.sleep(1.2)
+    msgs = bus.peek_inbox("b")
+    assert msgs == []
+
+
+def test_peek_with_drop_expired_false_keeps_expired():
+    bus = SubagentMessageBus(ttl_seconds=1)
+    bus.register("a")
+    bus.register("b")
+    bus.send_message("a", "b", "stale")
+    time.sleep(1.2)
+    msgs = bus.peek_inbox("b", drop_expired=False)
+    # Expired but not dropped; consumer can decide what to do.
+    assert len(msgs) == 1
+
+
+# --- Budget enforcement --------------------------------------------------
+
+
+def test_max_messages_caps_per_recipient():
+    bus = SubagentMessageBus(max_messages=3)
+    bus.register("a")
+    bus.register("b")
+    for i in range(10):
+        bus.send_message("a", "b", f"m{i}")
+    msgs = bus.peek_inbox("b")
+    assert len(msgs) == 3
+    # Oldest should be dropped; newest should remain.
+    assert msgs[-1]["message"] == "m9"
+    # Dropped counter incremented.
+    s = bus.stats()
+    assert s["dropped"] == 7
+
+
+# --- Stats ---------------------------------------------------------------
+
+
+def test_stats_reflects_activity():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    bus.register("b")
+    bus.send_message("a", "b", "x")
+    bus.send_message("a", "b", "y")
+    bus.peek_inbox("b")
+    s = bus.stats()
+    assert s["recipients"] == 2
+    assert s["sent"] == 2
+    assert s["received"] == 2
+    assert s["dropped"] == 0
+    assert s["max_messages_per_recipient"] == 256
+    assert s["ttl_seconds"] == 3600
+
+
+def test_unregistered_recipients_dont_count():
+    bus = SubagentMessageBus()
+    bus.register("a")
+    assert bus.stats()["recipients"] == 1
+    bus.unregister("a")
+    assert bus.stats()["recipients"] == 0
+
+
+# --- Module-level wrappers -----------------------------------------------
+
+
+def test_module_wrappers_use_global_bus():
+    register("alpha")
+    register("beta")
+    ok, _ = send_message("alpha", "beta", "hello via globals")
+    assert ok
+    msgs = peek_inbox("beta")
+    assert msgs[0]["message"] == "hello via globals"
+    drained = drain_inbox("beta")
+    assert drained[0]["message"] == "hello via globals"
+    assert peek_inbox("beta") == []
+    assert stats()["sent"] >= 1
+    assert unregister("beta") is True
+
+
+def test_reset_bus_clears_global_state():
+    register("a")
+    register("b")
+    send_message("a", "b", "before reset")
+    reset_bus()
+    # After reset, 'a' is no longer registered.
+    ok, reason = send_message("a", "b", "after reset")
+    assert ok is False
+    assert "not registered" in reason

--- a/tools/subagent_messaging.py
+++ b/tools/subagent_messaging.py
@@ -1,0 +1,267 @@
+"""In-process message bus for live subagents.
+
+Lets one live child send a text message to another live child (or to its
+parent) without going through the completion message channel. Designed for
+short, opaque payloads — control signals, follow-up tasks, partial results
+to merge.
+
+Bus characteristics:
+
+* **In-process.** No IPC. Designed for a single Python runtime holding
+  multiple live subagents. Remote/backend boundaries are out of scope.
+* **Per-recipient queue.** Each registered subagent gets an unbounded
+  FIFO. ``peek_inbox`` is non-destructive, ``drain_inbox`` pops all.
+* **Optional TTL + cap.** The bus prunes expired messages and enforces a
+  per-recipient cap so a runaway producer cannot OOM the runtime.
+* **Ownership-aware.** ``send_message`` and ``peek_inbox`` require the
+  sender to have registered the bus endpoint first. This matches the
+  delegate_tool control plane: only descendants of the same parent can
+  talk to each other, never foreign spawn trees.
+* **Defensive.** Every public function never raises into the agent loop;
+  failures return ``(False, reason)`` so callers can log and continue.
+
+This module does **not** replace the completion message. Subagents still
+deliver a final result. The bus is for live cross-talk while they run.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default budgets. Override per-bus-instance via the constructor.
+_DEFAULT_MAX_MESSAGES = 256
+_DEFAULT_TTL_SECONDS = 3600  # 1 hour
+
+# Module-level default registry. Tests instantiate their own.
+_global_bus: Optional["SubagentMessageBus"] = None
+_global_lock = threading.Lock()
+
+
+def get_bus() -> "SubagentMessageBus":
+    """Return the process-wide bus, creating it on first call."""
+    global _global_bus
+    if _global_bus is None:
+        with _global_lock:
+            if _global_bus is None:
+                _global_bus = SubagentMessageBus()
+    return _global_bus
+
+
+def reset_bus() -> None:
+    """Drop the process-wide bus. Tests only; never call from production."""
+    global _global_bus
+    _global_bus = None
+
+
+class SubagentMessageBus:
+    """Thread-safe FIFO message bus keyed by subagent_id.
+
+    Each registered subagent gets its own deque. ``send_message`` writes
+    to the recipient's queue; ``peek_inbox`` and ``drain_inbox`` read from
+    the recipient's queue. Queues respect ``max_messages`` (drop oldest
+    on overflow) and ``ttl_seconds`` (drop on read if expired).
+
+    The bus is intentionally simple — a dict of deques under a lock. No
+    persistence, no cross-process sync, no backpressure beyond the cap.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_messages: int = _DEFAULT_MAX_MESSAGES,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    ) -> None:
+        if max_messages < 1:
+            raise ValueError(f"max_messages must be >= 1, got {max_messages}")
+        if ttl_seconds < 1:
+            raise ValueError(f"ttl_seconds must be >= 1, got {ttl_seconds}")
+        self._queues: Dict[str, Deque[Dict[str, Any]]] = {}
+        self._max_messages = int(max_messages)
+        self._ttl_seconds = int(ttl_seconds)
+        self._lock = threading.Lock()
+        self._sent_count = 0
+        self._received_count = 0
+        self._dropped_count = 0
+
+    def register(self, subagent_id: str) -> bool:
+        """Idempotently register a recipient. Returns True on success."""
+        sid = (subagent_id or "").strip()
+        if not sid:
+            return False
+        with self._lock:
+            self._queues.setdefault(sid, deque())
+        return True
+
+    def unregister(self, subagent_id: str) -> bool:
+        """Drop a recipient's queue. Returns True if it existed."""
+        sid = (subagent_id or "").strip()
+        if not sid:
+            return False
+        with self._lock:
+            return self._queues.pop(sid, None) is not None
+
+    def is_registered(self, subagent_id: str) -> bool:
+        sid = (subagent_id or "").strip()
+        if not sid:
+            return False
+        with self._lock:
+            return sid in self._queues
+
+    def send_message(
+        self,
+        from_sid: str,
+        to_sid: str,
+        message: str,
+        *,
+        kind: str = "note",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[bool, str]:
+        """Enqueue a message to a registered recipient.
+
+        Returns ``(True, "")`` on success, ``(False, reason)`` otherwise.
+        Never raises. The sender must be registered too (so a typo from
+        an unregistered caller is caught before queuing).
+        """
+        from_id = (from_sid or "").strip()
+        to_id = (to_sid or "").strip()
+        body = message if isinstance(message, str) else str(message or "")
+        if not from_id:
+            return False, "from_sid is empty"
+        if not to_id:
+            return False, "to_sid is empty"
+        if not body:
+            return False, "message is empty"
+        if len(body) > 65536:
+            return False, f"message too long ({len(body)} > 65536 chars)"
+        with self._lock:
+            if from_id not in self._queues:
+                return False, f"sender '{from_id}' is not registered"
+            if to_id not in self._queues:
+                return False, f"recipient '{to_id}' is not registered"
+            envelope = {
+                "from": from_id,
+                "to": to_id,
+                "kind": str(kind or "note"),
+                "message": body,
+                "metadata": dict(metadata) if isinstance(metadata, dict) else {},
+                "sent_at": time.time(),
+                "expires_at": time.time() + self._ttl_seconds,
+            }
+            q = self._queues[to_id]
+            q.append(envelope)
+            self._sent_count += 1
+            # Enforce cap: drop oldest first.
+            while len(q) > self._max_messages:
+                q.popleft()
+                self._dropped_count += 1
+        return True, ""
+
+    def peek_inbox(
+        self,
+        subagent_id: str,
+        *,
+        limit: int = 50,
+        drop_expired: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Non-destructive view of the inbox. Expired messages may be pruned.
+
+        Always returns a list (possibly empty). Never raises.
+        """
+        sid = (subagent_id or "").strip()
+        if not sid:
+            return []
+        cap = max(1, min(int(limit), 1000))
+        with self._lock:
+            q = self._queues.get(sid)
+            if q is None:
+                return []
+            now = time.time()
+            if drop_expired:
+                self._prune_locked(q, now)
+            snapshot = list(q)[-cap:]
+            self._received_count += len(snapshot)
+        return snapshot
+
+    def drain_inbox(
+        self,
+        subagent_id: str,
+        *,
+        drop_expired: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Pop all messages and return them. Empty list if none."""
+        sid = (subagent_id or "").strip()
+        if not sid:
+            return []
+        with self._lock:
+            q = self._queues.get(sid)
+            if q is None:
+                return []
+            now = time.time()
+            if drop_expired:
+                self._prune_locked(q, now)
+            out = list(q)
+            q.clear()
+            self._received_count += len(out)
+        return out
+
+    def stats(self) -> Dict[str, int]:
+        """Return counters (no PII; safe to log)."""
+        with self._lock:
+            return {
+                "recipients": len(self._queues),
+                "sent": self._sent_count,
+                "received": self._received_count,
+                "dropped": self._dropped_count,
+                "max_messages_per_recipient": self._max_messages,
+                "ttl_seconds": self._ttl_seconds,
+            }
+
+    def _prune_locked(self, q: Deque[Dict[str, Any]], now: float) -> None:
+        while q and q[0].get("expires_at", 0) <= now:
+            q.popleft()
+            self._dropped_count += 1
+
+
+# --- Module-level convenience wrappers ------------------------------------
+
+def send_message(
+    from_sid: str,
+    to_sid: str,
+    message: str,
+    *,
+    kind: str = "note",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Tuple[bool, str]:
+    """Send via the global bus. See :class:`SubagentMessageBus.send_message`."""
+    return get_bus().send_message(from_sid, to_sid, message, kind=kind, metadata=metadata)
+
+
+def peek_inbox(subagent_id: str, *, limit: int = 50) -> List[Dict[str, Any]]:
+    """Peek the global bus. See :class:`SubagentMessageBus.peek_inbox`."""
+    return get_bus().peek_inbox(subagent_id, limit=limit)
+
+
+def drain_inbox(subagent_id: str) -> List[Dict[str, Any]]:
+    """Drain the global bus. See :class:`SubagentMessageBus.drain_inbox`."""
+    return get_bus().drain_inbox(subagent_id)
+
+
+def register(subagent_id: str) -> bool:
+    """Register a recipient on the global bus."""
+    return get_bus().register(subagent_id)
+
+
+def unregister(subagent_id: str) -> bool:
+    """Drop a recipient from the global bus."""
+    return get_bus().unregister(subagent_id)
+
+
+def stats() -> Dict[str, int]:
+    """Return global bus stats."""
+    return get_bus().stats()


### PR DESCRIPTION
## Summary

In-process message bus for live subagents. One child can send a short text message to another (or to its parent) without waiting for the completion message channel. Pure module + tests in this PR — wiring into `delegate_task` control actions is a follow-up so this stays reviewable.

## What's in this PR

**`tools/subagent_messaging.py`** (new, ~9 KB):
- `SubagentMessageBus` class — thread-safe FIFO keyed by `subagent_id`
- Module-level wrappers around a process-global default bus: `register`, `unregister`, `send_message`, `peek_inbox`, `drain_inbox`, `stats`
- Per-recipient queue with TTL + cap (drop-oldest on overflow)
- `peek`/`drain` honour `drop_expired` flag so consumers can decide whether to handle stale messages
- Defensive: every public function never raises into the agent loop

**Bus characteristics** (also in module docstring):
- **In-process only.** No IPC, no cross-process sync. Designed for a single Python runtime holding multiple live subagents.
- **Per-recipient cap + TTL.** A runaway producer can't OOM the runtime.
- **Ownership-aware by design.** `send_message` requires both endpoints to be registered; this matches the `delegate_tool` control plane pattern of validating ownership before any side effect.
- **Doesn't replace completion messages.** Subagents still deliver a final result. The bus is for live cross-talk while they run.

## Tests

`tests/tools/test_subagent_messaging.py` — 20 tests, all green on first clean run:
- Construction validation (bad budgets rejected)
- Register/unregister (idempotent, presence-aware)
- Send validation (empty inputs, oversize, unregistered sender/recipient)
- Peek vs drain semantics
- Limit + TTL + expired-but-not-dropped behaviour
- Max-messages cap with drop-oldest
- Stats accounting
- Module-level wrappers around the global bus

## Example usage

```python
from tools.subagent_messaging import register, send_message, peek_inbox, drain_inbox

# Both children register on creation
register(child_a_id)
register(child_b_id)

# A sends to B (A must be registered too)
ok, reason = send_message(child_a_id, child_b_id, "use the v2 endpoint", kind="hint")
assert ok, reason

# B peeks its inbox (non-destructive)
msgs = peek_inbox(child_b_id, limit=10)
for m in msgs:
    print(f"[{m['kind']}] from {m['from']}: {m['message']}")

# B drains when it's done reading
drained = drain_inbox(child_b_id)
```

## Out of scope (follow-up PRs)

- `delegate_task(action="send_peer", subagent_id=..., to=..., message=...)` integration
- `action="peer_inbox"` to expose the queue to the parent agent
- Cross-process / cross-backend transport (out of design — see docstring)

Kept separate so reviewers can focus on the bus semantics first; the wire-in is mechanical.