### PR TITLE
fix(tui): hot-apply native compaction threshold as automatic, not 200000

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -276,8 +276,34 @@ def test_removing_codex_native_compaction_restores_false(monkeypatch):
     assert session["agent"].codex_responses_native_compaction is False
 
 
-def test_removing_codex_native_threshold_restores_default(monkeypatch):
+def test_removing_codex_native_threshold_restores_automatic_default(monkeypatch):
+    """Absence must restore agent_init.py's current construction-time
+    default: None, meaning "derive automatically from the local compression
+    trigger" (a2af8405d1) — not the old absolute 200000 this hot-apply path
+    fell back to before that construction-time semantics change ever
+    reached it. codex_responses_compact_threshold's raw value (None vs. an
+    absolute int) is what resolve_compact_threshold() at request time
+    branches on, so restoring the wrong one silently reverts an
+    already-running native-compaction session to a fixed 200000 threshold
+    on every live config reload instead of the intended local-trigger-
+    derived one.
+    """
     session, _ = _neutral_session()
     session["agent"].codex_responses_compact_threshold = 120_000
     _sync_with_cfg(monkeypatch, session, {"compression": {}})
-    assert session["agent"].codex_responses_compact_threshold == 200_000
+    assert session["agent"].codex_responses_compact_threshold is None
+
+
+def test_invalid_codex_native_threshold_falls_back_to_automatic_default(monkeypatch):
+    """Mirrors agent_init.py's invalid-value handling exactly: an
+    unparseable/non-positive/bool/float value must fall back to None
+    (automatic), not the old absolute 200000."""
+    session, _ = _neutral_session()
+    for bad_value in ("garbage", True, -5, 1.5, 0):
+        session["agent"].codex_responses_compact_threshold = 120_000
+        _sync_with_cfg(
+            monkeypatch,
+            session,
+            {"compression": {"codex_responses_compact_threshold": bad_value}},
+        )
+        assert session["agent"].codex_responses_compact_threshold is None, bad_value

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6661,22 +6661,28 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     agent.codex_responses_native_compaction = is_truthy_value(
         compression.get("codex_responses_native", False)
     )
-    native_threshold_raw = compression.get(
-        "codex_responses_compact_threshold", 200_000
-    )
-    try:
-        if isinstance(native_threshold_raw, bool):
-            raise ValueError
-        native_threshold = int(native_threshold_raw)
-        if native_threshold <= 0:
-            raise ValueError
-    except (TypeError, ValueError):
-        logger.warning(
-            "Invalid compression.codex_responses_compact_threshold=%r; "
-            "using 200000.",
-            native_threshold_raw,
-        )
-        native_threshold = 200_000
+    # None/omitted derives automatically from the local compression trigger
+    # at request time (agent_init.py's construction-time default since
+    # a2af8405d1) — this hot-apply path must mirror that derivation, not
+    # fall back to an absolute 200000, or a live config reload silently
+    # reverts an already-running native-compaction session from the
+    # auto-derived threshold back to the old fixed one.
+    native_threshold_raw = compression.get("codex_responses_compact_threshold")
+    native_threshold = None
+    if native_threshold_raw is not None:
+        try:
+            if isinstance(native_threshold_raw, (bool, float)):
+                raise ValueError
+            native_threshold = int(native_threshold_raw)
+            if native_threshold <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid compression.codex_responses_compact_threshold=%r; "
+                "using the automatic threshold derived from local compression.",
+                native_threshold_raw,
+            )
+            native_threshold = None
     agent.codex_responses_compact_threshold = native_threshold
 
     # Absence restores the agent_init/config default (0 = disabled).


### PR DESCRIPTION
## Problem

`_apply_live_compression_config()` (TUI-gateway live config reload, added by #96740) still treats `compression.codex_responses_compact_threshold`'s absence or an invalid value as "fall back to a hardcoded `200000`":

```python
native_threshold_raw = compression.get(
    "codex_responses_compact_threshold", 200_000
)
try:
    ...
    native_threshold = int(native_threshold_raw)
    if native_threshold <= 0:
        raise ValueError
except (TypeError, ValueError):
    logger.warning(..., "using 200000.", ...)
    native_threshold = 200_000
agent.codex_responses_compact_threshold = native_threshold
```

That was `agent_init.py`'s construction-time semantics *before* #98183's precursor, `a2af8405d1` ("derive native threshold from local trigger"), changed the default to `None` — meaning "derive automatically from the local compression trigger with an 8192-token safety margin" — instead of an absolute `200000`. This hot-apply path predates that change in the branch's actual integration order and was never updated to match, even though its own docstring already promises parity:

> "removing a key from config.yaml restores the normalized default — or the model-derived value — on the next turn, **through the same derivation the construction path uses**"

## Impact

`resolve_compact_threshold()` (the function that actually turns this attribute into a request-time threshold) branches on `None` vs. an explicit int — this isn't a cosmetic default mismatch. Confirmed empirically: hot-applying a config with the key omitted (the current documented default) sets `agent.codex_responses_compact_threshold = 200000` instead of `None`. For an already-running native-compaction TUI-gateway session, that means every live config reload silently resets the threshold from the intended auto-derived value (e.g. `756808` for a 765k local trigger) back to a fixed `200000` — a real behavior regression, not just a stale display value.

`gateway/run.py`'s main-gateway path is unaffected: it busts the whole agent cache and rebuilds through `init_agent()` (the already-correct, already-fixed path) rather than mutating a live agent in place. This is TUI-gateway-only.

## Fix

Mirror `agent_init.py`'s exact handling: `None` on omit/invalid, rejecting `bool` **and** `float` the same way (the old code only rejected `bool`).

Also updates the one existing test whose own hardcoded assertion (`codex_responses_compact_threshold == 200000`) predates `a2af8405d1` and encoded the pre-fix behavior as "correct" — its section header already states the intended contract ("restore the normalized default... through the same derivation the construction path uses"), which is `None` post-`a2af8405d1`, not `200000`.

## Note on a nearby open PR

#97632 also touches `_apply_live_compression_config()`, but a different, non-overlapping concern (per-model `context_length` signature resolution for named custom providers, further down in the function). No semantic overlap with this fix.

## Verification

```
uv run --frozen python -m pytest tests/tui_gateway/test_compression_config_hot_reload.py -q
```
→ 19 passed.
```
uv run --frozen python -m pytest tests/tui_gateway/ -k compress -q
```
→ 31 passed.

**Mutation-verify**: stashed `tui_gateway/server.py` (kept the tests), re-ran — the two threshold-specific tests failed cleanly (`200000` instead of `None`, for both the omitted-key and invalid-value cases), all other 17 tests in the file unaffected. Restored the fix — all 19 green.

`ruff check` on both touched files: clean.

## Checklist

- [x] Tests updated (one pre-existing assertion corrected) and a new test added
- [x] Mutation-verified (fix stashed → both threshold tests fail cleanly; restored → all pass)
- [x] `ruff check` clean on touched files
- [x] Explicit valid positive-int values (e.g. `120000`) are unaffected — only the omitted/invalid-value fallback changes