### PR TITLE
fix(desktop): render single-question clarify batches

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -605,6 +605,75 @@ describe('readClarifyBatchResult', () => {
 })
 
 describe('ClarifyTool batch card', () => {
+  it('renders and answers a one-question array with the single-question card', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
+    const args = { questions: [{ choices: ['red', 'blue'], question: 'Color?' }] }
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [{ choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' }],
+      requestId: 'request-one-question',
+      sessionId: 'session-1'
+    })
+    renderClarify(
+      <ClarifyTool
+        {...liveBatchProps()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        toolCallId="clarify-one-question"
+      />
+    )
+
+    expect(screen.getByText('Color?')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-batch]')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'red',
+        question_id: 'q0',
+        request_id: 'request-one-question'
+      })
+    })
+  })
+
+  it('answers a one-question array when the gateway uses the single-question wire shape', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
+    const args = { questions: [{ choices: ['red', 'blue'], question: 'Color?' }] }
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: ['red', 'blue'],
+      multiSelect: false,
+      question: 'Color?',
+      requestId: 'request-single-wire',
+      sessionId: 'session-1'
+    })
+    renderClarify(
+      <ClarifyTool {...liveBatchProps()} args={args} argsText={JSON.stringify(args)} toolCallId="clarify-single-wire" />
+    )
+
+    expect(screen.getByText('Color?')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-batch]')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /blue/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'blue',
+        request_id: 'request-single-wire'
+      })
+    })
+  })
+
   it('renders every question at once', () => {
     renderLiveBatch()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -388,13 +388,26 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
     return <ToolFallback {...props} />
   }
 
-  // Batch: the gateway request carries qid-keyed questions. Args alone can't
-  // drive the form (no qids to respond with), so batch waits for the request.
-  if (request?.questions?.length || fromArgs.questions) {
+  const requestQuestionCount = request?.questions?.length ?? 0
+  const argsQuestionCount = fromArgs.questions?.length ?? 0
+
+  // A one-entry `questions` payload is still one question to the person using
+  // Desktop. Render the compact single-question card while retaining its qid
+  // below for the batch wire protocol. Only true multi-question payloads use
+  // the all-at-once form.
+  if (requestQuestionCount > 1 || argsQuestionCount > 1) {
     return <ClarifyToolBatchPending onAnswered={() => setAnswered(true)} request={request} />
   }
 
-  return <ClarifyToolSinglePending fromArgs={fromArgs} onAnswered={() => setAnswered(true)} request={request} />
+  const singleQuestionArgs = fromArgs.questions?.[0]
+
+  return (
+    <ClarifyToolSinglePending
+      fromArgs={singleQuestionArgs ?? fromArgs}
+      onAnswered={() => setAnswered(true)}
+      request={request}
+    />
+  )
 }
 
 function ClarifyToolSinglePending({
@@ -411,30 +424,34 @@ function ClarifyToolSinglePending({
   const gateway = useStore($gateway)
 
   const matchingRequest = useMemo(() => {
-    if (!request || request.questions?.length) {
+    if (!request || (request.questions?.length ?? 0) > 1) {
       return null
     }
 
-    if (fromArgs.question && request.question && fromArgs.question !== request.question) {
+    const requestQuestion = request.questions?.[0]?.question || request.question
+
+    if (fromArgs.question && requestQuestion && fromArgs.question !== requestQuestion) {
       return null
     }
 
     return request
   }, [fromArgs.question, request])
 
-  const question = fromArgs.question || matchingRequest?.question || ''
+  const batchQuestion = matchingRequest?.questions?.[0]
+  const question = fromArgs.question || batchQuestion?.question || matchingRequest?.question || ''
 
   const choices = useMemo(
     // Prefer the gateway request's choices over the raw tool args: the backend
     // labels the recommended option there (`mark_recommended`), and the card
     // only renders once `matchingRequest` exists, so the args are a fallback
     // for a hydration race, not the normal path.
-    () => matchingRequest?.choices ?? fromArgs.choices ?? [],
-    [fromArgs.choices, matchingRequest?.choices]
+    () => batchQuestion?.choices ?? matchingRequest?.choices ?? fromArgs.choices ?? [],
+    [batchQuestion?.choices, fromArgs.choices, matchingRequest?.choices]
   )
 
   const hasChoices = choices.length > 0
-  const multiSelect = hasChoices && Boolean(matchingRequest?.multiSelect ?? fromArgs.multiSelect)
+  const multiSelect =
+    hasChoices && Boolean(batchQuestion?.multiSelect ?? matchingRequest?.multiSelect ?? fromArgs.multiSelect)
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -483,7 +500,8 @@ function ClarifyToolSinglePending({
           'clarify.respond',
           {
             request_id: matchingRequest.requestId,
-            answer
+            answer,
+            ...(batchQuestion ? { question_id: batchQuestion.qid } : {})
           }
         )
         triggerHaptic('submit')
@@ -495,7 +513,16 @@ function ClarifyToolSinglePending({
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, gateway, matchingRequest, onAnswered, ready]
+    [
+      batchQuestion,
+      copy.gatewayDisconnected,
+      copy.notReady,
+      copy.sendFailed,
+      gateway,
+      matchingRequest,
+      onAnswered,
+      ready
+    ]
   )
 
   const trimmedDraft = draft.trim()


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop regression where the advertised `clarify` tool shape (`questions: [{ question, choices }]`) routed a single question through the multi-question card. The batch card requires qid-bearing gateway state and could remain a blank spinner when the request event was delayed or replayed, leaving valid choices invisible and eventually timing out.

This keeps true multi-question requests on the existing batch form, while rendering a one-entry `questions[]` payload with the existing single-question card. When the current batch wire includes a qid, the response preserves `question_id`; when the gateway uses the single-question wire shape, the response remains the existing scalar form.

## Related Issue

Fixes #98645

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx`
  - Route only payloads with more than one question to the batch card.
  - Read the question, choices, and multi-select mode from a one-question gateway request.
  - Include the batch question id when answering a one-question batch wire request.
- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx`
  - Verify a one-question array renders the compact visible card and submits its qid-bearing response.
  - Verify compatibility with the single-question gateway wire shape.

## How to Test

1. `cd apps/desktop`
2. `../../node_modules/.bin/vitest run src/components/assistant-ui/clarify-tool.test.tsx --reporter=dot`
3. `npm run typecheck`
4. `../../node_modules/.bin/prettier --check src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx`

Focused test result: 1 file passed, 38 tests passed. Desktop typecheck passed for renderer, Electron, and E2E projects.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused regression test and Desktop typecheck
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact (renderer-only change)

### Documentation & Housekeeping

- [x] N/A — no config, documentation, or tool schema changes
