### PR TITLE
fix(bluebubbles): preserve reply context for new chats

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -22,6 +22,7 @@ from urllib.parse import quote
 
 import httpx
 
+from gateway import rich_sent_store
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -79,8 +80,6 @@ def _get_scoped_secret(name, default=None):
     except _UnscopedSecretError:
         val = os.getenv(name)
     return val if val is not None else default
-
-from gateway import rich_sent_store
 
 logger = logging.getLogger(__name__)
 
@@ -521,9 +520,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             res = await self._api_post("/api/v1/chat/new", payload)
             data = res.get("data") or {}
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
-            return SendResult(success=True, message_id=str(msg_id), raw_response=res)
+            result = SendResult(success=True, message_id=str(msg_id), raw_response=res)
+            self._record_sent_message(address, message, result)
+            return result
         except Exception as exc:
             return SendResult(success=False, error=str(exc) or type(exc).__name__)
+
+    def _record_sent_message(
+        self, chat_id: str, text: str, result: SendResult
+    ) -> None:
+        message_id = result.message_id
+        if not result.success or not message_id or message_id == "ok":
+            return
+        rich_sent_store.record(chat_id, message_id, text)
+        self._sent_guids[message_id] = None
+        if len(self._sent_guids) > 500:
+            self._sent_guids.popitem(last=False)
 
     # ------------------------------------------------------------------
     # Text sending
@@ -585,11 +597,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 last = SendResult(
                     success=True, message_id=str(msg_id), raw_response=res
                 )
-                if msg_id and msg_id != "ok":
-                    rich_sent_store.record(chat_id, msg_id, chunk)
-                    self._sent_guids[msg_id] = None
-                    if len(self._sent_guids) > 500:
-                        self._sent_guids.popitem(last=False)
+                self._record_sent_message(chat_id, chunk, last)
             except Exception as exc:
                 return SendResult(success=False, error=str(exc) or type(exc).__name__)
         return last

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -80,6 +80,7 @@ def _get_scoped_secret(name, default=None):
         val = os.getenv(name)
     return val if val is not None else default
 
+from gateway import rich_sent_store
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._sent_guids: OrderedDict[str, None] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -583,6 +585,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 last = SendResult(
                     success=True, message_id=str(msg_id), raw_response=res
                 )
+                if msg_id and msg_id != "ok":
+                    rich_sent_store.record(chat_id, msg_id, chunk)
+                    self._sent_guids[msg_id] = None
+                    if len(self._sent_guids) > 500:
+                        self._sent_guids.popitem(last=False)
             except Exception as exc:
                 return SendResult(success=False, error=str(exc) or type(exc).__name__)
         return last
@@ -1049,20 +1056,31 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             user_name=sender,
             chat_id_alt=chat_identifier,
         )
+        message_id = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        reply_to_id = self._value(
+            record.get("threadOriginatorGuid"),
+            record.get("associatedMessageGuid"),
+        )
+        reply_to_text = None
+        reply_to_is_own = False
+        if reply_to_id:
+            reply_to_text = rich_sent_store.lookup(session_chat_id, reply_to_id)
+            reply_to_is_own = reply_to_id in self._sent_guids
+        if text and message_id:
+            rich_sent_store.record(session_chat_id, message_id, text)
         event = MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
-            reply_to_message_id=self._value(
-                record.get("threadOriginatorGuid"),
-                record.get("associatedMessageGuid"),
-            ),
+            message_id=message_id,
+            reply_to_message_id=reply_to_id,
+            reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own,
             media_urls=media_urls,
             media_types=media_types,
         )

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import pytest
 
