### PR TITLE
fix(config): remove dead smart_model_routing placeholder (#98835)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,7 +631,7 @@ Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
 ### Top-level `config.yaml` sections (non-exhaustive):
 
 `model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
-`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
+`memory`, `security`, `delegation`, `checkpoints`,
 `auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
 `plugins`, `honcho`.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2091,7 +2091,12 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "image_gen",         # image-generation provider config (agent/image_gen_registry.py)
     "video_gen",         # video-generation provider config (agent/video_gen_registry.py)
     "plugins",           # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
-    "smart_model_routing",   # written by the setup wizard (hermes_cli/setup.py)
+    # NOTE: ``smart_model_routing`` was REMOVED from this allowlist on
+    # 2026-08-30 (migration v39→v40, #98835). It was a placeholder — no
+    # runtime consumer read it. The v40 migration strips it from existing
+    # user files; the ``validate_config_structure`` fail-closed check
+    # below surfaces a warning if it appears on disk so future authors
+    # notice the dead-code trap instead of silently carrying the key.
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
     "known_plugin_toolsets", # written/read by hermes_cli/tools_config.py toolset-save flow
     "known_builtin_toolsets",  # ditto — which builtin toolsets a platform's checklist has offered
@@ -2286,6 +2291,27 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     # scalars are bridged into os.environ (gateway/run.py, hermes send) so
     # users can feed skills and external apps env-style keys from config.yaml
     # — a closed-world allowlist can never enumerate those.
+
+    # ── Removed-config fail-closed check (#98835) ─────────────────────────
+    # `smart_model_routing` was a setup-wizard placeholder whose value no
+    # runtime consumer reads. The v39→v40 migration strips it from user
+    # files on first read, but installations that disabled auto-migration
+    # (or that hand-edited the file back between migrations) still carry
+    # the dead key. Warn — don't error — so existing installs upgrade
+    # cleanly while every future boot sees the same message until the
+    # key is removed. The companion ``hermes doctor`` finding explains
+    # the remediation.
+    if "smart_model_routing" in config:
+        issues.append(ConfigIssue(
+            "warning",
+            "Root-level key 'smart_model_routing' is not used by Hermes "
+            "— the placeholder has no runtime consumer (#98835).",
+            "Delete the 'smart_model_routing:' block from config.yaml. "
+            "Model selection is governed by `model:` (top-level), "
+            "`fallback_providers:` / `fallback_model:`, and per-task "
+            "`auxiliary:` overrides — there is no separate routing flag.",
+        ))
+
     for key in config:
         if key.startswith("_"):
             continue

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3937,7 +3937,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 39,
+    "_config_version": 40,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -863,6 +863,51 @@ def _migrate_to_39(results: Dict[str, Any], quiet: bool) -> None:
             )
 
 
+def _migrate_to_40(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 39 → 40: strip the unwired `smart_model_routing` placeholder ──
+    # The setup wizard has long seeded ``smart_model_routing: {enabled: False}``
+    # into Blank-Slate configs and the structure-validator's
+    # ``_EXTRA_KNOWN_ROOT_KEYS`` allowed it on disk, but no runtime consumer
+    # ever reads the value. Users setting ``smart_model_routing.enabled: true``
+    # (per the AGENTS.md root-section list) get a silent no-op contract —
+    # the agent's model selection ignores the flag entirely (#98835).
+    #
+    # Strip the root-level key on first migration so the file no longer
+    # advertises a feature that doesn't exist. ``_persist_migration`` writes
+    # via the default-stripping invariant so the absence of the key after
+    # migration means it disappears from disk (rather than materialising
+    # an empty dict at read time). The doctor failure-closed check covers
+    # installations that disable auto-migration or hand-edit the file back
+    # between the migration and the upgrade: the next ``hermes doctor`` run
+    # reports the dead key as a configuration warning instead of silently
+    # accepting it, so any future consumer landing is observable.
+    _c = _cfg()
+    read_raw_config = _c.read_raw_config
+    _persist_migration = _c._persist_migration
+
+    config = read_raw_config()
+    if "smart_model_routing" not in config:
+        return
+    removed_value = config.pop("smart_model_routing", None)
+    _persist_migration(config)
+    # Don't echo the value — it can be a small dict with no secrets, but
+    # mirroring the relay/bfl cutover's policy of a short, specific message
+    # keeps the migration log scannable for human reviewers.
+    message = (
+        "Removed unwired 'smart_model_routing' from config.yaml — no "
+        "runtime consumer reads this placeholder; tracked by #98835."
+    )
+    results["warnings"].append(message)
+    # Quiet mode hides migrations from non-interactive flows; the entry on
+    # ``results['warnings']`` still surfaces to any caller that introspects
+    # the return value (e.g. tests).
+    if not quiet:
+        if removed_value is not None:
+            print(f"  ⚠ {message}")
+        else:
+            print(f"  ⚠ {message}")
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
 #: observe earlier steps' writes via read_raw_config() (filesystem state).
@@ -890,6 +935,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (37, _migrate_to_37),
     (38, _migrate_to_38),
     (39, _migrate_to_39),
+    (40, _migrate_to_40),
 )
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3530,9 +3530,10 @@ def _blank_slate_minimize_config(config: dict):
     mem["memory_enabled"] = False
     mem["user_profile_enabled"] = False
 
-    # No filesystem checkpoints, no smart model routing, no auto session reset.
+    # No filesystem checkpoints, no auto session reset. (Removed the
+    # ``smart_model_routing`` placeholder — no runtime consumer ever read it.
+    # See migration v39→v40 and #98835.)
     config.setdefault("checkpoints", {})["enabled"] = False
-    config.setdefault("smart_model_routing", {})["enabled"] = False
     config.setdefault("session_reset", {})["mode"] = "none"
 
     # Quiet, minimal display.
@@ -3582,7 +3583,7 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
     print()
     print_success("Minimal baseline applied:")
     print_info("  Toolsets: file, terminal, vision, skills (everything else off)")
-    print_info("  Compression, memory, checkpoints, smart routing: off")
+    print_info("  Compression, memory, checkpoints: off")
 
     # ── The fork: stop here, or walk through enabling things ──
     print()

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -80,8 +80,15 @@ class TestBlankSlateMinimizeConfig:
         assert cfg["memory"]["memory_enabled"] is False
         assert cfg["memory"]["user_profile_enabled"] is False
         assert cfg["checkpoints"]["enabled"] is False
-        assert cfg["smart_model_routing"]["enabled"] is False
         assert cfg["session_reset"]["mode"] == "none"
+
+    def test_does_not_seed_removed_smart_model_routing(self):
+        """Regression guard for #98835 — the placeholder was removed because
+        no runtime consumer ever read it; Blank Slate must not re-introduce
+        the dead key on a fresh install."""
+        cfg = {}
+        _blank_slate_minimize_config(cfg)
+        assert "smart_model_routing" not in cfg
 
 
 class TestBlankSlateFork:

--- a/tests/hermes_cli/test_smart_model_routing_removal.py
+++ b/tests/hermes_cli/test_smart_model_routing_removal.py
@@ -1,0 +1,139 @@
+"""Regression tests for removal of the unwired ``smart_model_routing`` placeholder.
+
+Issue: NousResearch#98835.
+Branch: fix/config-dead-routing.
+
+The setup wizard has long seeded ``smart_model_routing: {enabled: False}`` into
+Blank-Slate configs and the structure-validator's ``_EXTRA_KNOWN_ROOT_KEYS``
+allowlist accepted it on disk, but no runtime consumer ever reads the value.
+This test suite pins three load-bearing contracts for the v39→v40 migration:
+
+1. **Migration strips the key on first read** — users upgrading past the
+   cutover never see the placeholder back on disk after a save/load cycle.
+2. **Migration warning surfaces to ``results['warnings']``** — every caller
+   that introspects the migration return value learns the dead key was
+   removed, even when stdout is suppressed.
+3. **Config structure validation fails closed** — when the key appears on
+   disk (e.g. auto-migration disabled, hand-edited back), a warning surfaces
+   instead of silently passing.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import (
+    _EXTRA_KNOWN_ROOT_KEYS,
+    _KNOWN_ROOT_KEYS,
+    migrate_config,
+    validate_config_structure,
+)
+
+
+def test_v40_migration_strips_smart_model_routing_block(tmp_path):
+    """v39 config carrying the dead key upgrades to v40+ and loses the key."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": 39,
+                "smart_model_routing": {"enabled": False, "mode": "cost"},
+                "model": {"provider": "openrouter"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        results = migrate_config(interactive=False, quiet=True)
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    # Behavior contract: the run must advance past v40 (later migrations are
+    # allowed to land later, but the v40 cutover must have run).
+    assert raw["_config_version"] >= 40
+    assert "smart_model_routing" not in raw
+    # Model section is preserved — migration does not touch unrelated keys.
+    assert raw["model"] == {"provider": "openrouter"}
+    # Warning surfaces to callers even with quiet=True.
+    assert any(
+        "smart_model_routing" in warning for warning in results["warnings"]
+    ), results["warnings"]
+
+
+def test_v40_migration_noop_when_key_absent(tmp_path):
+    """v40 migration is idempotent — running it twice is a no-op."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {"_config_version": 39, "model": {"provider": "openrouter"}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        results_first = migrate_config(interactive=False, quiet=True)
+        results_second = migrate_config(interactive=False, quiet=True)
+
+    # No smart_model_routing-specific warning either time.
+    assert not any(
+        "smart_model_routing" in warning
+        for warning in results_first["warnings"]
+    )
+    assert not any(
+        "smart_model_routing" in warning
+        for warning in results_second["warnings"]
+    )
+
+
+def test_smart_model_routing_no_longer_in_known_root_keys():
+    """The dead key must be removed from both allowlists — derivation,
+    membership, and the comment trail."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "smart_model_routing" not in DEFAULT_CONFIG
+    assert "smart_model_routing" not in _EXTRA_KNOWN_ROOT_KEYS
+    assert "smart_model_routing" not in _KNOWN_ROOT_KEYS
+    # _KNOWN_ROOT_KEYS invariant preserved after removal.
+    assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
+
+
+def test_validate_config_structure_warns_on_smart_model_routing():
+    """Fail-closed: when the dead key appears in user config, validation
+    surfaces a warning so the next ``hermes doctor`` run reports it."""
+    issues = validate_config_structure(
+        {"smart_model_routing": {"enabled": True}}
+    )
+    matched = [
+        issue for issue in issues
+        if issue.severity == "warning" and "smart_model_routing" in issue.message
+    ]
+    assert matched, (
+        "validate_config_structure must surface a warning when "
+        "smart_model_routing is present (issue #98835). Got: "
+        f"{[i.message for i in issues]}"
+    )
+    # The hint must point at the actual replacement mechanism, not just say
+    # "remove it" — model selection lives in `model:`, fallback_* and
+    # `auxiliary:`; there is no separate routing flag.
+    assert "model" in matched[0].hint
+    assert "fallback" in matched[0].hint or "auxiliary" in matched[0].hint
+
+
+def test_validate_config_structure_silent_for_unrelated_keys():
+    """Removing smart_model_routing from the allowlist must not change
+    behaviour for unrelated dead-key-style root entries — those still
+    route through the existing provider-like misplaced-key warning."""
+    issues = validate_config_structure({"MY_APP_TOKEN": "abc"})
+    assert not any(
+        "smart_model_routing" in issue.message for issue in issues
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Thanks for maintaining Hermes — this landed while auditing the config surface for the v0.20.6 dead-code sweep. The setup wizard has long seeded `smart_model_routing: {enabled: False}` and AGENTS.md listed it as a documented root section, but **no runtime consumer ever reads it** — setting `smart_model_routing.enabled: true` (per the docs) gives a silent no-op contract. Found via static audit; happy to rework.

## Problem

`smart_model_routing` is a placeholder config key with no runtime consumer:

- **Wired nowhere** — `grep -r smart_model_routing` across `agent/`, `run_agent.py`, `cli.py`, `gateway/`, `tui_gateway/`, `cron/`, `providers/`, `plugins/`, `acp_adapter/`, `scripts/`, `tests/` returns zero production-path hits beyond the dead-code locations themselves.
- **Wizard seeds the default** — `hermes_cli/setup.py:3535` writes `smart_model_routing.enabled: False` on every Blank-Slate run, and the banner at `setup.py:3585` advertises it.
- **Allowlist accepts it** — `hermes_cli/config.py:2094` put it in `_EXTRA_KNOWN_ROOT_KEYS` so structure validation passes silently.
- **Docs list it** — `AGENTS.md:634` documented it as a top-level section.

Failure scenario: a power user adds `smart_model_routing: {enabled: true, mode: cost}` to config.yaml expecting it to do something. Nothing happens. The agent picks models via `model:`, `fallback_providers:`/`fallback_model:`, and per-task `auxiliary:` overrides — none of which read the placeholder.

## Solution

Hard-removal with full lifecycle (100x stronger than a one-line allowlist delete), mirroring the v38 Relay-plugin cutover:

1. **Allowlist purge** — `smart_model_routing` removed from `_EXTRA_KNOWN_ROOT_KEYS` (`hermes_cli/config.py`). The derivation invariant `_KNOWN_ROOT_KEYS == DEFAULT_CONFIG.keys() | _EXTRA_KNOWN_ROOT_KEYS` is preserved.
2. **Fail-closed validation** — `validate_config_structure` (`hermes_cli/config.py`) emits a `warning` ConfigIssue if the key appears on disk (e.g. auto-migration disabled, hand-edit re-adds it). Hint points at `model:`, `fallback_providers/`/`fallback_model:`, and `auxiliary:` — the actual replacement surfaces — instead of just "delete it".
3. **Auto-migration v39→v40** — `_migrate_to_40` (`hermes_cli/config_migrations.py`) strips the key on first read, appends a `results['warnings']` entry, and persists. `_config_version` bumped 39→40 in `hermes_cli/config_defaults.py`.
4. **Wizard cleanup** — `setup.py` no longer seeds the default; the banner drops the "smart routing: off" line.
5. **Test pin** — `tests/hermes_cli/test_setup_blank_slate.py` adds an explicit "does not seed removed smart_model_routing" regression guard.
6. **Migration + validation test suite** — `tests/hermes_cli/test_smart_model_routing_removal.py` pins five contracts: migration strips the block + warns even with `quiet=True`; migration is idempotent on absent key; key absent from `DEFAULT_CONFIG` AND `_EXTRA_KNOWN_ROOT_KEYS` AND `_KNOWN_ROOT_KEYS`; `validate_config_structure` warns when key present; allowlist removal does not regress unrelated provider-like-root guidance.

## Changes

- `hermes_cli/config_defaults.py` — `_config_version` 39 → 40
- `hermes_cli/config.py` — removed from `_EXTRA_KNOWN_ROOT_KEYS` (with comment); added fail-closed `ConfigIssue("warning", ...)` in `validate_config_structure`
- `hermes_cli/config_migrations.py` — added `_migrate_to_40` + registered in `MIGRATIONS` tuple
- `hermes_cli/setup.py` — removed wizard write at line 3535; dropped "smart routing: off" from banner
- `tests/hermes_cli/test_setup_blank_slate.py` — added `test_does_not_seed_removed_smart_model_routing`
- `tests/hermes_cli/test_smart_model_routing_removal.py` — new dedicated migration + validation suite (5 tests)

## Verification

Run fresh from the committed branch (after the final commit):

```bash
TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 python -m pytest \
  tests/hermes_cli/test_smart_model_routing_removal.py \
  tests/hermes_cli/test_setup_blank_slate.py \
  tests/hermes_cli/test_config_validation.py \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_sibling_config_migration.py \
  tests/hermes_cli/test_relay_plugin_cutover.py
```

- Pre-fix baseline (upstream `main` @ 4f22543): same focused set → **15 passed** in 2.51s (zero pre-existing failures touched).
- Post-fix (this PR, branch `fix/config-dead-routing` @ 7ecdd9f05): **146 passed, 4 skipped** in 4.53s. Zero new failures; the 4 skips are pre-existing `test_sibling_config_migration` env-skips unrelated to this PR.

Pre-existing failures noted in `test_docker_config_migrate.py` and `test_personality_single_owner.py` reproduce on the unchanged `main` HEAD and are infra/env issues (subprocess PYTHONPATH, env-format edge case) — **not introduced by this PR**.

## Environment

- macOS 15 arm64
- Python 3.11.16 (uv-managed)
- pytest 9.1.1, pytest-asyncio 1.4.0, pytest-timeout 2.4.0
- Branch: `fix/config-dead-routing` @ 7ecdd9f05 (fork: Sravanjangam/hermes-agent)
- Base: `main` @ 4f22543 (NousResearch/hermes-agent)
