### PR TITLE
fix(cron): cap the lifecycle-guard match span on a single line

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -91,22 +91,29 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # left the bypassable approval layer (tools/approval.py, skipped on
     # force=True) as the only cover, while this hard block — documented as
     # "force=True cannot help here" — let them through (#80260).
-    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
+    # Span cap (#98869): the verb and the gateway identifier must sit within
+    # 200 chars on the same line. Real commands keep verb and target close
+    # (even flag-heavy invocations stay under ~100 chars of separation), but
+    # a single-line data file (compact JSON) let the old `[^\n]*` join three
+    # unrelated words across 650 KB — a "lifecycle command" thousands of
+    # times longer than any real one. Branches B/C/D share the cap.
+    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]{0,200}\bhermes[.\-]?gateway)"
     # Branch C: systemctl ops on a hermes-gateway unit.
-    r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
+    r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]{0,200}\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
     # Leading \b ensures we match "pkill" or "kill" as whole words, not as
     # suffixes of other words (e.g. "skill" -> "kill").
-    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    r"|(?:\bp?kill\b[^\n]{0,200}\bhermes\b[^\n]{0,200}\bgateway)"
+    r"|(?:\bp?kill\b[^\n]{0,200}\bgateway\b[^\n]{0,200}\bhermes)"
 )
 
 
 # A backslash immediately followed by a newline is a POSIX shell line
 # continuation — the shell joins the two lines before parsing. Every branch
