### PR TITLE
feat(discord): support forum posts, thread messaging, and OpenCode permission bridge

### DIFF
--- a/contrib/discord-bridge/README.md
+++ b/contrib/discord-bridge/README.md
@@ -1,0 +1,51 @@
+# Discord bridge — out-of-repo counterparts
+
+The Discord OpenCode bridge (`plugins/platforms/discord/opencode_bridge.py`)
+only sees what an agent writes into its spool directory
+(`$HERMES_HOME/opencode_bridge/`). The agents themselves are separate
+programs, so their side lives here: these files are **copies of what runs
+on the machine**, kept in the repo so the two halves stay reviewable
+together.
+
+| File | Installed to | Purpose |
+|---|---|---|
+| `opencode-plugins/befehlswaechter.js` | `~/.config/opencode/plugins/` | Blocks shell commands touching paths outside the project and asks in Discord (allow once / reject) |
+| `opencode-plugins/sitzungsthread.js` | `~/.config/opencode/plugins/` | Announces each OpenCode session so the bridge opens one Discord thread per session |
+| `opencode-plugins/discord-melder.js.disabled` | `~/.config/opencode/plugins/` (drop `.disabled`) | Optional: posts each finished answer to a channel webhook. Superseded by session threads; kept for reference |
+| `claude-code-hooks/discord-bridge.py` | `~/.claude/hooks/` | Claude Code counterpart: forwards its own permission prompts and `AskUserQuestion`, and announces sessions |
+
+## Wire contract
+
+Both sides speak the spool protocol documented at the top of
+`opencode_bridge.py`: the agent writes `requests/<id>.json`, the bridge
+answers with `decisions/<id>.json` (`once` / `reject` / `answer`), and
+`notice` requests (start/prompt/result/child) need no answer at all.
+
+## Fail-closed posture
+
+Access stays blocked on rejection, on timeout, when the gateway is not
+running or Discord is not connected, and on any malformed or mismatched
+reply. There are no persistent grants: every request covers exactly one
+command.
+
+## Claude Code hook registration
+
+```json
+"hooks": {
+  "PermissionRequest": [{"hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/discord-bridge.py", "timeout": 360}]}],
+  "PreToolUse":        [{"hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/discord-bridge.py", "timeout": 360}]}],
+  "UserPromptSubmit":  [{"hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/discord-bridge.py", "timeout": 15}]}],
+  "Stop":              [{"hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/discord-bridge.py", "timeout": 15}]}]
+}
+```
+
+The hook only acts when Claude Code was started by Hermes (`HERMES_HOME` in
+the environment, a Hermes ancestor process, or `HERMES_CLAUDE_BRIDGE=1`).
+Switch it off with `~/.claude/discord-bridge.aus` or
+`HERMES_CLAUDE_BRIDGE=aus`.
+
+## Keeping the copies in sync
+
+These are copies, not the live files — edits made in `~/.claude/hooks/` or
+`~/.config/opencode/plugins/` do not appear here by themselves. Copy them
+over before committing, or symlink the live paths at this directory.

