### PR TITLE
fix(telegram): prefer native clarify choices

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -815,7 +815,9 @@ PLATFORM_HINTS = {
         "You are on Telegram. Standard Markdown auto-converts: **bold**, "
         "*italic*, ~~strikethrough~~, ||spoiler||, `code`, ```blocks```, "
         "[links](url), ## headers. Prefer bullets or labeled lines for "
-        "structured data (no tables). "
+        "structured data (no tables). For small decisions, use clarify: Telegram "
+        "renders inline buttons and routes the tap. Do not fake controls with "
+        "numbered or copy-text buttons. "
         + _MEDIA_NATIVE +
         "Images (.png, .jpg, .webp) send as photos, videos (.mp4) play "
         "inline; image URLs via ![alt](url) send as photos. Audio: add "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -697,6 +697,20 @@ class TestPromptBuilderConstants:
             assert "do not use markdown" not in hint.lower()
             assert "markdown" in hint.lower()
 
+    def test_telegram_hint_prefers_native_choices_over_copy_workarounds(self):
+        """Telegram should steer small decisions to the shipped clarify UI.
+
+        Without this surface guidance, the agent can invent copy-to-clipboard
+        pseudo-buttons even though clarify already renders native inline
+        choices and routes the selected value back into the session.
+        """
+        hint = PLATFORM_HINTS["telegram"].lower()
+        assert "clarify" in hint
+        assert "inline" in hint and "button" in hint
+        assert "copy" in hint and any(
+            marker in hint for marker in ("do not", "don't", "never")
+        )
+
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging
         # gateway platforms. On the CLI they render as literal text and

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -3,8 +3,9 @@
 Clarify Tool Module - Interactive Clarifying Questions
 
 Allows the agent to present structured multiple-choice questions or open-ended
-prompts to the user. In CLI mode, choices are navigable with arrow keys. On
-messaging platforms, choices are rendered as a numbered list.
+prompts to the user. In CLI mode, choices are navigable with arrow keys.
+Messaging adapters use native controls where available (for example, Telegram
+inline buttons) and fall back to numbered choices otherwise.
 
 Supports both single-select (radio) and multi-select (checkbox) modes via the
 ``multi_select`` parameter.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -123,6 +123,18 @@ The first word filters the catalog; everything after it is carried into the sent
 
 Results are only served to users who pass your gateway allowlist — unauthorized users get an empty list, so your installed skill catalog is not exposed to strangers (inline queries can be sent from any chat, even ones the bot is not in).
 
+### Native interactions and capability boundaries
+
+Hermes uses Telegram-native controls when the gateway owns the full interaction:
+
+- `clarify` choices render as inline buttons and route the tap back to the waiting session.
+- Dangerous-command approvals and built-in pickers use gateway-owned inline keyboards.
+- The gateway acknowledges callback queries and removes or updates stale controls so Telegram does not leave a loading spinner.
+
+For a small decision, ask Hermes to use `clarify` rather than simulating controls with numbered prose or `copy_text` buttons. A copy button only places text on the clipboard; it does not send a decision to Hermes.
+
+Telegram's Bot API also offers pinning, message edits, polls, reactions, inline mode, and Mini Apps. Their presence in Telegram does **not** mean every capability is currently exposed as a generic agent action. Persistent custom buttons need a gateway-side callback owner because the same gateway owns polling or webhook updates and must call `answerCallbackQuery`. Generic agent-authored action buttons are tracked in [#15311](https://github.com/NousResearch/hermes-agent/issues/15311); platform-specific interaction logic belongs in the Telegram adapter or a gateway plugin, not in a prompt-only skill.
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.


### PR DESCRIPTION
## Summary

- teach Telegram sessions to use the shipped `clarify` inline-button flow for small decisions
- explicitly reject numbered or copy-to-clipboard pseudo-controls
- correct stale `clarify_tool.py` messaging documentation
- document shipped native interactions versus Bot API features that still require gateway/plugin support

Closes #98911.
Related: #15311, #95594.

## Why this belongs here

A skill can teach presentation, but it cannot own Telegram callbacks safely. The gateway owns polling/webhook updates and must acknowledge `callback_query` events. This PR only teaches the model to use an already-shipped gateway capability; generic persistent buttons remain in #15311/#95594.

## Testing

- `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/gateway/test_telegram_clarify_buttons.py tests/tools/test_clarify_tool.py -q` — 122 passed
- sabotage check — the new regression test fails when the platform-hint change is removed
- `python -m compileall -q agent/prompt_builder.py tools/clarify_tool.py`
- `git diff --check`

Docs build note: `npm --prefix website run build:fast` could not start locally because Docusaurus dependencies are not installed in this isolated worktree (`docusaurus: command not found`). No dependency files were changed; CI remains authoritative for the docs build.

## Scope

No callback routing, tool schema, config, or non-Telegram platform behavior changes.

## AI assistance

Hermes Agent assisted with duplicate research, test authoring, implementation, and an independent Codex review. Kevin owns and reviewed the submission.
