### PR TITLE
feat(cli,tui): add display.bell_on_clarify + display.bell_on_approval — terminal bell on clarify/approval prompts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1732,6 +1732,12 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Play terminal bell when the agent asks a clarification question.
+  # Same mechanism as bell_on_complete (\\a) — works over SSH.
+  #   true:  Ring on every clarify prompt
+  #   false: Silent (default)
+  bell_on_clarify: false
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1738,6 +1738,12 @@ display:
   #   false: Silent (default)
   bell_on_clarify: false
 
+  # Play terminal bell when a dangerous-command approval prompt opens.
+  # Same mechanism as bell_on_complete (\\a) — works over SSH.
+  #   true:  Ring on every approval prompt
+  #   false: Silent (default)
+  bell_on_approval: false
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -5257,6 +5257,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # bell_on_clarify: play terminal bell (\a) when agent asks a clarify question — same mechanism as bell_on_complete
+        self.bell_on_clarify = CLI_CONFIG["display"].get("bell_on_clarify", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -16208,6 +16210,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._clarify_freetext = is_open_ended
         self._clarify_multi_base = None
 
+        # Bell on clarify (same mechanism as bell_on_complete — \\a over SSH)
+        if getattr(self, "bell_on_clarify", False):
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         # Trigger an immediate prompt_toolkit repaint from this (non-main)
         # thread. Modal prompts must paint at once and must not be gated by the
         # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
@@ -16399,6 +16409,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._clarify_state = state
         self._clarify_batch_set_active(state, 0)
         self._clarify_deadline = None if timeout <= 0 else _time.monotonic() + timeout
+        if getattr(self, "bell_on_clarify", False):
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
         self._paint_now()
 
         _last_countdown_refresh = _time.monotonic()

--- a/cli.py
+++ b/cli.py
@@ -5259,6 +5259,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # bell_on_clarify: play terminal bell (\a) when agent asks a clarify question — same mechanism as bell_on_complete
         self.bell_on_clarify = CLI_CONFIG["display"].get("bell_on_clarify", False)
+        # bell_on_approval: play terminal bell (\a) when a dangerous-command approval prompt opens — same mechanism as bell_on_complete
+        self.bell_on_approval = CLI_CONFIG["display"].get("bell_on_approval", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -16533,6 +16535,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+
+            # Bell on approval (same mechanism as bell_on_complete — \a over SSH)
+            if getattr(self, "bell_on_approval", False):
+                try:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+                except Exception:
+                    pass
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1465,6 +1465,7 @@ DEFAULT_CONFIG = {
         "tui_agents_nudge": True,
         "bell_on_complete": False,
         "bell_on_clarify": False,
+        "bell_on_approval": False,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1464,6 +1464,7 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        "bell_on_clarify": False,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -420,7 +420,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
   const { rpc } = ctx.gateway
   const { STARTUP_RESUME_ID, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
-  const { bellOnClarify, bellOnComplete, stdout, sys } = ctx.system
+  const { bellOnApproval, bellOnClarify, bellOnComplete, stdout, sys } = ctx.system
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
   const { submitLiteralRef, submitRef } = ctx.submission
@@ -1250,6 +1250,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
               }
         })
         setStatus('waiting for input…')
+
         // Same BEL mechanism as bell_on_complete — works over SSH, triggers tmux bell-action
         if (bellOnClarify && stdout?.isTTY) {
           stdout.write('\x07')
@@ -1273,6 +1274,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           }
         })
         setStatus('approval needed')
+
+        // Same BEL mechanism as bell_on_complete — works over SSH, triggers tmux bell-action
+        if (bellOnApproval && stdout?.isTTY) {
+          stdout.write('\x07')
+        }
 
         return
       }

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -420,7 +420,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
   const { rpc } = ctx.gateway
   const { STARTUP_RESUME_ID, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
-  const { bellOnComplete, stdout, sys } = ctx.system
+  const { bellOnClarify, bellOnComplete, stdout, sys } = ctx.system
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
   const { submitLiteralRef, submitRef } = ctx.submission
@@ -1250,6 +1250,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
               }
         })
         setStatus('waiting for input…')
