### PR TITLE
fix(desktop): keep last-known remote roster rows when the union probe fails

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -574,6 +574,42 @@ describe('connect-on-demand sources', () => {
   })
 })
 
+describe('an aggregate roster failure keeps the last-known remote rows', () => {
+  // Same shape the pane paints: one rich local row + one remote row already
+  // carried into $lastRoster by a previous successful refresh.
+  const previouslyPainted = (connectionId: string) =>
+    [
+      { last_session: { id: 'this-chat', last_active: 1 }, name: 'default' },
+      {
+        connectionId,
+        connectionKind: 'ssh',
+        connectionLabel: 'Spark',
+        handle: 'bob',
+        name: 'bob',
+        remoteSource: true,
+        sourceScoped: true
+      }
+    ] as RosterRow[]
+
+  it('retains previously painted remote rows as unreachable when host.agents() rejects', async () => {
+    // mergedRoster(local, null) rejects host.agents(): the union probe fails
+    // (e.g. a registered WSL backend's localhost forwarding went down) while
+    // the active source's profiles.list still answers (#98844).
+    $lastRoster.set(previouslyPainted('spark'))
+
+    const rows = await mergedRoster(
+      { profiles: [{ last_session: { id: 'this-chat', last_active: 1 }, name: 'default' }] },
+      null
+    )
+
+    expect(rows.find(row => row.name === 'bob' && row.connectionId === 'spark')).toMatchObject({
+      remoteSource: true,
+      sourceReachable: false
+    })
+    expect(rows.filter(row => row.name === 'default')).toHaveLength(1)
+  })
+})
+
 describe('a stalled profiles.list cannot pin the spinner forever', () => {
   it('gives up after bounded retries and surfaces the error', async () => {
     // `retry: true` keeps React Query in isLoading until the first success, so

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -693,7 +693,21 @@ export function useRoster() {
             fetchedAt: issuedAt
           }
         } catch {
-          /* older build or roster failure — single-source list stands */
+          /* Aggregate-roster failure, not a registry change: keep the
+           * previously painted remote rows on the roster as unreachable
+           * instead of repainting Bot Mode local-only (#98844). `sources`
+           * stays absent so the pane falls back to its remembered source
+           * snapshot rather than clearing it. */
+          const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
+          const merged = mergeMultiSourceRoster(local, null, activeConnectionId, previous)
+
+          return {
+            ...merged,
+            profiles: (merged?.profiles || []).map(row =>
+              row?.remoteSource ? { ...row, sourceReachable: false } : row
+            ),
+            fetchedAt: issuedAt
+          }
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

When the union agent-roster probe (`host.agents()`) rejects on a multi-source desktop, the roster query's catch path returned a local-only snapshot, so every previously painted remote Bot row vanished from Bot Mode on the next 5s refresh — even though the connection stayed registered and credentialed. This is the aggregate-roster-failure branch of #98844 (a registered WSL bot disappearing when its localhost transport fails).

The catch path now feeds the last-known roster rows (``, the same source the pane already caches for connect-on-demand sources) through the existing `mergeMultiSourceRoster` merge with a null union, which carries previously painted remote rows forward, and marks carried remote rows `sourceReachable: false` so they paint as offline/unreachable instead of disappearing. The fallback payload intentionally omits `sources` so the pane falls back to its remembered source snapshot rather than clearing it.

Scope note: this fixes the in-session loss (defect 2 in the issue's analysis — the exception fallback bypassing the previous-roster merge). The durable-storage persistence across a full Desktop relaunch (defect 1) is a separate, larger change and is intentionally not bundled here.

## Related Issue

Fixes #98844

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/data.ts` — the `host.agents()` catch path in `useRoster`'s queryFn now merges the last-known remote rows via `mergeMultiSourceRoster(local, null, activeConnectionId, previous)` and marks carried remote rows `sourceReachable: false` instead of returning a local-only roster (`sources` omitted so the pane keeps its remembered snapshot).
- `apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx` — regression test: remote rows previously painted into `` survive a `host.agents()` rejection as unreachable rows, with no duplicate local row.

## How to Test

1. `cd apps/desktop && npx vitest run src/plugins/hermes-bots/data.roster.test.tsx` — observed result: 16 passed (was 15 before this change; the new `retains previously painted remote rows as unreachable when host.agents() rejects` test fails on unpatched main).
2. Also verified: `data.cached-roster`, `cross-connection-bots`, `roster-actions`, `hidden-bots`, `group-chat-view` suites — 39 passed; eslint clean on both touched files.
3. Manual path (matches the issue's repro): register a remote (e.g. WSL) connection, let its bots paint in Bot Mode, then make the endpoint unreachable without removing the registration — the remote rows should remain listed as Unavailable rather than disappearing, and reconcile without duplication once connectivity returns (the union probe succeeding again repaints authoritative rows).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (TS-only change; vitest suites above pass instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); fix is platform-neutral renderer logic, regression covered by vitest

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the reported scenario is Windows→WSL; the fix is in platform-neutral renderer merge logic and the cached-row carry-forward reuses the same mechanism already shipped for connect-on-demand SSH sources
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A