### PR TITLE
fix(dashboard): register shell hooks + outbound webhooks in serve/dashboard backend

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -419,6 +419,38 @@ async def _lifespan(app: "FastAPI"):
     # Desktop's 10-second WebSocket ready-probe to time out (GH-73083).
     _warm_gateway_module()
 
+    # Register declarative shell hooks + outbound webhooks from config.yaml.
+    # This ``serve`` backend is the process that actually drives Desktop
+    # chat turns (tui_gateway.ws over /api/ws) — it is a SEPARATE process
+    # from `hermes gateway run` and from the plain CLI, and until this fix
+    # it was the one startup path that never called
+    # agent.shell_hooks.register_from_config(). Any post_tool_call /
+    # pre_tool_call shell hook configured under `hooks:` (e.g. the
+    # second-brain housekeeper's vault-write gate) silently never fired for
+    # interactive Desktop sessions even though `hermes hooks doctor` reported
+    # it healthy — doctor only checks the script/allowlist, not which
+    # running processes actually registered it. No TTY here, so consent
+    # resolves the same way gateway/run.py does: accept_hooks=False and let
+    # register_from_config fall back to HERMES_ACCEPT_HOOKS /
+    # hooks_auto_accept — never block server startup on a prompt.
+    try:
+        from hermes_cli.config import load_config as _load_hooks_config
+        from agent.shell_hooks import register_from_config as _register_shell_hooks
+
+        _hooks_cfg = _load_hooks_config()
+        _register_shell_hooks(_hooks_cfg, accept_hooks=False)
+
+        from agent.outbound_webhooks import (
+            register_from_config as _register_outbound_webhooks,
+        )
+
+        _register_outbound_webhooks(_hooks_cfg)
+    except Exception:
+        _log.debug(
+            "shell-hook registration failed at dashboard/serve startup",
+            exc_info=True,
+        )
+
     # Snapshot the checkout revision at boot so risky lazy-import paths (the
     # model picker) can detect when `hermes update` replaced the code
     # underneath this long-lived process and refuse with a clear "restart


### PR DESCRIPTION
## Summary

`hermes_cli/web_server.py`'s `_lifespan()` — the startup path shared by `hermes dashboard` and `hermes serve` (this is also the process the **Desktop app** spawns as its own chat backend, driving turns over `tui_gateway.ws` on `/api/ws`) — never called `agent.shell_hooks.register_from_config()` or `agent.outbound_webhooks.register_from_config()`.

Those two calls already happen in `cli.py`, `hermes_cli/main.py`, and `gateway/run.py`. `web_server.py`'s lifespan was the one long-lived startup path missing them. Net effect: any `post_tool_call` / `pre_tool_call` shell hook or outbound webhook configured under `hooks:` in `config.yaml` **silently never fires** for:
- Interactive Desktop app chat sessions (the common case most users hit)
- A standalone `hermes dashboard` or `hermes serve`

No error, no warning — and `hermes hooks doctor` still reports the hook as healthy, because it only checks that the script exists/is allowlisted/produces valid JSON on a synthetic payload. It never checks which *running processes* actually registered the hook, so it gives false assurance in exactly this failure mode.

## Root cause

`grep -rn "register_from_config" --include=*.py | grep -v tests/` shows exactly three real call sites: `cli.py`, `hermes_cli/main.py`, `gateway/run.py`. `hermes_cli/web_server.py` (a fourth long-lived entrypoint) has none.

## Fix

Added the same registration block `gateway/run.py` already uses, in `_lifespan()` right after `_warm_gateway_module()`:
- `accept_hooks=False` — no TTY in a server process, so consent resolves via `HERMES_ACCEPT_HOOKS` / `hooks_auto_accept`, matching gateway's existing behavior exactly.
- Wrapped in `try/except`, logged at `debug` — a hook-config problem must never block server startup, same fail-open contract as every other call site.

## Verification

Manually reproduced and confirmed fixed against a real Desktop-driven `serve` process:
- **Before:** a real `post_tool_call` hook (a file-write side-effect script) never fired across multiple real `write_file`/`patch` calls from a live Desktop chat session. Confirmed via the hook's own log/side-effect staying stale, and via process + log inspection: `logs/agent.log` showed `"shell hook registered: post_tool_call -> ..."` only from the `gateway run` process, never from the `serve` process backing the Desktop session, even though both processes loaded the identical `hooks:` config.
- **After:** applying the equivalent of this patch and re-running the same write, the hook fired and produced fresh output on the very next call.
- `python -c "import ast; ast.parse(...)"` — syntax-checked.

No test suite was runnable in the environment this was authored in (no dev/test dependencies installed locally), so this leans on CI plus the manual verification above — happy to add a targeted unit test if a maintainer points at the preferred pattern for `_lifespan` (existing tests import `hermes_cli.web_server` directly, e.g. `tests/test_code_skew.py`, but don't appear to exercise the lifespan context manager itself).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