-# above uses `[^\n]*` between its verb and the gateway identifier so the
-# match can't span unrelated lines of a longer cron prompt/script, but that
+# above uses a same-line bounded gap (`[^\n]{0,200}`) between its verb and
+# the gateway identifier so the match can't span unrelated lines of a
+# longer cron prompt/script, but that
 # also means a real multi-line shell invocation split across continuation
 # lines (e.g. `launchctl submit \` / `  -l ai.hermes.gateway-... \` / `  -- ...`,
 # the exact reported shape in #62891) would otherwise slip past. Collapse

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -232,6 +232,42 @@ class TestGatewayLifecyclePattern:
         text = 'echo "unbalanced\nhermes gateway restart'
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
+    def test_single_line_data_file_long_span_not_matched(self):
+        # #98869: a compact single-line JSON data file whose path appears in
+        # a cron command is scanned as a referenced script. The old
+        # unbounded `[^\n]*` gap joined three unrelated words across ~650 KB
+        # of email metadata — "kill the deal review" in one record, a
+        # "gateway" in another, "Hermes" in a third — into a 652 KB
+        # "lifecycle command". A real command never separates verb and
+        # target by more than 200 chars, so the gap is capped; the words
+        # here are separated by tens of thousands of filler chars.
+        filler = " ".join(
+            f"summary of email {i} about quarterly planning" for i in range(1200)
+        )
+        one_line = (
+            '{"subject": "kill the deal review", "notes": "'
+            + filler
+            + ' gateway pool status ok '
+            + filler
+            + ' sent by Hermes bot"}'
+        )
+        assert len(one_line) > 100_000  # far beyond any real command span
+        assert not _contains_gateway_lifecycle_command(one_line)
+
+    @pytest.mark.parametrize("text", [
+        # The cap must not weaken real commands: verb and target within the
+        # 200-char budget stay blocked, whatever sits between them.
+        "pkill -f hermes-gateway",
+        "pkill -f " + "x" * 190 + " hermes gateway watcher.sh",
+        # A flag-heavy invocation: verb-to-unit distance sits well inside
+        # the cap, so Branches C/D keep blocking it.
+        "systemctl restart --no-block --no-wall "
+        "--job-mode=irreversibly-isolate hermes-gateway.service",
+        "launchctl bootout gui/$(id -u)/ai.hermes.gateway.plist",
+    ])
+    def test_span_cap_still_blocks_in_cap_commands(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
     @pytest.mark.parametrize("text", [
         # #68289: execute_code payloads carry the argv as a Python list —
         # brackets/commas separate the words the OS will exec.


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining half of the lifecycle-guard false positive reported in #98869: on a single-line data file (a compact JSON cache is one line), the unbounded `[^\n]*` gap in `_GATEWAY_LIFECYCLE_PATTERN` Branches B/C/D joined three unrelated words — a standalone `kill` in one email subject, a `gateway` in another record, `Hermes` in a third — into a 652 KB "lifecycle command", which blocked every cron command that referenced the data file by path. Real commands never separate the verb from its target by more than ~100 chars, so the same-line gap is capped at 200 chars across Branches B/C/D. Branch A needs no cap (its tokens are adjacent), and the order-independent launchctl pass (`_contains_launchctl_gateway_lifecycle`) is intentionally wider and unchanged.

The other half of #98869 (no left word boundary before `p?kill`, so "skill" matched "kill") was already fixed on main by a74eb2dd41 — the reporter was running v0.17.0. I verified on current main that the `"skill"` tail no longer matches, but the unbounded span still does: a constructed single-line JSON with a standalone `kill` + filler + `gateway` + filler + `Hermes` matched with a 373,850-char span before this change, and does not match after.

## Related Issue

Fixes #98869

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/lifecycle_guard.py`: cap the `[^\n]*` gap between verb and gateway identifier at `{0,200}` in Branches B (launchctl), C (systemctl), and D (pkill/kill, both token orders); comment the rationale referencing #98869; update the `_SHELL_LINE_CONTINUATION` comment that described the old unbounded gap.
- `tests/hermes_cli/test_gateway_restart_loop.py`: regression test that a >100 KB single-line JSON data payload with `kill`/`gateway`/`Hermes` far apart is NOT blocked, and that in-cap shapes (flag-heavy `systemctl restart ... hermes-gateway.service`, `launchctl bootout gui/$(id -u)/ai.hermes.gateway.plist`, `pkill -f ... hermes gateway watcher.sh` with a 190-char filler) ARE still blocked.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q` — all 302 tests pass (includes the new regressions).
2. Before/after proof of the reported false positive:
   ```python
   from cron.lifecycle_guard import _GATEWAY_LIFECYCLE_PATTERN as P
   filler = " ".join(f"summary of email {i} about quarterly planning" for i in range(4000))
   one_line = ("""{"subject": "kill the deal review", "notes": \"""" + filler
               + " gateway pool status ok " + filler + " sent by Hermes bot\"}")
   m = P.search(one_line)
   ```
   Observed result: before this change `m` is a 373,850-char match (same mechanism as the reported 652,315-char match); after this change `m is None`.
3. Real commands still blocked (observed): `pkill -f hermes-gateway`, `kill -9 $(pgrep -f gateway hermes)`, `launchctl bootout gui/501/ai.hermes.gateway`, `systemctl stop hermes-gateway.service`, and a flag-heavy `pkill -f "python3 /opt/hermes/bin/hermes-gateway --profile venus --log-level debug --config /etc/hermes/overrides.yaml"`.
4. Full lifecycle-guard surface: `.venv/bin/python -m pytest tests/tools/test_approval.py tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_desktop_lifecycle_windows_live.py -q` — 426 passed, 2 skipped, 1 pre-existing failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) that fails identically on unmodified `upstream/main` at 4f22543509 (verified via stash) and is unrelated to this change.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron): ...`)
- [x] I searched for existing PRs to make sure this is not a duplicate (no open PR references #98869; my only open guard-related PR #98809 touches the `_references_at` bare-path recursion, a different code path)
- [x] My PR contains only changes related to this fix (2 files, one commit)
- [x] I have run `pytest tests/ -q` for the lifecycle-guard-related suites — all pass except one pre-existing failure documented above
- [x] I have added tests for my changes (fail-closed: in-cap spans stay blocked)
- [x] I have tested on my platform: macOS 15.2 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I have updated relevant documentation — or N/A (regex-internal fix, commented in code)
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact — N/A (pure regex, platform-independent)
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill change.

## Screenshots / Logs

See "How to Test" step 2 for the before/after match-span proof.