+from gateway import rich_sent_store
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 
@@ -567,3 +568,148 @@ class TestBlueBubblesTimeoutErrorNormalization:
         assert "500 Internal Server Error" in (result.error or "")
 
 
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._unregister_webhook()
+        )
+        assert ok is False
+
+
+class TestReplyContextResolution:
+    """BlueBubbles webhook carries threadOriginatorGuid but never the quoted
+    text.  rich_sent_store resolves it so run.py can inject the disambiguation
+    prefix."""
+
+    @pytest.mark.asyncio
+    async def test_reply_to_own_earlier_message_resolves_text(self, monkeypatch):
+        """User replies to their own earlier message — text was indexed on the
+        earlier inbound, so the reply resolves it."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-prior",
+                "text": "remind me to buy milk",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "did you?",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-prior",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-prior"
+        assert reply_event.reply_to_text == "remind me to buy milk"
+        assert reply_event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_reply_to_bot_message_marks_own(self, monkeypatch):
+        """User replies to one of the bot's messages — the guid was tracked in
+        _sent_guids on outbound, so reply_to_is_own_message is True."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        rich_sent_store.record("iMessage;-;+15551234567", "msg-bot", "Sure, milk added.")
+        adapter._sent_guids["msg-bot"] = None
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "thanks",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-bot",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-bot"
+        assert reply_event.reply_to_text == "Sure, milk added."
+        assert reply_event.reply_to_is_own_message is True
+
+    @pytest.mark.asyncio
+    async def test_reply_to_unknown_message_id_no_text(self, monkeypatch):
+        """Quoted message we never indexed — id is surfaced, text is None."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-reply",
+                "text": "what about this",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "threadOriginatorGuid": "msg-gone",
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        reply_event = handled[-1]
+        assert reply_event.reply_to_message_id == "msg-gone"
+        assert reply_event.reply_to_text is None
+        assert reply_event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_non_reply_message_has_no_reply_context(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        monkeypatch.setattr(adapter, "handle_message", lambda e: handled.append(e) or asyncio.sleep(0))
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-plain",
+                "text": "hello",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15551234567"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        event = handled[-1]
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_send_records_outbound_text(self, monkeypatch):
+        """send() must index its guid -> text so replies to the bot resolve."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            return {"data": {"guid": "msg-out-1"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("iMessage;-;user@example.com", "here is your answer")
+        assert result.success
+        assert result.message_id == "msg-out-1"
+        assert rich_sent_store.lookup("iMessage;-;user@example.com", "msg-out-1") == "here is your answer"
+        assert "msg-out-1" in adapter._sent_guids

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -567,13 +567,6 @@ class TestBlueBubblesTimeoutErrorNormalization:
         assert not result.success
         assert "500 Internal Server Error" in (result.error or "")
 
-
-        ok = asyncio.get_event_loop().run_until_complete(
-            adapter._unregister_webhook()
-        )
-        assert ok is False
-
-
 class TestReplyContextResolution:
     """BlueBubbles webhook carries threadOriginatorGuid but never the quoted
     text.  rich_sent_store resolves it so run.py can inject the disambiguation
@@ -713,3 +706,25 @@ class TestReplyContextResolution:
         assert result.message_id == "msg-out-1"
         assert rich_sent_store.lookup("iMessage;-;user@example.com", "msg-out-1") == "here is your answer"
         assert "msg-out-1" in adapter._sent_guids
+
+    @pytest.mark.asyncio
+    async def test_send_records_outbound_text_when_creating_chat(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+
+        async def fake_resolve(chat_id):
+            return None
+
+        async def fake_api_post(path, payload):
+            assert path == "/api/v1/chat/new"
+            return {"data": {"guid": "msg-new-chat"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("user@example.com", "first message")
+
+        assert result.success
+        assert result.message_id == "msg-new-chat"
+        assert rich_sent_store.lookup("user@example.com", "msg-new-chat") == "first message"
+        assert "msg-new-chat" in adapter._sent_guids


### PR DESCRIPTION
Follow-up to #53005.

This adds the missing outbound registration path for first messages sent through _create_chat_for_handle (/chat/new), so replies to a bot message in a newly created chat resolve the quoted text just like the normal /message/text path.

The shared registration helper records the message text and sent GUID, while preserving the unknown-parent fallback. Added regression coverage for the new-chat path and reply-context resolution. No Private API changes are involved.

Automated validation:
- 29 BlueBubbles tests passed
- Ruff passed
- Python compilation passed

Functional validation:
- A live BlueBubbles test passed for a normal reply and a self-reply.
- Gateway logs confirmed reply_to_text contained the immediate parent message for both inbound events.