### PR TITLE
test: warm up before timing the idle-charge invariant

### DIFF
--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -457,10 +457,14 @@ class TestF6ExecutorSaturation:
 
 
 class TestS3IdleChargedFromLastProgress:
-    def test_silence_cannot_approach_double_idle_timeout(self):
-        """Progress early in an interval must not extend silence to ~2x idle."""
-        _drain_admission_slots()
-        idle = 0.4
+    @staticmethod
+    def _run_stall_to_fallback(idle: float):
+        """Drive one silent-stall attempt; return ``(prompt, elapsed)``.
+
+        ``elapsed`` spans worker dispatch to host return, so it covers the
+        thread-pool spawn and the post-timeout stall-fallback attempt as well
+        as the idle wait itself.
+        """
         release = threading.Event()
 
         def worker(fence: CompressionCommitFence):
@@ -471,7 +475,7 @@ class TestS3IdleChargedFromLastProgress:
 
         t0 = time.monotonic()
         try:
-            msgs, prompt = run_compress_context_with_progress_timeout(
+            _msgs, prompt = run_compress_context_with_progress_timeout(
                 worker=worker,
                 messages=[{"role": "user", "content": "a"}],
                 system_prompt_fallback="fb",
@@ -481,6 +485,27 @@ class TestS3IdleChargedFromLastProgress:
         finally:
             elapsed = time.monotonic() - t0
             release.set()
+        return prompt, elapsed
+
+    def test_silence_cannot_approach_double_idle_timeout(self):
+        """Progress early in an interval must not extend silence to ~2x idle."""
+        _drain_admission_slots()
+        idle = 0.4
+
+        # Warm up first, and time the SECOND attempt. The first call in a
+        # process pays one-off costs that land inside the measured window but
+        # are not what this test asserts: spawning the compress-timeout pool
+        # thread before the worker's first touch_progress, and the
+        # stall-fallback path's own first-use imports. Measured here, cold
+        # ~0.97s vs warm ~0.45s against a 0.72s budget — so a fresh pytest
+        # process failed deterministically while the same test passed once
+        # anything else had warmed the pool. The assertion below is about
+        # WHERE the idle budget is charged from, not about import speed.
+        warm_prompt, _warm_elapsed = self._run_stall_to_fallback(idle)
+        assert warm_prompt == "fb"
+        _drain_admission_slots()
+
+        prompt, elapsed = self._run_stall_to_fallback(idle)
         assert prompt == "fb"
         # Old behavior waited a full interval from the CHECK (~2x idle ≈
         # 0.85s+). New behavior times out ~idle after the last progress


### PR DESCRIPTION
## What does this PR do?

`tests/agent/test_compression_review_76354.py::TestS3IdleChargedFromLastProgress::test_silence_cannot_approach_double_idle_timeout` fails **deterministically** when it is the first thing to touch the compress-timeout path in a process. On this host it fails 3/3 runs in isolation on unmodified `main`.

I went looking to widen the wall-clock budget and found that would have been the wrong fix. The threshold is fine; the *measurement window* is wrong.

## Root cause

The test asserts `elapsed < idle * 1.8` (0.72s at `idle=0.4`), but `elapsed` is measured from worker dispatch to host return, so it also charges two one-off costs that have nothing to do with the invariant:

- spawning the compress-timeout pool thread before the worker's first `touch_progress`, and
- the post-timeout **stall-fallback** path's own first-use imports.

Both are paid only on the first call in a process. Instrumented:

```
call1: elapsed=0.973s  spawn->progress=0.201s  FAIL (budget 0.720)
call2: elapsed=0.452s  spawn->progress=0.051s  PASS
call3: elapsed=0.452s  spawn->progress=0.051s  PASS
call4..6: 0.452s       spawn->progress=0.050s  PASS
```

Splitting by `stall_fallback` isolates the second cost:

```
stall_fallback=True   run1: elapsed=0.997s   run2: 0.454s   run3: 0.457s
stall_fallback=False  run1: 0.451s           run2: 0.451s   run3: 0.451s
```

**The invariant under test is honoured the whole time.** The post-progress interval is a steady 0.401–0.407s, and the host logs `made no progress for 0.4s (total wait 0.5s, ceiling 5.0s)`. Idle is charged from the last progress event exactly as `wait_slice = min(max(idle - since_progress, 0.005), remaining_ceiling)` intends. Nothing is wrong with `agent/conversation_compression.py`.

So this is order-dependence, not flakiness and not host slowness: a fresh pytest process always measures call #1, while the same test passes once anything else has warmed the pool. That is why it survived in a full-suite run and dies when selected alone.

## Fix

Run one warmup attempt of identical shape, discard it, and time the second. The extracted `_run_stall_to_fallback()` helper keeps both attempts byte-identical so the warmup exercises exactly the paths being warmed.

**The 1.8x budget is unchanged.** I deliberately did not touch the threshold — loosening it would have hidden the real regression this test exists to catch.

## How Has This Been Tested?

| Check | Before | After |
|---|---|---|
| Isolated, 3 consecutive runs | **0/3 pass** (0.89s, 0.95s, 1.05s) | **3/3 pass** |
| Whole file via `scripts/run_tests.sh` | 9/10 | **10/10** |
| Warm-then-timed, 4 timed runs | — | 0.452s / 0.452s / 0.453s / 0.453s vs 0.720s budget (37% headroom) |

**Regression control** — the check that matters, since a warmup could in principle mask the bug instead of the noise. Reverting the production `wait_slice` to charge idle from the CHECK rather than from last progress:

```python
wait_slice = min(idle, remaining_ceiling)   # the pre-fix behaviour
```

still fails the assertion:

```
E  AssertionError: silence exceeded ~2x idle budget shape: 0.80s
E  assert 0.8048289900034433 < (0.4 * 1.8)
```

0.80s is ~2x idle — precisely the shape the test was written to exclude. The guard is intact.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

No existing issue — I searched open and closed issues for this test name and for `double_idle_timeout` and found none. Happy to file one first if you prefer that order.

## Notes

Only the test file changes; no production code is touched. If you would rather remove the timing dependence entirely — injecting a clock, or asserting on the host's `since_progress` bookkeeping instead of wall-clock `elapsed` — I'm glad to rework it that way. The warmup keeps the change minimal and preserves what the test currently proves.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (regression control above)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious part (why the first call is charged differently)
