### PR TITLE
feat(discord): show activity state in thread titles

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -93,6 +93,8 @@ _DISCORD_MODEL_SELECT_CAPACITY = (
 ) * _DISCORD_SELECT_MAX_OPTIONS
 _DISCORD_BUTTON_LABEL_LIMIT = 80
 _DISCORD_ELLIPSIS = "\u2026"
+_DISCORD_THREAD_ACTIVITY_PREFIX = "⏳ "
+_DISCORD_THREAD_FAILURE_PREFIX = "⛔ "
 _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
     "non_conversational_history",
@@ -1117,6 +1119,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
+        self._thread_activity_states: Dict[str, Dict[str, Any]] = {}
+        self._thread_activity_lock = asyncio.Lock()
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -3353,8 +3357,145 @@ class DiscordAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    def _thread_activity_indicator_enabled(self) -> bool:
+        """Return whether opt-in thread-title activity is enabled."""
+        return os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "false").lower() in {
+            "true",
+            "1",
+            "yes",
+            "on",
+        }
+
+    @staticmethod
+    def _thread_activity_title(prefix: str, base_title: str) -> str:
+        """Fit a prefixed title within Discord's 80 UTF-16-unit budget."""
+        budget = 80 - utf16_len(prefix)
+        return prefix + _prefix_within_utf16_limit(base_title, budget).rstrip()
+
+    @staticmethod
+    def _clean_discord_thread_title(name: str) -> str:
+        """Normalize and truncate a Discord thread title safely."""
+        cleaned = re.sub(r"\s+", " ", str(name or "")).strip()
+        if utf16_len(cleaned) > 80:
+            cleaned = _prefix_within_utf16_limit(cleaned, 77).rstrip() + "..."
+        return cleaned
+
+    @staticmethod
+    def _thread_activity_base_title(title: str) -> str:
+        """Remove activity markers left by a previous interrupted turn."""
+        base_title = title.strip()
+        while base_title.startswith(
+            (_DISCORD_THREAD_ACTIVITY_PREFIX, _DISCORD_THREAD_FAILURE_PREFIX)
+        ):
+            base_title = base_title[2:].lstrip()
+        return base_title
+
+    async def _thread_for_activity_event(self, event: MessageEvent) -> Optional[Any]:
+        thread_id = str(getattr(event.source, "thread_id", "") or "")
+        if not thread_id or not self._client:
+            return None
+        channel = getattr(getattr(event, "raw_message", None), "channel", None)
+        thread_type = getattr(discord, "Thread", ())
+        if isinstance(channel, thread_type) and str(getattr(channel, "id", "")) == thread_id:
+            return channel
+        try:
+            thread = self._client.get_channel(int(thread_id))
+            if thread is None:
+                thread = await self._client.fetch_channel(int(thread_id))
+            return thread if isinstance(thread, thread_type) else None
+        except Exception:
+            logger.debug(
+                "[%s] Failed to resolve Discord thread %s for activity indicator",
+                self.name,
+                thread_id,
+                exc_info=True,
+            )
+            return None
+
+    async def _start_thread_activity(self, event: MessageEvent) -> None:
+        if not self._thread_activity_indicator_enabled():
+            return
+        thread = await self._thread_for_activity_event(event)
+        if thread is None:
+            return
+        thread_id = str(thread.id)
+        async with self._thread_activity_lock:
+            state = self._thread_activity_states.get(thread_id)
+            if state is not None:
+                state["active_count"] += 1
+                return
+            base_title = self._thread_activity_base_title(
+                str(getattr(thread, "name", "") or "")
+            )
+            if not base_title:
+                return
+            active_title = self._thread_activity_title(
+                _DISCORD_THREAD_ACTIVITY_PREFIX,
+                base_title,
+            )
+            try:
+                await thread.edit(name=active_title, reason="Hermes processing activity")
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to mark Discord thread %s active",
+                    self.name,
+                    thread_id,
+                    exc_info=True,
+                )
+                return
+            self._thread_activity_states[thread_id] = {
+                "active_count": 1,
+                "base_title": base_title,
+                "display_title": active_title,
+                "failed": False,
+            }
+
+    async def _complete_thread_activity(
+        self,
+        event: MessageEvent,
+        outcome: ProcessingOutcome,
+    ) -> None:
+        thread_id = str(getattr(event.source, "thread_id", "") or "")
+        if not thread_id:
+            return
+        thread = await self._thread_for_activity_event(event)
+        async with self._thread_activity_lock:
+            state = self._thread_activity_states.get(thread_id)
+            if state is None:
+                return
+            if outcome == ProcessingOutcome.FAILURE:
+                state["failed"] = True
+            state["active_count"] -= 1
+            if state["active_count"] > 0:
+                return
+            if thread is None:
+                self._thread_activity_states.pop(thread_id, None)
+                return
+            current_title = str(getattr(thread, "name", "") or "").strip()
+            target_title = (
+                self._thread_activity_title(
+                    _DISCORD_THREAD_FAILURE_PREFIX,
+                    state["base_title"],
+                )
+                if state["failed"]
+                else state["base_title"]
+            )
+            try:
+                if current_title == state["display_title"] and current_title != target_title:
+                    await thread.edit(name=target_title, reason="Hermes processing activity")
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to finalize Discord thread %s activity indicator",
+                    self.name,
+                    thread_id,
+                    exc_info=True,
+                )
+            finally:
+                self._thread_activity_states.pop(thread_id, None)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""
+        await self._start_thread_activity(event)
         message = event.raw_message
         acked = False
         if self._reactions_enabled() and hasattr(message, "add_reaction"):
