### PR TITLE
fix(tests): reject drifted runner venvs

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -51,49 +51,94 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VENV=""
 VENV_PYTHON=""
 SKIPPED_VENVS=""
+# Minimum imports the suite needs to fail honestly. A venv with only pytest can
+# launch the runner but then misreports missing core/dev deps as code failures.
+REQUIRED_TEST_IMPORTS=(pytest croniter psutil pytest_asyncio)
+
+missing_test_imports() {
+  local python_bin="$1"
+  local output
+  if output=$("$python_bin" - "${REQUIRED_TEST_IMPORTS[@]}" <<'PY' 2>/dev/null
+import importlib
+import sys
+
+for module_name in sys.argv[1:]:
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        print(module_name)
+PY
+); then
+    printf "%s" "$output"
+  else
+    printf "%s" "__probe_failed__"
+  fi
+}
+
+python_has_required_test_imports() {
+  local python_bin="$1"
+  [ -z "$(missing_test_imports "$python_bin")" ]
+}
+
+record_skipped_python() {
+  local candidate="$1"
+  local python_bin="$2"
+  local missing
+  local missing_csv
+  missing="$(missing_test_imports "$python_bin")"
+  missing_csv="${missing//$'\n'/,}"
+  SKIPPED_VENVS="${SKIPPED_VENVS}${SKIPPED_VENVS:+ }$candidate(missing:${missing_csv:-unknown})"
+}
+
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
+    if python_has_required_test_imports "$candidate/bin/python"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/bin/python"
       break
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
+    record_skipped_python "$candidate" "$candidate/bin/python"
   fi
   # Native Windows venv layout: python.exe and activate live under
   # Scripts/, and there is no bin/. Anyone running this script from
   # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
   # this branch — without it the canonical runner refuses to start.
   if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if python_has_required_test_imports "$candidate/Scripts/python.exe"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/Scripts/python.exe"
       break
     fi
-    SKIPPED_VENVS="$SKIPPED_VENVS $candidate"
+    record_skipped_python "$candidate" "$candidate/Scripts/python.exe"
   fi
 done
 
 if [ -n "$SKIPPED_VENVS" ]; then
   for skipped in $SKIPPED_VENVS; do
-    echo "▶ skipping venv without pytest: $skipped" >&2
+    echo "▶ skipping venv missing test imports: $skipped" >&2
   done
 fi
 
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
-  # Guard with an import check: HERMES_PYTHON may point at the RELEASE
+    && python_has_required_test_imports "$HERMES_PYTHON"; then
+  # Guard with import checks: HERMES_PYTHON may point at the RELEASE
   # venv (no pytest) when inherited from a wrapped `hermes` binary rather
-  # than the devShell hook.
+  # than the devShell hook, or at a drifted dev venv missing suite deps.
   PYTHON="$HERMES_PYTHON"
   echo "▶ no local venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
 else
-  echo "error: no virtualenv with pytest found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
-  echo "       and HERMES_PYTHON is not a python with pytest (enter the Nix devShell or create a venv)" >&2
+  echo "error: no virtualenv with required test imports found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
+  echo "       and HERMES_PYTHON is not a python with the required test imports" >&2
+  echo "       (enter the Nix devShell or install dev extras in a local venv)" >&2
   if [ -n "$SKIPPED_VENVS" ]; then
-    echo "       (skipped for missing pytest:$SKIPPED_VENVS — install dev extras there, or create $REPO_ROOT/.venv)" >&2
+    echo "       skipped venvs: $SKIPPED_VENVS" >&2
+  fi
+  if [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ]; then
+    _hermes_missing="$(missing_test_imports "$HERMES_PYTHON")"
+    _hermes_missing_csv="${_hermes_missing//$'\n'/,}"
+    echo "       HERMES_PYTHON missing: ${_hermes_missing_csv:-unknown}" >&2
   fi
   exit 1
 fi

