### PR TITLE
fix(checkpoint): write project metadata atomically via temp+rename

### DIFF
--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -601,7 +601,20 @@ def _register_project(store: Path, working_dir: str) -> None:
             pass
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        tmp = meta_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(meta), encoding="utf-8")
+        # Best-effort fsync for crash durability; ignore if not supported.
+        try:
+            import os as _os
+
+            _fd = _os.open(str(tmp), _os.O_RDONLY)
+            try:
+                _os.fsync(_fd)
+            finally:
+                _os.close(_fd)
+        except OSError:
+            pass
+        tmp.replace(meta_path)
     except OSError as exc:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 
@@ -630,7 +643,19 @@ def _touch_project(store: Path, working_dir: str) -> None:
     if evidence:
         meta.update(evidence)
     try:
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        tmp = meta_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(meta), encoding="utf-8")
+        try:
+            import os as _os
+
+            _fd = _os.open(str(tmp), _os.O_RDONLY)
+            try:
+                _os.fsync(_fd)
+            finally:
+                _os.close(_fd)
+        except OSError:
+            pass
+        tmp.replace(meta_path)
     except OSError as exc:
         logger.debug("Could not update project metadata %s: %s", meta_path, exc)
 


### PR DESCRIPTION
## Problem
Fixes #98832

`_register_project` and `_touch_project` in `tools/checkpoint_manager.py:587,632` used single `write_text` for `projects/<hash>.json`. A crash or SIGKILL mid-write leaves truncated JSON → orphan detection deletes the ref → `/rollback` history is silently lost. Sibling `_save_ledger:262` already uses temp+rename correctly, so this is an inconsistency.

Who can trigger: any crash during project registration/touch — not attacker-controlled, but data loss is silent.

## Solution
Adopt the same temp+fsync+replace pattern as `_save_ledger`: write to `.json.tmp`, best-effort `fsync`, then atomic `replace`. Applied to both `_register_project` and `_touch_project`. Minimal diff, no new deps, matches existing ledger durability.

Alternative rejected: advisory locks would serialize but not fix crash atomicity; a full SQLite project table would be the next step but is out of scope for this fix.

## Changes
- `tools/checkpoint_manager.py` → `.with_suffix(".json.tmp")` + `fsync` + `replace` in both writers

## Verification
From committed branch `fix/checkpoint-atomic-write` (`6a7b7b8`):

- `python -m pytest tests/tools/test_checkpoint_manager.py -q` → **53 passed** (stash-compare: 53 pass on both `main` and branch — zero new errors)
- Variation 1: normal register → valid JSON, readable
- Variation 2: simulated crash mid-write (mock write_text to half-write + raise OSError) → original file remains intact, valid JSON, not truncated
- Variation 3: 10 rapid touches → final file valid, `last_touch` present

## Environment
macOS arm64, Python 3.14.2, pytest 8.x, branch `Sravanjangam:fix/checkpoint-atomic-write@6a7b7b8`, base `nousresearch:main@4f22543`

Thanks for the review — happy to add an fsync fallback for non-POSIX or fold in a truncated-JSON quarantine read if you prefer.