@@ -3367,6 +3508,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for final reaction and durable state."""
+        await self._complete_thread_activity(event, outcome)
         await asyncio.to_thread(
             self._record_discord_processing_complete,
             event,
@@ -7297,6 +7439,47 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         only_if_current_name: Optional[str] = None,
     ) -> bool:
+        """Rename a thread while preserving an active activity marker."""
+        normalized_id = str(thread_id)
+        async with self._thread_activity_lock:
+            state = self._thread_activity_states.get(normalized_id)
+            if state is None:
+                return await self._rename_thread_unlocked(
+                    thread_id,
+                    name,
+                    only_if_current_name=only_if_current_name,
+                )
+            if (
+                only_if_current_name is not None
+                and state["base_title"] != only_if_current_name
+            ):
+                return False
+            base_title = self._clean_discord_thread_title(
+                self._thread_activity_base_title(str(name or ""))
+            )
+            if not base_title:
+                return False
+            active_title = self._thread_activity_title(
+                _DISCORD_THREAD_ACTIVITY_PREFIX,
+                base_title,
+            )
+            renamed = await self._rename_thread_unlocked(
+                thread_id,
+                active_title,
+                only_if_current_name=state["display_title"],
+            )
+            if renamed:
+                state["base_title"] = base_title
+                state["display_title"] = active_title
+            return renamed
+
+    async def _rename_thread_unlocked(
+        self,
+        thread_id: str,
+        name: str,
+        *,
+        only_if_current_name: Optional[str] = None,
+    ) -> bool:
         """Best-effort Discord thread rename.
 
         ``only_if_current_name`` prevents overwriting human-renamed or
@@ -7310,14 +7493,9 @@ class DiscordAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return False
 
-        cleaned = re.sub(r"\s+", " ", str(name or "")).strip()
+        cleaned = self._clean_discord_thread_title(name)
         if not cleaned:
             return False
-        # Discord thread names are budgeted in UTF-16 code units (emoji count
-        # double) — truncate with the UTF-16 helpers, not code-point slices.
-        from gateway.platforms.base import utf16_len, _prefix_within_utf16_limit
-        if utf16_len(cleaned) > 80:
-            cleaned = _prefix_within_utf16_limit(cleaned, 77).rstrip() + "..."
 
         try:
             thread = self._client.get_channel(thread_id_int)
