### PR TITLE
fix(skills): refresh stale command and PDF references

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
@@ -43,7 +43,7 @@ it. New commands land often; `/help` in-session is always authoritative.
 /verbose                 Cycle tool progress: off → new → all → verbose → log (CLI)
 /voice [on|off|tts]      Voice mode
 /yolo                    Toggle approval bypass
-/busy [queue|steer|interrupt] How messages behave while working (CLI + gateway)
+/busy [queue|steer|interrupt|status] How messages behave while working (CLI + gateway)
 /indicator [style]       TUI busy indicator: kaomoji|emoji|unicode|ascii (CLI)
 /footer [on|off]         Gateway runtime-metadata footer on replies
 /skin [name]             Change theme (CLI)

--- a/skills/productivity/pdf/references/nano-pdf-editing.md
+++ b/skills/productivity/pdf/references/nano-pdf-editing.md
@@ -1,7 +1,7 @@
 # Natural-language PDF text editing with nano-pdf (merged from the nano-pdf skill)
 # nano-pdf
 
-Edit PDFs using natural-language instructions. Point it at a page and describe what to change. For structural PDF work (merge, split, forms, watermarks, creation), see the `pdf` skill; for text extraction from scans, see `ocr-and-documents`.
+Edit PDFs using natural-language instructions. Point it at a page and describe what to change. For structural PDF work (merge, split, forms, watermarks, creation), see the `pdf` skill; for text extraction from scans, see this skill's `references/ocr-extraction.md`.
 
 ## Prerequisites
 

--- a/skills/research/arxiv/SKILL.md
+++ b/skills/research/arxiv/SKILL.md
@@ -155,7 +155,7 @@ web_extract(urls=["https://arxiv.org/abs/2402.03300"])
 web_extract(urls=["https://arxiv.org/pdf/2402.03300"])
 ```
 
-For local PDF processing, see the `ocr-and-documents` skill.
+For local PDF processing, see the `pdf` skill.
 
 ## Common Categories
 
@@ -265,7 +265,7 @@ curl -s "https://api.semanticscholar.org/graph/v1/author/search?query=Yann+LeCun
 - arXiv IDs: old format (`hep-th/0601001`) vs new (`2402.03300`)
 - PDF: `https://arxiv.org/pdf/{id}` — Abstract: `https://arxiv.org/abs/{id}`
 - HTML (when available): `https://arxiv.org/html/{id}`
-- For local PDF processing, see the `ocr-and-documents` skill
+- For local PDF processing, see the `pdf` skill
 
 ## ID Versioning
 


### PR DESCRIPTION
## Summary
- Document the supported `/busy status` subcommand.
- Route arXiv local-PDF processing to the consolidated `pdf` skill and fix the remaining stale OCR handoff in its nano-PDF reference.
- Documentation only; remove source-reading/change-detector tests from the PR.

## Maintenance verification
Rebased onto pinned upstream base `bc1330eebc0aa8a443501b5f62586eb7361353a5`, preserving commit authorship.

- Bug remains on that base: `skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md:46` omits status; `skills/research/arxiv/SKILL.md:158,268` names the removed skill.
- `scripts/run_tests.sh tests/skills/test_hermes_agent_skill.py tests/cli/test_busy_input_mode_command.py tests/e2e/test_relay_native_openai_stream.py -q -j 2`: 12 passed.
- `git diff --check`: passed.
- Full local e2e suite is blocked by missing `pytest_asyncio`, also reproduced on the unchanged base. No dependencies installed.
- Previous e2e CI failure was Relay stream-usage finalizer synchronization, not skill-reference behavior. The exact Relay test file passes on base and this head; remote CI must establish whether that intermittent failure recurs.

Fresh CI readback on the pushed head: all reported checks passed or were skipped, including Python e2e and the required-check aggregate. No merge performed.
