### PR TITLE
fix(gateway): write wscript launchers as UTF-16 so non-ASCII HERMES_HOME parses

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -570,7 +570,11 @@ def _write_task_script() -> Path:
     vbs_content = _build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)
     vbs_path = script_path.with_suffix(".vbs")
     vbs_tmp = vbs_path.with_name(vbs_path.name + ".tmp")
-    vbs_tmp.write_text(vbs_content, encoding="utf-8", newline="")
+    # wscript.exe decodes a BOM-less .vbs as the ANSI system code page, which
+    # mojibakes every non-ASCII path at parse time and kills the launch
+    # silently under //B. The UTF-16 BOM makes wscript parse the file as
+    # UTF-16 (same rule the Scheduled Task XML already follows).
+    vbs_tmp.write_text(vbs_content, encoding="utf-16", newline="")
     vbs_tmp.replace(vbs_path)
     return script_path
 
@@ -707,7 +711,9 @@ def _install_startup_entry(script_path: Path) -> Path:
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
     tmp = entry.with_suffix(".tmp")
-    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    # Same wscript ANSI-vs-BOM rule as the gateway launcher: without a UTF-16
+    # BOM a non-ASCII profile path corrupts this launcher at parse time.
+    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-16", newline="")
     tmp.replace(entry)
     legacy_entry = _legacy_startup_entry_path()
     try:

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -340,6 +340,58 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+def _force_windows(monkeypatch):
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+
+
+def test_task_vbs_launcher_is_utf16_so_non_ascii_home_parses(monkeypatch, tmp_path):
+    """wscript.exe decodes a BOM-less .vbs as the ANSI system code page, so a
+    non-ASCII HERMES_HOME mojibakes every path in the launcher and the launch
+    dies silently under //B. The launcher must be written UTF-16: the BOM flips
+    wscript into UTF-16 mode (same rule the Scheduled Task XML follows) and the
+    home survives a decode round-trip."""
+    hermes_home = tmp_path / "SergioBéjar" / "hermes"
+    _force_windows(monkeypatch)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(gateway, "get_python_path", lambda: r"C:\venv\Scripts\python.exe")
+    monkeypatch.setattr(gateway, "_profile_arg", lambda home: "")
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(
+        gateway_windows, "_resolve_detached_python", lambda exe: (exe, r"C:\venv", [])
+    )
+    script_path = tmp_path / "Hermes_Gateway.cmd"
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+
+    gateway_windows._write_task_script()
+
+    vbs_path = script_path.with_suffix(".vbs")
+    raw = vbs_path.read_bytes()
+    assert raw[:2] == b"\xff\xfe"  # UTF-16 LE BOM — what wscript keys on
+    decoded = vbs_path.read_text(encoding="utf-16")
+    assert "SergioBéjar" in decoded
+    assert "hermes_cli.main" in decoded
+
+
+def test_startup_entry_launcher_is_utf16_so_non_ascii_target_parses(monkeypatch, tmp_path):
+    """The Startup-folder fallback launcher is executed by wscript too, so the
+    same ANSI-vs-BOM rule applies: without the UTF-16 BOM a non-ASCII profile
+    path corrupts the chained target path at parse time."""
+    _force_windows(monkeypatch)
+    script_path = tmp_path / "SergioBéjar" / "Hermes_Gateway.cmd"
+    entry = tmp_path / "startup" / "Hermes_Gateway.vbs"
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: entry)
+    monkeypatch.setattr(
+        gateway_windows, "_legacy_startup_entry_path", lambda: tmp_path / "startup" / "Hermes_Gateway.cmd"
+    )
+
+    gateway_windows._install_startup_entry(script_path)
+
+    raw = entry.read_bytes()
+    assert raw[:2] == b"\xff\xfe"
+    decoded = entry.read_text(encoding="utf-16")
+    assert str(script_path.with_suffix(".vbs")) in decoded
+
+
 
 
 


### PR DESCRIPTION
## Problem

`_write_task_scripts()` writes the gateway `.vbs` launcher with `encoding="utf-8"`, but `wscript.exe` decodes a BOM-less `.vbs` as the **ANSI system code page** unless the file carries a UTF-16 BOM. On any host whose `HERMES_HOME` contains a non-ASCII character (e.g. `é` in the profile path), every path inside the launcher mojibakes at parse time. `sh.CurrentDirectory = …` then raises, `//B` suppresses the dialog, **wscript exits 0**, and python is never launched — Task Scheduler reports success while the gateway silently never starts. The Startup-folder fallback (`_install_startup_entry`) writes its launcher the same way and has the identical defect.

Fixes #98897.

## Fix

Write both `.vbs` launchers with `encoding="utf-16"` — Python emits the UTF-16 LE BOM, wscript then parses the file as UTF-16 and every path round-trips. This is the same rule the repo already applies to the Scheduled Task XML (`_write_scheduled_task_xml` uses `encoding="utf-16"`); only the `.vbs` writers lagged behind.

## Testing

- Two new host-agnostic tests in `tests/hermes_cli/test_gateway_windows.py`: each launcher's bytes start with the UTF-16 LE BOM and a non-ASCII path (`SergioBéjar`) survives a decode round-trip. Both fail on `main` and pass with the fix (verified RED→GREEN).
- Full file green locally: 7 passed, 4 skipped (Windows-only marks skip on macOS as before).
- Adjacent suites touching `gateway_windows` still green: `test_gateway.py`, `test_gateway_wsl.py`, `test_service_manager.py`, `test_update_gateway_launcher_refresh.py`, `test_local_env_blocklist.py` — 126 passed.
