### PR TITLE
test(compression): pin the lease refresher's consecutive-failure give-up

### DIFF
--- a/scratch/repro_97948.py
+++ b/scratch/repro_97948.py
@@ -1,0 +1,297 @@
+"""Four-stage probe for #97948 — "Compression lease lost before publication".
+
+Run: ``python scratch/repro_97948.py`` (no pytest, no network, temp state.db).
+
+Symptom B of the issue: a large-session compression runs for 11+ minutes and
+then aborts at publication with ``Compression lease lost before publication``
+/ ``failure_class: session_split_failed``, rolls back, and the next turn
+re-triggers the same doomed compression.
+
+The lease IS refreshed while the summary streams
+(``_CompressionLockLeaseRefresher`` in agent/conversation_compression.py), so
+the interesting question is how a healthy, still-running compression ends up
+without one.  This probe isolates the give-up rule and its consequence:
+
+  S1  the refresher stops permanently after ttl/interval consecutive failures
+  S2  ownership was still recoverable at that exact moment — the loop simply
+      stopped asking (a direct contradiction of refresh_compression_lock's
+      own documented contract)
+  S3  the consequence at publication, over the SAME row S1 left behind: since
+      #99216 landed, publish_compression_child's final in-transaction refresh
+      lets the rotation through when nobody else claimed the lock — this is a
+      regression guard for that fix, not the original bug pin (S1/S2/S4
+      still describe the refresher-thread defect itself, which #99216 does
+      not touch)
+  S4  the give-up rule is a failure COUNT, and the wall-clock window it
+      produces depends on how long a failing refresh takes to return:
+      240s is the zero-latency FLOOR (the first refresh fires at t=0, so the
+      break-triggering attempt lands (threshold - 1) intervals later), while
+      a fully contended refresh burning SessionDB._WRITE_PATIENCE_S pushes
+      the same five failures out to ~340s — past the 300s TTL, not one
+      interval short of it. Measured on the real loop at both ends. A
+      refresher that keeps asking recovers from the same stall.
+
+Every stage prints PASS/FAIL; the process exits non-zero if any stage fails.
+
+Provenance caveat: FlakyDB returns falsy outcomes directly — it does not
+drive _execute_write, create real SQLite contention, or read production
+refresh telemetry. This probe establishes a reachable candidate mechanism
+for the reported Windows abort, not its proven root cause.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.conversation_compression import _CompressionLockLeaseRefresher  # noqa: E402
+from hermes_state import SessionDB  # noqa: E402
+
+# agent/conversation_compression.py: `_lock_ttl = float(getattr(agent,
+# "_compression_lock_ttl_seconds", 300.0) or 300.0)`, and the refresher
+# derives `interval = max(1.0, min(60.0, ttl / 2.0))`.
+PROD_TTL_S = 300.0
+PROD_INTERVAL_S = 60.0
+
+SESSION = "sess-parent"
+HOLDER = "holder-A"
+
+_failures: list[str] = []
+
+
+def check(stage: str, label: str, ok: bool, detail: str = "") -> None:
+    print(f"  [{'PASS' if ok else 'FAIL'}] {stage} {label}" + (f"  -- {detail}" if detail else ""))
+    if not ok:
+        _failures.append(f"{stage} {label} {detail}".strip())
+
+
+class FlakyDB:
+    """Wraps a real SessionDB and fails the first *n* refresh attempts.
+
+    Models the only thing the refresher can actually observe: a falsy return
+    from ``refresh_compression_lock``.  On the real path that is a write that
+    escaped ``_execute_write``'s retry budget under contention — a state.db on
+    ``journal_mode=DELETE`` while a 1497-message compaction clones rows.
+
+    ``fail_latency_s`` models how long such a call takes to answer: production
+    spends up to ``SessionDB._WRITE_PATIENCE_S`` inside ``_execute_write``
+    before turning an exhausted retry into ``False``, and ``_run()`` starts
+    its interval wait only after that return.  Entry and exit timestamps are
+    both recorded so S4 can measure the schedule instead of assuming the
+    calls are free.
+    """
+
+    def __init__(self, db: SessionDB, fail_first: int, fail_latency_s: float = 0.0):
+        self._db = db
+        self._remaining = fail_first
+        self._fail_latency_s = fail_latency_s
+        self.attempts = 0
+        self.granted = 0
+        self.attempt_times: list[float] = []
+        self.return_times: list[float] = []
+
+    def refresh_compression_lock(self, session_id, holder, ttl_seconds=300.0):
+        self.attempts += 1
+        self.attempt_times.append(time.monotonic())
+        if self._remaining > 0:
+            self._remaining -= 1
+            if self._fail_latency_s:
+                time.sleep(self._fail_latency_s)
+            self.return_times.append(time.monotonic())
+            return False
+        self.granted += 1
+        result = self._db.refresh_compression_lock(
+            session_id, holder, ttl_seconds=ttl_seconds
+        )
+        self.return_times.append(time.monotonic())
+        return result
+
+
+def give_up_threshold(ttl: float, interval: float) -> int:
+    """The refresher's own rule, restated: max(1, int(ttl / interval))."""
+    return max(1, int(ttl / interval))
+
+
+def run_refresher(db, *, fail_first: int, ttl: float, interval: float, ticks: int,
+                   release: bool = True, fail_latency_s: float = 0.0):
+    """Drive a real refresher over a real, genuinely held lock.
+
+    The lock must be acquired first: refresh_compression_lock updates
+    ``compression_locks WHERE session_id = ? AND holder = ?``, so with no
+    row every delegated refresh returns False and the loop breaks for the
+    wrong reason — which would make S4's counterfactual pass vacuously.
+
+    Acquires with the SAME *ttl* the refresher itself uses, not
+    ``PROD_TTL_S``: a caller that keeps the row alive past this call (via
+    ``release=False``) needs it to have actually expired by the time the
+    refresher gave up, not still be sitting on a fresh 300-second lease for
+    another ~299s (review on #98867).
+
+    ``fail_latency_s`` makes each failing refresh take that long to return,
+    the way a contended ``_execute_write`` does; *ticks* then counts whole
+    call-plus-interval cycles rather than bare intervals.
+    """
+    db.try_acquire_compression_lock(SESSION, HOLDER, ttl_seconds=ttl)
+    flaky = FlakyDB(db, fail_first, fail_latency_s=fail_latency_s)
+    r = _CompressionLockLeaseRefresher(flaky, SESSION, HOLDER, ttl, interval).start()
+    try:
+        time.sleep((interval + fail_latency_s) * (ticks + 0.5))
+    finally:
+        r.stop()
+        if release:
+            db.release_compression_lock(SESSION, HOLDER)
+    return flaky
+
+
+def stage_1_refresher_gives_up(db) -> None:
+    print("\nS1  the refresher stops permanently after ttl/interval failures")
+    ttl, interval = 2.0, 0.2          # threshold = 10, same rule as prod
+    threshold = give_up_threshold(ttl, interval)
+    check("S1", "give-up threshold is ttl/interval", threshold == 10, f"{threshold}")
+
+    flaky = run_refresher(db, fail_first=threshold, ttl=ttl, interval=interval, ticks=25)
+    check("S1", "loop stopped at the threshold", flaky.attempts == threshold,
+          f"{flaky.attempts} attempts, then silence for {25 - threshold} more ticks")
+    check("S1", "no refresh was ever granted afterwards", flaky.granted == 0,
+          "the lease is now on its own, counting down to expiry")
+
+
+def stage_2_ownership_was_recoverable(db) -> None:
+    print("\nS2  ownership was still recoverable when the loop quit")
+    # refresh_compression_lock decides ownership by `holder` ALONE, never by
+    # expires_at — its docstring: "a live owner whose refresher thread was
+    # starved ... past its own TTL must be able to revive its still-unclaimed
+    # row on the next tick."
+    db.try_acquire_compression_lock(SESSION, HOLDER, ttl_seconds=0.05)
+    time.sleep(0.2)                                   # lease is now expired
+    revived = db.refresh_compression_lock(SESSION, HOLDER, ttl_seconds=PROD_TTL_S)
+    check("S2", "an expired lease is still revivable by its owner", revived is True,
+          "so the DB contract says 'keep asking'")
+    check("S2", "but the loop guarantees there is no next tick", True,
+          "_run() breaks at the threshold — the two contracts contradict")
+    db.release_compression_lock(SESSION, HOLDER)
+
+
+def stage_3_publication_survives_the_giveup(db) -> None:
+    print("\nS3  consequence at publication, post-#99216")
+    db.create_session(session_id=SESSION, source="desktop", model="m")
+    ttl, interval = 1.0, 0.2
+    threshold = give_up_threshold(ttl, interval)
+    # Drive the real refresher to its real give-up point over the same
+    # TTL/holder/row publication will check, instead of seeding an unrelated
+    # short-lived lease — the mismatch that made this stage vacuous before
+    # #99216 landed (review on #98867).
+    flaky = run_refresher(
+        db, fail_first=threshold, ttl=ttl, interval=interval,
+        ticks=threshold + 5, release=False,
+    )
+    check("S3", "the refresher really gave up", flaky.granted == 0)
+
+    from hermes_state import CompressionSessionBusyError  # local: only needed here
+
+    raised = None
+    try:
+        db.publish_compression_child(
+            parent_session_id=SESSION,
+            child_session_id="sess-child",
+            source="desktop",
+            messages=[{"role": "user", "content": "handoff"}],
+            compression_lock_holder=HOLDER,
+            require_compression_lease=True,
+            require_lease_refresh=True,
+            lease_ttl_seconds=ttl,
+        )
+    except CompressionSessionBusyError as exc:
+        raised = str(exc)
+
+    check("S3", "publication succeeds when nobody stole the lock", raised is None,
+          (raised or "")[:64])
+    check("S3", "the child was published (rotation completes)",
+          db.get_session("sess-child") is not None,
+          "-> #99216's pre-publication refresh gave the give-up one last save")
+    db.release_compression_lock(SESSION, HOLDER)
+
+
+def stage_4_the_window_depends_on_call_latency(db) -> None:
+    print("\nS4  the give-up window is a range, plus the counterfactual")
+    threshold = give_up_threshold(PROD_TTL_S, PROD_INTERVAL_S)
+    check("S4", "production threshold is 5 failures", threshold == 5,
+          f"ttl={PROD_TTL_S:.0f}s interval={PROD_INTERVAL_S:.0f}s")
+
+    # Floor: the first refresh fires at t=0, then one interval passes before
+    # each later attempt, so with refreshes that fail INSTANTLY the
+    # break-triggering (threshold-th) failure lands (threshold - 1) intervals
+    # after the first — not `threshold` intervals (correction from review on
+    # #98867, where the original probe asserted `threshold * interval == TTL`).
+    floor = (threshold - 1) * PROD_INTERVAL_S
+    # Ceiling: refresh_compression_lock runs _execute_write on the routine
+    # _WRITE_PATIENCE_S budget and only then returns False, and _run() waits
+    # its interval after that return. Fully contended attempts START at
+    # 0, 80, 160, 240, 320 and the fifth False comes back ~340s in.
+    patience = SessionDB._WRITE_PATIENCE_S
+    ceiling = (threshold - 1) * (PROD_INTERVAL_S + patience) + patience
+    check("S4", "zero-latency floor is one interval short of the TTL",
+          floor == 240.0 and floor < PROD_TTL_S,
+          f"{floor:.0f}s < {PROD_TTL_S:.0f}s -- the MINIMUM, not the window")
+    check("S4", "exhausted write patience pushes it past the TTL",
+          ceiling == 340.0 and ceiling > PROD_TTL_S,
+          f"{ceiling:.0f}s > {PROD_TTL_S:.0f}s -- a stall clearing at 300s can still recover")
+    check("S4", "a 710s compression outlives the whole range",
+          710.0 > ceiling,
+          "issue log: total_duration_ms=710109, commit_status=aborted "
+          "(reachable, not proven -- no refresh telemetry for that run)")
+
+    # Measured, not restated: the same loop, with failing calls that take one
+    # interval to answer, gives up strictly later than the zero-latency floor.
+    ttl, interval, latency = 1.0, 0.2, 0.2
+    t = give_up_threshold(ttl, interval)
+    flaky = run_refresher(
+        db, fail_first=t, ttl=ttl, interval=interval, ticks=t + 3,
+        fail_latency_s=latency,
+    )
+    span = flaky.return_times[-1] - flaky.attempt_times[0]
+    expected = (t - 1) * (interval + latency) + latency
+    check("S4", "measured window grows with refresh call latency",
+          abs(span - expected) < (interval + latency) * 0.5
+          and span > (t - 1) * interval,
+          f"{span:.2f}s measured vs {expected:.2f}s predicted, "
+          f"floor was {(t - 1) * interval:.2f}s")
+
+    # Counterfactual: the same stall, but the loop keeps asking.
+    ttl, interval = 2.0, 0.2
+    flaky = run_refresher(
+        db, fail_first=give_up_threshold(ttl, interval) - 1,
+        ttl=ttl, interval=interval, ticks=15,
+    )
+    check("S4", "one failure below the threshold recovers fully", flaky.granted > 0,
+          f"{flaky.granted} refreshes granted after the same stall")
+
+
+def main() -> int:
+    # ignore_cleanup_errors: SessionDB holds the SQLite handle open, and
+    # Windows refuses to unlink a mapped file (WinError 32).
+    with tempfile.TemporaryDirectory(
+        prefix="repro97948_", ignore_cleanup_errors=True
+    ) as tmp:
+        db = SessionDB(Path(tmp) / "state.db")
+        stage_1_refresher_gives_up(db)
+        stage_2_ownership_was_recoverable(db)
+        stage_3_publication_survives_the_giveup(db)
+        stage_4_the_window_depends_on_call_latency(db)
+
+    print("\n" + "=" * 62)
+    if _failures:
+        print(f"{len(_failures)} FAILED:")
+        for f in _failures:
+            print(f"  - {f}")
+        return 1
+    print("all four stages PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_compression_lease_giveup.py
+++ b/tests/agent/test_compression_lease_giveup.py
@@ -1,0 +1,405 @@
+"""The compression lease refresher gives up on a failure COUNT (#97948).
+
+Symptom B of #97948: a large-session compression runs for 11+ minutes and then
+aborts at publication with ``Compression lease lost before publication`` /
+``failure_class: session_split_failed``, rolls back, and the next turn
+re-triggers the same work.
+
+The lease IS refreshed while the summary streams, so these controls pin how a
+still-running compression ends up without one: ``_CompressionLockLeaseRefresher
+._run`` (``agent/conversation_compression.py:2271``) breaks permanently after
+``max(1, int(ttl / interval))`` consecutive falsy refreshes -- 5 on production
+values. The durable hazard is that COUNT, not any particular wall clock: the
+loop never consults ``expires_at`` or elapsed time.
+
+The wall-clock give-up window is therefore not a constant, because ``_run()``
+starts waiting its interval only AFTER each refresh call returns:
+
+* **Zero-latency floor.** With refreshes that fail instantly, attempts land at
+  ``t = 0, 60, 120, 180, 240``; the break-triggering 5th failure is at
+  ``(threshold - 1) * interval = 240s``, one interval short of the 300s TTL.
+  This is the minimum, and it is what ``TestGiveUpTiming``'s first case
+  measures on the real loop.
+* **Contended ceiling.** ``SessionDB.refresh_compression_lock``
+  (``hermes_state.py:7821``) runs ``_execute_write(_do)`` on the routine
+  ``_WRITE_PATIENCE_S = 20.0`` budget (``hermes_state.py:4426``) and converts
+  an exhausted retry into ``False``, so a fully contended attempt burns that
+  whole budget before returning. Attempts then start at ``0, 80, 160, 240,
+  320`` and the 5th ``False`` returns around **340s** -- past the TTL, not
+  short of it.
+
+So neither "the window is 240s" nor "write contention shorter than the TTL is
+fatal" is established here: the window is
+``(threshold - 1) * (interval + call_latency) + call_latency``, and
+``TestGiveUpTiming`` measures both ends of that range on the real thread
+rather than restating a formula. (Both framings are corrections from review
+on #98867; the first version of this file asserted
+``threshold * interval == TTL``.)
+
+What survives independent of latency is the contradiction with
+``SessionDB.refresh_compression_lock``, which decides ownership by the
+``holder`` column alone precisely so a starved owner can revive its
+still-unclaimed row "on the next tick" -- the loop guarantees there is no
+next tick.
+
+Provenance caveat: ``FlakyDB`` returns falsy outcomes directly. It does not
+drive ``_execute_write``, create real SQLite contention, or record production
+refresh telemetry, so nothing here proves the reported Windows attempt
+actually experienced five consecutive refresh failures. This is a reachable
+candidate mechanism for that report, not its established root cause.
+
+#99216 has since landed the production repair: ``publish_compression_child``
+now takes one final in-transaction lease refresh (``WHERE session_id AND
+holder``, same conn as the expiry check) immediately before publication, so a
+refresher that gave up but whose row nobody else claimed still lets the
+rotation through. This file is diagnostic/provenance evidence for that fix,
+not an independent settlement: ``TestGiveUpWindow`` / ``TestGiveUpTiming`` /
+``TestRefresherStopsPermanently`` / ``TestOwnershipStaysRecoverable`` still
+pin the refresher-thread defect itself (#99216 does not touch
+``_CompressionLockLeaseRefresher._run``), while
+``TestPublicationAfterRefresherGivesUp`` is the regression guard for the
+merged fix -- it drives the real refresher to its real give-up point and
+then asserts publication now SUCCEEDS when nobody stole the lock,
+complementing the wrong-holder adversarial cases already covered by
+#99216's own ``tests/state/test_compression_lease_refresh_before_publish.py``.
+"""
+
+import time
+
+import pytest
+
+from agent.conversation_compression import _CompressionLockLeaseRefresher
+from hermes_state import CompressionSessionBusyError, SessionDB
+
+# agent/conversation_compression.py:3018 —
+# `_lock_ttl = float(getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0)`
+PROD_TTL_S = 300.0
+# _CompressionLockLeaseRefresher.__init__: max(1.0, min(60.0, ttl / 2.0))
+PROD_INTERVAL_S = 60.0
+
+SESSION = "sess-parent"
+HOLDER = "holder-A"
+
+# Compressed timescale with the same threshold arithmetic as production
+# (ttl / interval == 5 either way); keeps the suite around ten seconds.
+# INTERVAL_S must stay >= the constructor's 0.1 floor, or the clamp
+# silently changes the threshold this file is about. 0.2s (rather than the
+# original 0.1s) leaves the off-by-one timing assertions in TestGiveUpTiming
+# a full interval's margin against scheduling jitter.
+TTL_S = 1.0
+INTERVAL_S = 0.2
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(tmp_path / "state.db")
+    try:
+        yield d
+    finally:
+        d.close()
+
+
+class FlakyDB:
+    """Fails the first *n* refreshes, then delegates to the real SessionDB.
+
+    A falsy return is the only thing the refresher can observe, and on the
+    real path it covers both a genuinely lost row and a write that escaped
+    ``_execute_write``'s retry budget under contention.  That ambiguity is the
+    defect these tests describe.
+
+    ``fail_latency_s`` models how long a failing call takes to return.  It is
+    the difference between the two ends of the give-up range: production's
+    ``refresh_compression_lock`` spends up to ``_WRITE_PATIENCE_S`` inside
+    ``_execute_write`` before converting an exhausted retry into ``False``,
+    and ``_run()`` starts its interval wait only after that return.  Both
+    ``attempt_times`` (entry) and ``return_times`` (exit) are recorded so a
+    test can measure the schedule instead of assuming instant calls.
+    """
+
+    def __init__(self, real, fail_first, fail_latency_s=0.0):
+        self._real = real
+        self._remaining = fail_first
+        self._fail_latency_s = fail_latency_s
+        self.attempts = 0
+        self.granted = 0
+        self.attempt_times: list = []
+        self.return_times: list = []
+
+    def refresh_compression_lock(self, session_id, holder, ttl_seconds=PROD_TTL_S):
+        self.attempts += 1
+        self.attempt_times.append(time.monotonic())
+        if self._remaining > 0:
+            self._remaining -= 1
+            if self._fail_latency_s:
+                time.sleep(self._fail_latency_s)
+            self.return_times.append(time.monotonic())
+            return False
+        self.granted += 1
+        result = self._real.refresh_compression_lock(
+            session_id, holder, ttl_seconds=ttl_seconds
+        )
+        self.return_times.append(time.monotonic())
+        return result
+
+
+def _threshold(ttl, interval):
+    """The refresher's own give-up rule, restated — including the clamps.
+
+    ``__init__`` floors the interval at 0.1s before deriving
+    ``_max_consecutive_failures``, so a test that passes a smaller one
+    would be measuring a different threshold than it declares.
+    """
+    return max(1, int(ttl / max(0.1, interval)))
+
+
+def _drive(real_db, *, fail_first, ticks, release=True, fail_latency_s=0.0):
+    """Run a real refresher over a real, genuinely held lock.
+
+    The lock MUST be acquired first: ``refresh_compression_lock`` updates
+    ``compression_locks WHERE session_id = ? AND holder = ?``, so without a
+    row every delegated refresh returns False and the loop would break for
+    the wrong reason — making the counterfactual below pass vacuously.
+
+    Acquires with the SAME ``TTL_S`` the refresher itself uses, not
+    ``PROD_TTL_S``: a caller that keeps the row alive past this call (via
+    ``release=False``) needs it to have actually expired by the time the
+    refresher gave up, not still be sitting on a fresh 300-second lease for
+    another ~299s — the mismatch that made the old publication tests never
+    reproduce "refresher stops -> lease expires -> publication rejects"
+    (review on #98867).
+
+    ``fail_latency_s`` makes each failing refresh take that long to return,
+    the way a contended ``_execute_write`` does; ``ticks`` then counts whole
+    call-plus-interval cycles rather than bare intervals.
+    """
+    assert real_db.try_acquire_compression_lock(
+        SESSION, HOLDER, ttl_seconds=TTL_S
+    )
+    flaky = FlakyDB(real_db, fail_first, fail_latency_s=fail_latency_s)
+    refresher = _CompressionLockLeaseRefresher(
+        flaky, SESSION, HOLDER, TTL_S, INTERVAL_S
+    ).start()
+    try:
+        time.sleep((INTERVAL_S + fail_latency_s) * (ticks + 0.5))
+    finally:
+        refresher.stop()
+        if release:
+            real_db.release_compression_lock(SESSION, HOLDER)
+    return flaky
+
+
+class TestGiveUpWindow:
+    """The give-up rule, on the values production actually uses.
+
+    The rule itself is a failure COUNT. These cases bound the wall-clock
+    window that count produces; ``TestGiveUpTiming`` then measures both
+    bounds on the real loop rather than leaving them as arithmetic.
+    """
+
+    def test_production_threshold_is_five_failures(self):
+        assert _threshold(PROD_TTL_S, PROD_INTERVAL_S) == 5
+
+    def test_the_zero_latency_window_is_one_interval_short_of_the_ttl(self):
+        """Lower bound: five instant failures, four intervals apart = 240s.
+
+        The first refresh fires at t=0; the loop waits one interval before
+        each subsequent attempt, so with refreshes that fail immediately the
+        5th (break-triggering) failure lands at ``(5 - 1) * 60s = 240s``.
+        That is the FLOOR of the give-up window, reached only when refresh
+        calls cost nothing — not the window a contended production refresh
+        actually experiences (see the next case).
+        """
+        threshold = _threshold(PROD_TTL_S, PROD_INTERVAL_S)
+        window = (threshold - 1) * PROD_INTERVAL_S
+        assert window == 240.0
+        assert window < PROD_TTL_S
+
+    def test_exhausted_write_patience_pushes_the_window_past_the_ttl(self):
+        """Upper bound: failing calls are not free.
+
+        ``refresh_compression_lock`` runs ``_execute_write(_do)`` on the
+        routine ``_WRITE_PATIENCE_S`` budget and converts an exhausted retry
+        into ``False``, and ``_run()`` starts its interval wait only after
+        that return. Fully contended attempts therefore START at
+        ``0, 80, 160, 240, 320`` and the 5th ``False`` comes back around
+        340s — PAST the 300s TTL. A stall that clears before then can still
+        be caught by the 5th attempt and recover, so "write contention
+        shorter than the TTL is fatal" does not follow from this code.
+        """
+        threshold = _threshold(PROD_TTL_S, PROD_INTERVAL_S)
+        patience = SessionDB._WRITE_PATIENCE_S
+        window = (threshold - 1) * (PROD_INTERVAL_S + patience) + patience
+        assert window == 340.0
+        assert window > PROD_TTL_S
+
+    def test_a_long_compression_outlives_even_the_contended_window(self):
+        """The aborted attempt in the report ran 710s (total_duration_ms).
+
+        That is long enough to contain the give-up window at either end of
+        the range, which is what makes this mechanism reachable for that
+        report. It does NOT show the reported attempt's refreshes actually
+        failed — no refresh-outcome telemetry exists for that run.
+        """
+        threshold = _threshold(PROD_TTL_S, PROD_INTERVAL_S)
+        contended = (threshold - 1) * (
+            PROD_INTERVAL_S + SessionDB._WRITE_PATIENCE_S
+        ) + SessionDB._WRITE_PATIENCE_S
+        assert 710.0 > contended > (threshold - 1) * PROD_INTERVAL_S
+
+
+class TestGiveUpTiming:
+    """Drives the real loop and measures when it actually gives up, instead
+    of trusting the restated formula in ``TestGiveUpWindow`` (review on
+    #98867: the first version of this file asserted
+    ``threshold * interval``, but ``_run()`` waits an interval AFTER each
+    refresh, so with instant refreshes the break-triggering attempt lands
+    one interval earlier — and with slow ones, later).
+    """
+
+    def test_instant_failures_give_up_one_interval_early(self, db):
+        """The floor: refresh calls that cost nothing."""
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        flaky = _drive(db, fail_first=threshold, ticks=threshold + 3)
+        assert len(flaky.attempt_times) == threshold
+        elapsed = flaky.attempt_times[-1] - flaky.attempt_times[0]
+        # threading.Event.wait() timing has real jitter; the assertion only
+        # needs to distinguish (threshold - 1) intervals from threshold — a
+        # full INTERVAL_S apart.
+        assert elapsed == pytest.approx(
+            (threshold - 1) * INTERVAL_S, abs=INTERVAL_S * 0.5
+        )
+        assert elapsed < threshold * INTERVAL_S - INTERVAL_S * 0.25
+
+    def test_the_window_grows_with_refresh_call_latency(self, db):
+        """The controlled-latency witness: 240s is a floor, not the window.
+
+        Each failing refresh is made to take one interval to return, the way
+        a contended ``_execute_write`` burns its patience budget before
+        answering ``False``. The measured give-up point moves to
+        ``(threshold - 1) * (interval + latency) + latency`` — strictly past
+        the zero-latency floor the previous case measures, which is exactly
+        why the production window cannot be quoted as 240s.
+        """
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        latency = INTERVAL_S
+        flaky = _drive(
+            db, fail_first=threshold, ticks=threshold + 3, fail_latency_s=latency
+        )
+        assert len(flaky.attempt_times) == threshold
+        # Entry of the first attempt to RETURN of the break-triggering one:
+        # the loop dies when that last call answers, not when it starts.
+        span = flaky.return_times[-1] - flaky.attempt_times[0]
+        expected = (threshold - 1) * (INTERVAL_S + latency) + latency
+        assert span == pytest.approx(expected, abs=(INTERVAL_S + latency) * 0.5)
+        assert span > (threshold - 1) * INTERVAL_S
+
+
+class TestRefresherStopsPermanently:
+    def test_loop_exits_at_the_threshold(self, db):
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        flaky = _drive(db, fail_first=threshold, ticks=threshold * 2)
+        assert flaky.attempts == threshold
+
+    def test_no_refresh_is_granted_after_the_threshold(self, db):
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        flaky = _drive(db, fail_first=threshold, ticks=threshold * 2)
+        assert flaky.granted == 0
+
+    def test_one_failure_below_the_threshold_recovers(self, db):
+        """Isolates the give-up rule: the same stall, one failure shorter."""
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        flaky = _drive(db, fail_first=threshold - 1, ticks=threshold + 5)
+        assert flaky.granted > 0
+        assert flaky.attempts > threshold
+
+
+class TestOwnershipStaysRecoverable:
+    """The DB contract the loop stops honouring."""
+
+    def test_an_expired_lease_is_still_revivable_by_its_owner(self, db):
+        assert db.try_acquire_compression_lock(SESSION, HOLDER, ttl_seconds=0.05)
+        time.sleep(0.2)
+        assert db.refresh_compression_lock(
+            SESSION, HOLDER, ttl_seconds=PROD_TTL_S
+        ) is True
+        db.release_compression_lock(SESSION, HOLDER)
+
+    def test_a_reclaimed_lease_is_not_revivable(self, db):
+        """The give-up rule's legitimate case: ownership genuinely changed."""
+        assert db.try_acquire_compression_lock(SESSION, HOLDER, ttl_seconds=0.05)
+        time.sleep(0.2)
+        assert db.try_acquire_compression_lock(SESSION, "holder-B", ttl_seconds=60.0)
+        assert db.refresh_compression_lock(SESSION, HOLDER) is False
+        db.release_compression_lock(SESSION, "holder-B")
+
+
+class TestPublicationAfterRefresherGivesUp:
+    """Regression guard for #99216, not the original bug pin.
+
+    #99216's own ``tests/state/test_compression_lease_refresh_before_publish
+    .py`` seeds the lock row directly and covers the wrong-holder/adversarial
+    side of the pre-publication refresh. This drives the REAL
+    ``_CompressionLockLeaseRefresher`` thread through its real give-up timing
+    first, over the same TTL/holder/row that publication then checks, so the
+    row under test is the one an actual give-up event would leave behind.
+    """
+
+    def test_publish_succeeds_when_nobody_stole_the_lock(self, db):
+        db.create_session(session_id=SESSION, source="desktop", model="m")
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        flaky = _drive(db, fail_first=threshold, ticks=threshold + 5, release=False)
+        assert flaky.granted == 0  # the refresher really did give up
+        # _drive already slept past TTL_S with no successful refresh, so the
+        # un-refreshed lease has genuinely expired by now.
+
+        db.publish_compression_child(
+            parent_session_id=SESSION,
+            child_session_id="sess-child",
+            source="desktop",
+            messages=[{"role": "user", "content": "handoff"}],
+            compression_lock_holder=HOLDER,
+            require_compression_lease=True,
+            require_lease_refresh=True,
+            lease_ttl_seconds=TTL_S,
+        )
+        assert db.get_session("sess-child") is not None
+        assert db.get_session(SESSION)["ended_at"] is not None
+        db.release_compression_lock(SESSION, HOLDER)
+
+    def test_publish_still_refuses_when_another_holder_won_the_row(self, db):
+        """The give-up rule's legitimate case, still refused post-#99216:
+        the row was genuinely reclaimed, not merely left un-refreshed."""
+        db.create_session(session_id=SESSION, source="desktop", model="m")
+        threshold = _threshold(TTL_S, INTERVAL_S)
+        _drive(db, fail_first=threshold, ticks=threshold + 5, release=False)
+        assert db.try_acquire_compression_lock(SESSION, "holder-B", ttl_seconds=60.0)
+
+        with pytest.raises(CompressionSessionBusyError, match="lease lost"):
+            db.publish_compression_child(
+                parent_session_id=SESSION,
+                child_session_id="sess-child",
+                source="desktop",
+                messages=[{"role": "user", "content": "handoff"}],
+                compression_lock_holder=HOLDER,
+                require_compression_lease=True,
+                require_lease_refresh=True,
+                lease_ttl_seconds=TTL_S,
+            )
+        assert db.get_session("sess-child") is None
+        assert db.get_session(SESSION)["ended_at"] is None
+        db.release_compression_lock(SESSION, "holder-B")
+
+    def test_a_live_lease_publishes_normally(self, db):
+        """Negative control: the check is about the lease, nothing else."""
+        db.create_session(session_id=SESSION, source="desktop", model="m")
+        assert db.try_acquire_compression_lock(SESSION, HOLDER, ttl_seconds=PROD_TTL_S)
+        db.publish_compression_child(
+            parent_session_id=SESSION,
+            child_session_id="sess-child",
+            source="desktop",
+            messages=[{"role": "user", "content": "handoff"}],
+            compression_lock_holder=HOLDER,
+            require_compression_lease=True,
+        )
+        assert db.get_session("sess-child") is not None
+        db.release_compression_lock(SESSION, HOLDER)


### PR DESCRIPTION
## Summary

Executable controls for **symptom B** of #97948 — the `Compression lease lost before publication` / `failure_class: session_split_failed` abort that rolls a large-session rotation back and leaves the next turn to re-trigger the same work.

Tests only; no production file is touched. #99216 has already landed the production repair, so this branch is **diagnostic/provenance evidence interlocked to that fix, plus a regression guard for it** — not an independent or competing settlement. See **Scope**.

> **Update (this revision):** Squashed to one commit and reframed per the exact-head review. The give-up rule is a failure **count**; the wall-clock window it produces is a **range** bounded by refresh-call latency, and `TestGiveUpTiming` now measures both ends on the real thread. The earlier flat "240s / a stall shorter than the TTL is fatal" framing is withdrawn from the title, body, docstrings and probe stage S4.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Compression Acquires Lease<br/>ttl = 300s] --> B[⚡ Lease Refresher Thread<br/>interval = 60s, first tick at t=0]
    B --> C{🧬 Refresh Returned True?}
    C -->|yes| D[♻️ Reset Failure Counter]
    D --> B
    C -->|no| E[⌛ consecutive_failures += 1]
    E --> F{🔻 failures >= ttl / interval = 5}
    F -->|no| B
    F -->|yes| G[⛓️ break — Loop Dies Forever<br/>THE RULE IS A COUNT, NOT A CLOCK]

    G --> T1[📉 Zero-Latency Floor<br/>attempts at 0,60,120,180,240<br/>give-up at 240s — one interval under TTL]
    G --> T2[📈 Contended Ceiling<br/>each False burns _WRITE_PATIENCE_S = 20s<br/>attempts at 0,80,160,240,320<br/>5th False returns ~340s — PAST the TTL]

    T1 --> H[🕳️ Lease Left Untended]
    T2 --> H
    H --> I[🛰️ publish_compression_child<br/>in-transaction pre-publication refresh<br/>#99216, merged]
    I --> N{🔑 Row Still Holder's?}
    N -->|yes: nobody stole it| O[✅ Refresh Succeeds In-Transaction<br/>Rotation Publishes — #99216's fix]
    N -->|no: genuinely reclaimed| J[⛔ CompressionSessionBusyError<br/>Compression lease lost before publication]
    J --> K[🌑 Rotation Rolled Back<br/>session_split_failed]
    K --> L[🔁 Next Turn Repeats<br/>the same doomed compression]

    M[📡 refresh_compression_lock contract<br/>ownership by holder column ALONE<br/>a starved owner MUST revive<br/>on the next tick] -.->|row is still revivable<br/>the loop stopped asking| G
```

## Mechanism

`_CompressionLockLeaseRefresher` (`agent/conversation_compression.py:2271`) keeps the durable lock alive while the summary streams, so a healthy 11-minute compression should never reach publication without a lease. `_run()` stops permanently after `_max_consecutive_failures = max(1, int(ttl / interval))` consecutive falsy refreshes:

```python
consecutive_failures += 1
if consecutive_failures >= self._max_consecutive_failures:
    break
```

Production values — `_lock_ttl = 300.0` (`conversation_compression.py:3332`) and the derived `interval = max(1.0, min(60.0, ttl / 2.0)) = 60.0` — give a threshold of **5**.

**The durable hazard is that count, not any particular wall clock.** The loop never consults `expires_at` or elapsed time; five consecutive falsy outcomes stop renewal permanently, whenever they happen.

### The wall-clock window is a range

`_run()` starts waiting its interval only *after* each refresh call returns, so the give-up window is `(threshold - 1) * (interval + call_latency) + call_latency`:

| End of the range | Attempt schedule | Give-up at |
| --- | --- | --- |
| **Zero-latency floor** — refreshes that fail instantly | `0, 60, 120, 180, 240` | **240s**, one interval *under* the 300s TTL |
| **Contended ceiling** — `refresh_compression_lock` runs `_execute_write(_do)` on the routine `_WRITE_PATIENCE_S = 20.0` budget (`hermes_state.py:4426`) and converts an exhausted retry into `False` | starts at `0, 80, 160, 240, 320` | **~340s**, *past* the TTL |

Two claims are therefore **withdrawn** from earlier revisions of this PR, per review:

- ~~"the refresher gives up one interval before the TTL"~~ — 240s is the *minimum*, reached only when refresh calls cost nothing.
- ~~"write contention shorter than the TTL is fatal"~~ — a stall that clears at 300s can still be caught by the 5th attempt and recover.

`TestGiveUpTiming` measures both ends on the real thread — a controlled call-latency witness, not a restated formula.

## Why this is a defect, not a policy

`SessionDB.refresh_compression_lock` (`hermes_state.py:7821`) decides ownership by the `holder` column **alone**, never by `expires_at`, and says why in its own docstring:

> a live owner whose refresher thread was starved (GC pause, loaded CI runner, a slow write escaping `_execute_write`'s retry budget) past its own TTL **must be able to revive its still-unclaimed row on the next tick**. Requiring `expires_at >= now` here made such a stall permanent

The row stays revivable. The loop guarantees there is no next tick. `refresh_compression_lock` returns `False` for a genuinely reclaimed row *and* for a transient write failure, and the loop cannot tell them apart — that ambiguity is the whole defect, and it holds at either end of the timing range.

## Provenance scope

`FlakyDB` returns falsy outcomes directly. It does **not** drive `SessionDB._execute_write`, create real SQLite contention, or read production refresh telemetry, so nothing here proves the reported Windows attempt actually experienced five consecutive refresh failures. Its `total_duration_ms: 710109` shows only that the run outlived the whole window range.

This is a **reachable candidate mechanism** for that report, not its established root cause, and it is framed that way in the module docstring, the affected test docstrings, and the probe's S4 output.

## What the controls pin

`tests/agent/test_compression_lease_giveup.py` — **14 passed**, ~13s.

| Class | Asserts |
| --- | --- |
| `TestGiveUpWindow` | the threshold is 5 on production values; the zero-latency floor (240s, under the TTL) and the contended ceiling (340s, over it) bound the window from either side |
| `TestGiveUpTiming` | drives the real loop and measures it — both the instant-failure schedule and, with injected call latency, how the give-up point moves past that floor |
| `TestRefresherStopsPermanently` | the loop exits at the threshold, grants nothing afterwards, and — the counterfactual — recovers fully with one fewer consecutive failure |
| `TestOwnershipStaysRecoverable` | an expired lease is still revivable by its owner, **and** a genuinely reclaimed one is correctly refused (the give-up rule's legitimate case) |
| `TestPublicationAfterRefresherGivesUp` | drives the real refresher to its real give-up point over one TTL/holder/row, then asserts `publish_compression_child(..., require_lease_refresh=True)` now **succeeds** when nobody stole the lock (regression guard for #99216), and still refuses when a different holder genuinely won the row |

`TestGiveUpWindow` / `TestGiveUpTiming` / `TestRefresherStopsPermanently` / `TestOwnershipStaysRecoverable` pin the refresher-thread defect itself — #99216 never touches `_CompressionLockLeaseRefresher._run`. `TestPublicationAfterRefresherGivesUp` is the piece that guards the fix.

`scratch/repro_97948.py` is the same walk as a standalone 4-stage probe (`python scratch/repro_97948.py`) for anyone who wants it without pytest; S4 now prints both bounds and the measured latency-dependent window.

## Two harness defects found while writing this

Both are in the test harness, not in Hermes, and both are fixed here — recording them because either one silently weakens the evidence:

1. `__init__` floors `refresh_interval_seconds` at `0.1s` *before* deriving `_max_consecutive_failures`, so a test that passes a smaller interval measures a different threshold than the one it declares.
2. The driver originally never acquired the lock with the SAME TTL the refresher used, so a row that outlived a give-up event by ~299s never actually reached the "expired" state publication needed to check. Both `_drive()` and `run_refresher()` now acquire with the refresher's own TTL, and accept `release=False` so a caller can carry the exact row a give-up event left behind through to `publish_compression_child`.

## Scope

`Refs #97948`, not `Closes`. This covers symptom B's lease loss only.

- **Symptom A** (manual `/compress` reports a 120s timeout while the background worker succeeds minutes later) is a separate defect; @andrexibiza already traced it to the hard-coded budgets in `apps/desktop/.../slash.ts` and `tui_gateway/methods_session.py`. #97948 stays open for it.
- **The repair landed in #99216**, which this branch is stacked on. #99216 owns the production settlement: `publish_compression_child` takes one final in-transaction lease refresh (`WHERE session_id AND holder`, same conn as the expiry check) immediately before publication. This PR is diagnostic/provenance evidence plus a regression guard for that fix — see `TestPublicationAfterRefresherGivesUp`, complementary to #99216's own wrong-holder unit tests in `tests/state/test_compression_lease_refresh_before_publish.py`, since it exercises the real background-thread timing those row-seeded tests don't.

## Test plan

- [x] `tests/agent/test_compression_lease_giveup.py` — 14 passed
- [x] `python scratch/repro_97948.py` — all four stages PASS
- [x] `ruff check` — clean
- [x] No production file modified (`git diff --stat` against the merge-base is two test/scratch files)
- [x] Branch squashed to a single commit whose message carries the corrected timing and provenance framing — CI / Docker / Nix run on that exact head
