### PR TITLE
fix(desktop): pin 'en-US' in number/currency formatting so tests pass under non-en-US locales

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -578,7 +578,7 @@ export function renderRpcResult(response: unknown, name: string): string {
     const total = Number(r.total ?? 0)
 
     const lines: string[] = [
-      `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
+      `Usage: ${calls.toLocaleString('en-US')} calls · ${input.toLocaleString('en-US')} in / ${output.toLocaleString('en-US')} out · ${total.toLocaleString('en-US')} total`
     ]
 
     if (Array.isArray(r.credits_lines)) {

--- a/apps/desktop/src/app/settings/billing/billing-amounts.ts
+++ b/apps/desktop/src/app/settings/billing/billing-amounts.ts
@@ -114,7 +114,7 @@ export function formatMoney(value?: null | number | string): string {
     return EMPTY_BILLING_VALUE
   }
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat('en-US', {
     currency: 'USD',
     maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
     minimumFractionDigits: amount % 1 === 0 ? 0 : 2,

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -76,7 +76,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString('en-US')} more characters truncated — use Copy for the full output.`
 }
 
 export function prettyJson(value: unknown): string {


### PR DESCRIPTION
## Summary

Three desktop call sites format numbers/currency through the implicit system locale (bare `.toLocaleString()` / `new Intl.NumberFormat(undefined, ...)`), so the vitest suite fails on any machine running a non-`en-US` system locale (e.g. `pl_PL.UTF-8` groups thousands with U+00A0 and renders USD as `10 USD` with a non-breaking space, which also defeats `@testing-library`'s whitespace-normalized `getByText`).

- `fallback-model/format.ts` — `omitted.toLocaleString()` -> `omitted.toLocaleString('en-US')`
- `use-prompt-actions/utils.ts` — pin `'en-US'` on the four `.toLocaleString()` calls in the usage line
- `billing-amounts.ts` — `new Intl.NumberFormat(undefined, ...)` -> `new Intl.NumberFormat('en-US', ...)`

This matches the existing pinned-locale pattern already used in `use-billing-state.ts` (`credits.toLocaleString('en-US')`, `new Intl.NumberFormat('en-US', ...)`), so it is consistency rather than a new convention.

Fixes #98849

## Testing

Worktree from `main` (`4f22543`), `apps/desktop`, Node v26.7.0:

    $ LANG=pl_PL.UTF-8 LC_ALL=pl_PL.UTF-8 npx vitest run         src/components/assistant-ui/tool/fallback-model.test.ts         src/app/session/hooks/use-prompt-actions/utils.test.ts         src/app/settings/billing/index.test.tsx --project ui
     Test Files  3 passed (3)
          Tests  118 passed (118)

RED check on unpatched `main` under the same env — exactly the four tests named in the issue fail:

     x formats calls / input / output / total with thousands separators   (use-prompt-actions/utils.test.ts)
     x truncates oversized payloads and reports the omitted count          (fallback-model.test.ts)
     x rejects auto-refill amounts outside the billing bounds              (billing/index.test.tsx)
     x disables buy controls while polling and renders the settled outcome (billing/index.test.tsx)
     Tests  4 failed | 114 passed (118)

Also green under `en_US.UTF-8`, plus `tsc -p . --noEmit` and `eslint` clean on the three touched files.