### PR TITLE
test(desktop): cover the one-entry batch clarify shape end to end

### DIFF
--- a/apps/desktop/e2e/batch-clarify.spec.ts
+++ b/apps/desktop/e2e/batch-clarify.spec.ts
@@ -15,7 +15,7 @@
 import { expect, test } from './test'
 
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
-import { BATCH_CLARIFY_QUESTIONS, BATCH_CLARIFY_TRIGGER } from './mock-server'
+import { BATCH_CLARIFY_QUESTIONS, BATCH_CLARIFY_TRIGGER, SINGLE_BATCH_CLARIFY_QUESTIONS, SINGLE_BATCH_CLARIFY_TRIGGER } from './mock-server'
 
 let fixture: MockBackendFixture | null = null
 
@@ -81,6 +81,42 @@ test.describe('batch clarify card', () => {
     await expect(settled.getByText('Morning', { exact: true })).toBeVisible()
 
     // And still no duplicate live card lingering after settle.
+    await expect(page.locator('form[data-clarify-batch]')).toHaveCount(0)
+  })
+
+  // #98645: since the questions[]-only schema (#95907) a single question is a
+  // one-entry batch on both the tool args and the gateway wire. The card must
+  // mount and answer exactly like the 2+ case — a blank or spinner-only
+  // section that eats the 10-minute tool timeout is the reported failure.
+  test('renders and answers a one-entry batch like the 2+ case', async () => {
+    const page = fixture!.page
+    const composer = page.locator('[contenteditable="true"]').first()
+    await composer.waitFor({ state: 'visible', timeout: 10_000 })
+
+    await composer.click()
+    await composer.type(SINGLE_BATCH_CLARIFY_TRIGGER, { delay: 20 })
+    await page.keyboard.press('Enter')
+
+    const batchCard = page.locator('form[data-clarify-batch]')
+    await batchCard.first().waitFor({ state: 'visible', timeout: 60_000 })
+
+    await expect(batchCard).toHaveCount(1)
+    await expect(batchCard).toHaveAttribute('data-clarify-batch', '1')
+
+    await expect(batchCard.getByText(SINGLE_BATCH_CLARIFY_QUESTIONS[0]!.question)).toHaveCount(1)
+
+    const confirmButton = batchCard.locator('button[type="submit"]')
+    await expect(confirmButton).toBeDisabled()
+
+    await batchCard.getByRole('button', { name: /Espresso/ }).click()
+    await expect(confirmButton).toBeEnabled()
+    await confirmButton.click()
+
+    const settled = page.locator('[data-clarify-settled]')
+    await settled.waitFor({ state: 'visible', timeout: 30_000 })
+    await expect(settled.getByText(SINGLE_BATCH_CLARIFY_QUESTIONS[0]!.question)).toBeVisible()
+    await expect(settled.getByText('Espresso', { exact: true })).toBeVisible()
+
     await expect(page.locator('form[data-clarify-batch]')).toHaveCount(0)
   })
 })

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -357,6 +357,22 @@ const BATCH_CLARIFY_TURN: ScriptedTurn = {
   toolCalls: [{ name: 'clarify', args: { questions: BATCH_CLARIFY_QUESTIONS } }],
 }
 
