### PR TITLE
fix(doctor): make the live probes and the .env check tell the truth

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -811,6 +811,56 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
+# --- .env creation -------------------------------------------------------
+# Small seams (monkeypatchable in tests, and single points of control).
+
+def _chmod_owner_only(path) -> None:
+    """Seam: restrict a file to owner read/write."""
+    os.chmod(str(path), 0o600)
+
+
+def _env_file_mode(path):
+    """Seam: the POSIX mode bits actually on disk, or None if unreadable."""
+    import stat as _stat
+
+    try:
+        return _stat.S_IMODE(os.stat(str(path)).st_mode)
+    except OSError:
+        return None
+
+
+def _posix_modes_enforced() -> bool:
+    """Seam: do POSIX mode bits describe file access on this platform?"""
+    return os.name != "nt"
+
+
+def _create_protected_env_file(env_path) -> str:
+    """Create ``.env`` owner-only and report the protection that ACTUALLY applied.
+
+    Returns ``'secured'``, ``'unprotected'`` or ``'unsupported'``.
+
+    ``.env`` holds API keys. ``touch()`` obeys the umask (commonly 0o022),
+    which leaves the file group/world-readable, so it is tightened explicitly
+    — and then verified. A chmod that raises, or that silently does not take,
+    previously still printed a green "Created empty .env": the user was told
+    their key file was in place while it was world-readable. Verify, then
+    claim.
+
+    On Windows POSIX mode bits do not describe access (ACLs do), so the honest
+    answer there is ``'unsupported'`` rather than a pass we cannot justify or
+    a warning that would fire on every run.
+    """
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.touch()
+    try:
+        _chmod_owner_only(env_path)
+    except (OSError, NotImplementedError):
+        pass
+    if not _posix_modes_enforced():
+        return "unsupported"
+    return "secured" if _env_file_mode(env_path) == 0o600 else "unprotected"
+
+
 def _build_apikey_providers_list() -> list:
     """Build the API-key provider health-check list once and cache it.
 
@@ -1163,16 +1213,22 @@ def run_doctor(args):
         else:
             check_fail(f"{_DHH}/.env file missing")
             if should_fix:
-                env_path.parent.mkdir(parents=True, exist_ok=True)
-                env_path.touch()
-                # .env holds API keys — restrict to owner-only access from
-                # creation. touch() obeys umask which is commonly 0o022,
-                # leaving the file world-readable; tighten explicitly.
-                try:
-                    os.chmod(str(env_path), 0o600)
-                except OSError:
-                    pass
-                check_ok(f"Created empty {_DHH}/.env")
+                protection = _create_protected_env_file(env_path)
+                if protection == "secured":
+                    check_ok(f"Created empty {_DHH}/.env", "(mode 0600)")
+                elif protection == "unsupported":
+                    check_ok(f"Created empty {_DHH}/.env")
+                    check_info(
+                        "POSIX permissions are not enforced here — verify the "
+                        "file's ACL restricts it to your account before adding keys")
+                else:
+                    check_warn(
+                        f"Created empty {_DHH}/.env",
+                        "(could NOT restrict to 0600 — it may be readable by "
+                        "other users on this machine)")
+                    issues.append(
+                        f"Restrict {_DHH}/.env to owner-only before storing API "
+                        f"keys (chmod 600)")
                 check_info("Run 'hermes setup' to configure API keys")
                 fixed_count += 1
             else:

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -49,11 +49,37 @@ _LOCAL_AUDIO_PROVIDERS = {"", "local", "edge", "neutts", "kittentts", "piper"}
 
 @dataclass
 class ProbeResult:
-    """Outcome of one backend probe."""
+    """Outcome of one backend probe.
+
+    ``status`` names the stage that failed, not just that something did:
+
+    - ``pass``   the backend answered and the answer was good;
+    - ``warn``   inconclusive but not an outage (unconfigured key, throttled);
+    - ``fail``   the backend answered badly, or did not answer at all;
+    - ``broken`` this check never got a verdict out of the backend — a stale
+      endpoint, a malformed request, or a defect in the probe code. That is
+      news about us, not about the user's backend;
+    - ``skip``   nothing configured, nothing to probe.
+
+    ``fail`` and ``broken`` are kept apart deliberately. A red that fires on a
+    healthy backend is worse than no probe at all: it teaches the reader to
+    skip the whole section, and then a real outage goes unread.
+    """
 
     name: str
-    status: str  # "pass" | "warn" | "fail" | "skip"
+    status: str  # "pass" | "warn" | "fail" | "broken" | "skip"
     detail: str = ""
+
+
+# HTTP codes that mean the request we sent was wrong — the endpoint moved, was
+# retired, or we shaped the call badly. The backend is answering fine; the
+# probe is pointed at the wrong thing.
+_BROKEN_CHECK_CODES = frozenset({400, 404, 405, 410, 422})
+
+# Exception types that mean the probe code is defective rather than the backend
+# being unreachable. A network error is news; an AttributeError is a bug.
+_PROBE_DEFECT_ERRORS = (AttributeError, ImportError, NameError, TypeError,
+                        KeyError, IndexError)
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +178,25 @@ def _probe_mcp_server(name: str, config: dict, timeout: float):
 # ---------------------------------------------------------------------------
 
 def _classify_http(name: str, resp, key_hint: str) -> ProbeResult:
+    """Map an HTTP response to a verdict that names the stage that failed."""
     code = getattr(resp, "status_code", None)
-    if code is not None and 200 <= code < 300:
+    if not isinstance(code, int):
+        return ProbeResult(
+            name, "broken",
+            "(no HTTP response — the probe never reached a verdict)")
+    if 200 <= code < 300:
         return ProbeResult(name, "pass", f"(HTTP {code})")
     if code in (401, 403):
         return ProbeResult(name, "fail",
                            f"(HTTP {code} — check {key_hint})")
+    if code == 429:
+        # Reachable and authenticated, just throttled. Not an outage.
+        return ProbeResult(name, "warn", f"(HTTP {code} — rate limited)")
+    if code in _BROKEN_CHECK_CODES:
+        return ProbeResult(
+            name, "broken",
+            f"(HTTP {code} — this probe's endpoint or request is wrong, "
+            f"not the backend)")
     return ProbeResult(name, "fail", f"(HTTP {code})")
 
 
@@ -244,6 +283,14 @@ def _report(result: ProbeResult, issues: List[str]) -> None:
         check_ok(result.name, result.detail)
     elif result.status == "warn":
         check_warn(result.name, result.detail)
+    elif result.status == "broken":
+        # Surfaced, but never as evidence the backend is down — the remediation
+        # belongs on the probe, and the wording has to say so.
+        check_warn(result.name, result.detail)
+        issues.append(
+            f"Live probe for {result.name} could not reach a verdict "
+            f"{result.detail} — fix the probe or its config; this is not "
+            f"evidence that {result.name} is down")
     elif result.status == "fail":
         check_fail(result.name, result.detail)
         issues.append(f"Live probe failed: {result.name} {result.detail}")
@@ -258,6 +305,11 @@ def _run_one(name: str, fn: Callable[[], ProbeResult],
         result = fn()
     except TimeoutError as exc:
         result = ProbeResult(name, "fail", f"(timed out: {exc})")
+    except _PROBE_DEFECT_ERRORS as exc:
+        # The probe code is wrong; the backend never got a chance to answer.
+        result = ProbeResult(
+            name, "broken",
+            f"(probe defect: {type(exc).__name__}: {exc})")
     except Exception as exc:
         msg = str(exc) or exc.__class__.__name__
         if "time" in msg.lower():

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -34,7 +34,11 @@ DEFAULT_PROBE_TIMEOUT = 10.0
 
 # Metadata-only endpoints. None of these spend generation credits.
 FIRECRAWL_HEALTH_URL = "https://api.firecrawl.dev/v2/team/credit-usage"
-FAL_MODELS_URL = "https://fal.ai/api/models?page=1"
+# api.fal.ai validates the credential; fal.ai/api/models is the public
+# website catalog, which answers 200 to any key (or none) and made this
+# probe pass for an expired or typo'd FAL_KEY. A probe endpoint must
+# reject a bad credential or it is checking nothing.
+FAL_MODELS_URL = "https://api.fal.ai/v1/models"
 OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
 GROQ_MODELS_URL = "https://api.groq.com/openai/v1/models"
 ELEVENLABS_VOICES_URL = "https://api.elevenlabs.io/v1/voices"

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -148,6 +148,12 @@ _OPENVIKING_IDENTITY_LEGACY = "legacy"
 _OPENVIKING_IDENTITY_UNHEALTHY = "unhealthy"
 _OPENVIKING_IDENTITY_LEGACY_UNVERIFIED = "legacy-unverified"
 _OPENVIKING_IDENTITY_INVALID = "invalid"
+# Health verdicts. "unknown" exists so a probe that could not run is never
+# reported as a server that is down — see _VikingClient.health_status.
+_HEALTH_HEALTHY = "healthy"
+_HEALTH_UNHEALTHY = "unhealthy"
+_HEALTH_UNKNOWN = "unknown"
+
 _OPENVIKING_IDENTIFIED_STATES = frozenset({
     _OPENVIKING_IDENTITY_MODERN,
     _OPENVIKING_IDENTITY_LEGACY,
@@ -437,12 +443,36 @@ class _VikingClient:
             raise RuntimeError("OpenViking temp upload did not return temp_file_id")
         return temp_file_id
 
-    def health(self) -> bool:
+    def health_status(self) -> str:
+        """``'healthy'`` | ``'unhealthy'`` | ``'unknown'``.
+
+        ``'unknown'`` means this client never reached a verdict — the server
+        was not asked, or the probe raised before it could interpret an
+        answer. That is distinct from ``'unhealthy'``, which is the server
+        telling us something. Collapsing the two (as the bare
+        ``except Exception: return False`` below used to, without so much as a
+        log line) reports a defect in this client as the user's memory backend
+        being down — the one thing a health check must never do silently.
+        """
         try:
             identity, _health = _probe_openviking_identity(self)
-            return identity in _OPENVIKING_IDENTIFIED_STATES
         except Exception:
-            return False
+            logger.debug(
+                "OpenViking health probe did not reach a verdict", exc_info=True
+            )
+            return _HEALTH_UNKNOWN
+        if identity in _OPENVIKING_IDENTIFIED_STATES:
+            return _HEALTH_HEALTHY
+        return _HEALTH_UNHEALTHY
+
+    def health(self) -> bool:
+        """Boolean health for gating callers.
+
+        ``'unknown'`` is conservatively False: we will not claim a backend is
+        usable on the strength of a probe that failed to run. Callers needing
+        the distinction should use :meth:`health_status`.
+        """
+        return self.health_status() == _HEALTH_HEALTHY
 
     def _anonymous_json(self, path: str) -> dict:
         """Probe server identity without disclosing credentials or tenant IDs."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1471,3 +1471,58 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestEnvFileProtection:
