### PR TITLE
feat(gateway): add inert specialist candidate discovery

### DIFF
--- a/gateway/candidate_profile_requests.py
+++ b/gateway/candidate_profile_requests.py
@@ -1,0 +1,272 @@
+"""Bounded, inert requests for missing specialist capabilities.
+
+Rows contain canonical hashes and opaque evidence references only. Creating a
+candidate never creates a profile, dispatches work, or grants authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
+from hermes_cli import kanban_db
+
+
+CandidateRequestStatus = Literal["candidate", "duplicate", "cooldown", "rejected"]
+_DEFAULT_COOLDOWN_SECONDS = 3_600
+_MAX_SOURCE_KEY_CHARS = 512
+_MAX_EVIDENCE_REFERENCES = 16
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_ALLOWED_LOCAL_SCOPES: dict[str, tuple[frozenset[str], frozenset[str]]] = {
+    "repository-evidence": (
+        frozenset({"audit", "inspect", "read", "review", "validate"}),
+        frozenset({"repository-evidence:read"}),
+    ),
+    "research": (
+        frozenset({"audit", "read", "research", "review"}),
+        frozenset({"research:read"}),
+    ),
+}
+_POLICY = {
+    "external_egress": False,
+    "local_read_only_scopes": sorted(_ALLOWED_LOCAL_SCOPES),
+    "profile_creation": False,
+    "requested_permissions": "explicit-local-read-only",
+}
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS candidate_profile_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL UNIQUE,
+    request_hash TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    source_key_hash TEXT NOT NULL,
+    policy_digest TEXT NOT NULL,
+    evidence_ref_hashes_json TEXT NOT NULL,
+    lifecycle_status TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    cooldown_until INTEGER,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_candidate_request_identity
+ON candidate_profile_requests(request_hash, id);
+CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_update
+BEFORE UPDATE ON candidate_profile_requests BEGIN
+    SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_delete
+BEFORE DELETE ON candidate_profile_requests BEGIN
+    SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+END;
+"""
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+DEFAULT_POLICY_DIGEST = _hash(_POLICY)
+
+
+@dataclass(frozen=True, slots=True)
+class OpaqueEvidenceReference:
+    """A pre-hashed evidence identity safe for durable local storage."""
+
+    digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.digest, str) or not _HASH_RE.fullmatch(self.digest):
+            raise ValueError("opaque evidence references must be SHA-256 hex digests")
+
+
+@dataclass(frozen=True, slots=True)
+class SanitizedTaskEnvelope:
+    """The only task data accepted by the candidate ledger."""
+
+    evidence_refs: tuple[OpaqueEvidenceReference, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProfileRequest:
+    """Result of opening an inert candidate request."""
+
+    request_id: str
+    status: CandidateRequestStatus
+    profile_id: None
+    reason: str
+
+
+def _capability_rejection(signature: CapabilitySignature) -> str | None:
+    scope = _ALLOWED_LOCAL_SCOPES.get(signature.domain)
+    if scope is None or signature.evidence_class != "diagnostic-only":
+        return "unapproved_local_scope"
+    actions, permissions = scope
+    if not signature.actions or not set(signature.actions) <= actions:
+        return "non_read_only_action"
+    if not signature.requested_permissions or not set(signature.requested_permissions) <= permissions:
+        return "unapproved_permission"
+    return None
+
+
+def _reason(reason_code: str) -> str:
+    return {
+        "invalid_evidence_refs": "candidate requests store only sanitized evidence references",
+        "invalid_policy_digest": "candidate policy digest does not match the fixed local policy",
+        "non_read_only_action": "candidate requests require read-only actions",
+        "unapproved_local_scope": "candidate requests require an approved local read-only scope",
+        "unapproved_permission": "candidate requests require approved local read-only permissions",
+    }.get(reason_code, "candidate request rejected by fixed local policy")
+
+
+def _sanitize_evidence(envelope: SanitizedTaskEnvelope | None) -> tuple[str, ...] | None:
+    if envelope is None:
+        return ()
+    if not isinstance(envelope, SanitizedTaskEnvelope):
+        return None
+    refs = envelope.evidence_refs
+    if not isinstance(refs, tuple) or len(refs) > _MAX_EVIDENCE_REFERENCES:
+        return None
+    if any(not isinstance(reference, OpaqueEvidenceReference) for reference in refs):
+        return None
+    return tuple(sorted({reference.digest for reference in refs}))
+
+
+class CandidateProfileRequests:
+    """Open idempotent candidate rows under a fixed least-privilege policy."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        board: str | None = None,
+        cooldown_seconds: int = _DEFAULT_COOLDOWN_SECONDS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if isinstance(cooldown_seconds, bool) or not isinstance(cooldown_seconds, int) or cooldown_seconds <= 0:
+            raise ValueError("cooldown_seconds must be a positive integer")
+        self._db_path = db_path
+        self._board = board
+        self._cooldown_seconds = cooldown_seconds
+        self._clock = clock
+
+    @contextmanager
+    def _connection(self) -> Iterator[object]:
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            conn.executescript(_SCHEMA)
+            yield conn
+
+    def open_or_reuse(
+        self,
+        signature: CapabilitySignature,
+        *,
+        source_key: str,
+        resolution: RegistryResolution | None = None,
+        envelope: SanitizedTaskEnvelope | None = None,
+        policy_digest: str = DEFAULT_POLICY_DIGEST,
+    ) -> CandidateProfileRequest:
+        """Create or reuse a row only after this board's own registry lookup."""
+        del resolution
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        if not isinstance(source_key, str) or not source_key.strip() or len(source_key) > _MAX_SOURCE_KEY_CHARS:
+            raise ValueError("source_key must be a bounded non-empty string")
+
+        local_resolution = CapabilityRegistry(db_path=self._db_path, board=self._board).resolve(signature)
+        if local_resolution.status != "no_match":
+            return CandidateProfileRequest(
+                request_id="",
+                status="rejected",
+                profile_id=None,
+                reason=f"candidate request requires a local no-match; resolution was {local_resolution.status}",
+            )
+
+        evidence_refs = _sanitize_evidence(envelope)
+        reason_code = _capability_rejection(signature)
+        stored_policy_digest = DEFAULT_POLICY_DIGEST
+        if policy_digest != DEFAULT_POLICY_DIGEST:
+            stored_policy_digest = _hash({"untrusted_policy_digest": policy_digest})
+            reason_code = "invalid_policy_digest"
+        if evidence_refs is None:
+            evidence_refs = ()
+            reason_code = "invalid_evidence_refs"
+
+        source_key_hash = _hash(source_key)
+        request_hash = _hash(
+            {
+                "evidence_refs": evidence_refs,
+                "permissions_hash": signature.permissions_hash,
+                "policy_digest": stored_policy_digest,
+                "signature_hash": signature.signature_hash,
+                "source_key_hash": source_key_hash,
+            }
+        )
+        now = int(self._clock())
+
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                latest = conn.execute(
+                    """
+                    SELECT request_id, lifecycle_status, cooldown_until
+                    FROM candidate_profile_requests
+                    WHERE request_hash = ? ORDER BY id DESC LIMIT 1
+                    """,
+                    (request_hash,),
+                ).fetchone()
+                if latest is not None:
+                    if latest["lifecycle_status"] == "candidate":
+                        return CandidateProfileRequest(
+                            latest["request_id"], "duplicate", None, "matching candidate already exists"
+                        )
+                    cooldown_until = latest["cooldown_until"]
+                    if isinstance(cooldown_until, int) and now < cooldown_until:
+                        return CandidateProfileRequest(
+                            latest["request_id"], "cooldown", None, "matching rejection is cooling down"
+                        )
+
+                lifecycle_status = "rejected" if reason_code else "candidate"
+                cooldown_until = now + self._cooldown_seconds if reason_code else None
+                request_id = f"cpr_{request_hash[:24]}_{_hash((lifecycle_status, now))[:8]}"
+                conn.execute(
+                    """
+                    INSERT INTO candidate_profile_requests (
+                        request_id, request_hash, signature_hash, permissions_hash,
+                        source_key_hash, policy_digest, evidence_ref_hashes_json,
+                        lifecycle_status, reason_code, cooldown_until, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        request_id,
+                        request_hash,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        source_key_hash,
+                        stored_policy_digest,
+                        _canonical_json(evidence_refs),
+                        lifecycle_status,
+                        reason_code or "local_no_match",
+                        cooldown_until,
+                        now,
+                    ),
+                )
+
+        if reason_code:
+            return CandidateProfileRequest(request_id, "rejected", None, _reason(reason_code))
+        return CandidateProfileRequest(
+            request_id,
+            "candidate",
+            None,
+            "local no-match queued for bounded inert candidate review",
+        )

--- a/gateway/candidate_profile_requests.py
+++ b/gateway/candidate_profile_requests.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Literal
 
 from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
-from hermes_cli import kanban_db
 
 
 CandidateRequestStatus = Literal["candidate", "duplicate", "cooldown", "rejected"]
@@ -42,8 +41,8 @@ _POLICY = {
     "requested_permissions": "explicit-local-read-only",
 }
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS candidate_profile_requests (
+_SCHEMA_STATEMENTS = (
+    """CREATE TABLE IF NOT EXISTS candidate_profile_requests (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     request_id TEXT NOT NULL UNIQUE,
     request_hash TEXT NOT NULL,
@@ -56,18 +55,18 @@ CREATE TABLE IF NOT EXISTS candidate_profile_requests (
     reason_code TEXT NOT NULL,
     cooldown_until INTEGER,
     created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_candidate_request_identity
-ON candidate_profile_requests(request_hash, id);
-CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_update
+)""",
+    """CREATE INDEX IF NOT EXISTS idx_candidate_request_identity
+ON candidate_profile_requests(request_hash, id)""",
+    """CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_update
 BEFORE UPDATE ON candidate_profile_requests BEGIN
     SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
-END;
-CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_delete
+END""",
+    """CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_delete
 BEFORE DELETE ON candidate_profile_requests BEGIN
     SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
-END;
-"""
+END""",
+)
 
 
 def _canonical_json(value: object) -> str:
@@ -76,6 +75,18 @@ def _canonical_json(value: object) -> str:
 
 def _hash(value: object) -> str:
     return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _kanban_db():
+    """Load board storage only when candidate I/O begins."""
+    from hermes_cli import kanban_db
+
+    return kanban_db
+
+
+def _initialize_schema(conn: object) -> None:
+    for statement in _SCHEMA_STATEMENTS:
+        conn.execute(statement)
 
 
 DEFAULT_POLICY_DIGEST = _hash(_POLICY)
@@ -163,9 +174,10 @@ class CandidateProfileRequests:
         self._clock = clock
 
     @contextmanager
-    def _connection(self) -> Iterator[object]:
-        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
-            conn.executescript(_SCHEMA)
+    def _connection(self, registry: CapabilityRegistry) -> Iterator[object]:
+        # Reuse the registry connection so resolution and insertion share one
+        # BEGIN IMMEDIATE transaction and one exact board snapshot.
+        with registry._connection() as conn:
             yield conn
 
     def open_or_reuse(
@@ -183,15 +195,6 @@ class CandidateProfileRequests:
             raise TypeError("signature must be a CapabilitySignature")
         if not isinstance(source_key, str) or not source_key.strip() or len(source_key) > _MAX_SOURCE_KEY_CHARS:
             raise ValueError("source_key must be a bounded non-empty string")
-
-        local_resolution = CapabilityRegistry(db_path=self._db_path, board=self._board).resolve(signature)
-        if local_resolution.status != "no_match":
-            return CandidateProfileRequest(
-                request_id="",
-                status="rejected",
-                profile_id=None,
-                reason=f"candidate request requires a local no-match; resolution was {local_resolution.status}",
-            )
 
         evidence_refs = _sanitize_evidence(envelope)
         reason_code = _capability_rejection(signature)
@@ -215,8 +218,21 @@ class CandidateProfileRequests:
         )
         now = int(self._clock())
 
-        with self._connection() as conn:
-            with kanban_db.write_txn(conn):
+        registry = CapabilityRegistry(db_path=self._db_path, board=self._board)
+        with self._connection(registry) as conn:
+            with _kanban_db().write_txn(conn):
+                local_resolution = registry._resolve_with_connection(conn, signature)
+                if local_resolution.status != "no_match":
+                    return CandidateProfileRequest(
+                        request_id="",
+                        status="rejected",
+                        profile_id=None,
+                        reason=(
+                            "candidate request requires a local no-match; "
+                            f"resolution was {local_resolution.status}"
+                        ),
+                    )
+                _initialize_schema(conn)
                 latest = conn.execute(
                     """
                     SELECT request_id, lifecycle_status, cooldown_until

--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -1,0 +1,403 @@
+"""Local, fail-closed specialist capability declarations.
+
+The registry stores configured declarations and resolves exact advisory scope.
+It does not route work, create profiles, invoke models, or contact providers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from hermes_cli import kanban_db
+
+
+_MAX_EXPIRY_TIMESTAMP = 253402300799
+_PROFILE_ID_RE = re.compile(r"^[a-z][a-z0-9._-]{0,95}$")
+_REASON_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS capability_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_id TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    actions_json TEXT NOT NULL,
+    evidence_class TEXT NOT NULL,
+    requested_permissions_json TEXT NOT NULL,
+    expires_at INTEGER,
+    status TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_capability_profile_resolution
+ON capability_profiles(signature_hash, evidence_class, status);
+
+CREATE TABLE IF NOT EXISTS specialist_profile_revocations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    revocation_hash TEXT NOT NULL UNIQUE,
+    capability_profile_id INTEGER NOT NULL UNIQUE,
+    profile_id TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_specialist_profile_revocation
+ON specialist_profile_revocations(
+    capability_profile_id, profile_id, signature_hash, permissions_hash
+);
+
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_update
+BEFORE UPDATE ON capability_profiles BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_delete
+BEFORE DELETE ON capability_profiles BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_update
+BEFORE UPDATE ON specialist_profile_revocations BEGIN
+    SELECT RAISE(ABORT, 'specialist_profile_revocations is append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_delete
+BEFORE DELETE ON specialist_profile_revocations BEGIN
+    SELECT RAISE(ABORT, 'specialist_profile_revocations is append-only');
+END;
+"""
+
+
+def _canonical_tokens(values: tuple[str, ...], *, field: str) -> tuple[str, ...]:
+    if isinstance(values, str) or not isinstance(values, tuple):
+        raise TypeError(f"{field} must be a tuple of strings")
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field} must contain only non-empty strings")
+    return tuple(sorted(set(values)))
+
+
+def _hash_payload(payload: object) -> str:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _expiry_timestamp(expires_at: datetime | int | float | None) -> int | None:
+    if expires_at is None:
+        return None
+    if isinstance(expires_at, datetime):
+        if expires_at.tzinfo is None:
+            raise ValueError("expires_at datetime must be timezone-aware")
+        value = int(expires_at.timestamp())
+    elif isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+        raise TypeError("expires_at must be a timestamp or timezone-aware datetime")
+    else:
+        value = int(expires_at)
+    if value > _MAX_EXPIRY_TIMESTAMP:
+        raise ValueError("expires_at is outside the supported range")
+    return value
+
+
+def _unexpired(expires_at: object, *, now: int) -> bool:
+    if expires_at is None:
+        return True
+    return isinstance(expires_at, int) and not isinstance(expires_at, bool) and now < expires_at <= _MAX_EXPIRY_TIMESTAMP
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySignature:
+    """Canonical advisory scope declared by a specialist profile."""
+
+    domain: str
+    actions: tuple[str, ...]
+    evidence_class: str
+    requested_permissions: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, str) or not self.domain.strip():
+            raise ValueError("domain must be a non-empty string")
+        if not isinstance(self.evidence_class, str) or not self.evidence_class.strip():
+            raise ValueError("evidence_class must be a non-empty string")
+        object.__setattr__(self, "actions", _canonical_tokens(self.actions, field="actions"))
+        object.__setattr__(
+            self,
+            "requested_permissions",
+            _canonical_tokens(self.requested_permissions, field="requested_permissions"),
+        )
+
+    @property
+    def signature_hash(self) -> str:
+        return _hash_payload(
+            {
+                "actions": self.actions,
+                "domain": self.domain,
+                "evidence_class": self.evidence_class,
+            }
+        )
+
+    @property
+    def permissions_hash(self) -> str:
+        return _hash_payload({"requested_permissions": self.requested_permissions})
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryResolution:
+    """Fail-closed resolution; only ``active_match`` carries a profile."""
+
+    status: Literal["active_match", "no_match", "ambiguous", "unavailable"]
+    profile: str | None
+    reason: str
+
+
+class CapabilityRegistry:
+    """Persist and resolve configured specialist capability declarations."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        board: str | None = None,
+        configured_profiles: Mapping[str, CapabilitySignature] | None = None,
+    ) -> None:
+        declarations = dict(configured_profiles or {})
+        for profile_id, signature in declarations.items():
+            self._validate_profile_id(profile_id)
+            if not isinstance(signature, CapabilitySignature):
+                raise TypeError("configured profile declarations must be CapabilitySignature values")
+        self._db_path = db_path
+        self._board = board
+        self._configured_profiles = declarations
+
+    @staticmethod
+    def _validate_profile_id(profile_id: object) -> str:
+        if not isinstance(profile_id, str) or not _PROFILE_ID_RE.fullmatch(profile_id):
+            raise ValueError("profile_id must be a bounded canonical identifier")
+        return profile_id
+
+    @contextmanager
+    def _connection(self) -> Iterator[object]:
+        """Open the board-local registry connection after idempotent schema setup."""
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            conn.executescript(_SCHEMA)
+            yield conn
+
+    def register_configured_profile(
+        self,
+        profile_id: str,
+        *,
+        expires_at: datetime | int | float | None = None,
+    ) -> int:
+        """Return one active row for the exact trusted declaration generation.
+
+        A revocation permanently hides only its immutable row. Calling this
+        trusted registration boundary again after revocation appends a new
+        generation; repeated calls then reuse that unrevoked generation.
+        """
+        self._validate_profile_id(profile_id)
+        signature = self._configured_profiles.get(profile_id)
+        if signature is None:
+            raise ValueError("profile_id is not present in configured specialist declarations")
+        created_at = int(time.time())
+        expires_at_timestamp = _expiry_timestamp(expires_at)
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                existing = conn.execute(
+                    """
+                    SELECT profiles.id FROM capability_profiles AS profiles
+                    WHERE profiles.profile_id = ?
+                      AND profiles.signature_hash = ?
+                      AND profiles.permissions_hash = ?
+                      AND profiles.status = 'active'
+                      AND profiles.expires_at IS ?
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM specialist_profile_revocations AS revocations
+                          WHERE revocations.capability_profile_id = profiles.id
+                            AND revocations.profile_id = profiles.profile_id
+                            AND revocations.signature_hash = profiles.signature_hash
+                            AND revocations.permissions_hash = profiles.permissions_hash
+                      )
+                    LIMIT 1
+                    """,
+                    (
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        expires_at_timestamp,
+                    ),
+                ).fetchone()
+                if existing is not None:
+                    return int(existing["id"])
+                cursor = conn.execute(
+                    """
+                    INSERT INTO capability_profiles (
+                        profile_id, signature_hash, permissions_hash, domain,
+                        actions_json, evidence_class, requested_permissions_json,
+                        expires_at, status, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+                    """,
+                    (
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        signature.domain,
+                        json.dumps(signature.actions, separators=(",", ":")),
+                        signature.evidence_class,
+                        json.dumps(signature.requested_permissions, separators=(",", ":")),
+                        expires_at_timestamp,
+                        created_at,
+                    ),
+                )
+                return int(cursor.lastrowid)
+
+    def add_active(self, **_: object) -> None:
+        """Reject the former arbitrary active-profile entry point."""
+        raise ValueError("direct arbitrary active profile registration is disabled; use configured declarations")
+
+    def revoke(
+        self,
+        *,
+        declaration_id: int,
+        profile_id: str,
+        signature: CapabilitySignature,
+        reason_code: str,
+        now: int | None = None,
+    ) -> str:
+        """Append an immutable revocation for one exact declaration row."""
+        if isinstance(declaration_id, bool) or not isinstance(declaration_id, int) or declaration_id <= 0:
+            raise ValueError("declaration_id must be a positive integer")
+        self._validate_profile_id(profile_id)
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        if not isinstance(reason_code, str) or not _REASON_CODE_RE.fullmatch(reason_code):
+            raise ValueError("reason_code must be a bounded canonical code")
+        created_at = int(time.time()) if now is None else now
+        if isinstance(created_at, bool) or not isinstance(created_at, int):
+            raise ValueError("now must be an integer timestamp")
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                declaration = conn.execute(
+                    """
+                    SELECT profiles.id, revocations.revocation_hash
+                    FROM capability_profiles AS profiles
+                    LEFT JOIN specialist_profile_revocations AS revocations
+                      ON revocations.capability_profile_id = profiles.id
+                     AND revocations.profile_id = profiles.profile_id
+                     AND revocations.signature_hash = profiles.signature_hash
+                     AND revocations.permissions_hash = profiles.permissions_hash
+                    WHERE profiles.id = ?
+                      AND profiles.profile_id = ?
+                      AND profiles.signature_hash = ?
+                      AND profiles.permissions_hash = ?
+                      AND profiles.status = 'active'
+                    LIMIT 1
+                    """,
+                    (
+                        declaration_id,
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                    ),
+                ).fetchone()
+                if declaration is None:
+                    raise ValueError("declaration_id does not match the exact active capability declaration")
+                if declaration["revocation_hash"] is not None:
+                    return str(declaration["revocation_hash"])
+                receipt = _hash_payload(
+                    {
+                        "capability_profile_id": declaration_id,
+                        "permissions_hash": signature.permissions_hash,
+                        "profile_id": profile_id,
+                        "reason_code": reason_code,
+                        "signature_hash": signature.signature_hash,
+                    }
+                )
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO specialist_profile_revocations (
+                        revocation_hash, capability_profile_id, profile_id,
+                        signature_hash, permissions_hash, reason_code, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        receipt,
+                        declaration_id,
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        reason_code,
+                        created_at,
+                    ),
+                )
+        return receipt
+
+    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
+        """Resolve exactly one active, unexpired, non-expanding local profile."""
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        try:
+            with self._connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT profile_id, signature_hash, permissions_hash, domain,
+                           actions_json, evidence_class, requested_permissions_json, expires_at
+                    FROM capability_profiles AS profiles
+                    WHERE status = 'active' AND signature_hash = ? AND evidence_class = ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM specialist_profile_revocations AS revocations
+                          WHERE revocations.capability_profile_id = profiles.id
+                            AND revocations.profile_id = profiles.profile_id
+                            AND revocations.signature_hash = profiles.signature_hash
+                            AND revocations.permissions_hash = profiles.permissions_hash
+                      )
+                    ORDER BY profile_id, id
+                    """,
+                    (signature.signature_hash, signature.evidence_class),
+                ).fetchall()
+        except Exception as exc:
+            return RegistryResolution(
+                status="unavailable",
+                profile=None,
+                reason=f"local capability registry unavailable: {type(exc).__name__}",
+            )
+
+        now = int(time.time())
+        requested_permissions = set(signature.requested_permissions)
+        matches: set[str] = set()
+        for row in rows:
+            if not _unexpired(row["expires_at"], now=now):
+                continue
+            try:
+                stored = CapabilitySignature(
+                    domain=row["domain"],
+                    actions=tuple(json.loads(row["actions_json"])),
+                    evidence_class=row["evidence_class"],
+                    requested_permissions=tuple(json.loads(row["requested_permissions_json"])),
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if (
+                stored.signature_hash != row["signature_hash"]
+                or stored.permissions_hash != row["permissions_hash"]
+                or stored.domain != signature.domain
+                or stored.actions != signature.actions
+                or not set(stored.requested_permissions) <= requested_permissions
+            ):
+                continue
+            matches.add(row["profile_id"])
+
+        if len(matches) == 1:
+            return RegistryResolution(
+                "active_match",
+                next(iter(matches)),
+                "exact active capability profile matched locally",
+            )
+        if len(matches) > 1:
+            return RegistryResolution("ambiguous", None, "multiple active capability profiles matched the requested scope")
+        return RegistryResolution("no_match", None, "no active unexpired profile matched the requested scope")

--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -17,9 +17,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from hermes_cli import kanban_db
-
-
 _MAX_EXPIRY_TIMESTAMP = 253402300799
 _PROFILE_ID_RE = re.compile(r"^[a-z][a-z0-9._-]{0,95}$")
 _REASON_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
@@ -86,6 +83,13 @@ def _canonical_tokens(values: tuple[str, ...], *, field: str) -> tuple[str, ...]
 def _hash_payload(payload: object) -> str:
     encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _kanban_db():
+    """Load board storage only when registry I/O begins."""
+    from hermes_cli import kanban_db
+
+    return kanban_db
 
 
 def _expiry_timestamp(expires_at: datetime | int | float | None) -> int | None:
@@ -183,7 +187,7 @@ class CapabilityRegistry:
     @contextmanager
     def _connection(self) -> Iterator[object]:
         """Open the board-local registry connection after idempotent schema setup."""
-        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+        with _kanban_db().connect_closing(self._db_path, board=self._board) as conn:
             conn.executescript(_SCHEMA)
             yield conn
 
@@ -206,7 +210,7 @@ class CapabilityRegistry:
         created_at = int(time.time())
         expires_at_timestamp = _expiry_timestamp(expires_at)
         with self._connection() as conn:
-            with kanban_db.write_txn(conn):
+            with _kanban_db().write_txn(conn):
                 existing = conn.execute(
                     """
                     SELECT profiles.id FROM capability_profiles AS profiles
@@ -281,7 +285,7 @@ class CapabilityRegistry:
         if isinstance(created_at, bool) or not isinstance(created_at, int):
             raise ValueError("now must be an integer timestamp")
         with self._connection() as conn:
-            with kanban_db.write_txn(conn):
+            with _kanban_db().write_txn(conn):
                 declaration = conn.execute(
                     """
                     SELECT profiles.id, revocations.revocation_hash
@@ -348,7 +352,8 @@ class CapabilityRegistry:
                     SELECT profile_id, signature_hash, permissions_hash, domain,
                            actions_json, evidence_class, requested_permissions_json, expires_at
                     FROM capability_profiles AS profiles
-                    WHERE status = 'active' AND signature_hash = ? AND evidence_class = ?
+                    WHERE status = 'active' AND signature_hash = ?
+                      AND permissions_hash = ? AND evidence_class = ?
                       AND NOT EXISTS (
                           SELECT 1 FROM specialist_profile_revocations AS revocations
                           WHERE revocations.capability_profile_id = profiles.id
@@ -358,7 +363,11 @@ class CapabilityRegistry:
                       )
                     ORDER BY profile_id, id
                     """,
-                    (signature.signature_hash, signature.evidence_class),
+                    (
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        signature.evidence_class,
+                    ),
                 ).fetchall()
         except Exception as exc:
             return RegistryResolution(
@@ -368,7 +377,6 @@ class CapabilityRegistry:
             )
 
         now = int(time.time())
-        requested_permissions = set(signature.requested_permissions)
         matches: set[str] = set()
         for row in rows:
             if not _unexpired(row["expires_at"], now=now):
@@ -387,7 +395,7 @@ class CapabilityRegistry:
                 or stored.permissions_hash != row["permissions_hash"]
                 or stored.domain != signature.domain
                 or stored.actions != signature.actions
-                or not set(stored.requested_permissions) <= requested_permissions
+                or stored.requested_permissions != signature.requested_permissions
             ):
                 continue
             matches.add(row["profile_id"])