+/**
+ * A marker that makes the mock emit a ONE-ENTRY batch clarify — the exact
+ * payload shape every single question takes since the `questions[]`-only
+ * schema (#95907). Coverage gap called out in #98645: nothing exercised
+ * `questions:[{question, choices}]` before this.
+ */
+export const SINGLE_BATCH_CLARIFY_TRIGGER = 'E2E_SINGLE_BATCH_CLARIFY_TRIGGER'
+export const SINGLE_BATCH_CLARIFY_QUESTIONS = [
+  { question: 'Pick a single-batch drink?', choices: ['Espresso', 'Latte'] },
+]
+
+const SINGLE_BATCH_CLARIFY_TURN: ScriptedTurn = {
+  text: '',
+  toolCalls: [{ name: 'clarify', args: { questions: SINGLE_BATCH_CLARIFY_QUESTIONS } }],
+}
+
 function includesBatchClarifyTrigger(value: unknown): boolean {
   if (typeof value === 'string') {
     return value.includes(BATCH_CLARIFY_TRIGGER)
@@ -368,6 +384,22 @@ function includesBatchClarifyTrigger(value: unknown): boolean {
 
   if (value && typeof value === 'object') {
     return Object.values(value).some(includesBatchClarifyTrigger)
+  }
+
+  return false
+}
+
+function includesSingleBatchClarifyTrigger(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.includes(SINGLE_BATCH_CLARIFY_TRIGGER)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(includesSingleBatchClarifyTrigger)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(includesSingleBatchClarifyTrigger)
   }
 
   return false
@@ -531,6 +563,26 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
                 streamScriptedTurn(res, model, BATCH_CLARIFY_TURN)
               } else {
                 nonStreamingScriptedTurn(res, model, BATCH_CLARIFY_TURN)
+              }
+              return
+            }
+          }
+
+          if (includesSingleBatchClarifyTrigger(parsed.messages)) {
+            // Unlike the 2-question trigger (fresh conversation), this one
+            // shares history with it, so "any tool result" would false-positive
+            // — match only THIS turn's answered result by its question text.
+            const hasOwnToolResult = Array.isArray(parsed.messages)
+              && parsed.messages.some(
+                (message: { role?: string }) =>
+                  message?.role === 'tool' && JSON.stringify(message).includes('single-batch'),
+              )
+
+            if (!hasOwnToolResult) {
+              if (stream) {
+                streamScriptedTurn(res, model, SINGLE_BATCH_CLARIFY_TURN)
+              } else {
+                nonStreamingScriptedTurn(res, model, SINGLE_BATCH_CLARIFY_TURN)
               }
               return
             }

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -700,6 +700,102 @@ describe('ClarifyTool batch card', () => {
     })
   })
 
