### PR TITLE
fix(compaction): let a trusted proxy actually reach native compaction

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2841,6 +2841,12 @@ def init_agent(
         base_url=agent.base_url,
         provider=agent.provider,
         is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
+        # agent.capabilities (set above from the resolved custom_providers
+        # trust map) must reach this computation, not just the lower
+        # trusted_proxy check in native_compaction_context_management — that
+        # check is unreachable when this dict resolves native_compaction to
+        # False first.
+        trusted_proxy=bool(agent.capabilities.get("openai_native_compaction", False)),
     )
     agent.max_compression_attempts = compression_max_attempts
     agent.compression_idle_compact_after_seconds = (

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -74,16 +74,29 @@ def resolve_native_compaction_capabilities(
     base_url: Optional[str],
     provider: Optional[str] = None,
     is_codex_backend: bool = False,
+    trusted_proxy: bool = False,
 ) -> Dict[str, bool]:
     """Resolve the native-compaction capability for a runtime destination.
 
     The result is deliberately explicit: a resolved ``False`` is different
     from an unresolved capability and must survive model switches unchanged.
+
+    ``trusted_proxy`` is the caller's already-resolved
+    ``agent.capabilities``/``openai_native_compaction`` trust decision for
+    this destination (a ``custom_providers`` entry can opt a proxy in
+    explicitly). It must be folded into ``eligible`` here: this dict becomes
+    ``agent.runtime_capabilities``, and
+    ``native_compaction_context_management``'s very first gate short-circuits
+    to "not eligible" on a resolved False before the trusted-proxy fallback
+    further down ever runs — a trusted proxy that isn't reflected here can
+    never actually engage native compaction, no matter what
+    ``agent.capabilities`` says.
     """
     normalized_provider = (provider or "").strip().lower()
     direct_default = normalized_provider == "openai" and not base_url
     eligible = is_native_compaction_model(model) and (
         direct_default
+        or bool(trusted_proxy)
         or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend)
     )
     return {"native_compaction": eligible}

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2179,11 +2179,21 @@ def switch_model(
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model, allow_network=True)
     from agent.native_compaction import resolve_native_compaction_capabilities
