### PR TITLE
test: warn when the selected venv is missing suite dependencies

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -48,31 +48,60 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # .venv — every file then died with "No module named pytest" and the run
 # reported "0 tests passed" (which reads green at a glance even though the
 # exit code is 1). Skip such a venv and keep probing instead.
+#
+# pytest alone does not make the suite TRUSTWORTHY, though: a venv missing
+# other declared deps is selected, runs, and reports ordinary assertion
+# failures that read as code regressions. Absent croniter costs ~22 tests/cron
+# failures whose cause shows up only as a "'croniter' is not installed" log
+# warning; absent psutil stops conftest's _is_own_subtree() walking the process
+# tree, so _live_system_guard refuses the test's OWN children and tempts you
+# into @pytest.mark.live_system_guard_bypass — disabling a real guard to hide a
+# missing package; absent pytest-asyncio fails every async test with
+# "Unknown pytest.mark.asyncio".
+#
+# So: prefer a candidate satisfying the full set, fall back to pytest-only
+# (a lean venv still serves a narrow selection, and run_tests_parallel.py is
+# stdlib-only), and name the gap after selecting. Warning, not a gate — the
+# failure mode being prevented is a plausible wall of red, not a crash.
 VENV=""
 VENV_PYTHON=""
+FALLBACK_VENV=""
+FALLBACK_PYTHON=""
 SKIPPED_VENVS=""
+SUITE_IMPORTS="pytest croniter psutil pytest_asyncio yaml"
+
+# Echo the subset of SUITE_IMPORTS that $1 cannot import, space-separated.
+missing_suite_imports() {
+  "$1" - "$SUITE_IMPORTS" 2>/dev/null <<'PROBE_EOF' || true
+import importlib.util, sys
+missing = [m for m in sys.argv[1].split() if importlib.util.find_spec(m) is None]
+print(" ".join(missing))
+PROBE_EOF
+}
+
+# One pass, two tiers: a complete venv wins outright; otherwise the first
+# pytest-capable one is held as fallback. Both venv layouts are probed —
+# POSIX bin/python and native Windows Scripts/python.exe (Git Bash / MSYS,
+# where there is no bin/ at all).
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
-      VENV="$candidate"
-      VENV_PYTHON="$candidate/bin/python"
-      break
+  for _py in "$candidate/bin/python" "$candidate/Scripts/python.exe"; do
+    [ -x "$_py" ] || continue
+    if ! "$_py" -c 'import pytest' 2>/dev/null; then
+      SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
+      continue
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
-  fi
-  # Native Windows venv layout: python.exe and activate live under
-  # Scripts/, and there is no bin/. Anyone running this script from
-  # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
-  # this branch — without it the canonical runner refuses to start.
-  if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if [ -z "$(missing_suite_imports "$_py")" ]; then
       VENV="$candidate"
-      VENV_PYTHON="$candidate/Scripts/python.exe"
-      break
+      VENV_PYTHON="$_py"
+      break 2
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
-  fi
+    [ -n "$FALLBACK_VENV" ] || { FALLBACK_VENV="$candidate"; FALLBACK_PYTHON="$_py"; }
+  done
 done
+if [ -z "$VENV" ] && [ -n "$FALLBACK_VENV" ]; then
+  VENV="$FALLBACK_VENV"
+  VENV_PYTHON="$FALLBACK_PYTHON"
+fi
 
 if [ -n "$SKIPPED_VENVS" ]; then
   for skipped in $SKIPPED_VENVS; do
@@ -82,6 +111,18 @@ fi
 
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
+  # Selection succeeded, but say so plainly if the venv cannot give
+  # trustworthy results. Without this the run proceeds and misattributes
+  # missing packages as code failures (see the SUITE_IMPORTS note above).
+  MISSING_SUITE="$(missing_suite_imports "$PYTHON")"
+  if [ -n "$MISSING_SUITE" ]; then
+    echo "▶ WARNING: selected venv is missing suite dependencies:$(printf ' %s' $MISSING_SUITE)" >&2
+    echo "  $VENV" >&2
+    echo "  Tests will RUN but failures may be caused by these missing packages," >&2
+    echo "  not by your changes. Install the project's declared dependencies:" >&2
+    echo "    uv pip install --python '$PYTHON' -e '.[dev]'" >&2
+    echo "  (a uv-created venv has no pip module, so 'pip install' fails there)" >&2
+  fi
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
     && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE


