### PR TITLE
feat(buzz): allow flat reply delivery

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,11 +25,12 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+          reply_to_mode: first          # first (default) or off (flat replies)
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS
+    BUZZ_ALLOW_ALL_USERS, BUZZ_REPLY_TO_MODE  # first (default) or off (flat replies)
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
 ``~/.hermes/.env``.  It is passed to the CLI via the subprocess
@@ -344,6 +345,32 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _configured_reply_to_mode(config: Any) -> str:
+    """Resolve the env-overridable reply mode shared by every send path."""
+    env_mode = os.getenv("BUZZ_REPLY_TO_MODE", "").strip()
+    if env_mode:
+        return env_mode.lower()
+    configured = getattr(config, "reply_to_mode", "first")
+    # YAML 1.1 parses bare `off`/`on` as booleans before PlatformConfig sees it.
+    if configured is False:
+        return "off"
+    if configured is True:
+        return "first"
+    return str(configured or "first").strip().lower()
+
+
+def _reply_target(
+    reply_to: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    *,
+    reply_to_mode: str = "first",
+) -> Optional[str]:
+    """Return a reply anchor unless the configured mode requires flat delivery."""
+    if str(reply_to_mode).strip().lower() == "off":
+        return None
+    return reply_to or (metadata or {}).get("thread_id")
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -374,6 +401,7 @@ class BuzzAdapter(BasePlatformAdapter):
         self.channels: List[str] = [c.strip() for c in raw_channels if isinstance(c, str) and c.strip()]
 
         self.home_channel = (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+        self.reply_to_mode = _configured_reply_to_mode(config)
 
         try:
             interval = float(os.getenv("BUZZ_POLL_INTERVAL") or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
@@ -611,7 +639,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = _reply_target(reply_to, metadata, reply_to_mode=self.reply_to_mode)
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -683,8 +711,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = _reply_target(reply_to, metadata, reply_to_mode=self.reply_to_mode)
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1388,8 +1417,9 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
-    if thread_id:
-        args += ["--reply-to", str(thread_id)]
+    reply_target = _reply_target(thread_id, reply_to_mode=_configured_reply_to_mode(pconfig))
+    if reply_target:
+        args += ["--reply-to", str(reply_target)]
     for path in media_files or []:
         args += ["--file", str(path)]
     try:

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -45,6 +45,10 @@ optional_env:
     description: "Allow any community member to talk to the agent (true/false)"
     prompt: "Allow all users? (true/false)"
     password: false
+  - name: BUZZ_REPLY_TO_MODE
+    description: "Reply handling: first (default) preserves reply anchors; off sends flat replies"
+    prompt: "Reply mode (first/off)"
+    password: false
   - name: BUZZ_POLL_INTERVAL
     description: "Seconds between inbound poll sweeps (default: 4)"
     prompt: "Poll interval seconds"

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -42,6 +42,7 @@ _ENV_VARS = (
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
     "BUZZ_ALLOW_ALL_USERS",
+    "BUZZ_REPLY_TO_MODE",
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
@@ -68,10 +69,14 @@ def _event(event_id, pubkey=OTHER_PUBKEY, content="hello", created_at=1000, kind
     }
 
 
-def _make_adapter(extra=None):
+def _make_adapter(extra=None, reply_to_mode="first"):
     from gateway.config import PlatformConfig
 
-    cfg = PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay", **(extra or {})})
+    cfg = PlatformConfig(
+        enabled=True,
+        reply_to_mode=reply_to_mode,
+        extra={"relay_url": "https://test.relay", **(extra or {})},
+    )
     adapter = BuzzAdapter(cfg)
     adapter._self_pubkey = SELF_PUBKEY
     adapter._self_npub = SELF_NPUB
@@ -141,6 +146,32 @@ class TestBuzzAdapterInit:
         from gateway.config import PlatformConfig
         adapter = BuzzAdapter(PlatformConfig(enabled=True, extra={"relay_url": "https://cfg.relay"}))
         assert adapter.relay_url == "https://env.relay"
+
+    def test_bare_yaml_off_boolean_selects_flat_reply_mode(self):
+        """YAML 1.1 parses unquoted `off` as False; preserve its semantic token."""
+        from gateway.config import PlatformConfig
+
+        config = PlatformConfig.from_dict({
+            "enabled": True,
+            "reply_to_mode": False,
+            "extra": {"relay_url": "https://cfg.relay"},
+        })
+        assert BuzzAdapter(config).reply_to_mode == "off"
+
+    def test_loader_normalizes_unquoted_yaml_off(self, monkeypatch, tmp_path):
+        """The full YAML loader preserves the advertised unquoted `off` setting."""
+        from gateway.config import Platform, load_gateway_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n  platforms:\n    buzz:\n      enabled: true\n      reply_to_mode: off\n      extra:\n        relay_url: https://cfg.relay\n",
+            encoding="utf-8",
+        )
+
+        config = load_gateway_config()
+        buzz_config = config.platforms[Platform("buzz")]
+        assert buzz_config.reply_to_mode is False
+        assert BuzzAdapter(buzz_config).reply_to_mode == "off"
 
 
 # ── CLI error contract ────────────────────────────────────────────────────
@@ -407,6 +438,79 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_omits_reply_reference_when_reply_mode_off(self, monkeypatch):
+        """Flat Buzz DMs must not be rendered as reply threads."""
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "off")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "flat reply", reply_to="source-event")
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_send_omits_metadata_thread_reference_when_reply_mode_off(self, monkeypatch):
+        """Flat delivery also suppresses framework-provided thread metadata."""
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "off")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt125", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "flat metadata reply", metadata={"thread_id": "source-event"})
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_send_uses_canonical_reply_mode_config(self):
+        """YAML PlatformConfig reply_to_mode controls Buzz without an env override."""
+        adapter = _make_adapter(reply_to_mode="off")
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "configured flat reply", reply_to="source-event")
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_environment_reply_mode_overrides_canonical_config(self, monkeypatch):
+        """An explicit environment setting wins over config.yaml, like other Buzz settings."""
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "first")
+        adapter = _make_adapter(reply_to_mode="off")
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "env threaded reply", reply_to="source-event")
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "source-event"
+
+    @pytest.mark.asyncio
+    async def test_send_keeps_reply_reference_by_default(self):
+        """Existing threaded delivery remains the default for Buzz replies."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt125", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "threaded reply", reply_to="source-event")
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "source-event"
+
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +524,23 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_local_image_omits_reply_reference_when_reply_mode_off(self, monkeypatch, tmp_path):
+        """Local media sends honor flat reply mode as well as text sends."""
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "off")
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(CHANNEL, str(img), reply_to="source-event")
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" not in args
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -536,5 +657,32 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_omits_thread_when_reply_mode_off(self, monkeypatch, tmp_path):
+        """Cron/standalone sends share the same flat-delivery contract."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            captured["args"] = args
+            return 0, json.dumps({"accepted": True, "event_id": "evt-flat-cron"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}, reply_to_mode="off"),
+            CHANNEL,
+            "cron says hi",
+            thread_id="source-event",
+        )
+
+        assert result == {"success": True, "message_id": "evt-flat-cron"}
+        assert "--reply-to" not in captured["args"]
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -715,6 +715,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `BUZZ_HOME_CHANNEL` | Channel UUID for cron / notification delivery (defaults to the first watched channel) |
 | `BUZZ_ALLOWED_USERS` | Comma-separated npubs or hex pubkeys allowed to talk to the agent |
 | `BUZZ_ALLOW_ALL_USERS` | Allow any community member to talk to the agent (`true`/`false`) |
