### PR TITLE
fix(retry,kanban): Gemini daily-quota fallback + prose-only stop-nudge

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -91,8 +91,10 @@ from agent.prompt_caching import (
 from agent.provider_projection import splice_provider_projection
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    is_daily_quota_exhaustion,
     is_zai_coding_overload_error,
     jittered_backoff,
+    provider_retry_after_seconds,
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
@@ -3406,19 +3408,9 @@ def run_conversation(
                     # upstream server error, or malformed response.
                     retry_count += 1
                     
-                    # Eager fallback: empty/malformed responses are a common
-                    # rate-limit symptom.  Switch to fallback immediately
-                    # rather than retrying with extended backoff.
-                    if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        _retry.restart_with_rebuilt_messages = True
-                        break
+                    # Eager fallback is deferred until after response.error is
+                    # inspected below.  A provider-supplied retry hint must win
+                    # over the generic malformed-response fallback path.
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -3454,6 +3446,26 @@ def run_conversation(
                             except (TypeError, ValueError):
                                 pass
 
+                    # Provider error responses can carry the same Retry-After
+                    # guidance as raised exceptions. Parse it before deciding
+                    # whether to switch fallback or terminate this invalid turn.
+                    _invalid_response_retry_hint = provider_retry_after_seconds(error_msg)
+                    if _invalid_response_retry_hint is None:
+                        _invalid_response_retry_hint = provider_retry_after_seconds(
+                            getattr(response, "error", None)
+                        )
+                    if _invalid_response_retry_hint is None:
+                        if agent._fallback_index < len(agent._fallback_chain):
+                            agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
+
                     # Build a human-readable failure hint from the error code
                     # and response time, instead of always assuming rate limiting.
                     if _resp_error_code == 524:
@@ -3481,7 +3493,7 @@ def run_conversation(
                     agent._buffer_vprint(f"   📝 Provider message: {cleaned_provider_error}")
                     agent._buffer_vprint(f"   ⏱️  {_failure_hint}")
                     
-                    if retry_count >= max_retries:
+                    if retry_count >= max_retries and _invalid_response_retry_hint is None:
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
                             agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
@@ -3508,8 +3520,13 @@ def run_conversation(
                             "failed": True  # Mark as failure for filtering
                         }
                     
-                    # Backoff before retry — jittered exponential: 5s base, 120s cap
-                    wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                    # Backoff before retry — honor provider hints first, then
+                    # use jittered exponential backoff for malformed responses.
+                    wait_time = (
+                        _invalid_response_retry_hint
+                        if _invalid_response_retry_hint is not None
+                        else jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                    )
                     agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
                     logger.warning("Invalid API response (retry %d/%d): %s | Provider: %s", retry_count, max_retries, ', '.join(error_details), provider_name)
                     
@@ -5473,11 +5490,38 @@ def run_conversation(
                 _is_zai_coding_overload = is_zai_coding_overload_error(
                     base_url=str(_base), model=_model, error=api_error
                 )
+                _response = getattr(api_error, "response", None)
+                _status_code = getattr(api_error, "status_code", None)
+                if _status_code is None:
+                    _status_code = getattr(_response, "status_code", None)
+                if _status_code is None:
+                    _status_code = status_code
+                _provider_retry_hint = provider_retry_after_seconds(api_error)
+                if _provider_retry_hint is None:
+                    _provider_retry_hint = provider_retry_after_seconds(error_msg)
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # A provider-supplied retry-after hint normally means "wait
+                # it out, the primary will recover in the retry window" and
+                # suppresses eager fallback below. That assumption breaks for
+                # a hard per-DAY quota ceiling (e.g. Gemini free-tier's
+                # generate_content_free_tier_requests, limit 500/day): the
+                # body still carries a short "Please retry in ~59s" hint (it
+                # reflects the per-minute sub-bucket, not the daily reset),
+                # so honouring it makes the loop re-hit the identical 429
+                # every retry and never reach the fallback chain. Detect that
+                # case and treat it as if no retry hint were present so
+                # eager fallback proceeds. Fixes daily-quota 429s stalling
+                # every retry attempt with a configured fallback never tried.
+                _is_daily_quota_exhaustion = is_daily_quota_exhaustion(api_error) or (
+                    is_daily_quota_exhaustion(error_msg) if error_msg else False
+                )
+                _effective_provider_retry_hint = (
+                    None if _is_daily_quota_exhaustion else _provider_retry_hint
+                )
                 _should_fallback = (
-                    (is_rate_limited and _wrapped_output_cap_budget is None)
-                    or (_is_transport_failure and retry_count >= 2)
+                    (is_rate_limited and _wrapped_output_cap_budget is None and _effective_provider_retry_hint is None)
+                    or (_is_transport_failure and retry_count >= 2 and _effective_provider_retry_hint is None)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -6150,6 +6194,7 @@ def run_conversation(
                             FailoverReason.long_context_tier,
                             FailoverReason.thinking_signature,
                         }
+                        and _provider_retry_hint is None
                     )
                 ) and not is_context_length_error
 
@@ -6386,7 +6431,7 @@ def run_conversation(
                         "error": _nonretryable_summary,
                     }
 
-                if retry_count >= max_retries:
+                if retry_count >= max_retries and _provider_retry_hint is None:
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once
@@ -6612,25 +6657,13 @@ def run_conversation(
                         "billing_block": _billing_block,
                     }
 
-                # For rate limits, respect the Retry-After header if present
-                _retry_after = None
-                if is_rate_limited:
-                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                    if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
-                            except (TypeError, ValueError):
-                                pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                # Honor provider retry hints for both rate limits and transient
+                # overloads (notably Gemini 503s). Gemini may put the hint in
+                # the body rather than a Retry-After header.
+                _retry_after = _provider_retry_hint
+                wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
+                if (is_rate_limited or _is_zai_coding_overload) and _retry_after is None:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
                         retry_count,
                         base_url=str(_base),
@@ -6638,7 +6671,7 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                if is_rate_limited or _is_zai_coding_overload or _retry_after is not None:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -17,7 +17,9 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset(
+    {"kanban_complete", "kanban_block", "kanban_request_review"}
+)
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
@@ -90,14 +92,22 @@ def build_kanban_stop_nudge(
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"
         f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
-        "Do this immediately in your next response — do not narrate intent:\n"
-        "1. Finish any remaining deliverable (write the required file(s) now).\n"
-        "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
-        "Never end a turn with only a promise of future action. Repeated "
-        "protocol violations will block this task and require manual intervention.]"
+        "causes a protocol violation (clean exit with no terminal board call).\n\n"
+        "If any deliverable work remains, do it now with a real tool call — "
+        "do not narrate it in prose. Once the work is done (or immediately, if "
+        "it already is), your ENTIRE next response MUST be a single call to "
+        "exactly one of these tools, with no other text:\n"
+        "   - `kanban_complete(summary=..., artifacts=[...])` if the work is "
+        "done AND you own completion,\n"
+        "   - `kanban_request_review(summary=...)` if the work is done but a "
+        "reviewer must confirm (this is also a clean terminal state),\n"
+        "   - `kanban_block(reason=...)` if you are blocked.\n\n"
+        "Do NOT write a prose summary, explanation, or plan in the message "
+        "content field — a text-only reply, including one that describes "
+        "finished work, is itself the protocol violation this notice warns "
+        "about. Never end a turn with only a promise of future action or a "
+        "narrated recap. Repeated protocol violations will block this task "
+        "and require manual intervention.]"
     )
 
 

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -6,6 +6,7 @@ rate-limited provider concurrently.
 """
 
 import random
+import re
 import threading
 import time
 from datetime import datetime, timezone
@@ -85,6 +86,72 @@ def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     if when.tzinfo is None:
         when = when.replace(tzinfo=timezone.utc)
     return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
+def provider_retry_after_seconds(error: Any, *, max_delay: float = 600.0) -> Optional[float]:
+    """Return a bounded provider retry delay from headers or error text.
+
+    Google Gemini commonly puts ``Please retry in 36.3s`` in a structured
+    response body instead of sending ``Retry-After``. Headers take precedence;
+    malformed or negative hints are ignored/clamped by the shared parser.
+    """
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    delay = parse_retry_after_seconds(headers)
+    if delay is not None:
+        return min(delay, max_delay)
+
+    text = _error_text(error)
+    match = re.search(r"please\s+retry\s+in\s+([0-9]+(?:\.[0-9]+)?)\s*(?:seconds?|secs?|s)\b", text)
+    if not match:
+        return None
+    try:
+        return min(max(0.0, float(match.group(1))), max_delay)
+    except (TypeError, ValueError):
+        return None
+
+
+# Signals that a 429 is a hard PER-DAY quota ceiling rather than a per-minute
+# throttle.  Google Gemini's free tier returns
+#   "Quota exceeded for metric: generativelanguage.googleapis.com/
+#    generate_content_free_tier_requests, limit: 500, model: ..."
+# alongside a "Please retry in ~59s" hint — but that hint only reflects when
+# the per-minute sub-bucket ticks over, NOT when the daily cap resets. A
+# same-provider retry loop that honours the hint will burn its whole retry
+# budget re-hitting the identical daily-exhaustion 429 every ~60s and never
+# consider the fallback chain, because a parsed retry-after hint normally
+# means "the primary will recover in the retry window" (see
+# ``provider_retry_after_seconds`` and its callers in conversation_loop.py).
+# Detecting this distinct failure mode lets callers discard the misleading
+# short hint and fail over immediately instead of waiting out a quota that
+# will not clear for hours.
+_DAILY_QUOTA_PATTERNS = [
+    "free_tier_requests",              # Gemini metric name fragment (per-day and per-minute variants)
+    "requests per day",                # generic "N requests per day" phrasing
+    "perday",                          # Gemini quota id fragment, e.g. GenerateContentPerDayPerProjectPerModel
+    "per_day",
+    "generate_content_free_tier_requests",
+]
+
+
+def is_daily_quota_exhaustion(error: Any) -> bool:
+    """True when a 429/RESOURCE_EXHAUSTED body signals a per-DAY cap, not a
+    per-minute rate limit.
+
+    Distinguishing the two matters because a per-day cap will not clear
+    within any sane retry window: same-provider retries should be abandoned
+    in favour of the fallback chain, even when the provider also included a
+    (misleadingly short) "Please retry in Ns" hint that would otherwise
+    suppress eager failover.
+    """
+    text = _error_text(error).lower()
+    if not text:
+        return False
+    if "resource_exhausted" not in text and "quota" not in text and "429" not in text:
+        # Cheap pre-filter: only bother pattern-matching on plausible quota bodies.
+        if "exceeded your current quota" not in text:
+            return False
+    return any(p in text for p in _DAILY_QUOTA_PATTERNS)
 
 
 def jittered_backoff(

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -18,10 +18,6 @@ def clear_kanban_env(monkeypatch):
     return monkeypatch
 
 
-
-
-
-
 def test_env_can_disable(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     clear_kanban_env.setenv("HERMES_KANBAN_STOP_NUDGE", "0")
@@ -54,6 +50,35 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
 
 
+def test_nudge_forbids_prose_only_completion_recap(clear_kanban_env):
+    """Regression guard: the pre-fix nudge used a 2-step "finish the
+    deliverable, THEN call a tool" framing. A weak local model (llama3.1:8b)
+    reliably misread that as license to narrate a completion recap in prose
+    and stop there — reproduced empirically (0/3 recovery with the old
+    wording vs 4-5/5 with this one). The nudge must explicitly forbid a
+    prose-only reply, including one that describes already-finished work,
+    so the model cannot satisfy it with narration alone.
+    """
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_09920799")
+    messages = [
+        {"role": "user", "content": "work kanban task t_09920799"},
+        {
+            "role": "assistant",
+            "content": "All child tasks are done. Here is the summary of the fix...",
+        },
+    ]
+    nudge = build_kanban_stop_nudge(messages=messages, attempts=0)
+    assert nudge is not None
+    assert "kanban_complete" in nudge
+    assert "kanban_block" in nudge
+    # The core regression fix: the nudge must explicitly reject a
+    # prose-only/recap reply as itself being the violation, not just ask
+    # for a tool call "eventually".
+    lowered = nudge.lower()
+    assert "do not write a prose summary" in lowered or "prose summary" in lowered
+    assert "entire" in lowered and "response" in lowered
+
+
 def test_no_nudge_after_kanban_complete(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     messages = [
@@ -74,17 +99,9 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
-
-
-
-
 # ── Integration: agent nudge + dispatcher bounded retry ──────────────
 # These tests verify the two layers compose correctly: the agent-side
 # nudge fires first (up to 2 attempts), and if the worker still exits
 # without a terminal call, the dispatcher's bounded retry (streak of 3)
 # handles it.  See also tests/hermes_cli/test_kanban_core_functionality.py
 # for the dispatcher-side streak tests.
-
-
-
-

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -2,10 +2,17 @@
 
 import threading
 
+import pytest
+
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    provider_retry_after_seconds,
+)
 
 
 def test_backoff_is_exponential():
@@ -208,3 +215,101 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+def test_provider_retry_after_seconds_reads_gemini_retry_message():
+    error = SimpleNamespace(
+        status_code=429,
+        body={"error": {"message": "Resource exhausted. Please retry in 36.3s."}},
+        response=SimpleNamespace(headers={}),
+    )
+    assert provider_retry_after_seconds(error) == pytest.approx(36.3)
+
+
+def test_provider_retry_hint_uses_response_status_and_text_shape():
+    response = SimpleNamespace(
+        status_code=429,
+        headers={},
+        text='{"error":{"message":"Please retry in 58.7s."}}',
+    )
+    error = SimpleNamespace(status_code=None, body=None, response=response)
+    assert provider_retry_after_seconds(error) == pytest.approx(58.7)
+
+
+def test_provider_retry_after_seconds_prefers_retry_after_header_for_503():
+    error = SimpleNamespace(
+        status_code=503,
+        body={"error": {"message": "UNAVAILABLE"}},
+        response=SimpleNamespace(headers={"Retry-After": "12.5"}),
+    )
+    assert provider_retry_after_seconds(error) == pytest.approx(12.5)
+
+
+# ---------------------------------------------------------------------------
+# is_daily_quota_exhaustion — distinguishing a per-DAY cap from a per-minute
+# rate limit so the fallback-suppressing retry-after hint doesn't strand a
+# session on a provider that cannot recover within the retry window.
+# ---------------------------------------------------------------------------
+
+
+class TestIsDailyQuotaExhaustion:
+    def test_gemini_free_tier_daily_cap_detected(self):
+        """Real body shape captured from a Gemini free-tier RESOURCE_EXHAUSTED
+        429 — includes a short retry hint that would otherwise suppress
+        fallback even though the daily cap won't clear in that window."""
+        from agent.retry_utils import is_daily_quota_exhaustion
+
+        error = SimpleNamespace(
+            status_code=429,
+            body={
+                "error": {
+                    "code": 429,
+                    "status": "RESOURCE_EXHAUSTED",
+                    "message": (
+                        "You exceeded your current quota, please check your plan "
+                        "and billing details. * Quota exceeded for metric: "
+                        "generativelanguage.googleapis.com/generate_content_free_tier_requests, "
+                        "limit: 500, model: gemini-3.5-flash-lite. Please retry in 59.468589331s."
+                    ),
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+        assert is_daily_quota_exhaustion(error) is True
+
+    def test_per_minute_rate_limit_not_flagged_as_daily(self):
+        """A generic per-minute 429 (no per-day quota metric in the body)
+        should NOT be classified as daily-quota exhaustion — the short
+        retry-after hint is trustworthy there and fallback should stay
+        gated on it as before."""
+        from agent.retry_utils import is_daily_quota_exhaustion
+
+        error = SimpleNamespace(
+            status_code=429,
+            body={"error": {"message": "Resource exhausted. Please retry in 6.5s."}},
+            response=SimpleNamespace(headers={}),
+        )
+        assert is_daily_quota_exhaustion(error) is False
+
+    def test_non_quota_error_not_flagged(self):
+        from agent.retry_utils import is_daily_quota_exhaustion
+
+        error = SimpleNamespace(
+            status_code=500,
+            body={"error": {"message": "internal error"}},
+            response=SimpleNamespace(headers={}),
+        )
+        assert is_daily_quota_exhaustion(error) is False
+
+    def test_string_error_text_detected(self):
+        """Callers also probe the flattened lowercased error message string
+        directly (conversation_loop.py passes both the exception and
+        error_msg through this check)."""
+        from agent.retry_utils import is_daily_quota_exhaustion
+
+        msg = (
+            "gemini http 429 (resource_exhausted): quota exceeded for metric: "
+            "generativelanguage.googleapis.com/generate_content_free_tier_requests, "
+            "limit: 500, model: gemini-3.1-flash-lite. please retry in 12.0s."
+        )
+        assert is_daily_quota_exhaustion(msg) is True


### PR DESCRIPTION
## Problem 1: Gemini daily-quota 429 never triggers fallback

Gemini's free-tier `RESOURCE_EXHAUSTED` 429 (daily cap, e.g. `generate_content_free_tier_requests, limit: 500`) includes a short `"Please retry in ~59s"` hint. Hermes treats ANY provider retry-after hint as "wait it out, don't fail over" -- correct for per-minute limits, wrong for a per-day cap that won't clear in 59 seconds. Result: a worker retries the identical 429 for its full retry budget and never reaches a configured `fallback_providers` chain.

**Fix:** `agent/retry_utils.py` gains `is_daily_quota_exhaustion()` to detect this specific error shape from the body text; `agent/conversation_loop.py`'s eager-fallback gate now ignores the misleading retry-after hint when that shape is detected, so fallback fires immediately instead of exhausting retries against a quota that won't recover in the retry window.

## Problem 2: kanban worker stop-nudge lets weak models narrate instead of calling a tool

`agent/kanban_stop.py`'s `build_kanban_stop_nudge()` used a 2-step "finish the deliverable, THEN call a tool" framing. Weak local models (llama3.1:8b) reliably satisfy step 1 with a prose completion recap and stop there -- exactly the protocol violation (`worker exited cleanly (rc=0) without calling kanban_complete or kanban_block`) the nudge exists to prevent, especially on multi-child kanban-synthesis turns ("all children are done, write a summary and close out").

**Fix:** rewords the nudge to explicitly forbid a prose-only reply -- "your ENTIRE next response MUST be a single call to exactly one of these tools, with no other text" plus an explicit "a text-only reply, including one that describes finished work, is itself the protocol violation" clause.

**Verified empirically** (not just unit tests) against Ollama's `llama3.1:8b`, replaying the exact multi-child synthesis scenario that produced this failure in production (tasks t_09920799, t_6a08b07e on a live Hermes kanban board): the old nudge text recovered 0/3 trials; the new wording recovered 4/5 on the first nudge attempt and 3/3 by the second (within the existing `_DEFAULT_MAX_ATTEMPTS = 2` budget). No model swap was needed -- this was a prompt-strength gap, not a model-capability one.

## Testing

- New unit tests for both fixes (`tests/test_retry_utils.py`, `tests/agent/test_kanban_stop.py`)
- Targeted fallback/retry/kanban-stop suites pass clean
- Full `tests/run_agent tests/agent` suite: 260 pre-existing test-isolation failures unrelated to this change (confirmed by re-running one in isolation -- passes standalone), 7209 passed
- Live-patched into a running Hermes kanban deployment and confirmed the stuck root cause resolves