### PR DESCRIPTION
## What does this PR do?

Fixes #98774.

`scripts/run_tests.sh` selected a virtualenv on a single `import pytest` probe and took the first match. A venv that has pytest but is missing other declared dependencies passes that probe, gets selected silently, runs, and reports **ordinary assertion failures that read as code regressions**.

That is worse than the #22401 failure mode: instead of refusing to start with a clear error, the runner starts successfully and produces a plausible-looking wall of red.

Three cases measured on a drifted venv:

- **`croniter` absent** → ~22 `tests/cron/` failures whose real cause appears only as a `'croniter' is not installed` warning buried in captured log output.
- **`psutil` absent** → `tests/conftest.py::_is_own_subtree()` cannot walk the process tree, so `_live_system_guard` refuses the test's **own** spawned children and cancel-path tests die on `blocked os.killpg(...)`. That message points at gateway-kill paths and suggests `@pytest.mark.live_system_guard_bypass` — i.e. it tempts you into disabling a real safety guard to hide a missing package.
- **`pytest-asyncio` absent** (a declared `[dev]` dep) → every async test degrades to `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio` and fails, across `tests/acp/` and `tests/agent/`.

## Approach

Deliberately **not** a hard gate. `run_tests_parallel.py` is stdlib-only and a lean venv is still perfectly usable for a narrow file selection, so refusing to start would block work that currently succeeds. Three changes instead:

1. A **first pass prefers** a candidate satisfying the full suite set, so a checkout with both `.venv` and `venv` picks the provisioned one instead of whichever is first.
2. The original pytest-only probe order is kept as the **fallback**, unchanged.
3. After selection, any missing packages are **named on stderr** with the exact remediation command — including that a uv-created venv has no `pip` module, so `pip install` fails there.

The probe list is `pytest croniter psutil pytest_asyncio yaml`: the imports whose absence silently corrupts results rather than crashing loudly.

## How Has This Been Tested?

Four controls, each run against a real venv rather than asserted:

| Control | Setup | Expected | Result |
|---|---|---|---|
| 1. Healthy venv | fully provisioned | silent, tests pass | ✅ no warning, 19 passed |
| 2. Drifted venv | `.[dev]` then uninstall croniter/psutil/pytest-asyncio | warns, names all 3, still runs | ✅ `missing suite dependencies: croniter psutil pytest_asyncio`, 1 passed / 7 failed |
| 3. Preference pass | drifted `.venv` + complete `venv` | prefers complete, silent, passes | ✅ no warning, **8 passed / 0 failed** (same file that fails 7 under the drifted venv) |
| 4. No local venv | worktree with neither | falls through to `$HOME` venv | ✅ selected it and correctly reported its missing `pytest_asyncio` |

Control 3 is the decisive one — it is the exact real-world shape that produced ~300 false failures, and the fix turns 7 failures into 8 passes with no warning.

Regression: `tests/cron/` → **1057 passed, 0 failed, 1 skipped**, no warning. The runner's own tests (`tests/test_run_tests_parallel.py`, `tests/test_run_tests_parallel_stdio.py`) → **12 passed, 0 failed**. `bash -n` clean.

Control 4 also surfaced a genuine local gap: this machine's `~/.hermes/hermes-agent/venv` was itself missing `pytest_asyncio`. The warning reported it instead of hiding it, which is the point.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

Fixes #98774. Same class as #22401 (undeclared `pytest-split`, uv venv without pip), which was accepted and fixed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (4 behavioural controls above; happy to add a `tests/` case asserting the warning fires if you'd prefer it enforced in CI)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious parts (why selection stays pytest-keyed, why `psutil` absence is dangerous)

## Note on scope

I kept this to `run_tests.sh` and did not touch `pyproject.toml`. If you'd rather the probe list live in config, or be derived from `[project.dependencies]` automatically, say which shape you prefer and I'll rework it.
