### PR TITLE
feat(cron): dependency-aware job DAG resolver (RFC #08)

### DIFF
--- a/cron/dag.py
+++ b/cron/dag.py
@@ -1,0 +1,278 @@
+"""Cron job dependency DAG: resolve which jobs are ready to fire.
+
+A pure, framework-free module. Given the current set of jobs and the last
+known status of each (success/failure/skipped/never-run), compute:
+
+  - which jobs are ready to fire RIGHT NOW (deps satisfied)
+  - which jobs are blocked by missing/failed/pending deps
+  - whether the dep graph contains a cycle (must be reported, never silently
+    skipped)
+
+The module does NOT touch the scheduler tick loop. The scheduler calls
+:meth:`resolve_ready` each tick and filters its "due" set to the intersection.
+That keeps this change additive: existing schedules with no ``depends_on``
+field behave identically.
+
+Dependency model
+----------------
+
+Each job MAY carry a ``depends_on`` key (list of job_id strings). A job is
+ready iff every dependency's last status is "success". Any failure, missing,
+or unknown dependency blocks the job (recorded in the resolver's blocked
+list with a reason; never raises).
+
+Cycles are detected up front using Kahn's algorithm so a misconfigured
+graph fails loud at the first tick instead of producing a slow trickle of
+timeouts.
+
+Job shape
+---------
+
+Only a tiny subset of the cron job dict is read:
+
+  * ``job_id`` (or ``id``)
+  * ``depends_on`` (optional list of job_id strings)
+
+Everything else (schedule, prompt, skills) is ignored — this module only
+resolves deps.
+
+Example
+-------
+
+    from cron.dag import resolve_ready, validate_no_cycles
+
+    jobs = load_jobs()
+    validate_no_cycles(jobs)              # raise on misconfiguration
+    last = last_status_by_id(jobs)        # your own state lookup
+    ready_ids = resolve_ready(jobs, last) # filter "due" by these
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from typing import Any, Dict, Iterable, List, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# Status values used by this module. The cron subsystem records these as
+# ``effective_job_state``; we accept any of them but only "success" unlocks.
+SUCCESS = "success"
+FAILURE = "failure"
+PENDING = "pending"
+SKIPPED = "skipped"
+NEVER_RUN = "never_run"
+
+_UNLOCKING_STATUSES = frozenset({SUCCESS})
+
+
+class DagCycleError(ValueError):
+    """Raised when the dependency graph contains a cycle.
+
+    Includes the cycle path so callers can point the operator at the
+    misconfigured job(s).
+    """
+
+    def __init__(self, cycle_path: List[str]):
+        self.cycle_path = list(cycle_path)
+        super().__init__(
+            "cron dependency cycle detected: " + " -> ".join(cycle_path)
+        )
+
+
+def _job_id(job: Dict[str, Any]) -> str:
+    """Pull the canonical job_id out of a job dict (job_id OR id)."""
+    jid = job.get("job_id")
+    if not jid:
+        jid = job.get("id")
+    return str(jid or "").strip()
+
+
+def _job_deps(job: Dict[str, Any]) -> List[str]:
+    """Normalise the depends_on field to a list of strings (deduped, ordered)."""
+    raw = job.get("depends_on") or []
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: Set[str] = set()
+    out: List[str] = []
+    for item in raw:
+        s = str(item or "").strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def _build_graph(
+    jobs: Iterable[Dict[str, Any]],
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Set[str]]:
+    """Build adjacency lists.
+
+    Returns:
+        forward: job_id -> list of job_ids that depend on it (children)
+        reverse: job_id -> list of job_ids it depends on (parents)
+        all_nodes: every node in the graph (jobs + their deps)
+    """
+    forward: Dict[str, List[str]] = defaultdict(list)
+    reverse: Dict[str, List[str]] = defaultdict(list)
+    all_nodes: Set[str] = set()
+
+    for job in jobs:
+        jid = _job_id(job)
+        if not jid:
+            continue
+        all_nodes.add(jid)
+        deps = _job_deps(job)
+        reverse[jid].extend(deps)
+        all_nodes.update(deps)
+        for dep in deps:
+            forward[dep].append(jid)
+    return forward, reverse, all_nodes
+
+
+def validate_no_cycles(jobs: Iterable[Dict[str, Any]]) -> None:
+    """Raise :class:`DagCycleError` if the dep graph has a cycle.
+
+    Uses Kahn's algorithm (BFS over in-degree) so a cycle is detected
+    without recursion; the cycle path is reconstructed from leftover
+    nodes when Kahn finishes with a non-empty remainder.
+    """
+    forward, reverse, all_nodes = _build_graph(jobs)
+    in_degree: Dict[str, int] = {n: len(reverse.get(n, [])) for n in all_nodes}
+    queue: deque = deque(sorted(n for n, d in in_degree.items() if d == 0))
+    removed = 0
+    while queue:
+        n = queue.popleft()
+        removed += 1
+        for child in forward.get(n, []):
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+    leftover = [n for n, d in in_degree.items() if d > 0]
+    if not leftover:
+        return
+    # Reconstruct a concrete cycle path: pick any leftover, walk parents.
+    cycle = _extract_cycle(leftover[0], reverse)
+    raise DagCycleError(cycle)
+
+
+def _extract_cycle(start: str, reverse: Dict[str, List[str]]) -> List[str]:
+    """Return a cycle path starting and ending at ``start``."""
+    # Walk until we revisit a node. Use a deterministic order.
+    path: List[str] = [start]
+    visited: Set[str] = {start}
+    current = start
+    while True:
+        parents = [p for p in reverse.get(current, []) if p in visited or True]
+        # Prefer a parent that has been seen before (closing the cycle).
+        seen_parent = next((p for p in parents if p in visited), None)
+        next_node = seen_parent or (parents[0] if parents else start)
+        if next_node in visited:
+            path.append(next_node)
+            # Trim the prefix that does not belong to the cycle.
+            idx = path.index(next_node)
+            return path[idx:]
+        path.append(next_node)
+        visited.add(next_node)
+        current = next_node
+
+
+def resolve_ready(
+    jobs: Iterable[Dict[str, Any]],
+    last_status_by_id: Dict[str, str],
+) -> List[str]:
+    """Return job_ids whose dependencies are all satisfied.
+
+    A job is ready iff:
+
+      * it has no ``depends_on`` field, OR
+      * every dep's value in ``last_status_by_id`` is in
+        :data:`_UNLOCKING_STATUSES` (``success``).
+
+    Jobs with unknown / failed / pending deps are NOT returned. They will
+    be re-checked on the next tick after their deps succeed.
+
+    Cycles are NOT detected here — call :func:`validate_no_cycles` once
+    per scheduler reload to surface misconfigurations. A cyclic dep chain
+    will simply never become ready (all of its members blocked), so the
+    scheduler won't crash, but the cycle won't surface via this function.
+
+    Order: deterministic by job_id, ascending. This makes the function
+    idempotent and easy to test.
+    """
+    forward, reverse, all_nodes = _build_graph(jobs)
+    ready: List[str] = []
+    for job in jobs:
+        jid = _job_id(job)
+        if not jid:
+            continue
+        deps = _job_deps(job)
+        if not deps:
+            ready.append(jid)
+            continue
+        if all(last_status_by_id.get(d) in _UNLOCKING_STATUSES for d in deps):
+            ready.append(jid)
+    return sorted(ready)
+
+
+def explain_blocked(
+    jobs: Iterable[Dict[str, Any]],
+    last_status_by_id: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Return one record per blocked job describing why it's not ready.
+
+    Useful for surfacing diagnostics to operators without revealing internal
+    state. Each record::
+
+        {
+          "job_id": "...",
+          "blocked_by": [
+            {"job_id": "...", "status": "failure" | "pending" | "missing"}
+          ]
+        }
+    """
+    out: List[Dict[str, Any]] = []
+    for job in jobs:
+        jid = _job_id(job)
+        if not jid:
+            continue
+        deps = _job_deps(job)
+        if not deps:
+            continue
+        blocked_by: List[Dict[str, str]] = []
+        for d in deps:
+            status = last_status_by_id.get(d)
+            if status in _UNLOCKING_STATUSES:
+                continue
+            blocked_by.append({"job_id": d, "status": str(status or "missing")})
+        if blocked_by:
+            out.append({"job_id": jid, "blocked_by": blocked_by})
+    out.sort(key=lambda r: r["job_id"])
+    return out
+
+
+def topological_order(jobs: Iterable[Dict[str, Any]]) -> List[str]:
+    """Return job_ids in a valid topological order (deps first).
+
+    Raises :class:`DagCycleError` if the graph is cyclic. Useful for the
+    "replay" / one-shot-drain use case where the caller wants to fire
+    every job once in dep-respecting order.
+    """
+    forward, reverse, all_nodes = _build_graph(jobs)
+    in_degree: Dict[str, int] = {n: len(reverse.get(n, [])) for n in all_nodes}
+    queue: deque = deque(sorted(n for n, d in in_degree.items() if d == 0))
+    order: List[str] = []
+    while queue:
+        n = queue.popleft()
+        order.append(n)
+        for child in forward.get(n, []):
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+    if len(order) != len(all_nodes):
+        leftover = [n for n, d in in_degree.items() if d > 0]
+        cycle = _extract_cycle(leftover[0], reverse)
+        raise DagCycleError(cycle)
+    return order

--- a/tests/cron/test_dag.py
+++ b/tests/cron/test_dag.py
@@ -1,0 +1,185 @@
+"""Tests for cron/dag.py - cron job dependency resolution."""
+
+import pytest
+
+from cron.dag import (
+    DagCycleError,
+    explain_blocked,
+    resolve_ready,
+    SUCCESS,
+    topological_order,
+    validate_no_cycles,
+)
+
+
+# --- Job helpers --------------------------------------------------------
+
+
+def _j(jid, depends_on=None):
+    return {"job_id": jid, "depends_on": depends_on or []}
+
+
+def _empty_status():
+    return {}
+
+
+# --- resolve_ready ------------------------------------------------------
+
+
+def test_jobs_without_deps_are_always_ready():
+    jobs = [_j("a"), _j("b"), _j("c")]
+    assert resolve_ready(jobs, _empty_status()) == ["a", "b", "c"]
+
+
+def test_dep_unlocks_after_success():
+    jobs = [_j("a"), _j("b", ["a"])]
+    # No status yet -> b blocked
+    assert resolve_ready(jobs, _empty_status()) == ["a"]
+    # a succeeds -> b unblocks
+    assert resolve_ready(jobs, {"a": SUCCESS}) == ["a", "b"]
+
+
+def test_failed_dep_keeps_job_blocked():
+    jobs = [_j("a"), _j("b", ["a"])]
+    assert resolve_ready(jobs, {"a": "failure"}) == ["a"]
+
+
+def test_missing_dep_blocks():
+    jobs = [_j("b", ["ghost"])]
+    assert resolve_ready(jobs, _empty_status()) == []
+
+
+def test_multi_dep_requires_all_to_succeed():
+    jobs = [_j("a"), _j("b"), _j("c", ["a", "b"])]
+    # Only a succeeded -> c still blocked
+    assert resolve_ready(jobs, {"a": SUCCESS}) == ["a", "b"]
+    # Both succeeded -> c unblocks
+    assert resolve_ready(jobs, {"a": SUCCESS, "b": SUCCESS}) == ["a", "b", "c"]
+
+
+def test_results_are_sorted_for_determinism():
+    jobs = [_j("z"), _j("y"), _j("a")]
+    assert resolve_ready(jobs, _empty_status()) == ["a", "y", "z"]
+
+
+def test_jobs_with_blank_id_are_skipped():
+    assert resolve_ready([{"depends_on": []}, _j("ok")], {}) == ["ok"]
+
+
+def test_depends_on_accepts_strings_only():
+    # Non-string entries are coerced to strings (defensive); blank/whitespace
+    # entries are dropped. So [None, "", 42, "b"] becomes ["42", "b"].
+    jobs = [_j("a", [None, "", 42, "b"]), _j("b")]
+    assert resolve_ready(jobs, {"42": SUCCESS, "b": SUCCESS}) == ["a", "b"]
+    # Without the deps succeeding, 'a' is blocked.
+    assert resolve_ready(jobs, {}) == ["b"]
+
+
+def test_id_field_falls_back_when_job_id_missing():
+    jobs = [{"id": "alpha"}, {"job_id": "beta"}]
+    assert resolve_ready(jobs, {}) == ["alpha", "beta"]
+
+
+def test_dep_on_unknown_field_is_no_op():
+    """Sanity: a job dict without depends_on is treated as no deps."""
+    jobs = [{"job_id": "naked"}]
+    assert resolve_ready(jobs, {}) == ["naked"]
+
+
+# --- explain_blocked ----------------------------------------------------
+
+
+def test_explain_blocked_lists_unmet_deps():
+    jobs = [_j("a"), _j("b", ["a", "ghost"]), _j("c", ["a"])]
+    blocked = explain_blocked(jobs, {"a": "failure"})
+    assert len(blocked) == 2
+    by_id = {b["job_id"]: b for b in blocked}
+    assert by_id["b"]["blocked_by"] == [
+        {"job_id": "a", "status": "failure"},
+        {"job_id": "ghost", "status": "missing"},
+    ]
+    assert by_id["c"]["blocked_by"] == [{"job_id": "a", "status": "failure"}]
+
+
+def test_explain_blocked_empty_when_all_unlocked():
+    jobs = [_j("a"), _j("b", ["a"])]
+    assert explain_blocked(jobs, {"a": SUCCESS}) == []
+
+
+def test_explain_blocked_dedupes_dep_list():
+    jobs = [_j("a", ["x", "x", "x"])]
+    assert explain_blocked(jobs, {}) == [
+        {"job_id": "a", "blocked_by": [{"job_id": "x", "status": "missing"}]}
+    ]
+
+
+# --- Cycle detection ----------------------------------------------------
+
+
+def test_validate_no_cycles_passes_on_dag():
+    jobs = [_j("a"), _j("b", ["a"]), _j("c", ["a", "b"])]
+    validate_no_cycles(jobs)  # no exception
+
+
+def test_validate_no_cycles_detects_simple_cycle():
+    jobs = [_j("a", ["b"]), _j("b", ["a"])]
+    with pytest.raises(DagCycleError) as ei:
+        validate_no_cycles(jobs)
+    assert "a" in ei.value.cycle_path
+    assert "b" in ei.value.cycle_path
+
+
+def test_validate_no_cycles_detects_self_loop():
+    jobs = [_j("a", ["a"])]
+    with pytest.raises(DagCycleError):
+        validate_no_cycles(jobs)
+
+
+def test_validate_no_cycles_detects_three_node_cycle():
+    jobs = [_j("a", ["b"]), _j("b", ["c"]), _j("c", ["a"])]
+    with pytest.raises(DagCycleError) as ei:
+        validate_no_cycles(jobs)
+    # Path should contain all three
+    p = set(ei.value.cycle_path)
+    assert {"a", "b", "c"}.issubset(p)
+
+
+def test_validate_no_cycles_passes_with_unrelated_components():
+    jobs = [_j("a"), _j("b"), _j("c", ["b"])]
+    validate_no_cycles(jobs)
+
+
+def test_validate_no_cycles_ignores_blank_job_ids():
+    jobs = [{"depends_on": []}, {"job_id": "a", "depends_on": []}]
+    validate_no_cycles(jobs)  # no exception
+
+
+# --- topological_order --------------------------------------------------
+
+
+def test_topological_orders_deps_first():
+    jobs = [_j("c", ["a", "b"]), _j("a"), _j("b", ["a"])]
+    order = topological_order(jobs)
+    assert order.index("a") < order.index("b")
+    assert order.index("b") < order.index("c")
+
+
+def test_topological_handles_disconnected_graph():
+    jobs = [_j("z"), _j("a", ["b"]), _j("b")]
+    order = topological_order(jobs)
+    assert set(order) == {"a", "b", "z"}
+    assert order.index("b") < order.index("a")
+
+
+def test_topological_raises_on_cycle():
+    jobs = [_j("a", ["b"]), _j("b", ["a"])]
+    with pytest.raises(DagCycleError):
+        topological_order(jobs)
+
+
+def test_topological_returns_only_dag_nodes():
+    """Dangling deps (a depends on a missing job) still surface in the order."""
+    jobs = [_j("a", ["ghost"]), _j("b")]
+    order = topological_order(jobs)
+    assert "ghost" in order  # topological includes dep targets
+    assert "a" in order and "b" in order


### PR DESCRIPTION
## Summary

Pure, framework-free module that resolves which cron jobs are ready to fire based on an optional `depends_on` field on each job dict. Job dicts without `depends_on` behave exactly as before — this is a fully backwards-compatible additive change.

## What's in this PR

**`cron/dag.py`** (new, ~9 KB):

- `resolve_ready(jobs, last_status_by_id)` — list of job_ids whose deps are all satisfied
- `validate_no_cycles(jobs)` — raise `DagCycleError` (with cycle path) on misconfigured graphs
- `explain_blocked(jobs, last_status_by_id)` — diagnostic record per blocked job
- `topological_order(jobs)` — Kahn's-algorithm order, raises on cycle

**Dependency model**:
- `depends_on` is an optional list of job_id strings on each job
- A dep must be in `success` status to unlock; failure/pending/missing/never-run all block
- Cycles are detected up front using Kahn's algorithm — no recursion, no stack overflow on big graphs
- Cycle path is reconstructed and returned in `DagCycleError.cycle_path` for operator-friendly diagnostics
- Pure function, no I/O, no scheduler hooks

## Tests

`tests/cron/test_dag.py` — 23 tests covering:
- `resolve_ready`: no-deps, single-dep, multi-dep, missing-dep, failure-block, sorted output, blank-id skip, dep coercion (`[None, "", 42, "b"]` → `["42", "b"]`), `id` vs `job_id` fallback
- `explain_blocked`: lists unmet deps with status, dedupes dep list, empty when fully unlocked
- `validate_no_cycles`: passes on DAGs, detects 2-cycles, 3-cycles, self-loops, ignores blank ids, passes on disconnected components
- `topological_order`: deps-first ordering, disconnected graphs, raises on cycle, includes dangling dep nodes

All 23 tests green on first clean run.

## Example usage

```python
from cron.dag import resolve_ready, validate_no_cycles
from cron.jobs import load_jobs, effective_job_state

jobs = load_jobs()
validate_no_cycles(jobs)              # surface misconfig at startup

last_status = {
    j["job_id"]: effective_job_state(j)
    for j in jobs
}
ready_ids = set(resolve_ready(jobs, last_status))

# In the tick loop:
for job in due_jobs:
    if job["job_id"] in ready_ids:
        fire(job)
    # else: skip silently; will re-check on the next tick
```

## Out of scope (follow-up PRs)

- Wiring `resolve_ready` into `cron/scheduler.py::tick` (mechanical — intersect with the due set)
- Persisting `last_status` for cross-tick memory (the scheduler already tracks it; just thread it through)
- Conditional deps (`depends_on_when`, `depends_on_status`) — punted, kept model minimal

Kept separate so this PR is reviewable in one sitting; the wire-in is one function call in the tick.