### PR TITLE
fix(dashboard): clear stale resume on profile switch

### DIFF
--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -8,6 +8,7 @@ import {
 import { useLocation, useSearchParams } from "react-router";
 import { api, setManagementProfile } from "@/lib/api";
 import { ProfileContext } from "@/contexts/profile-context";
+import { profileSelectionSearchParams } from "@/contexts/profile-search-params";
 
 /**
  * Machine-level management-profile scope.
@@ -114,16 +115,12 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
       setManagementProfile(name);
       setProfileState(name);
       setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (name) next.set("profile", name);
-          else next.delete("profile");
-          return next;
-        },
+        (prev) =>
+          profileSelectionSearchParams(prev, name, profile, currentProfile),
         { replace: true },
       );
     },
-    [setSearchParams],
+    [currentProfile, profile, setSearchParams],
   );
 
   const value = useMemo(

--- a/web/src/contexts/profile-search-params.test.ts
+++ b/web/src/contexts/profile-search-params.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { profileSelectionSearchParams } from "./profile-search-params";
+
+describe("profileSelectionSearchParams", () => {
+  it("drops a resume target when the effective profile changes", () => {
+    const previous = new URLSearchParams(
+      "profile=default&resume=session-from-default&panel=models",
+    );
+
+    const next = profileSelectionSearchParams(
+      previous,
+      "research",
+      "default",
+      "default",
+    );
+
+    expect(next.get("profile")).toBe("research");
+    expect(next.has("resume")).toBe(false);
+    expect(next.get("panel")).toBe("models");
+  });
+
+  it("keeps the resume target when the effective profile is unchanged", () => {
+    const previous = new URLSearchParams(
+      "profile=default&resume=session-from-default",
+    );
+
+    const next = profileSelectionSearchParams(
+      previous,
+      "",
+      "default",
+      "default",
+    );
+
+    expect(next.has("profile")).toBe(false);
+    expect(next.get("resume")).toBe("session-from-default");
+  });
+});

--- a/web/src/contexts/profile-search-params.ts
+++ b/web/src/contexts/profile-search-params.ts
@@ -1,0 +1,24 @@
+function effectiveProfile(selection: string, currentProfile: string): string {
+  return selection || currentProfile || "default";
+}
+
+export function profileSelectionSearchParams(
+  previous: URLSearchParams,
+  selection: string,
+  previousSelection: string,
+  currentProfile: string,
+): URLSearchParams {
+  const next = new URLSearchParams(previous);
+
+  if (selection) next.set("profile", selection);
+  else next.delete("profile");
+
+  if (
+    effectiveProfile(selection, currentProfile) !==
+    effectiveProfile(previousSelection, currentProfile)
+  ) {
+    next.delete("resume");
+  }
+
+  return next;
+}


### PR DESCRIPTION
## What does this PR do?

The Dashboard profile switcher changed `?profile=` while leaving the previous profile's `?resume=<session-id>` in the chat URL. `ChatPage` then sent that stale session ID to the newly selected profile, which could only answer with `session not found`.

This clears `resume` when the effective profile actually changes. It treats the empty "this dashboard" selection as an alias for the dashboard's current profile, so selecting the same effective profile still preserves a valid resumed chat. Other query parameters are left alone.

## Related Issue

N/A. Reported through Discord support.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `ProfileProvider` to remove a stale chat resume target when its effective profile changes.
- Add a small query-parameter helper so effective-profile comparison is independently testable.
- Cover changed-profile cleanup, unrelated query-parameter preservation, and same-profile resume preservation.

## How to Test

1. Open a Dashboard chat through `/chat?profile=default&resume=<session-id>`.
2. Change the selected profile and verify the URL keeps the new profile but removes `resume`, without showing `session not found` from the previous profile.
3. Select the Dashboard's current profile through its empty-value alias and verify an existing resume target is preserved when the effective profile did not change.

Focused checks run on Windows:

- `npm run test --workspace web -- src/contexts/profile-search-params.test.ts`
- `npm run typecheck --workspace web`
- Focused ESLint on the three changed files (no errors; one pre-existing `react-hooks/set-state-in-effect` warning in `ProfileProvider.tsx`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, focused Dashboard Vitest and TypeScript checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. The regression is covered by the focused URL-state tests above.