--- a/contrib/discord-bridge/claude-code-hooks/discord-bridge.py
+++ b/contrib/discord-bridge/claude-code-hooks/discord-bridge.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""Discord-Brücke für Claude Code (PermissionRequest-Hook).
+
+Leitet genau die Nachfragen, die Claude Code selbst stellen würde, an die
+Hermes-Discord-Bridge weiter — aber nur, wenn Claude Code von Hermes
+gestartet wurde (z. B. ``claude -p`` aus dem Terminal-Werkzeug). In einer
+normalen interaktiven Sitzung tut der Hook nichts, Claude Code fragt wie
+gewohnt im Terminal.
+
+Was weitergeleitet wird:
+
+- Berechtigungsanfragen („Darf ich ausführen?“) für jedes Werkzeug
+  (Bash, Edit, Write, WebFetch, MCP-Werkzeuge …), und zwar nur dort, wo
+  Claude Code ohne den Hook nachfragen würde.
+- ``AskUserQuestion`` (Multiple-Choice-Rückfragen): Fragen und Optionen
+  erscheinen als Buttons in Discord, die Antworten gehen per
+  ``updatedInput`` zurück an Claude Code (nur in interaktiven Sitzungen —
+  im ``-p``-Modus bietet Claude Code das Werkzeug gar nicht an).
+
+Sitzungs-Threads: ``UserPromptSubmit`` meldet den Prompt (der erste einer
+Sitzung öffnet den Thread in Discord), ``Stop`` meldet die fertige Antwort
+der Runde. Beide sind reine Meldungen — sie legen eine Datei ab und warten
+auf nichts, blockieren die Sitzung also nie. Die Rückfragen derselben
+Sitzung stellt die Bridge dann in diesem Thread.
+
+Drei Hook-Ereignisarten, ein Skript:
+
+- ``PermissionRequest`` feuert genau dann, wenn Claude Code seinen
+  Rückfrage-Dialog zeigen würde (interaktive Sitzungen, etwa in tmux).
+- ``PreToolUse`` ist für ``claude -p`` nötig: dort gibt es keinen Dialog,
+  Werkzeuge ohne Freigabe werden still abgelehnt. Der Hook bildet deshalb
+  Claude Codes Regelwerk nach (``permissions.allow/deny`` aus den
+  settings.json-Dateien, ``--allowedTools``/``--disallowedTools`` aus der
+  Kommandozeile, ``permission_mode``, nie fragende Werkzeuge wie Read/Glob)
+  und fragt nur bei Werkzeugen nach, die sonst abgelehnt würden. Wird das
+  Werkzeug per PreToolUse erlaubt, gibt es keinen zweiten Dialog mehr.
+
+Erkennung „von Hermes gestartet“ (eine Bedingung genügt):
+
+- ``HERMES_CLAUDE_BRIDGE=1`` (oder ``an``/``on``) in der Umgebung — erzwingt
+  die Weiterleitung, auch aus einem normalen Terminal;
+- ``HERMES_HOME`` in der Umgebung — das Gateway setzt sie, Kindprozesse
+  erben sie;
+- ein Vorfahrenprozess gehört zu Hermes (``hermes_cli``, ``hermes-agent``).
+
+Ausschalten, ohne die settings.json anzufassen: Datei
+``~/.claude/discord-bridge.aus`` anlegen (löschen schaltet wieder ein) oder
+``HERMES_CLAUDE_BRIDGE=aus`` setzen. Bei Ablehnung, Timeout, nicht laufendem
+Gateway oder unklarer Antwort wird abgelehnt; Dauerfreigaben gibt es nicht.
+
+Einrichtung in ``~/.claude/settings.json`` (Hook-Timeout über der Wartezeit,
+Standard 330 s)::
+
+    "hooks": {
+      "PermissionRequest": [
+        {"hooks": [{"type": "command",
+                    "command": "python3 ~/.claude/hooks/discord-bridge.py",
+                    "timeout": 360}]}
+      ],
+      "PreToolUse": [
+        {"hooks": [{"type": "command",
+                    "command": "python3 ~/.claude/hooks/discord-bridge.py",
+                    "timeout": 360}]}
+      ],
+      "UserPromptSubmit": [
+        {"hooks": [{"type": "command",
+                    "command": "python3 ~/.claude/hooks/discord-bridge.py",
+                    "timeout": 15}]}
+      ],
+      "Stop": [
+        {"hooks": [{"type": "command",
+                    "command": "python3 ~/.claude/hooks/discord-bridge.py",
+                    "timeout": 15}]}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+import uuid
+
+HERMES_HOME = os.environ.get("HERMES_HOME") or os.path.join(os.path.expanduser("~"), ".hermes")
+ABLAGE = os.path.join(HERMES_HOME, "opencode_bridge")
+WARTEZEIT_S = float(os.environ.get("BEFEHLSWAECHTER_WARTEZEIT_S") or 330)
+ABFRAGE_S = 0.5
+HEARTBEAT_MAX_ALTER_S = 120
+AUS_DATEI = os.path.join(os.path.expanduser("~"), ".claude", "discord-bridge.aus")
+# Neben threads.json der Bridge, damit der Sitzungszustand demselben
+# HERMES_HOME folgt wie die Ablage (und Tests ihn sauber umlenken können).
+SITZUNGEN_DATEI = os.path.join(ABLAGE, "claude_sessions.json")
+SITZUNG_TTL_S = 7 * 24 * 3600
+NOTIZ_TEXT_MAX = 1700
+TRANSCRIPT_TAIL_BYTES = 4_000_000  # nur das Ende lesen; Transkripte werden groß
+SCHALTER_ENV = "HERMES_CLAUDE_BRIDGE"
+DETAILS_MAX = 900
+
+LESEND_WERKZEUGE = {"Read", "Glob", "Grep", "LS", "NotebookRead"}
+SCHREIBEND_WERKZEUGE = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+NETZ_WERKZEUGE = {"WebFetch", "WebSearch"}
+# Werkzeuge, für die Claude Code nie einen Rechte-Dialog zeigt.
+NIE_NACHFRAGEN = LESEND_WERKZEUGE | {
+    "TodoWrite", "TodoRead", "Task", "Agent", "ToolSearch", "ListMcpResourcesTool",
+    "ReadMcpResourceTool", "BashOutput", "KillShell", "TaskOutput", "TaskStop",
+    "AskUserQuestion", "EnterPlanMode", "ExitPlanMode", "Skill", "SendUserFile",
+    "Monitor", "ScheduleWakeup", "ReportFindings",
+}
+# Modi, in denen Claude Code selbst entscheidet (kein Dialog, den wir auslagern könnten).
+MODI_OHNE_DIALOG = {"bypassPermissions", "dontAsk", "auto", "plan"}
+
+
+# ---------------------------------------------------------------------------
+# Schalter und Hermes-Erkennung
+# ---------------------------------------------------------------------------
+
+
+def ausgeschaltet(env: dict | None = None) -> bool:
+    env = os.environ if env is None else env
+    if os.path.exists(AUS_DATEI):
+        return True
+    return (env.get(SCHALTER_ENV) or "").strip().lower() in {"aus", "off", "0", "false"}
+
+
+def hermes_vorfahr(pid: int | None = None, *, max_tiefe: int = 15) -> bool:
+    """Gehört ein Elternprozess zu Hermes? (Gateway, CLI oder deren Kinder)"""
+    pid = os.getppid() if pid is None else pid
+    muster = re.compile(r"hermes_cli|hermes-agent|hermes\s+gateway|/\.hermes/")
+    for _ in range(max_tiefe):
+        if pid <= 1:
+            return False
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "ppid=,command=", "-p", str(pid)],
+                capture_output=True, text=True, timeout=3,
+            ).stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            return False
+        if not out:
+            return False
+        ppid_text, _, befehl = out.partition(" ")
+        if muster.search(befehl):
+            return True
+        try:
+            pid = int(ppid_text)
+        except ValueError:
+            return False
+    return False
+
+
+def von_hermes_gestartet(env: dict | None = None, *, vorfahren_pruefen: bool = True) -> bool:
+    env = os.environ if env is None else env
+    if (env.get(SCHALTER_ENV) or "").strip().lower() in {"1", "an", "on", "true"}:
+        return True
+    if env.get("HERMES_HOME"):
+        return True
+    return vorfahren_pruefen and hermes_vorfahr()
+
+
+def aktiv(env: dict | None = None) -> bool:
+    return not ausgeschaltet(env) and von_hermes_gestartet(env)
+
+
+# ---------------------------------------------------------------------------
+# Regelwerk nachbilden: würde Claude Code für dieses Werkzeug nachfragen?
+# ---------------------------------------------------------------------------
+
+
+def _settings_regeln(pfad: str) -> dict:
+    try:
+        with open(pfad, encoding="utf-8") as fh:
+            daten = json.load(fh)
+    except (OSError, ValueError):
+        return {"allow": [], "deny": [], "ask": []}
+    perms = daten.get("permissions") if isinstance(daten, dict) else None
+    perms = perms if isinstance(perms, dict) else {}
+    return {
+        art: [str(r) for r in perms.get(art, []) if isinstance(r, str)]
+        for art in ("allow", "deny", "ask")
+    }
+
+
+def regeln_laden(cwd: str) -> dict:
+    """allow/deny/ask aus Nutzer-, Projekt- und lokalen Einstellungen."""
+    gesamt = {"allow": [], "deny": [], "ask": []}
+    for pfad in (
+        os.path.join(os.path.expanduser("~"), ".claude", "settings.json"),
+        os.path.join(cwd, ".claude", "settings.json"),
+        os.path.join(cwd, ".claude", "settings.local.json"),
+    ):
+        for art, regeln in _settings_regeln(pfad).items():
+            gesamt[art].extend(regeln)
+    return gesamt
+
+
+def _argv_werte(argv: list[str], namen: set[str]) -> list[str]:
+    """Werte hinter --allowedTools & Co. einsammeln (Komma- oder Leerzeichen-getrennt)."""
+    werte: list[str] = []
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        name, _, inline = tok.partition("=")
+        if name in namen:
+            if inline:
+                werte.extend(t.strip() for t in inline.split(",") if t.strip())
+            else:
+                i += 1
+                while i < len(argv) and not argv[i].startswith("-"):
+                    werte.extend(t.strip() for t in argv[i].split(",") if t.strip())
+                    i += 1
+                continue
+        i += 1
+    # ps trennt "Bash(git *)" in zwei Wörter — Klammern wieder zusammensetzen
+    zusammen: list[str] = []
+    for w in werte:
+        if zusammen and zusammen[-1].count("(") > zusammen[-1].count(")"):
+            zusammen[-1] += " " + w
+        else:
+            zusammen.append(w)
+    return zusammen
+
+
+def cli_regeln(ppid: int | None = None) -> dict:
+    """--allowedTools/--disallowedTools des aufrufenden claude-Prozesses."""
+    leer = {"allow": [], "deny": []}
+    pid = os.getppid() if ppid is None else ppid
+    try:
+        out = subprocess.run(["ps", "-o", "command=", "-p", str(pid)], capture_output=True, text=True, timeout=3).stdout.strip()
+        argv = shlex.split(out)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return leer
+    if not any(os.path.basename(a) == "claude" for a in argv[:2]):
+        return leer
+    return {
+        "allow": _argv_werte(argv, {"--allowedTools", "--allowed-tools"}),
+        "deny": _argv_werte(argv, {"--disallowedTools", "--disallowed-tools"}),
+    }
+
+
+def _pfad_passt(muster: str, pfad: str, cwd: str) -> bool:
+    if not pfad:
+        return False
+    absolut = os.path.normpath(os.path.join(cwd, os.path.expanduser(pfad)))
+    if muster.startswith("//"):
+        return fnmatch.fnmatch(absolut, muster[1:])
+    if muster.startswith("~/"):
+        return fnmatch.fnmatch(absolut, os.path.expanduser(muster))
+    if muster.startswith("/"):
+        return fnmatch.fnmatch(absolut, os.path.normpath(os.path.join(cwd, muster.lstrip("/"))))
+    rel = os.path.relpath(absolut, cwd)
+    return fnmatch.fnmatch(rel, muster) or fnmatch.fnmatch(absolut, muster) or fnmatch.fnmatch(rel, os.path.join("**", muster))
+
+
+def regel_passt(regel: str, werkzeug: str, eingabe: dict, cwd: str) -> bool:
+    """Eine Claude-Code-Berechtigungsregel gegen einen Werkzeugaufruf prüfen."""
+    m = re.match(r"^([^(]+)(?:\((.*)\))?$", regel.strip(), re.S)
+    if not m:
+        return False
+    name, muster = m.group(1).strip(), m.group(2)
+    if name != werkzeug and not (name.startswith("mcp__") and werkzeug.startswith(name + "__")):
+        return False
+    if muster is None or muster.strip() in ("", "*"):
+        return True
+    muster = muster.strip()
+    if werkzeug == "Bash":
+        befehl = str(eingabe.get("command") or "").strip()
+        if muster.endswith(":*"):
+            praefix = muster[:-2]
+            return befehl == praefix or befehl.startswith(praefix + " ") or befehl.startswith(praefix)
+        if muster.endswith(" *"):
+            praefix = muster[:-2]
+            return befehl == praefix or befehl.startswith(praefix + " ")
+        if muster.endswith("*"):
+            return befehl.startswith(muster[:-1])
+        return befehl == muster
+    if werkzeug in SCHREIBEND_WERKZEUGE | LESEND_WERKZEUGE:
+        pfad = str(eingabe.get("file_path") or eingabe.get("notebook_path") or eingabe.get("path") or "")
+        return _pfad_passt(muster, pfad, cwd)
+    if werkzeug in NETZ_WERKZEUGE:
+        ziel = str(eingabe.get("url") or eingabe.get("query") or "")
+        if muster.startswith("domain:"):
+            host = re.sub(r"^[a-z]+://", "", ziel).split("/")[0].lower()
+            return host == muster[7:].lower() or host.endswith("." + muster[7:].lower())
+        return fnmatch.fnmatch(ziel, muster)
+    return fnmatch.fnmatch(json.dumps(eingabe, sort_keys=True), muster)
+
+
+def braucht_erlaubnis(werkzeug: str, eingabe: dict, permission_mode: str, cwd: str, regeln: dict) -> bool:
+    """True, wenn Claude Code diesen Aufruf ohne Freigabe nicht ausführen würde."""
+    if werkzeug in NIE_NACHFRAGEN:
+        return False
+    if permission_mode in MODI_OHNE_DIALOG:
+        return False
+    if permission_mode == "acceptEdits" and werkzeug in SCHREIBEND_WERKZEUGE:
+        return False
+    for regel in regeln.get("deny", []):
+        if regel_passt(regel, werkzeug, eingabe, cwd):
+            return False  # Claude Code lehnt selbst ab — nichts zu fragen
+    for regel in regeln.get("allow", []):
+        if regel_passt(regel, werkzeug, eingabe, cwd):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Anfrage aus dem Hook-Input bauen
+# ---------------------------------------------------------------------------
+
+
+def _kurz(text: str, maximum: int = DETAILS_MAX) -> str:
+    text = str(text or "")
+    return text if len(text) <= maximum else text[: maximum - 1] + "…"
+
+
+def anfrage_aus_hook(daten: dict) -> dict:
+    """Übersetzt ein PermissionRequest-Ereignis in eine Bridge-Anfrage."""
+    werkzeug = str(daten.get("tool_name") or "?")
+    eingabe = daten.get("tool_input") or {}
+    if not isinstance(eingabe, dict):
+        eingabe = {"input": eingabe}
+    projekt = str(daten.get("cwd") or os.getcwd())
+
+    if werkzeug == "AskUserQuestion":
+        fragen = []
+        for frage in eingabe.get("questions") or []:
+            if not isinstance(frage, dict):
+                continue
+            optionen = [
+                {"label": str(o.get("label", "")), "description": str(o.get("description", ""))}
+                for o in (frage.get("options") or []) if isinstance(o, dict)
+            ]
+            fragen.append({
+                "question": str(frage.get("question", "")),
+                "header": str(frage.get("header", "")),
+                "options": optionen,
+                "multiSelect": bool(frage.get("multiSelect", False)),
+            })
+        return {"kind": "question", "questions": fragen, "project": projekt, "tool": werkzeug}
+
+    pfad, zugriff, details = "-", "unklar", ""
+    if werkzeug == "Bash":
+        befehl = str(eingabe.get("command") or "").strip() or "(leer)"
+        details = str(eingabe.get("description") or "")
+        zugriff = "ausführen"
+    elif werkzeug in SCHREIBEND_WERKZEUGE:
+        pfad = str(eingabe.get("file_path") or eingabe.get("notebook_path") or "-")
+        befehl = f"{werkzeug} {pfad}"
+        zugriff = "schreiben"
+        if werkzeug == "Write":
+            details = _kurz(str(eingabe.get("content") or ""), 400)
+        elif werkzeug == "Edit":
+            details = "alt: " + _kurz(str(eingabe.get("old_string") or ""), 300) + "\nneu: " + _kurz(str(eingabe.get("new_string") or ""), 300)
+    elif werkzeug in LESEND_WERKZEUGE:
+        pfad = str(eingabe.get("file_path") or eingabe.get("path") or "-")
+        ziel = pfad if pfad != "-" else str(eingabe.get("pattern") or "")
+        befehl = f"{werkzeug} {ziel}".strip()
+        zugriff = "lesen"
+    elif werkzeug in NETZ_WERKZEUGE:
+        ziel = str(eingabe.get("url") or eingabe.get("query") or "")
+        befehl = f"{werkzeug} {ziel}".strip()
+        zugriff = "netz"
+        details = str(eingabe.get("prompt") or "")
+    else:
+        befehl = werkzeug
+        try:
+            details = json.dumps(eingabe, ensure_ascii=False)
+        except (TypeError, ValueError):
+            details = str(eingabe)
+    return {
+        "kind": "permission",
+        "tool": werkzeug,
+        "command": befehl,
+        "path": pfad or "-",
+        "access": zugriff,
+        "details": _kurz(details),
+        "project": projekt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bridge-Ablage
+# ---------------------------------------------------------------------------
+
+
+def bruecke_ausgefallen(hermes_home: str = HERMES_HOME) -> str | None:
+    try:
+        with open(os.path.join(hermes_home, "state", "gateway.heartbeat"), encoding="utf-8") as fh:
+            heartbeat = json.load(fh)
+    except (OSError, ValueError):
+        return "kein Gateway-Heartbeat gefunden"
+    updated = str(heartbeat.get("updated_at") or "")
+    try:
+        from datetime import datetime
+
+        alter = time.time() - datetime.fromisoformat(updated.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return "Gateway-Heartbeat ohne Zeitstempel"
+    if not alter < HEARTBEAT_MAX_ALTER_S:
+        return f"Gateway-Heartbeat ist {round(alter)} s alt"
+    try:
+        with open(os.path.join(hermes_home, "gateway_state.json"), encoding="utf-8") as fh:
+            zustand = json.load(fh)
+    except (OSError, ValueError):
+        return "gateway_state.json nicht lesbar"
+    if zustand.get("gateway_state") != "running":
+        return f"Gateway-Zustand: {zustand.get('gateway_state') or 'unbekannt'}"
+    discord = (zustand.get("platforms") or {}).get("discord", {}).get("state")
+    if discord != "connected":
+        return f"Discord ist {discord or 'nicht konfiguriert'}"
+    return None
+
+
+def bruecke_fragen(
+    anfrage: dict,
+    *,
+    session_id: str,
+    ablage: str = ABLAGE,
+    wartezeit_s: float = WARTEZEIT_S,
+    abfrage_s: float = ABFRAGE_S,
+    ausfallpruefung: bool = True,
+    hermes_home: str = HERMES_HOME,
+) -> dict:
+    """Anfrage ablegen, auf die Entscheidung warten.
+
+    Rückgabe: ``{"erlaubt": bool, "grund": str, "answers": dict | None}``.
+    Alles außer einer sauberen once-/answer-Antwort mit passender ID zählt
+    als Ablehnung.
+    """
+    if ausfallpruefung:
+        ausfall = bruecke_ausgefallen(hermes_home)
+        if ausfall:
+            return {"erlaubt": False, "grund": f"Discord-Bridge nicht erreichbar: {ausfall}", "answers": None}
+    anfragen = os.path.join(ablage, "requests")
+    antworten = os.path.join(ablage, "decisions")
+    request_id = str(uuid.uuid4())
+    jetzt = time.time()
+    nutzlast = {
+        "version": 1,
+        "id": request_id,
+        "agent": "claude-code",
+        "created_at": jetzt,
+        "expires_at": jetzt + wartezeit_s,
+        "session_id": session_id,
+        **anfrage,
+    }
+    anfrage_datei = os.path.join(anfragen, f"{request_id}.json")
+    antwort_datei = os.path.join(antworten, f"{request_id}.json")
+    try:
+        for d in (ablage, anfragen, antworten):
+            os.makedirs(d, mode=0o700, exist_ok=True)
+        tmp = os.path.join(anfragen, f".tmp-{request_id}")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(nutzlast, fh, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, anfrage_datei)
+    except OSError as exc:
+        return {"erlaubt": False, "grund": f"Anfrage konnte nicht abgelegt werden ({exc})", "answers": None}
+
+    ende = time.monotonic() + wartezeit_s
+    try:
+        while time.monotonic() < ende:
+            try:
+                with open(antwort_datei, encoding="utf-8") as fh:
+                    roh = fh.read()
+            except OSError:
+                time.sleep(abfrage_s)
+                continue
+            try:
+                antwort = json.loads(roh)
+            except ValueError:
+                return {"erlaubt": False, "grund": "unlesbare Antwort der Bridge", "answers": None}
+            if not isinstance(antwort, dict) or antwort.get("version") != 1 or antwort.get("id") != request_id:
+                return {"erlaubt": False, "grund": "Antwort der Bridge passt nicht zur Anfrage", "answers": None}
+            entscheidung = antwort.get("decision")
+            if entscheidung == "once" and anfrage.get("kind") == "permission":
+                return {"erlaubt": True, "grund": "in Discord einmalig erlaubt", "answers": None}
+            if entscheidung == "answer" and anfrage.get("kind") == "question" and isinstance(antwort.get("answers"), dict):
+                return {"erlaubt": True, "grund": "in Discord beantwortet", "answers": antwort["answers"]}
+            if entscheidung == "reject":
+                if antwort.get("source") == "timeout":
+                    return {"erlaubt": False, "grund": "in Discord nicht rechtzeitig beantwortet", "answers": None}
+                return {"erlaubt": False, "grund": "in Discord abgelehnt", "answers": None}
+            return {"erlaubt": False, "grund": f"unpassende Entscheidung „{entscheidung}“", "answers": None}
+        return {"erlaubt": False, "grund": f"keine Antwort innerhalb von {int(wartezeit_s)} s", "answers": None}
+    finally:
+        for p in (anfrage_datei, antwort_datei):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sitzungs-Meldungen (Thread je Claude-Code-Sitzung)
+# ---------------------------------------------------------------------------
+
+
+def _sitzungen_laden() -> dict:
+    try:
+        with open(SITZUNGEN_DATEI, encoding="utf-8") as fh:
+            daten = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return daten if isinstance(daten, dict) else {}
+
+
+def _sitzungen_speichern(daten: dict) -> None:
+    jetzt = time.time()
+    daten = {
+        sid: eintrag for sid, eintrag in daten.items()
+        if isinstance(eintrag, dict) and jetzt - float(eintrag.get("ts") or 0) < SITZUNG_TTL_S
+    }
+    try:
+        os.makedirs(os.path.dirname(SITZUNGEN_DATEI), mode=0o700, exist_ok=True)
+        tmp = SITZUNGEN_DATEI + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(daten, fh)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, SITZUNGEN_DATEI)
+    except OSError:
+        pass  # Meldungen dürfen die Sitzung nie anhalten
+
+
+def notiz_melden(notice: str, *, session_id: str, project: str, text: str,
+                 ablage: str = ABLAGE) -> bool:
+    """Legt eine Sitzungs-Meldung ab (ohne auf eine Antwort zu warten)."""
+    if notice not in ("start", "prompt", "result"):
+        return False
+    if not session_id:
+        return False
+    anfragen = os.path.join(ablage, "requests")
+    request_id = str(uuid.uuid4())
+    jetzt = time.time()
+    nutzlast = {
+        "version": 1,
+        "id": request_id,
+        "agent": "claude-code",
+        "kind": "notice",
+        "notice": notice,
+        "created_at": jetzt,
+        "expires_at": jetzt + 3600,
+        "started_at": jetzt,
+        "session_id": session_id,
+        "project": project,
+        "text": _kurz(text, NOTIZ_TEXT_MAX),
+    }
+    try:
+        os.makedirs(anfragen, mode=0o700, exist_ok=True)
+        tmp = os.path.join(anfragen, f".tmp-{request_id}")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(nutzlast, fh, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, os.path.join(anfragen, f"{request_id}.json"))
+        return True
+    except OSError:
+        return False
+
+
+def letzte_antwort(transcript_path: str) -> tuple[str, str]:
+    """Letzte Assistenten-Textantwort aus dem Transkript → (id, text)."""
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return "", ""
+    try:
+        groesse = os.path.getsize(transcript_path)
+        with open(transcript_path, "rb") as fh:
+            if groesse > TRANSCRIPT_TAIL_BYTES:
+                fh.seek(groesse - TRANSCRIPT_TAIL_BYTES)
+                fh.readline()  # angebrochene Zeile verwerfen
+            roh = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return "", ""
+    letzte_id, letzter_text = "", ""
+    for zeile in roh.splitlines():
+        zeile = zeile.strip()
+        if not zeile:
+            continue
+        try:
+            eintrag = json.loads(zeile)
+        except ValueError:
+            continue
+        if not isinstance(eintrag, dict) or eintrag.get("type") != "assistant":
+            continue
+        nachricht = eintrag.get("message")
+        if not isinstance(nachricht, dict):
+            continue
+        teile = nachricht.get("content")
+        if not isinstance(teile, list):
+            continue
+        texte = [
+            t.get("text", "") for t in teile
+            if isinstance(t, dict) and t.get("type") == "text" and str(t.get("text") or "").strip()
+        ]
+        if texte:
+            letzte_id = str(nachricht.get("id") or eintrag.get("uuid") or "")
+            letzter_text = "\n".join(texte).strip()
+    return letzte_id, letzter_text
+
+
+def sitzung_prompt(daten: dict) -> bool:
+    """UserPromptSubmit: erster Prompt öffnet den Thread, weitere melden sich."""
+    session_id = str(daten.get("session_id") or "")
+    prompt = str(daten.get("prompt") or "").strip()
+    if not session_id or not prompt:
+        return False
+    sitzungen = _sitzungen_laden()
+    eintrag = sitzungen.get(session_id) or {}
+    notice = "prompt" if eintrag.get("gestartet") else "start"
+    ok = notiz_melden(notice, session_id=session_id,
+                      project=str(daten.get("cwd") or os.getcwd()), text=prompt)
+    if ok:
+        eintrag.update({"gestartet": True, "ts": time.time()})
+        sitzungen[session_id] = eintrag
+        _sitzungen_speichern(sitzungen)
+    return ok
+
+
+def sitzung_ergebnis(daten: dict) -> bool:
+    """Stop: die fertige Antwort der Runde melden (einmal je Nachricht)."""
+    session_id = str(daten.get("session_id") or "")
+    if not session_id:
+        return False
+    sitzungen = _sitzungen_laden()
+    eintrag = sitzungen.get(session_id) or {}
+    if not eintrag.get("gestartet"):
+        return False  # ohne Thread keine Antwort melden
+    antwort_id, text = letzte_antwort(str(daten.get("transcript_path") or ""))
+    if not text or eintrag.get("gemeldet") == (antwort_id or text[:80]):
+        return False
+    ok = notiz_melden("result", session_id=session_id,
+                      project=str(daten.get("cwd") or os.getcwd()), text=text)
+    if ok:
+        eintrag.update({"gemeldet": antwort_id or text[:80], "ts": time.time()})
+        sitzungen[session_id] = eintrag
+        _sitzungen_speichern(sitzungen)
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Hook-Ein- und -Ausgabe
+# ---------------------------------------------------------------------------
+
+
+def pretooluse_ausgabe(ergebnis: dict) -> dict:
+    """Baut das PreToolUse-Ausgabe-JSON aus dem Bridge-Ergebnis."""
+    if ergebnis["erlaubt"]:
+        entscheidung, grund = "allow", f"Vom Nutzer über Discord {ergebnis['grund']}"
+    else:
+        entscheidung = "deny"
+        grund = f"Vom Nutzer über Discord nicht erlaubt ({ergebnis['grund']}). Nicht erneut versuchen."
+    return {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": entscheidung,
+        "permissionDecisionReason": grund,
+    }}
+
+
+def entscheidung_ausgabe(ergebnis: dict, daten: dict) -> dict:
+    """Baut das PermissionRequest-Ausgabe-JSON aus dem Bridge-Ergebnis."""
+    werkzeug = str(daten.get("tool_name") or "")
+    if ergebnis["erlaubt"]:
+        decision: dict = {"behavior": "allow"}
+        if werkzeug == "AskUserQuestion" and isinstance(ergebnis.get("answers"), dict):
+            eingabe = daten.get("tool_input") or {}
+            eingabe = eingabe if isinstance(eingabe, dict) else {}
+            decision["updatedInput"] = {**eingabe, "answers": ergebnis["answers"]}
+    else:
+        decision = {
+            "behavior": "deny",
+            "message": (
+                f"Über Discord nicht beantwortet ({ergebnis['grund']}). Nicht erneut versuchen; "
+                "falls die Aktion nötig ist, den Nutzer direkt fragen."
+                if werkzeug == "AskUserQuestion"
+                else f"Vom Nutzer über Discord nicht erlaubt ({ergebnis['grund']}). Nicht erneut versuchen."
+            ),
+        }
+    return {"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": decision}}
+
+
+def main() -> int:
+    if not aktiv():
+        return 0
+    try:
+        daten = json.load(sys.stdin)
+    except ValueError:
+        return 0
+    if not isinstance(daten, dict):
+        return 0
+    ereignis = daten.get("hook_event_name") or ("PermissionRequest" if daten.get("tool_name") else "")
+    if ereignis == "UserPromptSubmit":
+        sitzung_prompt(daten)
+        return 0  # keine Ausgabe: der Prompt läuft unverändert weiter
+    if ereignis == "Stop":
+        sitzung_ergebnis(daten)
+        return 0
+    if not daten.get("tool_name"):
+        return 0
+    if ereignis not in ("PermissionRequest", "PreToolUse"):
+        return 0
+    werkzeug = str(daten["tool_name"])
+    eingabe = daten.get("tool_input") or {}
+    eingabe = eingabe if isinstance(eingabe, dict) else {}
+    cwd = str(daten.get("cwd") or os.getcwd())
+    if ereignis == "PreToolUse":
+        regeln = regeln_laden(cwd)
+        cli = cli_regeln()
+        regeln["allow"] += cli["allow"]
+        regeln["deny"] += cli["deny"]
+        if not braucht_erlaubnis(werkzeug, eingabe, str(daten.get("permission_mode") or "default"), cwd, regeln):
+            return 0  # Claude Code entscheidet wie gewohnt selbst
+    anfrage = anfrage_aus_hook(daten)
+    if anfrage["kind"] == "question" and not anfrage["questions"]:
+        return 0  # nichts Sinnvolles weiterzuleiten — Claude Code entscheidet selbst
+    ergebnis = bruecke_fragen(anfrage, session_id=str(daten.get("session_id") or ""))
+    if ereignis == "PreToolUse":
+        print(json.dumps(pretooluse_ausgabe(ergebnis), ensure_ascii=False))
+    else:
+        print(json.dumps(entscheidung_ausgabe(ergebnis, daten), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/discord-bridge/opencode-plugins/befehlswaechter.js
+++ b/contrib/discord-bridge/opencode-plugins/befehlswaechter.js
@@ -1,0 +1,405 @@
+/**
+ * Befehlswächter — prüft Bash-Befehle, bevor opencode sie ausführt.
+ *
+ * Vier Stufen, damit der Normalfall ohne Verzögerung durchläuft:
+ *   1. harte Sperre  — offensichtlich zerstörerische Muster, sofort blockiert
+ *   2. Fremdpfade    — Zugriff außerhalb des Projekts wird nicht mehr sofort
+ *                      abgelehnt, sondern über die Discord-Bridge von Hermes
+ *                      einmalig zur Freigabe vorgelegt (siehe unten)
+ *   3. Freiliste     — bekannte harmlose Befehle, sofort durchgelassen
+ *   4. Modellprüfung — alles Übrige geht an ein schnelles Modell (Claude Haiku)
+ *
+ * Gedacht als Netz für den Betrieb mit `--auto`. Ersetzt keine Sorgfalt:
+ * ein Sprachmodell ist eine zweite Meinung, keine Sicherheitsgarantie.
+ *
+ * Rückfrage über Discord (Stufe 2)
+ * --------------------------------
+ * opencodes eigenes Permission-System taugt dafür nicht: im Automatikmodus
+ * beantwortet die TUI jede native Anfrage sofort mit „once“, bevor Discord
+ * sie sieht. Deshalb hält dieses Plugin den Werkzeugaufruf selbst an und
+ * spricht mit der Bridge über einen privaten Ablageordner
+ * (`$HERMES_HOME/opencode_bridge`, sonst `~/.hermes/opencode_bridge`):
+ *
+ *   requests/<id>.json   — schreibt dieses Plugin (atomar per rename)
+ *   decisions/<id>.json  — schreibt die Bridge: {"decision": "once"|"reject"}
+ *
+ * Die Bridge zeigt Befehl, Pfad, Projektordner und Zugriffsart in Discord
+ * und bietet nur „einmal erlauben“ oder „ablehnen“ an. Blockiert bleibt der
+ * Zugriff bei Ablehnung, Zeitablauf, nicht laufendem Gateway und bei jeder
+ * unklaren Antwort. Dauerhafte Freigaben gibt es nicht — jede Anfrage gilt
+ * für genau einen Befehl.
+ */
+
+import crypto from "node:crypto"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+// Gemessen an einem Testbefehl: Haiku 0,9 s und korrektes Urteil.
+// GLM-4.7-Flash war zwar kostenlos und mit 0,2 s schneller, lief aber
+// reproduzierbar in HTTP 429 — ein Wächter darf unter Last nicht ausfallen.
+const MODELL = "claude-haiku-4.5"
+const ENDPUNKT = "https://api.githubcopilot.com/chat/completions"
+
+// Ablage für die Discord-Rückfrage
+const HERMES_HOME = process.env.HERMES_HOME || path.join(os.homedir(), ".hermes")
+const ABLAGE = path.join(HERMES_HOME, "opencode_bridge")
+const ANFRAGEN = path.join(ABLAGE, "requests")
+const ANTWORTEN = path.join(ABLAGE, "decisions")
+// Die Bridge lehnt nach ihrem eigenen Timeout (Standard 300 s) ab; das
+// Plugin wartet etwas länger, damit diese Absage normalerweise zuerst kommt.
+const WARTEZEIT_S = Number(process.env.BEFEHLSWAECHTER_WARTEZEIT_S) || 330
+const ABFRAGE_MS = 500
+// Ist der Heartbeat des Gateways älter, gilt die Bridge als ausgefallen —
+// dann wird sofort blockiert statt minutenlang zu warten.
+const HEARTBEAT_MAX_ALTER_S = 120
+
+// 1. Immer blockieren — unabhängig davon, was das Modell meint
+const GESPERRT = [
+  /\brm\s+(-[a-zA-Z]*\s+)*-[a-zA-Z]*[rf]/, // rm -rf und Varianten
+  /\bsudo\b/,
+  /\bmkfs|\bdd\s+if=|\bdiskutil\s+(erase|partition)/,
+  /:\(\)\s*\{.*\}\s*;\s*:/, // Fork-Bombe
+  /\bcurl\b[^|]*\|\s*(ba)?sh/, // curl … | sh
+  /\bwget\b[^|]*\|\s*(ba)?sh/,
+  /\bgit\s+push\b.*(--force|-f)\b/,
+  /\bgit\s+reset\s+--hard\b/,
+  /\bchmod\s+-R\s+777/,
+  />\s*\/dev\/(disk|rdisk)/,
+  /\bkillall\b|\bshutdown\b|\breboot\b/,
+  // Zugangsdaten — egal mit welchem Befehl
+  /\.ssh\/|\.aws\/|\.gnupg\/|\.netrc\b/,
+  /\.env\b|auth\.json|credentials|id_[re]d?sa\b|\.pem\b|\.p12\b/,
+  /\bsecurity\s+(find|dump)-(generic|internet)-password|\blogin\.keychain/,
+  /\bhistory\b.*\|/,
+]
+
+// 3. Ohne Rückfrage erlauben — der Alltag dieses Projekts.
+//    Lesebefehle nur auf projektrelative Pfade: kein ~, kein /, kein ..
+const IM_PROJEKT = "(?![^\\n]*(~|\\s\\/|\\.\\.\\/|\\$HOME))"
+const FREI = [
+  new RegExp(`^typst\\s${IM_PROJEKT}`),
+  new RegExp(`^typstyle\\s${IM_PROJEKT}`),
+  new RegExp(`^(pdftoppm|pdfinfo)\\s${IM_PROJEKT}`),
+  new RegExp(`^(ls|cat|head|tail|wc|file|grep|rg)\\s${IM_PROJEKT}`),
+  new RegExp(`^mkdir\\s+-p\\s${IM_PROJEKT}`),
+  new RegExp(`^(python3?|\\.)\\s*\\/?tools\\/${IM_PROJEKT}`),
+  /^ls$/, /^pwd$/,
+  /^(which|basename|dirname|echo)\s/,
+  /^git\s+(status|diff|log|show|add|branch)\b/,
+]
+
+function schluessel() {
+  try {
+    const p = path.join(os.homedir(), ".local/share/opencode/auth.json")
+    return JSON.parse(fs.readFileSync(p, "utf8"))["github-copilot"]?.access
+  } catch {
+    return null
+  }
+}
+
+async function modellUrteil(befehl, verzeichnis, key) {
+  const anweisung =
+    `Du prüfst einen Shell-Befehl, den ein KI-Agent ausführen will.\n` +
+    `Arbeitsverzeichnis: ${verzeichnis}\n` +
+    `Befehl: ${befehl}\n\n` +
+    `Blockiere, wenn der Befehl: Daten außerhalb des Arbeitsverzeichnisses löscht ` +
+    `oder verändert; Systemeinstellungen ändert; Dinge aus dem Netz herunterlädt ` +
+    `und ausführt; Zugangsdaten ausliest oder verschickt; Prozesse beendet, die ` +
+    `nicht zum Projekt gehören.\n\n` +
+    `Antworte mit genau einem Wort: OK oder STOP. ` +
+    `Bei STOP hänge nach einem Doppelpunkt eine kurze Begründung an.`
+
+  // Zeitgrenze: der Wächter darf die Arbeit nicht anhalten
+  const abbruch = AbortSignal.timeout(8000)
+  const antwort = await fetch(ENDPUNKT, {
+    method: "POST",
+    signal: abbruch,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      "Copilot-Integration-Id": "vscode-chat",
+      "Editor-Version": "vscode/1.95.0",
+    },
+    body: JSON.stringify({
+      model: MODELL,
+      max_tokens: 80,
+      temperature: 0,
+      messages: [{ role: "user", content: anweisung }],
+    }),
+  })
+  if (!antwort.ok) return { ok: true, grund: `Prüfung übersprungen (HTTP ${antwort.status})` }
+  const d = await antwort.json()
+  const text = (d.choices?.[0]?.message?.content ?? "").trim()
+  if (/^STOP/i.test(text)) return { ok: false, grund: text.replace(/^STOP:?\s*/i, "") }
+  return { ok: true }
+}
+
+// ---------------------------------------------------------------------------
+// Fremdpfade erkennen
+// ---------------------------------------------------------------------------
+
+/** Zerlegt einen Befehl in Wörter; Anführungszeichen bleiben zusammen. */
+function woerter(befehl) {
+  return (befehl.match(/"[^"]*"|'[^']*'|\S+/g) || []).map((w) => w.replace(/^["']|["']$/g, ""))
+}
+
+/** Löst ~, $HOME und relative Angaben zu einem absoluten Pfad auf. */
+function absolut(wort, projekt) {
+  const p = wort.replace(/^~(?=\/|$)/, os.homedir()).replace(/^\$HOME(?=\/|$)/, os.homedir())
+  return path.resolve(projekt, p)
+}
+
+/**
+ * Welche Pfade im Befehl liegen außerhalb des Projekts?
+ * Deterministische Regel — hier wird dem Modell bewusst nicht vertraut:
+ * im Test hat es `grep -r password ~/` durchgewinkt.
+ * Geprüft werden nur Wörter, die als Pfad BEGINNEN (auch nach `flag=`) —
+ * sonst schlägt "Zuordnungen/AO.typ" fälschlich an.
+ */
+export function ausserhalb(befehl, projekt) {
+  const gefunden = []
+  for (const roh of woerter(befehl)) {
+    const wort = roh.replace(/^[\w.-]+=(?=~\/|\/|\$HOME|\.\.)/, "")
+    if (!/^(~(\/|$)|\$HOME(\/|$)|\/|\.\.(\/|$))/.test(wort)) continue
+    const pfad = absolut(wort, projekt)
+    if (pfad === projekt || pfad.startsWith(projekt + path.sep)) continue
+    if (/^\/(usr|bin|sbin|opt|Applications)\//.test(pfad)) continue // Programmaufruf
+    if (/^\/dev\/(null|stdout|stderr)$/.test(pfad)) continue
+    if (!gefunden.includes(pfad)) gefunden.push(pfad)
+  }
+  return gefunden
+}
+
+const LESEND = new Set([
+  "cat", "head", "tail", "less", "more", "wc", "file", "stat", "grep", "rg", "egrep",
+  "fgrep", "find", "fd", "ls", "tree", "du", "df", "diff", "cmp", "md5", "shasum",
+  "sha256sum", "pdfinfo", "pdftotext", "pdftoppm", "identify", "exiftool", "realpath",
+  "readlink", "basename", "dirname", "test", "[", "strings", "xxd", "hexdump", "sort",
+  "uniq", "cut", "awk", "jq", "yq", "open", "qlmanage", "mdls", "xattr", "lsof",
+])
+const SCHREIBEND = new Set([
+  "cp", "mv", "rm", "rmdir", "mkdir", "touch", "ln", "chmod", "chown", "chgrp", "tee",
+  "truncate", "rsync", "install", "unzip", "zip", "tar", "dd", "patch", "ditto",
+])
+
+/** Teilt an && || ; | außerhalb von Anführungszeichen. */
+function abschnitte(befehl) {
+  const teile = []
+  let aktuell = ""
+  let quote = null
+  for (let i = 0; i < befehl.length; i++) {
+    const c = befehl[i]
+    if (quote) {
+      aktuell += c
+      if (c === quote) quote = null
+      continue
+    }
+    if (c === '"' || c === "'") { quote = c; aktuell += c; continue }
+    if (c === "&" && befehl[i + 1] === "&") { teile.push(aktuell); aktuell = ""; i++; continue }
+    if (c === "|" && befehl[i + 1] === "|") { teile.push(aktuell); aktuell = ""; i++; continue }
+    if (c === ";" || c === "|") { teile.push(aktuell); aktuell = ""; continue }
+    aktuell += c
+  }
+  teile.push(aktuell)
+  return teile.map((t) => t.trim()).filter(Boolean)
+}
+
+/**
+ * Art des Zugriffs auf die Fremdpfade: lesen, schreiben, ausführen oder
+ * unklar. Nur eine Einordnung für den Menschen — entschieden wird in Discord.
+ */
+export function zugriffsart(befehl, projekt) {
+  const arten = new Set()
+  for (const teil of abschnitte(befehl)) {
+    const fremd = ausserhalb(teil, projekt)
+    if (!fremd.length) continue
+    const w = woerter(teil).filter((x) => !/^[A-Za-z_][A-Za-z0-9_]*=/.test(x)) // VAR=… überspringen
+    const programm = path.basename(w[0] ?? "")
+    // Umleitung in einen Fremdpfad ist immer ein Schreibzugriff
+    const umleitung = teil.match(/>>?\s*("[^"]*"|'[^']*'|\S+)/)
+    if (umleitung && ausserhalb(umleitung[1].replace(/^["']|["']$/g, ""), projekt).length) {
+      arten.add("schreiben")
+      continue
+    }
+    if (programm === "sed") { arten.add(/\s-[a-zA-Z]*i/.test(teil) ? "schreiben" : "lesen"); continue }
+    if (fremd.some((p) => absolut(w[0] ?? "", projekt) === p)) { arten.add("ausführen"); continue }
+    if (SCHREIBEND.has(programm)) arten.add("schreiben")
+    else if (LESEND.has(programm)) arten.add("lesen")
+    else if (programm === "cd" || programm === "pushd") arten.add("ausführen")
+    else arten.add("ausführen")
+  }
+  if (arten.has("schreiben")) return "schreiben"
+  if (arten.has("ausführen")) return "ausführen"
+  if (arten.has("lesen")) return "lesen"
+  return "unklar"
+}
+
+// ---------------------------------------------------------------------------
+// Rückfrage über die Discord-Bridge
+// ---------------------------------------------------------------------------
+
+/** Läuft das Hermes-Gateway mit verbundenem Discord? Sonst Grund zurückgeben. */
+export function brueckeAusgefallen(hermesHome = HERMES_HOME) {
+  let heartbeat
+  try {
+    heartbeat = JSON.parse(fs.readFileSync(path.join(hermesHome, "state", "gateway.heartbeat"), "utf8"))
+  } catch {
+    return "kein Gateway-Heartbeat gefunden"
+  }
+  const alter = (Date.now() - Date.parse(heartbeat.updated_at ?? "")) / 1000
+  if (!(alter < HEARTBEAT_MAX_ALTER_S)) return `Gateway-Heartbeat ist ${Math.round(alter) || "?"} s alt`
+  let zustand
+  try {
+    zustand = JSON.parse(fs.readFileSync(path.join(hermesHome, "gateway_state.json"), "utf8"))
+  } catch {
+    return "gateway_state.json nicht lesbar"
+  }
+  if (zustand.gateway_state !== "running") return `Gateway-Zustand: ${zustand.gateway_state ?? "unbekannt"}`
+  const discord = zustand.platforms?.discord?.state
+  if (discord !== "connected") return `Discord ist ${discord ?? "nicht konfiguriert"}`
+  return null
+}
+
+function schlafen(ms) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+function leiseLoeschen(p) {
+  try { fs.unlinkSync(p) } catch {}
+}
+
+/**
+ * Legt die Anfrage ab und wartet auf die Entscheidung der Bridge.
+ * Rückgabe: { erlaubt: boolean, grund: string }. Alles außer einer sauberen
+ * „once“-Antwort mit passender ID gilt als Ablehnung.
+ */
+export async function brueckeFragen(anfrage, optionen = {}) {
+  // Gegen den Plugin-Fabrik-Aufruf beim Laden (Kontextobjekt statt Anfrage).
+  if (!anfrage || !Array.isArray(anfrage.pfade)) return { erlaubt: false, grund: "ungültige Anfrage" }
+  const ablage = optionen.ablage ?? ABLAGE
+  const anfragen = path.join(ablage, "requests")
+  const antworten = path.join(ablage, "decisions")
+  const wartezeitS = optionen.wartezeitS ?? WARTEZEIT_S
+  const abfrageMs = optionen.abfrageMs ?? ABFRAGE_MS
+
+  const ausfall = optionen.ausfallpruefung === false ? null : brueckeAusgefallen(optionen.hermesHome)
+  if (ausfall) return { erlaubt: false, grund: `Discord-Bridge nicht erreichbar: ${ausfall}` }
+
+  const id = crypto.randomUUID()
+  const jetzt = Date.now() / 1000
+  const nutzlast = {
+    version: 1,
+    id,
+    agent: "opencode",
+    created_at: jetzt,
+    expires_at: jetzt + wartezeitS,
+    session_id: anfrage.sessionID ?? "",
+    project: anfrage.projekt,
+    command: anfrage.befehl,
+    path: anfrage.pfade.join(", "),
+    access: anfrage.zugriff,
+  }
+  const anfrageDatei = path.join(anfragen, `${id}.json`)
+  const antwortDatei = path.join(antworten, `${id}.json`)
+  try {
+    for (const d of [ablage, anfragen, antworten]) fs.mkdirSync(d, { recursive: true, mode: 0o700 })
+    const tmp = path.join(anfragen, `.tmp-${id}`)
+    fs.writeFileSync(tmp, JSON.stringify(nutzlast), { mode: 0o600 })
+    fs.renameSync(tmp, anfrageDatei)
+  } catch (e) {
+    return { erlaubt: false, grund: `Anfrage konnte nicht abgelegt werden (${e.message})` }
+  }
+
+  const ende = Date.now() + wartezeitS * 1000
+  try {
+    while (Date.now() < ende) {
+      let roh
+      try {
+        roh = fs.readFileSync(antwortDatei, "utf8")
+      } catch {
+        await schlafen(abfrageMs)
+        continue
+      }
+      let antwort
+      try {
+        antwort = JSON.parse(roh)
+      } catch {
+        return { erlaubt: false, grund: "unlesbare Antwort der Bridge" }
+      }
+      if (antwort?.version !== 1 || antwort?.id !== id) {
+        return { erlaubt: false, grund: "Antwort der Bridge passt nicht zur Anfrage" }
+      }
+      if (antwort.decision === "once") return { erlaubt: true, grund: "in Discord einmalig erlaubt" }
+      if (antwort.decision === "reject") {
+        return {
+          erlaubt: false,
+          grund: antwort.source === "timeout" ? "in Discord nicht rechtzeitig beantwortet" : "in Discord abgelehnt",
+        }
+      }
+      return { erlaubt: false, grund: `unbekannte Entscheidung „${String(antwort.decision)}“` }
+    }
+    return { erlaubt: false, grund: `keine Antwort innerhalb von ${wartezeitS} s` }
+  } finally {
+    leiseLoeschen(anfrageDatei)
+    leiseLoeschen(antwortDatei)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export const Befehlswaechter = async ({ directory }) => {
+  const key = schluessel()
+  const projekt = path.resolve(directory ?? process.cwd())
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return
+      const befehl = String(output.args?.command ?? "").trim()
+      if (!befehl) return
+
+      for (const muster of GESPERRT) {
+        if (muster.test(befehl)) {
+          throw new Error(
+            `Befehlswächter: blockiert (harte Sperre).\nBefehl: ${befehl}\n` +
+              `Falls beabsichtigt, führe ihn selbst im Terminal aus.`,
+          )
+        }
+      }
+
+      const fremd = ausserhalb(befehl, projekt)
+      if (fremd.length) {
+        const zugriff = zugriffsart(befehl, projekt)
+        const ergebnis = await brueckeFragen({
+          befehl,
+          pfade: fremd,
+          projekt,
+          zugriff,
+          sessionID: input.sessionID,
+        })
+        if (ergebnis.erlaubt) return // einmalige Freigabe — keine weitere Prüfung
+        throw new Error(
+          `Befehlswächter: Zugriff außerhalb des Projekts blockiert (${ergebnis.grund}).\n` +
+            `Befehl: ${befehl}\nPfad: ${fremd.join(", ")}\nProjekt: ${projekt}\nZugriff: ${zugriff}\n` +
+            `Nicht erneut versuchen. Falls beabsichtigt, führe ihn selbst im Terminal aus.`,
+        )
+      }
+
+      if (FREI.some((m) => m.test(befehl))) return
+      if (!key) return // ohne Schlüssel keine Modellprüfung, Rest regelt die Berechtigung
+
+      try {
+        const urteil = await modellUrteil(befehl, directory, key)
+        if (!urteil.ok) {
+          throw new Error(
+            `Befehlswächter: ${MODELL} rät ab.\nBefehl: ${befehl}\nGrund: ${urteil.grund}`,
+          )
+        }
+      } catch (e) {
+        if (String(e.message).startsWith("Befehlswächter:")) throw e
+        // Netzfehler dürfen die Arbeit nicht anhalten
+      }
+    },
+  }
+}

--- a/contrib/discord-bridge/opencode-plugins/discord-melder.js.disabled
+++ b/contrib/discord-bridge/opencode-plugins/discord-melder.js.disabled
@@ -1,0 +1,123 @@
+/**
+ * Discord-Melder — schreibt am Ende jeder opencode-Antwort eine kurze
+ * Meldung in einen Discord-Kanal, über einen Kanal-Webhook.
+ *
+ * Warum Webhook statt eigenem Bot: für reine Meldungen braucht es kein
+ * Bot-Konto, keinen Token-Prozess und keinen laufenden Dienst. Der Webhook
+ * erscheint in Discord mit eigenem Namen („OpenCode“) und gilt als Bot-
+ * Nachricht — der Hermes-Bot ignoriert Bot-Nachrichten (DISCORD_ALLOW_BOTS
+ * steht standardmäßig auf „none“) und antwortet deshalb nicht darauf.
+ * Interaktive Rückfragen (Buttons) kann ein Webhook nicht; die laufen weiter
+ * über die Bridge im Hermes-Gateway (siehe befehlswaechter.js).
+ *
+ * Einrichtung: Webhook-URL im Kanal anlegen (Kanal-Einstellungen →
+ * Integrationen → Webhooks) und in `~/.config/opencode/discord-webhook.txt`
+ * ablegen (oder Umgebungsvariable OPENCODE_DISCORD_WEBHOOK). Fehlt beides,
+ * bleibt das Plugin still.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const WEBHOOK_DATEI = path.join(os.homedir(), ".config/opencode/discord-webhook.txt")
+const MAX_ZEICHEN = 1500 // Discord erlaubt 2000; Rest ist Kopfzeile
+const NAME = "OpenCode"
+
+export function webhookUrl() {
+  const env = (process.env.OPENCODE_DISCORD_WEBHOOK || "").trim()
+  if (env) return env
+  try {
+    return fs.readFileSync(WEBHOOK_DATEI, "utf8").trim()
+  } catch {
+    return ""
+  }
+}
+
+function kuerzen(text, max = MAX_ZEICHEN) {
+  const t = String(text || "").trim()
+  if (t.length <= max) return t
+  return t.slice(0, max - 1).trimEnd() + "…"
+}
+
+/** Baut den Nachrichtentext für eine abgeschlossene Antwort. */
+export function meldung({ projekt, sitzung, text, titel }) {
+  const kopf = `**${NAME}** · \`${path.basename(projekt || "") || projekt}\`` + (titel ? ` · ${kuerzen(titel, 80)}` : "")
+  const koerper = kuerzen(text)
+  return `${kopf}\n${koerper || "_(keine Textantwort)_"}\n-# Session ${String(sitzung || "").slice(0, 12)}`
+}
+
+/** Sammelt Assistententexte je Session und meldet beim Leerlauf. */
+export function meldeZustand() {
+  const rollen = new Map() // messageID → role
+  const texte = new Map() // sessionID → letzter abgeschlossener Assistententext
+  const titel = new Map() // sessionID → Titel
+  const gemeldet = new Map() // sessionID → zuletzt gemeldeter Text
+
+  function verarbeite(ev) {
+    const p = ev?.properties ?? {}
+    switch (ev?.type) {
+      case "message.updated": {
+        const info = p.info ?? {}
+        if (info.id && info.role) rollen.set(info.id, info.role)
+        return null
+      }
+      case "message.part.updated": {
+        const part = p.part ?? {}
+        if (part.type !== "text" || !part.sessionID) return null
+        if (rollen.get(part.messageID) !== "assistant") return null
+        if (!part.time?.end) return null
+        texte.set(part.sessionID, part.text ?? "")
+        return null
+      }
+      case "session.updated": {
+        const info = p.info ?? {}
+        if (info.id && info.title) titel.set(info.id, info.title)
+        return null
+      }
+      case "session.idle":
+      case "session.status": {
+        if (ev.type === "session.status" && p.status?.type !== "idle") return null
+        const sid = p.sessionID
+        if (!sid || !texte.has(sid)) return null
+        const text = texte.get(sid)
+        if (gemeldet.get(sid) === text) return null // Doppelmeldung vermeiden
+        gemeldet.set(sid, text)
+        return { sitzung: sid, text, titel: titel.get(sid) }
+      }
+      default:
+        return null
+    }
+  }
+  return { verarbeite }
+}
+
+export async function senden(url, inhalt, fetchFn = fetch) {
+  // Gegen den Plugin-Fabrik-Aufruf beim Laden (Kontextobjekt statt URL).
+  if (typeof url !== "string" || !/^https:\/\//.test(url)) return false
+  const antwort = await fetchFn(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: NAME, content: inhalt, allowed_mentions: { parse: [] } }),
+    signal: AbortSignal.timeout(8000),
+  })
+  return antwort.ok
+}
+
+export const DiscordMelder = async ({ directory }) => {
+  const url = webhookUrl()
+  if (!/^https:\/\/(discord\.com|discordapp\.com)\/api\/webhooks\//.test(url)) return {}
+  const projekt = path.resolve(directory ?? process.cwd())
+  const zustand = meldeZustand()
+  return {
+    event: async ({ event }) => {
+      const fertig = zustand.verarbeite(event)
+      if (!fertig) return
+      try {
+        await senden(url, meldung({ projekt, ...fertig }))
+      } catch {
+        // Meldungen dürfen die Arbeit nie anhalten
+      }
+    },
+  }
+}

--- a/contrib/discord-bridge/opencode-plugins/sitzungsthread.js
+++ b/contrib/discord-bridge/opencode-plugins/sitzungsthread.js
@@ -1,0 +1,162 @@
+/**
+ * Sitzungsthread — meldet jede opencode-Sitzung an die Hermes-Discord-Bridge,
+ * die daraus einen Thread im Bridge-Kanal macht:
+ *
+ *   Sitzungsstart  → Thread mit Startzeit, Projektordner und Prompt
+ *   weitere Prompts → „Neuer Prompt“ im Thread
+ *   Ende jeder Runde → „Antwort“ (letzter Assistententext) im Thread
+ *   Unteragenten   → ihre Rückfragen landen im Thread der Elternsitzung
+ *
+ * Die Rückfragen des Befehlswächters derselben Sitzung stellt die Bridge
+ * ebenfalls in diesem Thread. Transport ist dieselbe Ablage wie beim
+ * Befehlswächter (`$HERMES_HOME/opencode_bridge/requests`), nur ohne
+ * Antwortdatei: Meldungen werden abgelegt und nicht abgewartet. Ist die
+ * Bridge aus, bleiben die Dateien liegen, bis sie verfallen — die Arbeit
+ * von opencode hält das nie an.
+ */
+
+import crypto from "node:crypto"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const HERMES_HOME = process.env.HERMES_HOME || path.join(os.homedir(), ".hermes")
+const ABLAGE = path.join(HERMES_HOME, "opencode_bridge")
+const GUELTIG_S = 3600 // die Bridge verwirft ältere Meldungen
+const MAX_ZEICHEN = 1700
+const GUELTIGE_MELDUNGEN = new Set(["start", "prompt", "result", "child"])
+
+function kuerzen(text, max = MAX_ZEICHEN) {
+  const t = String(text || "").trim()
+  return t.length <= max ? t : t.slice(0, max - 1).trimEnd() + "…"
+}
+
+/** Legt eine Meldung atomar in der Ablage ab; Fehler werden geschluckt. */
+export function melden(meldung, ablage = ABLAGE) {
+  // opencode ruft JEDE Export-Funktion beim Laden als Plugin-Fabrik mit dem
+  // Kontext {client, project, directory, ...} auf. Ohne echtes notice-Feld
+  // ist das kein Meldeaufruf — nichts ablegen.
+  if (!meldung || typeof meldung !== "object" || !GUELTIGE_MELDUNGEN.has(meldung.notice)) return false
+  const anfragen = path.join(ablage, "requests")
+  const id = crypto.randomUUID()
+  const jetzt = Date.now() / 1000
+  const nutzlast = {
+    version: 1,
+    id,
+    agent: "opencode",
+    kind: "notice",
+    created_at: jetzt,
+    expires_at: jetzt + GUELTIG_S,
+    started_at: jetzt,
+    ...meldung,
+    text: kuerzen(meldung.text),
+  }
+  try {
+    fs.mkdirSync(anfragen, { recursive: true, mode: 0o700 })
+    const tmp = path.join(anfragen, `.tmp-${id}`)
+    fs.writeFileSync(tmp, JSON.stringify(nutzlast), { mode: 0o600 })
+    fs.renameSync(tmp, path.join(anfragen, `${id}.json`))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Verfolgt Sitzungen und Nachrichten aus dem Ereignisstrom und liefert die
+ * Meldungen, die abzulegen sind. Reine Zustandslogik, testbar ohne Discord.
+ */
+export function sitzungsZustand(projekt) {
+  // Reale opencode-Ereignisse (run- wie TUI-Modus, verifiziert):
+  //  - Der Nutzer-Textteil kommt OHNE time.end (der ganze Prompt steht sofort
+  //    im part.text). Deshalb wird hier NICHT auf end gewartet.
+  //  - Rolle (message.updated) und Textteil (message.part.updated) können in
+  //    beliebiger Reihenfolge eintreffen; darum wird beides gepuffert und die
+  //    Meldung erzeugt, sobald Rolle UND Text bekannt sind.
+  //  - Assistenten-Text streamt als Schnappschuss; der letzte Stand pro
+  //    Nachricht ist die fertige Antwort und wird beim session.idle gemeldet.
+  const rollen = new Map() // messageID → role
+  const texte = new Map() // messageID → { sid, text }
+  const sitzungen = new Map() // sessionID → Zustand
+  const eltern = new Map() // child sessionID → parent
+
+  function eintrag(sid) {
+    if (!sitzungen.has(sid)) {
+      sitzungen.set(sid, { gestartet: false, gemeldetePrompts: new Set(), letzteAntwort: null, gemeldeteAntwort: null })
+    }
+    return sitzungen.get(sid)
+  }
+
+  /** Erzeugt die Meldung für eine Nachricht, sobald Rolle und Text feststehen. */
+  function auswerten(mid) {
+    const rolle = rollen.get(mid)
+    const eintragText = texte.get(mid)
+    if (!rolle || !eintragText) return []
+    const { sid, text } = eintragText
+    const s = eintrag(sid)
+    if (rolle === "user") {
+      if (eltern.has(sid)) return [] // Unteragenten-Prompts nicht melden
+      if (s.gemeldetePrompts.has(mid)) return []
+      s.gemeldetePrompts.add(mid)
+      if (!s.gestartet) {
+        s.gestartet = true
+        return [{ notice: "start", session_id: sid, project: projekt, text }]
+      }
+      return [{ notice: "prompt", session_id: sid, project: projekt, text }]
+    }
+    if (rolle === "assistant") s.letzteAntwort = { id: mid, text }
+    return []
+  }
+
+  function verarbeite(ev) {
+    const p = ev?.properties ?? {}
+    switch (ev?.type) {
+      case "session.created":
+      case "session.updated": {
+        const info = p.info ?? {}
+        if (info.id && info.parentID && !eltern.has(info.id)) {
+          eltern.set(info.id, info.parentID)
+          return [{ notice: "child", session_id: info.id, parent_session_id: info.parentID, project: projekt }]
+        }
+        return []
+      }
+      case "message.updated": {
+        const info = p.info ?? {}
+        if (info.id && info.role) {
+          rollen.set(info.id, info.role)
+          return auswerten(info.id)
+        }
+        return []
+      }
+      case "message.part.updated": {
+        const part = p.part ?? {}
+        if (part.type !== "text" || !part.sessionID || !part.messageID) return []
+        texte.set(part.messageID, { sid: part.sessionID, text: part.text ?? "" })
+        return auswerten(part.messageID)
+      }
+      case "session.idle":
+      case "session.status": {
+        if (ev.type === "session.status" && p.status?.type !== "idle") return []
+        const sid = p.sessionID
+        if (!sid || eltern.has(sid)) return []
+        const s = sitzungen.get(sid)
+        if (!s?.letzteAntwort || s.gemeldeteAntwort === s.letzteAntwort.id) return []
+        s.gemeldeteAntwort = s.letzteAntwort.id
+        return [{ notice: "result", session_id: sid, project: projekt, text: s.letzteAntwort.text }]
+      }
+      default:
+        return []
+    }
+  }
+  return { verarbeite }
+}
+
+export const Sitzungsthread = async ({ directory }) => {
+  const projekt = path.resolve(directory ?? process.cwd())
+  const zustand = sitzungsZustand(projekt)
+  return {
+    event: async ({ event }) => {
+      for (const meldung of zustand.verarbeite(event)) melden(meldung)
+    },
+  }
+}

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1154,6 +1154,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # shutdown from a runtime websocket crash.
         self._disconnecting = False
         self._missed_message_backfill_task: Optional[asyncio.Task] = None
+        # OpenCode permission bridge (opt-in via config extra "opencode_bridge").
+        self._opencode_bridge: Optional[Any] = None
+        self._opencode_bridge_checked = False
         from hermes_constants import get_hermes_home
         from plugins.platforms.discord.recovery import DiscordRecoveryStore
         self._discord_recovery_store = DiscordRecoveryStore(get_hermes_home())
@@ -1402,6 +1405,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
+                adapter_self._ensure_opencode_bridge()
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -2202,6 +2206,14 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._opencode_bridge is not None:
+            try:
+                await self._opencode_bridge.aclose()
+            except Exception as e:  # pragma: no cover - defensive logging
+                logger.warning("[%s] Error stopping OpenCode bridge: %s", self.name, e)
+            self._opencode_bridge = None
+            self._opencode_bridge_checked = False
+
         self._running = False
         self._client = None
         self._ready_event.clear()
@@ -2568,6 +2580,36 @@ class DiscordAdapter(BasePlatformAdapter):
                 runner._startup_restore_tasks = tasks
             tasks.append(task)
         return task
+
+    def _ensure_opencode_bridge(self) -> None:
+        """Start the OpenCode permission bridge once, when configured (opt-in).
+
+        Mirrors ``_define_discord_view_classes``'s lazy-start posture: the
+        bridge is only constructed after a live connection exists. Misconfig
+        (non-loopback base_url, empty allowlist, missing channel) disables it
+        fail-closed with a one-time warning; absence/disabled stay silent.
+        """
+        if self._opencode_bridge_checked:
+            return
+        self._opencode_bridge_checked = True
+        try:
+            from plugins.platforms.discord.opencode_bridge import (
+                OpenCodeBridge,
+                parse_bridge_config,
+            )
+
+            config = parse_bridge_config(self.config.extra)
+            if not config.enabled:
+                if config.disabled_reason not in ("not configured", "disabled"):
+                    logger.warning(
+                        "[Discord] OpenCode permission bridge disabled: %s",
+                        config.disabled_reason,
+                    )
+                return
+            self._opencode_bridge = OpenCodeBridge(self, config)
+            self._opencode_bridge.start()
+        except Exception as e:
+            logger.warning("[Discord] Failed to start OpenCode bridge: %s", e)
 
     async def _run_missed_message_backfill(self) -> None:
         """Find and enqueue recent Discord messages missed while the bot was down.

--- a/plugins/platforms/discord/opencode_bridge.py
+++ b/plugins/platforms/discord/opencode_bridge.py
@@ -142,6 +142,16 @@ SSE_SOURCE = "sse"
 # answered with labels or free text.
 GUARD_KIND_PERMISSION = "permission"
 GUARD_KIND_QUESTION = "question"
+# "notice" = fire-and-forget session events (no decision file): the agent
+# started a session (→ one Discord thread per session, prompts of that
+# session are asked inside it), sent a further prompt, finished a turn, or
+# spawned a child session whose prompts belong to the parent's thread.
+GUARD_KIND_NOTICE = "notice"
+GUARD_NOTICES = frozenset({"start", "prompt", "result", "child"})
+GUARD_THREADS_FILE = "threads.json"
+GUARD_THREAD_TTL_SECONDS = 7 * 24 * 3600
+_NOTICE_TEXT_BUDGET = 1700
+_THREAD_NAME_BUDGET = 100
 GUARD_MAX_QUESTIONS = 4
 GUARD_MAX_OPTIONS = 8
 _DETAILS_BUDGET = 900
@@ -196,6 +206,12 @@ class OpenCodeBridgeConfig:
     # overrides the spool root.
     guard_enabled: bool = True
     guard_dir: str = ""
+    # Optional per-agent channels, e.g. {"claude-code": "123"}: guard prompts
+    # and session threads of that agent go there instead of ``channel_id``.
+    agent_channels: Dict[str, str] = field(default_factory=dict)
+
+    def channel_for(self, agent: str) -> str:
+        return self.agent_channels.get(agent) or self.channel_id
 
 
 def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
@@ -247,6 +263,16 @@ def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
     guard_enabled = guard_enabled if isinstance(guard_enabled, bool) else True
     guard_dir = str(section.get("guard_dir") or "").strip() or default_guard_dir()
 
+    raw_channels = section.get("agent_channels")
+    agent_channels: Dict[str, str] = {}
+    if isinstance(raw_channels, dict):
+        for agent, value in raw_channels.items():
+            agent, value = str(agent).strip(), str(value).strip()
+            # Only known agents and plain numeric ids; anything else is
+            # dropped so a typo cannot silently redirect prompts.
+            if agent in GUARD_AGENTS and value.isdigit():
+                agent_channels[agent] = value
+
     return OpenCodeBridgeConfig(
         enabled=True,
         base_url=base_url,
@@ -255,6 +281,7 @@ def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
         timeout_seconds=timeout_seconds,
         guard_enabled=guard_enabled,
         guard_dir=guard_dir,
+        agent_channels=agent_channels,
     )
 
 
@@ -287,6 +314,11 @@ class OpenCodePermissionRequest:
     tool: str = ""
     details: str = ""
     questions: tuple = ()
+    # Notice-only fields.
+    notice: str = ""
+    text: str = ""
+    started_at: float = 0.0
+    parent_session_id: str = ""
 
     @property
     def short_session_id(self) -> str:
@@ -299,6 +331,10 @@ class OpenCodePermissionRequest:
     @property
     def is_question(self) -> bool:
         return self.is_guard and self.guard_kind == GUARD_KIND_QUESTION
+
+    @property
+    def is_notice(self) -> bool:
+        return self.is_guard and self.guard_kind == GUARD_KIND_NOTICE
 
 
 def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
@@ -379,7 +415,7 @@ def parse_guard_request(
     if agent not in GUARD_AGENTS:
         return None
     kind = payload.get("kind", GUARD_KIND_PERMISSION)
-    if kind not in (GUARD_KIND_PERMISSION, GUARD_KIND_QUESTION):
+    if kind not in (GUARD_KIND_PERMISSION, GUARD_KIND_QUESTION, GUARD_KIND_NOTICE):
         return None
     project = payload.get("project")
     project = project if isinstance(project, str) else ""
@@ -388,7 +424,24 @@ def parse_guard_request(
     details = payload.get("details", "")
     details = details if isinstance(details, str) else ""
     questions: tuple = ()
-    if kind == GUARD_KIND_QUESTION:
+    notice, text, parent_session_id, started_at = "", "", "", 0.0
+    if kind == GUARD_KIND_NOTICE:
+        notice = payload.get("notice")
+        if notice not in GUARD_NOTICES:
+            return None
+        session = payload.get("session_id")
+        if not isinstance(session, str) or not session.strip():
+            return None
+        text = payload.get("text", "")
+        text = text if isinstance(text, str) else ""
+        parent = payload.get("parent_session_id", "")
+        parent_session_id = parent if isinstance(parent, str) else ""
+        if notice == "child" and not parent_session_id:
+            return None
+        started = payload.get("started_at", 0.0)
+        started_at = float(started) if isinstance(started, (int, float)) and not isinstance(started, bool) else 0.0
+        command, path, access = notice, "-", "unklar"
+    elif kind == GUARD_KIND_QUESTION:
         questions = _parse_questions(payload.get("questions"))
         if not questions:
             return None
@@ -433,7 +486,95 @@ def parse_guard_request(
         tool=tool,
         details=details,
         questions=questions,
+        notice=str(notice),
+        text=text,
+        started_at=started_at,
+        parent_session_id=parent_session_id,
     )
+
+
+class ThreadRegistry:
+    """session_id → Discord thread, persisted next to the spool.
+
+    Child sessions (subagents) map to their parent's thread. Entries expire
+    after a week so the file cannot grow without bound.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._sessions: Dict[str, Dict[str, Any]] = {}
+        self._parents: Dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return
+        if not isinstance(data, dict):
+            return
+        sessions = data.get("sessions")
+        parents = data.get("parents")
+        if isinstance(sessions, dict):
+            self._sessions = {
+                str(k): v for k, v in sessions.items()
+                if isinstance(v, dict) and isinstance(v.get("thread_id"), str)
+            }
+        if isinstance(parents, dict):
+            self._parents = {str(k): str(v) for k, v in parents.items()}
+
+    def _save(self) -> None:
+        payload = {"sessions": self._sessions, "parents": self._parents}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=".tmp-threads-", suffix=".json", dir=self.path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle)
+            os.replace(tmp_name, self.path)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    def root_session(self, session_id: str) -> str:
+        seen: Set[str] = set()
+        while session_id in self._parents and session_id not in seen:
+            seen.add(session_id)
+            session_id = self._parents[session_id]
+        return session_id
+
+    def thread_for(self, session_id: str) -> Optional[str]:
+        entry = self._sessions.get(self.root_session(session_id))
+        return entry.get("thread_id") if entry else None
+
+    def set_thread(self, session_id: str, thread_id: str, channel_id: str, *, now: Optional[float] = None) -> None:
+        self._sessions[session_id] = {
+            "thread_id": str(thread_id),
+            "channel_id": str(channel_id),
+            "created_at": time.time() if now is None else now,
+        }
+        self._save()
+
+    def set_parent(self, child_id: str, parent_id: str) -> None:
+        if child_id == parent_id:
+            return
+        self._parents[child_id] = parent_id
+        self._save()
+
+    def prune(self, *, now: Optional[float] = None) -> None:
+        current = time.time() if now is None else now
+        stale = [
+            sid for sid, entry in self._sessions.items()
+            if current - float(entry.get("created_at") or 0) > GUARD_THREAD_TTL_SECONDS
+        ]
+        if not stale:
+            return
+        for sid in stale:
+            del self._sessions[sid]
+        self._parents = {c: p for c, p in self._parents.items() if p in self._sessions}
+        self._save()
 
 
 def _parse_questions(raw: Any) -> tuple:
@@ -547,10 +688,19 @@ class GuardSpool:
                         logger.warning("OpenCode bridge: ignoring malformed guard request %s", name)
                     self._invalid.add(name)
                 continue
-            if self._decision_path(request_id).exists():
+            if not request.is_notice and self._decision_path(request_id).exists():
                 continue  # already answered, guard has not collected it yet
             found.append(request)
         return found
+
+    def remove_request(self, request_id: str) -> None:
+        """Drop a consumed notice file (notices have no decision file)."""
+        if GUARD_ID_RE.match(request_id):
+            self._unlink(self._request_path(request_id))
+
+    @property
+    def threads_path(self) -> Path:
+        return self.root / GUARD_THREADS_FILE
 
     def _drop_if_stale(self, file_path: Path, now: float) -> None:
         try:
@@ -803,6 +953,9 @@ class OpenCodeBridge:
             self._spool = GuardSpool(config.guard_dir)
         else:
             self._spool = None
+        self._threads: Optional[ThreadRegistry] = (
+            ThreadRegistry(self._spool.threads_path) if self._spool is not None else None
+        )
 
     @property
     def config(self) -> OpenCodeBridgeConfig:
@@ -815,6 +968,10 @@ class OpenCodeBridge:
     @property
     def spool(self) -> Optional[GuardSpool]:
         return self._spool
+
+    @property
+    def threads(self) -> Optional[ThreadRegistry]:
+        return self._threads
 
     def start(self) -> None:
         if self._task is None or self._task.done():
@@ -851,6 +1008,22 @@ class OpenCodeBridge:
             logger.warning("OpenCode bridge: guard spool scan failed: %s", exc)
             return 0
         for request in requests:
+            if request.is_notice:
+                try:
+                    if await self._handle_notice(request):
+                        posted += 1
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "OpenCode bridge: failed to handle %s notice %s: %s",
+                        request.notice, request.permission_id, exc,
+                    )
+                finally:
+                    # Notices are consumed exactly once; a failed one is not
+                    # retried (a second thread or duplicate post is worse).
+                    self._spool.remove_request(request.permission_id)
+                continue
             if self._registry.is_pending(request.permission_id):
                 continue
             try:
@@ -865,9 +1038,154 @@ class OpenCodeBridge:
                 )
         try:
             self._spool.sweep()
+            if self._threads is not None:
+                self._threads.prune()
         except Exception:  # pragma: no cover - best effort housekeeping
             pass
         return posted
+
+    # ------------------------------------------------------------------
+    # Session threads
+    # ------------------------------------------------------------------
+
+    async def _channel_for_agent(self, agent: str) -> Any:
+        """The Discord channel this agent's prompts belong in."""
+        client = self._adapter._client
+        if client is None:
+            return None
+        channel_id = self._config.channel_for(agent)
+        channel = client.get_channel(int(channel_id))
+        if channel is None:
+            try:
+                channel = await client.fetch_channel(int(channel_id))
+            except Exception as exc:
+                logger.warning("OpenCode bridge: channel %s unreachable (%s)", channel_id, exc)
+                return None
+        return channel
+
+    async def _main_channel(self) -> Any:
+        return await self._channel_for_agent("")
+
+    async def _thread_channel(self, session_id: str) -> Any:
+        """The session's thread, or None when unknown / unreachable."""
+        if self._threads is None or not session_id or session_id == "-":
+            return None
+        thread_id = self._threads.thread_for(session_id)
+        if not thread_id:
+            return None
+        client = self._adapter._client
+        if client is None:
+            return None
+        thread = client.get_channel(int(thread_id))
+        if thread is None:
+            try:
+                thread = await client.fetch_channel(int(thread_id))
+            except Exception as exc:
+                logger.debug("OpenCode bridge: thread %s unreachable (%s)", thread_id, exc)
+                return None
+        return thread
+
+    async def _target_channel(self, request: OpenCodePermissionRequest) -> Any:
+        """Prompts of a session go to its thread, else to the agent's channel."""
+        thread = await self._thread_channel(request.session_id)
+        return thread if thread is not None else await self._channel_for_agent(request.agent)
+
+    @staticmethod
+    def _thread_name(request: OpenCodePermissionRequest) -> str:
+        agent_label = GUARD_AGENTS.get(request.agent, request.agent)
+        project = os.path.basename((request.project or "").rstrip("/")) or "Projekt"
+        when = time.strftime("%d.%m. %H:%M", time.localtime(request.started_at or time.time()))
+        return _truncate(f"{agent_label} · {project} · {when}", _THREAD_NAME_BUDGET)
+
+    def _notice_text(self, request: OpenCodePermissionRequest) -> str:
+        agent_label = GUARD_AGENTS.get(request.agent, request.agent)
+        body = _truncate(request.text.strip(), _NOTICE_TEXT_BUDGET).replace("```", "'''")
+        when = time.strftime("%H:%M", time.localtime(request.started_at or time.time()))
+        if request.notice == "start":
+            return (
+                f"🧵 **{agent_label}-Sitzung gestartet** um {when}\n"
+                f"**Projektordner:** `{_truncate(request.project or '-', _PATH_BUDGET)}` · **Session:** `{request.short_session_id}`\n\n"
+                f"**Prompt:**\n{body or '_(kein Text)_'}"
+            )
+        if request.notice == "prompt":
+            return f"📝 **Neuer Prompt** ({when})\n{body or '_(kein Text)_'}"
+        if request.notice == "result":
+            return f"✅ **Antwort** ({when})\n{body or '_(keine Textantwort)_'}"
+        return body
+
+    async def _open_session_thread(self, request: OpenCodePermissionRequest) -> tuple[Any, Optional[str]]:
+        """Create the session's thread wherever the bridge channel allows it.
+
+        Returns (thread, pending_start_text). The configured channel may be a
+        text channel (thread hangs off a starter message), a forum channel
+        (each session is a new forum post), or itself a thread (Discord
+        forbids nesting, so the session thread is created in the parent and a
+        pointer is posted in the watched thread). pending_start_text is the
+        start message the caller still needs to post into the thread, or None
+        when it was already delivered (forum post content).
+        """
+        channel = await self._channel_for_agent(request.agent)
+        if channel is None:
+            return None, None
+        name = self._thread_name(request)
+        start_text = self._notice_text(request)
+        agent_label = GUARD_AGENTS.get(request.agent, request.agent)
+        project = os.path.basename((request.project or "").rstrip("/")) or "-"
+        pointer = f"🧵 **{agent_label}** · `{project}` · Session `{request.short_session_id}` — Verlauf und Rückfragen im Thread."
+
+        forum_cls = getattr(discord, "ForumChannel", ()) if DISCORD_AVAILABLE else ()
+        thread_cls = getattr(discord, "Thread", ()) if DISCORD_AVAILABLE else ()
+
+        if isinstance(channel, forum_cls):
+            created = await channel.create_thread(name=name, content=start_text)
+            return getattr(created, "thread", created), None
+
+        if isinstance(channel, thread_cls):
+            parent = getattr(channel, "parent", None)
+            if isinstance(parent, forum_cls):
+                created = await parent.create_thread(name=name, content=start_text)
+                thread = getattr(created, "thread", created)
+                pending: Optional[str] = None
+            elif parent is not None:
+                kind = getattr(getattr(discord, "ChannelType", None), "public_thread", None)
+                thread = await parent.create_thread(name=name, type=kind, auto_archive_duration=1440)
+                pending = start_text
+            else:
+                return None, None
+            await channel.send(content=f"{pointer} → {thread.mention}", allowed_mentions=self._allowed_mentions())
+            return thread, pending
+
+        # Plain text channel: thread attached to a starter message.
+        starter = await channel.send(content=pointer, allowed_mentions=self._allowed_mentions())
+        thread = await starter.create_thread(name=name, auto_archive_duration=1440)
+        return thread, start_text
+
+    async def _handle_notice(self, request: OpenCodePermissionRequest) -> bool:
+        """Create/feed the session thread for a notice; True when a message went out."""
+        if self._threads is None:
+            return False
+        if request.notice == "child":
+            self._threads.set_parent(request.session_id, request.parent_session_id)
+            return False
+        thread = await self._thread_channel(request.session_id)
+        if request.notice == "start" and thread is None:
+            thread, pending = await self._open_session_thread(request)
+            if thread is None:
+                return False
+            self._threads.set_thread(request.session_id, str(thread.id), self._config.channel_for(request.agent))
+            logger.info("OpenCode bridge: thread %s opened for session %s", thread.id, request.session_id)
+            if pending is None:
+                return True  # start text already posted (forum post content)
+            await thread.send(content=pending, allowed_mentions=self._allowed_mentions())
+            return True
+        if thread is None:
+            # No thread (notice arrived before its start, or start failed):
+            # fall back to the agent's channel so nothing is lost.
+            thread = await self._channel_for_agent(request.agent)
+            if thread is None:
+                return False
+        await thread.send(content=self._notice_text(request), allowed_mentions=self._allowed_mentions())
+        return True
 
     async def run(self) -> None:
         """Consume the event stream until cancelled."""
@@ -1013,18 +1331,12 @@ class OpenCodeBridge:
         """Post one Accept/Reject prompt; True when a message went out."""
         if not self._registry.register(request.permission_id):
             return False
-        client = self._adapter._client
-        if client is None:
-            self._registry.resolve(request.permission_id, "drop")
-            return False
-        channel = client.get_channel(int(self._config.channel_id))
-        if channel is None:
-            channel = await client.fetch_channel(int(self._config.channel_id))
+        channel = await self._target_channel(request) if request.is_guard else await self._main_channel()
         if channel is None:
             self._registry.resolve(request.permission_id, "drop")
             logger.warning(
                 "OpenCode bridge: channel %s not found, dropping %s",
-                self._config.channel_id, request.permission_id,
+                self._config.channel_for(request.agent), request.permission_id,
             )
             return False
 

--- a/plugins/platforms/discord/opencode_bridge.py
+++ b/plugins/platforms/discord/opencode_bridge.py
@@ -1,0 +1,667 @@
+"""OpenCode permission bridge for the Discord gateway adapter.
+
+Surfaces OpenCode's own permission requests (the agent asking before it
+runs a tool) in a configured Discord channel and routes Accept/Reject
+clicks back to OpenCode through its official server API.
+
+Wire contract (verified against the official ``@opencode-ai/sdk`` types,
+v1.18.25, ``packages/sdk/js/src/gen/types.gen.ts``):
+
+- Events: ``GET {base_url}/event`` (SSE) delivers
+  ``{"type": "permission.updated", "properties": Permission}`` where
+  ``Permission = {id, type, pattern?, sessionID, messageID, callID?,
+  title, metadata: {..}, time: {created}}``.  A reply is broadcast as
+  ``permission.replied`` so every connected client (TUI included)
+  observes the decision.
+- Reply: ``POST {base_url}/session/{sessionID}/permissions/{permissionID}``
+  with body ``{"response": "once" | "always" | "reject"}`` → 200 bool,
+  400 bad request, 404 not found (already answered elsewhere).
+
+Security posture (deliberate, non-negotiable):
+
+- Off by default; enabled only via the discord platform ``extra`` key
+  ``opencode_bridge`` (see :func:`parse_bridge_config`).
+- Loopback-only ``base_url`` — a non-loopback target disables the bridge
+  (fail-closed) instead of shipping permission metadata off-host.
+- Only Discord users in the explicit ``allowed_user_ids`` allowlist may
+  click; an empty allowlist disables the bridge entirely.
+- Only ``"once"`` and ``"reject"`` replies are ever sent.  The ``"always"``
+  response is intentionally unreachable from Discord — no persistent
+  grants, no privilege escalation, no YOLO path.
+- Timeout resolves to an explicit ``"reject"`` (fail-closed) so the
+  OpenCode session never hangs on a missing reply.
+- No secrets are read, stored, or transmitted; only event metadata the
+  OpenCode server itself emits is displayed.
+
+Out-of-repo counterpart: a small OpenCode plugin is only needed when the
+TUI is not attached; any OpenCode client (TUI, IDE, this bridge) answers
+through the same documented API above.  The bridge never writes OpenCode
+configuration and never bypasses OpenCode's own permission engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from urllib.parse import urlsplit
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - import guard mirrors the adapter module
+    import discord
+
+    DISCORD_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    discord = None
+    DISCORD_AVAILABLE = False
+
+
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+BRIDGE_CONFIG_KEY = "opencode_bridge"
+
+DEFAULT_BASE_URL = "http://127.0.0.1:4096"
+DEFAULT_TIMEOUT_SECONDS = 300
+TIMEOUT_MIN_SECONDS = 30
+TIMEOUT_MAX_SECONDS = 900
+MAX_CONCURRENT_PROMPTS = 10
+RESOLVED_MEMO_SIZE = 64
+
+SSE_RECONNECT_MIN_SECONDS = 2.0
+SSE_RECONNECT_MAX_SECONDS = 60.0
+
+_TITLE_BUDGET = 400
+_PATTERN_BUDGET = 200
+_METADATA_BUDGET = 500
+
+_TRUNCT_SUFFIX = "... [truncated]"
+
+
+def _truncate(text: str, budget: int) -> str:
+    text = str(text or "")
+    if len(text) <= budget:
+        return text
+    return text[: max(0, budget - len(_TRUNCT_SUFFIX))] + _TRUNCT_SUFFIX
+
+
+def is_loopback_url(url: str) -> bool:
+    """Return True when the URL's host is a loopback address.
+
+    The bridge refuses non-loopback targets so permission metadata can
+    never be shipped to a remote host by misconfiguration.
+    """
+    try:
+        host = (urlsplit(str(url)).hostname or "").lower()
+    except ValueError:
+        return False
+    return host in LOOPBACK_HOSTS
+
+
+@dataclass(frozen=True)
+class OpenCodeBridgeConfig:
+    """Validated bridge configuration (from discord platform ``extra``).
+
+    ``enabled`` is only True when every fail-closed precondition holds:
+    explicit opt-in, a loopback base_url, a non-empty user allowlist, and
+    a sane timeout.
+    """
+
+    enabled: bool = False
+    base_url: str = DEFAULT_BASE_URL
+    channel_id: str = ""
+    allowed_user_ids: frozenset = frozenset()
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    disabled_reason: str = ""
+
+
+def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
+    """Parse and validate the bridge config from a platform ``extra`` dict.
+
+    Fail-closed: any invalid or missing precondition yields a disabled
+    config with ``disabled_reason`` filled in (logged once by the caller).
+    """
+    section = extra.get(BRIDGE_CONFIG_KEY) if isinstance(extra, dict) else None
+    if not isinstance(section, dict):
+        return OpenCodeBridgeConfig(disabled_reason="not configured")
+
+    if not section.get("enabled"):
+        return OpenCodeBridgeConfig(disabled_reason="disabled")
+
+    base_url = str(section.get("base_url") or DEFAULT_BASE_URL).rstrip("/")
+    if not is_loopback_url(base_url):
+        return OpenCodeBridgeConfig(
+            base_url=base_url,
+            disabled_reason=f"base_url is not loopback ({base_url})",
+        )
+
+    raw_users = section.get("allowed_user_ids") or []
+    if isinstance(raw_users, str):
+        raw_users = [p.strip() for p in raw_users.split(",")]
+    allowed_user_ids = frozenset(
+        str(u).strip() for u in raw_users if str(u).strip()
+    )
+    if not allowed_user_ids:
+        return OpenCodeBridgeConfig(
+            base_url=base_url,
+            disabled_reason="allowed_user_ids is empty",
+        )
+
+    channel_id = str(section.get("channel_id") or "").strip()
+    if not channel_id:
+        return OpenCodeBridgeConfig(
+            base_url=base_url,
+            disabled_reason="channel_id is missing",
+        )
+
+    try:
+        timeout_seconds = int(section.get("timeout_seconds") or DEFAULT_TIMEOUT_SECONDS)
+    except (TypeError, ValueError):
+        timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+    timeout_seconds = max(TIMEOUT_MIN_SECONDS, min(TIMEOUT_MAX_SECONDS, timeout_seconds))
+
+    return OpenCodeBridgeConfig(
+        enabled=True,
+        base_url=base_url,
+        channel_id=channel_id,
+        allowed_user_ids=allowed_user_ids,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@dataclass(frozen=True)
+class OpenCodePermissionRequest:
+    """One OpenCode permission request, parsed from ``permission.updated``."""
+
+    permission_id: str
+    session_id: str
+    kind: str = ""
+    pattern: str = ""
+    title: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def short_session_id(self) -> str:
+        return self.session_id[:12]
+
+
+def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
+    """Parse a ``permission.updated`` SSE payload into a request.
+
+    Returns None for anything that is not a well-formed permission
+    request — malformed events are dropped (fail-closed), never guessed
+    into shape.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("type") != "permission.updated":
+        return None
+    props = payload.get("properties")
+    if not isinstance(props, dict):
+        return None
+    permission_id = props.get("id")
+    session_id = props.get("sessionID")
+    if not isinstance(permission_id, str) or not permission_id:
+        return None
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    pattern = props.get("pattern")
+    if pattern is not None and not isinstance(pattern, str):
+        if isinstance(pattern, list):
+            pattern = ", ".join(str(p) for p in pattern)
+        else:
+            pattern = json.dumps(pattern)
+    metadata = props.get("metadata")
+    return OpenCodePermissionRequest(
+        permission_id=permission_id,
+        session_id=session_id,
+        kind=str(props.get("type") or ""),
+        pattern=str(pattern) if pattern else "",
+        title=str(props.get("title") or ""),
+        metadata=metadata if isinstance(metadata, dict) else {},
+    )
+
+
+class SseAssembler:
+    """Incremental SSE line parser yielding JSON ``data:`` payloads.
+
+    Feed one line at a time (without trailing newline); a complete event
+    (blank line) returns the concatenated data payload as parsed JSON,
+    or None when the block was not JSON or carried no data.
+    """
+
+    def __init__(self) -> None:
+        self._data_lines: List[str] = []
+
+    def feed(self, line: str) -> Optional[dict]:
+        line = line.rstrip("\r")
+        if line == "":
+            block = "\n".join(self._data_lines)
+            self._data_lines = []
+            if not block:
+                return None
+            try:
+                payload = json.loads(block)
+            except ValueError:
+                logger.debug("OpenCode bridge: non-JSON SSE payload dropped")
+                return None
+            return payload if isinstance(payload, dict) else None
+        if line.startswith("data:"):
+            self._data_lines.append(line[5:].lstrip(" "))
+        # event:/id:/retry:/comment lines are irrelevant: the JSON payload
+        # itself carries the event type.
+        return None
+
+
+class BridgePendingRegistry:
+    """Tracks in-flight bridge prompts; first resolution wins.
+
+    Also memoizes recently resolved permission ids so a redelivered
+    ``permission.updated`` (SSE reconnect replay) cannot post a second
+    prompt for a request that was already answered.
+    """
+
+    def __init__(self, max_concurrent: int = MAX_CONCURRENT_PROMPTS) -> None:
+        self._max_concurrent = max_concurrent
+        self._pending: Dict[str, str] = {}
+        self._resolved_memo: List[str] = []
+        self._resolved_set: Set[str] = set()
+
+    def register(self, permission_id: str) -> bool:
+        """Reserve a prompt slot; False when deduped or at capacity."""
+        if permission_id in self._pending or permission_id in self._resolved_set:
+            return False
+        if len(self._pending) >= self._max_concurrent:
+            logger.warning(
+                "OpenCode bridge: %d prompts already pending, dropping %s",
+                len(self._pending), permission_id,
+            )
+            return False
+        self._pending[permission_id] = "pending"
+        return True
+
+    def resolve(self, permission_id: str, response: str) -> bool:
+        """Record the first resolution; later calls are no-ops (False)."""
+        if permission_id not in self._pending:
+            return False
+        del self._pending[permission_id]
+        self._resolved_set.add(permission_id)
+        self._resolved_memo.append(permission_id)
+        if len(self._resolved_memo) > RESOLVED_MEMO_SIZE:
+            dropped = self._resolved_memo.pop(0)
+            self._resolved_set.discard(dropped)
+        return True
+
+    def is_pending(self, permission_id: str) -> bool:
+        return permission_id in self._pending
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+
+class OpenCodeBridgeClient:
+    """HTTP client for the OpenCode server API (SSE events + replies).
+
+    Loopback-only by construction: both endpoints refuse to run against
+    a non-loopback base_url.
+    """
+
+    def __init__(self, base_url: str, *, transport: Optional[Any] = None) -> None:
+        if not is_loopback_url(base_url):
+            raise ValueError(f"OpenCode bridge refuses non-loopback base_url: {base_url}")
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(10.0, read=None),
+            transport=transport,
+        )
+
+    async def stream_events(self) -> Any:
+        """Yield parsed SSE payloads from ``GET /event``, reconnecting on drop.
+
+        Async generator; exits on cancellation. Reconnects use a bounded
+        linear backoff so a dead OpenCode server costs one attempt per
+        minute, not a busy loop.
+        """
+        assembler = SseAssembler()
+        backoff = SSE_RECONNECT_MIN_SECONDS
+        while True:
+            try:
+                async with self._client.stream("GET", "/event") as response:
+                    response.raise_for_status()
+                    backoff = SSE_RECONNECT_MIN_SECONDS
+                    async for line in response.aiter_lines():
+                        payload = assembler.feed(line)
+                        if payload is not None:
+                            yield payload
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("OpenCode bridge: event stream dropped (%s)", exc)
+            await asyncio.sleep(backoff)
+            backoff = min(SSE_RECONNECT_MAX_SECONDS, backoff * 2)
+
+    async def reply(
+        self, session_id: str, permission_id: str, response: str
+    ) -> tuple[bool, int]:
+        """POST a permission reply. Returns (delivered, status_code).
+
+        ``delivered`` is False when OpenCode answered 4xx (notably 404 —
+        the request was already answered by another client, e.g. the TUI).
+        """
+        url = f"/session/{session_id}/permissions/{permission_id}"
+        resp = await self._client.post(url, json={"response": response})
+        if resp.status_code == 200:
+            return True, 200
+        logger.warning(
+            "OpenCode bridge: reply %s/%s -> %s rejected (%s)",
+            session_id, permission_id, response, resp.status_code,
+        )
+        return False, resp.status_code
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+class OpenCodeBridge:
+    """Orchestrates event consumption, Discord prompts, and replies.
+
+    Owns one asyncio task (see :meth:`run`) living inside the Discord
+    adapter's event loop; per-request resolution happens either from a
+    button click or the view's timeout, both funneled through
+    :meth:`resolve` so first-wins semantics and the reply POST are in
+    exactly one place.
+    """
+
+    def __init__(
+        self,
+        adapter: Any,
+        config: OpenCodeBridgeConfig,
+        client: Optional[OpenCodeBridgeClient] = None,
+    ) -> None:
+        self._adapter = adapter
+        self._config = config
+        self._client = client or OpenCodeBridgeClient(config.base_url)
+        self._registry = BridgePendingRegistry()
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def config(self) -> OpenCodeBridgeConfig:
+        return self._config
+
+    @property
+    def registry(self) -> BridgePendingRegistry:
+        return self._registry
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self.run())
+
+    async def run(self) -> None:
+        """Consume the event stream until cancelled."""
+        logger.info(
+            "OpenCode bridge: streaming %s into Discord channel %s",
+            self._config.base_url, self._config.channel_id,
+        )
+        try:
+            async for payload in self._client.stream_events():
+                request = parse_permission_event(payload)
+                if request is None:
+                    continue
+                try:
+                    await self._post_prompt(request)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "OpenCode bridge: failed to post prompt for %s: %s",
+                        request.permission_id, exc,
+                    )
+        except asyncio.CancelledError:
+            pass
+
+    async def aclose(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Discord prompt
+    # ------------------------------------------------------------------
+
+    def _prompt_text(self, request: OpenCodePermissionRequest) -> tuple[str, str]:
+        """Return (plain content, embed description) for the request."""
+        title = _truncate(request.title or "(no title)", _TITLE_BUDGET)
+        kind = request.kind or "permission"
+        lines = [
+            "🔐 **OpenCode Permission Request**",
+            "",
+            f"**Type:** `{_truncate(kind, 60)}`",
+            f"**Request:**",
+            f"```bash\n{title}\n```",
+        ]
+        if request.pattern:
+            lines.append(f"**Pattern:** `{_truncate(request.pattern, _PATTERN_BUDGET)}`")
+        lines.append(f"**Session:** `{request.short_session_id}`")
+        lines.append("")
+        lines.append("Answer **Accept** to allow this operation once, or **Reject** to deny it. Nothing is ever allowed persistently from Discord.")
+        content = "\n".join(lines)
+
+        embed_desc = f"```bash\n{title}\n```"
+        return content, embed_desc
+
+    async def _post_prompt(self, request: OpenCodePermissionRequest) -> None:
+        if not self._registry.register(request.permission_id):
+            return
+        client = self._adapter._client
+        if client is None:
+            self._registry.resolve(request.permission_id, "drop")
+            return
+        channel = client.get_channel(int(self._config.channel_id))
+        if channel is None:
+            channel = await client.fetch_channel(int(self._config.channel_id))
+        if channel is None:
+            self._registry.resolve(request.permission_id, "drop")
+            logger.warning(
+                "OpenCode bridge: channel %s not found, dropping %s",
+                self._config.channel_id, request.permission_id,
+            )
+            return
+
+        content, embed_desc = self._prompt_text(request)
+        metadata_line = ""
+        if request.metadata:
+            metadata_line = _truncate(json.dumps(request.metadata, default=str), _METADATA_BUDGET)
+        embed = discord.Embed(
+            title="🔐 OpenCode Permission",
+            description=embed_desc,
+            color=discord.Color.gold(),
+        )
+        if metadata_line:
+            embed.add_field(name="Details", value=f"```json\n{metadata_line}\n```", inline=False)
+
+        view = _get_view_class()(
+            bridge=self,
+            request=request,
+            allowed_user_ids=self._config.allowed_user_ids,
+            timeout=self._config.timeout_seconds,
+        )
+        msg = await channel.send(content=content, embed=embed, view=view)
+        view._message = msg
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    async def resolve(
+        self,
+        request: OpenCodePermissionRequest,
+        response: str,
+        source: str,
+    ) -> str:
+        """Resolve a request and deliver the reply to OpenCode.
+
+        ``response`` is ``"once"`` or ``"reject"``. Returns a short
+        outcome label the caller renders in Discord. First-wins: a late
+        click after another client (TUI) answered or the timeout fired
+        never double-posts a reply.
+        """
+        if response not in ("once", "reject"):
+            response = "reject"
+        if not self._registry.resolve(request.permission_id, response):
+            return "already-resolved"
+        try:
+            delivered, status = await self._client.reply(
+                request.session_id, request.permission_id, response
+            )
+        except Exception as exc:
+            logger.error(
+                "OpenCode bridge: reply POST failed for %s: %s",
+                request.permission_id, exc,
+            )
+            return "reply-failed"
+        if not delivered:
+            if status == 404:
+                return "resolved-elsewhere"
+            return "reply-failed"
+        logger.info(
+            "OpenCode bridge: %s answered %s (%s)", request.permission_id, response, source
+        )
+        return "delivered"
+
+
+_VIEW_CLASS = None
+
+
+def _get_view_class():
+    """Build (once) the Accept/Reject view; requires discord.py."""
+    global _VIEW_CLASS
+    if _VIEW_CLASS is not None:
+        return _VIEW_CLASS
+    if not DISCORD_AVAILABLE:
+        raise RuntimeError("discord.py is not installed")
+
+    class OpenCodePermissionView(discord.ui.View):
+        """Two-button Accept/Reject prompt for one OpenCode permission.
+
+        Authorization is the bridge's explicit allowlist (fail-closed:
+        nobody outside it can click). The timeout resolves to an explicit
+        reject so the OpenCode session never hangs. There is deliberately
+        no persistent-allow button.
+        """
+
+        def __init__(
+            self,
+            bridge: OpenCodeBridge,
+            request: OpenCodePermissionRequest,
+            allowed_user_ids: frozenset,
+            timeout: int,
+        ) -> None:
+            super().__init__(timeout=timeout)
+            self._bridge = bridge
+            self._request = request
+            self._allowed_user_ids = allowed_user_ids
+            self._message = None
+            self._finished = False
+
+        def _authorized(self, interaction: discord.Interaction) -> bool:
+            user = getattr(interaction, "user", None)
+            uid = str(getattr(user, "id", "") or "")
+            return bool(uid) and uid in self._allowed_user_ids
+
+        async def _answer(self, interaction: discord.Interaction, response: str) -> None:
+            if not self._authorized(interaction):
+                await interaction.response.send_message(
+                    "You're not allowed to answer OpenCode permission requests~",
+                    ephemeral=True,
+                )
+                return
+            outcome = await self._bridge.resolve(self._request, response, "discord")
+            if outcome == "already-resolved":
+                await interaction.response.send_message(
+                    "This request was already resolved~", ephemeral=True
+                )
+                return
+            await self._finalize(interaction, response, outcome)
+
+        async def _finalize(
+            self,
+            interaction: discord.Interaction,
+            response: str,
+            outcome: str,
+        ) -> None:
+            self._finished = True
+            for child in self.children:
+                child.disabled = True
+            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            if embed:
+                if response == "once":
+                    embed.color = (
+                        discord.Color.green()
+                        if outcome == "delivered"
+                        else discord.Color.dark_grey()
+                    )
+                else:
+                    embed.color = (
+                        discord.Color.red()
+                        if outcome == "delivered"
+                        else discord.Color.dark_grey()
+                    )
+                footer = {
+                    "delivered": f"{'Accepted (once)' if response == 'once' else 'Rejected'}",
+                    "resolved-elsewhere": "Already resolved by another OpenCode client",
+                    "reply-failed": "Reply to OpenCode failed — answer in OpenCode directly",
+                }.get(outcome, outcome)
+                embed.set_footer(text=footer)
+            try:
+                await interaction.response.edit_message(embed=embed, view=self)
+            except Exception:
+                logger.debug("OpenCode bridge: could not edit prompt message")
+
+        async def _annotate_only(self, response: str, outcome: str) -> None:
+            """Edit the message without an interaction (timeout path)."""
+            self._finished = True
+            for child in self.children:
+                child.disabled = True
+            msg = self._message
+            if msg is None:
+                return
+            embed = msg.embeds[0] if msg.embeds else None
+            if embed:
+                embed.color = discord.Color.dark_grey()
+                embed.set_footer(text="⏱ Timed out — rejected (fail-closed)")
+            try:
+                await msg.edit(embed=embed, view=self)
+            except Exception:
+                pass  # message deleted or too old to edit
+
+        @discord.ui.button(label="Accept (once)", style=discord.ButtonStyle.green)
+        async def accept(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ) -> None:
+            await self._answer(interaction, "once")
+
+        @discord.ui.button(label="Reject", style=discord.ButtonStyle.red)
+        async def reject(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ) -> None:
+            await self._answer(interaction, "reject")
+
+        async def on_timeout(self) -> None:
+            if self._finished:
+                return
+            await self._bridge.resolve(self._request, "reject", "timeout")
+            await self._annotate_only("reject", "timeout")
+
+    _VIEW_CLASS = OpenCodePermissionView
+    return _VIEW_CLASS

--- a/plugins/platforms/discord/opencode_bridge.py
+++ b/plugins/platforms/discord/opencode_bridge.py
@@ -37,6 +37,41 @@ Out-of-repo counterpart: a small OpenCode plugin is only needed when the
 TUI is not attached; any OpenCode client (TUI, IDE, this bridge) answers
 through the same documented API above.  The bridge never writes OpenCode
 configuration and never bypasses OpenCode's own permission engine.
+
+OpenCode >= 1.18 additionally publishes the newer ``permission.asked``
+event (``{id, sessionID, permission, patterns, metadata, always}``) and
+answers on ``POST /permission/{requestID}/reply`` with ``{"reply": ..}``;
+both shapes are accepted and each is answered on its own endpoint.
+
+Command-guard spool (second request source)
+-------------------------------------------
+
+The out-of-repo OpenCode plugin ``befehlswaechter.js`` (and the matching
+Claude Code PreToolUse hook) cannot use OpenCode's permission engine for
+"path outside the project" decisions: a TUI running in auto mode answers
+every native permission with ``once`` before Discord ever sees it.  The
+guard therefore blocks the tool call itself and asks this bridge through a
+local, user-private spool directory (default ``$HERMES_HOME/opencode_bridge``):
+
+- ``requests/<id>.json`` — written atomically by the guard::
+
+      {"version": 1, "id": "<[A-Za-z0-9_-]{8,64}>", "agent": "opencode",
+       "created_at": <epoch s>, "expires_at": <epoch s>, "session_id": "..",
+       "project": "/abs/project", "command": "cat ~/x", "path": "/Users/..",
+       "access": "lesen" | "schreiben" | "ausführen" | "unklar"}
+
+- ``decisions/<id>.json`` — written atomically by this bridge::
+
+      {"version": 1, "id": "<id>", "decision": "once" | "reject",
+       "source": "discord" | "timeout" | "drop", "decided_at": <epoch s>}
+
+The guard polls for its decision file and denies on timeout, on a missing
+or malformed decision, and when the gateway is not running at all.  The
+bridge never answers a malformed or expired request (fail-closed: the
+guard's own timeout then blocks the command), only ever writes ``once`` or
+``reject``, and removes stale files on its scan cycle.  Only the request
+metadata the guard chose to send (command, path, project, access kind) is
+displayed; nothing is executed or read on the guard's behalf.
 """
 
 from __future__ import annotations
@@ -44,7 +79,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
+import tempfile
+import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import urlsplit
 
@@ -78,8 +118,30 @@ SSE_RECONNECT_MAX_SECONDS = 60.0
 _TITLE_BUDGET = 400
 _PATTERN_BUDGET = 200
 _METADATA_BUDGET = 500
+_COMMAND_BUDGET = 600
+_PATH_BUDGET = 300
 
 _TRUNCT_SUFFIX = "... [truncated]"
+
+# Command-guard spool (see module docstring).
+GUARD_SPOOL_DIRNAME = "opencode_bridge"
+GUARD_REQUESTS_SUBDIR = "requests"
+GUARD_DECISIONS_SUBDIR = "decisions"
+GUARD_PROTOCOL_VERSION = 1
+GUARD_SCAN_INTERVAL_SECONDS = 1.0
+GUARD_MAX_LIFETIME_SECONDS = 3600  # a request may not ask to live longer
+GUARD_DECISION_TTL_SECONDS = 3600  # orphaned decisions are swept after this
+GUARD_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
+GUARD_AGENTS = {"opencode": "OpenCode", "claude-code": "Claude Code"}
+GUARD_ACCESS_KINDS = frozenset({"lesen", "schreiben", "ausführen", "unklar"})
+GUARD_SOURCE = "guard"
+SSE_SOURCE = "sse"
+
+
+def default_guard_dir() -> str:
+    """Spool root: ``$HERMES_HOME/opencode_bridge`` (or ``~/.hermes/...``)."""
+    home = os.environ.get("HERMES_HOME") or os.path.join(os.path.expanduser("~"), ".hermes")
+    return os.path.join(home, GUARD_SPOOL_DIRNAME)
 
 
 def _truncate(text: str, budget: int) -> str:
@@ -117,6 +179,11 @@ class OpenCodeBridgeConfig:
     allowed_user_ids: frozenset = frozenset()
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
     disabled_reason: str = ""
+    # Command-guard spool: on by default once the bridge itself is enabled;
+    # ``guard_enabled: false`` keeps only the SSE path, ``guard_dir``
+    # overrides the spool root.
+    guard_enabled: bool = True
+    guard_dir: str = ""
 
 
 def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
@@ -164,18 +231,30 @@ def parse_bridge_config(extra: Any) -> OpenCodeBridgeConfig:
         timeout_seconds = DEFAULT_TIMEOUT_SECONDS
     timeout_seconds = max(TIMEOUT_MIN_SECONDS, min(TIMEOUT_MAX_SECONDS, timeout_seconds))
 
+    guard_enabled = section.get("guard_enabled", True)
+    guard_enabled = guard_enabled if isinstance(guard_enabled, bool) else True
+    guard_dir = str(section.get("guard_dir") or "").strip() or default_guard_dir()
+
     return OpenCodeBridgeConfig(
         enabled=True,
         base_url=base_url,
         channel_id=channel_id,
         allowed_user_ids=allowed_user_ids,
         timeout_seconds=timeout_seconds,
+        guard_enabled=guard_enabled,
+        guard_dir=guard_dir,
     )
 
 
 @dataclass(frozen=True)
 class OpenCodePermissionRequest:
-    """One OpenCode permission request, parsed from ``permission.updated``."""
+    """One permission request awaiting a Discord decision.
+
+    ``source`` says where it came from and therefore how the decision is
+    delivered: ``"sse"`` requests are answered on the OpenCode server API
+    (``reply_api`` picks the legacy or the v2 endpoint), ``"guard"``
+    requests are answered through the spool's decisions directory.
+    """
 
     permission_id: str
     session_id: str
@@ -183,14 +262,27 @@ class OpenCodePermissionRequest:
     pattern: str = ""
     title: str = ""
     metadata: Dict[str, Any] = field(default_factory=dict)
+    source: str = SSE_SOURCE
+    reply_api: str = "legacy"
+    # Guard-only display fields.
+    agent: str = "opencode"
+    command: str = ""
+    path: str = ""
+    project: str = ""
+    access: str = ""
+    expires_at: float = 0.0
 
     @property
     def short_session_id(self) -> str:
         return self.session_id[:12]
 
+    @property
+    def is_guard(self) -> bool:
+        return self.source == GUARD_SOURCE
+
 
 def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
-    """Parse a ``permission.updated`` SSE payload into a request.
+    """Parse a ``permission.updated`` / ``permission.asked`` SSE payload.
 
     Returns None for anything that is not a well-formed permission
     request — malformed events are dropped (fail-closed), never guessed
@@ -198,7 +290,8 @@ def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
     """
     if not isinstance(payload, dict):
         return None
-    if payload.get("type") != "permission.updated":
+    event_type = payload.get("type")
+    if event_type not in ("permission.updated", "permission.asked"):
         return None
     props = payload.get("properties")
     if not isinstance(props, dict):
@@ -209,21 +302,235 @@ def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
         return None
     if not isinstance(session_id, str) or not session_id:
         return None
+    metadata = props.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+
+    if event_type == "permission.asked":
+        patterns = props.get("patterns")
+        if not isinstance(patterns, list):
+            patterns = []
+        pattern = ", ".join(str(p) for p in patterns)
+        command = metadata.get("command")
+        title = command if isinstance(command, str) and command.strip() else pattern
+        return OpenCodePermissionRequest(
+            permission_id=permission_id,
+            session_id=session_id,
+            kind=str(props.get("permission") or ""),
+            pattern=pattern,
+            title=title,
+            metadata=metadata,
+            reply_api="v2",
+        )
+
     pattern = props.get("pattern")
     if pattern is not None and not isinstance(pattern, str):
         if isinstance(pattern, list):
             pattern = ", ".join(str(p) for p in pattern)
         else:
             pattern = json.dumps(pattern)
-    metadata = props.get("metadata")
     return OpenCodePermissionRequest(
         permission_id=permission_id,
         session_id=session_id,
         kind=str(props.get("type") or ""),
         pattern=str(pattern) if pattern else "",
         title=str(props.get("title") or ""),
-        metadata=metadata if isinstance(metadata, dict) else {},
+        metadata=metadata,
     )
+
+
+def parse_guard_request(
+    payload: Any, *, now: Optional[float] = None
+) -> Optional[OpenCodePermissionRequest]:
+    """Validate one spool request file's JSON into a guard request.
+
+    Strict on purpose: anything unclear (wrong version, bad id, unknown
+    agent or access kind, missing command/path, implausible lifetime,
+    already expired) yields None and is never shown or answered — the
+    guard's own timeout then keeps the command blocked.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("version") != GUARD_PROTOCOL_VERSION:
+        return None
+    request_id = payload.get("id")
+    if not isinstance(request_id, str) or not GUARD_ID_RE.match(request_id):
+        return None
+    agent = payload.get("agent")
+    if agent not in GUARD_AGENTS:
+        return None
+    command = payload.get("command")
+    path = payload.get("path")
+    if not isinstance(command, str) or not command.strip():
+        return None
+    if not isinstance(path, str) or not path.strip():
+        return None
+    project = payload.get("project")
+    project = project if isinstance(project, str) else ""
+    access = payload.get("access")
+    if access not in GUARD_ACCESS_KINDS:
+        return None
+    created_at = payload.get("created_at")
+    expires_at = payload.get("expires_at")
+    if isinstance(created_at, bool) or isinstance(expires_at, bool):
+        return None
+    if not isinstance(created_at, (int, float)) or not isinstance(expires_at, (int, float)):
+        return None
+    if expires_at <= created_at or expires_at - created_at > GUARD_MAX_LIFETIME_SECONDS:
+        return None
+    current = time.time() if now is None else now
+    if expires_at <= current:
+        return None
+    session_id = payload.get("session_id")
+    session_id = session_id if isinstance(session_id, str) and session_id else "-"
+    return OpenCodePermissionRequest(
+        permission_id=request_id,
+        session_id=session_id,
+        kind="befehlswaechter",
+        title=command,
+        source=GUARD_SOURCE,
+        agent=str(agent),
+        command=command,
+        path=path,
+        project=project,
+        access=str(access),
+        expires_at=float(expires_at),
+    )
+
+
+class GuardSpool:
+    """Filesystem mailbox between the command guard and this bridge.
+
+    ``scan`` returns valid, unexpired, not-yet-seen requests; ``write_decision``
+    publishes exactly one decision file atomically (temp file + rename) so
+    the guard never reads a half-written JSON.  Everything lives under a
+    user-private (0700) directory; the bridge never follows symlinks out of
+    it and never executes anything it finds there.
+    """
+
+    def __init__(self, root: str) -> None:
+        self.root = Path(root)
+        self.requests_dir = self.root / GUARD_REQUESTS_SUBDIR
+        self.decisions_dir = self.root / GUARD_DECISIONS_SUBDIR
+        self._invalid: Set[str] = set()
+
+    def ensure(self) -> None:
+        for directory in (self.root, self.requests_dir, self.decisions_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+            try:
+                os.chmod(directory, 0o700)
+            except OSError:  # pragma: no cover - best effort on odd filesystems
+                pass
+
+    def _request_path(self, request_id: str) -> Path:
+        return self.requests_dir / f"{request_id}.json"
+
+    def _decision_path(self, request_id: str) -> Path:
+        return self.decisions_dir / f"{request_id}.json"
+
+    def scan(self, *, now: Optional[float] = None) -> List[OpenCodePermissionRequest]:
+        """Return valid pending requests; drop expired files, remember bad ones."""
+        current = time.time() if now is None else now
+        found: List[OpenCodePermissionRequest] = []
+        try:
+            names = sorted(os.listdir(self.requests_dir))
+        except FileNotFoundError:
+            return found
+        present = set(names)
+        self._invalid &= present
+        for name in names:
+            if not name.endswith(".json"):
+                continue
+            request_id = name[: -len(".json")]
+            if not GUARD_ID_RE.match(request_id):
+                continue
+            file_path = self.requests_dir / name
+            if name in self._invalid:
+                continue
+            if file_path.is_symlink() or not file_path.is_file():
+                self._invalid.add(name)
+                continue
+            try:
+                payload = json.loads(file_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                # Possibly mid-write; a stale unreadable file is dropped once
+                # its own deadline (or the max lifetime) has passed.
+                self._drop_if_stale(file_path, current)
+                continue
+            request = parse_guard_request(payload, now=current)
+            if request is None or request.permission_id != request_id:
+                expires = payload.get("expires_at") if isinstance(payload, dict) else None
+                if isinstance(expires, (int, float)) and not isinstance(expires, bool) and expires <= current:
+                    self._unlink(file_path)
+                else:
+                    if name not in self._invalid:
+                        logger.warning("OpenCode bridge: ignoring malformed guard request %s", name)
+                    self._invalid.add(name)
+                continue
+            if self._decision_path(request_id).exists():
+                continue  # already answered, guard has not collected it yet
+            found.append(request)
+        return found
+
+    def _drop_if_stale(self, file_path: Path, now: float) -> None:
+        try:
+            age = now - file_path.stat().st_mtime
+        except OSError:
+            return
+        if age > GUARD_MAX_LIFETIME_SECONDS:
+            self._unlink(file_path)
+
+    def write_decision(
+        self, request_id: str, decision: str, source: str, *, now: Optional[float] = None
+    ) -> None:
+        if decision not in ("once", "reject"):
+            decision = "reject"
+        if not GUARD_ID_RE.match(request_id):
+            raise ValueError(f"invalid guard request id: {request_id!r}")
+        self.ensure()
+        payload = {
+            "version": GUARD_PROTOCOL_VERSION,
+            "id": request_id,
+            "decision": decision,
+            "source": source,
+            "decided_at": time.time() if now is None else now,
+        }
+        fd, tmp_name = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=self.decisions_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle)
+            os.chmod(tmp_name, 0o600)
+            os.replace(tmp_name, self._decision_path(request_id))
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    def sweep(self, *, now: Optional[float] = None) -> None:
+        """Remove decisions nobody collected and leftover temp files."""
+        current = time.time() if now is None else now
+        try:
+            names = os.listdir(self.decisions_dir)
+        except FileNotFoundError:
+            return
+        for name in names:
+            file_path = self.decisions_dir / name
+            try:
+                age = current - file_path.stat().st_mtime
+            except OSError:
+                continue
+            if name.startswith(".tmp-") and age > 60:
+                self._unlink(file_path)
+            elif age > GUARD_DECISION_TTL_SECONDS:
+                self._unlink(file_path)
+
+    @staticmethod
+    def _unlink(file_path: Path) -> None:
+        try:
+            file_path.unlink()
+        except OSError:
+            pass
 
 
 class SseAssembler:
@@ -347,17 +654,24 @@ class OpenCodeBridgeClient:
             backoff = min(SSE_RECONNECT_MAX_SECONDS, backoff * 2)
 
     async def reply(
-        self, session_id: str, permission_id: str, response: str
+        self, session_id: str, permission_id: str, response: str, api: str = "legacy"
     ) -> tuple[bool, int]:
         """POST a permission reply. Returns (delivered, status_code).
 
+        ``api`` selects the endpoint the request was observed on: the
+        legacy session-scoped route (``permission.updated``) or the v2
+        ``/permission/{id}/reply`` route (``permission.asked``).
         ``delivered`` is False when OpenCode answered 4xx (notably 404 —
         the request was already answered by another client, e.g. the TUI).
         """
-        url = f"/session/{session_id}/permissions/{permission_id}"
-        resp = await self._client.post(url, json={"response": response})
-        if resp.status_code == 200:
-            return True, 200
+        if api == "v2":
+            url = f"/permission/{permission_id}/reply"
+            resp = await self._client.post(url, json={"reply": response})
+        else:
+            url = f"/session/{session_id}/permissions/{permission_id}"
+            resp = await self._client.post(url, json={"response": response})
+        if resp.status_code in (200, 204):
+            return True, resp.status_code
         logger.warning(
             "OpenCode bridge: reply %s/%s -> %s rejected (%s)",
             session_id, permission_id, response, resp.status_code,
@@ -383,12 +697,20 @@ class OpenCodeBridge:
         adapter: Any,
         config: OpenCodeBridgeConfig,
         client: Optional[OpenCodeBridgeClient] = None,
+        spool: Optional[GuardSpool] = None,
     ) -> None:
         self._adapter = adapter
         self._config = config
         self._client = client or OpenCodeBridgeClient(config.base_url)
         self._registry = BridgePendingRegistry()
         self._task: Optional[asyncio.Task] = None
+        self._guard_task: Optional[asyncio.Task] = None
+        if spool is not None:
+            self._spool: Optional[GuardSpool] = spool
+        elif config.guard_enabled and config.guard_dir:
+            self._spool = GuardSpool(config.guard_dir)
+        else:
+            self._spool = None
 
     @property
     def config(self) -> OpenCodeBridgeConfig:
@@ -398,9 +720,62 @@ class OpenCodeBridge:
     def registry(self) -> BridgePendingRegistry:
         return self._registry
 
+    @property
+    def spool(self) -> Optional[GuardSpool]:
+        return self._spool
+
     def start(self) -> None:
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self.run())
+        if self._spool is not None and (self._guard_task is None or self._guard_task.done()):
+            self._guard_task = asyncio.create_task(self.run_guard_spool())
+
+    async def run_guard_spool(self) -> None:
+        """Poll the guard spool until cancelled; one prompt per new request."""
+        assert self._spool is not None
+        try:
+            self._spool.ensure()
+        except OSError as exc:
+            logger.warning("OpenCode bridge: guard spool %s unusable: %s", self._spool.root, exc)
+            return
+        logger.info(
+            "OpenCode bridge: watching guard spool %s for Discord channel %s",
+            self._spool.root, self._config.channel_id,
+        )
+        try:
+            while True:
+                await self.poll_guard_spool_once()
+                await asyncio.sleep(GUARD_SCAN_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            pass
+
+    async def poll_guard_spool_once(self) -> int:
+        """One scan cycle; returns how many prompts were posted."""
+        assert self._spool is not None
+        posted = 0
+        try:
+            requests = self._spool.scan()
+        except Exception as exc:  # pragma: no cover - defensive: keep polling
+            logger.warning("OpenCode bridge: guard spool scan failed: %s", exc)
+            return 0
+        for request in requests:
+            if self._registry.is_pending(request.permission_id):
+                continue
+            try:
+                if await self._post_prompt(request):
+                    posted += 1
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "OpenCode bridge: failed to post guard prompt for %s: %s",
+                    request.permission_id, exc,
+                )
+        try:
+            self._spool.sweep()
+        except Exception:  # pragma: no cover - best effort housekeeping
+            pass
+        return posted
 
     async def run(self) -> None:
         """Consume the event stream until cancelled."""
@@ -426,21 +801,47 @@ class OpenCodeBridge:
             pass
 
     async def aclose(self) -> None:
-        if self._task and not self._task.done():
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
+        for task in (self._task, self._guard_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
         self._task = None
+        self._guard_task = None
         await self._client.aclose()
 
     # ------------------------------------------------------------------
     # Discord prompt
     # ------------------------------------------------------------------
 
+    def _guard_prompt_text(self, request: OpenCodePermissionRequest) -> tuple[str, str]:
+        """German prompt for a command-guard request (command, path, project, access)."""
+        command = _truncate(request.command, _COMMAND_BUDGET).replace("```", "'''")
+        agent_label = GUARD_AGENTS.get(request.agent, request.agent)
+        remaining = max(1, int(round((request.expires_at - time.time()) / 60))) if request.expires_at else None
+        lines = [
+            "🛡️ **Befehlswächter: Zugriff außerhalb des Projekts**",
+            "",
+            f"**Agent:** {agent_label}",
+            "**Befehl:**",
+            f"```bash\n{command}\n```",
+            f"**Pfad:** `{_truncate(request.path, _PATH_BUDGET)}`",
+            f"**Projektordner:** `{_truncate(request.project or '-', _PATH_BUDGET)}`",
+            f"**Zugriff:** {request.access}",
+            f"**Session:** `{request.short_session_id}`",
+            "",
+            "**Einmal erlauben** lässt genau diesen Befehl einmal durch, **Ablehnen** blockiert ihn. "
+            + (f"Ohne Antwort innerhalb von etwa {remaining} min wird automatisch abgelehnt. " if remaining else "Ohne Antwort wird automatisch abgelehnt. ")
+            + "Dauerhafte Freigaben gibt es nicht.",
+        ]
+        return "\n".join(lines), f"```bash\n{command}\n```"
+
     def _prompt_text(self, request: OpenCodePermissionRequest) -> tuple[str, str]:
         """Return (plain content, embed description) for the request."""
+        if request.is_guard:
+            return self._guard_prompt_text(request)
         title = _truncate(request.title or "(no title)", _TITLE_BUDGET)
         kind = request.kind or "permission"
         lines = [
@@ -460,13 +861,14 @@ class OpenCodeBridge:
         embed_desc = f"```bash\n{title}\n```"
         return content, embed_desc
 
-    async def _post_prompt(self, request: OpenCodePermissionRequest) -> None:
+    async def _post_prompt(self, request: OpenCodePermissionRequest) -> bool:
+        """Post one Accept/Reject prompt; True when a message went out."""
         if not self._registry.register(request.permission_id):
-            return
+            return False
         client = self._adapter._client
         if client is None:
             self._registry.resolve(request.permission_id, "drop")
-            return
+            return False
         channel = client.get_channel(int(self._config.channel_id))
         if channel is None:
             channel = await client.fetch_channel(int(self._config.channel_id))
@@ -476,28 +878,52 @@ class OpenCodeBridge:
                 "OpenCode bridge: channel %s not found, dropping %s",
                 self._config.channel_id, request.permission_id,
             )
-            return
+            return False
 
         content, embed_desc = self._prompt_text(request)
-        metadata_line = ""
-        if request.metadata:
-            metadata_line = _truncate(json.dumps(request.metadata, default=str), _METADATA_BUDGET)
-        embed = discord.Embed(
-            title="🔐 OpenCode Permission",
-            description=embed_desc,
-            color=discord.Color.gold(),
-        )
-        if metadata_line:
-            embed.add_field(name="Details", value=f"```json\n{metadata_line}\n```", inline=False)
+        if request.is_guard:
+            embed = discord.Embed(
+                title="🛡️ Befehlswächter",
+                description=embed_desc,
+                color=discord.Color.gold(),
+            )
+            embed.add_field(name="Pfad", value=_truncate(request.path, _PATH_BUDGET), inline=False)
+            embed.add_field(name="Projektordner", value=_truncate(request.project or "-", _PATH_BUDGET), inline=False)
+            embed.add_field(name="Zugriff", value=request.access, inline=True)
+            embed.add_field(name="Agent", value=GUARD_AGENTS.get(request.agent, request.agent), inline=True)
+        else:
+            metadata_line = ""
+            if request.metadata:
+                metadata_line = _truncate(json.dumps(request.metadata, default=str), _METADATA_BUDGET)
+            embed = discord.Embed(
+                title="🔐 OpenCode Permission",
+                description=embed_desc,
+                color=discord.Color.gold(),
+            )
+            if metadata_line:
+                embed.add_field(name="Details", value=f"```json\n{metadata_line}\n```", inline=False)
 
+        timeout = self._config.timeout_seconds
+        if request.is_guard and request.expires_at:
+            # Never keep buttons alive past the guard's own deadline: the
+            # command is already denied by then, a late click must not
+            # look like it did anything.
+            timeout = max(1, min(timeout, int(request.expires_at - time.time())))
         view = _get_view_class()(
             bridge=self,
             request=request,
             allowed_user_ids=self._config.allowed_user_ids,
-            timeout=self._config.timeout_seconds,
+            timeout=timeout,
         )
-        msg = await channel.send(content=content, embed=embed, view=view)
+        try:
+            msg = await channel.send(content=content, embed=embed, view=view)
+        except BaseException:
+            # Nothing reached Discord: free the slot so the request is not
+            # stuck "pending" forever (the guard's own timeout denies it).
+            self._registry.resolve(request.permission_id, "drop")
+            raise
         view._message = msg
+        return True
 
     # ------------------------------------------------------------------
     # Resolution
@@ -520,9 +946,25 @@ class OpenCodeBridge:
             response = "reject"
         if not self._registry.resolve(request.permission_id, response):
             return "already-resolved"
+        if request.is_guard:
+            if self._spool is None:
+                return "reply-failed"
+            try:
+                self._spool.write_decision(request.permission_id, response, source)
+            except Exception as exc:
+                logger.error(
+                    "OpenCode bridge: writing guard decision for %s failed: %s",
+                    request.permission_id, exc,
+                )
+                return "reply-failed"
+            logger.info(
+                "OpenCode bridge: guard request %s answered %s (%s)",
+                request.permission_id, response, source,
+            )
+            return "delivered"
         try:
             delivered, status = await self._client.reply(
-                request.session_id, request.permission_id, response
+                request.session_id, request.permission_id, response, request.reply_api
             )
         except Exception as exc:
             logger.error(
@@ -573,6 +1015,12 @@ def _get_view_class():
             self._allowed_user_ids = allowed_user_ids
             self._message = None
             self._finished = False
+            if request.is_guard:
+                labels = {"Accept (once)": "Einmal erlauben", "Reject": "Ablehnen"}
+                for child in self.children:
+                    label = getattr(child, "label", None)
+                    if label in labels:
+                        child.label = labels[label]
 
         def _authorized(self, interaction: discord.Interaction) -> bool:
             user = getattr(interaction, "user", None)
@@ -582,14 +1030,19 @@ def _get_view_class():
         async def _answer(self, interaction: discord.Interaction, response: str) -> None:
             if not self._authorized(interaction):
                 await interaction.response.send_message(
-                    "You're not allowed to answer OpenCode permission requests~",
+                    "Du darfst diese Anfrage nicht beantworten."
+                    if self._request.is_guard
+                    else "You're not allowed to answer OpenCode permission requests~",
                     ephemeral=True,
                 )
                 return
             outcome = await self._bridge.resolve(self._request, response, "discord")
             if outcome == "already-resolved":
                 await interaction.response.send_message(
-                    "This request was already resolved~", ephemeral=True
+                    "Diese Anfrage wurde bereits beantwortet."
+                    if self._request.is_guard
+                    else "This request was already resolved~",
+                    ephemeral=True,
                 )
                 return
             await self._finalize(interaction, response, outcome)
@@ -617,11 +1070,17 @@ def _get_view_class():
                         if outcome == "delivered"
                         else discord.Color.dark_grey()
                     )
-                footer = {
-                    "delivered": f"{'Accepted (once)' if response == 'once' else 'Rejected'}",
-                    "resolved-elsewhere": "Already resolved by another OpenCode client",
-                    "reply-failed": "Reply to OpenCode failed — answer in OpenCode directly",
-                }.get(outcome, outcome)
+                if self._request.is_guard:
+                    footer = {
+                        "delivered": "Einmal erlaubt" if response == "once" else "Abgelehnt",
+                        "reply-failed": "Antwort konnte nicht abgelegt werden — der Befehl bleibt blockiert",
+                    }.get(outcome, outcome)
+                else:
+                    footer = {
+                        "delivered": f"{'Accepted (once)' if response == 'once' else 'Rejected'}",
+                        "resolved-elsewhere": "Already resolved by another OpenCode client",
+                        "reply-failed": "Reply to OpenCode failed — answer in OpenCode directly",
+                    }.get(outcome, outcome)
                 embed.set_footer(text=footer)
             try:
                 await interaction.response.edit_message(embed=embed, view=self)
@@ -639,7 +1098,11 @@ def _get_view_class():
             embed = msg.embeds[0] if msg.embeds else None
             if embed:
                 embed.color = discord.Color.dark_grey()
-                embed.set_footer(text="⏱ Timed out — rejected (fail-closed)")
+                embed.set_footer(
+                    text="⏱ Zeit abgelaufen — abgelehnt"
+                    if self._request.is_guard
+                    else "⏱ Timed out — rejected (fail-closed)"
+                )
             try:
                 await msg.edit(embed=embed, view=self)
             except Exception:

--- a/plugins/platforms/discord/opencode_bridge.py
+++ b/plugins/platforms/discord/opencode_bridge.py
@@ -133,9 +133,21 @@ GUARD_MAX_LIFETIME_SECONDS = 3600  # a request may not ask to live longer
 GUARD_DECISION_TTL_SECONDS = 3600  # orphaned decisions are swept after this
 GUARD_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
 GUARD_AGENTS = {"opencode": "OpenCode", "claude-code": "Claude Code"}
-GUARD_ACCESS_KINDS = frozenset({"lesen", "schreiben", "ausführen", "unklar"})
+GUARD_ACCESS_KINDS = frozenset({"lesen", "schreiben", "ausführen", "netz", "unklar"})
 GUARD_SOURCE = "guard"
 SSE_SOURCE = "sse"
+# Request kinds: "permission" = one Accept/Reject decision (the original
+# command-guard shape, also used for Claude Code's own permission prompts);
+# "question" = a multiple-choice question set (Claude Code's AskUserQuestion)
+# answered with labels or free text.
+GUARD_KIND_PERMISSION = "permission"
+GUARD_KIND_QUESTION = "question"
+GUARD_MAX_QUESTIONS = 4
+GUARD_MAX_OPTIONS = 8
+_DETAILS_BUDGET = 900
+_QUESTION_BUDGET = 600
+_OPTION_LABEL_BUDGET = 80  # Discord button label limit
+_FREE_TEXT_BUDGET = 1500
 
 
 def default_guard_dir() -> str:
@@ -271,6 +283,10 @@ class OpenCodePermissionRequest:
     project: str = ""
     access: str = ""
     expires_at: float = 0.0
+    guard_kind: str = GUARD_KIND_PERMISSION
+    tool: str = ""
+    details: str = ""
+    questions: tuple = ()
 
     @property
     def short_session_id(self) -> str:
@@ -279,6 +295,10 @@ class OpenCodePermissionRequest:
     @property
     def is_guard(self) -> bool:
         return self.source == GUARD_SOURCE
+
+    @property
+    def is_question(self) -> bool:
+        return self.is_guard and self.guard_kind == GUARD_KIND_QUESTION
 
 
 def parse_permission_event(payload: Any) -> Optional[OpenCodePermissionRequest]:
@@ -358,17 +378,32 @@ def parse_guard_request(
     agent = payload.get("agent")
     if agent not in GUARD_AGENTS:
         return None
-    command = payload.get("command")
-    path = payload.get("path")
-    if not isinstance(command, str) or not command.strip():
-        return None
-    if not isinstance(path, str) or not path.strip():
+    kind = payload.get("kind", GUARD_KIND_PERMISSION)
+    if kind not in (GUARD_KIND_PERMISSION, GUARD_KIND_QUESTION):
         return None
     project = payload.get("project")
     project = project if isinstance(project, str) else ""
-    access = payload.get("access")
-    if access not in GUARD_ACCESS_KINDS:
-        return None
+    tool = payload.get("tool", "")
+    tool = tool if isinstance(tool, str) else ""
+    details = payload.get("details", "")
+    details = details if isinstance(details, str) else ""
+    questions: tuple = ()
+    if kind == GUARD_KIND_QUESTION:
+        questions = _parse_questions(payload.get("questions"))
+        if not questions:
+            return None
+        command = "; ".join(q["question"] for q in questions)
+        path, access = "-", "unklar"
+    else:
+        command = payload.get("command")
+        path = payload.get("path")
+        if not isinstance(command, str) or not command.strip():
+            return None
+        if not isinstance(path, str) or not path.strip():
+            return None
+        access = payload.get("access")
+        if access not in GUARD_ACCESS_KINDS:
+            return None
     created_at = payload.get("created_at")
     expires_at = payload.get("expires_at")
     if isinstance(created_at, bool) or isinstance(expires_at, bool):
@@ -394,7 +429,53 @@ def parse_guard_request(
         project=project,
         access=str(access),
         expires_at=float(expires_at),
+        guard_kind=str(kind),
+        tool=tool,
+        details=details,
+        questions=questions,
     )
+
+
+def _parse_questions(raw: Any) -> tuple:
+    """Validate an AskUserQuestion-style question list; () when unclear."""
+    if not isinstance(raw, list) or not 1 <= len(raw) <= GUARD_MAX_QUESTIONS:
+        return ()
+    out = []
+    seen: Set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            return ()
+        question = item.get("question")
+        if not isinstance(question, str) or not question.strip() or question in seen:
+            return ()
+        seen.add(question)
+        header = item.get("header", "")
+        header = header if isinstance(header, str) else ""
+        options_raw = item.get("options")
+        if not isinstance(options_raw, list) or not 1 <= len(options_raw) <= GUARD_MAX_OPTIONS:
+            return ()
+        options = []
+        labels: Set[str] = set()
+        for opt in options_raw:
+            if not isinstance(opt, dict):
+                return ()
+            label = opt.get("label")
+            if not isinstance(label, str) or not label.strip() or label in labels:
+                return ()
+            labels.add(label)
+            description = opt.get("description", "")
+            options.append({
+                "label": label,
+                "description": description if isinstance(description, str) else "",
+            })
+        multi = item.get("multiSelect", False)
+        out.append({
+            "question": question,
+            "header": header,
+            "options": tuple(options),
+            "multiSelect": multi if isinstance(multi, bool) else False,
+        })
+    return tuple(out)
 
 
 class GuardSpool:
@@ -480,20 +561,31 @@ class GuardSpool:
             self._unlink(file_path)
 
     def write_decision(
-        self, request_id: str, decision: str, source: str, *, now: Optional[float] = None
+        self,
+        request_id: str,
+        decision: str,
+        source: str,
+        *,
+        answers: Optional[Dict[str, Any]] = None,
+        now: Optional[float] = None,
     ) -> None:
-        if decision not in ("once", "reject"):
+        """Publish one decision: ``once``/``reject``, or ``answer`` with answers."""
+        if decision == "answer" and not isinstance(answers, dict):
+            decision = "reject"
+        if decision not in ("once", "reject", "answer"):
             decision = "reject"
         if not GUARD_ID_RE.match(request_id):
             raise ValueError(f"invalid guard request id: {request_id!r}")
         self.ensure()
-        payload = {
+        payload: Dict[str, Any] = {
             "version": GUARD_PROTOCOL_VERSION,
             "id": request_id,
             "decision": decision,
             "source": source,
             "decided_at": time.time() if now is None else now,
         }
+        if decision == "answer":
+            payload["answers"] = answers
         fd, tmp_name = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=self.decisions_dir)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
@@ -816,27 +908,83 @@ class OpenCodeBridge:
     # Discord prompt
     # ------------------------------------------------------------------
 
+    def _with_mentions(self, content: str) -> str:
+        """Prefix the allowlisted users so Discord notifies them.
+
+        A guard prompt that nobody notices simply times out and blocks the
+        agent's command (this happened in practice while the user was busy
+        in a thread); the ping is the cheapest fix.
+        """
+        mentions = " ".join(f"<@{uid}>" for uid in sorted(self._config.allowed_user_ids) if uid.isdigit())
+        return f"{mentions}\n{content}" if mentions else content
+
+    def _allowed_mentions(self) -> Any:
+        if not DISCORD_AVAILABLE:
+            return None
+        return discord.AllowedMentions(everyone=False, roles=False, users=True, replied_user=False)
+
+    @staticmethod
+    def _remaining_minutes(request: OpenCodePermissionRequest) -> Optional[int]:
+        if not request.expires_at:
+            return None
+        return max(1, int(round((request.expires_at - time.time()) / 60)))
+
     def _guard_prompt_text(self, request: OpenCodePermissionRequest) -> tuple[str, str]:
-        """German prompt for a command-guard request (command, path, project, access)."""
+        """German prompt for a command-guard / permission request."""
         command = _truncate(request.command, _COMMAND_BUDGET).replace("```", "'''")
         agent_label = GUARD_AGENTS.get(request.agent, request.agent)
-        remaining = max(1, int(round((request.expires_at - time.time()) / 60))) if request.expires_at else None
-        lines = [
-            "🛡️ **Befehlswächter: Zugriff außerhalb des Projekts**",
-            "",
-            f"**Agent:** {agent_label}",
-            "**Befehl:**",
-            f"```bash\n{command}\n```",
-            f"**Pfad:** `{_truncate(request.path, _PATH_BUDGET)}`",
-            f"**Projektordner:** `{_truncate(request.project or '-', _PATH_BUDGET)}`",
-            f"**Zugriff:** {request.access}",
+        remaining = self._remaining_minutes(request)
+        if request.tool:
+            heading = f"🛡️ **{agent_label} bittet um Erlaubnis: {_truncate(request.tool, 60)}**"
+        else:
+            heading = "🛡️ **Befehlswächter: Zugriff außerhalb des Projekts**"
+        lines = [heading, "", f"**Agent:** {agent_label}"]
+        if request.tool:
+            lines.append(f"**Werkzeug:** `{_truncate(request.tool, 60)}`")
+        lines += ["**Befehl:**", f"```bash\n{command}\n```"]
+        if request.details:
+            details = _truncate(request.details, _DETAILS_BUDGET).replace("```", "'''")
+            lines += ["**Details:**", f"```\n{details}\n```"]
+        if request.path and request.path != "-":
+            lines.append(f"**Pfad:** `{_truncate(request.path, _PATH_BUDGET)}`")
+        lines.append(f"**Projektordner:** `{_truncate(request.project or '-', _PATH_BUDGET)}`")
+        if request.access and request.access != "-":
+            lines.append(f"**Zugriff:** {request.access}")
+        lines += [
             f"**Session:** `{request.short_session_id}`",
             "",
-            "**Einmal erlauben** lässt genau diesen Befehl einmal durch, **Ablehnen** blockiert ihn. "
+            "**Einmal erlauben** lässt genau diese Aktion einmal durch, **Ablehnen** blockiert sie. "
             + (f"Ohne Antwort innerhalb von etwa {remaining} min wird automatisch abgelehnt. " if remaining else "Ohne Antwort wird automatisch abgelehnt. ")
             + "Dauerhafte Freigaben gibt es nicht.",
         ]
         return "\n".join(lines), f"```bash\n{command}\n```"
+
+    def _question_prompt_text(self, request: OpenCodePermissionRequest, index: int) -> str:
+        """German prompt for question ``index`` of a question request."""
+        q = request.questions[index]
+        agent_label = GUARD_AGENTS.get(request.agent, request.agent)
+        remaining = self._remaining_minutes(request)
+        total = len(request.questions)
+        counter = f" ({index + 1}/{total})" if total > 1 else ""
+        header = f" · {_truncate(q['header'], 60)}" if q.get("header") else ""
+        lines = [
+            f"❓ **{agent_label} fragt{counter}{header}**",
+            "",
+            _truncate(q["question"], _QUESTION_BUDGET),
+            "",
+        ]
+        for opt in q["options"]:
+            desc = f" — {_truncate(opt['description'], 200)}" if opt.get("description") else ""
+            lines.append(f"• **{_truncate(opt['label'], _OPTION_LABEL_BUDGET)}**{desc}")
+        lines += [
+            "",
+            f"**Projektordner:** `{_truncate(request.project or '-', _PATH_BUDGET)}` · **Session:** `{request.short_session_id}`",
+            "",
+            ("Mehrere Antworten möglich: anklicken und mit **Fertig** abschließen. " if q.get("multiSelect") else "Eine Antwort anklicken. ")
+            + "**Andere Antwort…** öffnet ein Textfeld. "
+            + (f"Ohne Antwort innerhalb von etwa {remaining} min wird die Frage abgebrochen." if remaining else "Ohne Antwort wird die Frage abgebrochen."),
+        ]
+        return "\n".join(lines)
 
     def _prompt_text(self, request: OpenCodePermissionRequest) -> tuple[str, str]:
         """Return (plain content, embed description) for the request."""
@@ -880,16 +1028,21 @@ class OpenCodeBridge:
             )
             return False
 
+        if request.is_question:
+            return await self._post_question_prompts(channel, request)
+
         content, embed_desc = self._prompt_text(request)
         if request.is_guard:
             embed = discord.Embed(
-                title="🛡️ Befehlswächter",
+                title="🛡️ Befehlswächter" if not request.tool else f"🛡️ Erlaubnis: {_truncate(request.tool, 60)}",
                 description=embed_desc,
                 color=discord.Color.gold(),
             )
-            embed.add_field(name="Pfad", value=_truncate(request.path, _PATH_BUDGET), inline=False)
+            if request.path and request.path != "-":
+                embed.add_field(name="Pfad", value=_truncate(request.path, _PATH_BUDGET), inline=False)
             embed.add_field(name="Projektordner", value=_truncate(request.project or "-", _PATH_BUDGET), inline=False)
-            embed.add_field(name="Zugriff", value=request.access, inline=True)
+            if request.access and request.access != "-":
+                embed.add_field(name="Zugriff", value=request.access, inline=True)
             embed.add_field(name="Agent", value=GUARD_AGENTS.get(request.agent, request.agent), inline=True)
         else:
             metadata_line = ""
@@ -915,14 +1068,50 @@ class OpenCodeBridge:
             allowed_user_ids=self._config.allowed_user_ids,
             timeout=timeout,
         )
+        if request.is_guard:
+            content = self._with_mentions(content)
         try:
-            msg = await channel.send(content=content, embed=embed, view=view)
+            msg = await channel.send(
+                content=content, embed=embed, view=view, allowed_mentions=self._allowed_mentions()
+            )
         except BaseException:
             # Nothing reached Discord: free the slot so the request is not
             # stuck "pending" forever (the guard's own timeout denies it).
             self._registry.resolve(request.permission_id, "drop")
             raise
         view._message = msg
+        return True
+
+    async def _post_question_prompts(self, channel: Any, request: OpenCodePermissionRequest) -> bool:
+        """One message per question; the set resolves once all are answered."""
+        timeout = self._config.timeout_seconds
+        if request.expires_at:
+            timeout = max(1, min(timeout, int(request.expires_at - time.time())))
+        session = QuestionSession(self, request)
+        view_class, _ = _get_question_classes()
+        views = []
+        try:
+            for index in range(len(request.questions)):
+                view = view_class(
+                    session=session,
+                    index=index,
+                    allowed_user_ids=self._config.allowed_user_ids,
+                    timeout=timeout,
+                )
+                content = self._question_prompt_text(request, index)
+                if index == 0:
+                    content = self._with_mentions(content)
+                msg = await channel.send(
+                    content=content, view=view, allowed_mentions=self._allowed_mentions()
+                )
+                view._message = msg
+                views.append(view)
+        except BaseException:
+            self._registry.resolve(request.permission_id, "drop")
+            for view in views:
+                view.stop()
+            raise
+        session.views = views
         return True
 
     # ------------------------------------------------------------------
@@ -934,15 +1123,19 @@ class OpenCodeBridge:
         request: OpenCodePermissionRequest,
         response: str,
         source: str,
+        answers: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Resolve a request and deliver the reply to OpenCode.
+        """Resolve a request and deliver the reply.
 
-        ``response`` is ``"once"`` or ``"reject"``. Returns a short
-        outcome label the caller renders in Discord. First-wins: a late
-        click after another client (TUI) answered or the timeout fired
-        never double-posts a reply.
+        ``response`` is ``"once"`` or ``"reject"`` (``"answer"`` with
+        ``answers`` for question requests). Returns a short outcome label
+        the caller renders in Discord. First-wins: a late click after
+        another client (TUI) answered or the timeout fired never
+        double-posts a reply.
         """
-        if response not in ("once", "reject"):
+        if response == "answer" and not (request.is_question and isinstance(answers, dict)):
+            response = "reject"
+        if response not in ("once", "reject", "answer"):
             response = "reject"
         if not self._registry.resolve(request.permission_id, response):
             return "already-resolved"
@@ -950,7 +1143,7 @@ class OpenCodeBridge:
             if self._spool is None:
                 return "reply-failed"
             try:
-                self._spool.write_decision(request.permission_id, response, source)
+                self._spool.write_decision(request.permission_id, response, source, answers=answers)
             except Exception as exc:
                 logger.error(
                     "OpenCode bridge: writing guard decision for %s failed: %s",
@@ -982,7 +1175,201 @@ class OpenCodeBridge:
         return "delivered"
 
 
+class QuestionSession:
+    """Collects the answers of one question request across its messages.
+
+    First complete answer set wins; a timeout on any unanswered question
+    rejects the whole request (the agent then gets no answers at all
+    rather than a partial, misleading set).
+    """
+
+    def __init__(self, bridge: OpenCodeBridge, request: OpenCodePermissionRequest) -> None:
+        self.bridge = bridge
+        self.request = request
+        self.answers: Dict[str, Any] = {}
+        self.views: List[Any] = []
+        self.finished = False
+
+    @property
+    def complete(self) -> bool:
+        return len(self.answers) == len(self.request.questions)
+
+    async def answer(self, index: int, value: Any) -> str:
+        """Record one answer; returns the outcome once the set is complete."""
+        if self.finished:
+            return "already-resolved"
+        question = self.request.questions[index]["question"]
+        self.answers[question] = value
+        if not self.complete:
+            return "pending"
+        self.finished = True
+        outcome = await self.bridge.resolve(self.request, "answer", "discord", answers=dict(self.answers))
+        for view in self.views:
+            view.stop()
+        return outcome
+
+    async def abort(self, source: str) -> str:
+        if self.finished:
+            return "already-resolved"
+        self.finished = True
+        outcome = await self.bridge.resolve(self.request, "reject", source)
+        for view in self.views:
+            view.stop()
+        return outcome
+
+
 _VIEW_CLASS = None
+_QUESTION_CLASSES = None
+
+
+def _get_question_classes():
+    """Build (once) the question view and free-text modal; requires discord.py."""
+    global _QUESTION_CLASSES
+    if _QUESTION_CLASSES is not None:
+        return _QUESTION_CLASSES
+    if not DISCORD_AVAILABLE:
+        raise RuntimeError("discord.py is not installed")
+
+    class FreeTextModal(discord.ui.Modal):
+        """Free-text answer for one question ("Andere Antwort…")."""
+
+        def __init__(self, view: "QuestionView") -> None:
+            super().__init__(title=_truncate(view.question["header"] or "Andere Antwort", 45))
+            self._view = view
+            self.text = discord.ui.TextInput(
+                label="Antwort",
+                style=discord.TextStyle.paragraph,
+                max_length=_FREE_TEXT_BUDGET,
+                required=True,
+            )
+            self.add_item(self.text)
+
+        async def on_submit(self, interaction: discord.Interaction) -> None:
+            await self._view.submit(interaction, str(self.text.value).strip())
+
+    class QuestionView(discord.ui.View):
+        """Buttons for one question: one per option, plus free text / done."""
+
+        def __init__(
+            self,
+            session: QuestionSession,
+            index: int,
+            allowed_user_ids: frozenset,
+            timeout: int,
+        ) -> None:
+            super().__init__(timeout=timeout)
+            self._session = session
+            self._index = index
+            self._allowed_user_ids = allowed_user_ids
+            self._message = None
+            self._selected: List[str] = []
+            self._done = False
+            self.question = session.request.questions[index]
+            for opt in self.question["options"]:
+                button = discord.ui.Button(
+                    label=_truncate(opt["label"], _OPTION_LABEL_BUDGET),
+                    style=discord.ButtonStyle.primary,
+                )
+                button.callback = self._option_callback(button, opt["label"])
+                self.add_item(button)
+            other = discord.ui.Button(label="Andere Antwort…", style=discord.ButtonStyle.secondary)
+            other.callback = self._other_callback
+            self.add_item(other)
+            if self.question["multiSelect"]:
+                done = discord.ui.Button(label="Fertig", style=discord.ButtonStyle.success)
+                done.callback = self._done_callback
+                self.add_item(done)
+
+        def _authorized(self, interaction: discord.Interaction) -> bool:
+            user = getattr(interaction, "user", None)
+            uid = str(getattr(user, "id", "") or "")
+            return bool(uid) and uid in self._allowed_user_ids
+
+        async def _guard(self, interaction: discord.Interaction) -> bool:
+            if not self._authorized(interaction):
+                await interaction.response.send_message("Du darfst diese Frage nicht beantworten.", ephemeral=True)
+                return False
+            if self._done or self._session.finished:
+                await interaction.response.send_message("Diese Frage wurde bereits beantwortet.", ephemeral=True)
+                return False
+            return True
+
+        def _option_callback(self, button: Any, label: str) -> Callable[[Any], Awaitable[None]]:
+            async def callback(interaction: discord.Interaction) -> None:
+                if not await self._guard(interaction):
+                    return
+                if self.question["multiSelect"]:
+                    if label in self._selected:
+                        self._selected.remove(label)
+                        button.style = discord.ButtonStyle.primary
+                    else:
+                        self._selected.append(label)
+                        button.style = discord.ButtonStyle.success
+                    await self._edit(interaction)
+                    return
+                await self.submit(interaction, label)
+            return callback
+
+        async def _other_callback(self, interaction: discord.Interaction) -> None:
+            if not await self._guard(interaction):
+                return
+            await interaction.response.send_modal(FreeTextModal(self))
+
+        async def _done_callback(self, interaction: discord.Interaction) -> None:
+            if not await self._guard(interaction):
+                return
+            if not self._selected:
+                await interaction.response.send_message("Bitte erst mindestens eine Antwort anklicken.", ephemeral=True)
+                return
+            await self.submit(interaction, list(self._selected))
+
+        async def submit(self, interaction: discord.Interaction, value: Any) -> None:
+            if self._done or self._session.finished:
+                await interaction.response.send_message("Diese Frage wurde bereits beantwortet.", ephemeral=True)
+                return
+            self._done = True
+            for child in self.children:
+                child.disabled = True
+            shown = ", ".join(value) if isinstance(value, list) else str(value)
+            outcome = await self._session.answer(self._index, value)
+            suffix = {
+                "pending": "✅ Antwort gespeichert — bitte auch die anderen Fragen beantworten.",
+                "delivered": "✅ Antwort übermittelt.",
+                "reply-failed": "⚠️ Antwort konnte nicht abgelegt werden — die Frage bleibt unbeantwortet.",
+            }.get(outcome, outcome)
+            await self._edit(interaction, footer=f"**Antwort:** {_truncate(shown, 300)}\n{suffix}")
+
+        async def _edit(self, interaction: discord.Interaction, footer: Optional[str] = None) -> None:
+            content = None
+            if footer is not None:
+                base = getattr(interaction.message, "content", "") or ""
+                content = f"{base}\n\n{footer}"
+            try:
+                if content is None:
+                    await interaction.response.edit_message(view=self)
+                else:
+                    await interaction.response.edit_message(content=content, view=self)
+            except Exception:
+                logger.debug("OpenCode bridge: could not edit question message")
+
+        async def on_timeout(self) -> None:
+            if self._done or self._session.finished:
+                return
+            self._done = True
+            for child in self.children:
+                child.disabled = True
+            await self._session.abort("timeout")
+            msg = self._message
+            if msg is None:
+                return
+            try:
+                base = getattr(msg, "content", "") or ""
+                await msg.edit(content=f"{base}\n\n⏱ Zeit abgelaufen — Frage abgebrochen.", view=self)
+            except Exception:
+                pass
+
+    _QUESTION_CLASSES = (QuestionView, FreeTextModal)
+    return _QUESTION_CLASSES
 
 
 def _get_view_class():

--- a/tests/plugins/platforms/test_discord_opencode_bridge.py
+++ b/tests/plugins/platforms/test_discord_opencode_bridge.py
@@ -349,35 +349,69 @@ class TestOpenCodeBridgeClient:
 
 
 class FakeMessage:
-    def __init__(self, embeds=None, content=""):
+    def __init__(self, embeds=None, content="", channel=None):
         self.embeds = embeds or []
         self.content = content
         self.edits = []
+        self.channel = channel
 
     async def edit(self, **kwargs):
         self.edits.append(kwargs)
         if "embed" in kwargs:
             self.embeds = [kwargs["embed"]]
 
+    async def create_thread(self, name, auto_archive_duration=None, **kwargs):
+        thread = FakeChannel(channel_id=900_000 + (len(self.channel.threads) if self.channel else 0))
+        thread.name = name
+        thread.mention = f"<#{thread.id}>"
+        if self.channel is not None:
+            self.channel.threads.append(thread)
+            self.channel.client.channels[thread.id] = thread
+        return thread
+
 
 class FakeChannel:
-    def __init__(self):
+    def __init__(self, channel_id=123):
+        self.id = channel_id
         self.sent = []
+        self.threads = []
+        self.client = None
+        self.name = ""
+
+    mention = "<#0>"
 
     async def send(self, **kwargs):
         self.sent.append(kwargs)
-        return FakeMessage(embeds=[kwargs["embed"]] if kwargs.get("embed") else [], content=kwargs.get("content", ""))
+        return FakeMessage(
+            embeds=[kwargs["embed"]] if kwargs.get("embed") else [],
+            content=kwargs.get("content", ""),
+            channel=self,
+        )
+
+    async def create_thread(self, name=None, content=None, **kwargs):
+        thread = FakeChannel(channel_id=900_000 + len(self.threads))
+        thread.name = name
+        thread.mention = f"<#{thread.id}>"
+        self.threads.append(thread)
+        if self.client is not None:
+            self.client.channels[thread.id] = thread
+        if content is not None:  # forum-style: starter content is the first message
+            thread.sent.append({"content": content})
+            return SimpleNamespace(thread=thread)
+        return thread
 
 
 class FakeDiscordClient:
     def __init__(self, channel):
         self._channel = channel
+        self.channels = {channel.id: channel}
+        channel.client = self
 
     def get_channel(self, channel_id):
-        return self._channel
+        return self.channels.get(int(channel_id), self._channel if int(channel_id) == self._channel.id else None)
 
     async def fetch_channel(self, channel_id):
-        return self._channel
+        return self.get_channel(channel_id)
 
 
 class FakeAdapter:
@@ -1228,3 +1262,269 @@ class TestQuestionFlow:
         spool = GuardSpool(str(tmp_path))
         spool.write_decision("frage000-0001", "answer", "discord", now=NOW)
         assert json.loads((spool.decisions_dir / "frage000-0001.json").read_text())["decision"] == "reject"
+
+
+# ---------------------------------------------------------------------------
+# Session notices and per-session threads
+# ---------------------------------------------------------------------------
+
+from plugins.platforms.discord.opencode_bridge import ThreadRegistry  # noqa: E402
+
+
+def _notice(notice, session_id="ses-thread-1", **overrides):
+    payload = _fresh(id=f"notice00-{notice}-{len(session_id)}", agent="opencode", kind="notice", notice=notice,
+                     session_id=session_id, text="Bitte Kapitel 3 bauen", started_at=time.time())
+    for key in ("command", "path", "access"):
+        payload.pop(key, None)
+    payload.update(overrides)
+    return payload
+
+
+class TestNoticeParsing:
+    def test_start_notice_parses(self):
+        r = parse_guard_request(_notice("start"), now=time.time())
+        assert r is not None and r.is_notice and r.notice == "start"
+        assert r.text == "Bitte Kapitel 3 bauen" and r.session_id == "ses-thread-1"
+
+    @pytest.mark.parametrize("overrides", [
+        {"notice": "explode"},
+        {"session_id": ""},
+        {"notice": "child"},  # child without parent
+    ])
+    def test_unclear_notices_refused(self, overrides):
+        payload = _notice("start")
+        payload.update(overrides)
+        assert parse_guard_request(payload, now=time.time()) is None
+
+    def test_child_notice_needs_parent(self):
+        r = parse_guard_request(_notice("child", parent_session_id="ses-root"), now=time.time())
+        assert r is not None and r.parent_session_id == "ses-root"
+
+
+class TestThreadRegistry:
+    def test_roundtrip_and_parent_resolution(self, tmp_path):
+        reg = ThreadRegistry(tmp_path / "threads.json")
+        reg.set_thread("root", "42", "123")
+        reg.set_parent("child", "root")
+        reg.set_parent("grandchild", "child")
+        assert reg.thread_for("grandchild") == "42"
+        assert reg.thread_for("unknown") is None
+        again = ThreadRegistry(tmp_path / "threads.json")
+        assert again.thread_for("child") == "42"
+
+    def test_prune_drops_old_threads(self, tmp_path):
+        reg = ThreadRegistry(tmp_path / "threads.json")
+        reg.set_thread("old", "1", "123", now=time.time() - 8 * 24 * 3600)
+        reg.set_thread("new", "2", "123")
+        reg.set_parent("kid", "old")
+        reg.prune()
+        assert reg.thread_for("old") is None and reg.thread_for("new") == "2"
+        assert reg.thread_for("kid") is None
+
+    def test_corrupt_file_is_ignored(self, tmp_path):
+        (tmp_path / "threads.json").write_text("{kaputt", encoding="utf-8")
+        assert ThreadRegistry(tmp_path / "threads.json").thread_for("x") is None
+
+
+class TestSessionThreads:
+    @pytest.mark.asyncio
+    async def test_start_notice_opens_thread_with_prompt(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+        posted = await bridge.poll_guard_spool_once()
+        assert posted == 1
+        assert len(channel.threads) == 1
+        thread = channel.threads[0]
+        assert thread.name.startswith("OpenCode · Projekt · ")
+        assert "Session `ses-thread-1`" in channel.sent[0]["content"]
+        assert "Bitte Kapitel 3 bauen" in thread.sent[0]["content"]
+        assert "Sitzung gestartet" in thread.sent[0]["content"]
+        assert bridge.threads.thread_for("ses-thread-1") == str(thread.id)
+        assert os.listdir(bridge.spool.requests_dir) == []  # notice consumed
+
+    @pytest.mark.asyncio
+    async def test_prompts_of_session_land_in_thread(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+        await bridge.poll_guard_spool_once()
+        thread = channel.threads[0]
+        _write_request(bridge.spool, _fresh(id="perm0000-thread", session_id="ses-thread-1"))
+        _write_request(bridge.spool, _question_payload(session_id="ses-thread-1"))
+        await bridge.poll_guard_spool_once()
+        assert len(channel.sent) == 1  # only the starter in the channel
+        assert any("Befehlswächter" in m["content"] for m in thread.sent)
+        assert any("Welche Farbe?" in m["content"] for m in thread.sent)
+        # answering inside the thread still writes the decision file
+        view = next(m["view"] for m in thread.sent if "Befehlswächter" in m["content"])
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, _interaction("111", message=FakeMessage(embeds=[])), None)
+        assert _read_decision(bridge, "perm0000-thread")["decision"] == "once"
+
+    @pytest.mark.asyncio
+    async def test_child_session_uses_parent_thread(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+        await bridge.poll_guard_spool_once()
+        _write_request(bridge.spool, _notice("child", session_id="ses-kind", parent_session_id="ses-thread-1"))
+        await bridge.poll_guard_spool_once()
+        _write_request(bridge.spool, _fresh(id="perm0000-kind0", session_id="ses-kind"))
+        await bridge.poll_guard_spool_once()
+        assert any("Befehlswächter" in m["content"] for m in channel.threads[0].sent)
+        assert len(channel.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_prompt_and_result_notices_post_into_thread(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+        await bridge.poll_guard_spool_once()
+        _write_request(bridge.spool, _notice("prompt", text="Und jetzt Kapitel 4"))
+        _write_request(bridge.spool, _notice("result", text="Fertig, 2 Dateien."))
+        await bridge.poll_guard_spool_once()
+        texts = [m["content"] for m in channel.threads[0].sent]
+        assert any("Neuer Prompt" in t and "Kapitel 4" in t for t in texts)
+        assert any("Antwort" in t and "Fertig, 2 Dateien." in t for t in texts)
+
+    @pytest.mark.asyncio
+    async def test_second_start_for_same_session_does_not_open_second_thread(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+        await bridge.poll_guard_spool_once()
+        _write_request(bridge.spool, _notice("start", id="notice00-start-again"))
+        await bridge.poll_guard_spool_once()
+        assert len(channel.threads) == 1
+        assert len(channel.threads[0].sent) == 2
+
+    @pytest.mark.asyncio
+    async def test_prompt_without_thread_falls_back_to_channel(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _fresh(session_id="ses-unbekannt"))
+        _write_request(bridge.spool, _notice("result", session_id="ses-unbekannt", text="ohne Thread"))
+        await bridge.poll_guard_spool_once()
+        assert channel.threads == []
+        assert any("Befehlswächter" in m["content"] for m in channel.sent)
+        assert any("ohne Thread" in m["content"] for m in channel.sent)
+
+    @pytest.mark.asyncio
+    async def test_failed_notice_is_not_retried(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _notice("start"))
+
+        async def boom(**kwargs):
+            raise RuntimeError("discord down")
+        channel.send = boom
+        await bridge.poll_guard_spool_once()
+        assert os.listdir(bridge.spool.requests_dir) == []
+
+
+class TestBridgeChannelIsThread:
+    """When the configured channel is itself a thread, session threads go to the parent."""
+
+    def _bridge_with_thread_channel(self, tmp_path, monkeypatch):
+        import plugins.platforms.discord.opencode_bridge as bridge_mod
+
+        class FakeThreadType:
+            pass
+
+        class FakeForumType:
+            pass
+
+        class FakeChannelType:
+            public_thread = "public_thread"
+
+        fake_discord = SimpleNamespace(
+            Thread=FakeThreadType,
+            ForumChannel=FakeForumType,
+            ChannelType=FakeChannelType,
+            AllowedMentions=lambda **k: SimpleNamespace(**k),
+        )
+        monkeypatch.setattr(bridge_mod, "discord", fake_discord)
+
+        class FakeBridgeThread(FakeChannel, FakeThreadType):
+            pass
+
+        parent = FakeChannel(channel_id=555)
+        thread_channel = FakeBridgeThread(channel_id=1543687087310643277)
+        thread_channel.parent = parent
+        client = FakeDiscordClient(thread_channel)
+        client.channels[parent.id] = parent
+        parent.client = client
+        adapter = SimpleNamespace(_client=client)
+        config = _bridge_config(guard_dir=str(tmp_path), channel_id=str(thread_channel.id))
+        bridge = OpenCodeBridge(adapter, config, client=StubBridgeClient())
+        return bridge, thread_channel, parent
+
+    @pytest.mark.asyncio
+    async def test_start_creates_thread_in_parent_and_points_from_channel(self, tmp_path, monkeypatch):
+        bridge, thread_channel, parent = self._bridge_with_thread_channel(tmp_path, monkeypatch)
+        _write_request(bridge.spool, _notice("start"))
+        await bridge.poll_guard_spool_once()
+        assert len(parent.threads) == 1, "session thread created in the parent"
+        new_thread = parent.threads[0]
+        assert any(new_thread.mention in m["content"] for m in thread_channel.sent), "pointer posted in the watched thread"
+        assert any("Sitzung gestartet" in m["content"] for m in new_thread.sent)
+        assert bridge.threads.thread_for("ses-thread-1") == str(new_thread.id)
+
+
+# ---------------------------------------------------------------------------
+# Per-agent channels (e.g. #opencode vs #claudecode)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentChannels:
+    def test_valid_mapping_is_kept(self):
+        config = _bridge_config(agent_channels={"claude-code": "777", "opencode": "888"})
+        assert config.channel_for("claude-code") == "777"
+        assert config.channel_for("opencode") == "888"
+        assert config.channel_for("") == "123"  # falls back to channel_id
+
+    @pytest.mark.parametrize("mapping", [
+        {"unbekannt": "777"},          # unknown agent
+        {"claude-code": "nicht-numerisch"},
+        {"claude-code": ""},
+        "kein dict",
+    ])
+    def test_bad_mapping_falls_back(self, mapping):
+        config = _bridge_config(agent_channels=mapping)
+        assert config.channel_for("claude-code") == "123"
+
+    def test_absent_mapping_uses_channel_id(self):
+        assert _bridge_config().channel_for("claude-code") == "123"
+
+    @pytest.mark.asyncio
+    async def test_claude_code_prompt_goes_to_its_own_channel(self, tmp_path):
+        opencode_channel = FakeChannel(channel_id=123)
+        claude_channel = FakeChannel(channel_id=777)
+        client = FakeDiscordClient(opencode_channel)
+        client.channels[claude_channel.id] = claude_channel
+        claude_channel.client = client
+        adapter = SimpleNamespace(_client=client)
+        config = _bridge_config(guard_dir=str(tmp_path), agent_channels={"claude-code": "777"})
+        bridge = OpenCodeBridge(adapter, config, client=StubBridgeClient())
+
+        _write_request(bridge.spool, _fresh(id="perm0000-cc001", agent="claude-code", tool="Bash"))
+        _write_request(bridge.spool, _fresh(id="perm0000-oc001", agent="opencode"))
+        await bridge.poll_guard_spool_once()
+
+        assert len(claude_channel.sent) == 1 and "Claude Code" in claude_channel.sent[0]["content"]
+        assert len(opencode_channel.sent) == 1 and "Befehlswächter" in opencode_channel.sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_claude_code_session_thread_opens_in_its_channel(self, tmp_path):
+        opencode_channel = FakeChannel(channel_id=123)
+        claude_channel = FakeChannel(channel_id=777)
+        client = FakeDiscordClient(opencode_channel)
+        client.channels[claude_channel.id] = claude_channel
+        claude_channel.client = client
+        adapter = SimpleNamespace(_client=client)
+        config = _bridge_config(guard_dir=str(tmp_path), agent_channels={"claude-code": "777"})
+        bridge = OpenCodeBridge(adapter, config, client=StubBridgeClient())
+
+        _write_request(bridge.spool, _notice("start", agent="claude-code"))
+        await bridge.poll_guard_spool_once()
+        assert len(claude_channel.threads) == 1
+        assert opencode_channel.threads == []
+        # a later prompt of that session lands in the same thread
+        _write_request(bridge.spool, _fresh(id="perm0000-cc002", agent="claude-code", session_id="ses-thread-1"))
+        await bridge.poll_guard_spool_once()
+        assert any("Befehlswächter" in m.get("content", "") or "Erlaubnis" in m.get("content", "")
+                   for m in claude_channel.threads[0].sent)

--- a/tests/plugins/platforms/test_discord_opencode_bridge.py
+++ b/tests/plugins/platforms/test_discord_opencode_bridge.py
@@ -1,0 +1,615 @@
+"""Tests for the OpenCode permission bridge (Discord plugin).
+
+Covers the fail-closed contract end to end without network access:
+
+- events: SSE assembly + ``permission.updated`` parsing (malformed dropped)
+- config: opt-in gating, loopback enforcement, allowlist requirement
+- discord: Accept/Reject buttons, allowlist authorization, timeout->reject,
+  parallel requests resolving independently
+- replies: official API body ``{"response": "once" | "reject"}`` via
+  ``POST /session/{id}/permissions/{permissionID}`` (mock transport)
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from plugins.platforms.discord.opencode_bridge import (
+    BridgePendingRegistry,
+    OpenCodeBridge,
+    OpenCodeBridgeClient,
+    SseAssembler,
+    is_loopback_url,
+    parse_bridge_config,
+    parse_permission_event,
+)
+
+
+def _permission_event(permission_id="perm-1", session_id="ses-abc", **overrides):
+    props = {
+        "id": permission_id,
+        "type": "bash",
+        "sessionID": session_id,
+        "messageID": "msg-1",
+        "title": "rm -rf build/",
+        "metadata": {"command": ["rm", "-rf", "build/"]},
+        "time": {"created": 1756500000},
+    }
+    props.update(overrides)
+    return {"type": "permission.updated", "properties": props}
+
+
+# ---------------------------------------------------------------------------
+# Config parsing (fail-closed gating)
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeConfig:
+    def test_absent_section_is_disabled(self):
+        config = parse_bridge_config({})
+        assert config.enabled is False
+        assert config.disabled_reason == "not configured"
+
+    def test_explicitly_disabled(self):
+        config = parse_bridge_config({"opencode_bridge": {"enabled": False}})
+        assert config.enabled is False
+        assert config.disabled_reason == "disabled"
+
+    def test_empty_allowlist_disables(self):
+        config = parse_bridge_config({
+            "opencode_bridge": {
+                "enabled": True,
+                "channel_id": "123",
+                "allowed_user_ids": [],
+            }
+        })
+        assert config.enabled is False
+        assert config.disabled_reason == "allowed_user_ids is empty"
+
+    def test_non_loopback_base_url_disables(self):
+        config = parse_bridge_config({
+            "opencode_bridge": {
+                "enabled": True,
+                "base_url": "http://example.com:4096",
+                "channel_id": "123",
+                "allowed_user_ids": ["42"],
+            }
+        })
+        assert config.enabled is False
+        assert "loopback" in config.disabled_reason
+
+    def test_missing_channel_disables(self):
+        config = parse_bridge_config({
+            "opencode_bridge": {"enabled": True, "allowed_user_ids": ["42"]}
+        })
+        assert config.enabled is False
+        assert config.disabled_reason == "channel_id is missing"
+
+    def test_valid_config_enabled(self):
+        config = parse_bridge_config({
+            "opencode_bridge": {
+                "enabled": True,
+                "channel_id": "123",
+                "allowed_user_ids": ["42", "43"],
+                "timeout_seconds": 120,
+            }
+        })
+        assert config.enabled is True
+        assert config.base_url == "http://127.0.0.1:4096"
+        assert set(config.allowed_user_ids) == {"42", "43"}
+        assert config.timeout_seconds == 120
+
+    def test_string_allowlist_is_split(self):
+        config = parse_bridge_config({
+            "opencode_bridge": {
+                "enabled": True,
+                "channel_id": "123",
+                "allowed_user_ids": "42, 43",
+            }
+        })
+        assert config.enabled is True
+        assert set(config.allowed_user_ids) == {"42", "43"}
+
+    def test_timeout_is_clamped(self):
+        base = {"enabled": True, "channel_id": "123", "allowed_user_ids": ["42"]}
+        assert parse_bridge_config({
+            "opencode_bridge": {**base, "timeout_seconds": 1}
+        }).timeout_seconds == 30
+        assert parse_bridge_config({
+            "opencode_bridge": {**base, "timeout_seconds": 99999}
+        }).timeout_seconds == 900
+        assert parse_bridge_config({
+            "opencode_bridge": {**base, "timeout_seconds": "garbage"}
+        }).timeout_seconds == 300
+
+    def test_non_dict_section_is_disabled(self):
+        assert parse_bridge_config({"opencode_bridge": "yes"}).enabled is False
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("http://127.0.0.1:4096", True),
+        ("http://localhost:4096", True),
+        ("http://[::1]:4096", True),
+        ("http://example.com", False),
+        ("http://0.0.0.0:4096", False),
+        ("not a url", False),
+        ("", False),
+    ],
+)
+def test_is_loopback_url(url, expected):
+    assert is_loopback_url(url) is expected
+
+
+# ---------------------------------------------------------------------------
+# Event parsing
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionEventParsing:
+    def test_valid_event_parses(self):
+        request = parse_permission_event(_permission_event())
+        assert request is not None
+        assert request.permission_id == "perm-1"
+        assert request.session_id == "ses-abc"
+        assert request.kind == "bash"
+        assert request.title == "rm -rf build/"
+        assert request.metadata == {"command": ["rm", "-rf", "build/"]}
+        assert request.short_session_id == "ses-abc"[:12]
+
+    def test_non_permission_event_dropped(self):
+        assert parse_permission_event({"type": "session.idle"}) is None
+
+    def test_missing_properties_dropped(self):
+        assert parse_permission_event({"type": "permission.updated"}) is None
+
+    def test_non_dict_payload_dropped(self):
+        assert parse_permission_event("permission.updated") is None
+        assert parse_permission_event(None) is None
+
+    @pytest.mark.parametrize("props", [
+        {"sessionID": "s", "title": "t"},           # no id
+        {"id": "p", "title": "t"},                  # no sessionID
+        {"id": 42, "sessionID": "s"},               # non-string id
+        {"id": "p", "sessionID": 42},               # non-string sessionID
+    ])
+    def test_malformed_properties_dropped(self, props):
+        payload = {"type": "permission.updated", "properties": props}
+        assert parse_permission_event(payload) is None
+
+    def test_pattern_list_is_joined(self):
+        request = parse_permission_event(
+            _permission_event(pattern=["src/*.env", ".env*"])
+        )
+        assert request is not None
+        assert request.pattern == "src/*.env, .env*"
+
+    def test_non_dict_metadata_becomes_empty(self):
+        request = parse_permission_event(_permission_event(metadata="oops"))
+        assert request is not None
+        assert request.metadata == {}
+
+
+class TestSseAssembler:
+    def test_complete_event_yields_payload(self):
+        assembler = SseAssembler()
+        assert assembler.feed("data: " + json.dumps(_permission_event())) is None
+        payload = assembler.feed("")
+        assert payload is not None
+        assert payload["type"] == "permission.updated"
+
+    def test_multi_line_data_is_joined(self):
+        assembler = SseAssembler()
+        raw = json.dumps(_permission_event())
+        # Split at a top-level token boundary: SSE joins data lines with
+        # "\n", which is only valid JSON whitespace between tokens.
+        split_at = raw.index(", ") + 1
+        assembler.feed(f"data: {raw[:split_at]}")
+        assembler.feed(f"data: {raw[split_at:]}")
+        payload = assembler.feed("")
+        assert payload == _permission_event()
+
+    def test_non_json_block_returns_none(self):
+        assembler = SseAssembler()
+        assembler.feed("data: [DONE]")
+        assert assembler.feed("") is None
+
+    def test_comment_and_event_lines_are_ignored(self):
+        assembler = SseAssembler()
+        assembler.feed(": keepalive")
+        assembler.feed("event: permission.updated")
+        assert assembler.feed("") is None
+
+    def test_two_events_in_sequence(self):
+        assembler = SseAssembler()
+        first = assembler.feed("")  # empty start is harmless
+        assert first is None
+        assembler.feed("data: " + json.dumps(_permission_event(permission_id="p1")))
+        assembler.feed("")
+        assembler.feed("data: " + json.dumps(_permission_event(permission_id="p2")))
+        second = assembler.feed("")
+        assert second["properties"]["id"] == "p2"
+
+
+# ---------------------------------------------------------------------------
+# Pending registry (dedup, first-wins, parallel independence)
+# ---------------------------------------------------------------------------
+
+
+class TestBridgePendingRegistry:
+    def test_register_and_resolve(self):
+        registry = BridgePendingRegistry()
+        assert registry.register("p1") is True
+        assert registry.is_pending("p1") is True
+        assert registry.resolve("p1", "once") is True
+        assert registry.is_pending("p1") is False
+
+    def test_duplicate_register_dropped(self):
+        registry = BridgePendingRegistry()
+        assert registry.register("p1") is True
+        assert registry.register("p1") is False
+
+    def test_first_resolution_wins(self):
+        registry = BridgePendingRegistry()
+        registry.register("p1")
+        assert registry.resolve("p1", "once") is True
+        assert registry.resolve("p1", "reject") is False
+
+    def test_resolved_requests_are_memoized(self):
+        registry = BridgePendingRegistry()
+        registry.register("p1")
+        registry.resolve("p1", "once")
+        # Redelivery after SSE reconnect must not re-arm a prompt.
+        assert registry.register("p1") is False
+
+    def test_parallel_requests_are_independent(self):
+        registry = BridgePendingRegistry()
+        assert registry.register("p1") is True
+        assert registry.register("p2") is True
+        assert registry.resolve("p1", "reject") is True
+        assert registry.is_pending("p2") is True
+        assert registry.resolve("p2", "once") is True
+
+    def test_capacity_limit_drops_new_requests(self):
+        registry = BridgePendingRegistry(max_concurrent=2)
+        assert registry.register("p1") is True
+        assert registry.register("p2") is True
+        assert registry.register("p3") is False
+        registry.resolve("p1", "once")
+        assert registry.register("p3") is True
+
+
+# ---------------------------------------------------------------------------
+# Reply client (official API contract)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeBridgeClient:
+    def _client(self, handler):
+        return OpenCodeBridgeClient(
+            "http://127.0.0.1:4096", transport=httpx.MockTransport(handler)
+        )
+
+    @pytest.mark.asyncio
+    async def test_reply_once_posts_official_body(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["path"] = request.url.path
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json=True)
+
+        client = self._client(handler)
+        delivered, status = await client.reply("ses-1", "perm-1", "once")
+        await client.aclose()
+        assert delivered is True
+        assert status == 200
+        assert seen["path"] == "/session/ses-1/permissions/perm-1"
+        assert seen["body"] == {"response": "once"}
+
+    @pytest.mark.asyncio
+    async def test_reply_reject_posts_reject(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json=True)
+
+        client = self._client(handler)
+        delivered, _ = await client.reply("ses-1", "perm-1", "reject")
+        await client.aclose()
+        assert delivered is True
+        assert seen["body"] == {"response": "reject"}
+
+    @pytest.mark.asyncio
+    async def test_404_means_resolved_elsewhere(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"error": "not found"})
+
+        client = self._client(handler)
+        delivered, status = await client.reply("ses-1", "perm-1", "once")
+        await client.aclose()
+        assert delivered is False
+        assert status == 404
+
+    def test_non_loopback_base_url_refused(self):
+        with pytest.raises(ValueError):
+            OpenCodeBridgeClient("http://example.com:4096")
+
+
+# ---------------------------------------------------------------------------
+# Discord prompt flow (views run against real discord.py UI plumbing)
+# ---------------------------------------------------------------------------
+
+
+class FakeMessage:
+    def __init__(self, embeds=None):
+        self.embeds = embeds or []
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+        if "embed" in kwargs:
+            self.embeds = [kwargs["embed"]]
+
+
+class FakeChannel:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return FakeMessage(embeds=[kwargs["embed"]] if kwargs.get("embed") else [])
+
+
+class FakeDiscordClient:
+    def __init__(self, channel):
+        self._channel = channel
+
+    def get_channel(self, channel_id):
+        return self._channel
+
+    async def fetch_channel(self, channel_id):
+        return self._channel
+
+
+class FakeAdapter:
+    def __init__(self, channel):
+        self._client = FakeDiscordClient(channel)
+
+
+class StubBridgeClient:
+    """Replaces OpenCodeBridgeClient in orchestrator tests."""
+
+    def __init__(self, delivered=True, status=200):
+        self.calls = []
+        self._result = (delivered, status)
+
+    async def reply(self, session_id, permission_id, response):
+        self.calls.append((session_id, permission_id, response))
+        return self._result
+
+    async def aclose(self):
+        pass
+
+
+def _bridge_config(**overrides):
+    config = parse_bridge_config({
+        "opencode_bridge": {
+            "enabled": True,
+            "channel_id": "123",
+            "allowed_user_ids": ["111"],
+            "timeout_seconds": 30,
+            **overrides,
+        }
+    })
+    assert config.enabled
+    return config
+
+
+def _make_bridge(**stub_kwargs):
+    channel = FakeChannel()
+    stub = StubBridgeClient(**stub_kwargs)
+    bridge = OpenCodeBridge(FakeAdapter(channel), _bridge_config(), client=stub)
+    return bridge, channel, stub
+
+
+class FakeResponse:
+    def __init__(self):
+        self.calls = []
+
+    async def send_message(self, content=None, **kwargs):
+        self.calls.append(("send", content))
+
+    async def edit_message(self, **kwargs):
+        self.calls.append(("edit", kwargs))
+
+
+def _interaction(uid, message=None):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=uid),
+        response=FakeResponse(),
+        message=message or FakeMessage(),
+    )
+
+
+async def _drain():
+    await asyncio.sleep(0)
+
+
+class TestDiscordPromptFlow:
+    @pytest.mark.asyncio
+    async def test_accept_sends_once_reply_and_disables_buttons(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        assert len(channel.sent) == 1
+        view = channel.sent[0]["view"]
+        content = channel.sent[0]["content"]
+        assert "Accept" in content and "Reject" in content
+
+        interaction = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        assert stub.calls == [(request.session_id, request.permission_id, "once")]
+        assert all(child.disabled for child in view.children)
+        edit = interaction.response.calls[0]
+        assert edit[0] == "edit"
+
+    @pytest.mark.asyncio
+    async def test_reject_sends_reject_reply(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        interaction = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().reject(view, interaction, None)
+        await _drain()
+
+        assert stub.calls == [(request.session_id, request.permission_id, "reject")]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_cannot_answer(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        interaction = _interaction("999", message=FakeMessage())
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        assert stub.calls == []
+        assert len(interaction.response.calls) == 1
+        assert interaction.response.calls[0][0] == "send"
+        assert interaction.response.calls[0][1]  # ephemeral notice text
+        assert not any(child.disabled for child in view.children)
+
+    @pytest.mark.asyncio
+    async def test_double_click_answers_exactly_once(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        embeds = [channel.sent[0]["embed"]]
+        first = _interaction("111", message=FakeMessage(embeds=embeds))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, first, None)
+        second = _interaction("111", message=FakeMessage(embeds=embeds))
+        await _get_view_class().accept(view, second, None)
+        await _drain()
+
+        assert len(stub.calls) == 1
+        assert len(second.response.calls) == 1
+        assert second.response.calls[0][0] == "send"  # already-resolved notice
+
+    @pytest.mark.asyncio
+    async def test_timeout_resolves_reject_fail_closed(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        await view.on_timeout()
+        await _drain()
+
+        assert stub.calls == [(request.session_id, request.permission_id, "reject")]
+        assert all(child.disabled for child in view.children)
+
+    @pytest.mark.asyncio
+    async def test_click_after_timeout_does_not_double_reply(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        await view.on_timeout()
+        interaction = _interaction("111", message=FakeMessage())
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        assert len(stub.calls) == 1
+        assert stub.calls[0][2] == "reject"
+
+    @pytest.mark.asyncio
+    async def test_parallel_requests_resolve_independently(self):
+        bridge, channel, stub = _make_bridge()
+        request_a = parse_permission_event(_permission_event(permission_id="p-a"))
+        request_b = parse_permission_event(_permission_event(permission_id="p-b"))
+        await bridge._post_prompt(request_a)
+        await bridge._post_prompt(request_b)
+        await _drain()
+
+        assert len(channel.sent) == 2
+        view_a, view_b = channel.sent[0]["view"], channel.sent[1]["view"]
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        interaction_a = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        await _get_view_class().accept(view_a, interaction_a, None)
+        interaction_b = _interaction("111", message=FakeMessage(embeds=[channel.sent[1]["embed"]]))
+        await _get_view_class().reject(view_b, interaction_b, None)
+        await _drain()
+
+        assert stub.calls == [
+            (request_a.session_id, "p-a", "once"),
+            (request_b.session_id, "p-b", "reject"),
+        ]
+        assert all(child.disabled for child in view_a.children)
+        assert all(child.disabled for child in view_b.children)
+
+    @pytest.mark.asyncio
+    async def test_resolved_elsewhere_is_annotated(self):
+        bridge, channel, stub = _make_bridge(delivered=False, status=404)
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await _drain()
+
+        view = channel.sent[0]["view"]
+        interaction = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        assert stub.calls == [(request.session_id, request.permission_id, "once")]
+        edit_kwargs = interaction.response.calls[0][1]
+        assert "another OpenCode client" in edit_kwargs["embed"].footer.text
+
+    @pytest.mark.asyncio
+    async def test_redelivered_event_posts_only_one_prompt(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_permission_event())
+        await bridge._post_prompt(request)
+        await bridge._post_prompt(parse_permission_event(_permission_event()))
+        await _drain()
+
+        assert len(channel.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_prompt_content_is_self_contained(self):
+        bridge, channel, stub = _make_bridge()
+        await bridge._post_prompt(parse_permission_event(_permission_event()))
+        await _drain()
+
+        sent = channel.sent[0]
+        # The command must be visible in plain content, not only in the
+        # embed (some Discord clients hide embeds), matching the
+        # exec-approval prompt contract.
+        assert "rm -rf build/" in sent["content"]
+        assert sent["view"] is not None

--- a/tests/plugins/platforms/test_discord_opencode_bridge.py
+++ b/tests/plugins/platforms/test_discord_opencode_bridge.py
@@ -349,8 +349,9 @@ class TestOpenCodeBridgeClient:
 
 
 class FakeMessage:
-    def __init__(self, embeds=None):
+    def __init__(self, embeds=None, content=""):
         self.embeds = embeds or []
+        self.content = content
         self.edits = []
 
     async def edit(self, **kwargs):
@@ -365,7 +366,7 @@ class FakeChannel:
 
     async def send(self, **kwargs):
         self.sent.append(kwargs)
-        return FakeMessage(embeds=[kwargs["embed"]] if kwargs.get("embed") else [])
+        return FakeMessage(embeds=[kwargs["embed"]] if kwargs.get("embed") else [], content=kwargs.get("content", ""))
 
 
 class FakeDiscordClient:
@@ -431,6 +432,9 @@ class FakeResponse:
 
     async def edit_message(self, **kwargs):
         self.calls.append(("edit", kwargs))
+
+    async def send_modal(self, modal):
+        self.calls.append(("modal", modal))
 
 
 def _interaction(uid, message=None):
@@ -997,3 +1001,230 @@ class TestGuardPromptFlow:
         config = _bridge_config(guard_dir=str(tmp_path), guard_enabled=False)
         bridge = OpenCodeBridge(FakeAdapter(channel), config, client=StubBridgeClient())
         assert bridge.spool is None
+
+
+# ---------------------------------------------------------------------------
+# Mentions, permission requests from Claude Code, question requests
+# ---------------------------------------------------------------------------
+
+from plugins.platforms.discord.opencode_bridge import _get_question_classes  # noqa: E402
+
+
+def _fresh(**overrides):
+    now = time.time()
+    return _guard_payload(expires_at=now + 300, created_at=now, **overrides)
+
+
+def _question_payload(**overrides):
+    payload = _fresh(
+        id="frage000-0001",
+        agent="claude-code",
+        kind="question",
+        questions=[
+            {
+                "question": "Welche Farbe?",
+                "header": "Farbe",
+                "options": [
+                    {"label": "Rot", "description": "warm"},
+                    {"label": "Blau", "description": "kalt"},
+                ],
+                "multiSelect": False,
+            },
+            {
+                "question": "Welche Kapitel?",
+                "header": "Kapitel",
+                "options": [{"label": "1"}, {"label": "2"}, {"label": "3"}],
+                "multiSelect": True,
+            },
+        ],
+    )
+    for key in ("command", "path", "access"):
+        payload.pop(key, None)
+    payload.update(overrides)
+    return payload
+
+
+class TestMentionsAndToolPermissions:
+    @pytest.mark.asyncio
+    async def test_guard_prompt_mentions_allowlisted_user(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _fresh())
+        await bridge.poll_guard_spool_once()
+        sent = channel.sent[0]
+        assert sent["content"].startswith("<@111>")
+        assert sent["allowed_mentions"] is not None
+
+    def test_permission_request_with_tool_and_details(self):
+        request = parse_guard_request(
+            _fresh(agent="claude-code", tool="Edit", details="{\"file_path\": \"x\"}", path="-", access="schreiben"),
+            now=time.time(),
+        )
+        assert request is not None
+        assert request.tool == "Edit"
+        assert request.details.startswith("{")
+        assert request.is_question is False
+
+    @pytest.mark.asyncio
+    async def test_tool_permission_prompt_shows_tool_and_hides_dash_path(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _fresh(agent="claude-code", tool="WebFetch", details="https://example.org", path="-", access="netz", command="WebFetch https://example.org"))
+        await bridge.poll_guard_spool_once()
+        content = channel.sent[0]["content"]
+        assert "Claude Code bittet um Erlaubnis: WebFetch" in content
+        assert "https://example.org" in content
+        assert "**Pfad:**" not in content
+        assert "netz" in content
+
+    def test_unknown_access_kind_still_refused(self):
+        assert parse_guard_request(_fresh(access="egal"), now=time.time()) is None
+
+
+class TestQuestionParsing:
+    def test_valid_question_request(self):
+        request = parse_guard_request(_question_payload(), now=time.time())
+        assert request is not None
+        assert request.is_question is True
+        assert len(request.questions) == 2
+        assert request.questions[0]["options"][1]["label"] == "Blau"
+        assert request.questions[1]["multiSelect"] is True
+        assert request.command == "Welche Farbe?; Welche Kapitel?"
+
+    @pytest.mark.parametrize("questions", [
+        [],
+        "nope",
+        [{"question": "", "options": [{"label": "a"}]}],
+        [{"question": "q", "options": []}],
+        [{"question": "q", "options": [{"label": ""}]}],
+        [{"question": "q", "options": [{"label": "a"}, {"label": "a"}]}],
+        [{"question": "q", "options": [{"label": "a"}]}] * 5,
+        [{"question": "q", "options": [{"label": str(i)} for i in range(9)]}],
+        [{"question": "q", "options": [{"label": "a"}]}, {"question": "q", "options": [{"label": "b"}]}],
+    ])
+    def test_unclear_questions_refused(self, questions):
+        assert parse_guard_request(_question_payload(questions=questions), now=time.time()) is None
+
+    def test_unknown_kind_refused(self):
+        assert parse_guard_request(_fresh(kind="wunsch"), now=time.time()) is None
+
+
+def _click(view, label):
+    for child in view.children:
+        if getattr(child, "label", None) == label:
+            return child.callback
+    raise AssertionError(f"no button {label!r} in {[c.label for c in view.children]}")
+
+
+class TestQuestionFlow:
+    @pytest.mark.asyncio
+    async def test_questions_become_one_message_each(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload())
+        posted = await bridge.poll_guard_spool_once()
+        assert posted == 1
+        assert len(channel.sent) == 2
+        first, second = channel.sent
+        assert first["content"].startswith("<@111>")
+        assert "Welche Farbe?" in first["content"] and "**Rot** — warm" in first["content"]
+        assert [c.label for c in first["view"].children] == ["Rot", "Blau", "Andere Antwort…"]
+        assert [c.label for c in second["view"].children] == ["1", "2", "3", "Andere Antwort…", "Fertig"]
+        # a second poll must not repost
+        await bridge.poll_guard_spool_once()
+        assert len(channel.sent) == 2
+
+    @pytest.mark.asyncio
+    async def test_answers_are_written_once_all_questions_answered(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload())
+        await bridge.poll_guard_spool_once()
+        v1, v2 = channel.sent[0]["view"], channel.sent[1]["view"]
+
+        i1 = _interaction("111", message=FakeMessage(content="f1"))
+        await _click(v1, "Blau")(i1)
+        assert _read_decision(bridge, "frage000-0001") is None
+        assert all(c.disabled for c in v1.children)
+        assert "Antwort gespeichert" in i1.response.calls[0][1]["content"]
+
+        i2 = _interaction("111", message=FakeMessage(content="f2"))
+        await _click(v2, "1")(i2)
+        await _click(v2, "3")(_interaction("111", message=FakeMessage(content="f2")))
+        assert _read_decision(bridge, "frage000-0001") is None
+        i3 = _interaction("111", message=FakeMessage(content="f2"))
+        await _click(v2, "Fertig")(i3)
+        decision = _read_decision(bridge, "frage000-0001")
+        assert decision["decision"] == "answer"
+        assert decision["answers"] == {"Welche Farbe?": "Blau", "Welche Kapitel?": ["1", "3"]}
+        assert stub.calls == []
+        assert "Antwort übermittelt" in i3.response.calls[0][1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_multiselect_toggle_and_empty_done(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload())
+        await bridge.poll_guard_spool_once()
+        v2 = channel.sent[1]["view"]
+        await _click(v2, "2")(_interaction("111", message=FakeMessage()))
+        await _click(v2, "2")(_interaction("111", message=FakeMessage()))  # abwählen
+        i = _interaction("111", message=FakeMessage())
+        await _click(v2, "Fertig")(i)
+        assert i.response.calls[0][0] == "send"  # Hinweis: erst auswählen
+        assert not v2._done
+
+    @pytest.mark.asyncio
+    async def test_free_text_via_modal(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload(questions=[{
+            "question": "Wie heißt die Datei?", "options": [{"label": "a.typ"}], "multiSelect": False,
+        }]))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        i = _interaction("111", message=FakeMessage())
+        await _click(view, "Andere Antwort…")(i)
+        assert i.response.calls[0][0] == "modal"
+        modal = i.response.calls[0][1]
+        modal.text._value = "  b.typ  "
+        i2 = _interaction("111", message=FakeMessage(content="frage"))
+        await modal.on_submit(i2)
+        assert _read_decision(bridge, "frage000-0001")["answers"] == {"Wie heißt die Datei?": "b.typ"}
+
+    @pytest.mark.asyncio
+    async def test_timeout_of_one_question_rejects_all(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload())
+        await bridge.poll_guard_spool_once()
+        v1, v2 = channel.sent[0]["view"], channel.sent[1]["view"]
+        await _click(v1, "Rot")(_interaction("111", message=FakeMessage()))
+        await v2.on_timeout()
+        decision = _read_decision(bridge, "frage000-0001")
+        assert decision["decision"] == "reject" and decision["source"] == "timeout"
+        assert "answers" not in decision
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_cannot_answer_questions(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload())
+        await bridge.poll_guard_spool_once()
+        v1 = channel.sent[0]["view"]
+        i = _interaction("999", message=FakeMessage())
+        await _click(v1, "Rot")(i)
+        assert i.response.calls[0][0] == "send"
+        assert not v1._done
+        assert _read_decision(bridge, "frage000-0001") is None
+
+    @pytest.mark.asyncio
+    async def test_second_answer_to_same_question_is_ignored(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _question_payload(questions=[{
+            "question": "Nur eine", "options": [{"label": "A"}, {"label": "B"}],
+        }]))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        await _click(view, "A")(_interaction("111", message=FakeMessage()))
+        late = _interaction("111", message=FakeMessage())
+        await _click(view, "B")(late)
+        assert late.response.calls[0][0] == "send"
+        assert _read_decision(bridge, "frage000-0001")["answers"] == {"Nur eine": "A"}
+
+    def test_write_decision_answer_without_answers_becomes_reject(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.write_decision("frage000-0001", "answer", "discord", now=NOW)
+        assert json.loads((spool.decisions_dir / "frage000-0001.json").read_text())["decision"] == "reject"

--- a/tests/plugins/platforms/test_discord_opencode_bridge.py
+++ b/tests/plugins/platforms/test_discord_opencode_bridge.py
@@ -12,6 +12,8 @@ Covers the fail-closed contract end to end without network access:
 
 import asyncio
 import json
+import os
+import time
 from types import SimpleNamespace
 
 import httpx
@@ -387,10 +389,12 @@ class StubBridgeClient:
 
     def __init__(self, delivered=True, status=200):
         self.calls = []
+        self.apis = []
         self._result = (delivered, status)
 
-    async def reply(self, session_id, permission_id, response):
+    async def reply(self, session_id, permission_id, response, api="legacy"):
         self.calls.append((session_id, permission_id, response))
+        self.apis.append(api)
         return self._result
 
     async def aclose(self):
@@ -613,3 +617,383 @@ class TestDiscordPromptFlow:
         # exec-approval prompt contract.
         assert "rm -rf build/" in sent["content"]
         assert sent["view"] is not None
+
+
+# ---------------------------------------------------------------------------
+# OpenCode >= 1.18: permission.asked / v2 reply endpoint
+# ---------------------------------------------------------------------------
+
+
+def _asked_event(permission_id="req-1", session_id="ses-abc", **overrides):
+    props = {
+        "id": permission_id,
+        "sessionID": session_id,
+        "permission": "bash",
+        "patterns": ["cat ~/foo"],
+        "always": ["cat *"],
+        "metadata": {"command": "cat ~/foo"},
+    }
+    props.update(overrides)
+    return {"type": "permission.asked", "properties": props}
+
+
+class TestPermissionAskedEvent:
+    def test_asked_event_parses_as_v2(self):
+        request = parse_permission_event(_asked_event())
+        assert request is not None
+        assert request.reply_api == "v2"
+        assert request.kind == "bash"
+        assert request.title == "cat ~/foo"
+        assert request.pattern == "cat ~/foo"
+        assert request.is_guard is False
+
+    def test_asked_event_without_command_uses_patterns(self):
+        request = parse_permission_event(_asked_event(metadata={}, patterns=["a", "b"]))
+        assert request.title == "a, b"
+
+    @pytest.mark.asyncio
+    async def test_v2_reply_uses_permission_endpoint(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["path"] = request.url.path
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(204)
+
+        client = OpenCodeBridgeClient("http://127.0.0.1:4096", transport=httpx.MockTransport(handler))
+        delivered, status = await client.reply("ses-1", "req-1", "once", "v2")
+        await client.aclose()
+        assert delivered is True
+        assert status == 204
+        assert seen["path"] == "/permission/req-1/reply"
+        assert seen["body"] == {"reply": "once"}
+
+    @pytest.mark.asyncio
+    async def test_bridge_routes_v2_request_to_v2_api(self):
+        bridge, channel, stub = _make_bridge()
+        request = parse_permission_event(_asked_event())
+        await bridge._post_prompt(request)
+        outcome = await bridge.resolve(request, "once", "discord")
+        assert outcome == "delivered"
+        assert stub.apis == ["v2"]
+
+
+# ---------------------------------------------------------------------------
+# Command-guard spool (befehlswaechter.js / Claude Code hook counterpart)
+# ---------------------------------------------------------------------------
+
+from plugins.platforms.discord.opencode_bridge import (  # noqa: E402
+    GUARD_DECISION_TTL_SECONDS,
+    GuardSpool,
+    parse_guard_request,
+)
+
+NOW = 1_800_000_000.0
+
+
+def _guard_payload(**overrides):
+    payload = {
+        "version": 1,
+        "id": "abcdef12-3456",
+        "agent": "opencode",
+        "created_at": NOW,
+        "expires_at": NOW + 300,
+        "session_id": "ses-guard-1",
+        "project": "/Users/me/Projekt",
+        "command": "cat ~/Notizen/todo.md",
+        "path": "/Users/me/Notizen/todo.md",
+        "access": "lesen",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestGuardRequestParsing:
+    def test_valid_request_parses(self):
+        request = parse_guard_request(_guard_payload(), now=NOW)
+        assert request is not None
+        assert request.is_guard is True
+        assert request.permission_id == "abcdef12-3456"
+        assert request.session_id == "ses-guard-1"
+        assert request.command == "cat ~/Notizen/todo.md"
+        assert request.path == "/Users/me/Notizen/todo.md"
+        assert request.project == "/Users/me/Projekt"
+        assert request.access == "lesen"
+        assert request.agent == "opencode"
+        assert request.expires_at == NOW + 300
+
+    def test_missing_session_becomes_dash(self):
+        payload = _guard_payload()
+        del payload["session_id"]
+        assert parse_guard_request(payload, now=NOW).session_id == "-"
+
+    @pytest.mark.parametrize("overrides", [
+        {"version": 2},
+        {"id": "short"},
+        {"id": "has space in it"},
+        {"id": "../../etc/passwd"},
+        {"agent": "unknown-agent"},
+        {"command": ""},
+        {"command": 42},
+        {"path": ""},
+        {"access": "alles"},
+        {"expires_at": NOW - 1},
+        {"expires_at": NOW + 7200},
+        {"expires_at": NOW - 10, "created_at": NOW - 20},
+        {"created_at": True, "expires_at": True},
+        {"created_at": "now"},
+    ])
+    def test_unclear_requests_are_refused(self, overrides):
+        assert parse_guard_request(_guard_payload(**overrides), now=NOW) is None
+
+    def test_non_dict_refused(self):
+        assert parse_guard_request("nope", now=NOW) is None
+        assert parse_guard_request(None, now=NOW) is None
+
+
+def _write_request(spool, payload, name=None):
+    spool.ensure()
+    target = spool.requests_dir / f"{name or payload['id']}.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+class TestGuardSpool:
+    def test_scan_returns_valid_request(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        _write_request(spool, _guard_payload())
+        found = spool.scan(now=NOW)
+        assert [r.permission_id for r in found] == ["abcdef12-3456"]
+
+    def test_scan_ignores_malformed_and_logs_once(self, tmp_path, caplog):
+        spool = GuardSpool(str(tmp_path))
+        _write_request(spool, _guard_payload(access="alles"))
+        with caplog.at_level("WARNING"):
+            assert spool.scan(now=NOW) == []
+            assert spool.scan(now=NOW) == []
+        assert sum("malformed guard request" in r.message for r in caplog.records) == 1
+        # the file stays (the guard removes it after its own timeout)
+        assert (spool.requests_dir / "abcdef12-3456.json").exists()
+
+    def test_scan_ignores_id_mismatch(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        _write_request(spool, _guard_payload(), name="zzzzzzzz-0000")
+        assert spool.scan(now=NOW) == []
+
+    def test_scan_drops_expired_file(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        target = _write_request(spool, _guard_payload(expires_at=NOW - 5, created_at=NOW - 60))
+        assert spool.scan(now=NOW) == []
+        assert not target.exists()
+
+    def test_scan_skips_non_json_and_bad_names(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.ensure()
+        (spool.requests_dir / ".tmp-abcdef12-3456").write_text("{}", encoding="utf-8")
+        (spool.requests_dir / "bad name.json").write_text(json.dumps(_guard_payload()), encoding="utf-8")
+        (spool.requests_dir / "notes.txt").write_text("hi", encoding="utf-8")
+        assert spool.scan(now=NOW) == []
+
+    def test_scan_ignores_symlinked_request(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.ensure()
+        real = tmp_path / "outside.json"
+        real.write_text(json.dumps(_guard_payload()), encoding="utf-8")
+        (spool.requests_dir / "abcdef12-3456.json").symlink_to(real)
+        assert spool.scan(now=NOW) == []
+
+    def test_scan_skips_already_decided(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        _write_request(spool, _guard_payload())
+        spool.write_decision("abcdef12-3456", "once", "discord", now=NOW)
+        assert spool.scan(now=NOW) == []
+
+    def test_write_decision_is_json_with_contract(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.write_decision("abcdef12-3456", "once", "discord", now=NOW)
+        decision = json.loads((spool.decisions_dir / "abcdef12-3456.json").read_text())
+        assert decision == {
+            "version": 1,
+            "id": "abcdef12-3456",
+            "decision": "once",
+            "source": "discord",
+            "decided_at": NOW,
+        }
+        assert not any(n.startswith(".tmp-") for n in os.listdir(spool.decisions_dir))
+
+    def test_write_decision_never_emits_always(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.write_decision("abcdef12-3456", "always", "discord", now=NOW)
+        decision = json.loads((spool.decisions_dir / "abcdef12-3456.json").read_text())
+        assert decision["decision"] == "reject"
+
+    def test_write_decision_refuses_bad_id(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        with pytest.raises(ValueError):
+            spool.write_decision("../escape", "once", "discord")
+
+    def test_sweep_removes_orphaned_decisions(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.write_decision("abcdef12-3456", "reject", "timeout", now=NOW)
+        target = spool.decisions_dir / "abcdef12-3456.json"
+        old = time.time() - GUARD_DECISION_TTL_SECONDS - 10
+        os.utime(target, (old, old))
+        spool.sweep()
+        assert not target.exists()
+
+    def test_sweep_keeps_fresh_decisions(self, tmp_path):
+        spool = GuardSpool(str(tmp_path))
+        spool.write_decision("abcdef12-3456", "reject", "timeout")
+        spool.sweep()
+        assert (spool.decisions_dir / "abcdef12-3456.json").exists()
+
+
+def _make_guard_bridge(tmp_path):
+    channel = FakeChannel()
+    stub = StubBridgeClient()
+    config = _bridge_config(guard_dir=str(tmp_path))
+    assert config.guard_enabled and config.guard_dir == str(tmp_path)
+    bridge = OpenCodeBridge(FakeAdapter(channel), config, client=stub)
+    return bridge, channel, stub
+
+
+def _read_decision(bridge, request_id):
+    path = bridge.spool.decisions_dir / f"{request_id}.json"
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
+
+
+class TestGuardPromptFlow:
+    @pytest.mark.asyncio
+    async def test_request_file_becomes_german_prompt(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        posted = await bridge.poll_guard_spool_once()
+        await _drain()
+
+        assert posted == 1
+        sent = channel.sent[0]
+        content = sent["content"]
+        assert "Befehlswächter" in content
+        assert "cat ~/Notizen/todo.md" in content
+        assert "/Users/me/Notizen/todo.md" in content
+        assert "/Users/me/Projekt" in content
+        assert "lesen" in content
+        assert "OpenCode" in content
+        labels = [child.label for child in sent["view"].children]
+        assert labels == ["Einmal erlauben", "Ablehnen"]
+        assert sent["view"].timeout <= 300
+
+    @pytest.mark.asyncio
+    async def test_second_poll_does_not_repost(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        await bridge.poll_guard_spool_once()
+        assert len(channel.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_accept_writes_once_decision_and_never_calls_api(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        interaction = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        decision = _read_decision(bridge, "abcdef12-3456")
+        assert decision["decision"] == "once"
+        assert decision["source"] == "discord"
+        assert stub.calls == []
+        assert all(child.disabled for child in view.children)
+        assert interaction.response.calls[0][1]["embed"].footer.text == "Einmal erlaubt"
+
+    @pytest.mark.asyncio
+    async def test_reject_writes_reject_decision(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        interaction = _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]]))
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().reject(view, interaction, None)
+        await _drain()
+
+        assert _read_decision(bridge, "abcdef12-3456")["decision"] == "reject"
+        assert interaction.response.calls[0][1]["embed"].footer.text == "Abgelehnt"
+
+    @pytest.mark.asyncio
+    async def test_timeout_writes_reject(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        await view.on_timeout()
+        await _drain()
+
+        decision = _read_decision(bridge, "abcdef12-3456")
+        assert decision["decision"] == "reject"
+        assert decision["source"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_writes_nothing(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        interaction = _interaction("999", message=FakeMessage())
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().accept(view, interaction, None)
+        await _drain()
+
+        assert _read_decision(bridge, "abcdef12-3456") is None
+        assert interaction.response.calls[0][0] == "send"
+
+    @pytest.mark.asyncio
+    async def test_double_click_writes_exactly_one_decision(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(expires_at=time.time() + 300, created_at=time.time()))
+        await bridge.poll_guard_spool_once()
+        view = channel.sent[0]["view"]
+        embeds = [channel.sent[0]["embed"]]
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        await _get_view_class().reject(view, _interaction("111", message=FakeMessage(embeds=embeds)), None)
+        second = _interaction("111", message=FakeMessage(embeds=embeds))
+        await _get_view_class().accept(view, second, None)
+        await _drain()
+
+        assert _read_decision(bridge, "abcdef12-3456")["decision"] == "reject"
+        assert second.response.calls[0][0] == "send"
+
+    @pytest.mark.asyncio
+    async def test_malformed_request_is_never_answered(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        _write_request(bridge.spool, _guard_payload(access="alles", expires_at=time.time() + 300, created_at=time.time()))
+        posted = await bridge.poll_guard_spool_once()
+        assert posted == 0
+        assert channel.sent == []
+        assert _read_decision(bridge, "abcdef12-3456") is None
+
+    @pytest.mark.asyncio
+    async def test_parallel_guard_requests_are_independent(self, tmp_path):
+        bridge, channel, stub = _make_guard_bridge(tmp_path)
+        now = time.time()
+        _write_request(bridge.spool, _guard_payload(id="aaaaaaaa-0001", expires_at=now + 300, created_at=now))
+        _write_request(bridge.spool, _guard_payload(id="bbbbbbbb-0002", expires_at=now + 300, created_at=now, access="schreiben"))
+        await bridge.poll_guard_spool_once()
+        assert len(channel.sent) == 2
+        from plugins.platforms.discord.opencode_bridge import _get_view_class
+        views = {sent["view"]._request.permission_id: sent["view"] for sent in channel.sent}
+        await _get_view_class().accept(views["aaaaaaaa-0001"], _interaction("111", message=FakeMessage(embeds=[channel.sent[0]["embed"]])), None)
+        await _get_view_class().reject(views["bbbbbbbb-0002"], _interaction("111", message=FakeMessage(embeds=[channel.sent[1]["embed"]])), None)
+        await _drain()
+        assert _read_decision(bridge, "aaaaaaaa-0001")["decision"] == "once"
+        assert _read_decision(bridge, "bbbbbbbb-0002")["decision"] == "reject"
+
+    @pytest.mark.asyncio
+    async def test_guard_disabled_config_has_no_spool(self, tmp_path):
+        channel = FakeChannel()
+        config = _bridge_config(guard_dir=str(tmp_path), guard_enabled=False)
+        bridge = OpenCodeBridge(FakeAdapter(channel), config, client=StubBridgeClient())
+        assert bridge.spool is None

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -3,7 +3,7 @@
 import json
 import urllib.error
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -283,15 +283,20 @@ class TestCreateThread:
     @patch("tools.discord_tool._discord_request")
     def test_create_standalone_thread(self, mock_req, monkeypatch):
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
-        mock_req.return_value = {"id": "800", "name": "New Thread"}
+        mock_req.side_effect = [
+            {"id": "11", "type": 0},               # GET /channels/11 → text
+            {"id": "800", "name": "New Thread"},   # POST /channels/11/threads
+        ]
         result = json.loads(discord_core(action="create_thread", channel_id="11", name="New Thread"))
         assert result["success"] is True
         assert result["thread_id"] == "800"
-        # Verify the API call
-        mock_req.assert_called_once_with(
-            "POST", "/channels/11/threads", "test-token",
-            body={"name": "New Thread", "auto_archive_duration": 1440, "type": 11},
-        )
+        # Two API calls: channel-type lookup, then thread creation.
+        # Text channels keep the legacy payload — no starter message field.
+        assert mock_req.call_args_list == [
+            call("GET", "/channels/11", "test-token"),
+            call("POST", "/channels/11/threads", "test-token",
+                 body={"name": "New Thread", "auto_archive_duration": 1440, "type": 11}),
+        ]
 
     @patch("tools.discord_tool._discord_request")
     def test_create_thread_from_message(self, mock_req, monkeypatch):
@@ -301,10 +306,142 @@ class TestCreateThread:
             action="create_thread", channel_id="11", name="Discussion", message_id="1001",
         ))
         assert result["success"] is True
+        # Anchored path needs no channel-type lookup.
         mock_req.assert_called_once_with(
             "POST", "/channels/11/messages/1001/threads", "test-token",
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_forum_post_with_content(self, mock_req, monkeypatch):
+        """Forum channel (type 15): name + content become a forum post via
+        the Start-Thread-in-Forum payload."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "15", "type": 15},               # GET /channels/15 → forum
+            {"id": "900", "name": "Build Status"},  # POST /channels/15/threads
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="15", name="Build Status",
+            content="All checks passed.",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "900"
+        assert result["forum_post"] is True
+        assert result["starter_content"] == "All checks passed."
+        assert mock_req.call_args_list == [
+            call("GET", "/channels/15", "test-token"),
+            call("POST", "/channels/15/threads", "test-token",
+                 body={
+                     "name": "Build Status",
+                     "auto_archive_duration": 1440,
+                     "type": 11,
+                     "message": {"content": "All checks passed."},
+                 }),
+        ]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_forum_post_without_content_falls_back_to_name(self, mock_req, monkeypatch):
+        """Discord requires a message object for forum posts; without
+        content the thread name doubles as the starter content."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "15", "type": 15},
+            {"id": "901", "name": "Weekly Digest"},
+        ]
+        result = json.loads(discord_core(action="create_thread", channel_id="15", name="Weekly Digest"))
+        assert result["success"] is True
+        assert result["forum_post"] is True
+        assert result["starter_content"] == "Weekly Digest"
+        assert mock_req.call_args_list[1] == call(
+            "POST", "/channels/15/threads", "test-token",
+            body={
+                "name": "Weekly Digest",
+                "auto_archive_duration": 1440,
+                "type": 11,
+                "message": {"content": "Weekly Digest"},
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_media_channel_post_treated_like_forum(self, mock_req, monkeypatch):
+        """Media channels (type 16) share the forum creation payload."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "16", "type": 16},
+            {"id": "902", "name": "Screenshots"},
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="16", name="Screenshots",
+            content="See attached.",
+        ))
+        assert result["success"] is True
+        assert result["forum_post"] is True
+        assert mock_req.call_args_list[1] == call(
+            "POST", "/channels/16/threads", "test-token",
+            body={
+                "name": "Screenshots",
+                "auto_archive_duration": 1440,
+                "type": 11,
+                "message": {"content": "See attached."},
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_thread_with_content_sends_starter_message(self, mock_req, monkeypatch):
+        """Normal threads have no starter-message field — optional content
+        is delivered as the thread's first message after creation."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "11", "type": 0},
+            {"id": "800", "name": "New Thread"},
+            {"id": "5000", "content": "first message"},
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="New Thread",
+            content="first message",
+        ))
+        assert result["success"] is True
+        assert result["starter_message_id"] == "5000"
+        assert mock_req.call_args_list == [
+            call("GET", "/channels/11", "test-token"),
+            call("POST", "/channels/11/threads", "test-token",
+                 body={"name": "New Thread", "auto_archive_duration": 1440, "type": 11}),
+            call("POST", "/channels/800/messages", "test-token",
+                 body={"content": "first message"}),
+        ]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_from_message_with_content(self, mock_req, monkeypatch):
+        """Anchored creation ignores no channel lookup; content still lands
+        in the new thread afterwards."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "801", "name": "Discussion"},
+            {"id": "5001"},
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Discussion",
+            message_id="1001", content="kickoff note",
+        ))
+        assert result["success"] is True
+        assert result["starter_message_id"] == "5001"
+        assert mock_req.call_args_list == [
+            call("POST", "/channels/11/messages/1001/threads", "test-token",
+                 body={"name": "Discussion", "auto_archive_duration": 1440}),
+            call("POST", "/channels/801/messages", "test-token",
+                 body={"content": "kickoff note"}),
+        ]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_channel_lookup_failure_returns_error_without_creation(self, mock_req, monkeypatch):
+        """If the channel-type lookup fails, no thread creation is attempted."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = DiscordAPIError(404, '{"message": "Unknown Channel"}')
+        result = json.loads(discord_core(action="create_thread", channel_id="99", name="X"))
+        assert "error" in result
+        assert "404" in result["error"]
+        assert mock_req.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +484,16 @@ class TestRegistration:
         """Core + admin actions should cover all known actions."""
         assert set(_CORE_ACTIONS.keys()) | set(_ADMIN_ACTIONS.keys()) == set(_ACTIONS.keys())
         assert set(_CORE_ACTIONS.keys()) & set(_ADMIN_ACTIONS.keys()) == set()
+
+    def test_create_thread_schema_exposes_content_param(self):
+        """The discord tool schema must document the optional content param
+        (starter message / forum post body) so the model can use it."""
+        from tools.discord_tool import _STATIC_CORE_SCHEMA
+        assert _STATIC_CORE_SCHEMA is not None
+        props = _STATIC_CORE_SCHEMA["parameters"]["properties"]
+        assert "content" in props
+        assert props["content"]["type"] == "string"
+        assert "forum" in props["content"]["description"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -10,6 +10,7 @@ import pytest
 from tools.discord_tool import (
     DiscordAPIError,
     _ACTIONS,
+    _ACTION_MANIFEST,
     _ADMIN_ACTIONS,
     _CORE_ACTIONS,
     _available_actions,
@@ -442,6 +443,210 @@ class TestCreateThread:
         assert "error" in result
         assert "404" in result["error"]
         assert mock_req.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Action: send_message
+# ---------------------------------------------------------------------------
+
+class TestSendMessage:
+    @patch("tools.discord_tool._discord_request")
+    def test_send_to_text_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "5000", "channel_id": "11", "content": "hello"}
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="hello"))
+        assert result["success"] is True
+        assert result["message_id"] == "5000"
+        assert result["channel_id"] == "11"
+        # Single call — no channel-type lookup needed for text channels.
+        mock_req.assert_called_once_with(
+            "POST", "/channels/11/messages", "test-token",
+            body={"content": "hello"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_send_to_existing_thread(self, mock_req, monkeypatch):
+        """Threads ARE channels in Discord's API — the same endpoint works,
+        with no channel-type lookup round trip."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "6000"}
+        result = json.loads(discord_core(
+            action="send_message", channel_id="800", content="thread reply",
+        ))
+        assert result["success"] is True
+        assert result["message_id"] == "6000"
+        mock_req.assert_called_once_with(
+            "POST", "/channels/800/messages", "test-token",
+            body={"content": "thread reply"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_send_to_existing_forum_post(self, mock_req, monkeypatch):
+        """A forum post is a thread — addressed by its own channel ID."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "7000"}
+        result = json.loads(discord_core(
+            action="send_message", channel_id="900", content="follow-up on the post",
+        ))
+        assert result["success"] is True
+        assert result["message_id"] == "7000"
+        mock_req.assert_called_once_with(
+            "POST", "/channels/900/messages", "test-token",
+            body={"content": "follow-up on the post"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_missing_content_rejected(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", channel_id="11"))
+        assert "error" in result
+        assert "content" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_whitespace_only_content_rejected(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="   "))
+        assert "error" in result
+        assert "non-empty" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_missing_channel_id_rejected(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", content="hi"))
+        assert "error" in result
+        assert "channel_id" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_api_error_handled(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = DiscordAPIError(400, '{"message": "Cannot send to a forum channel"}')
+        result = json.loads(discord_core(action="send_message", channel_id="15", content="hi"))
+        assert "error" in result
+        assert "400" in result["error"]
+        assert "forum channel" in result["error"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_403_is_enriched(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = DiscordAPIError(403, '{"message": "Missing Access"}')
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="hi"))
+        assert "error" in result
+        assert "SEND_MESSAGES" in result["error"]
+        assert "Missing Access" in result["error"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_unexpected_error_handled(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = RuntimeError("boom")
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="hi"))
+        assert "error" in result
+        assert "boom" in result["error"]
+
+    def test_send_message_in_core_schema_only(self):
+        """send_message is a participation action — core tool, not admin."""
+        from tools.discord_tool import _STATIC_ADMIN_SCHEMA, _STATIC_CORE_SCHEMA
+        core_actions = _STATIC_CORE_SCHEMA["parameters"]["properties"]["action"]["enum"]
+        admin_actions = _STATIC_ADMIN_SCHEMA["parameters"]["properties"]["action"]["enum"]
+        assert "send_message" in core_actions
+        assert "send_message" not in admin_actions
+        # Manifest line describes all three target kinds.
+        manifest = {m[0]: m for m in _ACTION_MANIFEST}
+        assert "thread" in manifest["send_message"][2]
+        assert "forum" in manifest["send_message"][2]
+
+
+# ---------------------------------------------------------------------------
+# Fake-Discord E2E: real HTTP transport against a localhost REST stub
+# ---------------------------------------------------------------------------
+
+class TestFakeDiscordE2E:
+    """Exercise the tool's REAL urllib request path against a local HTTP
+    server that stubs the Discord REST API — no mocks between handler and
+    transport, no live network (localhost only)."""
+
+    @pytest.fixture
+    def fake_discord(self, monkeypatch):
+        import threading
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        received = []
+
+        class _Handler(BaseHTTPRequestHandler):
+            def _reply(self, status, payload):
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                payload = json.loads(self.rfile.read(length) or b"{}")
+                received.append({"method": "POST", "path": self.path,
+                                 "body": payload,
+                                 "auth": self.headers.get("Authorization")})
+                if "/messages" in self.path:
+                    channel_id = self.path.split("/")[2]
+                    if channel_id == "missing-channel":
+                        self._reply(404, {"message": "Unknown Channel", "code": 10003})
+                    else:
+                        self._reply(200, {"id": f"msg-{channel_id}",
+                                          "channel_id": channel_id,
+                                          "content": payload.get("content", "")})
+                else:
+                    self._reply(404, {"message": "Unknown endpoint", "code": 0})
+
+            def log_message(self, *args):  # silence request logging
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        monkeypatch.setattr(
+            "tools.discord_tool.DISCORD_API_BASE",
+            f"http://127.0.0.1:{server.server_address[1]}",
+        )
+        yield received
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    @pytest.mark.parametrize("channel_id,kind", [
+        ("11", "text-channel"),
+        ("800", "thread"),
+        ("900", "forum-post"),
+    ])
+    def test_send_message_real_transport(self, fake_discord, monkeypatch, channel_id, kind):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(
+            action="send_message", channel_id=channel_id, content=f"hi from {kind}",
+        ))
+        assert result["success"] is True
+        assert result["message_id"] == f"msg-{channel_id}"
+        assert result["channel_id"] == channel_id
+        assert len(fake_discord) == 1
+        req = fake_discord[0]
+        assert req["path"] == f"/channels/{channel_id}/messages"
+        assert req["body"] == {"content": f"hi from {kind}"}
+        assert req["auth"] == "Bot test-token"
+
+    def test_error_response_propagates_through_real_transport(
+        self, fake_discord, monkeypatch,
+    ):
+        """HTTP error responses surface as tool errors end-to-end: the stub
+        404s the designated channel → real urllib HTTPError → tool_error with
+        the real response body preserved."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(
+            action="send_message", channel_id="missing-channel", content="hi",
+        ))
+        assert "error" in result
+        assert "Unknown Channel" in result["error"]
+        assert fake_discord[0]["path"] == "/channels/missing-channel/messages"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -665,6 +665,29 @@ def _create_thread(
     return json.dumps(result)
 
 
+def _send_message(token: str, channel_id: str, content: str, **_kwargs: Any) -> str:
+    """Send a message to a text channel, thread, or forum post.
+
+    Threads and forum posts are channels in Discord's API, so a single
+    ``POST /channels/{id}/messages`` covers all three targets — no
+    channel-type lookup needed.  Forum/media channels themselves (types
+    15/16) reject direct messages; use ``create_thread`` to start a post
+    there.
+    """
+    text = (content or "").strip()
+    if not text:
+        return tool_error("content must be a non-empty string.")
+    msg = _discord_request(
+        "POST", f"/channels/{channel_id}/messages", token,
+        body={"content": text},
+    )
+    return json.dumps({
+        "success": True,
+        "message_id": msg.get("id"),
+        "channel_id": channel_id,
+    })
+
+
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
     """Add a role to a guild member."""
     _discord_request("PUT", f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}", token)
@@ -695,11 +718,12 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "send_message": _send_message,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread", "send_message"})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -722,6 +746,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name, [content])", "create a public thread or forum post (content = starter message); optional message_id anchor"),
+    ("send_message", "(channel_id, content)", "send a message to a text channel, thread, or forum post"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -743,6 +768,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "send_message": ["channel_id", "content"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -907,8 +933,9 @@ def _build_schema(
         "content": {
             "type": "string",
             "description": (
-                "Starter message content (create_thread). Optional for normal "
-                "threads (sent as first thread message); for forum channels it "
+                "Message text (send_message) or starter message content "
+                "(create_thread). Optional for create_thread in normal threads "
+                "(sent as first thread message); for forum channels it "
                 "becomes the post's first message (falls back to the thread "
                 "name when omitted)."
             ),
@@ -993,6 +1020,10 @@ _ACTION_403_HINT = {
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it. "
         "Forum channels additionally need SEND_MESSAGES to create posts."
+    ),
+    "send_message": (
+        "Bot lacks SEND_MESSAGES or VIEW_CHANNEL in this channel, or the "
+        "target forbids posting (archived/locked thread)."
     ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
@@ -1092,6 +1123,7 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "content": content,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -152,6 +152,11 @@ def _channel_type_name(type_id: int) -> str:
     return _CHANNEL_TYPE_NAMES.get(type_id, f"unknown({type_id})")
 
 
+# Channel types whose thread creation requires a starter message object
+# (Discord "Start Thread in Forum" API): forum (15) and media (16).
+_FORUM_CHANNEL_TYPES = frozenset({15, 16})
+
+
 # ---------------------------------------------------------------------------
 # Capability detection (application intents)
 # ---------------------------------------------------------------------------
@@ -587,9 +592,22 @@ def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
     auto_archive_duration: int = 1440,
+    content: str = "",
     **_kwargs: Any,
 ) -> str:
-    """Create a thread in a channel."""
+    """Create a thread in a channel, or a post in a forum channel.
+
+    Forum/media channels (types 15/16) don't accept the plain thread
+    creation payload — they use the "Start Thread in Forum" API, which
+    requires a ``message`` object carrying the post's starter content.
+    The channel type is resolved via ``GET /channels/{id}`` on the
+    standalone path (no anchor message) so forum channels work without
+    the caller having to know the type.  If no ``content`` is given for
+    a forum post, the thread name doubles as the starter content
+    (mirrors the gateway adapter's ``_send_to_forum`` fallback).
+    """
+    starter = (content or "").strip()
+
     if message_id:
         # Create thread from an existing message
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
@@ -597,20 +615,54 @@ def _create_thread(
             "name": name,
             "auto_archive_duration": auto_archive_duration,
         }
+        is_forum = False
     else:
-        # Create a standalone thread
+        # Create a standalone thread — resolve the channel type first so
+        # forum/media channels take the message-bearing payload.
+        channel = _discord_request("GET", f"/channels/{channel_id}", token)
+        is_forum = channel.get("type") in _FORUM_CHANNEL_TYPES
         path = f"/channels/{channel_id}/threads"
-        body = {
-            "name": name,
-            "auto_archive_duration": auto_archive_duration,
-            "type": 11,  # PUBLIC_THREAD
-        }
+        if is_forum:
+            body = {
+                "name": name,
+                "auto_archive_duration": auto_archive_duration,
+                "type": 11,  # PUBLIC_THREAD
+                # Forum/media channels require a starter message object.
+                # Without caller content, the thread name doubles as the
+                # post body (mirrors the adapter's _send_to_forum fallback).
+                "message": {"content": starter or name},
+            }
+        else:
+            body = {
+                "name": name,
+                "auto_archive_duration": auto_archive_duration,
+                "type": 11,  # PUBLIC_THREAD
+            }
+
     thread = _discord_request("POST", path, token, body=body)
-    return json.dumps({
+    thread_id = thread["id"]
+
+    starter_message_id = None
+    # Non-forum threads have no starter-message field — deliver optional
+    # content as the thread's first message instead.
+    if starter and not is_forum:
+        msg = _discord_request(
+            "POST", f"/channels/{thread_id}/messages", token,
+            body={"content": starter},
+        )
+        starter_message_id = msg.get("id")
+
+    result: Dict[str, Any] = {
         "success": True,
-        "thread_id": thread["id"],
+        "thread_id": thread_id,
         "name": thread.get("name"),
-    })
+    }
+    if is_forum:
+        result["forum_post"] = True
+        result["starter_content"] = starter or name
+    if starter_message_id:
+        result["starter_message_id"] = starter_message_id
+    return json.dumps(result)
 
 
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
@@ -669,7 +721,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
-    ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_thread", "(channel_id, name, [content])", "create a public thread or forum post (content = starter message); optional message_id anchor"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -852,6 +904,15 @@ def _build_schema(
             "type": "string",
             "description": "New thread name (create_thread).",
         },
+        "content": {
+            "type": "string",
+            "description": (
+                "Starter message content (create_thread). Optional for normal "
+                "threads (sent as first thread message); for forum channels it "
+                "becomes the post's first message (falls back to the thread "
+                "name when omitted)."
+            ),
+        },
         "limit": {
             "type": "integer",
             "minimum": 1,
@@ -930,7 +991,8 @@ _ACTION_403_HINT = {
         "Bot lacks MANAGE_MESSAGES permission in this channel, or cannot view the channel/message."
     ),
     "create_thread": (
-        "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
+        "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it. "
+        "Forum channels additionally need SEND_MESSAGES to create posts."
     ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
@@ -998,6 +1060,7 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    content: str = "",
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -1051,6 +1114,7 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            content=content,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -1080,6 +1144,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "content": "",
 }
 
 


### PR DESCRIPTION
## Summary
- add Forum-channel support to the existing `create_thread` action
- accept `content` as the starter message for Forum posts and normal threads
- preserve anchor-thread behavior and add fallback/error handling

## Verification
- `scripts/run_tests.sh tests/tools/test_discord_tool.py` — 52 passed
- Discord-related suite — 130 passed
- `ruff check .` — passed
- real-path E2E against a local fake Discord server — passed

The change was tested after restarting the local Hermes gateway. A real Forum post with a starter message was created and read back successfully.