--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -341,34 +341,37 @@ class CapabilityRegistry:
                 )
         return receipt
 
-    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
-        """Resolve exactly one active, unexpired, non-expanding local profile."""
+    def _resolve_with_connection(
+        self,
+        conn: object,
+        signature: CapabilitySignature,
+    ) -> RegistryResolution:
+        """Resolve using the caller's already-open board transaction."""
         if not isinstance(signature, CapabilitySignature):
             raise TypeError("signature must be a CapabilitySignature")
         try:
-            with self._connection() as conn:
-                rows = conn.execute(
-                    """
-                    SELECT profile_id, signature_hash, permissions_hash, domain,
-                           actions_json, evidence_class, requested_permissions_json, expires_at
-                    FROM capability_profiles AS profiles
-                    WHERE status = 'active' AND signature_hash = ?
-                      AND permissions_hash = ? AND evidence_class = ?
-                      AND NOT EXISTS (
-                          SELECT 1 FROM specialist_profile_revocations AS revocations
-                          WHERE revocations.capability_profile_id = profiles.id
-                            AND revocations.profile_id = profiles.profile_id
-                            AND revocations.signature_hash = profiles.signature_hash
-                            AND revocations.permissions_hash = profiles.permissions_hash
-                      )
-                    ORDER BY profile_id, id
-                    """,
-                    (
-                        signature.signature_hash,
-                        signature.permissions_hash,
-                        signature.evidence_class,
-                    ),
-                ).fetchall()
+            rows = conn.execute(
+                """
+                SELECT profile_id, signature_hash, permissions_hash, domain,
+                       actions_json, evidence_class, requested_permissions_json, expires_at
+                FROM capability_profiles AS profiles
+                WHERE status = 'active' AND signature_hash = ?
+                  AND permissions_hash = ? AND evidence_class = ?
+                  AND NOT EXISTS (
+                      SELECT 1 FROM specialist_profile_revocations AS revocations
+                      WHERE revocations.capability_profile_id = profiles.id
+                        AND revocations.profile_id = profiles.profile_id
+                        AND revocations.signature_hash = profiles.signature_hash
+                        AND revocations.permissions_hash = profiles.permissions_hash
+                  )
+                ORDER BY profile_id, id
+                """,
+                (
+                    signature.signature_hash,
+                    signature.permissions_hash,
+                    signature.evidence_class,
+                ),
+            ).fetchall()
         except Exception as exc:
             return RegistryResolution(
                 status="unavailable",
@@ -409,3 +412,17 @@ class CapabilityRegistry:
         if len(matches) > 1:
             return RegistryResolution("ambiguous", None, "multiple active capability profiles matched the requested scope")
         return RegistryResolution("no_match", None, "no active unexpired profile matched the requested scope")
+
+    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
+        """Resolve exactly one active, unexpired declaration identity."""
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        try:
+            with self._connection() as conn:
+                return self._resolve_with_connection(conn, signature)
+        except Exception as exc:
+            return RegistryResolution(
+                status="unavailable",
+                profile=None,
+                reason=f"local capability registry unavailable: {type(exc).__name__}",
+            )

--- a/gateway/specialist_discovery.py
+++ b/gateway/specialist_discovery.py
@@ -1,0 +1,72 @@
+"""Provider-free orchestration for local specialist capability discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from gateway.candidate_profile_requests import CandidateProfileRequests, SanitizedTaskEnvelope
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+
+
+@dataclass(frozen=True, slots=True)
+class SpecialistDiscoveryDecision:
+    """One fail-closed local resolution or inert candidate result."""
+
+    status: Literal["active_match", "ambiguous", "candidate", "rejected", "unavailable"]
+    profile: str | None
+    candidate_request_id: str | None
+    reason: str
+
+
+class SpecialistDiscovery:
+    """Resolve configured specialists and record bounded local gaps."""
+
+    def __init__(self, *, db_path: Path | None = None, board: str | None = None) -> None:
+        self._registry = CapabilityRegistry(db_path=db_path, board=board)
+        self._candidates = CandidateProfileRequests(db_path=db_path, board=board)
+
+    def resolve_or_request(
+        self,
+        signature: CapabilitySignature,
+        *,
+        source_key: str,
+        envelope: SanitizedTaskEnvelope | None = None,
+    ) -> SpecialistDiscoveryDecision:
+        """Return an exact configured match or an inert local request."""
+        resolution = self._registry.resolve(signature)
+        if resolution.status == "active_match":
+            return SpecialistDiscoveryDecision(
+                status="active_match",
+                profile=resolution.profile,
+                candidate_request_id=None,
+                reason=resolution.reason,
+            )
+        if resolution.status in {"ambiguous", "unavailable"}:
+            return SpecialistDiscoveryDecision(
+                status=resolution.status,
+                profile=None,
+                candidate_request_id=None,
+                reason=resolution.reason,
+            )
+
+        candidate = self._candidates.open_or_reuse(
+            signature,
+            source_key=source_key,
+            resolution=resolution,
+            envelope=envelope,
+        )
+        if candidate.status in {"candidate", "duplicate"}:
+            return SpecialistDiscoveryDecision(
+                status="candidate",
+                profile=None,
+                candidate_request_id=candidate.request_id,
+                reason=candidate.reason,
+            )
+        return SpecialistDiscoveryDecision(
+            status="rejected",
+            profile=None,
+            candidate_request_id=candidate.request_id or None,
+            reason=candidate.reason,
+        )

--- a/tests/gateway/test_candidate_profile_requests.py
+++ b/tests/gateway/test_candidate_profile_requests.py
@@ -1,0 +1,192 @@
+"""Safety contracts for inert local specialist-candidate requests."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+
+import pytest
+
+
+def _registry_api():
+    from gateway.capability_registry import (
+        CapabilityRegistry,
+        CapabilitySignature,
+        RegistryResolution,
+    )
+
+    return CapabilityRegistry, CapabilitySignature, RegistryResolution
+
+
+def _candidate_api():
+    try:
+        from gateway.candidate_profile_requests import (
+            CandidateProfileRequests,
+            OpaqueEvidenceReference,
+            SanitizedTaskEnvelope,
+        )
+    except ImportError as exc:  # RED: the split starts without this capability.
+        pytest.fail(f"specialist candidate requests are unavailable: {exc}")
+    return CandidateProfileRequests, OpaqueEvidenceReference, SanitizedTaskEnvelope
+
+
+def _kanban_db():
+    from hermes_cli import kanban_db
+
+    return kanban_db
+
+
+def _repository_review():
+    _, CapabilitySignature, _ = _registry_api()
+    return CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read", "review"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+
+
+def _opaque(label: str):
+    _, OpaqueEvidenceReference, _ = _candidate_api()
+    return OpaqueEvidenceReference(hashlib.sha256(label.encode()).hexdigest())
+
+
+def test_local_no_match_creates_one_inert_candidate(tmp_path):
+    CandidateProfileRequests, _, SanitizedTaskEnvelope = _candidate_api()
+    requests = CandidateProfileRequests(db_path=tmp_path / "candidates.db")
+
+    result = requests.open_or_reuse(
+        _repository_review(),
+        source_key="gateway:request-1",
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque("request-1"),)),
+    )
+
+    assert result.status == "candidate"
+    assert result.profile_id is None
+    assert result.request_id.startswith("cpr_")
+
+
+def test_caller_supplied_no_match_cannot_override_local_active_match(tmp_path):
+    CapabilityRegistry, _, RegistryResolution = _registry_api()
+    CandidateProfileRequests, _, _ = _candidate_api()
+    db_path = tmp_path / "candidates.db"
+    signature = _repository_review()
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile("repository-reviewer")
+    requests = CandidateProfileRequests(db_path=db_path)
+
+    result = requests.open_or_reuse(
+        signature,
+        source_key="gateway:forged",
+        resolution=RegistryResolution("no_match", None, "caller assertion"),
+    )
+
+    assert result.status == "rejected"
+    assert result.request_id == ""
+    with _kanban_db().connect_closing(db_path) as conn:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'candidate_profile_requests'"
+        ).fetchone()
+    assert table is None
+
+
+def test_local_ambiguity_is_preserved_without_candidate_side_effect(tmp_path):
+    CapabilityRegistry, CapabilitySignature, _ = _registry_api()
+    CandidateProfileRequests, _, _ = _candidate_api()
+    db_path = tmp_path / "candidates.db"
+    broad = CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"one": broad, "two": broad},
+    )
+    registry.register_configured_profile("one")
+    registry.register_configured_profile("two")
+
+    result = CandidateProfileRequests(db_path=db_path).open_or_reuse(
+        broad,
+        source_key="gateway:ambiguous",
+    )
+
+    assert result.status == "rejected"
+    assert result.request_id == ""
+    assert "ambiguous" in result.reason
+    with _kanban_db().connect_closing(db_path) as conn:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'candidate_profile_requests'"
+        ).fetchone()
+    assert table is None
+
+
+def test_duplicate_source_and_scope_reuses_candidate(tmp_path):
+    CandidateProfileRequests, _, _ = _candidate_api()
+    requests = CandidateProfileRequests(db_path=tmp_path / "candidates.db")
+
+    first = requests.open_or_reuse(_repository_review(), source_key="gateway:request-1")
+    repeated = requests.open_or_reuse(_repository_review(), source_key="gateway:request-1")
+
+    assert repeated.status == "duplicate"
+    assert repeated.request_id == first.request_id
+    assert repeated.profile_id is None
+
+
+def test_write_scope_is_rejected_then_bounded_by_cooldown(tmp_path):
+    _, CapabilitySignature, _ = _registry_api()
+    CandidateProfileRequests, _, _ = _candidate_api()
+    requests = CandidateProfileRequests(
+        db_path=tmp_path / "candidates.db",
+        cooldown_seconds=30,
+        clock=lambda: 1_000,
+    )
+    write_scope = CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read", "write"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read", "repository-evidence:write"),
+    )
+
+    rejected = requests.open_or_reuse(write_scope, source_key="gateway:request-2")
+    repeated = requests.open_or_reuse(write_scope, source_key="gateway:request-2")
+
+    assert rejected.status == "rejected"
+    assert repeated.status == "cooldown"
+    assert repeated.request_id == rejected.request_id
+
+
+def test_raw_evidence_is_rejected_and_never_persisted(tmp_path):
+    CandidateProfileRequests, _, SanitizedTaskEnvelope = _candidate_api()
+    requests = CandidateProfileRequests(db_path=tmp_path / "candidates.db")
+
+    result = requests.open_or_reuse(
+        _repository_review(),
+        source_key="gateway:unsafe-evidence",
+        envelope=SanitizedTaskEnvelope(evidence_refs=("raw payload",)),
+    )
+
+    assert result.status == "rejected"
+    with _kanban_db().connect_closing(tmp_path / "candidates.db") as conn:
+        row = conn.execute(
+            "SELECT evidence_ref_hashes_json FROM candidate_profile_requests WHERE request_id = ?",
+            (result.request_id,),
+        ).fetchone()
+    assert "raw payload" not in row["evidence_ref_hashes_json"]
+
+
+def test_candidate_rows_are_append_only(tmp_path):
+    CandidateProfileRequests, _, _ = _candidate_api()
+    requests = CandidateProfileRequests(db_path=tmp_path / "candidates.db")
+    result = requests.open_or_reuse(_repository_review(), source_key="gateway:request-1")
+
+    with _kanban_db().connect_closing(tmp_path / "candidates.db") as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE candidate_profile_requests SET lifecycle_status = 'active' WHERE request_id = ?",
+                (result.request_id,),
+            )

