### PR TITLE
fix(cron): surface no_agent runs in desktop run-history via execution ledger

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13205,6 +13205,64 @@ def _get_cron_job_sync(job_id: str, profile: Optional[str] = None):
 
 
 
+def _execution_to_session_info(exec_row: Dict[str, Any], job_id: str, profile: Optional[str]) -> Dict[str, Any]:
+    """Project a ``cron/executions`` ledger row into a SessionInfo-shaped dict.
+
+    ``no_agent`` (script-only) cron jobs short-circuit in ``run_job`` *before*
+    any ``sessions`` row is created (cron/scheduler.py:5469), so they never
+    appear in ``SessionDB.list_cron_job_runs``. But every attempt — including
+    no_agent — is already recorded in the durable execution ledger by
+    ``run_one_job`` (create_execution/finish_execution). Surface those here so
+    the Desktop run-history list is not empty for no_agent jobs.
+
+    The projected row deliberately carries no transcript (there is no agent
+    conversation to open) and reuses the ``cron`` source badge so the UI treats
+    it like any other cron run. The id prefix ``exec_`` can never collide with
+    the ``cron_{job_id}_`` session ids.
+    """
+    from datetime import datetime as _dt
+
+    def _iso_to_ts(value: Optional[str]) -> Optional[float]:
+        if not value:
+            return None
+        try:
+            return _dt.fromisoformat(value).timestamp()
+        except (ValueError, TypeError):
+            return None
+
+    started = _iso_to_ts(exec_row.get("started_at")) or _iso_to_ts(exec_row.get("claimed_at")) or 0.0
+    ended = _iso_to_ts(exec_row.get("finished_at"))
+    status = exec_row.get("status") or "unknown"
+    is_active = status in ("claimed", "running")
+    error = exec_row.get("error")
+    preview = (str(error) if error else f"no_agent run: {status}") if status != "completed" else f"no_agent run: {status}"
+    info: Dict[str, Any] = {
+        "id": f"exec_{job_id}_{exec_row.get('claimed_at', '')}",
+        "source": "cron",
+        "title": f"cron {job_id}",
+        "preview": preview,
+        "started_at": started,
+        "ended_at": ended,
+        "last_active": ended or started,
+        "is_active": is_active,
+        "archived": False,
+        "message_count": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "tool_call_count": 0,
+        "actual_cost_usd": None,
+        "estimated_cost_usd": None,
+        "model": None,
+        "cwd": None,
+        "parent_session_id": None,
+        "pinned": False,
+        "unread": False,
+    }
+    if profile:
+        info["profile"] = profile
+    return info
+
+
 def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: int = 20):
     """Run sessions produced by a cron job, newest first.
 
@@ -13219,6 +13277,14 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
     id-range scan, not the compression-chain CTE used for the recents list,
     so the cost scales with the requested window and not the (unbounded) total
     cron history.
+
+    ``no_agent`` (script-only) jobs never open a ``sessions`` row (by design —
+    see cron/scheduler.py:5653, they must not pay for SessionDB/AIAgent
+    construction), yet ``run_one_job`` still records every attempt in the
+    durable execution ledger (cron/executions.db). Merge that ledger in so
+    no_agent runs are visible in run-history without changing the no_agent
+    cost model. The two sources are keyed by disjoint id prefixes
+    (``cron_`` vs ``exec_``) so there is nothing to de-duplicate.
     """
     selected = profile or _find_cron_job_profile(job_id)
     # job_id may be a human name; resolve to the canonical id used in run-session ids.
@@ -13245,6 +13311,28 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
             s["archived"] = bool(s.get("archived"))
             if selected:
                 s["profile"] = selected
+
+        # Merge the durable execution ledger so no_agent (script-only) jobs,
+        # which never create a `sessions` row, still show in run-history.
+        try:
+            from cron.executions import EXECUTIONS_FILE, list_executions
+
+            if EXECUTIONS_FILE is None and selected:
+                _prof_name, _prof_home = _cron_profile_home(selected)
+                import cron.executions as _exec_mod
+
+                _exec_mod.EXECUTIONS_FILE = _prof_home / "cron" / "executions.db"
+            ledger = list_executions(job_id=canonical, limit=limit_n)
+            for _row in ledger:
+                runs.append(_execution_to_session_info(_row, canonical, selected))
+        except Exception:
+            # A missing/corrupt ledger must never break the session-backed list.
+            _log.debug("Job '%s': execution-ledger merge skipped", canonical, exc_info=True)
+
+        # Newest-first across both sources; ledger rows use claimed_at as their
+        # stable anchor so ordering is deterministic.
+        runs.sort(key=lambda r: r.get("started_at", 0), reverse=True)
+        runs = runs[:limit_n]
         return {"runs": runs, "limit": limit_n}
     finally:
         db.close()