+        // Same BEL mechanism as bell_on_complete — works over SSH, triggers tmux bell-action
+        if (bellOnClarify && stdout?.isTTY) {
+          stdout.write('\x07')
+        }
 
         return
       }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -499,6 +499,7 @@ export interface GatewayEventHandlerContext {
   system: {
     bellOnComplete: boolean
     bellOnClarify?: boolean
+    bellOnApproval?: boolean
     stdout?: NodeJS.WriteStream
     sys: (text: string) => void
   }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -498,6 +498,7 @@ export interface GatewayEventHandlerContext {
   }
   system: {
     bellOnComplete: boolean
+    bellOnClarify?: boolean
     stdout?: NodeJS.WriteStream
     sys: (text: string) => void
   }

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -254,10 +254,11 @@ export async function hydrateFullConfig(
   gw: GatewayClient,
   setBell: (v: boolean) => void,
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
-  setBellOnClarify?: (v: boolean) => void
+  setBellOnClarify?: (v: boolean) => void,
+  setBellOnApproval?: (v: boolean) => void
 ): Promise<ConfigFullResponse | null> {
   const cfg = await quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' })
-  applyDisplay(cfg, setBell, setVoiceRecordKey, setBellOnClarify)
+  applyDisplay(cfg, setBell, setVoiceRecordKey, setBellOnClarify, setBellOnApproval)
 
   return cfg
 }
@@ -266,13 +267,21 @@ export const applyDisplay = (
   cfg: ConfigFullResponse | null,
   setBell: (v: boolean) => void,
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
-  setBellOnClarify?: (v: boolean) => void
+  setBellOnClarify?: (v: boolean) => void,
+  setBellOnApproval?: (v: boolean) => void
 ) => {
   const d = cfg?.config?.display ?? {}
   const approvals = cfg?.config?.approvals
 
   setBell(!!d.bell_on_complete)
-  if (setBellOnClarify) setBellOnClarify(!!d.bell_on_clarify)
+
+  if (setBellOnClarify) {
+    setBellOnClarify(!!d.bell_on_clarify)
+  }
+
+  if (setBellOnApproval) {
+    setBellOnApproval(!!d.bell_on_approval)
+  }
 
   applyConfiguredTuiTheme(d.tui_theme)
 
@@ -318,6 +327,7 @@ export function useConfigSync({
   gw,
   setBellOnComplete,
   setBellOnClarify,
+  setBellOnApproval,
   setVoiceEnabled,
   setVoiceRecordKey,
   sid
@@ -343,8 +353,8 @@ export function useConfigSync({
       // mcp_rev) look like an MCP change and fire a needless reload.mcp.
       mcpRevRef.current.accepted = String(r?.mcp_rev ?? '')
     })
-    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify)
-  }, [gw, setBellOnComplete, setBellOnClarify, setVoiceEnabled, setVoiceRecordKey, sid])
+    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify, setBellOnApproval)
+  }, [gw, setBellOnComplete, setBellOnClarify, setBellOnApproval, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
     if (!sid) {
@@ -391,18 +401,19 @@ export function useConfigSync({
           )
         }
 
-        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify)
+        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify, setBellOnApproval)
       })
     }, MTIME_POLL_MS)
 
     return () => clearInterval(id)
-  }, [gw, setBellOnComplete, setBellOnClarify, setVoiceRecordKey, sid])
+  }, [gw, setBellOnComplete, setBellOnClarify, setBellOnApproval, setVoiceRecordKey, sid])
 }
 
 export interface UseConfigSyncOptions {
   gw: GatewayClient
   setBellOnComplete: (v: boolean) => void
   setBellOnClarify?: (v: boolean) => void
+  setBellOnApproval?: (v: boolean) => void
   setVoiceEnabled: (v: boolean) => void
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
   sid: null | string

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -253,10 +253,11 @@ const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number =
 export async function hydrateFullConfig(
   gw: GatewayClient,
   setBell: (v: boolean) => void,
-  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
+  setBellOnClarify?: (v: boolean) => void
 ): Promise<ConfigFullResponse | null> {
   const cfg = await quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' })
-  applyDisplay(cfg, setBell, setVoiceRecordKey)
+  applyDisplay(cfg, setBell, setVoiceRecordKey, setBellOnClarify)
 
   return cfg
 }
@@ -264,12 +265,14 @@ export async function hydrateFullConfig(
 export const applyDisplay = (
   cfg: ConfigFullResponse | null,
   setBell: (v: boolean) => void,
-  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
+  setBellOnClarify?: (v: boolean) => void
 ) => {
   const d = cfg?.config?.display ?? {}
   const approvals = cfg?.config?.approvals
 
   setBell(!!d.bell_on_complete)
+  if (setBellOnClarify) setBellOnClarify(!!d.bell_on_clarify)
 
   applyConfiguredTuiTheme(d.tui_theme)
 
@@ -314,6 +317,7 @@ export const applyDisplay = (
 export function useConfigSync({
   gw,
   setBellOnComplete,
+  setBellOnClarify,
   setVoiceEnabled,
   setVoiceRecordKey,
   sid
@@ -339,8 +343,8 @@ export function useConfigSync({
       // mcp_rev) look like an MCP change and fire a needless reload.mcp.
       mcpRevRef.current.accepted = String(r?.mcp_rev ?? '')
     })
-    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
-  }, [gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid])
+    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify)
+  }, [gw, setBellOnComplete, setBellOnClarify, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
     if (!sid) {
@@ -387,17 +391,18 @@ export function useConfigSync({
           )
         }
 
-        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
+        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setBellOnClarify)
       })
     }, MTIME_POLL_MS)
 
     return () => clearInterval(id)