--- a/tests/test_run_tests_sh_venv_probe.py
+++ b/tests/test_run_tests_sh_venv_probe.py
@@ -1,0 +1,97 @@
+"""Regression tests for scripts/run_tests.sh virtualenv probing."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REQUIRED_TEST_IMPORTS = {"pytest", "croniter", "psutil", "pytest_asyncio"}
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _make_fake_python(venv_dir: Path, modules: set[str]) -> Path:
+    bin_dir = venv_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "activate").write_text("# fake activate\n", encoding="utf-8")
+    (bin_dir / "modules.txt").write_text("\n".join(sorted(modules)), encoding="utf-8")
+    python_bin = bin_dir / "python"
+    _write_executable(
+        python_bin,
+        textwrap.dedent(
+            f"""
+            #!{sys.executable}
+            from __future__ import annotations
+
+            import sys
+            from pathlib import Path
+
+            modules = set((Path(__file__).with_name("modules.txt")).read_text().splitlines())
+            args = sys.argv[1:]
+            if args and args[0] == "-":
+                sys.stdin.read()
+                for module_name in args[1:]:
+                    if module_name not in modules:
+                        print(module_name)
+                raise SystemExit(0)
+            if args[:2] == ["-m", "compileall"]:
+                raise SystemExit(0)
+            if args and args[0].endswith("run_tests_parallel.py"):
+                print(f"SELECTED:{{Path(__file__).as_posix()}}")
+                raise SystemExit(0)
+            raise SystemExit(f"unexpected fake-python args: {{args!r}}")
+            """
+        ).lstrip(),
+    )
+    return python_bin
+
+
+def test_run_tests_sh_skips_drifted_venv_and_reports_missing_imports(
+    tmp_path: Path,
+) -> None:
+    """A pytest-only venv must not launch the suite with missing deps."""
+    repo_root = Path(__file__).resolve().parents[1]
+    test_repo = tmp_path / "repo"
+    scripts_dir = test_repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    run_tests = scripts_dir / "run_tests.sh"
+    run_tests.write_text(
+        (repo_root / "scripts" / "run_tests.sh").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    _make_fake_python(test_repo / ".venv", {"pytest"})
+    selected_python = _make_fake_python(test_repo / "venv", REQUIRED_TEST_IMPORTS)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "git", "#!/usr/bin/env sh\nexit 0\n")
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    proc = subprocess.run(
+        ["bash", str(run_tests), "tests/cron/test_due_stale_cron_edit.py"],
+        cwd=test_repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stdout
+    assert "skipping venv missing test imports:" in proc.stdout
+    assert (
+        f"{test_repo / '.venv'}(missing:croniter,psutil,pytest_asyncio)" in proc.stdout
+    )
+    assert f"SELECTED:{selected_python.as_posix()}" in proc.stdout


### PR DESCRIPTION
## Summary

`scripts/run_tests.sh` previously selected the first venv that could import only `pytest`, allowing drifted environments to run the suite while missing core/dev dependencies such as `croniter`, `psutil`, or `pytest_asyncio`. This changes the venv probe to require the imports the suite needs for honest failures and prints the exact missing modules for skipped candidates.

---

## Changes

### `scripts/run_tests.sh`
- Adds a shared required-import probe for local venvs and `HERMES_PYTHON`.
- Skips incomplete venvs before launching the suite.
- Reports exact missing imports for skipped candidates.

### `tests/test_run_tests_sh_venv_probe.py`
- Adds one subprocess regression test with fake venv Python shims.
- Covers the drifted `.venv` case and confirms a complete `venv` is selected instead.

---

## How to Test

```bash
python -m pytest tests/test_run_tests_sh_venv_probe.py tests/test_run_tests_parallel.py tests/test_run_tests_parallel_stdio.py -q
```

```text
13 passed, 1 skipped in 82.63s
```

Note: the canonical wrapper was also attempted on Termux:

```bash
bash scripts/run_tests.sh tests/test_run_tests_sh_venv_probe.py -q
```

It is blocked in this environment by `PermissionError(13, 'Permission denied')` before the test file runs, which matches the known Termux runner limitation; the targeted pytest coverage above passed.

---

## Checklist

- [x] Tests pass — 13/13 targeted tests passed, 1 skipped
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded `~/.hermes`
- [x] `.env` not used for non-credential settings (behavioral settings → config.yaml)

---

## Risk & Impact

Low. This only changes test-runner interpreter selection so incomplete venvs fail earlier with clearer diagnostics instead of producing misleading suite failures.

Type: Bug fix
Closes: #98774