+| `BUZZ_REPLY_TO_MODE` | Reply handling: `first` (default) preserves reply anchors; `off` sends flat replies |
 | `BUZZ_TRANSPORT` | Inbound transport: `auto` (WebSocket w/ poll fallback, default), `websocket`, or `poll` |
 | `BUZZ_POLL_INTERVAL` | Seconds between inbound poll sweeps (default: `4`) |
 | `BUZZ_AUTH_TAG` | Optional NIP-OA owner-attestation auth tag JSON for NIP-42 WebSocket auth |

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -25,6 +25,7 @@ gateway:
   platforms:
     buzz:
       enabled: true
+      reply_to_mode: first          # default; use reply_to_mode: "off" for flat replies
       extra:
         relay_url: https://mycommunity.communities.buzz.xyz
         channels:                  # channel UUIDs to watch (empty = all joined)
@@ -52,6 +53,7 @@ BUZZ_PRIVATE_KEY=nsec1...
 | `BUZZ_HOME_CHANNEL` | — | Channel UUID for cron / notification delivery (defaults to the first watched channel) |
 | `BUZZ_ALLOWED_USERS` | — | Comma-separated npubs or hex pubkeys allowed to talk to the agent |
 | `BUZZ_ALLOW_ALL_USERS` | — | Allow any community member to talk to the agent |
+| `BUZZ_REPLY_TO_MODE` | — | `first` (default) preserves reply anchors; `off` sends flat replies |
 | `BUZZ_POLL_INTERVAL` | — | Seconds between inbound poll sweeps (default: 4) |
 | `BUZZ_CLI_PATH` | — | Path to the `buzz` binary (default: `buzz` on PATH, then `~/bin/buzz`) |
 | `BUZZ_CREDENTIALS_FILE` | — | JSON credentials file holding the nsec, used when `BUZZ_PRIVATE_KEY` is unset |
@@ -70,6 +72,7 @@ gateway:
   platforms:
     buzz:
       enabled: true
+      reply_to_mode: first                 # first (default) preserves reply anchors; use off for flat replies
       extra:
         relay_url: https://mycommunity.communities.buzz.xyz
         channels:                         # channel UUIDs to watch (empty = all joined)


### PR DESCRIPTION
## Summary
- add `BUZZ_REPLY_TO_MODE=off` to suppress Buzz reply anchors for flat DM delivery
- honor canonical `gateway.platforms.buzz.reply_to_mode` configuration, with the environment variable taking precedence
- apply the same policy to text, local-image, and standalone/cron sends
- document the setting in the plugin manifest and user-facing Buzz references

## Test plan
- `pytest -q tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py`

## Compatibility
Default behavior remains `first`; flat delivery is opt-in via `BUZZ_REPLY_TO_MODE=off` or `reply_to_mode: off`.