### PR TITLE
test(gateway): isolate HOME from the runner in credential-surface media tests

### DIFF
--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -906,6 +906,11 @@ class TestDockerContainerMediaPathTranslation:
         (secret / "auth.json").write_text('{"token": "SECRET"}')
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
+        # Isolate HOME from the runner's real home (#98879): with HOME=/root
+        # the literal below resolves to an existing host file and the /root
+        # denylist prefix is waived as "the running user's own home", so the
+        # assertion would track runner state instead of the guard.
+        monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
@@ -1338,11 +1343,16 @@ class TestDockerProfileSandboxMediaTranslation:
             "/root/note.txt", session_key=self.SESSION_KEY
         ) == str(produced.resolve())
 
-    def test_home_credential_surface_still_refused(self, monkeypatch):
+    def test_home_credential_surface_still_refused(self, monkeypatch, tmp_path):
         """The /root/.hermes exclusion survives profile scoping: translating
         the home mount must never expose the container's secret surface —
         in the profile layout AND the legacy session layout."""
         self._enable_docker(monkeypatch)
+        # Isolate HOME from the runner's real home (#98879): on a root-homed
+        # runner (/root/.hermes/auth.json exists, HOME=/root) the literal
+        # below passes the existence check and the /root denylist prefix is
+        # waived as "the running user's own home", flipping the verdict.
+        monkeypatch.setenv("HOME", str(tmp_path))
         for task in ("default", f"session:{self.SESSION_KEY}"):
             secrets = self._sandbox_dir(task) / "home" / ".hermes"
             secrets.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

Makes the two docker credential-surface media tests in `tests/gateway/test_platform_base.py` independent of the runner's real home directory, fixing the failures reported on root-homed hosts (`HOME=/root`).

Both tests assert that the container literal `/root/.hermes/auth.json` is refused by `validate_media_delivery_path`. The production guard is intact — but the tests were not isolated:

1. The conftest sandbox redirects `HERMES_HOME`, so the module-level `_HERMES_HOME`/`_HERMES_ROOT` credential-denylist entries no longer cover `/root/.hermes/auth.json`.
2. `_translate_docker_container_media_path` correctly refuses to translate the credential surface through the home mount, so the validator falls back to resolving the literal on the host.
3. On a runner where `HOME=/root` and `/root/.hermes/auth.json` actually exists, the file passes the existence check, and the `/root` system denylist prefix is waived by the "running user's own home" exception in `_path_under_denied_prefix` — so the secret surface is accepted and the assertion fails.

The fix keeps the literal container path (so the home-mount exclusion branch stays covered) and instead points `HOME` at an isolated tmp dir for these two tests. With `HOME != /root`, the `/root` denylist prefix refuses unconditionally, so the verdict no longer tracks runner state.

## Related Issue

Fixes #98879

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_platform_base.py` — `TestDockerContainerMediaPathTranslation::test_container_credential_path_never_translates_through_home`: pin `HOME` to an isolated tmp dir so the `/root` denylist prefix cannot be waived as the runner's own home.
- `tests/gateway/test_platform_base.py` — `TestDockerProfileSandboxMediaTranslation::test_home_credential_surface_still_refused`: same `HOME` isolation (adds the `tmp_path` fixture).

No production code changes — this is a test-isolation defect; the delivery guard itself refuses every `/root` path when `HERMES_HOME` is not redirected.

## How to Test

Reproduce on a root-homed host (Linux, `HOME=/root`, with a real `/root/.hermes/auth.json` present):

1. `python -m pytest "tests/gateway/test_platform_base.py::TestDockerContainerMediaPathTranslation::test_container_credential_path_never_translates_through_home" "tests/gateway/test_platform_base.py::TestDockerProfileSandboxMediaTranslation::test_home_credential_surface_still_refused" -q`
   - Observed on `main` (python:3.11-slim container as root, `/root/.hermes/auth.json` created): **2 failed** (`assert '/root/.hermes/auth.json' is None` — path returned as deliverable).
   - Observed with this PR: **2 passed**.
2. Non-root sanity check (`tests/gateway/test_platform_base.py` full file, macOS): **94 passed, 1 skipped** — same as before the change.
3. Related media-delivery suites (`tests/gateway/test_media_tag_separator.py`, `tests/cron/test_media_delivery_parity.py`, `tests/plugins/platforms/photon/test_outbound_media.py`): **12 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64) + Linux (python:3.11-slim container running as root, `HOME=/root`)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
