### PR TITLE
feat(sessions): add clear transcript and pruning across CLI, API, and Desktop (#98822)

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -597,3 +597,36 @@ export function renameSession(
     body: { title, ...(profile ? { profile } : {}) }
   })
 }
+
+export function clearSession(
+  id: string,
+  options?: { keep_last_n?: number; before_timestamp?: number },
+  profile?: ProfileScope
+): Promise<{ ok: boolean; session_id: string }> {
+  return hermesApi<{ ok: boolean; session_id: string }>({
+    ...sessionScoped(profile),
+    path: `/api/sessions/${encodeURIComponent(id)}/clear`,
+    method: 'POST',
+    body: {
+      ...(options?.keep_last_n !== undefined ? { keep_last_n: options.keep_last_n } : {}),
+      ...(options?.before_timestamp !== undefined ? { before_timestamp: options.before_timestamp } : {}),
+      ...(sessionScoped(profile).profile ? { profile: sessionScoped(profile).profile } : {})
+    }
+  })
+}
+
+export function deleteSessionMessages(
+  id: string,
+  messageIds: number[],
+  profile?: ProfileScope
+): Promise<{ ok: boolean; session_id: string; deleted: number }> {
+  return hermesApi<{ ok: boolean; session_id: string; deleted: number }>({
+    ...sessionScoped(profile),
+    path: `/api/sessions/${encodeURIComponent(id)}/messages/bulk-delete`,
+    method: 'POST',
+    body: {
+      message_ids: messageIds,
+      ...(sessionScoped(profile).profile ? { profile: sessionScoped(profile).profile } : {})
+    }
+  })
+}

