### PR TITLE
docs: correct WebSocket framing, TUI event list, and webhook replay guidance

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -407,9 +407,10 @@ def _serialize_payload(
     """Render the POST body.  Same top-level shape as shell hooks' stdin
     (documented in :mod:`agent.shell_hooks`), plus delivery metadata.
 
-    ``delivery_id`` is shared with the ``X-Hermes-Delivery`` header so
-    receivers can dedupe on either — and since it (plus ``timestamp``)
-    lives inside the HMAC-signed body, it doubles as replay protection.
+    When signed, ``delivery_id`` and ``timestamp`` give receivers
+    authenticated inputs for deduplication and freshness checks. Receivers
+    must enforce both and must compare the unsigned event and delivery
+    headers with their signed body values.
     """
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
     try:

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -108,7 +108,7 @@ export class JsonRpcGatewayClient {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
   private heartbeatSequence = 0
   private lastInboundAt = 0
-  /** Last observed event seq per session_id — drives lossless reconnect replay. */
+  /** Last observed event seq per session_id — drives bounded best-effort reconnect replay. */
   private lastSeenSeq = new Map<string, number>()
   /** Set while a post-reconnect replay fetch is in flight (dedup guard). */
   private replayInFlight = false

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -4,7 +4,9 @@ Every gateway event frame that flows through :func:`server.write_json` (and
 therefore ``_emit``) is stamped with a per-session monotonic ``seq`` and
 appended to a small ring buffer keyed by session id. A reconnecting client
 calls the ``session.events.since`` RPC with its last observed seq; the server
-replays everything newer from the buffer, then live events resume seamlessly.
+returns newer events that remain in the bounded buffer, then live delivery
+continues. Clients must reconcile authoritative history when the ring is
+truncated, absent, or otherwise cannot prove a complete gap recovery.
 
 Design constraints honored:
 - stdio TUI path unaffected: frames gain a ``seq`` field only on event frames;

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2490,8 +2490,8 @@ def write_json(obj: dict) -> bool:
 
     Every routed event frame is stamped with a per-session monotonic
     ``seq`` and recorded in the bounded replay ring (tui_gateway.event_replay)
-    so a WS client can resume losslessly after a reconnect via
-    ``session.events.since``.
+    so a WS client can request best-effort recovery of retained events after a
+    reconnect via ``session.events.since``.
     """
     if obj.get("method") == "event":
         params = obj.get("params")

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -7,9 +7,10 @@ web client over WebSocket.
 
 Wire protocol
 -------------
-Identical to stdio: newline-delimited JSON-RPC in both directions. The server
-emits a ``gateway.ready`` event immediately after connection accept, then
-echoes responses/events for inbound requests. No framing differences.
+The JSON-RPC schema matches stdio, but framing differs: each WebSocket text
+message carries one JSON-RPC object, while stdio uses newline-delimited JSON.
+The server emits a ``gateway.ready`` event immediately after connection
+accept, then sends responses/events as individual text messages.
 
 Mounting
 --------

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -1,10 +1,10 @@
 /**
  * Browser WebSocket client for the tui_gateway JSON-RPC protocol.
  *
- * Speaks the exact same newline-delimited JSON-RPC dialect that the Ink TUI
- * drives over stdio. The server-side transport abstraction
- * (tui_gateway/transport.py + ws.py) routes the same dispatcher's writes
- * onto either stdout or a WebSocket depending on how the client connected.
+ * Speaks the same JSON-RPC schema that the Ink TUI drives over stdio, with
+ * transport-specific framing: each WebSocket text message carries one object,
+ * while stdio is newline-delimited. The server transport abstraction routes
+ * the same dispatcher's writes onto the appropriate connection.
  *
  *   const gw = new GatewayClient()
  *   await gw.connect()

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -38,6 +38,8 @@ hermes acp --setup          # interactive provider/model setup for ACP terminal 
 
 `tui_gateway/server.py` is the protocol the Ink TUI (`hermes --tui`) and the embedded dashboard PTY bridge talk to. Any external host can speak the same protocol over stdio (or WebSocket via `tui_gateway/ws.py`).
 
+Stdio uses newline-delimited JSON. Each WebSocket text message instead carries one complete JSON-RPC object; do not split or join WebSocket messages on newlines.
+
 ### Method catalog (selected)
 
 ```
@@ -74,7 +76,7 @@ On a successful truncating submit against a durable session, the `prompt.submit`
 
 ### Events streamed back
 
-`message.delta`, `message.complete`, `tool.start`, `tool.progress`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.
+`message.delta`, `message.complete`, `tool.start`, `tool.generating`, `tool.output_risk`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. The separate REST/SSE API emits `tool.progress` and `hermes.tool.progress`; the current Python TUI gateway instead emits `tool.generating` and `tool.output_risk` and has no `tool.progress` producer. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.
 
 ### Pi-style RPC mapping
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1891,6 +1891,13 @@ Each firing POSTs a JSON body with the same top-level shape as shell hooks' stdi
 }
 ```
 
+For `pre_approval_request`, the ordinary gateway approval path places its
+approval context under `extra`, but does not include the approval queue's
+`request_id`. Treat that webhook as a notification: reconnect and reattach or
+resume the relevant session (using `extra.session_key` when necessary), call
+`approval.pending` for the authoritative pending record and `request_id`, and
+only then call `approval.respond`.
+
 Headers:
 
 | Header | Value |
@@ -1910,9 +1917,10 @@ def verify(body: bytes, header: str, secret: str) -> bool:
     return hmac.compare_digest(expected, header)
 ```
 
-Because `delivery_id` and `timestamp` live **inside the signed body**, a verified receiver also gets replay protection for free:
+Because `delivery_id` and `timestamp` live **inside the signed body**, a verified receiver has authenticated inputs with which to implement replay protection. Replay protection is not automatic; the receiver must:
 
-- **Dedupe** on `delivery_id` (or the matching `X-Hermes-Delivery` header) — remember recently seen ids and skip duplicates. Hermes retries failed deliveries once, so the same id can legitimately arrive twice.
+- **Match the headers to the signed body** — require `X-Hermes-Event` to equal the authenticated body's `hook_event_name` and `X-Hermes-Delivery` to equal its `delivery_id`; the HMAC covers the body, not the headers.
+- **Dedupe** on the signed body's `delivery_id` — remember recently seen ids and skip duplicates. Hermes retries failed deliveries once, so the same id can legitimately arrive twice.
 - **Reject stale events** by checking `timestamp` against your clock with a tolerance window (5 minutes is the common default). An attacker replaying a captured request can't forge a fresh timestamp without the secret.
 
 ### Delivery semantics


### PR DESCRIPTION
## What does this PR do?

Five documentation and comment corrections found while building
[Ipsima](https://github.com/Phasmotic/Ipsima), an unfinished native iOS and watchOS client for
Hermes, against the `tui_gateway` protocol (tracking issue #35966). The client is not shipping and
development has stopped, but the protocol work is what turned these up.

Every change is a comment, docstring, or `website/docs` edit — **no behavioural change, no API
change, no test change.** Each correction cites the source that establishes it, so it can be
checked without trusting this description. Verified against `4f22543509d1b91dc45bcb369447126c5eb14fb7`, the base of this branch; every
line reference below is relative to it.

**1. WebSocket framing is described as newline-delimited; it is not.**
`tui_gateway/ws.py:10-12` states the wire protocol is "Identical to stdio: newline-delimited
JSON-RPC in both directions... No framing differences", and `web/src/lib/gatewayClient.ts:4-7`
repeats it. In fact each WebSocket text message carries exactly one JSON-RPC object
(`tui_gateway/ws.py:141-145,236-260,420-443`); newline framing is the stdio path only
(`tui_gateway/entry.py:486-502`). A client that follows the comments gets no warning and two
failure modes: framing inbound by delimiter — buffering until a newline, the standard NDJSON
reader idiom — stalls forever, because the server appends no terminator
(`tui_gateway/ws.py:145,247,260`); and joining outbound requests with newlines into a single text
message returns `-32700`, because the server calls `json.loads` on the whole message
(`tui_gateway/ws.py:435-443`). The JSON-RPC *schema* is shared; the *framing* is not.

**2. The documented TUI event list names an event the TUI gateway never emits.**
`website/docs/developer-guide/programmatic-integration.md:75-77` lists `tool.progress` among
events streamed back. There is no `tool.progress` producer anywhere in `tui_gateway/`. The gateway
emits `tool.generating` (`tui_gateway/server.py:8106`) and `tool.output_risk`
(`tui_gateway/server.py:7878`), both conditional. The name is not fictional — the separate REST/SSE
API does emit `tool.progress` (`gateway/platforms/api_server.py:4826-4830,4961`) and
`hermes.tool.progress` (`gateway/platforms/api_server.py:5213,5449,5455`) — so the list appears to
have crossed the two surfaces. The patch corrects the list and states the distinction explicitly
rather than deleting the name. Consumers that accept `tool.progress` for compatibility are left
untouched — including `ui-tui/README.md:285`, which tables it with a `{ name, preview }` payload as
the Ink client's accept-list.

**3. Webhook docs promise replay protection that receivers must actually implement.**
`website/docs/user-guide/features/hooks.md:1913-1916` says that because `delivery_id` and
`timestamp` are inside the signed body, "a verified receiver also gets replay protection for free."
The HMAC covers the body only (`agent/outbound_webhooks.py:404-455`); there is no sender-side
freshness, nonce store, or replay rejection. A receiver gets *authenticated inputs* with which to
implement replay protection, which is not the same thing — and the surrounding text offers the
unsigned, attacker-controllable `X-Hermes-Delivery` header as an equivalent dedupe key. This is the
one correction with a security consequence, so the replacement prose is worth seeing without
opening the diff:

> **Before —** Because `delivery_id` and `timestamp` live **inside the signed body**, a verified
> receiver also gets replay protection for free:
>
> **After —** Because `delivery_id` and `timestamp` live **inside the signed body**, a verified
> receiver has authenticated inputs with which to implement replay protection. Replay protection
> is not automatic; the receiver must:
>
> - **Match the headers to the signed body** — require `X-Hermes-Event` to equal the authenticated
>   body's `hook_event_name` and `X-Hermes-Delivery` to equal its `delivery_id`; the HMAC covers
>   the body, not the headers.

**4. The `pre_approval_request` webhook lacks the field a responder needs.**
The ordinary gateway approval path puts approval context under `extra` but omits the approval
queue's `request_id` (`tools/approval.py:4606-4616`; `tui_gateway/methods_prompt.py:1659-1668`). A
consumer cannot answer *that* approval from the webhook payload alone: with no `request_id`,
`approval.respond` resolves the session's oldest pending approval
(`tools/approval.py:2865-2895`), which is the right one only when exactly one is queued. The patch
documents treating the webhook as a notification and calling `approval.pending` for the
authoritative record first.

**5. "Lossless" and "seamless" replay wording overstates a bounded ring.**
Comments in `apps/shared/src/json-rpc-gateway.ts:111`, `tui_gateway/event_replay.py:3-8`, and
`tui_gateway/server.py:2489-2495` describe reconnect replay as lossless or seamless. The ring is
bounded at 512 events per session across at most 64 remembered sessions, with FIFO session
eviction, and is reset by restart (`tui_gateway/event_replay.py:33-75`). `replay_epoch` correctly
identifies a process generation, but does not recover evicted or pre-restart events, and an unknown
or evicted ring is indistinguishable from a session that never emitted one. The patch qualifies the
wording as bounded best-effort recovery.

## Related Issue

No existing issue — these were found while building against the gateway. Happy to open one first
if you would prefer that order.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

Comments and docstrings:

- `tui_gateway/ws.py` — corrects the "Wire protocol" header's framing claim
- `web/src/lib/gatewayClient.ts` — same correction on the browser client
- `tui_gateway/event_replay.py`, `tui_gateway/server.py`, `apps/shared/src/json-rpc-gateway.ts` —
  qualify "lossless"/"seamless" replay as bounded best-effort
- `agent/outbound_webhooks.py` — corrects the `_serialize_payload` docstring's replay-protection
  claim

Documentation:

- `website/docs/developer-guide/programmatic-integration.md` — adds one framing sentence; corrects
  the streamed-events list
- `website/docs/user-guide/features/hooks.md` — corrects the replay-protection guidance; adds the
  `pre_approval_request` reconciliation caveat

8 files, +31/−17, no executable line changed.

## How to Test

1. The branch is based on current `main` (`4f22543`) and needs no rebase.
2. Spot-check any citation above against your own tree; each names a file and line range.
3. `grep -rn "tool\.progress" tui_gateway/` returns nothing, which is correction 2 in one command.
4. Nothing to run: no executable line changes, so behaviour and tests are untouched.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [ ] commit messages follow Conventional Commits
- [ ] searched existing PRs for duplicates
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] `pytest tests/ -q` passes
- [x] N/A — tests: no executable line is changed, so there is no behaviour to cover
- [ ] platform tested

### Documentation & Housekeeping

- [x] This PR *is* the documentation update
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] N/A — comment and prose only, no cross-platform surface
- [x] N/A — no tool behaviour, description, or schema changed

## Notes

The protocol surface was derived programmatically from Hermes source at a pinned commit, then
re-derived and re-verified against the SHA above — a commit on `main` as of 2026-08-30 — before
this was prepared; claims that had gone stale in between were dropped rather than filed. Two
findings were withdrawn as our own errors rather than upstream defects. The full claim-by-claim
record, including everything dropped, is in
[`HEAD-REVERIFICATION.md`](https://github.com/Phasmotic/Ipsima/blob/main/contributions/nous-research/HEAD-REVERIFICATION.md).

These corrections were prepared with AI assistance and reviewed against source line by line. Happy
to split this up — correction 3 stands alone if you would rather land the security wording first —
or to adjust any wording to house style. If you would rather treat correction 4 as a missing field
than a documented caveat, say so and I will drop that hunk and file it as an issue instead.

I am not developing the client further, but I will answer review comments on this PR, and I am
happy to keep going on any of it if it is useful to you. The client was paused on a judgement
about where the effort was best spent, not on losing interest — so if you would want the derived
protocol catalog and its generator upstream, a native Apple-platform client against
`tui_gateway`, or simply more corrections of this kind as we find them, say so and I will pick it
back up. `contributions/nous-research/catalog-offer.md` in the linked repository describes the
catalog and, more usefully, what adopting it would actually cost you.