@@ -10374,6 +10552,7 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     throughout the connect / handle code paths (``DISCORD_ALLOWED_USERS``,
     ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
     ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
+    ``DISCORD_THREAD_ACTIVITY_INDICATOR``,
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
@@ -10456,6 +10635,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+    if (
+        "thread_activity_indicator" in discord_cfg
+        and not os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR")
+    ):
+        os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] = str(
+            discord_cfg["thread_activity_indicator"]
+        ).lower()
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1077,6 +1077,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
+        if (
+            _profile_scoped_config_load()
+            and "thread_activity_indicator" not in self.config.extra
+        ):
+            self._thread_activity_indicator_enabled_value = (
+                self._thread_activity_indicator_enabled()
+            )
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
@@ -3359,7 +3366,28 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _thread_activity_indicator_enabled(self) -> bool:
         """Return whether opt-in thread-title activity is enabled."""
-        return os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "false").lower() in {
+        cached = getattr(self, "_thread_activity_indicator_enabled_value", None)
+        if isinstance(cached, bool):
+            return cached
+        extra = (
+            self.config.extra
+            if isinstance(getattr(self.config, "extra", None), dict)
+            else {}
+        )
+        if "thread_activity_indicator" in extra:
+            configured = extra["thread_activity_indicator"]
+            if isinstance(configured, bool):
+                return configured
+            raw = (
+                configured.strip().lower()
+                if isinstance(configured, str)
+                else str(configured).lower()
+            )
+        else:
+            raw = _scoped_gate_env(
+                "DISCORD_THREAD_ACTIVITY_INDICATOR", "false"
+            ).lower()
+        return raw in {
             "true",
             "1",
             "yes",
@@ -10678,13 +10706,26 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
-    if (
-        "thread_activity_indicator" in discord_cfg
-        and not os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR")
-    ):
-        os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] = str(
-            discord_cfg["thread_activity_indicator"]
-        ).lower()
+    _missing = object()
+    thread_activity_cfg = (
+        discord_cfg["thread_activity_indicator"]
+        if "thread_activity_indicator" in discord_cfg
+        else platform_extra_cfg.get("thread_activity_indicator", _missing)
+    )
+    if thread_activity_cfg is _missing:
+        if _skip_env_bridge:
+            seeded_extra["thread_activity_indicator"] = False
+    else:
+        effective_thread_activity_cfg = thread_activity_cfg
+        if not _skip_env_bridge:
+            env_override = os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR")
+            if env_override:
+                effective_thread_activity_cfg = env_override
+            else:
+                os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] = str(
+                    thread_activity_cfg
+                ).lower()
+        seeded_extra["thread_activity_indicator"] = effective_thread_activity_cfg
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3412,6 +3412,30 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return None
 
+    async def _fetch_thread_for_activity(self, thread_id: str) -> Optional[Any]:
+        """Fetch authoritative thread state instead of trusting Discord's cache."""
+        if not self._client:
+            return None
+        thread_type = getattr(discord, "Thread", ())
+        try:
+            thread = await self._client.fetch_channel(int(thread_id))
+            return thread if isinstance(thread, thread_type) else None
+        except Exception:
+            logger.debug(
+                "[%s] Failed to fetch Discord thread %s for activity indicator",
+                self.name,
+                thread_id,
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    async def _edit_discord_thread(thread: Any, *, name: str, reason: str) -> Any:
+        """Return discord.py's updated Thread, falling back for compatible fakes."""
+        updated = await thread.edit(name=name, reason=reason)
+        thread_type = getattr(discord, "Thread", ())
+        return updated if isinstance(updated, thread_type) else thread
+
     async def _start_thread_activity(self, event: MessageEvent) -> None:
         if not self._thread_activity_indicator_enabled():
             return
@@ -3434,7 +3458,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 base_title,
             )
             try:
