### PR TITLE
toolchain-self-improve: skip destructive node_modules install when symlinked to a shared tree

### DIFF
--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -190,6 +190,27 @@ def _script_runner(package_manager: str | None, entry: str) -> str:
     return f"npm run {entry}"
 
 
+def _shared_node_modules_target(root: Path) -> Path | None:
+    """Return the resolved target when ``root/node_modules`` is a symlink
+    pointing OUTSIDE ``root`` (e.g. a git-worktree checkout sharing an
+    install with its primary tree, ``ln -s ../primary/node_modules``),
+    else ``None``. Distinguishes the common worktree-sharing pattern from
+    an in-place directory, which is safe to reinstall into.
+    """
+    link = root / "node_modules"
+    try:
+        if not link.is_symlink():
+            return None
+        target = link.resolve()
+    except OSError:
+        return None
+    try:
+        target.relative_to(root.resolve())
+    except ValueError:
+        return target
+    return None
+
+
 def _detect_node_recipe(root: Path, pkg: dict[str, Any]) -> Recipe:
     raw_scripts = pkg.get("scripts")
     scripts: dict[str, str] = raw_scripts if isinstance(raw_scripts, dict) else {}
@@ -222,6 +243,9 @@ def _detect_node_recipe(root: Path, pkg: dict[str, Any]) -> Recipe:
         "npm": "npm install",
     }.get(package_manager or "npm", "npm install")
 
+    shared_target = _shared_node_modules_target(root)
+    bootstrap = [] if shared_target else [install]
+
     start_script = "dev" if scripts.get("dev") else ("start" if scripts.get("start") else None)
     start_body = scripts.get(start_script) if start_script else None
     start = _script_runner(package_manager, start_script) if start_script else None
@@ -237,7 +261,7 @@ def _detect_node_recipe(root: Path, pkg: dict[str, Any]) -> Recipe:
     return Recipe(
         name=label,
         kind=kind,
-        bootstrap=[install],
+        bootstrap=bootstrap,
         build=build,
         test=test,
         start=start,
@@ -247,6 +271,13 @@ def _detect_node_recipe(root: Path, pkg: dict[str, Any]) -> Recipe:
                 "Detected package.json",
                 f"Package manager: {package_manager}" if package_manager else None,
                 f"Scripts: {', '.join(scripts) or '(none)'}",
+                (
+                    f"node_modules is a symlink to {shared_target} (outside this "
+                    "project root, e.g. a shared git-worktree install) — skipped "
+                    f"'{install}' to avoid mutating the shared install"
+                )
+                if shared_target
+                else None,
             ]
         ),
     )

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -1,6 +1,7 @@
 """Tests for agent/verify/recipes.py — static run-recipe detection."""
 
 import json
+import sys
 
 import pytest
 
@@ -105,6 +106,43 @@ class TestNodeDetection:
         (tmp_path / "go.mod").write_text("module x\n", encoding="utf-8")
         recipe = detect_recipe(tmp_path)
         assert recipe.kind == "go"
+
+    def test_symlinked_node_modules_outside_root_skips_install(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("Symlinks require elevated privileges on Windows")
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        (primary / "node_modules").mkdir()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "node_modules").symlink_to(primary / "node_modules")
+        write_pkg(worktree, {"scripts": {"build": "tsc", "test": "jest"}})
+        (worktree / "yarn.lock").touch()
+        recipe = detect_recipe(worktree)
+        assert recipe.bootstrap == []
+        assert any("symlink" in e and "skipped" in e for e in recipe.evidence)
+        # build/test are unaffected — only the destructive install is skipped
+        assert recipe.build == ["yarn build"]
+        assert recipe.test == ["yarn test"]
+
+    def test_in_place_node_modules_directory_still_installs(self, tmp_path):
+        (tmp_path / "node_modules").mkdir()
+        write_pkg(tmp_path, {"scripts": {"test": "jest"}})
+        recipe = detect_recipe(tmp_path)
+        assert recipe.bootstrap == ["npm install"]
+
+    def test_symlinked_node_modules_inside_root_still_installs(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("Symlinks require elevated privileges on Windows")
+        # A symlink that resolves back inside the project root (e.g. a
+        # relocated cache dir within the same tree) is not the
+        # worktree-sharing hazard — must not be treated as shared.
+        real_dir = tmp_path / "_node_modules_real"
+        real_dir.mkdir()
+        (tmp_path / "node_modules").symlink_to(real_dir)
+        write_pkg(tmp_path, {"scripts": {"test": "jest"}})
+        recipe = detect_recipe(tmp_path)
+        assert recipe.bootstrap == ["npm install"]
 
 
 class TestPythonDetection:


### PR DESCRIPTION
## Friction
While reviewing Kibana PR #284701 in a git worktree (session `20260830_172113_39888b`), `hermes verify --detect-only --save` wrote a manifest recommending `yarn install` against that worktree's `node_modules` — which is a symlink to `~/Projects/kibana/node_modules` (the primary checkout, on a *different* branch, shared with every sibling worktree). Running that saved manifest via bare `hermes verify` would install into the shared tree from the wrong branch context. The agent caught it in-session and refused to overwrite the manifest without consent, but the underlying detector still emits the destructive recipe for anyone who doesn't catch it.

## Proven gap
`agent/verify/recipes.py::detect_recipe` (and its Node/Python/etc. sub-detectors) had zero references to `node_modules` before this change — confirmed via `grep -n "node_modules" agent/verify/recipes.py agent/verify/environment.py agent/verify/runner.py hermes_cli/verify_cmd.py` (no match). Reproduced directly:

```python
# worktree/node_modules -> primary/node_modules (symlink, outside root)
recipe = detect_recipe(worktree)
recipe.bootstrap  # ['yarn install']  <- destructive if run
```

This is a genuine capability gap in the tool (`hermes verify` lacks worktree-shared-install awareness), not a documentation/discoverability issue — no existing flag or manifest field suppresses bootstrap for this case.

## Change
`agent/verify/recipes.py`:
- New `_shared_node_modules_target(root)`: returns the resolved target when `root/node_modules` is a symlink pointing *outside* `root`, else `None`.
- `_detect_node_recipe` skips the `<mgr> install` bootstrap command when this is true, and records why in `recipe.evidence`. `build`/`test`/`start` are untouched — only the destructive install is suppressed.
- In-place `node_modules` directories, and symlinks that resolve back *inside* the project root, still install normally (no behavior change for the common case).

`tests/verify/test_recipes.py`: 3 new tests in `TestNodeDetection` (symlink-outside skips install + evidence note, in-place directory still installs, symlink-inside-root still installs). Windows-skip-guarded per repo convention (`sys.platform == "win32"`).

## Gate output
```
$ python3 -m pytest tests/verify/ -q -o "addopts="
........................................................................ [ 92%]
......                                                                   [100%]
78 passed in 6.18s
```
(38 in `test_recipes.py`, including the 3 new; full `tests/verify/` suite unaffected.)

## Scope
One capability, one file's detection logic + its tests. No dispatcher/registry changes needed — this is a pure detection-layer fix, not a new tool surface.

Source session: `20260830_172113_39888b` (Kibana PR #284701 review — see `session_search` for the `.hermes/environment.json` protected-write blocker that surfaced this).

Draft only — autonomy ceiling per `toolchain-self-improve`: opened by the `toolchain-self-improve-pilot` cron, human review/merge required.