-  }, [gw, setBellOnComplete, setVoiceRecordKey, sid])
+  }, [gw, setBellOnComplete, setBellOnClarify, setVoiceRecordKey, sid])
 }
 
 export interface UseConfigSyncOptions {
   gw: GatewayClient
   setBellOnComplete: (v: boolean) => void
+  setBellOnClarify?: (v: boolean) => void
   setVoiceEnabled: (v: boolean) => void
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
   sid: null | string

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -208,6 +208,7 @@ export function useMainApp(gw: GatewayClient) {
   const goodVibesTick = useStore($goodVibesTick)
   const [bellOnComplete, setBellOnComplete] = useState(false)
   const [bellOnClarify, setBellOnClarify] = useState(false)
+  const [bellOnApproval, setBellOnApproval] = useState(false)
 
   const ui = useStore($uiState)
   const overlay = useStore($overlayState)
@@ -579,7 +580,7 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [ui.busy, turnStartedAt])
 
-  useConfigSync({ gw, setBellOnComplete, setBellOnClarify, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
+  useConfigSync({ gw, setBellOnComplete, setBellOnClarify, setBellOnApproval, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
   useBatteryPoll(gw)
 
   useEffect(() => {
@@ -858,7 +859,7 @@ export function useMainApp(gw: GatewayClient) {
           setCatalog
         },
         submission: { submitLiteralRef, submitRef },
-        system: { bellOnComplete, bellOnClarify, stdout, sys },
+        system: { bellOnComplete, bellOnClarify, bellOnApproval, stdout, sys },
         transcript: { appendMessage, panel, setHistoryItems },
         voice: {
           setProcessing: setVoiceProcessing,
@@ -869,6 +870,7 @@ export function useMainApp(gw: GatewayClient) {
       }),
     [
       appendMessage,
+      bellOnApproval,
       bellOnClarify,
       bellOnComplete,
       composerActions.setInput,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -207,6 +207,7 @@ export function useMainApp(gw: GatewayClient) {
   // Bumped by the gateway `reaction` event (core-detected affection).
   const goodVibesTick = useStore($goodVibesTick)
   const [bellOnComplete, setBellOnComplete] = useState(false)
+  const [bellOnClarify, setBellOnClarify] = useState(false)
 
   const ui = useStore($uiState)
   const overlay = useStore($overlayState)
@@ -578,7 +579,7 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [ui.busy, turnStartedAt])
 
-  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
+  useConfigSync({ gw, setBellOnComplete, setBellOnClarify, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
   useBatteryPoll(gw)
 
   useEffect(() => {
@@ -857,7 +858,7 @@ export function useMainApp(gw: GatewayClient) {
           setCatalog
         },
         submission: { submitLiteralRef, submitRef },
-        system: { bellOnComplete, stdout, sys },
+        system: { bellOnComplete, bellOnClarify, stdout, sys },
         transcript: { appendMessage, panel, setHistoryItems },
         voice: {
           setProcessing: setVoiceProcessing,
@@ -868,6 +869,7 @@ export function useMainApp(gw: GatewayClient) {
       }),
     [
       appendMessage,
+      bellOnClarify,
       bellOnComplete,
       composerActions.setInput,
       gateway,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -80,6 +80,7 @@ export interface ConfigDisplayConfig {
   battery?: boolean
   bell_on_complete?: boolean
   bell_on_clarify?: boolean
+  bell_on_approval?: boolean
   busy_input_mode?: string
   details_mode?: string
   /** Focus view (/focus) — display-only reduced-output mode. */

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -79,6 +79,7 @@ export type CommandDispatchResponse =
 export interface ConfigDisplayConfig {
   battery?: boolean
   bell_on_complete?: boolean
+  bell_on_clarify?: boolean
   busy_input_mode?: string
   details_mode?: string
   /** Focus view (/focus) — display-only reduced-output mode. */

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1882,6 +1882,7 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   bell_on_clarify: false  # Play terminal bell when the agent asks a clarification question (same BEL mechanism, works over SSH)
+  bell_on_approval: false # Play terminal bell when a dangerous-command approval prompt opens (same BEL mechanism, works over SSH)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1881,6 +1881,7 @@ display:
   cli_multiline_shortcuts: true  # CLI: Ctrl+J, \ + Enter, and supported Shift+Enter insert newlines (false = legacy c-j submit fallback)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
+  bell_on_clarify: false  # Play terminal bell when the agent asks a clarification question (same BEL mechanism, works over SSH)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar


### PR DESCRIPTION
## Summary
Adds two new display flags — `display.bell_on_clarify` and `display.bell_on_approval` (both default `false`) — that ring the terminal BEL (`\a` / `\x07`) when the agent opens a `clarify` prompt or a dangerous-command approval prompt, using the same mechanism as `display.bell_on_complete`. Works over SSH and triggers tmux `bell-action` / iTerm2 / Windows Terminal audible bell. For long-running tasks where the agent would otherwise time out on `clarify_timeout` / `approvals.timeout` while the user is away.

## What / Why
`bell_on_complete` only fires after a turn finishes. When an agent pauses mid-turn for `clarify` (single or batch `questions` / `clarify.request`) or blocks on a dangerous-command approval (`approval.request`), a user away during a long task misses the modal and the prompt times out ("agent will decide" / command denied). This rings the same bell at modal open so the user can return and answer. Off by default, no behaviour change unless enabled.

## Changes
- `hermes_cli/config_defaults.py`: `display.bell_on_clarify: False`, `display.bell_on_approval: False`
- `cli-config.yaml.example`: both documented alongside `bell_on_complete`
- `website/docs/user-guide/configuration.md`: both flags added
- `cli.py`: `HermesCLI.bell_on_clarify` / `bell_on_approval` init; `sys.stdout.write("\a")` in `_clarify_callback`, `_clarify_callback_batch`, and `_approval_callback` before `_paint_now()` (try/flush, getattr fallback)
- `ui-tui`: `gatewayTypes.ConfigDisplayConfig` + `interfaces.system` plumbing, `useConfigSync.applyDisplay/hydrateFullConfig` + `useMainApp` state, `createGatewayEventHandler` rings `stdout.write('\x07')` on `clarify.request` (when `bellOnClarify && stdout.isTTY`) and on `approval.request` (when `bellOnApproval && stdout.isTTY`)

## How tested
- `python -m py_compile cli.py hermes_cli/config_defaults.py` — ok
- `npm --prefix ui-tui run typecheck` — ok
- `npm --prefix ui-tui run lint` — 0 errors (fixed the `curly` error from the previous push; the CI `JS & TS checks` failure was this repo-committed eslint error, not a logic issue)
- `ui-tui` vitest: 1727/1727 passed
- Manual (CLI): `bell_on_clarify: true` → single + batch `clarify` → BEL audible in Ghostty / over SSH; batch rings once per modal (not per question switch), matching completion bell semantics; default `false` → silent
- Cross-platform: same path as `bell_on_complete` (isTTY guard in TUI, no sounddevice)

## Platforms
CLI (prompt_toolkit, WSL2, macOS), TUI (Ink). No deps, no migration, backward compatible (missing key → `False`).

Refs: complements `display.bell_on_complete`

## Infographic

<img width="1055" height="1491" alt="clarifybell" src="https://github.com/user-attachments/assets/8bd67dc6-d37f-4377-a2dd-825d044d4de2" />