-                await thread.edit(name=active_title, reason="Hermes processing activity")
+                updated_thread = await self._edit_discord_thread(
+                    thread,
+                    name=active_title,
+                    reason="Hermes processing activity",
+                )
             except Exception:
                 logger.debug(
                     "[%s] Failed to mark Discord thread %s active",
@@ -3443,10 +3471,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 return
+            display_title = str(
+                getattr(updated_thread, "name", active_title) or active_title
+            ).strip()
             self._thread_activity_states[thread_id] = {
                 "active_count": 1,
                 "base_title": base_title,
-                "display_title": active_title,
+                "display_title": display_title,
                 "failed": False,
             }
 
@@ -3458,7 +3489,6 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_id = str(getattr(event.source, "thread_id", "") or "")
         if not thread_id:
             return
-        thread = await self._thread_for_activity_event(event)
         async with self._thread_activity_lock:
             state = self._thread_activity_states.get(thread_id)
             if state is None:
@@ -3468,6 +3498,7 @@ class DiscordAdapter(BasePlatformAdapter):
             state["active_count"] -= 1
             if state["active_count"] > 0:
                 return
+            thread = await self._fetch_thread_for_activity(thread_id)
             if thread is None:
                 self._thread_activity_states.pop(thread_id, None)
                 return
@@ -3482,7 +3513,11 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             try:
                 if current_title == state["display_title"] and current_title != target_title:
-                    await thread.edit(name=target_title, reason="Hermes processing activity")
+                    await self._edit_discord_thread(
+                        thread,
+                        name=target_title,
+                        reason="Hermes processing activity",
+                    )
             except Exception:
                 logger.debug(
                     "[%s] Failed to finalize Discord thread %s activity indicator",
@@ -7498,9 +7533,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
         try:
-            thread = self._client.get_channel(thread_id_int)
-            if thread is None:
+            if only_if_current_name is not None:
                 thread = await self._client.fetch_channel(thread_id_int)
+            else:
+                thread = self._client.get_channel(thread_id_int)
+                if thread is None:
+                    thread = await self._client.fetch_channel(thread_id_int)
         except Exception:
             logger.debug("[%s] Failed to resolve Discord thread %s for rename", self.name, thread_id, exc_info=True)
             return False
@@ -7519,10 +7557,15 @@ class DiscordAdapter(BasePlatformAdapter):
         if edit is None:
             return False
         try:
-            await edit(name=cleaned, reason="Hermes semantic session title")
+            updated_thread = await self._edit_discord_thread(
+                thread,
+                name=cleaned,
+                reason="Hermes semantic session title",
+            )
+            updated_name = getattr(updated_thread, "name", cleaned)
             logger.info(
-                "[%s] Renamed Discord thread %s from %r to %r",
-                self.name, thread_id, current_name, cleaned,
+                "[%s] Renamed Discord thread %s from %r to %r (returned %r)",
+                self.name, thread_id, current_name, cleaned, updated_name,
             )
             return True
         except Exception:

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -81,3 +81,14 @@ def test_yaml_config_seeds_websocket_health_with_primary_precedence(monkeypatch)
     }
 
 
+def test_yaml_config_bridges_thread_activity_indicator_without_overriding_env(monkeypatch):
+    monkeypatch.delenv("DISCORD_THREAD_ACTIVITY_INDICATOR", raising=False)
+
+    _apply_yaml_config({}, {"thread_activity_indicator": True})
+    assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "true"
+
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "false")
+    _apply_yaml_config({}, {"thread_activity_indicator": True})
+    assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "false"
+
+

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -84,6 +84,32 @@ def _make_event(message_id: str, raw_message) -> MessageEvent:
     )
 
 