--- a/tests/cron/test_cron_run_history_executions.py
+++ b/tests/cron/test_cron_run_history_executions.py
@@ -1,0 +1,189 @@
+"""Desktop run-history must surface no_agent (script-only) cron runs.
+
+``no_agent`` jobs short-circuit in ``run_job`` before any ``sessions`` row is
+created (by design — they must not pay for SessionDB/AIAgent construction), so
+``SessionDB.list_cron_job_runs`` never sees them. But ``run_one_job`` still
+records every attempt in the durable execution ledger (cron/executions.db).
+
+``hermes_cli.web_server._list_cron_job_runs_sync`` merges that ledger into the
+session-backed run-history so no_agent jobs are visible in the Desktop UI
+without changing the no_agent cost model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _seed_execution(executions, job_id: str, *, success: bool, error=None):
+    rec = executions.create_execution(job_id, source="builtin")
+    executions.mark_execution_running(rec["id"])
+    return executions.finish_execution(rec["id"], success=success, error=error)
+
+
+def _make_session_run(db, job_id: str, started_at: float):
+    """Mimic an LLM-path cron run row so the sessions source is also exercised."""
+    sid = f"cron_{job_id}_{int(started_at)}"
+    db.create_session(session_id=sid, source="cron")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?", (started_at, sid)
+    )
+    db._conn.commit()
+    # Checkpoint WAL before end_session() so a later read-only reopen of this
+    # file (what the endpoint does) sees the row. list_cron_job_runs filters on
+    # id prefix + source only, so ended_at visibility is irrelevant here.
+    db._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    db.end_session(sid, "completed")
+    return sid
+
+
+def test_execution_to_session_info_shapes_no_agent_run():
+    import hermes_cli.web_server as ws
+
+    row = {
+        "id": "exec-1",
+        "job_id": "watchdog",
+        "source": "builtin",
+        "status": "completed",
+        "claimed_at": "2026-08-30T10:00:00",
+        "started_at": "2026-08-30T10:00:01",
+        "finished_at": "2026-08-30T10:00:05",
+        "error": None,
+    }
+    info = ws._execution_to_session_info(row, "watchdog", "default")
+
+    assert info["id"].startswith("exec_watchdog_")
+    assert info["source"] == "cron"
+    assert info["title"] == "cron watchdog"
+    assert info["started_at"] > 0
+    assert info["ended_at"] is not None
+    assert info["is_active"] is False
+    assert info["message_count"] == 0
+    assert info["model"] is None
+    assert info["profile"] == "default"
+
+
+def test_execution_to_session_info_marks_active_and_error_preview():
+    import hermes_cli.web_server as ws
+
+    running = {
+        "id": "exec-2", "job_id": "watchdog", "source": "builtin",
+        "status": "running", "claimed_at": "2026-08-30T10:00:00",
+        "started_at": "2026-08-30T10:00:01", "finished_at": None, "error": None,
+    }
+    info = ws._execution_to_session_info(running, "watchdog", None)
+    assert info["is_active"] is True
+    assert info["ended_at"] is None
+
+    failed = {
+        "id": "exec-3", "job_id": "watchdog", "source": "builtin",
+        "status": "failed", "claimed_at": "2026-08-30T10:00:00",
+        "started_at": "2026-08-30T10:00:01", "finished_at": "2026-08-30T10:00:09",
+        "error": "script exited 1",
+    }
+    info_f = ws._execution_to_session_info(failed, "watchdog", None)
+    assert info_f["is_active"] is False
+    assert "script exited 1" in info_f["preview"]
+
+
+def _patch_endpoint(monkeypatch, ws, home, job_profile=None):
+    """Route the endpoint at an isolated temp store without the real profile layer.
+
+    ``_open_session_db_for_profile`` is redirected to the REAL opener pointed at
+    the seeded temp state.db (so ``_conn`` is initialized correctly); the
+    execution ledger reads from the isolated file via EXECUTIONS_FILE.
+    """
+    import cron.executions as executions
+
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", home / "cron" / "executions.db")
+    monkeypatch.setattr(
+        ws,
+        "_open_session_db_for_profile",
+        lambda profile, *, read_only=True: ws._open_session_db_at_path(
+            home / "state.db", read_only=True
+        ),
+    )
+    if job_profile is not None:
+        monkeypatch.setattr(ws, "_find_cron_job_profile", lambda job_id: job_profile)
+
+
+def test_run_history_merges_execution_ledger_for_no_agent(tmp_path, monkeypatch):
+    """No session row exists (no_agent path) but the ledger does → surfaced."""
+    import cron.executions as executions
+    import hermes_cli.web_server as ws
+
+    home = tmp_path / "default"
+    (home / "cron").mkdir(parents=True)
+    # Point the ledger at the temp store BEFORE seeding so seed + read agree.
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", home / "cron" / "executions.db")
+
+    # A no_agent job's attempts live ONLY in the ledger (no sessions row).
+    _seed_execution(executions, "noagent-job", success=True)
+    _seed_execution(executions, "noagent-job", success=False, error="boom")
+
+    _patch_endpoint(monkeypatch, ws, home, job_profile=None)
+    result = ws._list_cron_job_runs_sync("noagent-job", profile=None, limit=20)
+
+    runs = result["runs"]
+    assert len(runs) == 2, f"expected 2 ledger rows, got {len(runs)}"
+    assert all(r["id"].startswith("exec_noagent-job_") for r in runs)
+    # Newest-first ordering preserved.
+    sts = [r["started_at"] for r in runs]
+    assert sts == sorted(sts, reverse=True)
+    # Failed run carries its error in the preview.
+    assert any("boom" in r["preview"] for r in runs)
+
+
+def test_run_history_keeps_session_runs_and_merges_ledger(tmp_path, monkeypatch):
+    """LLM job (sessions) + no_agent sibling (ledger) both appear, newest-first."""
+    import cron.executions as executions
+    import hermes_cli.web_server as ws
+    from hermes_state import SessionDB
+
+    home = tmp_path / "default"
+    (home / "cron").mkdir(parents=True)
+
+    # Point the ledger at the temp store BEFORE seeding so seed + read agree.
+    import cron.executions as executions
+
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", home / "cron" / "executions.db")
+
+    # An LLM job run (sessions source) — seed the real temp state.db.
+    seed_db = SessionDB(home / "state.db")
+    _make_session_run(seed_db, "llm-job", 1_700_000_000.0)
+    seed_db.close()
+    # A no_agent job run (ledger only).
+    _seed_execution(executions, "noagent-job", success=True)
+
+    _patch_endpoint(monkeypatch, ws, home, job_profile=None)
+    llm = ws._list_cron_job_runs_sync("llm-job", profile=None, limit=20)
+    noagent = ws._list_cron_job_runs_sync("noagent-job", profile=None, limit=20)
+
+    assert len(llm["runs"]) == 1
+    assert llm["runs"][0]["id"].startswith("cron_llm-job_")
+    assert len(noagent["runs"]) == 1
+    assert noagent["runs"][0]["id"].startswith("exec_noagent-job_")
+
+
+def test_run_history_ledger_merge_is_best_effort_on_failure(tmp_path, monkeypatch):
+    """A broken ledger must not break the session-backed list."""
+    import cron.executions as executions
+    import hermes_cli.web_server as ws
+    from hermes_state import SessionDB
+
+    home = tmp_path / "default"
+    (home / "cron").mkdir(parents=True)
+
+    seed_db = SessionDB(home / "state.db")
+    _make_session_run(seed_db, "llm-job", 1_700_000_000.0)
+    seed_db.close()
+
+    _patch_endpoint(monkeypatch, ws, home, job_profile=None)
+    with patch.object(executions, "list_executions", side_effect=RuntimeError("ledger gone")):
+        result = ws._list_cron_job_runs_sync("llm-job", profile=None, limit=20)
+
+    assert len(result["runs"]) == 1
+    assert result["runs"][0]["id"].startswith("cron_llm-job_")


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop cron detail "RUN HISTORY" list being permanently empty for `no_agent=True` (script-only) jobs such as `mcp-health-check` and other watchdogs.

## Problem

`no_agent` jobs short-circuit in `run_job()` (cron/scheduler.py:5469) **before** any `sessions` row is created — by design, so they don't pay for `SessionDB`/`AIAgent` construction (cron/scheduler.py:5653). The run-history list is backed by `SessionDB.list_cron_job_runs` (hermes_cli/web_server.py:_list_cron_job_runs_sync), which only reads the `sessions` table, so no_agent jobs never appeared.

## Root cause

The bug is a **read-path gap**, not a missing-write gap: `run_one_job()` already records every attempt — including no_agent — in the durable execution ledger `cron/executions.db` via `create_execution`/`finish_execution` (cron/scheduler.py:7152 / :7516). `list_cron_job_runs` simply never consulted that ledger.

## Fix

Merge the execution ledger into `_list_cron_job_runs_sync`. Each ledger row is projected into a `SessionInfo`-compatible dict (id prefix `exec_` — disjoint from the `cron_{job_id}_` session ids, so no de-dup needed) and merged newest-first with the session-backed runs, trimmed to the requested window. A missing/corrupt ledger is best-effort and never breaks the session-backed list.

This deliberately keeps the intentional no_agent cost model intact (no `SessionDB` write on the hot path) — it reuses the ledger that already exists.

## Why not write a `sessions` row per no_agent tick (alternative)?

That was the obvious fix, but it would violate the explicit design goal at cron/scheduler.py:5653 (no_agent ticks must not construct `SessionDB`). The ledger-merge approach is strictly cheaper and reuses data already being written.

## Testing

- `tests/cron/test_cron_run_history_executions.py` (5 new): projection shapes, active/error preview, ledger merge for no_agent-only jobs, LLM-session + no_agent-ledger merge, and best-effort on ledger failure.
- Manual: a real `run_one_job` for a no_agent job wrote a ledger row and the endpoint surfaced it (`exec_{job_id}_{claimed_at}`).
- Existing `tests/cron/test_cron_no_agent.py` + `tests/cron/test_execution_ledger.py` still green (37 passed).

## CI

All checks run locally + ruff clean on the changed files.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)