--- a/tests/gateway/test_candidate_profile_requests.py
+++ b/tests/gateway/test_candidate_profile_requests.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import sqlite3
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
@@ -125,6 +130,51 @@ def test_local_ambiguity_is_preserved_without_candidate_side_effect(tmp_path):
     assert table is None
 
 
+def test_profile_registration_between_precheck_and_insert_creates_no_candidate(
+    tmp_path, monkeypatch
+):
+    CapabilityRegistry, _, _ = _registry_api()
+    CandidateProfileRequests, _, _ = _candidate_api()
+    db_path = tmp_path / "candidates.db"
+    signature = _repository_review()
+    competing_registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    original_connection = CandidateProfileRequests._connection
+
+    @contextmanager
+    def connection_after_registration(self, *args, **kwargs):
+        competing_registry.register_configured_profile("repository-reviewer")
+        with original_connection(self, *args, **kwargs) as conn:
+            yield conn
+
+    monkeypatch.setattr(
+        CandidateProfileRequests,
+        "_connection",
+        connection_after_registration,
+    )
+
+    result = CandidateProfileRequests(db_path=db_path).open_or_reuse(
+        signature,
+        source_key="gateway:registration-race",
+    )
+
+    assert result.status == "rejected"
+    assert result.request_id == ""
+    with _kanban_db().connect_closing(db_path) as conn:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'candidate_profile_requests'"
+        ).fetchone()
+        row_count = (
+            conn.execute("SELECT COUNT(*) FROM candidate_profile_requests").fetchone()[0]
+            if table is not None
+            else 0
+        )
+    assert row_count == 0
+
+
 def test_duplicate_source_and_scope_reuses_candidate(tmp_path):
     CandidateProfileRequests, _, _ = _candidate_api()
     requests = CandidateProfileRequests(db_path=tmp_path / "candidates.db")