+    """``doctor --fix`` creates ``.env``, which holds API keys.
+
+    ``Path.touch()`` obeys the umask (commonly 0o022), leaving the file
+    group/world-readable. The chmod that tightens it used to be wrapped in a
+    bare ``except OSError: pass`` followed unconditionally by a green check —
+    so on any filesystem where chmod fails or silently no-ops (NFS, some
+    mounts, a restrictive container) the doctor reported the key file as
+    created while it was in fact world-readable. A check must report the
+    protection that actually applied, not the one it attempted.
+    """
+
+    def test_reports_secured_when_chmod_applies(self, tmp_path):
+        env_path = tmp_path / ".env"
+        assert doctor._create_protected_env_file(env_path) == "secured"
+        assert env_path.exists()
+        assert (env_path.stat().st_mode & 0o777) == 0o600
+
+    def test_reports_unprotected_when_mode_did_not_take(
+            self, tmp_path, monkeypatch):
+        """The dangerous case: chmod appears to succeed but the bits are wrong."""
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(doctor, "_env_file_mode", lambda p: 0o644)
+        assert doctor._create_protected_env_file(env_path) == "unprotected"
+        assert env_path.exists(), "the file is still created; only the claim changes"
+
+    def test_reports_unprotected_when_mode_unreadable(
+            self, tmp_path, monkeypatch):
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(doctor, "_env_file_mode", lambda p: None)
+        assert doctor._create_protected_env_file(env_path) == "unprotected"
+
+    def test_windows_reports_unsupported_not_a_false_alarm(
+            self, tmp_path, monkeypatch):
+        """POSIX mode bits do not describe access on Windows.
+
+        Reporting 'unprotected' there would be its own false negative — the
+        opposite failure, and just as untrustworthy."""
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(doctor, "_posix_modes_enforced", lambda: False)
+        assert doctor._create_protected_env_file(env_path) == "unsupported"
+
+    def test_chmod_oserror_does_not_propagate(self, tmp_path, monkeypatch):
+        """A filesystem that refuses chmod must downgrade the claim, not crash."""
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(doctor, "_chmod_owner_only",
+                            lambda p: (_ for _ in ()).throw(OSError("nope")))
+        assert doctor._create_protected_env_file(env_path) == "unprotected"
+
+    def test_creates_parent_directory(self, tmp_path):
+        env_path = tmp_path / "nested" / "dir" / ".env"
+        doctor._create_protected_env_file(env_path)
+        assert env_path.exists()

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -366,3 +366,80 @@ class TestProbeEndpointsAuthenticate:
         results = {r.name: r for r in run_live_checks(issues)}
         assert results["FAL"].status == "fail"
         assert any("FAL" in i for i in issues)
