### PR TITLE
test: add tests for hermes_cli/gitlock.py stale lock recovery

### DIFF
--- a/tests/hermes_cli/test_gitlock.py
+++ b/tests/hermes_cli/test_gitlock.py
@@ -1,0 +1,36 @@
+"""Tests for hermes_cli/gitlock.py — stale lock detection and recovery."""
+
+from pathlib import Path
+import tempfile
+from unittest.mock import patch
+
+
+def test_clear_stale_locks_returns_list():
+    from hermes_cli.gitlock import clear_stale_git_locks
+    with tempfile.TemporaryDirectory() as d:
+        result = clear_stale_git_locks(Path(d))
+        assert isinstance(result, list)
+
+
+def test_clear_stale_locks_discovers_shallow_lock():
+    from hermes_cli.gitlock import clear_stale_git_locks
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        shallow = root / ".git" / "shallow.lock"
+        shallow.parent.mkdir(parents=True)
+        shallow.write_text("")
+        with patch("hermes_cli.gitlock._git_proc_running", return_value=False):
+            result = clear_stale_git_locks(root)
+        assert len(result) > 0
+
+
+def test_is_ancestor_of_head_nonexistent_repo():
+    from hermes_cli.gitlock import is_ancestor_of_head
+    with tempfile.TemporaryDirectory() as d:
+        assert is_ancestor_of_head(Path(d), "HEAD") is False
+
+
+def test_is_ancestor_of_head_empty_rev():
+    from hermes_cli.gitlock import is_ancestor_of_head
+    with tempfile.TemporaryDirectory() as d:
+        assert is_ancestor_of_head(Path(d), "") is False

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Tests for hermes_cli/gitlock.py — stale git lock-file detection and recovery helpers.
