### PR TITLE
fix(skills): correct research-paper citation handoff

### DIFF
--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -25,9 +25,10 @@ the fetched page text), claims from model knowledge are flagged `[unverified]`,
 and `verify --evidence` fails any draft whose cited sources carry no evidence.
 
 This skill covers answers in chat, written documents (markdown, PDF, docx,
-slides), and research reports. It does not cover academic BibTeX pipelines —
-for conference papers use the `arxiv` skill, which this skill
-feeds (see `references/citation-formats.md`).
+slides), and research reports. It does not cover full academic manuscript or
+venue-formatting pipelines. Use the `arxiv` skill for paper discovery and
+BibTeX generation, then apply the verification procedure in
+`references/citation-formats.md`.
 
 ## When to Use
 

--- a/skills/research/grounded-citations/references/citation-formats.md
+++ b/skills/research/grounded-citations/references/citation-formats.md
@@ -53,10 +53,12 @@ consistency is the reason not to reset the ledger between pages of one build.
 
 ## Research papers
 
-Hand off to the `grounded-citations` skill. Export with
-`--style bibtex` into `references.bib`, then follow that skill's citation
-verification (it greps `\cite{...}` against the .bib). The ledger's job ends at
-producing verified URL entries; venue formatting is that skill's domain.
+Use the `arxiv` skill to discover papers and generate BibTeX entries, then save
+those entries in `references.bib`. Before delivery, verify that every
+`\cite{...}` key in the draft has a matching bibliography entry. Keep the web
+evidence ledger separate: `sources.py render --style bibtex` emits ledger keys
+such as `source1` and must not overwrite the paper bibliography. Venue
+formatting remains a separate step.
 
 ## Code and config artifacts
 


### PR DESCRIPTION
## Summary
- Fix the self-referential research-paper handoff in `grounded-citations/references/citation-formats.md`, which remains broken on pinned base `bc1330eebc0aa8a443501b5f62586eb7361353a5:56` despite the main skill's partial routing fix.
- Scope `arxiv` to paper discovery and BibTeX generation, keep citation-key verification explicit, and keep the web evidence ledger separate from the paper bibliography and venue formatting.
- Documentation only; remove the source-reading/change-detector test from the PR.

## Verification
- Rebased onto the pinned base, preserving original commit authorship.
- `scripts/run_tests.sh tests/skills/test_grounded_citations_skill.py -q -j 2`: 47 passed.
- `git diff --check`: passed.

Fresh CI readback on the pushed head: all reported checks passed or were skipped. No merge performed.