+    # runtime_capabilities currently holds resolve_runtime_provider()'s
+    # openai_native_compaction trust decision for the destination resolved
+    # above (a matching custom_providers entry, if any) — capture it before
+    # it's unconditionally replaced below with the differently-shaped
+    # {"native_compaction": bool} dict. Without this, a /model switch onto a
+    # trusted custom proxy silently drops the trust: resolve_native_compaction_
+    # capabilities can't otherwise see it, and the resulting ModelSwitchResult.
+    # runtime_capabilities resolves native_compaction to False.
+    _trusted_proxy = bool(runtime_capabilities.get("openai_native_compaction", False))
     runtime_capabilities = resolve_native_compaction_capabilities(
         model=new_model,
         base_url=base_url,
         provider=target_provider,
         is_codex_backend=target_provider.strip().lower() == "openai-codex",
+        trusted_proxy=_trusted_proxy,
     )
 
     # --- Get full model info from models.dev ---

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -455,6 +455,101 @@ def test_switch_model_does_not_send_ollama_headers_to_unrelated_custom_endpoint(
     assert validation_headers == [None]
 
 
+def test_switch_model_preserves_trusted_proxy_native_compaction_capability(monkeypatch):
+    """A /model switch onto a custom_providers entry that declares
+    openai_native_compaction: true must carry that trust into
+    ModelSwitchResult.runtime_capabilities.
+
+    resolve_runtime_provider() already resolves this trust map correctly
+    (into the local ``runtime_capabilities`` variable), but it used to be
+    unconditionally overwritten a few lines later by
+    resolve_native_compaction_capabilities() — which has no other way to
+    learn about proxy trust — silently dropping it. Without this, a /model
+    switch onto a trusted proxy could never actually engage native
+    compaction: agent.switch_model() receives this result's
+    runtime_capabilities as its own ``capabilities=`` kwarg and assigns it
+    straight to agent.runtime_capabilities.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "proxy-key",
+            "base_url": "https://trusted-proxy.example/v1",
+            "api_mode": "chat_completions",
+            "capabilities": {"openai_native_compaction": True},
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+    result = switch_model(
+        raw_input="trusted-proxy/gpt-5.6",
+        current_provider="openai-api",
+        current_model="gpt-5.5",
+        current_base_url="https://api.openai.com/v1",
+        current_api_key="sk-test",
+        explicit_provider="custom:trusted-proxy",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "trusted-proxy",
+                "base_url": "https://trusted-proxy.example/v1",
+                "capabilities": {"openai_native_compaction": True},
+                "models": [{"id": "gpt-5.6", "name": "gpt-5.6"}],
+            }
+        ],
+    )
+
+    assert result.success is True, result.error_message
+    assert result.runtime_capabilities == {"native_compaction": True}
+
+
+def test_switch_model_untrusted_proxy_stays_ineligible(monkeypatch):
+    """Same shape as the trusted-proxy case, but the resolved runtime carries
+    no capabilities — confirms the fix doesn't make every custom-provider
+    switch eligible, only ones resolve_runtime_provider actually trusts."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "proxy-key",
+            "base_url": "https://untrusted-proxy.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+    result = switch_model(
+        raw_input="untrusted-proxy/gpt-5.6",
+        current_provider="openai-api",
+        current_model="gpt-5.5",
+        current_base_url="https://api.openai.com/v1",
+        current_api_key="sk-test",
+        explicit_provider="custom:untrusted-proxy",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "untrusted-proxy",
+                "base_url": "https://untrusted-proxy.example/v1",
+                "models": [{"id": "gpt-5.6", "name": "gpt-5.6"}],
+            }
+        ],
+    )
+
+    assert result.success is True, result.error_message
+    assert result.runtime_capabilities == {"native_compaction": False}
+
+
 
 def test_is_routing_aggregator_excludes_flat_namespace_resellers():
     """opencode-go / opencode-zen stay ``is_aggregator=True`` (model-switch

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -17,6 +17,7 @@ from agent.native_compaction import (
     is_native_compaction_rejection,
     native_compaction_context_management,
     resolve_compact_threshold,
+    resolve_native_compaction_capabilities,
 )
 
 
@@ -28,7 +29,10 @@ def _agent(
     threshold: object = DEFAULT_COMPACT_THRESHOLD,
     compressor=None,
     capabilities=None,
+    provider=None,
+    is_codex_backend=False,
 ):
+    capabilities = capabilities or {}
     return SimpleNamespace(
         model=model,
         base_url=base_url,
@@ -36,7 +40,20 @@ def _agent(
         compression_enabled=compression_enabled,
         codex_responses_compact_threshold=threshold,
         context_compressor=compressor,
-        capabilities=capabilities or {},
+        capabilities=capabilities,
+        # Computed the same way agent_init.py's init_agent() actually sets
+        # it on every real agent. A fixture that leaves this unset can't
+        # catch a bug in native_compaction_context_management's own
+        # runtime_capabilities gate — that gate short-circuits BEFORE the
+        # lower agent.capabilities/trusted_proxy check ever runs, and only a
+        # fixture that mirrors production hits it.
+        runtime_capabilities=resolve_native_compaction_capabilities(
+            model=model,
+            base_url=base_url,
+            provider=provider,
+            is_codex_backend=is_codex_backend,
+            trusted_proxy=bool(capabilities.get("openai_native_compaction", False)),
+        ),
     )
 
 
@@ -87,7 +104,10 @@ class TestRequestGate:
 
     def test_codex_backend_gets_payload(self):
         payload = native_compaction_context_management(
-            _agent(base_url="https://chatgpt.com/backend-api/codex"),
+            _agent(
+                base_url="https://chatgpt.com/backend-api/codex",
+                is_codex_backend=True,
+            ),
             is_codex_backend=True,
         )
         assert payload is not None
@@ -163,6 +183,54 @@ class TestRequestGate:
             _agent(threshold=None, compressor=compressor), is_codex_backend=False
         )
         assert payload == [{"type": "compaction", "compact_threshold": 756_808}]
+
+
+class TestResolveCapabilitiesTrustedProxy:
+    """resolve_native_compaction_capabilities's trusted_proxy parameter.
+
+    Regression coverage: this dict becomes agent.runtime_capabilities, and
+    native_compaction_context_management's very first gate short-circuits to
+    "not eligible" on a resolved False before the lower
+    agent.capabilities/openai_native_compaction check ever runs. Before this
+    fix, resolve_native_compaction_capabilities had no way to learn about a
+    trusted custom_providers proxy at all, so that lower check was dead code
+    for every non-api.openai.com destination — no matter what
+    agent.capabilities said.
+    """
+
+    def test_trusted_proxy_makes_non_direct_route_eligible(self):
+        assert resolve_native_compaction_capabilities(
+            model="gpt-5.6",
+            base_url="https://trusted-proxy.example/v1",
+            provider="custom:trusted-proxy",
+            trusted_proxy=True,
+        ) == {"native_compaction": True}
+
+    def test_untrusted_non_direct_route_stays_ineligible(self):
+        assert resolve_native_compaction_capabilities(
+            model="gpt-5.6",
+            base_url="https://untrusted-proxy.example/v1",
+            provider="custom:untrusted-proxy",
+            trusted_proxy=False,
+        ) == {"native_compaction": False}
+
+    def test_trusted_proxy_does_not_override_ineligible_model(self):
+        """Trust opts a route into the model gate, not around it."""
+        assert resolve_native_compaction_capabilities(
+            model="gpt-5.1",
+            base_url="https://trusted-proxy.example/v1",
+            provider="custom:trusted-proxy",
+            trusted_proxy=True,
+        ) == {"native_compaction": False}
+
+    def test_direct_openai_route_unaffected_by_trusted_proxy_default(self):
+        """The default (trusted_proxy omitted) matches the pre-fix behavior
+        for every route this parameter doesn't change."""
+        assert resolve_native_compaction_capabilities(
+            model="gpt-5.6",
+            base_url="https://api.openai.com/v1",
+            provider="openai",
+        ) == {"native_compaction": True}
 
 
 class TestThresholdClamp:
