### PR TITLE
fix(desktop): preserve lock-owned remote backends

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_constants import get_default_hermes_root
+
 
 def _m():
     """Lazy ``hermes_cli.main`` reference (call-time; keeps patches working)."""
@@ -795,10 +797,14 @@ _HEX16 = _HEX32
 
 
 def _hermes_home_dir() -> Path:
-    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
-    override = os.environ.get("HERMES_HOME", "").strip()
-    if override:
-        return Path(override).expanduser()
+    """Native Hermes root containing Desktop SSH ownership locks.
+
+    Remote Desktop backends may run with ``HERMES_HOME`` set to a named profile
+    or a custom deployment root. Electron does not use that environment value
+    for ownership records: ``remote-lifecycle.ts`` writes them to the literal
+    remote path ``~/.hermes/desktop-ssh``. Resolve the same native root here so
+    orphan cleanup sees every ownership lock the Desktop writer creates.
+    """
     return Path.home() / ".hermes"
 
 
@@ -850,55 +856,61 @@ def _valid_lockfile_payload(parsed: object, ownership_id: str) -> bool:
 def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
     """PIDs claimed as owners by valid ``backend.lock.json`` records on this host.
 
-    Scans ``{hermes_home}/desktop-ssh/<ownershipId>/backend.lock.json`` (the
-    same directory the Desktop SSH runtime writes to). Any PID a valid lock
-    names is a legitimately-owned backend — including backends another client
-    or machine started over SSH — and must be spared by the orphan reap.
+    Scans both ``~/.hermes/desktop-ssh`` (the path Electron writes today) and
+    ``{configured_hermes_root}/desktop-ssh`` for custom-root compatibility.
+    Any PID a valid lock names is a legitimately-owned backend — including
+    backends another client or machine started over SSH — and must be spared by
+    the orphan reap.
 
     Best-effort: any read/parse/IO error for a single record is swallowed and
     that record contributes no PID. Never raises.
     """
     import json
 
-    root = base_dir if base_dir is not None else (
-        _hermes_home_dir() / _REMOTE_LOCK_SUBDIR
-    )
+    if base_dir is not None:
+        roots = (base_dir,)
+    else:
+        native_root = _hermes_home_dir() / _REMOTE_LOCK_SUBDIR
+        configured_root = get_default_hermes_root() / _REMOTE_LOCK_SUBDIR
+        roots = tuple(dict.fromkeys((native_root, configured_root)))
+
     owned: set[int] = set()
-    if not root.is_dir():
-        return owned
-    try:
-        entries = list(root.iterdir())
-    except OSError:
-        return owned
-    for entry in entries:
+    for root in roots:
+        if not root.is_dir():
+            continue
         try:
-            if not entry.is_dir():
-                continue
+            entries = list(root.iterdir())
         except OSError:
             continue
-        ownership_id = entry.name
-        # Mirror validateOwnershipId(): exactly 32 lowercase hex chars.
-        if len(ownership_id) != 32 or set(ownership_id) - _HEX32:
-            continue
-        lock_path = entry / "backend.lock.json"
-        try:
-            if not lock_path.is_file():
-                continue
-            with open(lock_path, "rb") as handle:
-                data = handle.read()
-        except OSError:
-            continue
-        if len(data) > 65536:
-            continue
-        try:
-            parsed = json.loads(data)
-        except (UnicodeDecodeError, ValueError):
-            continue
-        if _valid_lockfile_payload(parsed, ownership_id):
+        for entry in entries:
             try:
-                owned.add(int(parsed["pid"]))
-            except (TypeError, ValueError):
+                if not entry.is_dir():
+                    continue
+            except OSError:
                 continue
+            ownership_id = entry.name
+            # Mirror validateOwnershipId(): exactly 32 lowercase hex chars.
+            if len(ownership_id) != 32 or set(ownership_id) - _HEX32:
+                continue
+            lock_path = entry / "backend.lock.json"
+            try:
+                if not lock_path.is_file():
+                    continue
+                with open(lock_path, "rb") as handle:
+                    data = handle.read()
+            except OSError:
+                continue
+            if len(data) > 65536:
+                continue
+            try:
+                parsed = json.loads(data)
+            except (UnicodeDecodeError, ValueError):
+                continue
+            if _valid_lockfile_payload(parsed, ownership_id):
+                try:
+                    owned.add(int(parsed["pid"]))
+                except (TypeError, ValueError):
+                    continue
     return owned
 
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -121,6 +121,7 @@ def test_reap_passes_child_pid_exclude_to_scan():
 
 import json
 from hermes_cli.dashboard_procs import (
+    _hermes_home_dir,
     _lock_owned_serve_pids,
     _valid_lockfile_payload,
 )
@@ -142,6 +143,42 @@ def _valid_lock_payload(pid: int, ownership_id: str, spawn_nonce: str) -> dict:
         "logPath": f"~/.hermes/desktop-ssh/{ownership_id}/{spawn_nonce}.log",
         "startedAt": "2026-08-04T20:00:00Z",
     }
