### PR TITLE
fix(cli): resolve real-profile data dirs from the OS account home

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -15,7 +15,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 
 logger = logging.getLogger(__name__)
 
@@ -260,12 +260,21 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
     Darwin/Windows paths are not stat'ed. Paths are built with the TARGET
     system's separator (posix for Darwin/Linux, backslash for Windows) so an
     explicit ``system`` argument resolves correctly regardless of the host OS.
+    The base directory is ``get_real_home()`` so a Hermes profile HOME
+    (``{HERMES_HOME}/home``) never misdirects resolution (#98815).
     """
     if browser not in _CHROMIUM_BROWSERS:
         return None
     system = system or platform.system()
     mac_parts, win_parts, linux_name = _real_profile_relparts(browser)
-    home = os.path.expanduser("~")
+    home = get_real_home()
+    expanded = os.path.expanduser("~")
+    if os.path.normcase(expanded) != os.path.normcase(home):
+        logger.info(
+            "real-profile: resolving from real home %s, ignoring Hermes profile HOME %s",
+            home,
+            expanded,
+        )
     if system == "Darwin":
         return posixpath.join(home, "Library", "Application Support", *mac_parts)
     if system == "Windows":

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -9,6 +9,7 @@ are limited to OS detection and process launch.
 import json
 import os
 import ntpath
+import posixpath
 from unittest.mock import Mock, patch
 
 import pytest
@@ -33,6 +34,39 @@ class TestRealProfileResolvers:
     def test_data_dir_unknown_browser_is_none(self):
         import hermes_cli.browser_connect as bc
         assert bc.real_profile_data_dir("firefox", "Windows") is None
+
+    def test_data_dir_linux_skips_hermes_profile_home(self, tmp_path, monkeypatch):
+        # #98815: under a Hermes profile HOME points at {HERMES_HOME}/home, so
+        # resolution must repair to the OS account home instead of looking for
+        # a Chromium profile inside the Hermes profile.
+        import hermes_cli.browser_connect as bc
+
+        hermes_home = tmp_path / "hermes-home"
+        (hermes_home / "home").mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(hermes_home / "home"))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        got = bc.real_profile_data_dir("brave", "Linux")
+        assert got == posixpath.join(
+            str(real_home), ".config", "BraveSoftware", "Brave-Browser"
+        )
+
+    def test_data_dir_windows_skips_hermes_profile_home(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+
+        hermes_home = tmp_path / "hermes-home"
+        (hermes_home / "home").mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(hermes_home / "home"))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        got = bc.real_profile_data_dir("chrome", "Windows")
+        assert got == ntpath.join(
+            str(real_home), "AppData", "Local", "Google", "Chrome", "User Data"
+        )
 
     def test_detect_default_windows_progid_maps(self):
         import hermes_cli.browser_connect as bc


### PR DESCRIPTION
## What does this PR do?

Under a Hermes profile (`HOME={HERMES_HOME}/home`), `real_profile_data_dir()` in `hermes_cli/browser_connect.py` built every Chromium/Brave user-data-dir path from `os.path.expanduser("~")`, which expands to the profile home — so with `browser.use_real_profile: true` the resolver looked for `~/.config/google-chrome` etc. *inside the Hermes profile*, found nothing, and failed with "profile directory not found" (and combined with the desktop hang class, wedged sessions, #98815).

The fix resolves the base directory through the existing `get_real_home()` repair helper (`hermes_constants.py`), which already exists for exactly this profile-HOME hazard and is used by the rest of the CLI. It also logs one INFO line when a profile HOME is detected and bypassed, so mis-resolution is diagnosable from `agent.log` alone (the diagnosability gap called out in the issue).

## Related Issue

Fixes #98815

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/browser_connect.py` — `real_profile_data_dir()` now uses `get_real_home()` (added to the existing `hermes_constants` import) instead of `os.path.expanduser("~")` as the base for all Darwin/Windows/Linux(XDG/snap/flatpak) profile paths; added an INFO log when the profile HOME differs from the resolved real home; docstring updated.
- `tests/tools/test_browser_real_profile.py` — regressions `test_data_dir_linux_skips_hermes_profile_home` and `test_data_dir_windows_skips_hermes_profile_home`: set up a real `{HERMES_HOME}/home` profile HOME with `HERMES_REAL_HOME` pointing at the account home, assert resolution returns `<real-home>/.config/BraveSoftware/Brave-Browser` (Linux) and `<real-home>\AppData\Local\Google\Chrome\User Data` (Windows) instead of paths inside the Hermes profile.

## How to Test

1. `python -m pytest tests/tools/test_browser_real_profile.py -q` — Observed result: 79 passed.
2. `python -m pytest tests/hermes_cli/test_browser_connect_default_chromium.py tests/hermes_cli/test_browser_connect_dual_stack.py tests/hermes_cli/test_graphical_browser_detection.py tests/tools/test_browser_real_profile_pin.py tests/tools/test_browser_real_profile.py -q` — Observed result: 125 passed, 1 skipped.
3. Red/green observed locally: on the pre-fix code both new tests fail (resolution lands under the Hermes profile home); with the fix they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (resolver is cross-platform by design; both Linux and Windows branches covered by new tests)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A