### PR TITLE
fix(skills): resolve categorized skill names under external_dirs too

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -759,6 +759,60 @@ class TestExternalSkillMutations:
         assert not (local / "ext-skill").exists()
 
 
+    def test_find_skill_resolves_categorized_path_under_external_dir(self, tmp_path):
+        """The categorized form (category/skill-name) must resolve for a
+        skill living under skills.external_dirs, not just the local skills
+        dir.
+
+        Regression: _find_skill's categorized-path matching resolved every
+        candidate skill's relative path against the FIXED local skills root
+        regardless of which directory get_all_skills_dirs() actually found
+        it under. relative_to() raises ValueError for a path outside that
+        root, so an external-dir skill's categorized path never matched —
+        only its bare name did — even though skill_view's own categorized
+        resolution has no such restriction (the "parity with skill_view"
+        this lookup exists for).
+        """
+        local = tmp_path / "local"
+        external = tmp_path / "vault"
+        local.mkdir(); external.mkdir()
+        skill_dir = external / "mlops" / "axolotl"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: axolotl\ndescription: An external categorized skill.\n---\n\nBody.\n"
+        )
+
+        with _two_roots(local, external):
+            found_categorized = _find_skill("mlops/axolotl")
+            found_bare = _find_skill("axolotl")
+
+        assert found_categorized is not None, (
+            "categorized path must resolve for an external-dir skill"
+        )
+        assert found_categorized["path"] == skill_dir
+        assert found_bare is not None
+        assert found_bare["path"] == skill_dir
+
+    def test_patch_external_skill_by_categorized_path(self, tmp_path):
+        """skill_manage's categorized-path resolution must work end-to-end
+        for a skill under skills.external_dirs — not just the ability to
+        locate it (previous test), but to actually patch it in place."""
+        local = tmp_path / "local"
+        external = tmp_path / "vault"
+        local.mkdir(); external.mkdir()
+        skill_dir = external / "mlops" / "axolotl"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: axolotl\ndescription: An external categorized skill.\n---\n\n"
+            "Body with OLD_MARKER here.\n"
+        )
+
+        with _two_roots(local, external):
+            result = _patch_skill("mlops/axolotl", "OLD_MARKER", "NEW_MARKER")
+
+        assert result["success"] is True, result
+        assert "NEW_MARKER" in (skill_dir / "SKILL.md").read_text()
+
     def test_background_review_refuses_to_patch_pinned_skill(self, tmp_path):
         """#25839: the autonomous review fork respects pin like the curator
         does — a pinned skill is off-limits to background maintenance, even

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -689,31 +689,21 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     resolves, and the form skill_view's ambiguity hint explicitly tells
     the caller to use. The bare-name match compares the skill's own
     directory name (``parent.name``), so bare lookups keep working for
-    category-nested skills.
+    category-nested skills. The categorized form matches relative to
+    WHICHEVER directory (local or external) the skill was actually found
+    under — a skill from ``skills.external_dirs`` has its own root, distinct
+    from the local skills dir, and a fixed root would raise ValueError for
+    it on every categorized lookup.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
-
-    # Resolve the local skills root once — the categorized form matches the
-    # skill dir's path RELATIVE to that root. Only computed lazily (bare-name
-    # lookups never need it) and never for external dirs (relative_to raises).
-    _resolved_root: Optional[Path] = None
-
-    def _local_root() -> Path:
-        nonlocal _resolved_root
-        if _resolved_root is None:
-            try:
-                _resolved_root = _skills_dir().resolve()
-            except OSError:
-                logger.debug(
-                    "skills dir resolve failed; categorized lookups fall back to the unresolved path",
-                    exc_info=True,
-                )
-                _resolved_root = _skills_dir()
-        return _resolved_root
 
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
+        # Resolved lazily per directory — only needed when a categorized
+        # lookup is actually being performed, and shared across every
+        # skill_md found under this one directory.
+        _dir_root: Optional[Path] = None
         for skill_md in skills_dir.rglob("SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
@@ -724,8 +714,17 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
             # Categorized form (``category/skill-name``): compare the skill
             # dir's POSIX relative path so the lookup works on Windows too.
             if "/" in name or "\\" in name:
+                if _dir_root is None:
+                    try:
+                        _dir_root = skills_dir.resolve()
+                    except OSError:
+                        logger.debug(
+                            "skills dir resolve failed; categorized lookups fall back to the unresolved path",
+                            exc_info=True,
+                        )
+                        _dir_root = skills_dir
                 try:
-                    rel = skill_md.parent.resolve().relative_to(_local_root())
+                    rel = skill_md.parent.resolve().relative_to(_dir_root)
                 except ValueError:
                     continue
                 if rel.as_posix() == name:


### PR DESCRIPTION
## Problem

`_find_skill()`'s categorized-path matching (`category/skill-name`, added for `skill_manage`/`skill_view` resolution parity) resolves every candidate skill's relative path against a **single fixed local skills root**:

```python
def _local_root() -> Path:
    nonlocal _resolved_root
    if _resolved_root is None:
        ...
        _resolved_root = _skills_dir().resolve()
    return _resolved_root

for skills_dir in get_all_skills_dirs():   # local dir + all skills.external_dirs
    ...
    for skill_md in skills_dir.rglob("SKILL.md"):
        ...
        rel = skill_md.parent.resolve().relative_to(_local_root())
```

`get_all_skills_dirs()` returns the local dir **plus every configured `skills.external_dirs` entry**, but `_local_root()` always resolves to the local dir only. `Path.relative_to()` raises `ValueError` for any path outside that root — so a skill actually found under an external directory always hits the `except ValueError: continue` and never matches by its categorized name, even though its bare name still resolves fine via the earlier fast path.

Confirmed empirically before writing the fix (patched `get_all_skills_dirs()` to return `[local_dir, ext_dir]`, wrote a skill under `ext_dir/mlops/axolotl/SKILL.md`):

```
categorized (external dir): None
bare name (external dir): {'path': PosixPath('/tmp/ext_skills_test/mlops/axolotl')}
```

Practical impact: `skill_view()`'s own ambiguity hint explicitly tells the model to retry with the categorized form on a name collision — for any skill actually living under `skills.external_dirs`, every `skill_manage` action that follows that hint (edit/patch/delete/write_file/remove_file) fails with `"not found in active profile"`.

## Fix

Resolve the relative-path root against the loop's own `skills_dir` for whichever directory a given `skill_md` was actually found under, instead of one directory fixed ahead of time. Resolved lazily per directory (only when a categorized lookup is actually being performed, matching the existing lazy-resolution intent) and shared across every `skill_md` found under that one directory — no behavior or performance change for bare-name lookups or local-dir-only setups.

## Verification

```
uv run --frozen python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skills_tool.py -q
```
→ 107 passed.

**Mutation-verify**: stashed the `tools/skill_manager_tool.py` change (kept the tests), re-ran — the two new tests failed cleanly (categorized lookup returned `None`; `skill_manage` returned `"not found in active profile"`), all 63 pre-existing tests in the file still passed unaffected. Restored the fix — all 65 green.

`ruff check` on both touched files: clean.

## Checklist

- [x] Tests added and passing
- [x] Mutation-verified (fix stashed → new tests fail cleanly; restored → all pass)
- [x] `ruff check` clean on touched files
- [x] No behavior change for the local-only / bare-name case