+def _make_thread_event(message_id: str, raw_message, thread_id: str = "123") -> MessageEvent:
+    event = _make_event(message_id, raw_message)
+    event.source.chat_type = "thread"
+    event.source.thread_id = thread_id
+    event.source.chat_id = thread_id
+    return event
+
+
+def _activity_thread(adapter, title="Investigate flaky build"):
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = title
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    raw_message = SimpleNamespace(
+        channel=thread,
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    return thread, raw_message
+
+
 @pytest.mark.asyncio
 async def test_process_message_background_adds_and_swaps_reactions(adapter):
     raw_message = SimpleNamespace(
@@ -138,5 +164,250 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     raw_message.remove_reaction.assert_not_awaited()
     # Response should still be sent
     adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_marks_start_and_restores_on_success(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = "Investigate flaky build"
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    raw_message = SimpleNamespace(
+        channel=thread,
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    event = _make_thread_event("5", raw_message)
+
+    await adapter.on_processing_start(event)
+    assert thread.name == "⏳ Investigate flaky build"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert thread.name == "Investigate flaky build"
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_marks_failure(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = "Investigate flaky build"
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    event = _make_thread_event(
+        "6",
+        SimpleNamespace(
+            channel=thread,
+            add_reaction=AsyncMock(),
+            remove_reaction=AsyncMock(),
+        ),
+    )
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert thread.name == "⛔ Investigate flaky build"
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_waits_for_concurrent_turns_and_keeps_failure(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = "Investigate flaky build"
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    raw_message = SimpleNamespace(
+        channel=thread,
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    first = _make_thread_event("8", raw_message)
+    second = _make_thread_event("9", raw_message)
+
+    await adapter.on_processing_start(first)
+    await adapter.on_processing_start(second)
+    await adapter.on_processing_complete(first, ProcessingOutcome.SUCCESS)
+    assert thread.name == "⏳ Investigate flaky build"
+
+    await adapter.on_processing_complete(second, ProcessingOutcome.FAILURE)
+    assert thread.name == "⛔ Investigate flaky build"
+    assert adapter._thread_activity_states == {}
+
+
+@pytest.mark.asyncio
+async def test_semantic_thread_rename_updates_active_base_title(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = "Investigate flaky build"
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    event = _make_thread_event(
+        "10",
+        SimpleNamespace(
+            channel=thread,
+            add_reaction=AsyncMock(),
+            remove_reaction=AsyncMock(),
+        ),
+    )
+
+    await adapter.on_processing_start(event)
+    renamed = await adapter.rename_thread(
+        "123",
+        "Stable build",
+        only_if_current_name="Investigate flaky build",
+    )
+
+    assert renamed is True
+    assert thread.name == "⏳ Stable build"
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert thread.name == "Stable build"
+
+
+@pytest.mark.asyncio
+async def test_semantic_thread_rename_keeps_base_within_utf16_budget(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread, raw_message = _activity_thread(adapter)
+    event = _make_thread_event("16", raw_message)
+
+    await adapter.on_processing_start(event)
+    assert await adapter.rename_thread("123", "😀" * 80) is True
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert len(thread.name.encode("utf-16-le")) // 2 <= 80
+    assert all(
+        len(call.kwargs["name"].encode("utf-16-le")) // 2 <= 80
+        for call in thread.edit.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_preserves_human_rename_on_success(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread, raw_message = _activity_thread(adapter)
+    event = _make_thread_event("11", raw_message)
+
+    await adapter.on_processing_start(event)
+    thread.name = "Human-chosen title"
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert thread.name == "Human-chosen title"
+    assert adapter._thread_activity_states == {}
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_restores_on_cancel(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread, raw_message = _activity_thread(adapter)
+    event = _make_thread_event("12", raw_message)
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+    assert thread.name == "Investigate flaky build"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled,thread_id", [(False, "123"), (True, None)])
+async def test_thread_activity_indicator_is_noop_when_disabled_or_not_a_thread(
+    adapter, monkeypatch, enabled, thread_id
+):
+    monkeypatch.setenv(
+        "DISCORD_THREAD_ACTIVITY_INDICATOR",
+        "true" if enabled else "false",
+    )
+    thread, raw_message = _activity_thread(adapter)
+    event = _make_thread_event("13", raw_message)
+    event.source.thread_id = thread_id
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert thread.name == "Investigate flaky build"
+    thread.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_rename_failure_is_fail_open(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread, raw_message = _activity_thread(adapter)
+    thread.edit.side_effect = PermissionError("Manage Threads required")
+    event = _make_thread_event("14", raw_message)
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert thread.name == "Investigate flaky build"
+    assert adapter._thread_activity_states == {}
+
+
+def test_thread_activity_indicator_title_respects_utf16_budget():
+    title = DiscordAdapter._thread_activity_title("⏳ ", "😀" * 80)
+
+    assert len(title.encode("utf-16-le")) // 2 <= 80
+    assert title.endswith("😀")
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_state_is_bounded_when_thread_resolution_fails(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread, raw_message = _activity_thread(adapter)
+    event = _make_thread_event("15", raw_message)
+
+    await adapter.on_processing_start(event)
+    raw_message.channel = None
+    adapter._client.get_channel = lambda _id: None
+    adapter._client.fetch_channel = AsyncMock(side_effect=RuntimeError("gone"))
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert adapter._thread_activity_states == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stale_prefix", ["⏳ ", "⛔ "])
+async def test_thread_activity_indicator_recovers_stale_prefix(adapter, monkeypatch, stale_prefix):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    thread = sys.modules["discord"].Thread()
+    thread.id = 123
+    thread.name = f"{stale_prefix}Investigate flaky build"
+
+    async def edit(*, name, reason):
+        thread.name = name
+
+    thread.edit = AsyncMock(side_effect=edit)
+    adapter._client.get_channel = lambda _id: thread
+    event = _make_thread_event(
+        "7",
+        SimpleNamespace(
+            channel=thread,
+            add_reaction=AsyncMock(),
+            remove_reaction=AsyncMock(),
+        ),
+    )
+
+    await adapter.on_processing_start(event)
+    assert thread.name == "⏳ Investigate flaky build"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert thread.name == "Investigate flaky build"
 
 

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -102,12 +102,42 @@ def _activity_thread(adapter, title="Investigate flaky build"):
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     raw_message = SimpleNamespace(
         channel=thread,
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
     )
     return thread, raw_message
+
+
+def _distinct_return_activity_thread(adapter, title="Investigate flaky build"):
+    """Model discord.py Thread.edit returning a fresh, authoritative object."""
+    thread_type = sys.modules["discord"].Thread
+    server = SimpleNamespace(name=title, edits=[])
+
+    def make_thread(name):
+        thread = thread_type()
+        thread.id = 123
+        thread.name = name
+
+        async def edit(*, name, reason):
+            server.name = name
+            server.edits.append(name)
+            return make_thread(name)
+
+        thread.edit = AsyncMock(side_effect=edit)
+        return thread
+
+    cached_thread = make_thread(title)
+    adapter._client.get_channel = lambda _id: cached_thread
+    adapter._client.fetch_channel = AsyncMock(side_effect=lambda _id: make_thread(server.name))
+    raw_message = SimpleNamespace(
+        channel=cached_thread,
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    return cached_thread, raw_message, server
 
 
 @pytest.mark.asyncio
@@ -178,6 +208,7 @@ async def test_thread_activity_indicator_marks_start_and_restores_on_success(ada
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     raw_message = SimpleNamespace(
         channel=thread,
         add_reaction=AsyncMock(),
@@ -204,6 +235,7 @@ async def test_thread_activity_indicator_marks_failure(adapter, monkeypatch):
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     event = _make_thread_event(
         "6",
         SimpleNamespace(
@@ -231,6 +263,7 @@ async def test_thread_activity_indicator_waits_for_concurrent_turns_and_keeps_fa
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     raw_message = SimpleNamespace(
         channel=thread,
         add_reaction=AsyncMock(),
@@ -261,6 +294,7 @@ async def test_semantic_thread_rename_updates_active_base_title(adapter, monkeyp
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     event = _make_thread_event(
         "10",
         SimpleNamespace(
@@ -281,6 +315,70 @@ async def test_semantic_thread_rename_updates_active_base_title(adapter, monkeyp
     assert thread.name == "⏳ Stable build"
     await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
     assert thread.name == "Stable build"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome, expected_title",
+    [
+        (ProcessingOutcome.SUCCESS, "Investigate flaky build"),
+        (ProcessingOutcome.CANCELLED, "Investigate flaky build"),
+        (ProcessingOutcome.FAILURE, "⛔ Investigate flaky build"),
+    ],
+)
+async def test_thread_activity_indicator_finalizes_when_edit_returns_distinct_thread(
+    adapter, monkeypatch, outcome, expected_title
+):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    cached_thread, raw_message, server = _distinct_return_activity_thread(adapter)
+    event = _make_thread_event("distinct-final", raw_message)
+
+    await adapter.on_processing_start(event)
+    assert cached_thread.name == "Investigate flaky build"
+    assert server.name == "⏳ Investigate flaky build"
+
+    await adapter.on_processing_complete(event, outcome)
+
+    assert server.name == expected_title
+    assert server.edits == ["⏳ Investigate flaky build", expected_title]
+
+
+@pytest.mark.asyncio
+async def test_semantic_thread_rename_uses_distinct_edit_result(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    cached_thread, raw_message, server = _distinct_return_activity_thread(adapter)
+    event = _make_thread_event("distinct-semantic", raw_message)
+
+    await adapter.on_processing_start(event)
+    assert cached_thread.name == "Investigate flaky build"
+
+    assert await adapter.rename_thread(
+        "123",
+        "Stable build",
+        only_if_current_name="Investigate flaky build",
+    ) is True
+    assert server.name == "⏳ Stable build"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    assert server.name == "Stable build"
+
+
+@pytest.mark.asyncio
+async def test_thread_activity_indicator_fetches_before_preserving_human_rename(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+    cached_thread, raw_message, server = _distinct_return_activity_thread(adapter)
+    event = _make_thread_event("distinct-human", raw_message)
+
+    await adapter.on_processing_start(event)
+    cached_thread.name = "⏳ Investigate flaky build"
+    server.name = "Human-chosen title"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert server.name == "Human-chosen title"
+    assert server.edits == ["⏳ Investigate flaky build"]
 
 
 @pytest.mark.asyncio
@@ -395,6 +493,7 @@ async def test_thread_activity_indicator_recovers_stale_prefix(adapter, monkeypa
 
     thread.edit = AsyncMock(side_effect=edit)
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
     event = _make_thread_event(
         "7",
         SimpleNamespace(

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -435,6 +435,7 @@ async def test_rename_thread_edits_only_when_current_name_matches(adapter):
         edit=AsyncMock(),
     )
     adapter._client.get_channel = lambda _id: thread
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
 
     result = await adapter.rename_thread(
         "999",

--- a/tests/plugins/platforms/test_discord_gate_isolation.py
+++ b/tests/plugins/platforms/test_discord_gate_isolation.py
@@ -36,6 +36,7 @@ GATE_VARS = [
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
     "DISCORD_ALLOW_BOTS",
+    "DISCORD_THREAD_ACTIVITY_INDICATOR",
 ]
 
 
@@ -372,6 +373,121 @@ class TestYamlBridgeSeeding:
 
         assert a._get_allowed_channels() == {"111"}
         assert b._get_allowed_channels() == {"222"}
+
+
+class TestThreadActivityIndicatorIsolation:
+    @staticmethod
+    def _load_adapter(
+        tmp_path, monkeypatch, name: str, setting: str | None = None
+    ):
+        from gateway.config import load_gateway_config
+
+        hermes_home = tmp_path / name
+        hermes_home.mkdir()
+        lines = ["discord:", "  enabled: true"]
+        if setting is not None:
+            lines.append(f"  thread_activity_indicator: {setting}")
+        (hermes_home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        return DiscordAdapter(config.platforms[Platform.DISCORD])
+
+    def test_profile_false_and_scoped_profile_true_stay_independent(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        disabled = self._load_adapter(tmp_path, monkeypatch, "disabled", "false")
+        assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "false"
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            enabled = self._load_adapter(tmp_path, monkeypatch, "enabled", "true")
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert disabled._thread_activity_indicator_enabled() is False
+        assert enabled._thread_activity_indicator_enabled() is True
+
+    def test_scoped_true_does_not_enable_unconfigured_adapter_or_pollute_env(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        unconfigured = self._load_adapter(tmp_path, monkeypatch, "unconfigured")
+        assert os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR") is None
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            enabled = self._load_adapter(tmp_path, monkeypatch, "scoped", "true")
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert os.getenv("DISCORD_THREAD_ACTIVITY_INDICATOR") is None
+        assert unconfigured._thread_activity_indicator_enabled() is False
+        assert enabled._thread_activity_indicator_enabled() is True
+
+    def test_default_true_does_not_enable_scoped_unconfigured_adapter(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        enabled = self._load_adapter(tmp_path, monkeypatch, "default-enabled", "true")
+        assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "true"
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            unconfigured = self._load_adapter(
+                tmp_path, monkeypatch, "scoped-unconfigured"
+            )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert enabled._thread_activity_indicator_enabled() is True
+        assert unconfigured._thread_activity_indicator_enabled() is False
+        assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "true"
+
+    def test_scoped_env_only_adapter_snapshots_missing_value_as_false(
+        self, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "true")
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            adapter = DiscordAdapter(PlatformConfig(enabled=True, token="scoped"))
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert adapter._thread_activity_indicator_enabled() is False
+
+    def test_single_profile_env_override_and_bridge_remain_supported(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        monkeypatch.setenv("DISCORD_THREAD_ACTIVITY_INDICATOR", "yes")
+        overridden = self._load_adapter(tmp_path, monkeypatch, "override", "false")
+        assert overridden._thread_activity_indicator_enabled() is True
+
+        monkeypatch.delenv("DISCORD_THREAD_ACTIVITY_INDICATOR")
+        bridged = self._load_adapter(tmp_path, monkeypatch, "bridge", "true")
+        assert os.environ["DISCORD_THREAD_ACTIVITY_INDICATOR"] == "true"
+        assert bridged._thread_activity_indicator_enabled() is True
+
+    @pytest.mark.parametrize("malformed", ["sometimes", [], {}, None])
+    def test_malformed_adapter_local_boolean_fails_closed(self, malformed):
+        adapter = _adapter({"thread_activity_indicator": malformed})
+
+        assert adapter._thread_activity_indicator_enabled() is False
 
 
 class TestTelegramGateIsolation:

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -303,6 +303,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
+| `DISCORD_THREAD_ACTIVITY_INDICATOR` | No | `false` | Compatibility override for `discord.thread_activity_indicator`. Prefer `config.yaml`. When enabled, active thread titles receive a temporary ⏳ prefix and failed turns leave a ⛔ prefix. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
 | `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
@@ -337,6 +338,7 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  thread_activity_indicator: false # Temporarily mark active/failed thread titles
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
@@ -420,6 +422,22 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 - ❌ added if an error occurs during processing
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+
+#### `discord.thread_activity_indicator`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, processing a message inside a Discord thread temporarily changes
+its title to `⏳ <title>`. Successful and cancelled turns restore the current
+base title; failed turns leave `⛔ <title>` so blocked work remains visible in
+the thread list. Concurrent turns share one indicator, and the title is not
+restored until the final active turn completes. Semantic or human title changes
+made during processing are preserved.
+
+This is best-effort and never fails the agent turn. The bot needs Discord's
+**Manage Threads** permission to edit thread titles; without it, Hermes logs the
+rename failure and continues without the indicator. No status message is posted
+and no notification sound is triggered.
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## Summary
- add an opt-in `discord.thread_activity_indicator` setting (default `false`)
- prefix active Discord thread titles with `⏳` while a turn is running
- restore the original title on success and retain `⛔` on failure
- keep concurrent turns, manual renames, stale markers, and Discord's UTF-16 title limit safe
- isolate config resolution across multiplexed profiles

## Why
Long-running work in several Discord threads is otherwise difficult to locate. The title marker makes active and failed threads visible without adding messages or changing agent prompt/tool behavior.

## Test plan
- `scripts/run_tests.sh tests/plugins/platforms/test_discord_gate_isolation.py -k ThreadActivityIndicatorIsolation -q`
- `scripts/run_tests.sh tests/gateway/test_discord_reactions.py -k 'thread_activity_indicator or semantic_thread_rename' -q`
- `scripts/run_tests.sh tests/gateway/test_discord*.py -q`

Result on current `main`: 281 Discord gateway tests passed, 0 failed.
