### PR TITLE
fix(models): correct the nvidia curated catalog - add kimi-k3, drop 404 z-ai phantoms

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -394,9 +394,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3.5-lightning-30b-a3b",
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         # Third-party agentic models hosted on build.nvidia.com
-        # (map to OpenRouter defaults — users get familiar picks on NIM)
-        "z-ai/glm-5.3",
-        "z-ai/glm-5.2",
+        # NOTE: z-ai/glm-5.3 and z-ai/glm-5.2 were removed - NVIDIA's live
+        # /v1/models catalog serves no z-ai models and calls 404 (verified
+        # 2026-08-28 against integrate.api.nvidia.com).
+        "moonshotai/kimi-k3",
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m3",
     ],


### PR DESCRIPTION
## Problem

The static (fallback) nvidia list in `_PROVIDER_MODELS` (hermes_cli/models.py) contains:

- `z-ai/glm-5.3` and `z-ai/glm-5.2` - **not served by NVIDIA's API**. The live catalog at `integrate.api.nvidia.com/v1/models` (83 models at verification time) contains **zero z-ai entries**, and chat completions against both ids return **HTTP 404**. The comment assumed these "map to OpenRouter defaults" on NIM - they do not.
- `moonshotai/kimi-k3` - **missing** even though it shipped on the NVIDIA endpoint on 2026-08-27.

## Impact

`/model` prefers the live `/v1/models` list, but when that fetch fails (rate-limited key, network hiccup) it falls back to this static list - users are then offered models that can only 404, while a working model (`moonshotai/kimi-k3`) is hidden.

## Change

- remove `z-ai/glm-5.3` and `z-ai/glm-5.2` (404-verified against the live endpoint, 2026-08-28)
- add `moonshotai/kimi-k3` (live-verified)
- keep `moonshotai/kimi-k2.6` and `minimaxai/minimax-m3` (both live-verified)
- correct the stale comment

## Verification

- `GET /v1/models` on `integrate.api.nvidia.com`: 83 models, no `z-ai/*`, `moonshotai/kimi-k3` present
- `POST /v1/chat/completions` with `z-ai/glm-5.3` -> HTTP 404
- `POST /v1/chat/completions` with `moonshotai/kimi-k3` -> 200, valid completion (also exercised end-to-end through Hermes with `--provider nvidia`)