@@ -190,3 +240,44 @@ def test_candidate_rows_are_append_only(tmp_path):
                 "UPDATE candidate_profile_requests SET lifecycle_status = 'active' WHERE request_id = ?",
                 (result.request_id,),
             )
+
+
+def test_import_before_hermes_home_does_not_pin_candidate_storage(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    late_home = tmp_path / "late-home"
+    code = """
+import os
+import sys
+
+os.environ.pop("HERMES_HOME", None)
+import gateway.candidate_profile_requests as candidate_module
+assert "hermes_cli.kanban_db" not in sys.modules
+os.environ["HERMES_HOME"] = sys.argv[1]
+signature = candidate_module.CapabilitySignature(
+    domain="repository-evidence",
+    actions=("read",),
+    evidence_class="diagnostic-only",
+    requested_permissions=("repository-evidence:read",),
+)
+result = candidate_module.CandidateProfileRequests().open_or_reuse(
+    signature,
+    source_key="subprocess:late-home",
+)
+assert result.status == "candidate"
+"""
+    env = os.environ.copy()
+    env.pop("HERMES_HOME", None)
+    env["PYTHONPATH"] = str(repo)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(late_home)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (late_home / "kanban.db").is_file()

--- a/tests/gateway/test_capability_registry.py
+++ b/tests/gateway/test_capability_registry.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import sqlite3
+import os
+import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -216,6 +220,74 @@ def test_permission_variant_registration_is_not_hidden_by_revoked_version(tmp_pa
     assert resolution.status == "active_match"
     assert resolution.profile == "repository-reviewer"
     assert renewed_declaration_id != original_declaration_id
+
+
+def test_unregistered_permission_expansion_does_not_reuse_narrow_declaration(tmp_path):
+    CapabilityRegistry, CapabilitySignature = _registry_api()
+    original = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": original},
+    ).register_configured_profile("repository-reviewer")
+    expanded = CapabilitySignature(
+        domain=original.domain,
+        actions=original.actions,
+        evidence_class=original.evidence_class,
+        requested_permissions=(
+            "repository-evidence:metadata",
+            "repository-evidence:read",
+        ),
+    )
+
+    resolution = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": expanded},
+    ).resolve(expanded)
+
+    assert resolution.status == "no_match"
+    assert resolution.profile is None
+
+
+def test_import_before_hermes_home_does_not_pin_kanban_paths(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    late_home = tmp_path / "late-home"
+    code = """
+import os
+import sys
+
+os.environ.pop("HERMES_HOME", None)
+import gateway.capability_registry as registry_module
+assert "hermes_cli.kanban_db" not in sys.modules
+os.environ["HERMES_HOME"] = sys.argv[1]
+signature = registry_module.CapabilitySignature(
+    domain="repository-evidence",
+    actions=("read",),
+    evidence_class="diagnostic-only",
+    requested_permissions=("repository-evidence:read",),
+)
+registry = registry_module.CapabilityRegistry(
+    configured_profiles={"reviewer": signature},
+)
+registry.register_configured_profile("reviewer")
+assert registry.resolve(signature).status == "active_match"
+"""
+    env = os.environ.copy()
+    env.pop("HERMES_HOME", None)
+    env["PYTHONPATH"] = str(repo)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(late_home)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (late_home / "kanban.db").is_file()
 
 
 def test_each_revocation_binds_the_latest_unrevoked_generation(tmp_path):

--- a/tests/gateway/test_capability_registry.py
+++ b/tests/gateway/test_capability_registry.py
@@ -1,0 +1,256 @@
+"""Behavior contracts for the local specialist capability registry."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+def _registry_api():
+    try:
+        from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+    except ImportError as exc:  # RED: the clean replacement starts without this capability.
+        pytest.fail(f"specialist capability registry is unavailable: {exc}")
+    return CapabilityRegistry, CapabilitySignature
+
+
+def _kanban_db():
+    from hermes_cli import kanban_db
+
+    return kanban_db
+
+
+def _repository_read_signature():
+    _, CapabilitySignature = _registry_api()
+    return CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read", "review"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+
+
+def test_configured_profile_resolves_only_its_exact_active_scope(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+
+    registry.register_configured_profile("repository-reviewer")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+
+
+def test_unconfigured_profile_cannot_use_direct_activation_api(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(db_path=tmp_path / "registry.db")
+
+    with pytest.raises(ValueError, match="configured"):
+        registry.register_configured_profile("undeclared")
+    with pytest.raises(ValueError, match="direct arbitrary"):
+        registry.add_active(profile_id="undeclared", signature=signature)
+
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_expired_profile_does_not_resolve(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_multiple_exact_profiles_fail_closed_as_ambiguous(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"reviewer-one": signature, "reviewer-two": signature},
+    )
+    registry.register_configured_profile("reviewer-one")
+    registry.register_configured_profile("reviewer-two")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "ambiguous"
+    assert resolution.profile is None
+
+
+def test_expired_configured_profile_can_append_one_unambiguous_renewal(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    registry.register_configured_profile(
+        "repository-reviewer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+
+
+def test_registry_rows_are_append_only_and_revocation_hides_profile(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    registry = CapabilityRegistry(
+        db_path=tmp_path / "registry.db",
+        configured_profiles={"repository-reviewer": signature},
+    )
+    declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    with _kanban_db().connect_closing(tmp_path / "registry.db") as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE capability_profiles SET status = 'inactive' "
+                "WHERE profile_id = 'repository-reviewer'"
+            )
+
+    receipt = registry.revoke(
+        declaration_id=declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    assert len(receipt) == 64
+    assert registry.resolve(signature).status == "no_match"
+
+
+def test_trusted_reregistration_after_revocation_creates_one_new_generation(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    first_declaration_id = registry.register_configured_profile("repository-reviewer")
+    registry.revoke(
+        declaration_id=first_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    renewed_declaration_id = registry.register_configured_profile("repository-reviewer")
+    duplicate_declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    resolution = registry.resolve(signature)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+    assert renewed_declaration_id != first_declaration_id
+    assert duplicate_declaration_id == renewed_declaration_id
+    with _kanban_db().connect_closing(db_path) as conn:
+        profile_rows = conn.execute(
+            "SELECT COUNT(*) FROM capability_profiles WHERE profile_id = ?",
+            ("repository-reviewer",),
+        ).fetchone()[0]
+        revocation_rows = conn.execute(
+            "SELECT COUNT(*) FROM specialist_profile_revocations WHERE profile_id = ?",
+            ("repository-reviewer",),
+        ).fetchone()[0]
+    assert profile_rows == 2
+    assert revocation_rows == 1
+
+
+def test_permission_variant_registration_is_not_hidden_by_revoked_version(tmp_path):
+    CapabilityRegistry, CapabilitySignature = _registry_api()
+    original = _repository_read_signature()
+    expanded = CapabilitySignature(
+        domain=original.domain,
+        actions=original.actions,
+        evidence_class=original.evidence_class,
+        requested_permissions=(
+            "repository-evidence:metadata",
+            "repository-evidence:read",
+        ),
+    )
+    db_path = tmp_path / "registry.db"
+    original_registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": original},
+    )
+    original_declaration_id = original_registry.register_configured_profile(
+        "repository-reviewer"
+    )
+    original_registry.revoke(
+        declaration_id=original_declaration_id,
+        profile_id="repository-reviewer",
+        signature=original,
+        reason_code="permission_version_revoked",
+    )
+
+    renewed_registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": expanded},
+    )
+    renewed_declaration_id = renewed_registry.register_configured_profile(
+        "repository-reviewer"
+    )
+
+    assert renewed_registry.resolve(original).status == "no_match"
+    resolution = renewed_registry.resolve(expanded)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "repository-reviewer"
+    assert renewed_declaration_id != original_declaration_id
+
+
+def test_each_revocation_binds_the_latest_unrevoked_generation(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    signature = _repository_read_signature()
+    db_path = tmp_path / "registry.db"
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    first_declaration_id = registry.register_configured_profile("repository-reviewer")
+    first_receipt = registry.revoke(
+        declaration_id=first_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+    second_declaration_id = registry.register_configured_profile("repository-reviewer")
+
+    second_receipt = registry.revoke(
+        declaration_id=second_declaration_id,
+        profile_id="repository-reviewer",
+        signature=signature,
+        reason_code="operator_revoked",
+    )
+
+    assert second_receipt != first_receipt
+    assert registry.resolve(signature).status == "no_match"
+    with _kanban_db().connect_closing(db_path) as conn:
+        declaration_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT capability_profile_id FROM specialist_profile_revocations "
+                "ORDER BY capability_profile_id"
+            ).fetchall()
+        ]
+    assert len(declaration_ids) == 2
+    assert len(set(declaration_ids)) == 2

--- a/tests/gateway/test_specialist_discovery.py
+++ b/tests/gateway/test_specialist_discovery.py
@@ -1,0 +1,109 @@
+"""End-to-end contracts for provider-free specialist discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _registry_api():
+    from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+
+    return CapabilityRegistry, CapabilitySignature
+
+
+def _discovery_api():
+    try:
+        from gateway.specialist_discovery import SpecialistDiscovery
+    except ImportError as exc:  # RED: the split starts without the orchestrator.
+        pytest.fail(f"specialist discovery orchestration is unavailable: {exc}")
+    return SpecialistDiscovery
+
+
+def _repository_review():
+    _, CapabilitySignature = _registry_api()
+    return CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read", "review"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+
+
+def test_configured_match_returns_profile_without_candidate_side_effect(tmp_path):
+    CapabilityRegistry, _ = _registry_api()
+    SpecialistDiscovery = _discovery_api()
+    db_path = tmp_path / "discovery.db"
+    signature = _repository_review()
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"repository-reviewer": signature},
+    )
+    registry.register_configured_profile("repository-reviewer")
+    discovery = SpecialistDiscovery(db_path=db_path)
+
+    decision = discovery.resolve_or_request(signature, source_key="gateway:request-1")
+
+    assert decision.status == "active_match"
+    assert decision.profile == "repository-reviewer"
+    assert decision.candidate_request_id is None
+
+
+def test_missing_scope_returns_inert_candidate_identity(tmp_path):
+    SpecialistDiscovery = _discovery_api()
+    discovery = SpecialistDiscovery(db_path=tmp_path / "discovery.db")
+
+    decision = discovery.resolve_or_request(
+        _repository_review(),
+        source_key="gateway:request-1",
+    )
+
+    assert decision.status == "candidate"
+    assert decision.profile is None
+    assert decision.candidate_request_id.startswith("cpr_")
+
+
+def test_ambiguous_match_is_preserved_without_candidate_side_effect(tmp_path):
+    CapabilityRegistry, CapabilitySignature = _registry_api()
+    SpecialistDiscovery = _discovery_api()
+    db_path = tmp_path / "discovery.db"
+    signature = CapabilitySignature(
+        domain="repository-evidence",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:read",),
+    )
+    registry = CapabilityRegistry(
+        db_path=db_path,
+        configured_profiles={"one": signature, "two": signature},
+    )
+    registry.register_configured_profile("one")
+    registry.register_configured_profile("two")
+
+    decision = SpecialistDiscovery(db_path=db_path).resolve_or_request(
+        signature,
+        source_key="gateway:ambiguous",
+    )
+
+    assert decision.status == "ambiguous"
+    assert decision.profile is None
+    assert decision.candidate_request_id is None
+
+
+def test_disallowed_scope_fails_closed_without_profile(tmp_path):
+    _, CapabilitySignature = _registry_api()
+    SpecialistDiscovery = _discovery_api()
+    discovery = SpecialistDiscovery(db_path=tmp_path / "discovery.db")
+    write_scope = CapabilitySignature(
+        domain="repository-evidence",
+        actions=("write",),
+        evidence_class="diagnostic-only",
+        requested_permissions=("repository-evidence:write",),
+    )
+
+    decision = discovery.resolve_or_request(
+        write_scope,
+        source_key="gateway:request-2",
+    )
+
+    assert decision.status == "rejected"
+    assert decision.profile is None


### PR DESCRIPTION
## Summary

- add local, read-only candidate discovery for capability gaps
- revalidate candidate eligibility and insert the inert candidate in one `BEGIN IMMEDIATE` transaction
- persist bounded diagnostic scopes and hashes, not source contents
- keep production Kanban imports lazy

## Stack

This is the second focused extraction from #97870 and is stacked on #98892. The registry layer is included through rebased parent head `22e8cd583a`, and this branch is reconciled with current `main` at `63279301bc`. It should remain draft until maintainer review and hosted checks are available.

## Scope

Candidates are inert. This PR does not create or activate profiles, dispatch work, call models, publish data, or perform network operations.

## Verification

- 24 focused gateway tests passed
- Ruff and bytecode compilation passed
- diff, ancestry, and bounded privacy scans passed
- current GitHub head: `f9005637b631dc478bb10db830617c6bb8f1d200`
- no hosted checks are currently reported for this fork branch
