### PR TITLE
feat(gateway): bind approval to canonical dashboard identity

### DIFF
--- a/gateway/operator_approval_authority.py
+++ b/gateway/operator_approval_authority.py
@@ -1,0 +1,50 @@
+"""Authenticated dashboard identity boundary for specialist approval."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+from hermes_cli.dashboard_auth.base import Session
+
+
+def canonical_dashboard_subject(*, provider: str, user_id: str) -> str:
+    """Serialize one provider/user tuple without delimiter ambiguity."""
+    normalized_provider = provider.strip()
+    normalized_user_id = user_id.strip()
+    if not normalized_provider or not normalized_user_id:
+        raise ValueError("provider and user_id must be non-empty strings")
+    return json.dumps(
+        {"provider": normalized_provider, "user_id": normalized_user_id},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def dashboard_session_subject(session: Session | None, *, auth_required: bool) -> str | None:
+    """Return a verified dashboard session's canonical subject, if available."""
+    if not auth_required or not isinstance(session, Session):
+        return None
+    if not isinstance(session.provider, str) or not session.provider.strip():
+        return None
+    if not isinstance(session.user_id, str) or not session.user_id.strip():
+        return None
+    return canonical_dashboard_subject(provider=session.provider, user_id=session.user_id)
+
+
+def authenticated_operator_identity(
+    session: Session | None,
+    *,
+    auth_required: bool,
+    allowed_subjects: Iterable[str],
+) -> str | None:
+    """Return an allowlisted authenticated subject, otherwise fail closed."""
+    subject = dashboard_session_subject(session, auth_required=auth_required)
+    if subject is None:
+        return None
+    configured = {
+        value.strip()
+        for value in allowed_subjects
+        if isinstance(value, str) and value.strip()
+    }
+    return subject if subject in configured else None

--- a/tests/gateway/test_operator_approval_authority.py
+++ b/tests/gateway/test_operator_approval_authority.py
@@ -1,0 +1,93 @@
+"""Contracts for authenticated specialist-promotion approval identity."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _approval_api():
+    try:
+        from gateway.operator_approval_authority import (
+            authenticated_operator_identity,
+            canonical_dashboard_subject,
+        )
+    except ImportError as exc:  # RED: the split starts without this boundary.
+        pytest.fail(f"operator approval authority is unavailable: {exc}")
+    return authenticated_operator_identity, canonical_dashboard_subject
+
+
+def _session(*, user_id: str = "operator-1", provider: str = "portal"):
+    from hermes_cli.dashboard_auth.base import Session
+
+    return Session(
+        user_id=user_id,
+        email="",
+        display_name="",
+        org_id="",
+        provider=provider,
+        expires_at=0,
+        access_token="",
+        refresh_token="",
+    )
+
+
+def test_gated_allowlisted_session_yields_canonical_operator_subject():
+    authenticated_operator_identity, canonical_dashboard_subject = _approval_api()
+    allowed = canonical_dashboard_subject(provider="portal", user_id="operator-1")
+
+    identity = authenticated_operator_identity(
+        _session(),
+        auth_required=True,
+        allowed_subjects=(allowed,),
+    )
+
+    assert identity == allowed
+
+
+def test_subject_encoding_cannot_collide_on_provider_user_delimiter():
+    _, canonical_dashboard_subject = _approval_api()
+
+    first = canonical_dashboard_subject(provider="portal:team", user_id="operator")
+    second = canonical_dashboard_subject(provider="portal", user_id="team:operator")
+
+    assert first != second
+    assert first == '{"provider":"portal:team","user_id":"operator"}'
+    assert second == '{"provider":"portal","user_id":"team:operator"}'
+
+
+def test_legacy_delimited_allowlist_value_does_not_authorize():
+    authenticated_operator_identity, _ = _approval_api()
+
+    assert authenticated_operator_identity(
+        _session(provider="portal:team", user_id="operator"),
+        auth_required=True,
+        allowed_subjects=("portal:team:operator",),
+    ) is None
+
+
+def test_loopback_mode_and_unlisted_subject_fail_closed():
+    authenticated_operator_identity, canonical_dashboard_subject = _approval_api()
+    allowed = canonical_dashboard_subject(provider="portal", user_id="operator-1")
+
+    assert authenticated_operator_identity(
+        _session(), auth_required=False, allowed_subjects=(allowed,)
+    ) is None
+    assert authenticated_operator_identity(
+        _session(),
+        auth_required=True,
+        allowed_subjects=(canonical_dashboard_subject(provider="portal", user_id="someone-else"),),
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "session",
+    (None, _session(user_id=""), _session(provider="")),
+)
+def test_incomplete_session_identity_fails_closed(session):
+    authenticated_operator_identity, canonical_dashboard_subject = _approval_api()
+
+    assert authenticated_operator_identity(
+        session,
+        auth_required=True,
+        allowed_subjects=(canonical_dashboard_subject(provider="portal", user_id="operator-1"),),
+    ) is None


### PR DESCRIPTION
## Summary
- add a small approval-authority boundary for specialist promotion
- require a verified authenticated dashboard `Session`
- compare provider/user identity through canonical structured encoding rather than delimiter-joined strings
- enforce an explicit allowlist and fail closed on local or unauthenticated sessions

## Scope
This PR adds only the approval authority and its behavior tests. It does not create profiles, route tasks, call models, activate specialists, or add platform/network side effects.

## Verification
- 7 focused approval-authority tests passed
- 20 grouped adjacent tests passed
- Ruff, bytecode compilation, diff checks, and full content/metadata privacy scans passed

This is a clean extraction from a larger local experiment; product-specific roles and routing tables were intentionally excluded.