@@ -441,6 +509,29 @@ class TestAgentInitConfig:
         )
         assert agent.codex_responses_native_compaction is False
         assert agent.codex_responses_compact_threshold is None
+
+    def test_trusted_proxy_capability_survives_construction(self):
+        """A custom_providers entry's openai_native_compaction trust must
+        reach agent.runtime_capabilities at construction time, not just
+        agent.capabilities — otherwise native_compaction_context_management's
+        own runtime_capabilities gate denies the destination before ever
+        checking agent.capabilities (the bug this test guards against)."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://trusted-proxy.example/v1",
+            api_mode="chat_completions",
+            model="gpt-5.6",
+            provider="custom:trusted-proxy",
+            capabilities={"openai_native_compaction": True},
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+        )
+        assert agent.capabilities == {"openai_native_compaction": True}
+        assert agent.runtime_capabilities == {"native_compaction": True}
 
     def test_public_config_default_selects_automatic_threshold(self):
         from hermes_cli.config import DEFAULT_CONFIG


### PR DESCRIPTION
## Problem

`resolve_native_compaction_capabilities()` computes `agent.runtime_capabilities` from `model` + `base_url` + `provider` only — it has no awareness of the `openai_native_compaction` trust a `custom_providers` entry can grant a proxy. Its `"native_compaction"` key resolves to `False` for any non-`api.openai.com` route regardless of trust.

`native_compaction_context_management()`'s very first gate:

```python
capabilities = getattr(agent, "runtime_capabilities", None)
if isinstance(capabilities, dict):
    if not bool(capabilities.get("native_compaction", False)):
        return None
```

short-circuits on that resolved `False` **before** the lower `agent.capabilities.get("openai_native_compaction")` "trusted_proxy" check further down ever runs:

```python
trusted_proxy = bool(getattr(agent, "capabilities", {}).get("openai_native_compaction", False))
if not trusted_proxy and not is_direct_openai_route(...):
    return None
```

So the trusted-proxy exception has been unreachable on every non-direct-OpenAI destination since the day it was added — confirmed empirically by constructing an agent the same way `init_agent()` actually does (`runtime_capabilities` set as a dict) and calling `native_compaction_context_management()` directly: the payload comes back `None` even with `agent.capabilities = {"openai_native_compaction": True}`.

The existing test `test_trusted_proxy_capability_gets_payload` passed anyway because its `_agent()` `SimpleNamespace` fixture never set `runtime_capabilities` at all — `getattr(agent, "runtime_capabilities", None)` returned `None`, so the early gate's `isinstance(capabilities, dict)` check was `False` and the gate was skipped, letting execution reach the trusted_proxy check the test actually meant to exercise. A fixture that doesn't mirror what `init_agent()` sets on every real agent can't catch a bug living in that exact gate.

## Fix

Add a `trusted_proxy: bool = False` parameter to `resolve_native_compaction_capabilities()` and fold it into `eligible`. Thread the already-resolved trust decision into it at its two primary call sites:

- **`agent/agent_init.py`** (construction time): `agent.capabilities` is already set from the caller's resolved `custom_providers` trust map earlier in the same function — reuse it directly, no new lookup.
- **`hermes_cli/model_switch.py`** (`/model` switching): `resolve_runtime_provider()` already resolves the destination's capabilities into the local `runtime_capabilities` variable a few lines above the native-compaction recompute — capture the trust bit *before* it gets unconditionally overwritten with the differently-shaped `{"native_compaction": bool}` dict. This is the exact clobber bug: the earlier assignment was correct, it just never survived to the `ModelSwitchResult`.

Also updated `tests/run_agent/test_native_compaction.py`'s shared `_agent()` fixture to compute `runtime_capabilities` the same way `agent_init.py` actually does (including the new `trusted_proxy` wiring), so every existing test in that file now exercises the real gate instead of silently bypassing it.

## Scope note

Not covered here — narrower/rarer paths, left for a follow-up:
- `agent/chat_completion_helpers.py`'s provider-fallback recovery recompute (a fallback provider being a trusted native-compaction proxy is an edge case of an edge case).
- `agent/agent_runtime_helpers.py::switch_model()`'s no-explicit-`capabilities` fallback branch, which only runs for direct callers outside the `/model` flow (the `/model` flow — CLI and gateway both — always supplies `capabilities=` explicitly via `hermes_cli.model_switch.switch_model()`'s result, which this PR fixes).

## Verification

- `uv run --frozen python -m pytest tests/run_agent/test_native_compaction.py tests/hermes_cli/test_model_switch_custom_providers.py tests/run_agent/test_native_compaction_switch_capabilities.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_switch_model_rollback.py tests/tools/test_delegate_capability_inheritance.py tests/agent/test_custom_provider_extra_body_matching.py tests/agent/test_custom_provider_extra_body.py tests/agent/test_switch_model_request_overrides.py tests/gateway/test_agent_cache.py tests/gateway/test_model_switch_persistence.py -q` — 295 passed.
- Mutation-verify: stashed the three production-file changes (kept the tests), re-ran the two directly-relevant test files — 15 failures, including the exact `{'native_compaction': False} == {'native_compaction': True}` mismatch the `/model`-switch test targets. Restored the fix, re-ran — all green.
- `ruff check` on all touched files: clean.

## Checklist

- [x] Tests added/updated and passing
- [x] Mutation-verified (fix stashed → tests fail; restored → tests pass)
- [x] `ruff check` clean on touched files
- [x] No behavior change for untrusted/default routes (default `trusted_proxy=False` preserves prior `eligible` computation exactly)