+  // ─── Single-entry batch (one-question questions[]) ────────────────────────
+  // #95907 made `questions[]` the only advertised shape, so a single question
+  // now arrives as a one-entry batch on BOTH sides: tool args carry
+  // `questions:[{question, choices}]` and the gateway wire carries
+  // `questions:[{qid, question, choices}]` with no top-level question. The
+  // batch card must mount for the one-entry case exactly as it does for 2+.
+
+  function singleBatchArgs(): { questions: { question: string; choices: string[] }[] } {
+    return {
+      questions: [{ choices: ['Local Markdown under .scratch/', 'GitHub Issues', 'Linear', 'GitLab Issues'], question: 'Which issue tracker should this repository use?' }]
+    }
+  }
+
+  function liveSingleBatchProps(): ToolCallMessagePartProps {
+    const args = singleBatchArgs()
+
+    return {
+      addResult: vi.fn(),
+      args,
+      argsText: JSON.stringify(args),
+      isError: false,
+      respondToApproval: vi.fn(),
+      result: undefined,
+      resume: vi.fn(),
+      status: { type: 'running' },
+      toolCallId: 'clarify-single-batch',
+      toolName: 'clarify',
+      type: 'tool-call'
+    }
+  }
+
+  function singleBatchRequest() {
+    return {
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        {
+          choices: ['Local Markdown under .scratch/', 'GitHub Issues', 'Linear', 'GitLab Issues'],
+          multiSelect: false,
+          qid: 'q0',
+          question: 'Which issue tracker should this repository use?'
+        }
+      ],
+      requestId: 'request-single-batch',
+      sessionId: 'session-1'
+    }
+  }
+
+  it('renders a one-entry batch as the batch card, not a blank/spinner single card', () => {
+    const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest(singleBatchRequest())
+    renderClarify(<ClarifyTool {...liveSingleBatchProps()} />)
+
+    expect(screen.getByText('Which issue tracker should this repository use?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /GitHub Issues/ })).toBeTruthy()
+    expect(document.querySelector('form[data-clarify-batch]')?.getAttribute('data-clarify-batch')).toBe('1')
+  })
+
+  it('mounts the batch card once the wire request lands after the tool row (#98645 timing)', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+
+    // Tool row mounts FIRST with the model's args; the gateway wire (with the
+    // qid the renderer needs) arrives a beat later — same ordering as
+    // tool.start → clarify.request in a live session.
+    const { rerender } = renderClarify(<ClarifyTool {...liveSingleBatchProps()} />)
+
+    await act(async () => {
+      setClarifyRequest(singleBatchRequest())
+    })
+    rerender(clarifyTree(<ClarifyTool {...liveSingleBatchProps()} />))
+
+    await waitFor(() => {
+      expect(screen.getByText('Which issue tracker should this repository use?')).toBeTruthy()
+    })
+    expect(screen.getByRole('button', { name: /GitHub Issues/ })).toBeTruthy()
+
+    // And the single pick answers with the qid-keyed lock.
+    fireEvent.click(screen.getByRole('button', { name: /GitHub Issues/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Confirm and continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'GitHub Issues',
+        question_id: 'q0',
+        request_id: 'request-single-batch'
+      })
+    })
+  })
+
   it('renders the settled batch with all questions and answers', () => {
     renderClarify(
       <ClarifyTool


### PR DESCRIPTION
## What does this PR do?

Since the `questions[]`-only schema (#95907), every single question is a one-entry batch on both the tool args and the gateway wire — yet no test exercised `questions:[{question, choices}]` with `length === 1` (the coverage gap called out in #98645). This PR locks that behavior down at two layers:

- **Unit** (`clarify-tool.test.tsx`): a one-entry batch mounts the batch card (with its question, choices, and `data-clarify-batch="1"` marker) — not a blank or spinner-only single card — both when the gateway request is already parked and when the wire lands *after* the tool row (the real `tool.start` → `clarify.request` ordering). It also answers via the qid-keyed lock.
- **E2E** (`batch-clarify.spec.ts` + a new `SINGLE_BATCH_CLARIFY_TRIGGER` in the mock server): drives the real chain (composer → gateway → agent → clarify tool → `clarify.request` → renderer) through mount, pick, single confirm, and settle for `questions.length === 1`, mirroring the existing 2-question case.

While verifying the routing of the new trigger I found the mock's any-tool-result guard would false-positive once a second scripted clarify shares the conversation history, so the single-batch trigger scopes the check to its own answered turn (by question text) instead.

No product code changes — the renderer, store, and wire layers already handle the one-entry shape correctly on current `main`; these tests pin that contract so a future regression in either branch cannot silently reintroduce the blank-card symptom.

## Related Issue

Relates to #98645 (adds the requested `questions:[{q,c}]` coverage; does not claim to fix it — see my reproduction notes on the issue)

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx` — two one-entry-batch unit cases: synchronous wire-already-parked, and wire-lands-after-mount timing including the `question_id: q0` answer
- `apps/desktop/e2e/mock-server.ts` — `SINGLE_BATCH_CLARIFY_TRIGGER` + scripted one-entry batch turn; the new trigger's answered-turn guard is scoped to its own question text so it can coexist with the 2-question trigger in one conversation
- `apps/desktop/e2e/batch-clarify.spec.ts` — one-entry batch e2e: single card, `data-clarify-batch="1"`, pick + Confirm and continue, settled view, no lingering live card

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/components/assistant-ui/clarify-tool.test.tsx`
   - Observed result: 38 passed (36 pre-existing + 2 new)
2. `cd apps/desktop && npm run build && npx playwright test e2e/batch-clarify.spec.ts --reporter=list`
   - Observed result: 2 passed — the existing 2-question case and the new one-entry case both mount exactly one card and settle after answering
3. `npx vitest run --project ui src/store/clarify.test.ts src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts src/lib/chat-messages`
   - Observed result: 101 passed (no regressions in the neighboring clarify/chat-message suites)

Note: `e2e/chat.spec.ts` → "offers stop, steer, and queue actions while busy" fails identically with and without this branch (verified via stash) — pre-existing on `main`, unrelated to these changes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: JS-only change; ran the desktop vitest + Playwright suites listed under How to Test instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: tests only, platform-neutral assertions
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A