### PR TITLE
fix(mcp): create stdio child watcher once

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -110,8 +110,15 @@ def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):
         mcp_tool, "srv-midcall", _hanging_call, children_dead=lambda: False
     )
 
-    async def _watch_children():
-        return  # children die immediately → watcher resolves first
+    watcher_calls = {"n": 0}
+
+    def _watch_children():
+        watcher_calls["n"] += 1
+
+        async def _wait():
+            return  # children die immediately → watcher resolves first
+
+        return _wait()
 
     server._watch_stdio_children = _watch_children
     mcp_tool._ensure_mcp_loop()
@@ -122,5 +129,6 @@ def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):
         assert "error" in parsed, parsed
         assert "exited mid-call" in parsed["error"], parsed
         assert server._reconnect_event.set_calls == 1
+        assert watcher_calls["n"] == 1
     finally:
         _cleanup(mcp_tool, "srv-midcall")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6184,11 +6184,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
-                    _watch_ok = (
-                        _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
-                        and asyncio.iscoroutine(_call_coro)
+                    _watch_awaitable = (
+                        _watch_children()
+                        if _watch_children is not None and asyncio.iscoroutine(_call_coro)
+                        else None
                     )
+                    _watch_ok = inspect.isawaitable(_watch_awaitable)
                     if not _watch_ok:
                         # Stubbed sessions (MagicMock in tests) return a
                         # non-awaitable, or there is no child-watcher to race
@@ -6205,7 +6206,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # the call immediately instead of riding out the full
                         # tool timeout.
                         rpc_task = asyncio.ensure_future(_call_coro)
-                        watch_task = asyncio.ensure_future(_watch_children())
+                        watch_task = asyncio.ensure_future(_watch_awaitable)
                         try:
                             done, _pending = await asyncio.wait(
                                 {rpc_task, watch_task},


### PR DESCRIPTION
## Problem

The stdio fast-fail path calls `_watch_stdio_children()` once while checking awaitability and again when scheduling the watcher. The first coroutine is discarded without being awaited, which can emit a RuntimeWarning during MCP tool calls.

## Fix

Create the watcher awaitable once, validate it, and schedule that same object. The regression test now asserts that watcher construction occurs exactly once.

## Verification

- `tests/tools/test_mcp_stdio_fastfail_reconnect.py`: 2 passed
- `tests/tools/test_mcp_stdio_children_dead.py`: 8 passed
- `tests/tools/test_mcp_circuit_breaker.py`: 7 passed
- Total: 17 passed, 0 failed

The canonical Bash wrapper recognized the shared Windows venv but could not resolve the Windows worktree gitfile and script path through WSL, so the same repository per-file runner (`scripts/run_tests_parallel.py`) was invoked directly with that venv.