### PR TITLE
fix(doctor): accept vendor slugs for user-defined providers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1542,14 +1542,16 @@ def run_doctor(args):
                 except Exception:
                     custom_providers = []
 
+            user_provider_ids: set[str] = set()
             user_providers = cfg.get("providers")
             if isinstance(user_providers, dict):
                 from hermes_cli.config import is_provider_enabled
-                known_providers.update(
+                user_provider_ids = {
                     str(name).strip().lower()
                     for name, prov_cfg in user_providers.items()
                     if str(name).strip() and is_provider_enabled(prov_cfg)
-                )
+                }
+                known_providers.update(user_provider_ids)
             for entry in custom_providers:
                 if not isinstance(entry, dict):
                     continue
@@ -1638,6 +1640,7 @@ def run_doctor(args):
                 provider_policy_id in providers_accepting_vendor_slugs
                 or provider_policy_id == "custom"
                 or provider_policy_id.startswith("custom:")
+                or provider in user_provider_ids
             )
             if (
                 default_model

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -656,6 +656,54 @@ def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, 
     assert "Either set model.provider to 'openrouter', or drop the vendor prefix." not in out
 
 
+def test_run_doctor_accepts_vendor_slugs_for_user_defined_provider(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: gateway\n"
+        "  default: codex/gpt-5.5-xhigh\n"
+        "providers:\n"
+        "  gateway:\n"
+        "    base_url: http://127.0.0.1:20130/v1\n"
+        "    api_key: test-key\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'gateway' is not a recognised provider" not in out
+    assert (
+        "model.default 'codex/gpt-5.5-xhigh' uses a vendor/model slug but provider is "
+        "'gateway'"
+        not in out
+    )
+    assert "Either set model.provider to 'openrouter', or drop the vendor prefix." not in out
+
+
+
 
 
 def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
`hermes doctor` already treats enabled `config.yaml` `providers:` entries as known providers, but still warns when `model.default` uses a `vendor/model` slug unless the provider is a hardcoded aggregator or `custom:*`.

A local OpenAI-compatible user provider such as `gateway` serving `codex/gpt-5.5-xhigh` is valid and should not fail doctor.

## Test plan
- [x] `test_run_doctor_accepts_vendor_slugs_for_user_defined_provider`

This is the same local-provider case Hermes VPS installs hit with OmniRoute.