+
+
+class TestBrokenCheckIsDistinctFromFailedBackend:
+    """A probe must say which stage failed.
+
+    'fail' means the backend answered and the answer was bad. 'broken' means
+    the probe never got a verdict out of the backend — a stale endpoint, a
+    malformed request, or a defect in the probe code itself. Collapsing the
+    second into the first reports our own bug as the user's outage, and a red
+    that fires on a healthy backend teaches the reader to ignore the section.
+    """
+
+    def _probe(self, status_code, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setattr(
+            doctor_live, "_http_get",
+            lambda *a, **k: SimpleNamespace(status_code=status_code))
+        return {r.name: r for r in run_live_checks([])}["Firecrawl"]
+
+    @pytest.mark.parametrize("code", [200, 204])
+    def test_success_passes(self, code, monkeypatch):
+        assert self._probe(code, monkeypatch).status == "pass"
+
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_rejected_credential_is_a_real_failure(self, code, monkeypatch):
+        assert self._probe(code, monkeypatch).status == "fail"
+
+    @pytest.mark.parametrize("code", [500, 502, 503])
+    def test_server_error_is_a_real_failure(self, code, monkeypatch):
+        assert self._probe(code, monkeypatch).status == "fail"
+
+    @pytest.mark.parametrize("code", [400, 404, 405, 410, 422])
+    def test_endpoint_or_request_wrong_is_a_broken_check(self, code, monkeypatch):
+        """A stale probe URL is our defect, not the backend's."""
+        assert self._probe(code, monkeypatch).status == "broken"
+
+    def test_rate_limited_is_a_warning_not_an_outage(self, monkeypatch):
+        """429 means reachable and authenticated, just throttled."""
+        assert self._probe(429, monkeypatch).status == "warn"
+
+    def test_no_response_object_is_a_broken_check(self, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setattr(doctor_live, "_http_get", lambda *a, **k: object())
+        results = {r.name: r for r in run_live_checks([])}
+        assert results["Firecrawl"].status == "broken"
+
+    def test_probe_code_defect_is_broken_not_failed(self, monkeypatch):
+        """An AttributeError in the probe is a bug in us."""
+        def _boom(*a, **k):
+            raise AttributeError("'NoneType' object has no attribute 'get'")
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setattr(doctor_live, "_http_get", _boom)
+        results = {r.name: r for r in run_live_checks([])}
+        assert results["Firecrawl"].status == "broken"
+
+    def test_timeout_remains_a_real_failure(self, monkeypatch):
+        """The backend genuinely did not answer — that is news about it."""
+        def _slow(*a, **k):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setattr(doctor_live, "_http_get", _slow)
+        results = {r.name: r for r in run_live_checks([])}
+        assert results["Firecrawl"].status == "fail"
+
+    def test_broken_check_issue_blames_the_probe_not_the_backend(self, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setattr(
+            doctor_live, "_http_get",
+            lambda *a, **k: SimpleNamespace(status_code=404))
+        issues: list = []
+        run_live_checks(issues)
+        blamed = [i for i in issues if "Firecrawl" in i]
+        assert blamed, "a broken probe must still be surfaced"
+        assert not any("Live probe failed" in i for i in blamed), (
+            "a broken check must not be reported as a failed backend")

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -314,3 +314,55 @@ class TestReadOnly:
         issues: list[str] = []
         run_live_checks(issues)
         assert issues == []
+
+
+class TestProbeEndpointsAuthenticate:
+    """A live probe must fail on a bad credential, or it is not a probe.
+
+    ``fal.ai/api/models`` is the public website's model catalog: it answers
+    200 to an unauthenticated request and ignores the ``Authorization`` header
+    entirely, so the FAL probe reported ``pass`` for *any* non-empty
+    ``FAL_KEY`` — an expired or typo'd key included. The credential was never
+    checked. Mocked tests cannot catch that (they stub ``_http_get``), so this
+    pins the one property that is checkable offline: every probe URL must be
+    an authenticated API host rather than a public marketing domain.
+
+    To re-verify against the real services (no quota spent, metadata GET only)::
+
+        curl -s -o /dev/null -w '%{http_code}' \\
+             -H 'Authorization: Bearer bogus-key' <url>
+
+    A correct probe endpoint answers 401/403 there. 200 means it authenticates
+    nothing and the probe is decorative.
+    """
+
+    PROBE_URLS = (
+        doctor_live.FIRECRAWL_HEALTH_URL,
+        doctor_live.FAL_MODELS_URL,
+        doctor_live.OPENAI_MODELS_URL,
+        doctor_live.GROQ_MODELS_URL,
+        doctor_live.ELEVENLABS_VOICES_URL,
+    )
+
+    @pytest.mark.parametrize("url", PROBE_URLS)
+    def test_probe_url_is_an_api_host(self, url):
+        from urllib.parse import urlparse
+
+        host = urlparse(url).hostname or ""
+        assert host.split(".")[0] in {"api", "rest"}, (
+            f"{host} is not an API host — a public site can answer 200 to any "
+            f"credential, which makes the probe a false green")
+
+    def test_fal_probe_targets_authenticated_api(self):
+        assert doctor_live.FAL_MODELS_URL.startswith("https://api.fal.ai/")
+
+    def test_fal_invalid_key_fails_and_appends_issue(self, monkeypatch):
+        """Mirror of the Firecrawl case: a rejected key must surface as fail."""
+        monkeypatch.setenv("FAL_KEY", "bad-key")
+        monkeypatch.setattr(
+            doctor_live, "_http_get",
+            lambda *a, **k: SimpleNamespace(status_code=401))
+        issues: list = []
+        results = {r.name: r for r in run_live_checks(issues)}
+        assert results["FAL"].status == "fail"
+        assert any("FAL" in i for i in issues)

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1775,3 +1775,65 @@ class TestOpenVikingEnvWriter:
         assert env.read_text(encoding="utf-8").splitlines() == [
             "A=1", "OPENAI_API_KEY=new", "B=2",
         ]
+
+
+class TestHealthStatusNamesTheStage:
+    """``health()`` is a bool, so it cannot distinguish "the server is
+    unhealthy" from "this client could not tell". The old body swallowed every
+    exception into ``return False`` with no log line, so a defect in the probe
+    (an AttributeError, a missing import) was reported as the user's memory
+    backend being down, silently and indistinguishably.
+
+    ``health()`` keeps its boolean contract for existing callers; the stage is
+    available via ``health_status()`` and the swallowed path now logs.
+    """
+
+    def _client(self):
+        return _VikingClient("http://localhost:1", "key")
+
+    def test_healthy_server(self, monkeypatch):
+        client = self._client()
+        monkeypatch.setattr(
+            openviking_module, "_probe_openviking_identity",
+            lambda c: (openviking_module._OPENVIKING_IDENTITY_MODERN, {}))
+        assert client.health_status() == "healthy"
+        assert client.health() is True
+
+    def test_server_answers_but_is_not_openviking(self, monkeypatch):
+        client = self._client()
+        monkeypatch.setattr(
+            openviking_module, "_probe_openviking_identity",
+            lambda c: (openviking_module._OPENVIKING_IDENTITY_INVALID, {}))
+        assert client.health_status() == "unhealthy"
+        assert client.health() is False
+
+    def test_probe_that_cannot_reach_a_verdict_is_unknown(self, monkeypatch):
+        client = self._client()
+
+        def _boom(c):
+            raise AttributeError("'NoneType' object has no attribute 'get'")
+
+        monkeypatch.setattr(
+            openviking_module, "_probe_openviking_identity", _boom)
+        assert client.health_status() == "unknown"
+
+    def test_unknown_is_still_false_for_boolean_callers(self, monkeypatch):
+        """Backward compatible: callers gating on health() must not change."""
+        client = self._client()
+        monkeypatch.setattr(
+            openviking_module, "_probe_openviking_identity",
+            lambda c: (_ for _ in ()).throw(RuntimeError("connection refused")))
+        assert client.health() is False
+
+    def test_swallowed_failure_is_logged_not_silent(self, monkeypatch, caplog):
+        """The silence was the defect — a probe bug left no trace at all."""
+        import logging
+
+        client = self._client()
+        monkeypatch.setattr(
+            openviking_module, "_probe_openviking_identity",
+            lambda c: (_ for _ in ()).throw(AttributeError("probe bug")))
+        with caplog.at_level(logging.DEBUG, logger=openviking_module.__name__):
+            client.health_status()
+        assert any("health" in r.message.lower() for r in caplog.records), (
+            "a probe that could not reach a verdict must leave a trace")


### PR DESCRIPTION
Four fixes to checks that reported a verdict they had not earned. Each was found by asking one question of an existing check: *can this distinguish "the thing is broken" from "I am broken"?*

## 1. `doctor --live` passed FAL with any key, validating nothing

`FAL_MODELS_URL` pointed at `fal.ai/api/models` — the public website's model catalog. It answers 200 to an unauthenticated request and ignores the `Authorization` header, so the probe reported `pass` for **any** non-empty `FAL_KEY`, expired or typo'd included.

Verified against the live services (metadata GET, no quota spent):

```
fal.ai/api/models?page=1   bogus key -> 200   (old)
api.fal.ai/v1/models       bogus key -> 401   (new)
```

The other four probe endpoints (Firecrawl, OpenAI, Groq, ElevenLabs) were checked the same way and all correctly reject a bad credential.

The existing test could not catch this — it monkeypatches `_http_get`, so it exercises the wiring, not the endpoint. Added a class-level guard that every probe URL is on an API host rather than a public marketing domain, which covers probes added later too. The re-verification `curl` is in the test docstring, since the property that actually matters ("a bad credential must fail") is only checkable against the live service.

## 2. `doctor --fix` reported `.env` created when it was left world-readable

`.env` holds API keys. `Path.touch()` obeys the umask (commonly 0o022), so it lands group/world-readable. The chmod that tightened it was wrapped in `except OSError: pass`, followed unconditionally by a green `check_ok`. On any filesystem where chmod fails or silently no-ops (NFS, some container mounts), the doctor told the user their key file was in place while every other account could read it.

`_create_protected_env_file()` now verifies the mode that actually landed:

| result | condition | output |
|---|---|---|
| `secured` | chmod took, mode is 0600 | green check, `(mode 0600)` |
| `unprotected` | chmod raised or did not take | **warn** + remediation issue |
| `unsupported` | Windows — ACLs, not POSIX bits | green check + explicit note |

Windows is deliberately its own state: reporting `unprotected` there would fire on every run and be its own false alarm.

Permission checks go through small module-local seams (`_chmod_owner_only`, `_env_file_mode`, `_posix_modes_enforced`), matching the seam idiom `doctor_live` already documents, so tests never monkeypatch the global `os` module.

## 3. `doctor --live` reported a broken probe as a failed backend

`_classify_http` mapped every non-2xx to `fail`; `_run_one` mapped every exception to `fail`. A stale endpoint (404), a malformed request (400/422), a missing import, or an `AttributeError` inside a probe all printed red against the user's backend and appended "Live probe failed: X".

This is the mechanism that hid #1: with no way to say *"this check is pointed at the wrong thing"*, a wrong endpoint can only render as a sick backend.

New `broken` status, distinct from `fail`:

- **`fail`** — the backend answered badly (401/403, 5xx) or did not answer (timeout)
- **`broken`** — no verdict was reached: 400/404/405/410/422, no response object, or a probe-code defect (`AttributeError`, `ImportError`, `NameError`, `TypeError`, `KeyError`, `IndexError`)
- **`warn`** — 429: reachable and authenticated, just throttled

A `broken` probe is still surfaced, but its remediation line names the probe and says it is not evidence the backend is down. Timeouts and connection errors stay `fail` on purpose — those are genuine news, and guessing that an unreachable host means a typo in our own constant would trade one wrong verdict for another.

## 4. `openviking.health()` reported probe defects as a dead server, silently

```python
except Exception:
    return False
```

A bool cannot distinguish "the server is unhealthy" from "I could not tell", and the bare swallow left no log line, so an `AttributeError` inside the probe surfaced as the user's memory backend being unavailable with nothing anywhere to say otherwise. Three call sites gate on this.

Adds `health_status() -> 'healthy' | 'unhealthy' | 'unknown'` and logs the swallowed path at debug with `exc_info` — the pattern `_probe_openviking_identity` already uses for its own inner swallow. `health()` keeps its boolean contract, with `unknown` conservatively False, so no gating caller changes behaviour.

## Testing

`scripts/run_tests.sh tests/hermes_cli/ tests/plugins/memory/` — **6,558 passed, 10 failed, 84 skipped** across 681 files.

All 10 failures are pre-existing on unmodified `main` (verified by stashing this branch and re-running the same files): `test_kanban_review_surfaces`, `test_service_manager`, `test_user_providers_model_switch` ×2, `test_hindsight_provider` ×6. None are in files this PR touches.

The four directly affected files are green: 50/50 `test_doctor_live.py`, 60/60 `test_doctor.py`, 65/65 `test_openviking_provider.py`.

Each fix was written test-first; the new tests fail on `main` for the right reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG7ani1iZ6c7hPBujNN57k