### PR TITLE
feat(gateway): add versioned specialist capability registry

### DIFF
--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -1,0 +1,403 @@
+"""Local, fail-closed specialist capability declarations.
+
+The registry stores configured declarations and resolves exact advisory scope.
+It does not route work, create profiles, invoke models, or contact providers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from hermes_cli import kanban_db
+
+
+_MAX_EXPIRY_TIMESTAMP = 253402300799
+_PROFILE_ID_RE = re.compile(r"^[a-z][a-z0-9._-]{0,95}$")
+_REASON_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS capability_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_id TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    actions_json TEXT NOT NULL,
+    evidence_class TEXT NOT NULL,
+    requested_permissions_json TEXT NOT NULL,
+    expires_at INTEGER,
+    status TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_capability_profile_resolution
+ON capability_profiles(signature_hash, evidence_class, status);
+
+CREATE TABLE IF NOT EXISTS specialist_profile_revocations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    revocation_hash TEXT NOT NULL UNIQUE,
+    capability_profile_id INTEGER NOT NULL UNIQUE,
+    profile_id TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_specialist_profile_revocation
+ON specialist_profile_revocations(
+    capability_profile_id, profile_id, signature_hash, permissions_hash
+);
+
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_update
+BEFORE UPDATE ON capability_profiles BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_delete
+BEFORE DELETE ON capability_profiles BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_update
+BEFORE UPDATE ON specialist_profile_revocations BEGIN
+    SELECT RAISE(ABORT, 'specialist_profile_revocations is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_delete
+BEFORE DELETE ON specialist_profile_revocations BEGIN
+    SELECT RAISE(ABORT, 'specialist_profile_revocations is append-only');
+END;
+"""
+
+
+def _canonical_tokens(values: tuple[str, ...], *, field: str) -> tuple[str, ...]:
+    if isinstance(values, str) or not isinstance(values, tuple):
+        raise TypeError(f"{field} must be a tuple of strings")
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field} must contain only non-empty strings")
+    return tuple(sorted(set(values)))
+
+
+def _hash_payload(payload: object) -> str:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _expiry_timestamp(expires_at: datetime | int | float | None) -> int | None:
+    if expires_at is None:
+        return None
+    if isinstance(expires_at, datetime):
+        if expires_at.tzinfo is None:
+            raise ValueError("expires_at datetime must be timezone-aware")
+        value = int(expires_at.timestamp())
+    elif isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+        raise TypeError("expires_at must be a timestamp or timezone-aware datetime")
+    else:
+        value = int(expires_at)
+    if value > _MAX_EXPIRY_TIMESTAMP:
+        raise ValueError("expires_at is outside the supported range")
+    return value
+
+
+def _unexpired(expires_at: object, *, now: int) -> bool:
+    if expires_at is None:
+        return True
+    return isinstance(expires_at, int) and not isinstance(expires_at, bool) and now < expires_at <= _MAX_EXPIRY_TIMESTAMP
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySignature:
+    """Canonical advisory scope declared by a specialist profile."""
+
+    domain: str
+    actions: tuple[str, ...]
+    evidence_class: str
+    requested_permissions: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, str) or not self.domain.strip():
+            raise ValueError("domain must be a non-empty string")
+        if not isinstance(self.evidence_class, str) or not self.evidence_class.strip():
+            raise ValueError("evidence_class must be a non-empty string")
+        object.__setattr__(self, "actions", _canonical_tokens(self.actions, field="actions"))
+        object.__setattr__(
+            self,
+            "requested_permissions",
+            _canonical_tokens(self.requested_permissions, field="requested_permissions"),
+        )
+
+    @property
+    def signature_hash(self) -> str:
+        return _hash_payload(
+            {
+                "actions": self.actions,
+                "domain": self.domain,
+                "evidence_class": self.evidence_class,
+            }
+        )
+
+    @property
+    def permissions_hash(self) -> str:
+        return _hash_payload({"requested_permissions": self.requested_permissions})
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryResolution:
+    """Fail-closed resolution; only ``active_match`` carries a profile."""
+
+    status: Literal["active_match", "no_match", "ambiguous", "unavailable"]
+    profile: str | None
+    reason: str
+
+
+class CapabilityRegistry:
+    """Persist and resolve configured specialist capability declarations."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        board: str | None = None,
+        configured_profiles: Mapping[str, CapabilitySignature] | None = None,
+    ) -> None:
+        declarations = dict(configured_profiles or {})
+        for profile_id, signature in declarations.items():
+            self._validate_profile_id(profile_id)
+            if not isinstance(signature, CapabilitySignature):
+                raise TypeError("configured profile declarations must be CapabilitySignature values")
+        self._db_path = db_path
+        self._board = board
+        self._configured_profiles = declarations
+
+    @staticmethod
+    def _validate_profile_id(profile_id: object) -> str:
+        if not isinstance(profile_id, str) or not _PROFILE_ID_RE.fullmatch(profile_id):
+            raise ValueError("profile_id must be a bounded canonical identifier")
+        return profile_id
+
+    @contextmanager
+    def _connection(self) -> Iterator[object]:
+        """Open the board-local registry connection after idempotent schema setup."""
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            conn.executescript(_SCHEMA)
+            yield conn
+
+    def register_configured_profile(
+        self,
+        profile_id: str,
+        *,
+        expires_at: datetime | int | float | None = None,
+    ) -> int:
+        """Return one active row for the exact trusted declaration generation.
+
+        A revocation permanently hides only its immutable row. Calling this
+        trusted registration boundary again after revocation appends a new
+        generation; repeated calls then reuse that unrevoked generation.
+        """
+        self._validate_profile_id(profile_id)
+        signature = self._configured_profiles.get(profile_id)
+        if signature is None:
+            raise ValueError("profile_id is not present in configured specialist declarations")
+        created_at = int(time.time())
+        expires_at_timestamp = _expiry_timestamp(expires_at)
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                existing = conn.execute(
+                    """
+                    SELECT profiles.id FROM capability_profiles AS profiles
+                    WHERE profiles.profile_id = ?
+                      AND profiles.signature_hash = ?
+                      AND profiles.permissions_hash = ?
+                      AND profiles.status = 'active'
+                      AND profiles.expires_at IS ?
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM specialist_profile_revocations AS revocations
+                          WHERE revocations.capability_profile_id = profiles.id
+                            AND revocations.profile_id = profiles.profile_id
+                            AND revocations.signature_hash = profiles.signature_hash
+                            AND revocations.permissions_hash = profiles.permissions_hash
+                      )
+                    LIMIT 1
+                    """,
+                    (
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        expires_at_timestamp,
+                    ),
+                ).fetchone()
+                if existing is not None:
+                    return int(existing["id"])
+                cursor = conn.execute(
+                    """
+                    INSERT INTO capability_profiles (
+                        profile_id, signature_hash, permissions_hash, domain,
+                        actions_json, evidence_class, requested_permissions_json,
+                        expires_at, status, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+                    """,
+                    (
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        signature.domain,
+                        json.dumps(signature.actions, separators=(",", ":")),
+                        signature.evidence_class,
+                        json.dumps(signature.requested_permissions, separators=(",", ":")),
+                        expires_at_timestamp,
+                        created_at,
+                    ),
+                )
+                return int(cursor.lastrowid)
+
+    def add_active(self, **_: object) -> None:
+        """Reject the former arbitrary active-profile entry point."""
+        raise ValueError("direct arbitrary active profile registration is disabled; use configured declarations")
+
+    def revoke(
+        self,
+        *,
+        declaration_id: int,
+        profile_id: str,
+        signature: CapabilitySignature,
+        reason_code: str,
+        now: int | None = None,
+    ) -> str:
+        """Append an immutable revocation for one exact declaration row."""
+        if isinstance(declaration_id, bool) or not isinstance(declaration_id, int) or declaration_id <= 0:
+            raise ValueError("declaration_id must be a positive integer")
+        self._validate_profile_id(profile_id)
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        if not isinstance(reason_code, str) or not _REASON_CODE_RE.fullmatch(reason_code):
+            raise ValueError("reason_code must be a bounded canonical code")
+        created_at = int(time.time()) if now is None else now
+        if isinstance(created_at, bool) or not isinstance(created_at, int):
+            raise ValueError("now must be an integer timestamp")
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                declaration = conn.execute(
+                    """
+                    SELECT profiles.id, revocations.revocation_hash
+                    FROM capability_profiles AS profiles
+                    LEFT JOIN specialist_profile_revocations AS revocations
+                      ON revocations.capability_profile_id = profiles.id
+                     AND revocations.profile_id = profiles.profile_id
+                     AND revocations.signature_hash = profiles.signature_hash
+                     AND revocations.permissions_hash = profiles.permissions_hash
+                    WHERE profiles.id = ?
+                      AND profiles.profile_id = ?
+                      AND profiles.signature_hash = ?
+                      AND profiles.permissions_hash = ?
+                      AND profiles.status = 'active'
+                    LIMIT 1
+                    """,
+                    (
+                        declaration_id,
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                    ),
+                ).fetchone()
+                if declaration is None:
+                    raise ValueError("declaration_id does not match the exact active capability declaration")
+                if declaration["revocation_hash"] is not None:
+                    return str(declaration["revocation_hash"])
+                receipt = _hash_payload(
+                    {
+                        "capability_profile_id": declaration_id,
+                        "permissions_hash": signature.permissions_hash,
+                        "profile_id": profile_id,
+                        "reason_code": reason_code,
+                        "signature_hash": signature.signature_hash,
+                    }
+                )
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO specialist_profile_revocations (
+                        revocation_hash, capability_profile_id, profile_id,
+                        signature_hash, permissions_hash, reason_code, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        receipt,
+                        declaration_id,
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        reason_code,
+                        created_at,
+                    ),
+                )
+        return receipt
+
+    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
+        """Resolve exactly one active, unexpired, non-expanding local profile."""
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        try:
+            with self._connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT profile_id, signature_hash, permissions_hash, domain,
+                           actions_json, evidence_class, requested_permissions_json, expires_at
+                    FROM capability_profiles AS profiles
+                    WHERE status = 'active' AND signature_hash = ? AND evidence_class = ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM specialist_profile_revocations AS revocations
+                          WHERE revocations.capability_profile_id = profiles.id
+                            AND revocations.profile_id = profiles.profile_id
+                            AND revocations.signature_hash = profiles.signature_hash
+                            AND revocations.permissions_hash = profiles.permissions_hash
+                      )
+                    ORDER BY profile_id, id
+                    """,
+                    (signature.signature_hash, signature.evidence_class),
+                ).fetchall()
+        except Exception as exc:
+            return RegistryResolution(
+                status="unavailable",
+                profile=None,
+                reason=f"local capability registry unavailable: {type(exc).__name__}",
+            )
+
+        now = int(time.time())
+        requested_permissions = set(signature.requested_permissions)
+        matches: set[str] = set()
+        for row in rows:
+            if not _unexpired(row["expires_at"], now=now):
+                continue
+            try:
+                stored = CapabilitySignature(
+                    domain=row["domain"],
+                    actions=tuple(json.loads(row["actions_json"])),
+                    evidence_class=row["evidence_class"],
+                    requested_permissions=tuple(json.loads(row["requested_permissions_json"])),
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if (
+                stored.signature_hash != row["signature_hash"]
+                or stored.permissions_hash != row["permissions_hash"]
+                or stored.domain != signature.domain
+                or stored.actions != signature.actions
+                or not set(stored.requested_permissions) <= requested_permissions
+            ):
+                continue
+            matches.add(row["profile_id"])
+
+        if len(matches) == 1:
+            return RegistryResolution(
+                "active_match",
+                next(iter(matches)),
+                "exact active capability profile matched locally",
+            )
+        if len(matches) > 1:
+            return RegistryResolution("ambiguous", None, "multiple active capability profiles matched the requested scope")
+        return RegistryResolution("no_match", None, "no active unexpired profile matched the requested scope")

--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -17,9 +17,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from hermes_cli import kanban_db
-
-
 _MAX_EXPIRY_TIMESTAMP = 253402300799
 _PROFILE_ID_RE = re.compile(r"^[a-z][a-z0-9._-]{0,95}$")
 _REASON_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
@@ -86,6 +83,13 @@ def _canonical_tokens(values: tuple[str, ...], *, field: str) -> tuple[str, ...]
 def _hash_payload(payload: object) -> str:
     encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _kanban_db():
+    """Load board storage only when registry I/O begins."""
+    from hermes_cli import kanban_db
+
+    return kanban_db
 
 
 def _expiry_timestamp(expires_at: datetime | int | float | None) -> int | None:
@@ -183,7 +187,7 @@ class CapabilityRegistry:
     @contextmanager
     def _connection(self) -> Iterator[object]:
         """Open the board-local registry connection after idempotent schema setup."""
-        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+        with _kanban_db().connect_closing(self._db_path, board=self._board) as conn:
             conn.executescript(_SCHEMA)
             yield conn
 
@@ -206,7 +210,7 @@ class CapabilityRegistry:
         created_at = int(time.time())
         expires_at_timestamp = _expiry_timestamp(expires_at)
         with self._connection() as conn:
-            with kanban_db.write_txn(conn):
+            with _kanban_db().write_txn(conn):
                 existing = conn.execute(
                     """
                     SELECT profiles.id FROM capability_profiles AS profiles
@@ -281,7 +285,7 @@ class CapabilityRegistry:
         if isinstance(created_at, bool) or not isinstance(created_at, int):
             raise ValueError("now must be an integer timestamp")
         with self._connection() as conn:
-            with kanban_db.write_txn(conn):
+            with _kanban_db().write_txn(conn):
                 declaration = conn.execute(
                     """
                     SELECT profiles.id, revocations.revocation_hash
@@ -348,7 +352,8 @@ class CapabilityRegistry:
                     SELECT profile_id, signature_hash, permissions_hash, domain,
                            actions_json, evidence_class, requested_permissions_json, expires_at
                     FROM capability_profiles AS profiles
-                    WHERE status = 'active' AND signature_hash = ? AND evidence_class = ?
+                    WHERE status = 'active' AND signature_hash = ?
+                      AND permissions_hash = ? AND evidence_class = ?
                       AND NOT EXISTS (
                           SELECT 1 FROM specialist_profile_revocations AS revocations
                           WHERE revocations.capability_profile_id = profiles.id
@@ -358,7 +363,11 @@ class CapabilityRegistry:
                       )
                     ORDER BY profile_id, id
                     """,
-                    (signature.signature_hash, signature.evidence_class),
+                    (
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        signature.evidence_class,
+                    ),
                 ).fetchall()
         except Exception as exc:
             return RegistryResolution(
@@ -368,7 +377,6 @@ class CapabilityRegistry:
             )
 
         now = int(time.time())
-        requested_permissions = set(signature.requested_permissions)
         matches: set[str] = set()
         for row in rows:
             if not _unexpired(row["expires_at"], now=now):
@@ -387,7 +395,7 @@ class CapabilityRegistry:
                 or stored.permissions_hash != row["permissions_hash"]
                 or stored.domain != signature.domain
                 or stored.actions != signature.actions
-                or not set(stored.requested_permissions) <= requested_permissions
+                or stored.requested_permissions != signature.requested_permissions
             ):
                 continue
             matches.add(row["profile_id"])

--- a/tests/gateway/test_capability_registry.py
+++ b/tests/gateway/test_capability_registry.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import sqlite3
+import os
+import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -216,6 +220,74 @@ def test_permission_variant_registration_is_not_hidden_by_revoked_version(tmp_pa
     assert resolution.status == "active_match"
     assert resolution.profile == "repository-reviewer"
     assert renewed_declaration_id != original_declaration_id
+
+
+def test_unregistered_permission_expansion_does_not_reuse_narrow_declaration(tmp_path):
+    CapabilityRegistry, CapabilitySignature = _registry_api()
+    original = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": original},
+    ).register_configured_profile("repository-reviewer")
+    expanded = CapabilitySignature(
+        domain=original.domain,
+        actions=original.actions,
+        evidence_class=original.evidence_class,
+        requested_permissions=(
+            "repository-evidence:metadata",
+            "repository-evidence:read",
+        ),
+    )
+
+    resolution = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": expanded},
+    ).resolve(expanded)
+
+    assert resolution.status == "no_match"
+    assert resolution.profile is None
+
+
+def test_import_before_hermes_home_does_not_pin_kanban_paths(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    late_home = tmp_path / "late-home"
+    code = """
+import os
+import sys
+
+os.environ.pop("HERMES_HOME", None)
+import gateway.capability_registry as registry_module
+assert "hermes_cli.kanban_db" not in sys.modules
+os.environ["HERMES_HOME"] = sys.argv[1]
+signature = registry_module.CapabilitySignature(
+    domain="repository-evidence",
+    actions=("read",),
+    evidence_class="diagnostic-only",
+    requested_permissions=("repository-evidence:read",),
+)
+registry = registry_module.CapabilityRegistry(
+    configured_profiles={"reviewer": signature},
+)
+registry.register_configured_profile("reviewer")
+assert registry.resolve(signature).status == "active_match"
+"""
+    env = os.environ.copy()
+    env.pop("HERMES_HOME", None)
+    env["PYTHONPATH"] = str(repo)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(late_home)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (late_home / "kanban.db").is_file()
 
 
 def test_each_revocation_binds_the_latest_unrevoked_generation(tmp_path):

--- a/tests/gateway/test_capability_registry.py
+++ b/tests/gateway/test_capability_registry.py
@@ -1,0 +1,256 @@
+"""Behavior contracts for the local specialist capability registry."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+def _registry_api():
+    try:
+        from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+    except ImportError as exc:  # RED: the clean replacement starts without this capability.
+        pytest.fail(f"specialist capability registry is unavailable: {exc}")
+    return CapabilityRegistry, CapabilitySignature
+
+
+def _kanban_db():
+    from hermes_cli import kanban_db
+
+    return kanban_db
+
+
+def _repository_read_signature():
+    _, CapabilitySignature = _registry_api()
+    return CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read", "review"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+
+
+def test_configured_profile_resolves_only_its_exact_active_scope(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+
+    registry.register_configured_profile("repository-reviewer")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+
+
+def test_unconfigured_profile_cannot_use_direct_activation_api(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(db_path=tmp_path / "registry.db")
+
+    with pytest.raises(ValueError, match="configured"):
+        registry.register_configured_profile("undeclared")
+    with pytest.raises(ValueError, match="direct arbitrary"):
+        registry.add_active(profile_id="undeclared", signature=signature)
+
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_expired_profile_does_not_resolve(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_multiple_exact_profiles_fail_closed_as_ambiguous(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"reviewer-one": signature, "reviewer-two": signature},
+    )
+    registry.register_configured_profile("reviewer-one")
+    registry.register_configured_profile("reviewer-two")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "ambiguous"
+    assert resolution.profile is None
+
+
+def test_expired_configured_profile_can_append_one_unambiguous_renewal(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+
+
+def test_registry_rows_are_append_only_and_revocation_hides_profile(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    with _kanban_db().connect_closing(tmp_path / "registry.db") as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE capability_profiles SET status = 'inactive' "
+                "WHERE profile_id = 'repository-reviewer'"
+            )
+
+    receipt = registry.revoke(
+        declaration_id=declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    assert len(receipt) == 64
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_trusted_reregistration_after_revocation_creates_one_new_generation(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    first_declaration_id = registry.register_configured_profile("repository-reviewer")
+    registry.revoke(
+        declaration_id=first_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    renewed_declaration_id = registry.register_configured_profile("repository-reviewer")
+    duplicate_declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+    assert renewed_declaration_id != first_declaration_id
+    assert duplicate_declaration_id == renewed_declaration_id
+    with _kanban_db().connect_closing(db_path) as conn:
+        profile_rows = conn.execute(
+            "SELECT COUNT(*) FROM capability_profiles WHERE profile_id = ?",
+            ("repository-reviewer",),
+        ).fetchone()[0]
+        revocation_rows = conn.execute(
+            "SELECT COUNT(*) FROM specialist_profile_revocations WHERE profile_id = ?",
+            ("repository-reviewer",),
+        ).fetchone()[0]
+    assert profile_rows == 2
+    assert revocation_rows == 1
+
+
+def test_permission_variant_registration_is_not_hidden_by_revoked_version(tmp_path):
+    CapabilityRegistry, CapabilitySignature = _registry_api()
+    original = _repository_read_signature()
+    expanded = CapabilitySignature(
+        domain=original.domain,
+        actions=original.actions,
+        evidence_class=original.evidence_class,
+        requested_permissions=(
+            "repository-evidence:metadata",
+            "repository-evidence:read",
+        ),
+    )
+    db_path = tmp_path / "registry.db"
+    original_registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": original},
+    )
+    original_declaration_id = original_registry.register_configured_profile(
+        "repository-reviewer"
+    )
+    original_registry.revoke(
+        declaration_id=original_declaration_id,
+        profile_id="repository-reviewer",
+        signature=original,
+        reason_code="permission_version_revoked",
+    )
+
+    renewed_registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": expanded},
+    )
+    renewed_declaration_id = renewed_registry.register_configured_profile(
+        "repository-reviewer"
+    )
+
+    assert renewed_registry.resolve(original).status == "no_match"
+    resolution = renewed_registry.resolve(expanded)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+    assert renewed_declaration_id != original_declaration_id
+
+
+def test_each_revocation_binds_the_latest_unrevoked_generation(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    first_declaration_id = registry.register_configured_profile("repository-reviewer")
+    first_receipt = registry.revoke(
+        declaration_id=first_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+    second_declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    second_receipt = registry.revoke(
+        declaration_id=second_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    assert second_receipt != first_receipt
+    assert registry.resolve(signature).status == "no_match"
+    with _kanban_db().connect_closing(db_path) as conn:
+        declaration_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT capability_profile_id FROM specialist_profile_revocations "
+                "ORDER BY capability_profile_id"
+            ).fetchall()
+        ]
+    assert len(declaration_ids) == 2
+    assert len(set(declaration_ids)) == 2


### PR DESCRIPTION
## Summary

- add a versioned capability registry keyed by canonical task signatures
- require exact permission identity rather than authorizing permission expansions
- bind revocation to the exact registered capability identity
- defer the Kanban import until a registry connection is actually needed

## Scope

This is the first focused extraction from #97870. It adds only the inert registry and behavior tests. It does not create profiles, discover candidates, route tasks, call models, activate specialists, or perform network operations.

## Verification

- 11 focused registry tests passed
- grouped registry and Kanban tests passed
- Ruff, bytecode compilation, and diff checks passed
- exact-head independent review found no blockers
- content and metadata scope scan passed