### PR TITLE
fix(security): fold single-segment POSIX homes so /root writes are flagged

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -492,6 +492,77 @@ class TestSensitiveInPlaceEditPattern:
         assert key is None
 
 
+class TestSingleSegmentHomeFolding:
+    """A single-segment POSIX home (``/root``) must fold to ``~/`` too.
+
+    Regression #84639: ``_home_prefix_fold_regex`` required at least two path
+    components below the root, so ``/home/alice`` folded but ``/root`` did not.
+    Running as root, absolute-path writes to sensitive files were therefore
+    never matched by the ``~``-anchored patterns while the ``~`` and ``$HOME``
+    spellings were caught — a persistence bypass (plant an SSH key, append to
+    a shell rc) with no approval prompt. Measured before the fix: the absolute
+    form was flagged 0/3 where the tilde form was flagged 3/3.
+
+    A filesystem or drive root must still be refused, otherwise folding would
+    rewrite every absolute path in the command.
+    """
+
+    def test_root_home_absolute_sensitive_writes_are_flagged(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/root")
+        for cmd in (
+            "echo ssh-rsa AAAAB3 attacker >> /root/.ssh/authorized_keys",
+            "echo key | tee -a /root/.ssh/authorized_keys",
+            "cp /tmp/evil /root/.ssh/id_rsa",
+            "echo x >> /root/.netrc",
+            "echo evil >> /root/.bashrc",
+            "echo evil >> /root/.profile",
+        ):
+            dangerous, key, _ = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert key is not None, cmd
+
+    def test_root_home_matches_tilde_verdict(self, monkeypatch):
+        """The absolute and tilde spellings must agree, which is the invariant
+        the fold exists to provide."""
+        monkeypatch.setenv("HOME", "/root")
+        pairs = [
+            ("echo k >> /root/.ssh/authorized_keys", "echo k >> ~/.ssh/authorized_keys"),
+            ("cp /tmp/evil /root/.ssh/id_rsa", "cp /tmp/evil ~/.ssh/id_rsa"),
+            ("echo evil >> /root/.bashrc", "echo evil >> ~/.bashrc"),
+        ]
+        for absolute, tilde in pairs:
+            assert (
+                detect_dangerous_command(absolute)[0]
+                is detect_dangerous_command(tilde)[0]
+            ), absolute
+
+    def test_ordinary_root_home_paths_stay_unflagged(self, monkeypatch):
+        """Folding must not turn routine work under /root into a prompt."""
+        monkeypatch.setenv("HOME", "/root")
+        for cmd in (
+            "cat /root/notes.txt",
+            "cp report.txt /root/reports/out.txt",
+            "git -C /root/repo status",
+            "echo hi > /root/tmp.log",
+        ):
+            dangerous, key, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+            assert key is None, cmd
+
+    def test_degenerate_roots_are_still_refused(self):
+        """``/``, a bare drive root, and a bare UNC root must not fold."""
+        from tools.approval import _home_prefix_fold_regex
+
+        for degenerate in ("", "/", "//", "C:\\", "C:/", "\\\\server", "/C:"):
+            assert _home_prefix_fold_regex(degenerate) is None, degenerate
+
+    def test_real_homes_still_fold(self):
+        from tools.approval import _home_prefix_fold_regex
+
+        for real in ("/root", "/home/alice", "/Users/alice", "C:\\Users\\alice"):
+            assert _home_prefix_fold_regex(real) is not None, real
+
+
 class TestWindowsAbsolutePathFolding:
     """Windows absolute home / Hermes-home prefixes must fold to ~/ and
     ~/.hermes/ in dangerous-command detection.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1386,6 +1386,25 @@ _PATH_TOKEN_STOP = r"""\s'"`;|&<>()"""
 _PATH_TAIL = r"(?P<tail>(?:[/\\][^/\\" + _PATH_TOKEN_STOP + r"]*)+)"
 
 
+def _is_posix_absolute_home(path: str) -> bool:
+    """True for a single-segment POSIX absolute home such as ``/root``.
+
+    Distinguishes a one-component path that names a real directory from a
+    filesystem or drive root that merely looks like one. Only the
+    single-segment case needs this: multi-component paths already satisfy the
+    ordinary component count in :func:`_home_prefix_fold_regex`.
+
+    Refused: ``/`` (the filesystem root), ``//`` and ``//host`` (POSIX's
+    implementation-defined namespace, and the Windows UNC spelling), ``C:\\``
+    and ``C:/`` (drive roots, which have no leading separator), and ``/C:``
+    (a drive-letter spelling under a separator).
+    """
+    if not path.startswith("/") or path.startswith("//"):
+        return False
+    segment = path.strip("/")
+    return bool(segment) and "/" not in segment and ":" not in segment
+
+
 @functools.lru_cache(maxsize=64)
 def _home_prefix_fold_regex(path: str):
     """Compile a regex matching *path* used as an absolute directory prefix.
@@ -1398,19 +1417,24 @@ def _home_prefix_fold_regex(path: str):
     patterns (``~/.ssh/authorized_keys``) still match. The trailing tail is
     required (``+``), so a bare home with no path under it is not folded.
 
-    Returns ``None`` for an unset or degenerate path — one with fewer than two
-    components below the root — so a stray HOME / HERMES_HOME such as ``/``,
-    ``C:\\`` or ``""`` cannot rewrite unrelated filesystem prefixes. Cached
-    because the resolved home is stable across calls on this hot path.
+    Returns ``None`` for an unset or degenerate path — one with no component
+    below the root, or a bare Windows drive/UNC root — so a stray HOME /
+    HERMES_HOME such as ``/``, ``C:\\`` or ``""`` cannot rewrite unrelated
+    filesystem prefixes. A single-segment POSIX home such as ``/root`` IS
+    folded: it names a real directory, not a filesystem root, and refusing it
+    left absolute-path writes to ``/root/.ssh/authorized_keys`` unmatched by the
+    ``~/.ssh``-anchored patterns while the ``~`` and ``$HOME`` spellings were
+    caught (#84639 — a persistence bypass whenever Hermes runs as root).
+    Cached because the resolved home is stable across calls on this hot path.
     """
     if not path:
         return None
     components = [c for c in re.split(r"[/\\]+", path) if c]
-    # Require at least two non-empty components below the root. For POSIX this
-    # mirrors the historical ``count("/") >= 2`` guard (``/home/alice`` folds,
-    # ``/home`` does not); for Windows it rejects a bare drive root (``C:\\``)
-    # while accepting a real home (``C:\\Users\\alice``).
-    if len(components) < 2:
+    if len(components) < 2 and not _is_posix_absolute_home(path):
+        # No component at all ("/"), or one component that is still a root
+        # rather than a directory (``C:\``, ``\\server``). Folding either would
+        # rewrite every absolute path in the command. A POSIX ``/root``-style
+        # home has one component but IS a directory, so it falls through.
         return None
     body = r"[/\\]+".join(re.escape(c) for c in components)
     # Optional leading root separator (POSIX ``/`` or UNC ``\\``); a Windows


### PR DESCRIPTION
## What does this PR do?

Fixes #84639.

`_home_prefix_fold_regex` required at least two path components below the root, so `/home/alice` folded to `~/` but `/root` did not. Detection folds absolute home paths *before* pattern matching precisely so the `~`-anchored sensitive-path patterns also catch absolute spellings. Without the fold, running as root left absolute-path writes unmatched while the `~` and `$HOME` spellings were caught.

Measured with `HOME=/root` on unmodified `main` — absolute flagged **0/3**, tilde **3/3**:

| Command | `dangerous` |
|---|---|
| `echo ssh-rsa ... >> /root/.ssh/authorized_keys` | **False** |
| `echo ssh-rsa ... >> ~/.ssh/authorized_keys` | True |
| `echo key \| tee -a /root/.ssh/authorized_keys` | **False** |
| `echo key \| tee -a ~/.ssh/authorized_keys` | True |
| `cp /tmp/evil /root/.ssh/authorized_keys` | **False** |
| `cp /tmp/evil ~/.ssh/authorized_keys` | True |

**The scope is wider than SSH.** Sweeping twelve sensitive families found five bypassed: `.ssh/authorized_keys`, `.ssh/id_rsa`, `.netrc`, `.bashrc`, and `.profile`. The last two are shell-rc persistence vectors that execute on next login, not just credential reads. After this change, **0/12** families differ between absolute and tilde spellings.

**An existing test already caught this.** `TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` asserts `Path.home() / ".ssh" / "authorized_keys"` is flagged; it fails on unmodified `main` under `HOME=/root` and passes here. The suite has been detecting this on any root-homed runner, which may be why it went unnoticed on normal-user CI.

## Approach

A new `_is_posix_absolute_home()` lets a single-segment POSIX home fold while preserving the guard's original purpose — a degenerate root must never fold, or folding would rewrite every absolute path in the command.

| Path | Folds? | Changed? |
|---|---|---|
| `/root` | yes | **← this fix** |
| `/home/alice`, `/Users/alice`, `C:\Users\alice`, `C:/Users/alice`, `//server/share` | yes | no |
| `/`, `//`, `""`, `C:\`, `C:/`, `\\server`, `/C:` | no | no |

Only single-segment POSIX homes change behaviour. All 14 boundaries are asserted in the new tests.

## How Has This Been Tested?

`tests/tools/test_approval.py` + `tests/hermes_cli/test_approvals_suggest.py` → **135 passed, 0 failed** via `bash scripts/run_tests.sh`.

Two controls, because a security fix that only ever answers "dangerous" is not a fix:

- **Positive** — reverting `tools/approval.py` to `main` while keeping the new tests fails **4** (three new, plus the pre-existing redirect test). The tests discriminate rather than merely passing.
- **Negative** — eight ordinary commands under `/root` (`cat /root/notes.txt`, `cp report.txt /root/reports/out.txt`, `git -C /root/repo status`, `echo hi > /root/tmp.log`, …) stay unflagged **0/8**. The fold does not turn routine work into an approval prompt.

Five new tests in `TestSingleSegmentHomeFolding` cover: absolute sensitive writes are flagged; absolute and tilde verdicts agree; ordinary `/root` paths stay unflagged; degenerate roots are still refused; real homes still fold.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

Fixes #84639 (`type/security`, `P2`, was labelled `needs-repro` — repro posted on the issue).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious part (why a degenerate root must still be refused)

## Note on scope

Deliberately limited to the approval fold. Two `tests/gateway/test_platform_base.py` cases also fail under `HOME=/root`, but through a different mechanism — `validate_media_delivery_path`, where the tests use `/root/...` as a *container* path that collides with the real host home. That is a test-fixture issue rather than a guard hole (called directly, the denylist correctly refuses `/root/.hermes/auth.json`), so it does not belong in a security fix. Happy to file it separately.
