### PR TITLE
toolchain-self-improve: expose --context-from / --attach-to-session on hermes cron CLI

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -544,6 +544,8 @@ def cron_create(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        context_from=getattr(args, "context_from", None),
+        attach_to_session=getattr(args, "attach_to_session", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):
@@ -619,6 +621,8 @@ def cron_edit(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        context_from=getattr(args, "context_from", None),
+        attach_to_session=getattr(args, "attach_to_session", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -132,6 +132,30 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "monitors, incremental digests). First run is unchanged."
         ),
     )
+    cron_create.add_argument(
+        "--context-from",
+        dest="context_from",
+        action="append",
+        help=(
+            "Job ID whose most recent completed output is injected into "
+            "this job's prompt as context (chains jobs: A collects, B "
+            "processes). Repeatable for multiple sources. For the job's own "
+            "previous output use --continuity instead."
+        ),
+    )
+    cron_create.add_argument(
+        "--attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Make this job's delivery CONTINUABLE — the user can reply and "
+            "the agent has the brief in context (threads on thread-capable "
+            "platforms). Use for conversational recurring jobs (briefings); "
+            "omit for fire-and-forget alerts. No effect when --deliver local."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -212,6 +236,36 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "Turn off run-to-run continuity (other context_from job refs "
             "are preserved)."
         ),
+    )
+    cron_edit.add_argument(
+        "--context-from",
+        dest="context_from",
+        action="append",
+        help=(
+            "Job ID whose most recent completed output is injected into "
+            "this job's prompt as context. Repeatable for multiple sources; "
+            "REPLACES the job's existing context_from list (its own 'self' "
+            "continuity entry is dropped unless --continuity is passed in "
+            "the same edit). Pass an empty string to clear all refs."
+        ),
+    )
+    cron_edit.add_argument(
+        "--attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Make this job's delivery CONTINUABLE — the user can reply and "
+            "the agent has the brief in context. No effect when deliver=local."
+        ),
+    )
+    cron_edit.add_argument(
+        "--no-attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=False,
+        help="Turn off attach_to_session (delivery reverts to fire-and-forget).",
     )
     cron_edit.add_argument(
         "--monitor-script",

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -46,6 +46,55 @@ class TestCronCommandLifecycle:
         assert updated["provider"] == "nous"
         assert "Updated job" in capsys.readouterr().out
 
+    def test_create_and_edit_persist_context_from_and_attach_to_session(
+        self, tmp_cron_dir, capsys
+    ):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        source_job = create_job(prompt="Collect data", schedule="every 1h")
+
+        create_args = parser.parse_args(
+            [
+                "cron",
+                "create",
+                "every 2h",
+                "Process collected data",
+                "--context-from",
+                source_job["id"],
+                "--attach-to-session",
+            ]
+        )
+        cron_command(create_args)
+        capsys.readouterr()
+
+        consumer_jobs = [
+            j for j in list_jobs() if j.get("prompt") == "Process collected data"
+        ]
+        assert len(consumer_jobs) == 1
+        consumer = consumer_jobs[0]
+        assert consumer["context_from"] == [source_job["id"]]
+        assert consumer["attach_to_session"] is True
+
+        # CLI edit: swap the reference and turn attach_to_session back off —
+        # exercises the gap this test closes (hermes cron edit previously had
+        # no flags at all for these two already-supported job fields).
+        edit_args = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                consumer["id"],
+                "--no-attach-to-session",
+            ]
+        )
+        cron_command(edit_args)
+
+        updated = get_job(consumer["id"])
+        assert updated["attach_to_session"] is False
+        # context_from untouched by an edit that didn't mention it
+        assert updated["context_from"] == [source_job["id"]]
+
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(
             prompt="Combine skill outputs",

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,45 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_create_accepts_context_from_and_attach_to_session():
+    parser = _build()
+    ns = parser.parse_args(
+        [
+            "cron",
+            "create",
+            "30m",
+            "prompt",
+            "--context-from",
+            "job-a",
+            "--context-from",
+            "job-b",
+            "--attach-to-session",
+        ]
+    )
+    assert ns.context_from == ["job-a", "job-b"]
+    assert ns.attach_to_session is True
+    # Omitted -> None (no accidental clear on create)
+    ns2 = parser.parse_args(["cron", "create", "30m", "prompt"])
+    assert ns2.context_from is None
+    assert ns2.attach_to_session is None
+
+
+def test_cron_edit_context_from_and_attach_to_session_tristate():
+    parser = _build()
+    ns = parser.parse_args(
+        ["cron", "edit", "j", "--context-from", "job-a", "--attach-to-session"]
+    )
+    assert ns.context_from == ["job-a"]
+    assert ns.attach_to_session is True
+
+    ns2 = parser.parse_args(["cron", "edit", "j", "--no-attach-to-session"])
+    assert ns2.attach_to_session is False
+
+    ns3 = parser.parse_args(["cron", "edit", "j"])
+    assert ns3.context_from is None
+    assert ns3.attach_to_session is None
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.


### PR DESCRIPTION
## Friction
While wiring `context_from`/`attach_to_session` onto the `toolchain-self-improve-pilot` and `memory-triage` cron jobs (session `20260830_170551_e643bc`), the agent had to go through the agent-facing `cronjob` model tool (`update` action) because `hermes cron edit --help` exposed no flag for either field — quote from that session: *"The JSON-RPC gateway layer doesn't expose it, but my agent-facing tool does (`context_from` on update)"* and *"Knowledge file updated with the two new patterns, including the CLI gaps (`hermes cron edit` lacks `--context-from`/`--attach`)."*

## Proven gap
`grep -n "context_from\|attach_to_session" hermes_cli/subcommands/cron.py hermes_cli/cron.py` returned zero matches before this change — confirmed on `main` at `5cc1369fa2`. Meanwhile the underlying capability was already fully wired everywhere else:
- `cron/jobs.py::create_job()` / `update_job()` — both parameters present and handled.
- `tools/cronjob_tools.py::cronjob()` — both parameters present, validated, and documented in `CRONJOB_SCHEMA` (the agent-facing tool schema).
- `tests/tools/test_cronjob_tools.py` — existing coverage for both fields via the tool layer.

Only the human-facing CLI (`hermes cron create` / `hermes cron edit`) had no `--context-from` / `--attach-to-session` argparse options — a pure discoverability/CLI-parity gap in `hermes_cli/subcommands/cron.py`, not a missing capability (correctly routed here rather than as a plugin/skill fix per `toolchain-self-improve`'s routing table, since the fix is in the tool's own argparse wiring).

## Change
`hermes_cli/subcommands/cron.py`:
- `cron create` gains `--context-from` (repeatable `append`) and `--attach-to-session` (flag), mirroring the existing `--continuity` pattern.
- `cron edit` gains `--context-from` (repeatable, replaces the stored list — combine with `--continuity` in the same edit to also keep the job's own `"self"` entry) and `--attach-to-session` / `--no-attach-to-session` (tristate, same `store_const` pattern already used for `--agent`/`--no-agent`).

`hermes_cli/cron.py`:
- `cron_create()` / `cron_edit()` forward `context_from` and `attach_to_session` through the existing `_cron_api(...)` call. No changes to `cron/jobs.py`, `tools/cronjob_tools.py`, or `CRONJOB_SCHEMA` — those already accept and validate both fields correctly.

## Gate output
```
$ python3 -m pytest tests/hermes_cli/test_cron.py \
    tests/hermes_cli/test_cron_parser_builder.py \
    tests/cron/test_cron_context_from.py -q -o "addopts="
...........................................                              [100%]
43 passed in 4.78s
```
3 new tests: 2 parser-only (`test_cron_parser_builder.py` — repeatable `--context-from` + `--attach-to-session` on create, tristate `--attach-to-session`/`--no-attach-to-session` + `--context-from` on edit), 1 end-to-end (`test_cron.py` — real `cron_command()` dispatch against a temp job store: create with both new flags, then edit with `--no-attach-to-session`, asserting `context_from` is left untouched by an edit that didn't mention it).

Manually verified the new flags are live in `--help` output:
```
$ python3 -m hermes_cli.main cron edit --help | grep -A2 -i context-from
  --context-from CONTEXT_FROM
                        Job ID whose most recent completed output is injected
                        into this job's prompt as context. Repeatable...
```

## Scope
One capability (CLI flag parity for two already-supported job fields), two files' argparse wiring + their tests. No changes to the scheduler, job storage, or the model-facing `cronjob` tool — this closes the *human* discoverability gap, the agent-facing surface was already complete.

Source session: `20260830_170551_e643bc`.

Draft only — autonomy ceiling per `toolchain-self-improve`: opened by the `toolchain-self-improve-pilot` cron, human review/merge required.
