### PR TITLE
fix(cli): escape the single-query label so query-file markup can't crash startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22105,7 +22105,12 @@ def main(
                 # invocations are fast.
                 _query_label = query or ("[image attached]" if single_query_images else "")
                 if _query_label:
-                    cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+                    # The label derives from -q/--query-file text (the Bot
+                    # Mode DM transport), so it must render literally —
+                    # unescaped it is parsed as Rich markup and something
+                    # like a pytest id ``test_case[/a/b.webp]`` raises
+                    # MarkupError before the agent turn starts (#98789).
+                    cli.console.print(f"[bold blue]Query:[/] {_escape(_query_label)}")
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()

--- a/tests/cli/test_single_query_label_markup.py
+++ b/tests/cli/test_single_query_label_markup.py
@@ -1,0 +1,99 @@
+"""Single-query label must render literally, not as Rich markup (#98789).
+
+``-q`` / ``--query-file`` text is user-controlled (the Bot Mode DM transport
+feeds arbitrary handoff prose through it). The human single-query branch
+prints it as ``[bold blue]Query:[/] {_query_label}`` via ``Console.print``,
+which parses the string as Rich markup — an unmatched closing tag such as a
+pytest id ``test_case[/fb-images/a/../b.webp?w=336]`` raised
+``rich.errors.MarkupError`` before the agent turn even started.
+
+These tests drive ``cli.main()`` through the same FakeCLI harness as
+``test_single_query_session_finalize.py`` but give the fake console a *real*
+``rich.console.Console`` so the markup parser actually runs.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+import cli as cli_mod
+
+# The exact reproduction token from the issue: Rich sees ``[/fb-images/...]``
+# as an unmatched closing tag.
+_MARKUP_BREAKING_QUERY = "test_case[/fb-images/a/../b.webp?w=336]"
+
+
+@pytest.fixture
+def fake_cli_factory():
+    calls = []
+    stdout = io.StringIO()
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = Console(
+                file=stdout, width=80, no_color=True, highlight=False
+            )
+            self.session_id = "single-query-session"
+            self.agent = SimpleNamespace(
+                session_id="single-query-session",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _show_security_advisories(self):
+            calls.append("advisories")
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query, images))
+            return "done"
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append("summary")
+
+    return calls, stdout, FakeCLI
+
+
+def _run_single_query(monkeypatch, fake_cli_factory, query):
+    calls, stdout, fake_cls = fake_cli_factory
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cls)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    cli_mod.main(query=query, quiet=False, toolsets="terminal")
+
+    assert calls == [
+        ("claim", "cli", False),
+        "advisories",
+        ("chat", query, None),
+        "summary",
+        ("finalize", "single-query-session"),
+    ]
+    return stdout.getvalue()
+
+
+def test_single_query_label_with_unmatched_closing_tag_reaches_chat(
+    monkeypatch, fake_cli_factory
+):
+    # Before the fix this raises MarkupError inside Console.print, so the
+    # agent turn never starts; after it the run completes and the label is
+    # rendered literally.
+    output = _run_single_query(monkeypatch, fake_cli_factory, _MARKUP_BREAKING_QUERY)
+
+    assert _MARKUP_BREAKING_QUERY in output
+
+
+def test_single_query_label_plain_text_still_renders(monkeypatch, fake_cli_factory):
+    output = _run_single_query(monkeypatch, fake_cli_factory, "plain query")
+
+    assert "Query: plain query" in output


### PR DESCRIPTION
## What does this PR do?

The human single-query branch (`hermes chat -q` / `--query-file`) prints the query label via `Console.print` with markup enabled:

```python
cli.console.print(f"[bold blue]Query:[/] {_query_label}")
```

`_query_label` derives entirely from user-controlled text (the `--query-file` transport is what Bot Mode DM uses for handoffs). When that text contains something Rich parses as an unmatched closing tag — e.g. a pytest-style id `test_case[/fb-images/a/../b.webp?w=336]` — `Console.print` raises `rich.errors.MarkupError` and the CLI exits with status 1 **before the agent turn starts**, so a valid autonomous handoff can fail purely on incidental prose (test ids, Markdown, regexes, array syntax).

This PR wraps the label with `rich.markup.escape` (already imported in `cli.py` as `_escape` and used for other user-controlled strings, e.g. the input echo at cli.py:7784), so arbitrary query text renders literally while the `[bold blue]Query:[/]` prefix keeps its styling.

## Related Issue

Fixes #98789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — escape `_query_label` with `_escape` before the single-query `Console.print`, plus a comment pinning why the label must render literally (#98789)
- `tests/cli/test_single_query_label_markup.py` — new regression tests (see below)

## How to Test

1. On main, create a query file containing `test_case[/fb-images/a/../b.webp?w=336]` and run `hermes chat --query-file /tmp/query.md --max-turns 5` — Observed result: exits 1 with `rich.errors.MarkupError: closing tag '[/fb-images/a/../b.webp?w=336]' ... doesn't match any open tag` before any agent turn.
2. With this PR, the same invocation starts normally and renders the label literally — should pass.
3. `python -m pytest tests/cli/test_single_query_label_markup.py tests/cli/test_single_query_session_finalize.py tests/test_cli_quiet_stdout_leak.py -v` — Observed result: 15 passed. The new breaking-token test was verified red on unpatched main (MarkupError) and green with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression test output on this branch:

```
tests/cli/test_single_query_label_markup.py::test_single_query_label_with_unmatched_closing_tag_reaches_chat PASSED
tests/cli/test_single_query_label_markup.py::test_single_query_label_plain_text_still_renders PASSED
======================== 7 passed, 6 warnings in 0.40s
```