### PR TITLE
fix(profiles): ignore unmarked runtime directories in multiplex serve

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1158,6 +1158,8 @@ def profiles_to_serve(
                 continue
             if named_profile_is_deleted(entry):
                 continue
+            if not (entry / "profile.yaml").is_file():
+                continue
             if allowed is not None and name not in allowed:
                 continue
             serve.append((name, entry))
@@ -1356,15 +1358,14 @@ def create_profile(
     # Persist description if the caller provided one. Done last so a
     # partial-create failure doesn't strand a description file in an
     # incomplete profile.
-    if description and description.strip():
-        try:
-            write_profile_meta(
-                profile_dir,
-                description=description.strip(),
-                description_auto=False,
-            )
-        except Exception:
-            pass  # non-fatal — user can describe later with `hermes profile describe`
+    try:
+        meta_kwargs = {}
+        if description and description.strip():
+            meta_kwargs["description"] = description.strip()
+            meta_kwargs["description_auto"] = False
+        write_profile_meta(profile_dir, **meta_kwargs)
+    except Exception:
+        pass  # non-fatal — user can describe later with `hermes profile describe`
 
     # Phase 4: when running inside a container under s6, register the
     # new profile's gateway as a runtime s6 service so

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1126,10 +1126,16 @@ class TestProfilesToServe:
         assert set(serve) == {"default", "worker"}
         assert serve["worker"] == get_profile_dir("worker")
 
+    def test_unmarked_runtime_directory_is_ignored(self, profile_env):
+        create_profile("coder", no_alias=True)
+        junk = get_profile_dir("coder").parent / "cachetmp"
+        junk.mkdir()
+        (junk / "state.db").write_bytes(b"")
+        serve = dict(profiles_to_serve(multiplex=True))
+        assert "cachetmp" not in serve
+        assert "coder" in serve
+        assert (get_profile_dir("coder") / "profile.yaml").is_file()
 
-
-        assert set(serve) == {"default", "worker"}
-        assert serve["worker"] == get_profile_dir("worker")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`profiles_to_serve(multiplex=True)` currently treats any valid-named directory under `profiles/` as an agent. Runtime/cache leftovers then get bootstrapped as extra profiles.

This requires `profile.yaml` (now always written by `hermes profile create`) as the marker, and skips unmarked directories.

## Test plan
- [x] `test_unmarked_runtime_directory_is_ignored`
- [x] existing `TestProfilesToServe` cases still apply because create now writes `profile.yaml`

Fixes gateway multiplex enumerating unmarked dirs under `profiles/`.