--- a/apps/desktop/src/app/chat/sidebar/clear-transcript-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/clear-transcript-dialog.tsx
@@ -1,0 +1,221 @@
+import * as React from 'react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { FieldHint } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export type ClearMode = 'all' | 'last_n' | 'before'
+
+export interface ClearTranscriptOptions {
+  keep_last_n?: number
+  before_timestamp?: string
+}
+
+export interface ClearTranscriptDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (options?: ClearTranscriptOptions) => Promise<void> | void
+  sessionTitle: string
+}
+
+export function ClearTranscriptDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  sessionTitle
+}: ClearTranscriptDialogProps) {
+  const [mode, setMode] = useState<ClearMode>('all')
+  const [keepLastN, setKeepLastN] = useState<number>(5)
+  const [beforeTime, setBeforeTime] = useState<string>('1d')
+  const [submitting, setSubmitting] = useState<boolean>(false)
+
+  const handleSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault()
+    if (submitting) return
+
+    setSubmitting(true)
+    try {
+      if (mode === 'all') {
+        await onConfirm()
+      } else if (mode === 'last_n') {
+        await onConfirm({ keep_last_n: Math.max(1, keepLastN) })
+      } else if (mode === 'before') {
+        await onConfirm({ before_timestamp: beforeTime.trim() })
+      }
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const PRESET_LAST = [2, 5, 10]
+  const PRESET_BEFORE = [
+    { label: '1 hour', value: '1h' },
+    { label: '1 day', value: '1d' },
+    { label: '1 week', value: '1w' },
+    { label: '30 days', value: '30d' }
+  ]
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm font-semibold">
+            <Codicon name="clear-all" size="1rem" className="text-destructive" />
+            <span>Clear transcript</span>
+          </DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground">
+            Clear messages from &ldquo;{sessionTitle}&rdquo;. The session title, pins, and settings will be preserved.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-3 py-2 text-xs">
+          {/* Mode 1: All */}
+          <div
+            onClick={() => setMode('all')}
+            className={cn(
+              'cursor-pointer rounded border p-2.5 transition-colors',
+              mode === 'all'
+                ? 'border-destructive/60 bg-destructive/5 dark:bg-destructive/10'
+                : 'border-border hover:bg-muted/40'
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-foreground">All messages</span>
+              <span className="text-[0.6875rem] text-muted-foreground">Reset context to 0%</span>
+            </div>
+            <p className="mt-1 text-[0.6875rem] text-muted-foreground">
+              Delete all conversation turns and tool results completely.
+            </p>
+          </div>
+
+          {/* Mode 2: Keep last N */}
+          <div
+            onClick={() => setMode('last_n')}
+            className={cn(
+              'cursor-pointer rounded border p-2.5 transition-colors',
+              mode === 'last_n'
+                ? 'border-primary/60 bg-primary/5 dark:bg-primary/10'
+                : 'border-border hover:bg-muted/40'
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-foreground">Keep recent messages</span>
+            </div>
+            <p className="mt-1 text-[0.6875rem] text-muted-foreground">
+              Keep the newest messages and wipe older turns.
+            </p>
+
+            {mode === 'last_n' && (
+              <div className="mt-2.5 flex items-center gap-2 pt-1" onClick={e => e.stopPropagation()}>
+                <span className="text-muted-foreground">Keep last:</span>
+                <Input
+                  type="number"
+                  min={1}
+                  max={500}
+                  value={keepLastN}
+                  onChange={e => setKeepLastN(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                  className="w-16 text-center"
+                  size="sm"
+                />
+                <span className="text-muted-foreground">messages</span>
+                <div className="ml-auto flex gap-1">
+                  {PRESET_LAST.map(n => (
+                    <Button
+                      key={n}
+                      type="button"
+                      variant={keepLastN === n ? 'default' : 'outline'}
+                      size="xs"
+                      onClick={() => setKeepLastN(n)}
+                    >
+                      {n}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Mode 3: Clear older than */}
+          <div
+            onClick={() => setMode('before')}
+            className={cn(
+              'cursor-pointer rounded border p-2.5 transition-colors',
+              mode === 'before'
+                ? 'border-primary/60 bg-primary/5 dark:bg-primary/10'
+                : 'border-border hover:bg-muted/40'
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-foreground">Clear older than</span>
+            </div>
+            <p className="mt-1 text-[0.6875rem] text-muted-foreground">
+              Delete messages created before a timeframe or date.
+            </p>
+
+            {mode === 'before' && (
+              <div className="mt-2.5 space-y-2 pt-1" onClick={e => e.stopPropagation()}>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-muted-foreground">Older than:</span>
+                  {PRESET_BEFORE.map(p => (
+                    <Button
+                      key={p.value}
+                      type="button"
+                      variant={beforeTime === p.value ? 'default' : 'outline'}
+                      size="xs"
+                      onClick={() => setBeforeTime(p.value)}
+                    >
+                      {p.label}
+                    </Button>
+                  ))}
+                </div>
+                <Input
+                  type="text"
+                  value={beforeTime}
+                  onChange={e => setBeforeTime(e.target.value)}
+                  placeholder="e.g. 2d, 5h, 2026-08-01"
+                  className="w-full text-xs"
+                  size="sm"
+                />
+                <FieldHint>
+                  Formats: <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">30m</code>, <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">5h</code>, <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">2d</code>, <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">1w</code>, <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">30d</code>, or <code className="rounded bg-muted/80 px-1 py-0.5 font-mono text-[0.625rem] text-foreground">YYYY-MM-DD</code>
+                </FieldHint>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={submitting}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="destructive"
+              size="sm"
+              disabled={submitting}
+            >
+              {submitting ? 'Clearing…' : 'Clear transcript'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -24,11 +24,12 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { CopyButton } from '@/components/ui/copy-button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { renameSession } from '@/hermes'
+import { clearSession, renameSession } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
+import { ClearTranscriptDialog, type ClearTranscriptOptions } from './clear-transcript-dialog'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
@@ -107,6 +108,7 @@ interface SessionActions {
   onToggleUnread?: () => void
   onBranch?: () => void
   onArchive?: () => void
+  onClearTranscript?: () => void
   onDelete?: () => void
   /** Close this surface (a tile tab) — omitted where nothing closes (sidebar
    *  rows, the main tab). */
@@ -191,6 +193,7 @@ function useSessionActions({
   onToggleUnread,
   onBranch,
   onArchive,
+  onClearTranscript,
   onDelete,
   onClose,
   onHideTabBar,
@@ -208,10 +211,13 @@ function useSessionActions({
   // action leaves the restore alone (it's the correct behavior for them). Mirrors
   // the project menu's appearance-popover guard.
   const suppressCloseFocusRef = useRef(false)
+  const [clearOpen, setClearOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const isRemote = useStore($connection)?.mode === 'remote'
+  const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
+  const hasMessages = (session?.message_count ?? 0) > 0
   // The row's finished-unread dot is cleared by opening the session (main or
   // tile) — this menu item is the explicit escape hatch for the rest.
   const isUnread = useStore($unreadFinishedSessionIds).includes(sessionId)
@@ -438,6 +444,15 @@ function useSessionActions({
         onArchive?.()
       }
     }),
+    spec({
+      disabled: !sessionId || !hasMessages,
+      icon: 'clear-all',
+      label: 'Clear transcript',
+      onSelect: () => {
+        triggerHaptic('warning')
+        setClearOpen(true)
+      }
+    }),
     {
       className: 'text-destructive focus:text-destructive',
       disabled: !onDelete,
@@ -538,6 +553,42 @@ function useSessionActions({
     }
   }
 
+  const handleClearTranscript = async (options?: ClearTranscriptOptions) => {
+    if (onClearTranscript) {
+      onClearTranscript()
+      return
+    }
+
+    if (!sessionId) {
+      return
+    }
+
+    try {
+      await clearSession(sessionId, options, profile)
+      if (!options?.keep_last_n && !options?.before_timestamp) {
+        setSessions(prev =>
+          prev.map(s =>
+            s.id === sessionId
+              ? { ...s, message_count: 0, input_tokens: 0, output_tokens: 0 }
+              : s
+          )
+        )
+      }
+      notify({ durationMs: 2_000, kind: 'success', message: 'Transcript cleared' })
+    } catch (err) {
+      notifyError(err, 'Failed to clear transcript')
+    }
+  }
+
+  const clearDialog = (
+    <ClearTranscriptDialog
+      onConfirm={handleClearTranscript}
+      onOpenChange={setClearOpen}
+      open={clearOpen}
+      sessionTitle={title}
+    />
+  )
+
   const deleteDialog = (
     <DeleteSessionDialog
       onConfirm={() => {
@@ -549,7 +600,7 @@ function useSessionActions({
     />
   )
 
-  return { deleteDialog, onCloseAutoFocus, renameDialog, renderItems }
+  return { clearDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems }
 }
 
 interface DeleteSessionDialogProps {
@@ -590,7 +641,7 @@ interface SessionActionsMenuProps
 
 export function SessionActionsMenu({ children, align = 'end', sideOffset = 6, ...actions }: SessionActionsMenuProps) {
   const { t } = useI18n()
-  const { deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
+  const { clearDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
 
   return (
     <>
@@ -605,6 +656,7 @@ export function SessionActionsMenu({ children, align = 'end', sideOffset = 6, ..
         {children}
       </ActionsMenu>
       {renameDialog}
+      {clearDialog}
       {deleteDialog}
     </>
   )
@@ -616,7 +668,7 @@ interface SessionContextMenuProps extends SessionActions {
 
 export function SessionContextMenu({ children, ...actions }: SessionContextMenuProps) {
   const { t } = useI18n()
-  const { deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
+  const { clearDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
 
   return (
     <>
@@ -629,6 +681,7 @@ export function SessionContextMenu({ children, ...actions }: SessionContextMenuP
         {children}
       </ActionsContextMenu>
       {renameDialog}
+      {clearDialog}
       {deleteDialog}
     </>
   )

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -543,6 +543,47 @@ def _cmd_delete(db, args):
     print(f"Deleted session '{resolved_session_id}'.")
 
 
+def _cmd_clear(db, args):
+    resolved_session_id = db.resolve_session_id(args.session_id)
+    if not resolved_session_id:
+        return _not_found(args.session_id)
+    session = db.get_session(resolved_session_id)
+    _pinned_note = " (this session is PINNED)" if (session or {}).get("pinned") else ""
+
+    keep_last_n = getattr(args, "last", None)
+    before_arg = getattr(args, "before", None)
+    before_ts = None
+    if before_arg:
+        from hermes_cli.session_filters import parse_point_in_time
+        before_ts = parse_point_in_time(before_arg)
+        if before_ts is None:
+            print(f"Error: Invalid time format '{before_arg}'. Use a duration like '2d'/'5h' or an ISO timestamp.")
+            return 1
+
+    detail = ""
+    if keep_last_n is not None and keep_last_n > 0:
+        detail = f" (keeping last {keep_last_n} messages)"
+    elif before_ts is not None:
+        detail = f" (messages before {before_arg})"
+
+    if not args.yes:
+        if not _confirm_prompt(f"Clear transcript for session '{resolved_session_id}'{_pinned_note}{detail}? [y/N] "):
+            print("Cancelled.")
+            return
+    elif _pinned_note:
+        print(f"Warning: clearing a pinned session '{resolved_session_id}'.")
+
+    if not db.clear_session_messages(
+        resolved_session_id,
+        keep_last_n=keep_last_n,
+        before_timestamp=before_ts,
+        sessions_dir=_sessions_dir(),
+    ):
+        return _not_found(args.session_id)
+
+    print(f"Cleared transcript for session '{resolved_session_id}'{detail}.")
+
+
 #: Age floor for `prune --never-active`; generous: a young never-active row may be a chat nobody replied to yet.
 _NEVER_ACTIVE_DEFAULT_DAYS = 30.0
 
@@ -938,7 +979,7 @@ def _cmd_stats(db, args):
 
 _PRE_DB_HANDLERS = {"repair": _cmd_repair, "recover": _cmd_recover, "import": _cmd_import}
 _DB_HANDLERS = {
-    "list": _cmd_list, "export": _cmd_export, "delete": _cmd_delete, "rename": _cmd_rename, "pinned": _cmd_pinned,
+    "list": _cmd_list, "export": _cmd_export, "delete": _cmd_delete, "clear": _cmd_clear, "rename": _cmd_rename, "pinned": _cmd_pinned,
     "prune": partial(_cmd_prune_or_archive, action="prune"), "pin": partial(_cmd_pin, pinning=True),
     "archive": partial(_cmd_prune_or_archive, action="archive"), "unpin": partial(_cmd_pin, pinning=False),
     "retitle-skills": _cmd_retitle_skills, "browse": _cmd_browse, "optimize": _cmd_optimize,

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -101,6 +101,15 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     sessions_delete.add_argument("session_id", help="Session ID to delete")
     add_yes_flag(sessions_delete, "Skip confirmation")
 
+    sessions_clear = sessions_subparsers.add_parser(
+        "clear", help="Clear a session's message history while preserving title and settings")
+    sessions_clear.add_argument("session_id", help="Session ID (or prefix) to clear")
+    sessions_clear.add_argument("--last", type=int, metavar="N",
+        help="Keep the newest N messages, deleting older turns")
+    sessions_clear.add_argument("--before", metavar="TIME",
+        help="Delete messages created before TIME (duration like '2d'/'5h', or ISO timestamp)")
+    add_yes_flag(sessions_clear, "Skip confirmation")
+
     sessions_prune = sessions_subparsers.add_parser(
         "prune", help="Delete old sessions (filterable by time window, source, title, ...)")
     _add_session_filter_args(

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, SecretStr, field_validator
 
@@ -251,6 +251,17 @@ class SessionOwnerBackfill(BaseModel):
     """POST /api/sessions/owner-backfill (legacy migration). ``profile`` scopes WHICH state.db is
     stamped; the stamped value is always that store's own serving-profile identity — the caller
     cannot inject an arbitrary owner."""
+    profile: Optional[str] = None
+
+class SessionClear(BaseModel):
+    """Body for POST /api/sessions/{session_id}/clear."""
+    profile: Optional[str] = None
+    keep_last_n: Optional[int] = None
+    before_timestamp: Optional[Union[str, float]] = None
+
+class SessionMessagesDelete(BaseModel):
+    """Body for POST /api/sessions/{session_id}/messages/bulk-delete."""
+    message_ids: List[int]
     profile: Optional[str] = None
 
 class SessionPrune(BaseModel):

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -21,7 +21,8 @@ from hermes_cli.web_deps import late
 from hermes_cli.web_server_gateway import _strip_session_list_rows
 from hermes_cli.web_server_sessions import _maybe_auto_archive_for_profile, _session_latest_descendant
 from hermes_cli.web_models import (
-    BulkDeleteSessions, SessionImport, SessionOwnerBackfill, SessionPrune, SessionRename)
+    BulkDeleteSessions, SessionClear, SessionImport, SessionMessagesDelete,
+    SessionOwnerBackfill, SessionPrune, SessionRename)
 from hermes_cli.web_routers._common import log as _log, http_failure
 from hermes_state import is_malformed_db_error
 from hermes_state_errors import is_transient_sqlite_error
@@ -574,6 +575,50 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
         return {"ok": True}
 
     return await asyncio.to_thread(_with_db, profile, _delete, read_only=False)
+
+
+@manage_router.post("/api/sessions/{session_id}/clear")
+async def clear_session_endpoint(
+    session_id: str,
+    body: Optional[SessionClear] = None,
+):
+    """Clear transcript / messages for a session while preserving metadata."""
+    profile = body.profile if body else None
+    keep_last_n = body.keep_last_n if body else None
+    before_timestamp = body.before_timestamp if body else None
+
+    if isinstance(before_timestamp, str):
+        from hermes_cli.session_filters import parse_point_in_time
+        before_timestamp = parse_point_in_time(before_timestamp)
+
+    def _clear(db):
+        sid = _resolve_session_id(db, session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        success = db.clear_session_messages(
+            sid,
+            keep_last_n=keep_last_n,
+            before_timestamp=before_timestamp,
+        )
+        return {"ok": success, "session_id": sid}
+
+    return await asyncio.to_thread(_with_db, profile, _clear, read_only=False)
+
+
+@manage_router.post("/api/sessions/{session_id}/messages/bulk-delete")
+async def delete_session_messages_endpoint(
+    session_id: str,
+    body: SessionMessagesDelete,
+):
+    """Delete specific messages by ID within a session."""
+    def _delete(db):
+        sid = _resolve_session_id(db, session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        deleted = db.delete_session_messages(sid, body.message_ids)
+        return {"ok": True, "session_id": sid, "deleted": deleted}
+
+    return await asyncio.to_thread(_with_db, body.profile, _delete, read_only=False)
 
 
 @manage_router.post("/api/sessions/owner-backfill")

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY, split_user_originated_turn
@@ -1100,12 +1101,170 @@ class SessionMessagesMixin:
         generation = int(row["generation"]) if row is not None and row["generation"] is not None else 0
         return generation if generation > 0 else None
 
+    def clear_session_messages(
+        self,
+        session_id: str,
+        keep_last_n: Optional[int] = None,
+        before_timestamp: Optional[float] = None,
+        sessions_dir: Optional[Path] = None,
+    ) -> bool:
+        """Clear messages for a session while preserving the session record.
+
+        When *keep_last_n* is specified (> 0), keeps the most recent *keep_last_n*
+        messages (by id) and deletes older ones.
+        When *before_timestamp* is specified, deletes messages with timestamp < before_timestamp.
+        Otherwise, deletes all messages for the session.
+
+        Recalculates or resets message_count, tool_call_count, token counters,
+        and cleans unreferenced system prompts.
+        When all messages are removed and *sessions_dir* is provided, cleans up on-disk
+        transcript files.
+
+        Returns True if the session was found and cleared, False if session was not found.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (session_id,)
+            )
+            if cursor.fetchone() is None:
+                return False
+
+            if keep_last_n is not None and keep_last_n > 0:
+                conn.execute(
+                    """
+                    DELETE FROM messages
+                    WHERE session_id = ?
+                      AND id NOT IN (
+                          SELECT id FROM messages
+                          WHERE session_id = ?
+                          ORDER BY id DESC
+                          LIMIT ?
+                      )
+                    """,
+                    (session_id, session_id, keep_last_n),
+                )
+            elif before_timestamp is not None:
+                conn.execute(
+                    "DELETE FROM messages WHERE session_id = ? AND timestamp < ?",
+                    (session_id, before_timestamp),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM messages WHERE session_id = ?", (session_id,)
+                )
+
+            # Check remaining messages count
+            row = conn.execute(
+                """
+                SELECT COUNT(*) as msg_cnt,
+                       SUM(CASE WHEN role = 'tool' OR (tool_calls IS NOT NULL AND tool_calls != '' AND tool_calls != '[]') THEN 1 ELSE 0 END) as tool_cnt
+                FROM messages
+                WHERE session_id = ? AND active = 1
+                """,
+                (session_id,),
+            ).fetchone()
+
+            remaining_msgs = row["msg_cnt"] if row and row["msg_cnt"] is not None else 0
+            remaining_tools = row["tool_cnt"] if row and row["tool_cnt"] is not None else 0
+
+            if remaining_msgs == 0:
+                conn.execute(
+                    """
+                    UPDATE sessions SET
+                        message_count = 0,
+                        tool_call_count = 0,
+                        input_tokens = 0,
+                        output_tokens = 0,
+                        cache_read_tokens = 0,
+                        cache_write_tokens = 0,
+                        reasoning_tokens = 0,
+                        api_call_count = 0,
+                        last_activity_at = ?
+                    WHERE id = ?
+                    """,
+                    (time.time(), session_id),
+                )
+                conn.execute(
+                    "DELETE FROM session_model_usage WHERE session_id = ?",
+                    (session_id,),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE sessions SET
+                        message_count = ?,
+                        tool_call_count = ?,
+                        last_activity_at = ?
+                    WHERE id = ?
+                    """,
+                    (remaining_msgs, remaining_tools, time.time(), session_id),
+                )
+
+            self._delete_unreferenced_system_prompts(conn)
+            return True
+
+        cleared = self._execute_write(_do)
+        if cleared:
+            if keep_last_n is None and before_timestamp is None:
+                self._remove_session_files(sessions_dir, session_id)
+        return bool(cleared)
+
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
+        self.clear_session_messages(session_id)
+
+    def delete_session_messages(
+        self,
+        session_id: str,
+        message_ids: List[int],
+    ) -> int:
+        """Delete specific messages by ID within a session.
+
+        Recalculates message_count and tool_call_count for the session.
+        Returns the number of deleted messages.
+        """
+        if not message_ids:
+            return 0
+        valid_ids = [mid for mid in message_ids if isinstance(mid, int) or (isinstance(mid, str) and str(mid).isdigit())]
+        if not valid_ids:
+            return 0
+
         def _do(conn):
-            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-            conn.execute(_RESET_COUNTERS_SQL, (session_id,))
-        self._execute_write(_do)
+            placeholders = ",".join("?" * len(valid_ids))
+            cursor = conn.execute(
+                f"DELETE FROM messages WHERE session_id = ? AND id IN ({placeholders})",
+                [session_id, *valid_ids],
+            )
+            deleted_count = cursor.rowcount
+
+            if deleted_count > 0:
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*) as msg_cnt,
+                           SUM(CASE WHEN role = 'tool' OR (tool_calls IS NOT NULL AND tool_calls != '' AND tool_calls != '[]') THEN 1 ELSE 0 END) as tool_cnt
+                    FROM messages
+                    WHERE session_id = ? AND active = 1
+                    """,
+                    (session_id,),
+                ).fetchone()
+
+                remaining_msgs = row["msg_cnt"] if row and row["msg_cnt"] is not None else 0
+                remaining_tools = row["tool_cnt"] if row and row["tool_cnt"] is not None else 0
+
+                conn.execute(
+                    """
+                    UPDATE sessions SET
+                        message_count = ?,
+                        tool_call_count = ?,
+                        last_activity_at = ?
+                    WHERE id = ?
+                    """,
+                    (remaining_msgs, remaining_tools, time.time(), session_id),
+                )
+
+            return deleted_count
+
+        return self._execute_write(_do) or 0
 
     def purge_stale_tool_call_markers(self, *, dry_run: bool = False, backup: bool = True) -> Dict[str, Any]:
         """Permanently clear bare tool-call marker content ("[memory]") left by pre-fix sessions

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -114,7 +114,7 @@ def _session_filter_where(
         ("s.session_key = ?", [session_key] if session_key else []),
         (f"s.source NOT IN ({_session_ids_placeholders(exclude_sources or ())})", exclude_sources or []),
         (_cwd_prefix_clause(cwd_prefix) if cwd_prefix else ("", [])),
-        ("s.message_count >= ?", [min_message_count] if min_message_count > 0 else []),
+        ("(s.message_count >= ? OR (s.title IS NOT NULL AND s.title != '') OR s.pinned = 1)", [min_message_count] if min_message_count > 0 else []),
     ):
         if values:
             where.append(clause)

--- a/tests/hermes_cli/test_sessions_clear.py
+++ b/tests/hermes_cli/test_sessions_clear.py
@@ -1,0 +1,110 @@
+import sys
+import pytest
+
+
+def test_sessions_clear_accepts_unique_id_prefix(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"] = session_id
+            return "20260315_092437_c9a6ff"
+
+        def get_session(self, session_id):
+            return {"id": session_id, "title": "My Session", "pinned": 1}
+
+        def clear_session_messages(self, session_id, **kwargs):
+            captured["cleared"] = session_id
+            captured["kwargs"] = kwargs
+            return True
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "clear", "20260315_092437_c9a6", "--yes"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured["resolved_from"] == "20260315_092437_c9a6"
+    assert captured["cleared"] == "20260315_092437_c9a6ff"
+    assert captured["closed"] is True
+    assert "Cleared transcript for session '20260315_092437_c9a6ff'." in output
+
+
+def test_sessions_clear_with_last_n(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            return session_id
+
+        def get_session(self, session_id):
+            return {"id": session_id, "title": "My Session"}
+
+        def clear_session_messages(self, session_id, keep_last_n=None, **kwargs):
+            captured["session_id"] = session_id
+            captured["keep_last_n"] = keep_last_n
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "clear", "sess123", "--last", "5", "--yes"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured["keep_last_n"] == 5
+    assert "Cleared transcript for session 'sess123' (keeping last 5 messages)." in output
+
+
+def test_sessions_clear_confirmation_abort(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            return session_id
+
+        def get_session(self, session_id):
+            return {"id": session_id, "title": "My Session"}
+
+        def clear_session_messages(self, session_id, **kwargs):
+            captured["cleared"] = True
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "clear", "sess123"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "Cancelled." in output
+    assert "cleared" not in captured

--- a/tests/test_hermes_state_clear_messages.py
+++ b/tests/test_hermes_state_clear_messages.py
@@ -1,0 +1,186 @@
+import time
+from pathlib import Path
+try:
+    import pytest
+    fixture = pytest.fixture
+except ImportError:
+    fixture = lambda f: f
+
+from hermes_state import SessionDB
+
+
+@fixture
+def temp_db(tmp_path):
+    db_file = tmp_path / "test_state.db"
+    db = SessionDB(db_path=db_file)
+    yield db
+    db.close()
+
+
+def test_clear_session_messages_full(temp_db, tmp_path):
+    sid = "test_sess_full_clear"
+    temp_db.create_session(
+        session_id=sid,
+        source="cli",
+        model="gpt-5",
+    )
+    temp_db.set_session_title(sid, "My Project Session")
+    temp_db.set_session_pinned(sid, True)
+
+    # Append some messages
+    temp_db.append_message(sid, role="user", content="Hello", token_count=10)
+    temp_db.append_message(sid, role="assistant", content="Hi there!", token_count=20)
+    temp_db.append_message(sid, role="user", content="Do task", token_count=15)
+    temp_db.append_message(
+        sid,
+        role="assistant",
+        content="",
+        tool_calls=[{"id": "call_1", "name": "terminal", "args": {"command": "ls"}}],
+        token_count=30,
+    )
+    temp_db.append_message(
+        sid,
+        role="tool",
+        content="file1.txt\nfile2.txt",
+        tool_call_id="call_1",
+        token_count=50,
+    )
+
+    # Verify messages and counters before clear
+    msgs_before = temp_db.get_messages(sid)
+    assert len(msgs_before) == 5
+    sess_before = temp_db.get_session(sid)
+    assert sess_before["message_count"] == 5
+    assert sess_before["pinned"] == 1
+    assert sess_before["title"] == "My Project Session"
+
+    # Create dummy transcript files
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / f"{sid}.json").write_text("{}")
+    (sessions_dir / f"{sid}.jsonl").write_text("{}")
+
+    # Clear messages
+    cleared = temp_db.clear_session_messages(sid, sessions_dir=sessions_dir)
+    assert cleared is True
+
+    # Verify messages and counters after clear
+    msgs_after = temp_db.get_messages(sid)
+    assert len(msgs_after) == 0
+
+    sess_after = temp_db.get_session(sid)
+    assert sess_after["message_count"] == 0
+    assert sess_after["tool_call_count"] == 0
+    assert sess_after["input_tokens"] == 0
+    assert sess_after["output_tokens"] == 0
+    # Metadata preserved
+    assert sess_after["title"] == "My Project Session"
+    assert sess_after["pinned"] == 1
+    assert sess_after["source"] == "cli"
+
+    # Files removed
+    assert not (sessions_dir / f"{sid}.json").exists()
+    assert not (sessions_dir / f"{sid}.jsonl").exists()
+
+
+def test_clear_session_messages_keep_last_n(temp_db):
+    sid = "test_sess_keep_last"
+    temp_db.create_session(session_id=sid, source="cli")
+    temp_db.set_session_title(sid, "Keep Last Test")
+
+    for i in range(10):
+        temp_db.append_message(sid, role="user" if i % 2 == 0 else "assistant", content=f"msg_{i}")
+
+    assert len(temp_db.get_messages(sid)) == 10
+
+    # Keep only the last 3 messages
+    cleared = temp_db.clear_session_messages(sid, keep_last_n=3)
+    assert cleared is True
+
+    msgs_after = temp_db.get_messages(sid)
+    assert len(msgs_after) == 3
+    assert [m["content"] for m in msgs_after] == ["msg_7", "msg_8", "msg_9"]
+
+    sess_after = temp_db.get_session(sid)
+    assert sess_after["message_count"] == 3
+    assert sess_after["title"] == "Keep Last Test"
+
+
+def test_clear_session_messages_before_timestamp(temp_db):
+    sid = "test_sess_before_ts"
+    temp_db.create_session(session_id=sid, source="cli")
+    temp_db.set_session_title(sid, "Before Timestamp Test")
+
+    t0 = 1000.0
+    temp_db.append_message(sid, role="user", content="old_1", timestamp=t0)
+    temp_db.append_message(sid, role="assistant", content="old_2", timestamp=t0 + 10)
+    temp_db.append_message(sid, role="user", content="new_1", timestamp=t0 + 100)
+    temp_db.append_message(sid, role="assistant", content="new_2", timestamp=t0 + 110)
+
+    assert len(temp_db.get_messages(sid)) == 4
+
+    # Delete messages before t0 + 50
+    cleared = temp_db.clear_session_messages(sid, before_timestamp=t0 + 50)
+    assert cleared is True
+
+    msgs_after = temp_db.get_messages(sid)
+    assert len(msgs_after) == 2
+    assert [m["content"] for m in msgs_after] == ["new_1", "new_2"]
+
+    sess_after = temp_db.get_session(sid)
+    assert sess_after["message_count"] == 2
+
+
+def test_clear_session_messages_not_found(temp_db):
+    cleared = temp_db.clear_session_messages("nonexistent_session")
+    assert cleared is False
+
+
+def test_delete_session_messages_selective(temp_db):
+    sid = "test_sess_selective"
+    temp_db.create_session(session_id=sid, source="cli")
+    temp_db.set_session_title(sid, "Selective Delete")
+
+    m1 = temp_db.append_message(sid, role="user", content="msg 1")
+    m2 = temp_db.append_message(sid, role="assistant", content="msg 2")
+    m3 = temp_db.append_message(sid, role="user", content="msg 3")
+
+    assert len(temp_db.get_messages(sid)) == 3
+
+    # Delete message 2
+    deleted = temp_db.delete_session_messages(sid, [m2])
+    assert deleted == 1
+
+    msgs_after = temp_db.get_messages(sid)
+    assert len(msgs_after) == 2
+    assert [m["id"] for m in msgs_after] == [m1, m3]
+
+    sess_after = temp_db.get_session(sid)
+    assert sess_after["message_count"] == 2
+
+
+def test_list_sessions_rich_cleared_session_visibility(temp_db):
+    # 1. Blank draft session (no messages, no title, not pinned) -> hidden with min_message_count=1
+    temp_db.create_session("draft_1", source="cli")
+
+    # 2. Real session with messages -> visible
+    temp_db.create_session("active_1", source="cli")
+    temp_db.append_message("active_1", role="user", content="hello")
+
+    # 3. Cleared session with a title -> visible
+    temp_db.create_session("cleared_1", source="cli")
+    temp_db.set_session_title("cleared_1", "My Saved Chat")
+
+    # 4. Cleared session pinned -> visible
+    temp_db.create_session("pinned_1", source="cli")
+    temp_db.set_session_pinned("pinned_1", True)
+
+    sessions = temp_db.list_sessions_rich(min_message_count=1, order_by_last_active=True)
+    ids = [s["id"] for s in sessions]
+
+    assert "draft_1" not in ids
+    assert "active_1" in ids
+    assert "cleared_1" in ids
+    assert "pinned_1" in ids
+    assert temp_db.session_count(min_message_count=1) == 3
+

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1574,6 +1574,7 @@ Subcommands:
 | `browse` | Interactive session picker with search and resume. Each row shows a lifecycle status tag (`done` / `intr` / `err` / `empty`, derived from the session's final message) and its message count. Press `d` on a highlighted row (while the search filter is empty) to delete that session after a y/N confirmation; while a filter is active, `d` types into the search instead. |
 | `export <output> [--session-id ID]` | Export sessions to JSONL. |
 | `delete <session-id>` | Delete one session. |
+| `clear <session-id>` | Clear a session's message history and reset token counters while preserving title, settings, and metadata. Options: `-y`/`--yes` (skip confirmation), `--last <N>` (keep newest N messages), `--before <TIME>` (delete messages older than duration or date). |
 | `prune` | Delete sessions matching filters: time bounds `--older-than`/`--newer-than`/`--before`/`--after` (durations like `5h`/`2d`, bare days, or ISO timestamps); attributes `--source`, `--title`, `--model`, `--provider`, `--branch`, `--end-reason`, `--user`, `--chat-id`, `--chat-type`, `--cwd`; numeric bounds `--min/--max-messages`, `--min/--max-tokens`, `--min/--max-cost`, `--min/--max-tool-calls`; plus `--include-archived`, `--dry-run`, `--yes`. Default: older than 90 days. |
 | `archive` | Bulk-archive (soft-hide, no deletion) sessions matching the same filters as `prune`. Requires at least one filter. |
 | `stats` | Show session-store statistics. |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -451,6 +451,27 @@ hermes sessions delete 20250305_091523_a1b2c3d4
 hermes sessions delete 20250305_091523_a1b2c3d4 --yes
 ```
 
+### Clear a Session's Transcript
+
+Clearing a session wipes its message history and resets token counters back to zero while preserving the session container itself (title, pinned status, working directory, model preferences, and session settings).
+
+```bash
+# Clear all messages in a session (interactive confirmation)
+hermes sessions clear 20250305_091523_a1b2c3d4
+
+# Clear without confirmation prompt
+hermes sessions clear 20250305_091523_a1b2c3d4 --yes
+
+# Keep the most recent N messages and delete older turns
+hermes sessions clear 20250305_091523_a1b2c3d4 --last 5
+
+# Delete messages created before a specific duration or date
+hermes sessions clear 20250305_091523_a1b2c3d4 --before 2d
+hermes sessions clear 20250305_091523_a1b2c3d4 --before "2026-08-01 12:00"
+```
+
+In the Desktop app, right-click any session in the sidebar and choose **"Clear transcript"** to open the pruning dialog with options to clear all messages, keep recent turns, or delete messages older than a selected duration.
+
 ### Rename a Session
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Implements the ability to clear the transcript (message history) of a session without deleting the session container itself. Session metadata (title, pinned status, working directory, model preferences, and session configuration) are preserved while resetting conversation turns and token usage counters.

In addition to full transcript clearing, this PR extends the capability with granular pruning options (`--last N` to keep recent turns, and `--before TIME` to prune older turns) across the entire stack: SQLite database/state layer, CLI, REST API, Desktop UI, and user documentation.

It also introduces smart 0-message filtering in `hermes_state.py` so that cleared (0-message) sessions with a title or pin remain visible in the Desktop sidebar across reloads, while continuing to filter out unstarted blank drafts.

## Related Issue

Fixes #98822

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **Database & Core State (`hermes_state.py`)**:
  - Added `clear_session_messages(session_id, keep_last_n=None, before_timestamp=None, sessions_dir=None)` to prune messages, reset token counters (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `api_call_count`), remove model usage tracking records, and delete unreferenced system prompts/dump files.
  - Added `delete_session_messages(session_id, message_ids)` for selective message ID deletion.
  - Updated `list_sessions_rich` and `session_count` `min_message_count` condition to `(s.message_count >= ? OR (s.title IS NOT NULL AND s.title != '') OR s.pinned = 1)` to keep named/pinned cleared chats in the sidebar.
- **CLI (`hermes_cli/main.py` & `hermes_cli/sessions_cmd.py`)**:
  - Added `hermes sessions clear <session_id>` command supporting `-y`/`--yes`, `--last <N>`, and `--before <TIME>`.
  - Added prefix resolution and pinned session confirmation prompts.
- **REST API (`hermes_cli/web_routers/sessions.py` & `hermes_cli/web_models.py`)**:
  - Added `POST /api/sessions/{session_id}/clear` and `POST /api/sessions/{session_id}/messages/bulk-delete` endpoints and Pydantic models.
- **Desktop UI (`apps/desktop/`)**:
  - Added `clearSession` and `deleteSessionMessages` REST API client functions in `apps/desktop/src/api/sessions.ts`.
  - Created `ClearTranscriptDialog` in `apps/desktop/src/app/chat/sidebar/clear-transcript-dialog.tsx` with 3 modes: All messages, Keep recent messages, Clear older than (with presets and `FieldHint` format examples).
  - Wired into `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` with dynamic disable state when `session.message_count === 0`.
- **Documentation (`website/docs/`)**:
  - Added `### Clear a Session's Transcript` section to `website/docs/user-guide/sessions.md`.
  - Added `clear <session-id>` entry to `website/docs/reference/cli-commands.md`.
- **Tests (`tests/`)**:
  - Added unit test suite in `tests/test_hermes_state_clear_messages.py`.
  - Added CLI test suite in `tests/hermes_cli/test_sessions_clear.py`.

## How to Test

1. **Automated tests:**
   - State tests: `pytest tests/test_hermes_state_clear_messages.py`
   - CLI tests: `pytest tests/hermes_cli/test_sessions_clear.py`
   - Desktop vitest suite: `npm --prefix apps/desktop test -- run apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx`
2. **CLI manual verification:**
   - Run `hermes sessions clear <session_id>` and verify full message reset while keeping title/pins.
   - Run `hermes sessions clear <session_id> --last 2` and verify only the last 2 messages remain.
   - Run `hermes sessions clear <session_id> --before 1d` and verify older messages are pruned.
3. **Desktop manual verification:**
   - Right click an active chat -> "Clear transcript".
   - Test "All messages", "Keep recent messages" (e.g. 5), and "Clear older than" (e.g. 1 day).
   - Verify context gauge updates and session remains visible in the sidebar upon reload.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu / Wayland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
