### PR TITLE
test(gateway): isolate credential-surface media tests from the runner's home

### DIFF
--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -911,6 +911,15 @@ class TestDockerContainerMediaPathTranslation:
         monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
         monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(sandbox))
         monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        # The refusal must come from the /root denylist prefix itself, not
+        # from resolve(strict=True) happening to miss the file. On a
+        # root-homed runner (HOME=/root) the home-prefix exception in
+        # _path_under_denied_prefix accepts the runner's own real
+        # /root/.hermes/auth.json as a deliverable — the collision this
+        # test guards against.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HOME", str(fake_home))
 
         assert BasePlatformAdapter.validate_media_delivery_path(
             "/root/.hermes/auth.json"
@@ -1338,11 +1347,18 @@ class TestDockerProfileSandboxMediaTranslation:
             "/root/note.txt", session_key=self.SESSION_KEY
         ) == str(produced.resolve())
 
-    def test_home_credential_surface_still_refused(self, monkeypatch):
+    def test_home_credential_surface_still_refused(self, tmp_path, monkeypatch):
         """The /root/.hermes exclusion survives profile scoping: translating
         the home mount must never expose the container's secret surface —
         in the profile layout AND the legacy session layout."""
         self._enable_docker(monkeypatch)
+        # Same isolation as the container-path test above: with HOME=/root
+        # the home-prefix exception in _path_under_denied_prefix would
+        # accept the runner's real /root/.hermes/auth.json. Point HOME at
+        # tmp_path so the refusal is produced by the /root prefix itself.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HOME", str(fake_home))
         for task in ("default", f"session:{self.SESSION_KEY}"):
             secrets = self._sandbox_dir(task) / "home" / ".hermes"
             secrets.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Two tests in `tests/gateway/test_platform_base.py` flip from pass to fail on any runner whose `$HOME` is `/root` **when the runner's real `/root/.hermes/auth.json` exists** — i.e. exactly the root-homed CI/dev containers where Hermes itself runs as root (#98879). Root cause, verified against `main`:

1. `_translate_docker_container_media_path` deliberately skips the synthetic `/root` home mount for `/root/.hermes/*` (container credential surface), so translation returns `None` — intended.
2. The literal `/root/.hermes/auth.json` then falls through to the host-side `resolve(strict=True)` + `is_file()` branch, which on a root-homed runner finds the **runner's own real credential file**.
3. `_path_under_denied_prefix` then hits the documented `resolved_denied == home` exception (`/root` *is* `$HOME` there) and un-blocks it — so the tests' acceptance tracks host filesystem state, not the denylist.

The fix follows the established `fake_home` pattern already used seven times in this file (e.g. `TestMediaDeliveryDefaultMode`): point `HOME` at the test's `tmp_path` in the two affected tests, so the refusal is produced by the `/root` denylist prefix itself, regardless of whether the file exists on the runner. No production code changes; the guard's semantics are untouched.

RED→GREEN evidence (standalone repro on unmodified `main`, denied-prefix home + existing credential file, `HERMES_HOME` redirected away like the conftest fixture does):

```
file exists           : True
home == denied prefix : True
verdict               : '/private/var/folders/.../fakeroot/.hermes/auth.json'   <- accepted
```

With this change the verdict is `None` (refused) in both branches — file present and absent.

## Testing

```
$ python -m pytest tests/gateway/test_platform_base.py -q
94 passed, 1 skipped in 1.87s
```

Also re-run with `HOME` pointed at a directory containing a real `auth.json` (simulating the root-homed runner): `94 passed, 1 skipped`. Full file green before and after; the two previously-failing tests are isolated under `TestDockerContainerMediaPathTranslation` / `TestDockerProfileSandboxMediaTranslation`.

Fixes #98879