+
+
+def test_lock_scan_uses_native_root_from_named_profile_home(tmp_path, monkeypatch):
+    """A standard named profile must discover Desktop's global ownership locks."""
+    native_home = tmp_path / "home"
+    root = native_home / ".hermes"
+    ownership_id = "c" * 32
+    spawn_nonce = "b" * 16
+    lock_dir = root / "desktop-ssh" / ownership_id
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(7171, ownership_id, spawn_nonce))
+    )
+    monkeypatch.setenv("HOME", str(native_home))
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "dev"))
+
+    assert _hermes_home_dir() == root
+    assert _lock_owned_serve_pids() == {7171}
+
+
+def test_lock_scan_uses_native_root_from_custom_profile_home(tmp_path, monkeypatch):
+    """Custom HERMES_HOME must not hide locks written to Desktop's native root."""
+    native_home = tmp_path / "home"
+    native_root = native_home / ".hermes"
+    ownership_id = "d" * 32
+    spawn_nonce = "c" * 16
+    lock_dir = native_root / "desktop-ssh" / ownership_id
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(8181, ownership_id, spawn_nonce))
+    )
+    monkeypatch.setenv("HOME", str(native_home))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom" / "profiles" / "dev"))
+
+    assert _hermes_home_dir() == native_root
+    assert _lock_owned_serve_pids() == {8181}
 
 
 def test_lock_owned_serve_pids_reads_valid_backend_lock(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Prevents a named-profile Desktop SSH backend from killing other live, lock-owned Desktop SSH backends during startup orphan cleanup.

Electron writes remote ownership records to the literal remote path:

```text
~/.hermes/desktop-ssh/<ownership-id>/backend.lock.json
```

A backend launched for a named profile changes its effective Hermes profile home. The orphan reaper previously derived its lock scan from that profile-local `HERMES_HOME`, so it searched the profile directory instead of the path Electron writes. After the 180-second startup grace, a new pooled backend could classify older active PPID-1 remote serves as unowned and terminate them. Electron then observed the induced outage, exhausted the primary liveness failure streak, and replaced the primary backend too.

The reaper now scans the union of Electron's native SSH-user path (`Path.home() / ".hermes" / "desktop-ssh"`) and the configured Hermes root. This protects current Electron locks while preserving custom-root compatibility.

## Related Issue

No standalone issue. This is a focused follow-up to #92775 and #95891.

## Relationship to #94039

#94039 addresses the same native lock-root mismatch with a machine-root-only helper. It is 1,263 commits behind the current base. When its exact head is merged onto current `main`, the relevant canonical selection reports **123 passed, 1 failed, 7 skipped**. The failure is `test_update_cleanup_spares_backend_owned_by_valid_ssh_lock`, because current update cleanup still protects valid ownership locks under the configured Hermes root.

This PR keeps #94039's native-root protection and also scans the configured root. That preserves the current update-cleanup contract while fixing named-profile Desktop SSH replacement.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_procs.py`: discover ownership locks from both Electron's literal `~/.hermes/desktop-ssh` writer path and the configured Hermes root, deduplicating identical paths.
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py`: cover both standard named-profile and custom-root environments with real lockfile parsing.

## How to Test

1. Run the custom-root regression alone. Before the fix it misses the lock under the native Desktop path.
   ```bash
   pytest -o 'addopts=' -q tests/hermes_cli/test_orphan_desktop_serve_reap.py::test_lock_scan_uses_native_root_from_custom_profile_home
   ```
2. Run the focused orphan-reaper suite.
   ```bash
   pytest -o 'addopts=' -q tests/hermes_cli/test_orphan_desktop_serve_reap.py
   ```
3. Run adjacent process and profile-root suites.
   ```bash
   pytest -o 'addopts=' -q \
     tests/hermes_cli/test_lazy_command_exports.py \
     tests/hermes_cli/test_orphan_desktop_serve_reap.py \
     tests/hermes_cli/test_update_stale_dashboard.py \
     tests/hermes_cli/test_serve_runtime_inventory.py \
     tests/hermes_cli/test_dashboard_lifecycle_flags.py \
     tests/test_hermes_constants.py
   ```

## Diagnostic Evidence

A current-stack production trace reproduced the initiating sequence:

1. A pooled SSH backend dispatch probe started a replacement backend.
2. The replacement backend's launch log reported that startup orphan cleanup terminated two older Desktop-local `serve --port 0` processes.
3. One reaped PID was tied to active Desktop sessions immediately before the reap.
4. About four seconds after the replacement launch began, the active primary WebSocket closed with service-restart code 1012.
5. Native Desktop logs show the same ordering in earlier occurrences: pooled dispatch failure, replacement spawn, three primary liveness failures, `dropping stale connection`, then a new primary backend becoming ready.

Source tracing confirms the mismatch:

- Electron writes lock records under literal `~/.hermes/desktop-ssh`.
- Named remote serves launch with `--profile`.
- Profile activation changes effective Hermes home resolution.
- The baseline reaper used that profile-local home to find lock records.

A live read-only check of SSH-owned backend processes confirmed their login-shell `HOME` matches the native `~` used by Electron, while ownership records are under `~/.hermes/desktop-ssh`. The successor scans that native path plus the configured root and discovers all six current lock records.

The current `# client-version` badge reports build `4f22534`, which resolves to full commit `4f22543509d1b91dc45bcb369447126c5eb14fb7` and Desktop version `0.17.0`. This matches the upstream backend base used for the reproduction and candidate. The initiating kill occurs in the current Linux backend, which is why this fix is scoped to backend orphan cleanup rather than renderer reconnect policy.

## Verification

- Original named-profile regression before implementation: **failed as expected**.
- Custom-root regression against the first candidate: **failed as expected**.
- Native plus configured-root contract check: **14 passed**.
- Focused and adjacent suites: **140 passed, 7 skipped**.
- Ruff on changed files: **passed**.
- `py_compile` on changed files: **passed**.
- `git diff --check`: **passed**.
- Added-line security scan: **no matches**.
- The canonical full runner was attempted. It encountered unrelated optional-provider failures in the local environment before the Desktop restart dropped its output handle, so this box remains unchecked and GitHub CI is authoritative for the full matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 remote backend with Hermes Desktop over SSH

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the reap remains POSIX-only and scans both the POSIX SSH writer's native-home path and the configured root
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot is needed. The regression is process-lifecycle and path-resolution behavior. The tests and sanitized event ordering above capture it without publishing private connection details.
