### PR TITLE
fix(tools): keep injected kanban lifecycle tools when the worker profile disables kanban

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -424,6 +424,10 @@ def _compute_tool_definitions(
     # Determine which tool names the caller wants
     tools_to_include: set = set()
 
+    # Work on a copy so the dispatcher-worker injection below can exempt
+    # "kanban" from the caller's own disabled list without mutating it (#98808).
+    effective_disabled_toolsets = list(disabled_toolsets) if disabled_toolsets else []
+
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
         if (
@@ -438,6 +442,12 @@ def _compute_tool_definitions(
             # (for token/cost reasons), but that should not strip the kanban
             # worker's completion/block/heartbeat surface.
             effective_enabled_toolsets.append("kanban")
+            # The subtraction pass below iterates the caller's disabled
+            # toolsets; a worker profile that disables "kanban" for its
+            # normal chat surface would otherwise strip the injected
+            # lifecycle tools right back out (#98808).
+            if "kanban" in effective_disabled_toolsets:
+                effective_disabled_toolsets.remove("kanban")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -461,8 +471,8 @@ def _compute_tool_definitions(
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
     # stripped out. See issue #17309.
-    if disabled_toolsets:
-        for toolset_name in disabled_toolsets:
+    if effective_disabled_toolsets:
+        for toolset_name in effective_disabled_toolsets:
             if validate_toolset(toolset_name):
                 from toolsets import bundle_non_core_tools, get_toolset
                 if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -509,3 +509,75 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+class TestKanbanWorkerToolsetInjection:
+    """Regression test for #98808: the dispatcher-worker injection appends
+    "kanban" to the enabled toolsets so workers always keep their lifecycle
+    handoff tools (complete/block/heartbeat). The subtraction pass used to
+    iterate the caller's original disabled_toolsets, so a worker profile
+    listing "kanban" in agent.disabled_toolsets (the recommended setup for
+    profiles that delegate but shouldn't carry the orchestrator toolset in
+    normal chat) stripped the injected tools right back out."""
+
+    def test_worker_keeps_lifecycle_tools_despite_own_disabled_toolsets(self, monkeypatch):
+        from model_tools import _compute_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "worker-test-task")
+        invalidate_check_fn_cache()
+        tools = _compute_tool_definitions(
+            enabled_toolsets=["file"],
+            disabled_toolsets=["kanban"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert {"kanban_complete", "kanban_block", "kanban_heartbeat"} <= names, (
+            f"dispatcher worker lost lifecycle tools: {names & {'kanban_complete', 'kanban_block', 'kanban_heartbeat'}}"
+        )
+
+    def test_non_worker_disabled_kanban_still_strips_tools(self, monkeypatch):
+        """Outside the worker context, an explicit disable must keep its
+        normal chat semantics: kanban tools are removed."""
+        from model_tools import _compute_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        invalidate_check_fn_cache()
+        tools = _compute_tool_definitions(
+            enabled_toolsets=["file", "kanban"],
+            disabled_toolsets=["kanban"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert not any(n.startswith("kanban_") for n in names)
+
+    def test_delegated_child_does_not_inherit_forced_kanban(self, monkeypatch):
+        """A delegate_task child spawned inside a worker process must not
+        inherit the forced kanban toolset (existing isolation guarantee)."""
+        from agent.delegation_context import delegated_child_context
+        from model_tools import _compute_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "worker-test-task")
+        with delegated_child_context():
+            invalidate_check_fn_cache()
+            tools = _compute_tool_definitions(
+                enabled_toolsets=["file"],
+                disabled_toolsets=["kanban"],
+                quiet_mode=True,
+            )
+        names = {t["function"]["name"] for t in tools}
+        assert not any(n.startswith("kanban_") for n in names)
+
+    def test_caller_disabled_toolsets_list_not_mutated(self, monkeypatch):
+        from model_tools import _compute_tool_definitions
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "worker-test-task")
+        disabled = ["kanban"]
+        _compute_tool_definitions(
+            enabled_toolsets=["file"],
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+        )
+        assert disabled == ["kanban"]


### PR DESCRIPTION
## What does this PR do?

`_compute_tool_definitions()` already re-injects the `kanban` toolset for dispatcher-spawned workers on the enabled side (so workers always keep `kanban_complete`/`kanban_block`/`kanban_heartbeat`), but the subtraction pass at the end still iterated the caller's **original** `disabled_toolsets` list. A worker profile that lists `kanban` in `agent.disabled_toolsets` — the recommended setup for delegation-only profiles that shouldn't carry the orchestrator toolset in normal chat — therefore stripped the injected lifecycle tools right back out, leaving the worker unable to signal completion through the intended tool surface.

The fix works on a copy of `disabled_toolsets` (`effective_disabled_toolsets`) and removes the injected `kanban` exemption from that copy, so the subtraction pass can't undo the injection. The caller's list is never mutated, and outside the dispatcher-worker context the disable semantics are byte-for-byte what they were before.

## Related Issue

Fixes #98808

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py` — `_compute_tool_definitions()` now builds `effective_disabled_toolsets` (a copy); when the dispatcher-worker guard appends `kanban` to the enabled side, it also drops `kanban` from that copy before the subtraction pass runs. The `if disabled_toolsets:` subtraction loop now iterates the effective copy.
- `tests/test_model_tools.py` — new `TestKanbanWorkerToolsetInjection` with four regression tests (see How to Test).

## How to Test

1. `pytest tests/test_model_tools.py::TestKanbanWorkerToolsetInjection -q` — should pass all 4:
   - worker with `disabled_toolsets=["kanban"]` still gets `kanban_complete`/`kanban_block`/`kanban_heartbeat` (FAILED on `main` before this fix, passes after),
   - non-worker with `enabled_toolsets=["file", "kanban"], disabled_toolsets=["kanban"]` still has zero `kanban_*` tools (disable semantics preserved),
   - a `delegate_task` child spawned inside a worker process does not inherit the forced kanban toolset (isolation guarantee unaffected),
   - the caller's `disabled_toolsets` list is not mutated.
2. Observed result: `4 passed` after the fix; `1 failed` (first test) with the fix stashed, confirming the regression test covers the bug.
3. Adjacent suites stay green: `pytest tests/test_model_tools.py tests/test_get_tool_definitions_cache_isolation.py tests/tools/test_kanban_tools.py tests/tools/test_hermes_subprocess_env.py tests/test_model_tools_async_bridge.py -q` → `93 passed`; `pytest tests/test_toolsets.py tests/agent/test_tool_executor_checkpoint_paths.py -q` → `26 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no new skill in this PR.

## Screenshots / Logs

Not applicable — behavior is covered by the regression tests above.