### PR TITLE
fix(browser): resolve real profiles from OS home

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -15,7 +15,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
         return None
     system = system or platform.system()
     mac_parts, win_parts, linux_name = _real_profile_relparts(browser)
-    home = os.path.expanduser("~")
+    home = get_real_home()
     if system == "Darwin":
         return posixpath.join(home, "Library", "Application Support", *mac_parts)
     if system == "Windows":

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -4,6 +4,7 @@ These exercise the parsers with real command output shapes instead of
 patching the detectors themselves, so a change in what macOS / xdg report is
 caught here rather than in a user's browser session.
 """
+import posixpath
 from unittest.mock import patch
 
 import pytest
@@ -145,26 +146,43 @@ class TestLinuxProfileDir:
 
     def test_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
-        assert bc.real_profile_data_dir("chromium", "Linux") == str(tmp_path / ".config" / "chromium")
+        assert bc.real_profile_data_dir("chromium", "Linux") == posixpath.join(str(tmp_path), ".config", "chromium")
+
+    def test_profile_home_resolves_browser_from_real_os_home(self, tmp_path, monkeypatch):
+        profile_root = tmp_path / ".hermes" / "profiles" / "work"
+        profile_home = profile_root / "home"
+        real_home = tmp_path / "account"
+        profile_home.mkdir(parents=True)
+        real_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_root))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        expected = posixpath.join(str(real_home), ".config", "BraveSoftware", "Brave-Browser")
+        assert bc.real_profile_data_dir("brave", "Linux") == expected
 
     def test_snap_chromium_profile_is_found(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
         snap = tmp_path / "snap" / "chromium" / "common" / "chromium"
         snap.mkdir(parents=True)
-        assert bc.real_profile_data_dir("chromium", "Linux") == str(snap)
+        expected = posixpath.join(str(tmp_path), "snap", "chromium", "common", "chromium")
+        assert bc.real_profile_data_dir("chromium", "Linux") == expected
 
     def test_flatpak_chrome_profile_is_found(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
         flatpak = tmp_path / ".var" / "app" / "com.google.Chrome" / "config" / "google-chrome"
         flatpak.mkdir(parents=True)
-        assert bc.real_profile_data_dir("chrome", "Linux") == str(flatpak)
+        expected = posixpath.join(str(tmp_path), ".var", "app", "com.google.Chrome", "config", "google-chrome")
+        assert bc.real_profile_data_dir("chrome", "Linux") == expected
 
     def test_native_profile_wins_when_present(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
         native = tmp_path / ".config" / "BraveSoftware" / "Brave-Browser"
         native.mkdir(parents=True)
         (tmp_path / ".var" / "app" / "com.brave.Browser" / "config" / "BraveSoftware" / "Brave-Browser").mkdir(parents=True)
-        assert bc.real_profile_data_dir("brave", "Linux") == str(native)
+        expected = posixpath.join(str(tmp_path), ".config", "BraveSoftware", "Brave-Browser")
+        assert bc.real_profile_data_dir("brave", "Linux") == expected
 
     def test_xdg_config_home_is_honoured(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- resolve Chromium real-profile paths from the OS account home instead of a profile-scoped `HOME`
- preserve native, Snap, and Flatpak profile lookup behavior
- cover named Hermes profiles with a regression test

## Root cause

`real_profile_data_dir()` used `expanduser("~")`. Named Hermes profiles can point `HOME` at `<profile>/home`, so browser profile candidates were built inside Hermes state rather than under the OS account home. `get_real_home()` already implements the profile-aware account-home resolution contract.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_browser_connect_default_chromium.py -q` (31 passed)
- `scripts/run_tests.sh tests/tools/test_browser_real_profile.py -q` (73 passed on automatic retry; first attempt hit the existing 300s file timeout)

## Related Issue

N/A
