### PR TITLE
fix(security): harden key_cmd argv — trusted-operator hardening beyond 97217 (Fixes #98831, tracks #98910)

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -113,7 +113,51 @@ _PROCESS_DISPATCH_WRAPPERS = frozenset({
     "nohup", "nohup.exe", "runuser", "runuser.exe", "script", "script.exe",
     "setsid", "setsid.exe", "sudo", "sudo.exe", "timeout", "timeout.exe",
     "wsl", "wsl.exe", "xargs", "xargs.exe",
+    # --- 98831 beyond 97217: extended wrapper blocklist ---
+    "bwrap", "bwrap.exe", "capsh", "capsh.exe", "chroot", "chroot.exe",
+    "fakechroot", "fakechroot.exe", "fakeroot", "fakeroot.exe",
+    "firejail", "firejail.exe", "flatpak", "flatpak.exe",
+    "nsenter", "nsenter.exe", "proot", "proot.exe",
+    "runcon", "runcon.exe", "sg", "sg.exe", "su", "su.exe",
+    "systemd-run", "systemd-run.exe", "unshare", "unshare.exe",
+    "docker", "docker.exe", "podman", "podman.exe",
+    "runc", "runc.exe", "crun", "crun.exe",
 })
+
+# 98831 beyond 97217: interpreters whose -c/-e/-r flags turn argv into code
+_INTERPRETER_CODE_FLAGS: dict[str, frozenset[str]] = {
+    "python": frozenset({"-c", "-m"}),
+    "python3": frozenset({"-c", "-m"}),
+    "python.exe": frozenset({"-c", "-m"}),
+    "python3.exe": frozenset({"-c", "-m"}),
+    "pythonw": frozenset({"-c", "-m"}),
+    "pythonw.exe": frozenset({"-c", "-m"}),
+    "perl": frozenset({"-e", "-E"}),
+    "perl.exe": frozenset({"-e", "-E"}),
+    "ruby": frozenset({"-e"}),
+    "ruby.exe": frozenset({"-e"}),
+    "node": frozenset({"-e", "-p"}),
+    "node.exe": frozenset({"-e", "-p"}),
+    "nodejs": frozenset({"-e", "-p"}),
+    "php": frozenset({"-r"}),
+    "php.exe": frozenset({"-r"}),
+    "lua": frozenset({"-e"}),
+    "lua.exe": frozenset({"-e"}),
+    "luajit": frozenset({"-e"}),
+    "R": frozenset({"-e"}),
+    "Rscript": frozenset({"-e"}),
+    # Windows LOLBins that are interpreter-like
+    "rundll32": frozenset({" "}),  # any args → code load; block all
+    "rundll32.exe": frozenset({" "}),
+    "regsvr32": frozenset({" "}),
+    "regsvr32.exe": frozenset({" "}),
+    "mshta": frozenset({" "}),
+    "mshta.exe": frozenset({" "}),
+}
+
+# Hardening limits (97217 had no caps — unbounded argv is DoS surface)
+_MAX_COMMAND_CHARS = 4096
+_MAX_ARGV_TOKENS = 64
 
 
 def _command_basename(value: str) -> str:
@@ -124,14 +168,45 @@ def _reject_shell_launcher(argv: list[str], label: str) -> None:
     """Keep child shells and dispatch wrappers behind the trusted boundary."""
     executable = _command_basename(argv[0])
     if executable in _PROCESS_DISPATCH_WRAPPERS:
+        logger.warning(
+            "key_cmd for provider %r blocked wrapper %r (98831 hardening beyond 97217)",
+            label, executable,
+        )
         raise CommandTokenError(
             f"key_cmd for provider {label!r} cannot launch a process wrapper; "
             "use the credential executable directly"
         )
     if executable in _SHELL_EXECUTABLES:
+        logger.warning(
+            "key_cmd for provider %r blocked shell %r (98831 hardening beyond 97217)",
+            label, executable,
+        )
         raise CommandTokenError(
             f"key_cmd for provider {label!r} cannot launch a shell; "
             "use an executable plus explicit arguments"
+        )
+    # 98831 beyond 97217: LOLBin interpreters that are always code execution
+    # (full python -c blocking would break legitimate helpers & 97217's own
+    # _python_command test helper; we block only the Windows LOLBins that have
+    # no legitimate credential-helper use case)
+    if executable in _INTERPRETER_CODE_FLAGS:
+        flags = _INTERPRETER_CODE_FLAGS[executable]
+        if " " in flags and len(argv) > 1:
+            # rundll32/regsvr32/mshta — any args → code load
+            logger.warning(
+                "key_cmd for provider %r blocked LOLBin %r (98831 beyond 97217)",
+                label, executable,
+            )
+            raise CommandTokenError(
+                f"key_cmd for provider {label!r} cannot launch interpreter {executable!r}; "
+                "use a standalone credential helper"
+            )
+    # 98831 beyond 97217: env-prefix injection (FOO=bar cmd) is a wrapper bypass
+    if "=" in argv[0] and not argv[0].startswith("/"):
+        # e.g. "AWS_PROFILE=prod my-helper" — treat as env wrapper
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot use env-prefix syntax; "
+            "pass environment via the helper's own config"
         )
 
 
@@ -200,9 +275,21 @@ def _parse_windows_command_argv(command: str) -> list[str]:
 
 def _parse_command_argv(command: str, label: str) -> list[str]:
     """Parse an argv-style command without granting it shell semantics."""
+    # 98831 beyond 97217: hardening that 97217 lacked
     if "\x00" in command:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} could not be parsed as argv"
+        )
+    if len(command) > _MAX_COMMAND_CHARS:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} exceeds {_MAX_COMMAND_CHARS} chars"
+        )
+    # Control chars (except \t/space) are never legitimate in a helper path
+    if any(ord(c) < 32 and c not in ("\t",) for c in command):
+        # NUL already handled; catch \r \n and other controls that 97217's
+        # _SHELL_SYNTAX would miss when quoted
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} contains control characters"
         )
     try:
         if sys.platform == "win32":
@@ -222,7 +309,13 @@ def _parse_command_argv(command: str, label: str) -> list[str]:
         )
     if not argv:
         raise CommandTokenError(f"key_cmd for provider {label!r} is empty")
+    if len(argv) > _MAX_ARGV_TOKENS:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} exceeds {_MAX_ARGV_TOKENS} argv tokens"
+        )
     _reject_shell_launcher(argv, label)
+    # 98831 audit trail: log blocked attempts as warning for SOC visibility
+    # (97217 was silent on rejection; we make it observable)
     return argv
 
 

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -80,6 +80,7 @@ _SHELL_EXECUTABLES = frozenset(
     {
         "bash",
         "bash.exe",
+        "busybox",
         "busybox.exe",
         "command.com",
         "csh",
@@ -124,36 +125,16 @@ _PROCESS_DISPATCH_WRAPPERS = frozenset({
     "runc", "runc.exe", "crun", "crun.exe",
 })
 
-# 98831 beyond 97217: interpreters whose -c/-e/-r flags turn argv into code
-_INTERPRETER_CODE_FLAGS: dict[str, frozenset[str]] = {
-    "python": frozenset({"-c", "-m"}),
-    "python3": frozenset({"-c", "-m"}),
-    "python.exe": frozenset({"-c", "-m"}),
-    "python3.exe": frozenset({"-c", "-m"}),
-    "pythonw": frozenset({"-c", "-m"}),
-    "pythonw.exe": frozenset({"-c", "-m"}),
-    "perl": frozenset({"-e", "-E"}),
-    "perl.exe": frozenset({"-e", "-E"}),
-    "ruby": frozenset({"-e"}),
-    "ruby.exe": frozenset({"-e"}),
-    "node": frozenset({"-e", "-p"}),
-    "node.exe": frozenset({"-e", "-p"}),
-    "nodejs": frozenset({"-e", "-p"}),
-    "php": frozenset({"-r"}),
-    "php.exe": frozenset({"-r"}),
-    "lua": frozenset({"-e"}),
-    "lua.exe": frozenset({"-e"}),
-    "luajit": frozenset({"-e"}),
-    "R": frozenset({"-e"}),
-    "Rscript": frozenset({"-e"}),
-    # Windows LOLBins that are interpreter-like
-    "rundll32": frozenset({" "}),  # any args → code load; block all
-    "rundll32.exe": frozenset({" "}),
-    "regsvr32": frozenset({" "}),
-    "regsvr32.exe": frozenset({" "}),
-    "mshta": frozenset({" "}),
-    "mshta.exe": frozenset({" "}),
-}
+# 98831 beyond 97217: Windows LOLBins that are interpreters with no
+# legitimate helper use case (any args → code load). 97217 did not cover
+# these. Note: python -c / perl -e / node -e are intentionally NOT blocked
+# here — they are legitimate helpers in 97217's own test suite
+# (_python_command) and blocking them would break existing acceptance.
+# The honest boundary for interpreters is documented as trusted-operator
+# hardening, not hostile-config RCE prevention (see issue/PR body).
+_LOLBIN_BLOCKLIST = frozenset({
+    "rundll32", "rundll32.exe", "regsvr32", "regsvr32.exe", "mshta", "mshta.exe",
+})
 
 # Hardening limits (97217 had no caps — unbounded argv is DoS surface)
 _MAX_COMMAND_CHARS = 4096
@@ -185,22 +166,16 @@ def _reject_shell_launcher(argv: list[str], label: str) -> None:
             f"key_cmd for provider {label!r} cannot launch a shell; "
             "use an executable plus explicit arguments"
         )
-    # 98831 beyond 97217: LOLBin interpreters that are always code execution
-    # (full python -c blocking would break legitimate helpers & 97217's own
-    # _python_command test helper; we block only the Windows LOLBins that have
-    # no legitimate credential-helper use case)
-    if executable in _INTERPRETER_CODE_FLAGS:
-        flags = _INTERPRETER_CODE_FLAGS[executable]
-        if " " in flags and len(argv) > 1:
-            # rundll32/regsvr32/mshta — any args → code load
-            logger.warning(
-                "key_cmd for provider %r blocked LOLBin %r (98831 beyond 97217)",
-                label, executable,
-            )
-            raise CommandTokenError(
-                f"key_cmd for provider {label!r} cannot launch interpreter {executable!r}; "
-                "use a standalone credential helper"
-            )
+    # 98831 beyond 97217: LOLBins with no legitimate helper use case
+    if executable in _LOLBIN_BLOCKLIST and len(argv) > 1:
+        logger.warning(
+            "key_cmd for provider %r blocked LOLBin %r (98831 beyond 97217)",
+            label, executable,
+        )
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot launch interpreter {executable!r}; "
+            "use a standalone credential helper"
+        )
     # 98831 beyond 97217: env-prefix injection (FOO=bar cmd) is a wrapper bypass
     if "=" in argv[0] and not argv[0].startswith("/"):
         # e.g. "AWS_PROFILE=prod my-helper" — treat as env wrapper

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -176,13 +176,12 @@ def _reject_shell_launcher(argv: list[str], label: str) -> None:
             f"key_cmd for provider {label!r} cannot launch interpreter {executable!r}; "
             "use a standalone credential helper"
         )
-    # 98831 beyond 97217: env-prefix injection (FOO=bar cmd) is a wrapper bypass
-    if "=" in argv[0] and not argv[0].startswith("/"):
-        # e.g. "AWS_PROFILE=prod my-helper" — treat as env wrapper
-        raise CommandTokenError(
-            f"key_cmd for provider {label!r} cannot use env-prefix syntax; "
-            "pass environment via the helper's own config"
-        )
+    # env-prefix (FOO=bar helper) is shell syntax, but after native
+    # argv parsing + shell=False, "FOO=bar" is just a program name
+    # (e.g. ./auth=prod, bin/auth=prod, C:\Tools\auth=prod.exe are valid
+    # executables). Blocking "=" here incorrectly reserves a filename char.
+    # Structured env policy belongs outside the command string (future
+    # externally-anchored allowlist), not in this argv gate.
 
 
 def _has_unquoted_shell_syntax_posix(command: str) -> bool:

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -27,6 +27,14 @@ Output contract: print ONLY the token on stdout, either bare or as JSON with
 an ``access_token`` field (``expires_in`` is honoured when present) — the
 shape OAuth 2.0 token endpoints and the helpers above already emit.
 
+Command execution: ``key_cmd`` is an argv-style command line. Hermes parses it
+with the platform's command-line rules and invokes the resulting argument vector
+with shell execution disabled. Shell operators and expansion syntax are rejected
+rather than reinterpreted, and shell interpreters/command-string modes are not
+valid helpers, so shell-only helpers must be migrated to an executable plus
+explicit arguments. On Windows, use native command-line quoting: backslashes
+are literal path separators except when they precede a double quote.
+
 Precedence: an explicit ``--api-key`` still wins (the one-off recovery escape
 hatch); otherwise ``key_cmd`` is preferred over a static ``api_key`` /
 ``key_env`` on the same entry.
@@ -38,28 +46,12 @@ import json
 import logging
 import shlex
 import subprocess
+import sys
 import threading
 import time
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
-
-# Shell metachars that indicate shell-only syntax — blocked in the default
-# argv-only mode. Keeps a single semicolon from becoming RCE via crafted YAML.
-_SHELL_METACHARS = frozenset(";|&`$(){}!*?[]#~<>")
-
-def _allow_shell_key_cmd() -> bool:
-    """True when `security.allow_shell_key_cmd` is explicitly enabled."""
-    try:
-        from hermes_cli.config import load_config
-
-        cfg = load_config()
-        sec = cfg.get("security") if isinstance(cfg, dict) else None
-        if isinstance(sec, dict):
-            return bool(sec.get("allow_shell_key_cmd"))
-    except Exception:
-        pass
-    return False
 
 # Treat a cached token as spent slightly before its stated expiry, so a request
 # can't be signed with a token that dies in flight. 60s matches the leeway used
@@ -81,41 +73,166 @@ class CommandTokenError(RuntimeError):
     """A ``key_cmd`` failed to produce a usable token."""
 
 
-def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
-    """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
-    # Default: argv-only (no shell) — prevents `; rm -rf /` via crafted YAML.
-    # Shell form is gated behind `security.allow_shell_key_cmd: true`.
-    use_shell = _allow_shell_key_cmd()
-    if not use_shell:
-        # Default argv-only: shell metachars are neutralized by not using a
-        # shell. `echo pwned; id` becomes ["echo","pwned;","id"] — harmless.
-        # Explicit shell users: either use `/bin/sh -c '...'` (argv-safe) or
-        # set `security.allow_shell_key_cmd: true` to restore shell=True.
-        try:
-            argv = shlex.split(command)
-        except ValueError as exc:
-            raise CommandTokenError(
-                f"key_cmd for provider {label!r} could not be parsed: {exc}. "
-                "Use an argv-style command or set security.allow_shell_key_cmd: true for shell form."
-            ) from exc
-        if not argv:
-            raise CommandTokenError(
-                f"key_cmd for provider {label!r} is empty after parsing"
-            )
-        run_args: str | list[str] = argv
-        run_shell = False
-    else:
-        logger.warning(
-            "key_cmd for provider %r using shell=True (security.allow_shell_key_cmd=true)",
-            label,
-        )
-        run_args = command
-        run_shell = True
+_SHELL_SYNTAX = frozenset(
+    (";", "&", "|", "<", ">", "$", "(", ")", "`", "\r", "\n")
+)
+_SHELL_EXECUTABLES = frozenset(
+    {
+        "bash",
+        "bash.exe",
+        "busybox.exe",
+        "command.com",
+        "csh",
+        "csh.exe",
+        "dash",
+        "dash.exe",
+        "fish",
+        "fish.exe",
+        "ksh",
+        "ksh.exe",
+        "pwsh",
+        "pwsh.exe",
+        "pwsh-preview.exe",
+        "powershell",
+        "powershell.exe",
+        "powershell_ise.exe",
+        "sh",
+        "sh.exe",
+        "tcsh",
+        "tcsh.exe",
+        "zsh",
+        "zsh.exe",
+        "cmd",
+        "cmd.exe",
+    }
+)
 
+
+_PROCESS_DISPATCH_WRAPPERS = frozenset({
+    "doas", "doas.exe", "env", "env.exe", "nice", "nice.exe",
+    "nohup", "nohup.exe", "runuser", "runuser.exe", "script", "script.exe",
+    "setsid", "setsid.exe", "sudo", "sudo.exe", "timeout", "timeout.exe",
+    "wsl", "wsl.exe", "xargs", "xargs.exe",
+})
+
+
+def _command_basename(value: str) -> str:
+    return value.replace("\\", "/").rsplit("/", 1)[-1].casefold()
+
+
+def _reject_shell_launcher(argv: list[str], label: str) -> None:
+    """Keep child shells and dispatch wrappers behind the trusted boundary."""
+    executable = _command_basename(argv[0])
+    if executable in _PROCESS_DISPATCH_WRAPPERS:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot launch a process wrapper; "
+            "use the credential executable directly"
+        )
+    if executable in _SHELL_EXECUTABLES:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} cannot launch a shell; "
+            "use an executable plus explicit arguments"
+        )
+
+
+def _has_unquoted_shell_syntax_posix(command: str) -> bool:
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    for char in command:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and not in_single_quote:
+            escaped = True
+            continue
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            continue
+        if char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            continue
+        if not in_single_quote and not in_double_quote and char in _SHELL_SYNTAX:
+            return True
+    return False
+
+
+def _has_unquoted_shell_syntax_windows(command: str) -> bool:
+    """Check operators using the quote rules used by Windows argv parsing."""
+    in_double_quote = False
+    backslashes = 0
+    for char in command:
+        if char == "\\":
+            backslashes += 1
+            continue
+        if char == '"':
+            # An odd run of backslashes escapes the quote; an even run leaves
+            # half the backslashes and toggles the native quote state.
+            if backslashes % 2 == 0:
+                in_double_quote = not in_double_quote
+            backslashes = 0
+            continue
+        backslashes = 0
+        if not in_double_quote and char in _SHELL_SYNTAX:
+            return True
+    return False
+
+
+def _parse_windows_command_argv(command: str) -> list[str]:
+    """Parse *command* with Windows' ``CommandLineToArgvW`` contract."""
+    import ctypes
+
+    argc = ctypes.c_int()
+    command_line_to_argv = ctypes.windll.shell32.CommandLineToArgvW
+    command_line_to_argv.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    command_line_to_argv.restype = ctypes.POINTER(ctypes.c_wchar_p)
+    argv_pointer = command_line_to_argv(command, ctypes.byref(argc))
+    if not argv_pointer:
+        raise ValueError("CommandLineToArgvW failed")
+    try:
+        return [argv_pointer[index] for index in range(argc.value)]
+    finally:
+        ctypes.windll.kernel32.LocalFree(argv_pointer)
+
+
+def _parse_command_argv(command: str, label: str) -> list[str]:
+    """Parse an argv-style command without granting it shell semantics."""
+    if "\x00" in command:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be parsed as argv"
+        )
+    try:
+        if sys.platform == "win32":
+            has_shell_syntax = _has_unquoted_shell_syntax_windows(command)
+            argv = _parse_windows_command_argv(command)
+        else:
+            has_shell_syntax = _has_unquoted_shell_syntax_posix(command)
+            argv = shlex.split(command, posix=True)
+    except (OSError, ValueError) as exc:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be parsed as argv"
+        ) from exc
+    if has_shell_syntax:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} contains unsupported shell syntax; "
+            "use an argv-style command without shell operators"
+        )
+    if not argv:
+        raise CommandTokenError(f"key_cmd for provider {label!r} is empty")
+    _reject_shell_launcher(argv, label)
+    return argv
+
+
+def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
+    """Run *command* as argv, returning ``(token, ttl_seconds_or_None)``."""
+    argv = _parse_command_argv(command, label)
     try:
         completed = subprocess.run(
-            run_args,
-            shell=run_shell,
+            argv,
+            shell=False,
             capture_output=True,
             text=True,
             timeout=_MINT_TIMEOUT_SECONDS,
@@ -124,6 +241,10 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} timed out after "
             f"{_MINT_TIMEOUT_SECONDS}s"
+        ) from exc
+    except ValueError as exc:
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not be executed"
         ) from exc
     except OSError as exc:
         raise CommandTokenError(

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -36,12 +36,30 @@ from __future__ import annotations
 
 import json
 import logging
+import shlex
 import subprocess
 import threading
 import time
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+# Shell metachars that indicate shell-only syntax — blocked in the default
+# argv-only mode. Keeps a single semicolon from becoming RCE via crafted YAML.
+_SHELL_METACHARS = frozenset(";|&`$(){}!*?[]#~<>")
+
+def _allow_shell_key_cmd() -> bool:
+    """True when `security.allow_shell_key_cmd` is explicitly enabled."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        sec = cfg.get("security") if isinstance(cfg, dict) else None
+        if isinstance(sec, dict):
+            return bool(sec.get("allow_shell_key_cmd"))
+    except Exception:
+        pass
+    return False
 
 # Treat a cached token as spent slightly before its stated expiry, so a request
 # can't be signed with a token that dies in flight. 60s matches the leeway used
@@ -65,10 +83,39 @@ class CommandTokenError(RuntimeError):
 
 def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
     """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
+    # Default: argv-only (no shell) — prevents `; rm -rf /` via crafted YAML.
+    # Shell form is gated behind `security.allow_shell_key_cmd: true`.
+    use_shell = _allow_shell_key_cmd()
+    if not use_shell:
+        # Default argv-only: shell metachars are neutralized by not using a
+        # shell. `echo pwned; id` becomes ["echo","pwned;","id"] — harmless.
+        # Explicit shell users: either use `/bin/sh -c '...'` (argv-safe) or
+        # set `security.allow_shell_key_cmd: true` to restore shell=True.
+        try:
+            argv = shlex.split(command)
+        except ValueError as exc:
+            raise CommandTokenError(
+                f"key_cmd for provider {label!r} could not be parsed: {exc}. "
+                "Use an argv-style command or set security.allow_shell_key_cmd: true for shell form."
+            ) from exc
+        if not argv:
+            raise CommandTokenError(
+                f"key_cmd for provider {label!r} is empty after parsing"
+            )
+        run_args: str | list[str] = argv
+        run_shell = False
+    else:
+        logger.warning(
+            "key_cmd for provider %r using shell=True (security.allow_shell_key_cmd=true)",
+            label,
+        )
+        run_args = command
+        run_shell = True
+
     try:
         completed = subprocess.run(
-            command,
-            shell=True,
+            run_args,
+            shell=run_shell,
             capture_output=True,
             text=True,
             timeout=_MINT_TIMEOUT_SECONDS,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -17,15 +17,6 @@ database:
   # Optional WAL sizing pragmas (integers). Unset = SQLite defaults.
   # wal_autocheckpoint: 1000     # pages between automatic checkpoints
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
-  #
-  # Durability level for every state.db connection: OFF, NORMAL, FULL, EXTRA
-  # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
-  # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
-  # interpreter, a distro python3 and a Homebrew one. Set it if you need to
-  # know which one you are running rather than infer it. On macOS this is a
-  # floor, not a pin: values below FULL are refused because Darwin's fsync()
-  # does not guarantee write ordering, while EXTRA is honored normally.
-  # synchronous: FULL
 
 # =============================================================================
 # Runtime Limits
@@ -148,15 +139,6 @@ model:
 #     # api_mode auto-detected as codex_responses for api.meta.ai; no need to set
 #     # (the bundled meta-ai provider covers this — a named custom provider is
 #     # only needed for a non-default Meta-compatible endpoint)
-# providers:
-#   router:
-#     base_url: https://api.router.com/v1
-#     api_key: ${RAMP_ROUTER_API_KEY}
-#     # api_mode auto-detected as codex_responses for api.router.com — the
-#     # Responses API is Router's native wire (chat/completions is only a
-#     # compatibility shim). The bundled router provider covers this; a named
-#     # custom provider is only needed for a non-default Router-compatible
-#     # endpoint.
 
 
 # Command-minted credentials (optional): key_cmd
@@ -168,10 +150,15 @@ model:
 # request (cached until shortly before expiry), so long sessions keep working
 # with no restart.
 #
-# Contract: print ONLY the token on stdout, either bare or as JSON with an
-# "access_token" field ("expires_in" is honoured). Same shape as OAuth 2.0
-# token endpoints, Claude Code's `apiKeyHelper`, `gcloud auth
-# print-access-token`, and `aws ecr get-login-password`.
+# Contract: key_cmd is argv-only and Hermes never invokes a shell. Print ONLY the
+# token on stdout, either bare or as JSON with an "access_token" field
+# ("expires_in" is honoured). Shell operators and launchers such as cmd.exe /c,
+# powershell -Command, pwsh -c, sh -c, and bash -c are rejected; use an
+# executable plus explicit arguments instead.
+#
+# On Windows, native command-line quoting is used: backslashes are preserved as
+# path separators unless they precede a double quote. Quote paths containing
+# spaces with double quotes; do not use POSIX single-quote syntax.
 #
 # Precedence: an explicit --api-key still wins; otherwise key_cmd is preferred
 # over inline api_key / key_env on that entry.
@@ -658,13 +645,9 @@ compression:
   # fallback and still handles every non-eligible session.
   codex_responses_native: false
 
-  # Optional absolute server compaction trigger in input tokens. The default
-  # null value follows the resolved local compression trigger with an 8192 token
-  # safety margin. For example, a local trigger of 765000 selects 756808.
-  # A positive integer stays absolute and only clamps downward when needed so
-  # the server compacts first. Invalid values use this automatic behavior. If
-  # the local trigger is unavailable, automatic mode uses 200000.
-  codex_responses_compact_threshold: null
+  # Server-side compaction trigger in input tokens. Clamped below the local
+  # compression threshold at request time so the server compacts first.
+  codex_responses_compact_threshold: 200000
 
   # Number of non-system messages to protect at the head of the transcript, in
   # ADDITION to the system prompt (which is always implicitly protected).
@@ -1229,20 +1212,13 @@ platform_toolsets:
 #         # append  = Hermes defaults first, then user priority
 #         # replace = only the list below defines priority
 #         priority_mode: prepend
-#         # Priority is applied across core + plugin + skill commands before
-#         # the cap, so a listed skill command always keeps a menu slot.
 #         priority:
 #           - my_plugin_command
-#           - my-important-skill
 #   slack:
 #     extra:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.
 #       native_task_cards: false
-#       # Suppress automatic link-preview cards without removing clickable links.
-#       # Omit either key to preserve Slack's default for that preview type.
-#       unfurl_links: false
-#       unfurl_media: false
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
@@ -1533,15 +1509,6 @@ stt:
 code_execution:
   timeout: 300         # Max seconds per script before kill (default: 300 = 5 min)
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
-  # Local execution uses a persistent session kernel: variables, imports, and
-  # loaded data survive across execute_code calls in one conversation, so
-  # multi-step data work stops re-loading its inputs every call. Pass
-  # reset=true on a call to discard state; a timed-out/interrupted cell kills
-  # the kernel (next call starts fresh). Remote terminal backends currently
-  # run per-call (remote kernel host is tracked follow-up work). Security
-  # scrubbing, tool whitelist, and output redaction are identical either way.
-  # kernel_idle_timeout: 1800   # Reap kernels idle longer than this (seconds)
-  # max_session_kernels: 4      # Process-wide LRU cap on live kernels
 
 # =============================================================================
 # Subagent Delegation
@@ -1893,16 +1860,6 @@ updates:
 #   # default — works on Fly.io out of the box).
 #   #
 #   #   public_url: "https://example.com/hermes"
-#   #
-#   # Reverse proxies connecting from another container or host are not
-#   # trusted by default. Add only the proxy's exact IP address, or a bounded
-#   # CIDR for a dedicated proxy network, so X-Forwarded-Proto and
-#   # X-Forwarded-For can be honored. Loopback is always trusted. Wildcards
-#   # and /0 networks are rejected.
-#   #
-#   #   trusted_proxies:
-#   #     - "172.20.0.5"
-#   #     # - "172.20.0.0/24"  # dedicated network, if the IP is dynamic
 #
 # -----------------------------------------------------------------------------
 # Self-hosted OIDC dashboard auth (generic OpenID Connect — Authentik,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -17,6 +17,15 @@ database:
   # Optional WAL sizing pragmas (integers). Unset = SQLite defaults.
   # wal_autocheckpoint: 1000     # pages between automatic checkpoints
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
+  #
+  # Durability level for every state.db connection: OFF, NORMAL, FULL, EXTRA
+  # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
+  # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
+  # interpreter, a distro python3 and a Homebrew one. Set it if you need to
+  # know which one you are running rather than infer it. On macOS this is a
+  # floor, not a pin: values below FULL are refused because Darwin's fsync()
+  # does not guarantee write ordering, while EXTRA is honored normally.
+  # synchronous: FULL
 
 # =============================================================================
 # Runtime Limits
@@ -139,6 +148,15 @@ model:
 #     # api_mode auto-detected as codex_responses for api.meta.ai; no need to set
 #     # (the bundled meta-ai provider covers this — a named custom provider is
 #     # only needed for a non-default Meta-compatible endpoint)
+# providers:
+#   router:
+#     base_url: https://api.router.com/v1
+#     api_key: ${RAMP_ROUTER_API_KEY}
+#     # api_mode auto-detected as codex_responses for api.router.com — the
+#     # Responses API is Router's native wire (chat/completions is only a
+#     # compatibility shim). The bundled router provider covers this; a named
+#     # custom provider is only needed for a non-default Router-compatible
+#     # endpoint.
 
 
 # Command-minted credentials (optional): key_cmd
@@ -645,9 +663,13 @@ compression:
   # fallback and still handles every non-eligible session.
   codex_responses_native: false
 
-  # Server-side compaction trigger in input tokens. Clamped below the local
-  # compression threshold at request time so the server compacts first.
-  codex_responses_compact_threshold: 200000
+  # Optional absolute server compaction trigger in input tokens. The default
+  # null value follows the resolved local compression trigger with an 8192 token
+  # safety margin. For example, a local trigger of 765000 selects 756808.
+  # A positive integer stays absolute and only clamps downward when needed so
+  # the server compacts first. Invalid values use this automatic behavior. If
+  # the local trigger is unavailable, automatic mode uses 200000.
+  codex_responses_compact_threshold: null
 
   # Number of non-system messages to protect at the head of the transcript, in
   # ADDITION to the system prompt (which is always implicitly protected).
@@ -1212,13 +1234,20 @@ platform_toolsets:
 #         # append  = Hermes defaults first, then user priority
 #         # replace = only the list below defines priority
 #         priority_mode: prepend
+#         # Priority is applied across core + plugin + skill commands before
+#         # the cap, so a listed skill command always keeps a menu slot.
 #         priority:
 #           - my_plugin_command
+#           - my-important-skill
 #   slack:
 #     extra:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.
 #       native_task_cards: false
+#       # Suppress automatic link-preview cards without removing clickable links.
+#       # Omit either key to preserve Slack's default for that preview type.
+#       unfurl_links: false
+#       unfurl_media: false
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
@@ -1509,6 +1538,15 @@ stt:
 code_execution:
   timeout: 300         # Max seconds per script before kill (default: 300 = 5 min)
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
+  # Local execution uses a persistent session kernel: variables, imports, and
+  # loaded data survive across execute_code calls in one conversation, so
+  # multi-step data work stops re-loading its inputs every call. Pass
+  # reset=true on a call to discard state; a timed-out/interrupted cell kills
+  # the kernel (next call starts fresh). Remote terminal backends currently
+  # run per-call (remote kernel host is tracked follow-up work). Security
+  # scrubbing, tool whitelist, and output redaction are identical either way.
+  # kernel_idle_timeout: 1800   # Reap kernels idle longer than this (seconds)
+  # max_session_kernels: 4      # Process-wide LRU cap on live kernels
 
 # =============================================================================
 # Subagent Delegation
@@ -1860,6 +1898,16 @@ updates:
 #   # default — works on Fly.io out of the box).
 #   #
 #   #   public_url: "https://example.com/hermes"
+#   #
+#   # Reverse proxies connecting from another container or host are not
+#   # trusted by default. Add only the proxy's exact IP address, or a bounded
+#   # CIDR for a dedicated proxy network, so X-Forwarded-Proto and
+#   # X-Forwarded-For can be honored. Loopback is always trusted. Wildcards
+#   # and /0 networks are rejected.
+#   #
+#   #   trusted_proxies:
+#   #     - "172.20.0.5"
+#   #     # - "172.20.0.0/24"  # dedicated network, if the IP is dynamic
 #
 # -----------------------------------------------------------------------------
 # Self-hosted OIDC dashboard auth (generic OpenID Connect — Authentik,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2664,7 +2664,6 @@ DEFAULT_CONFIG = {
         "tirith_path": "tirith",
         "tirith_timeout": 5,
         "tirith_fail_open": True,
-        "allow_shell_key_cmd": False,  # gate shell=True for key_cmd (P0 fix; default argv-only)
         "website_blocklist": {
             "enabled": False,
             "domains": [],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2664,6 +2664,7 @@ DEFAULT_CONFIG = {
         "tirith_path": "tirith",
         "tirith_timeout": 5,
         "tirith_fail_open": True,
+        "allow_shell_key_cmd": False,  # gate shell=True for key_cmd (P0 fix; default argv-only)
         "website_blocklist": {
             "enabled": False,
             "domains": [],

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -489,25 +489,30 @@ class Test98831Beyond97217:
     97217 blocks direct shells + 12 wrappers + shell syntax. 98831 adds:
     bwrap/firejail/flatpak/nsenter/chroot/proot/docker/podman/runc/crun,
     capsh/su/sg/systemd-run/unshare/fakeroot, LOLBins (rundll32/regsvr32/mshta),
-    env-prefix, length/token/control-char limits, and warning audit trail.
-    Each test is a pre-effect regression: monkeypatched subprocess.run must
-    NOT be called (fails if process creation occurs).
+    length/token/control-char limits, and warning audit trail.
+    Each blocked test is a pre-effect process-boundary regression: it drives
+    _mint() with subprocess.run monkeypatched to fail if reached. Each allowed
+    test drives _mint() with a fake runner and asserts exact argv + shell=False.
     """
 
-    def _assert_blocked(self, monkeypatch, command: str):
-        """Helper: command must be rejected before subprocess.run."""
+    def _assert_blocked_via_mint(self, monkeypatch, caplog, command: str, expect_log: str | None = None):
+        """Helper: command must be rejected BEFORE subprocess.run (pre-effect)."""
         called = {}
 
         def fake_run(*a, **k):
             called["ran"] = True
-            return SimpleNamespace(returncode=0, stdout="tok", stderr="")
+            raise AssertionError(f"{command!r} reached subprocess.run — must be rejected pre-effect")
 
         monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+        caplog.clear()
         with pytest.raises(CommandTokenError):
-            _parse_command_argv(command, "test")
+            _mint(command, "test")
         assert "ran" not in called, f"{command!r} should not reach subprocess.run"
+        if expect_log:
+            # warning audit trail (SOC visibility) must be observable
+            assert expect_log in caplog.text, f"expected warning {expect_log!r} not in caplog: {caplog.text!r}"
 
-    def test_extended_wrappers_blocked(self, monkeypatch):
+    def test_extended_wrappers_blocked(self, monkeypatch, caplog):
         for cmd in [
             "bwrap --ro-bind / / helper",
             "firejail helper --arg",
@@ -527,9 +532,9 @@ class Test98831Beyond97217:
             "fakeroot helper",
             "fakechroot helper",
         ]:
-            self._assert_blocked(monkeypatch, cmd)
+            self._assert_blocked_via_mint(monkeypatch, caplog, cmd, expect_log="blocked wrapper")
 
-    def test_lolbins_blocked(self, monkeypatch):
+    def test_lolbins_blocked(self, monkeypatch, caplog):
         for cmd in [
             "rundll32 javascript:evil",
             "rundll32.exe javascript:evil",
@@ -538,48 +543,72 @@ class Test98831Beyond97217:
             "mshta http://evil",
             "mshta.exe http://evil",
         ]:
-            self._assert_blocked(monkeypatch, cmd)
+            self._assert_blocked_via_mint(monkeypatch, caplog, cmd, expect_log="blocked LOLBin")
 
-    def test_busybox_without_exe_blocked(self, monkeypatch):
+    def test_busybox_without_exe_blocked(self, monkeypatch, caplog):
         # 97217 had busybox.exe but not busybox (POSIX); 98831 fixes
-        self._assert_blocked(monkeypatch, "busybox sh -c 'echo hi'")
-        self._assert_blocked(monkeypatch, "busybox --help")
+        self._assert_blocked_via_mint(monkeypatch, caplog, "busybox sh -c 'echo hi'", expect_log="blocked shell")
+        self._assert_blocked_via_mint(monkeypatch, caplog, "busybox --help", expect_log="blocked shell")
 
-    def test_env_prefix_blocked(self, monkeypatch):
-        self._assert_blocked(monkeypatch, "FOO=bar helper --arg")
-        self._assert_blocked(monkeypatch, "AWS_PROFILE=prod my-auth-cli token")
-
-    def test_length_and_token_limits(self, monkeypatch):
+    def test_length_and_token_limits(self, monkeypatch, caplog):
         # _MAX_COMMAND_CHARS=4096, _MAX_ARGV_TOKENS=64
         long_cmd = "helper " + "x" * 5000
-        self._assert_blocked(monkeypatch, long_cmd)
+        self._assert_blocked_via_mint(monkeypatch, caplog, long_cmd)
         many_tokens = "helper " + " ".join(f"arg{i}" for i in range(70))
-        self._assert_blocked(monkeypatch, many_tokens)
+        self._assert_blocked_via_mint(monkeypatch, caplog, many_tokens)
 
-    def test_control_chars_blocked(self, monkeypatch):
-        self._assert_blocked(monkeypatch, "helper\x00injected")
-        self._assert_blocked(monkeypatch, "helper\x01bad")
-        self._assert_blocked(monkeypatch, "helper\rbad")
-        self._assert_blocked(monkeypatch, "helper\nbad")
+    def test_control_chars_blocked(self, monkeypatch, caplog):
+        self._assert_blocked_via_mint(monkeypatch, caplog, "helper\x00injected")
+        self._assert_blocked_via_mint(monkeypatch, caplog, "helper\x01bad")
+        self._assert_blocked_via_mint(monkeypatch, caplog, "helper\rbad")
+        self._assert_blocked_via_mint(monkeypatch, caplog, "helper\nbad")
 
     def test_legitimate_helpers_still_allowed(self, monkeypatch):
-        # Allowed-case controls: these must NOT be blocked (97217 parity)
-        allowed = {}
+        # Allowed-case positive execution controls: must reach subprocess.run
+        # with exact argv and shell=False and return the token.
+        cases = [
+            ("my-auth-cli print-token --profile prod", ["my-auth-cli", "print-token", "--profile", "prod"]),
+            ("python my-helper.py --arg", ["python", "my-helper.py", "--arg"]),
+            ("/usr/local/bin/helper --config /tmp/x", ["/usr/local/bin/helper", "--config", "/tmp/x"]),
+        ]
+        # Windows native quoting preserves backslashes; on POSIX shlex mangles
+        # C:\tmp -> C:tmp, so only assert the Windows exe case on Windows.
+        if sys.platform == "win32":
+            cases.append(('"C:\\Program Files\\helper.exe" --path C:\\tmp\\token', ["C:\\Program Files\\helper.exe", "--path", "C:\\tmp\\token"]))
+        for cmd, expected_argv in cases:
+            seen = {}
 
-        def fake_run(argv, **k):
-            allowed["argv"] = argv
-            return SimpleNamespace(returncode=0, stdout="tok", stderr="")
+            def fake_run(argv, **kwargs):
+                seen["argv"] = argv
+                seen["shell"] = kwargs.get("shell")
+                return SimpleNamespace(returncode=0, stdout="tok", stderr="")
 
-        monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
-        # Real helpers
-        for cmd, expected_first in [
-            ("my-auth-cli print-token --profile prod", "my-auth-cli"),
-            ("python my-helper.py --arg", "python"),
-            ("/usr/local/bin/helper --config /tmp/x", "/usr/local/bin/helper"),
-            ('"C:\\Program Files\\helper.exe" --path C:\\tmp\\token', "C:\\Program Files\\helper.exe"),
-        ]:
-            # Use _mint via fake_run to verify argv without shell
-            argv = _parse_command_argv(cmd, "test")
-            assert argv[0] == expected_first
-            # Ensure it would run (not blocked)
-            assert _parse_command_argv(cmd, "test") == argv
+            monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+            result = _mint(cmd, "test")
+            assert result == ("tok", None), f"{cmd!r} should mint tok"
+            assert seen["argv"] == expected_argv, f"{cmd!r} argv mismatch"
+            assert seen["shell"] is False, f"{cmd!r} must use shell=False"
+
+    def test_executable_path_with_equals_allowed(self, monkeypatch):
+        # argv contract must not reserve "=": ./auth=prod, bin/auth=prod,
+        # and Windows C:\Tools\auth=prod.exe are valid executable names.
+        cases = [
+            ("./auth=prod --token", "./auth=prod"),
+            ("bin/auth=prod --flag", "bin/auth=prod"),
+            ("/opt/auth=prod/helper --x", "/opt/auth=prod/helper"),
+        ]
+        if sys.platform == "win32":
+            cases.append(('"C:\\Tools\\auth=prod.exe" --arg', "C:\\Tools\\auth=prod.exe"))
+        for cmd, expected_first in cases:
+            seen = {}
+
+            def fake_run(argv, **kwargs):
+                seen["argv"] = argv
+                seen["shell"] = kwargs.get("shell")
+                return SimpleNamespace(returncode=0, stdout="tok-equals", stderr="")
+
+            monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+            result = _mint(cmd, "test")
+            assert result == ("tok-equals", None)
+            assert seen["argv"][0] == expected_first
+            assert seen["shell"] is False

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -64,12 +64,19 @@ class TestMinting:
             CommandTokenSource("true", "dbx")()
 
     def test_nonzero_exit_is_an_error(self):
+        # argv-style: /bin/sh -c lets us exit with a specific code without using
+        # shell-only metachars (the previous `exit 3` was a shell builtin that
+        # has no argv form). shlex.split() yields ["/bin/sh","-c","exit 3"] and
+        # the exit code is preserved.
         with pytest.raises(CommandTokenError, match="exited 3"):
-            CommandTokenSource("exit 3", "dbx")()
+            CommandTokenSource("/bin/sh -c 'exit 3'", "dbx")()
 
     def test_failure_message_is_actionable_without_echoing_the_command(self):
         """Actionable, but never echoes the command (it may embed a secret)."""
-        secret_cmd = "print-token --client-secret=SENTINEL-SECRET; exit 1"
+        # argv-style: the secret argument is a plain argv token, not a shell
+        # metachar — so the shell-mode rejection (which would otherwise fire on
+        # `;`) does not trigger.
+        secret_cmd = "/bin/sh -c 'print-token --client-secret=SENTINEL-SECRET; exit 1'"
         with pytest.raises(CommandTokenError) as excinfo:
             CommandTokenSource(secret_cmd, "dbx")()
         message = str(excinfo.value)
@@ -81,8 +88,12 @@ class TestMinting:
 class TestNoCredentialLeak:
     def test_failure_message_excludes_command_output(self):
         """A failing auth helper may print a token — it must not be surfaced."""
+        # argv-style: keep the multi-statement semantics inside a single quoted
+        # argv token (`/bin/sh -c '...'`) so the helper still emits SENTINEL to
+        # stdout/stderr before exiting non-zero. No shell metachars in the
+        # outer command string — the argv-mode default accepts it.
         source = CommandTokenSource(
-            "printf 'SENTINEL-SECRET'; printf 'stderr-SENTINEL' >&2; exit 1",
+            "/bin/sh -c \"printf 'SENTINEL-SECRET'; printf 'stderr-SENTINEL' >&2; exit 1\"",
             "dbx",
         )
         with pytest.raises(CommandTokenError) as excinfo:
@@ -98,10 +109,20 @@ class TestCaching:
         assert source() == source()
 
     def test_expired_token_is_reminted(self):
-        # date +%s%N changes every run; $RANDOM would be bash-only (empty
-        # under dash, which is what /bin/sh is on Debian-family CI).
+        # argv-style: a counter on disk changes every run. `$RANDOM` would be
+        # bash-only (empty under dash, which is /bin/sh on Debian-family CI),
+        # and the original `$(date +%s%N)` used `$()` — a shell metachar that
+        # the argv-mode default blocks. `cat /tmp/...` reads the counter.
+        import os
+        counter = os.path.join(os.environ.get("TMPDIR", "/tmp"), "hermes_keycmd_expired_test")
+        with open(counter, "w") as _f:
+            _f.write("0")
+        # python3 prints whatever value is in the file, then we bump it.
         source = CommandTokenSource(
-            """printf '{"access_token":"tok-%s","expires_in":3600}' "$(date +%s%N)" """,
+            f'python3 -c "import time; '
+            f'v=open({counter!r}).read().strip(); '
+            f'open({counter!r},\'w\').write(str(int(v)+1)); '
+            f'print(\'{{\\"access_token\\":\\"tok-\' + v + \'\\",\\"expires_in\\":3600}}\')"',
             "dbx",
         )
         first = source()
@@ -282,9 +303,14 @@ class TestAbsoluteExpiry:
     def test_the_token_actually_gets_re_minted(self, tmp_path):
         """The regression that mattered: a deadline must expire the cache."""
         counter = tmp_path / "calls"
+        # argv-style: a python one-liner appends `x` to the counter and prints
+        # the JSON token. The original used `printf x >> {counter}; printf ...`
+        # which depends on shell redirection (`>>`) and command chaining (`;`)
+        # — both shell metachars blocked by argv-mode.
+        deadline = self._iso(1)
         cmd = (
-            f"printf x >> {counter}; "
-            f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{self._iso(1)}\"}}'"
+            f"python3 -c \"open({str(counter)!r}, 'a').write('x'); "
+            f"print('{{\\\\\"access_token\\\\\":\\\\\"t\\\\\",\\\\\"expiry\\\\\":\\\\\"{deadline}\\\\\"}}')\""
         )
         src = CommandTokenSource(cmd, "p")
         src()

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -14,6 +14,10 @@ behaviours that make the feature work:
 
 from __future__ import annotations
 
+import json
+import shlex
+import subprocess
+import sys
 import time
 from types import SimpleNamespace
 
@@ -23,25 +27,139 @@ from agent.command_token_source import (
     CommandTokenError,
     CommandTokenSource,
     _mint,
+    _parse_command_argv,
     build_command_token_provider,
 )
 
 
+def _python_command(code: str) -> str:
+    argv = [sys.executable, "-c", code]
+    if sys.platform == "win32":
+        # Force quoting for Python snippets containing shell-like punctuation;
+        # native Windows argv parsing otherwise leaves ``print(...)`` unquoted.
+        return subprocess.list2cmdline([sys.executable, "-c", f"{code} "])
+    return " ".join(shlex.quote(part) for part in argv)
+
+
+def _python_print(value: str) -> str:
+    return _python_command(f"print({value!r}, end='')")
+
+
 class TestMinting:
+    def test_default_execution_uses_argv_without_shell(self, monkeypatch):
+        seen = {}
+
+        def fake_run(command, **kwargs):
+            seen["command"] = command
+            seen["shell"] = kwargs.get("shell")
+            return SimpleNamespace(returncode=0, stdout="tok-safe", stderr="")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+
+        assert _mint("token-helper --profile prod", "dbx") == ("tok-safe", None)
+        assert seen == {
+            "command": ["token-helper", "--profile", "prod"],
+            "shell": False,
+        }
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            (
+                r"helper --config C:\Users\andre\config.json",
+                ["helper", "--config", r"C:\Users\andre\config.json"],
+            ),
+            (
+                r'"C:\Program Files\helper.exe" --path C:\tmp\token',
+                [
+                    r"C:\Program Files\helper.exe",
+                    "--path",
+                    r"C:\tmp\token",
+                ],
+            ),
+            (
+                "helper --path C:\\tmp\\",
+                ["helper", "--path", "C:\\tmp\\"],
+            ),
+        ],
+    )
+    def test_windows_parser_preserves_native_backslashes(self, command, expected):
+        if sys.platform != "win32":
+            pytest.skip("native backslash parsing is Windows-specific")
+        assert _parse_command_argv(command, "dbx") == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'cmd.exe /d /c "echo pwned > marker"',
+            'powershell -NoProfile -Command "Set-Content marker pwned"',
+            'pwsh -NoProfile -c "Set-Content marker pwned"',
+            'sh -c "echo pwned > marker"',
+            'bash -c "echo pwned > marker"',
+        ],
+    )
+    def test_shell_launchers_are_rejected_before_execution(self, monkeypatch, command):
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("shell launcher must be rejected before process creation")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fail_if_called)
+        with pytest.raises(CommandTokenError, match="shell"):
+            _mint(command, "dbx")
+
+    @pytest.mark.parametrize("command", [
+        'env -u SECRET bash -c "echo pwned"',
+        'env --split-string="bash -c echo"',
+        'nice bash -c "echo pwned"',
+        'nohup sh -c "echo pwned"',
+        'xargs -0 bash -c "echo pwned"',
+        'wsl sh -c "echo pwned"',
+    ])
+    def test_process_dispatch_wrappers_are_rejected(self, monkeypatch, command):
+        monkeypatch.setattr(
+            "agent.command_token_source.subprocess.run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not spawn")),
+        )
+        with pytest.raises(CommandTokenError, match="process wrapper"):
+            _mint(command, "dbx")
+
+    def test_nul_command_is_normalized_to_provider_error(self):
+        with pytest.raises(CommandTokenError, match="could not be parsed") as excinfo:
+            _mint("helper\x00--token", "dbx")
+        assert "helper" not in str(excinfo.value)
+
+    def test_shell_injection_marker_never_runs(self, tmp_path):
+        marker = tmp_path / "marker"
+        python = sys.executable.replace("\\", "/")
+        marker_path = marker.as_posix()
+        first = (
+            f'"{python}" -c "from pathlib import Path; '
+            f"Path(r'{marker_path}').write_text('pwned')\""
+        )
+        second = f'"{python}" -c "print(\'tok\')"'
+        separator = "&" if sys.platform == "win32" else ";"
+
+        with pytest.raises(CommandTokenError):
+            _mint(f"{first} {separator} {second}", "dbx")
+
+        assert not marker.exists(), "shell metacharacters must not run a second operation"
+
     def test_bare_token_stdout(self):
-        source = CommandTokenSource("printf 'tok-abc'", "dbx")
+        source = CommandTokenSource(_python_command("print('tok-abc', end='')"), "dbx")
         assert source() == "tok-abc"
 
     def test_json_access_token(self):
         """The OAuth 2.0 token-endpoint response shape."""
         source = CommandTokenSource(
-            """printf '{"access_token":"tok-json","expires_in":3600}'""", "dbx"
+            _python_command(
+                "print('{\"access_token\":\"tok-json\",\"expires_in\":3600}', end='')"
+            ),
+            "dbx",
         )
         assert source() == "tok-json"
 
     def test_trailing_newline_is_stripped(self):
         """A raw newline in the credential would corrupt the auth header."""
-        assert CommandTokenSource("echo tok-nl", "dbx")() == "tok-nl"
+        assert CommandTokenSource(_python_command("print('tok-nl')"), "dbx")() == "tok-nl"
 
     def test_multiline_output_is_rejected_not_guessed(self):
         """Only the token may land on stdout.
@@ -50,33 +168,30 @@ class TestMinting:
         warning, two tokens) into a corrupt-credential 401 that is much harder
         to diagnose than an explicit refusal.
         """
-        source = CommandTokenSource("printf 'banner\\ntok-real'", "dbx")
+        source = CommandTokenSource(
+            _python_command("print('banner\\ntok-real', end='')"), "dbx"
+        )
         with pytest.raises(CommandTokenError, match="multiple lines"):
             source()
 
     def test_json_without_access_token_is_an_error(self):
-        source = CommandTokenSource("""printf '{"nope":1}'""", "dbx")
+        source = CommandTokenSource(_python_command("print('{\"nope\":1}', end='')"), "dbx")
         with pytest.raises(CommandTokenError, match="access_token"):
             source()
 
     def test_empty_output_is_an_error(self):
         with pytest.raises(CommandTokenError, match="no output"):
-            CommandTokenSource("true", "dbx")()
+            CommandTokenSource(_python_command("pass"), "dbx")()
 
     def test_nonzero_exit_is_an_error(self):
-        # argv-style: /bin/sh -c lets us exit with a specific code without using
-        # shell-only metachars (the previous `exit 3` was a shell builtin that
-        # has no argv form). shlex.split() yields ["/bin/sh","-c","exit 3"] and
-        # the exit code is preserved.
         with pytest.raises(CommandTokenError, match="exited 3"):
-            CommandTokenSource("/bin/sh -c 'exit 3'", "dbx")()
+            CommandTokenSource(_python_command("raise SystemExit(3)"), "dbx")()
 
     def test_failure_message_is_actionable_without_echoing_the_command(self):
         """Actionable, but never echoes the command (it may embed a secret)."""
-        # argv-style: the secret argument is a plain argv token, not a shell
-        # metachar — so the shell-mode rejection (which would otherwise fire on
-        # `;`) does not trigger.
-        secret_cmd = "/bin/sh -c 'print-token --client-secret=SENTINEL-SECRET; exit 1'"
+        secret_cmd = _python_command(
+            "import sys; print('SENTINEL-SECRET', file=sys.stderr); raise SystemExit(1)"
+        )
         with pytest.raises(CommandTokenError) as excinfo:
             CommandTokenSource(secret_cmd, "dbx")()
         message = str(excinfo.value)
@@ -88,12 +203,11 @@ class TestMinting:
 class TestNoCredentialLeak:
     def test_failure_message_excludes_command_output(self):
         """A failing auth helper may print a token — it must not be surfaced."""
-        # argv-style: keep the multi-statement semantics inside a single quoted
-        # argv token (`/bin/sh -c '...'`) so the helper still emits SENTINEL to
-        # stdout/stderr before exiting non-zero. No shell metachars in the
-        # outer command string — the argv-mode default accepts it.
         source = CommandTokenSource(
-            "/bin/sh -c \"printf 'SENTINEL-SECRET'; printf 'stderr-SENTINEL' >&2; exit 1\"",
+            _python_command(
+                "import sys; print('SENTINEL-SECRET', file=sys.stdout); "
+                "print('stderr-SENTINEL', file=sys.stderr); raise SystemExit(1)"
+            ),
             "dbx",
         )
         with pytest.raises(CommandTokenError) as excinfo:
@@ -105,24 +219,19 @@ class TestCaching:
     def test_token_is_cached_between_calls(self):
         """Without caching the command would run on every request."""
         # A command whose output changes each run: equal results prove caching.
-        source = CommandTokenSource("date +%s%N", "dbx")
+        source = CommandTokenSource(
+            _python_command("import time; print(time.time_ns(), end='')"), "dbx"
+        )
         assert source() == source()
 
     def test_expired_token_is_reminted(self):
-        # argv-style: a counter on disk changes every run. `$RANDOM` would be
-        # bash-only (empty under dash, which is /bin/sh on Debian-family CI),
-        # and the original `$(date +%s%N)` used `$()` — a shell metachar that
-        # the argv-mode default blocks. `cat /tmp/...` reads the counter.
-        import os
-        counter = os.path.join(os.environ.get("TMPDIR", "/tmp"), "hermes_keycmd_expired_test")
-        with open(counter, "w") as _f:
-            _f.write("0")
-        # python3 prints whatever value is in the file, then we bump it.
+        # time_ns changes every run and is available on every supported OS.
         source = CommandTokenSource(
-            f'python3 -c "import time; '
-            f'v=open({counter!r}).read().strip(); '
-            f'open({counter!r},\'w\').write(str(int(v)+1)); '
-            f'print(\'{{\\"access_token\\":\\"tok-\' + v + \'\\",\\"expires_in\\":3600}}\')"',
+            _python_command(
+                "import json, time; print(json.dumps({"
+                "'access_token': f'tok-{time.time_ns()}', 'expires_in': 3600"
+                "}), end='')"
+            ),
             "dbx",
         )
         first = source()
@@ -140,7 +249,9 @@ class TestCaching:
         """
         from agent.command_token_source import _NO_TTL_REFRESH_SECONDS
 
-        source = CommandTokenSource("date +%s%N", "dbx")
+        source = CommandTokenSource(
+            _python_command("import time; print(time.time_ns(), end='')"), "dbx"
+        )
         first = source()
         assert 0 < source._expires_at - time.monotonic() <= _NO_TTL_REFRESH_SECONDS
         assert source() == first  # cached inside the window
@@ -149,7 +260,7 @@ class TestCaching:
 
     def test_advertised_ttl_sets_an_expiry(self):
         source = CommandTokenSource(
-            """printf '{"access_token":"tok","expires_in":3600}'""", "dbx"
+            _python_print('{"access_token":"tok","expires_in":3600}'), "dbx"
         )
         source()
         assert source._expires_at is not None
@@ -157,7 +268,7 @@ class TestCaching:
     def test_ttl_shorter_than_the_leeway_still_caches_briefly(self):
         """A leeway larger than the TTL must not disable caching entirely."""
         source = CommandTokenSource(
-            """printf '{"access_token":"tok","expires_in":1}'""", "dbx"
+            _python_print('{"access_token":"tok","expires_in":1}'), "dbx"
         )
         source()
         assert source._expires_at is not None
@@ -270,47 +381,44 @@ class TestAbsoluteExpiry:
 
     def test_iso_expiry_yields_a_ttl(self):
         deadline = self._iso(3600)
-        _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{deadline}\"}}'", "p")
+        payload = json.dumps({"access_token": "t", "expiry": deadline})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is not None, "an advertised deadline must produce a TTL"
         assert 3500 < ttl <= 3600
 
     def test_azure_expires_on_spelling(self):
         deadline = self._iso(1800)
-        _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiresOn\":\"{deadline}\"}}'", "p")
+        payload = json.dumps({"access_token": "t", "expiresOn": deadline})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is not None and 1700 < ttl <= 1800
 
     def test_expires_in_still_wins_when_both_present(self):
         """The RFC 6749 field is authoritative where a helper sends both."""
         deadline = self._iso(3600)
-        _, ttl = _mint(
-            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":120,\"expiry\":\"{deadline}\"}}'",
-            "p",
+        payload = json.dumps(
+            {"access_token": "t", "expires_in": 120, "expiry": deadline}
         )
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl == 120.0
 
     def test_unparseable_expiry_is_not_a_ttl(self):
         """Junk must fall back to refresh-on-401, never to a guessed deadline."""
-        _, ttl = _mint('printf \'%s\' \'{"access_token":"t","expiry":"whenever"}\'', "p")
+        _, ttl = _mint(_python_print('{"access_token":"t","expiry":"whenever"}'), "p")
         assert ttl is None
 
     def test_already_past_expiry_is_not_a_ttl(self):
         """A stale deadline must not become a negative or zero TTL."""
-        _, ttl = _mint(
-            f"printf '%s' '{{\"access_token\":\"t\",\"expiry\":\"{self._iso(-60)}\"}}'", "p"
-        )
+        payload = json.dumps({"access_token": "t", "expiry": self._iso(-60)})
+        _, ttl = _mint(_python_print(payload), "p")
         assert ttl is None
 
     def test_the_token_actually_gets_re_minted(self, tmp_path):
         """The regression that mattered: a deadline must expire the cache."""
         counter = tmp_path / "calls"
-        # argv-style: a python one-liner appends `x` to the counter and prints
-        # the JSON token. The original used `printf x >> {counter}; printf ...`
-        # which depends on shell redirection (`>>`) and command chaining (`;`)
-        # — both shell metachars blocked by argv-mode.
-        deadline = self._iso(1)
-        cmd = (
-            f"python3 -c \"open({str(counter)!r}, 'a').write('x'); "
-            f"print('{{\\\\\"access_token\\\\\":\\\\\"t\\\\\",\\\\\"expiry\\\\\":\\\\\"{deadline}\\\\\"}}')\""
+        cmd = _python_command(
+            "import json; from pathlib import Path; "
+            f"p=Path({str(counter)!r}); p.open('a').write('x'); "
+            f"print(json.dumps({{'access_token': 't', 'expiry': {self._iso(1)!r}}}), end='')"
         )
         src = CommandTokenSource(cmd, "p")
         src()

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -481,3 +481,105 @@ class TestAuxiliaryResolverHonoursKeyCmd:
         assert self._resolve(
             monkeypatch, {**self.BASE, "key_cmd": "   "}
         ) == "no-key-required"
+
+
+class Test98831Beyond97217:
+    """98831 hardening beyond 97217 — extended wrappers, LOLBins, limits.
+
+    97217 blocks direct shells + 12 wrappers + shell syntax. 98831 adds:
+    bwrap/firejail/flatpak/nsenter/chroot/proot/docker/podman/runc/crun,
+    capsh/su/sg/systemd-run/unshare/fakeroot, LOLBins (rundll32/regsvr32/mshta),
+    env-prefix, length/token/control-char limits, and warning audit trail.
+    Each test is a pre-effect regression: monkeypatched subprocess.run must
+    NOT be called (fails if process creation occurs).
+    """
+
+    def _assert_blocked(self, monkeypatch, command: str):
+        """Helper: command must be rejected before subprocess.run."""
+        called = {}
+
+        def fake_run(*a, **k):
+            called["ran"] = True
+            return SimpleNamespace(returncode=0, stdout="tok", stderr="")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+        with pytest.raises(CommandTokenError):
+            _parse_command_argv(command, "test")
+        assert "ran" not in called, f"{command!r} should not reach subprocess.run"
+
+    def test_extended_wrappers_blocked(self, monkeypatch):
+        for cmd in [
+            "bwrap --ro-bind / / helper",
+            "firejail helper --arg",
+            "flatpak run helper",
+            "nsenter helper",
+            "chroot / helper",
+            "proot helper",
+            "docker run helper",
+            "podman run helper",
+            "runc run helper",
+            "crun run helper",
+            "capsh --print helper",
+            "su helper",
+            "sg helper",
+            "systemd-run helper",
+            "unshare helper",
+            "fakeroot helper",
+            "fakechroot helper",
+        ]:
+            self._assert_blocked(monkeypatch, cmd)
+
+    def test_lolbins_blocked(self, monkeypatch):
+        for cmd in [
+            "rundll32 javascript:evil",
+            "rundll32.exe javascript:evil",
+            "regsvr32 /s evil.dll",
+            "regsvr32.exe evil.dll",
+            "mshta http://evil",
+            "mshta.exe http://evil",
+        ]:
+            self._assert_blocked(monkeypatch, cmd)
+
+    def test_busybox_without_exe_blocked(self, monkeypatch):
+        # 97217 had busybox.exe but not busybox (POSIX); 98831 fixes
+        self._assert_blocked(monkeypatch, "busybox sh -c 'echo hi'")
+        self._assert_blocked(monkeypatch, "busybox --help")
+
+    def test_env_prefix_blocked(self, monkeypatch):
+        self._assert_blocked(monkeypatch, "FOO=bar helper --arg")
+        self._assert_blocked(monkeypatch, "AWS_PROFILE=prod my-auth-cli token")
+
+    def test_length_and_token_limits(self, monkeypatch):
+        # _MAX_COMMAND_CHARS=4096, _MAX_ARGV_TOKENS=64
+        long_cmd = "helper " + "x" * 5000
+        self._assert_blocked(monkeypatch, long_cmd)
+        many_tokens = "helper " + " ".join(f"arg{i}" for i in range(70))
+        self._assert_blocked(monkeypatch, many_tokens)
+
+    def test_control_chars_blocked(self, monkeypatch):
+        self._assert_blocked(monkeypatch, "helper\x00injected")
+        self._assert_blocked(monkeypatch, "helper\x01bad")
+        self._assert_blocked(monkeypatch, "helper\rbad")
+        self._assert_blocked(monkeypatch, "helper\nbad")
+
+    def test_legitimate_helpers_still_allowed(self, monkeypatch):
+        # Allowed-case controls: these must NOT be blocked (97217 parity)
+        allowed = {}
+
+        def fake_run(argv, **k):
+            allowed["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="tok", stderr="")
+
+        monkeypatch.setattr("agent.command_token_source.subprocess.run", fake_run)
+        # Real helpers
+        for cmd, expected_first in [
+            ("my-auth-cli print-token --profile prod", "my-auth-cli"),
+            ("python my-helper.py --arg", "python"),
+            ("/usr/local/bin/helper --config /tmp/x", "/usr/local/bin/helper"),
+            ('"C:\\Program Files\\helper.exe" --path C:\\tmp\\token', "C:\\Program Files\\helper.exe"),
+        ]:
+            # Use _mint via fake_run to verify argv without shell
+            argv = _parse_command_argv(cmd, "test")
+            assert argv[0] == expected_first
+            # Ensure it would run (not blocked)
+            assert _parse_command_argv(cmd, "test") == argv

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **Ramp Router** | `RAMP_ROUTER_API_KEY` in `~/.hermes/.env` (provider: `router`; aliases: `ramp-router`, `ramp`, `router.com`; Responses-native gateway, live account-scoped catalog) |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
@@ -28,20 +29,23 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **Nebius Token Factory** | `NEBIUS_API_KEY` in `~/.hermes/.env` (provider: `nebius-token-factory`; aliases: `nebius`, `nebius-tf`, `tokenfactory`) |
 | **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay, or `ACTUAL_BASE_URL=http://127.0.0.1:8080` for the local daemon — no key needed on loopback (provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok / Premium+)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
-| **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
-| **Alibaba Cloud (Coding Plan)** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
+| **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`; mainland-China endpoint: `alibaba-cn`) |
+| **Alibaba Cloud (Coding Plan)** | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) (provider: `alibaba-coding-plan`, alias: `alibaba_coding`; mainland-China endpoint: `alibaba-coding-plan-cn`) — separate billing SKU, different endpoint |
+| **Alibaba Cloud (Token Plan)** | `ALIBABA_TOKEN_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-token-plan`; mainland-China endpoint: `alibaba-token-plan-cn`) — Model Studio flat-token tier |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
+| **Tencent TokenPlan** | `TOKENPLAN_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenplan`, aliases: `tokenplan`, `tencent-lkeap`; Anthropic Messages endpoint) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
-| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously |
+| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously. The model list refreshes automatically from OpenCode's live catalog, so rotating free promotions appear (and delisted ones disappear) without a Hermes update |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
@@ -253,6 +257,10 @@ hermes chat --provider fireworks --model accounts/fireworks/models/kimi-k2p6
 hermes chat --provider novita --model moonshotai/kimi-k2.5
 # Requires: NOVITA_API_KEY in ~/.hermes/.env
 
+# Ramp Router (model IDs come from your account's live catalog)
+hermes chat --provider router --model gpt-5.4-mini
+# Requires: RAMP_ROUTER_API_KEY in ~/.hermes/.env
+
 # z.ai / ZhipuAI GLM
 hermes chat --provider zai --model glm-5
 # Requires: GLM_API_KEY in ~/.hermes/.env
@@ -281,9 +289,13 @@ hermes chat --provider alibaba --model qwen3.5-plus
 hermes chat --provider xiaomi --model mimo-v2-pro
 # Requires: XIAOMI_API_KEY in ~/.hermes/.env
 
-# Tencent TokenHub (Hy3 Preview)
-hermes chat --provider tencent-tokenhub --model hy3-preview
+# Tencent TokenHub (Hy4 preview)
+hermes chat --provider tencent-tokenhub --model hy4-preview
 # Requires: TOKENHUB_API_KEY in ~/.hermes/.env
+
+# Tencent TokenPlan (Hy4 preview via Anthropic Messages endpoint)
+hermes chat --provider tencent-tokenplan --model hy4-preview
+# Requires: TOKENPLAN_API_KEY in ~/.hermes/.env
 
 # Arcee AI (Trinity models)
 hermes chat --provider arcee --model trinity-large-thinking
@@ -297,6 +309,10 @@ hermes chat --provider meta-ai --model muse-spark-1.2
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Nebius Token Factory
+hermes chat --provider nebius --model deepseek-ai/DeepSeek-V4-Pro
+# Requires: NEBIUS_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -1285,7 +1301,7 @@ Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accept
 
 #### Command-minted credentials (`key_cmd`)
 
-Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names an **argv-only executable command** that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart. Hermes never invokes a shell for `key_cmd`.
+Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names an **argv-only executable command** that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart. Hermes never invokes a shell for `key_cmd`:
 
 ```yaml
 providers:
@@ -1336,6 +1352,8 @@ extra_body:
   chat_template_kwargs:
     enable_thinking: false
 ```
+
+The configured `extra_body` follows the provider everywhere: it is merged at agent construction, **survives every gateway turn** (including turns where `/fast` layers `service_tier`/`speed` overrides on top — those merge over your `extra_body` rather than replacing it), and is **re-derived on `/model` switches** — switching to a named custom provider applies its `extra_body`, and switching away clears it so it never leaks to another provider.
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
@@ -1587,7 +1605,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `tencent-tokenplan`, `nebius-token-factory`, `router`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,7 +20,6 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
-| **Ramp Router** | `RAMP_ROUTER_API_KEY` in `~/.hermes/.env` (provider: `router`; aliases: `ramp-router`, `ramp`, `router.com`; Responses-native gateway, live account-scoped catalog) |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
@@ -29,23 +28,20 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
-| **Nebius Token Factory** | `NEBIUS_API_KEY` in `~/.hermes/.env` (provider: `nebius-token-factory`; aliases: `nebius`, `nebius-tf`, `tokenfactory`) |
 | **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay, or `ACTUAL_BASE_URL=http://127.0.0.1:8080` for the local daemon — no key needed on loopback (provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok / Premium+)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
-| **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`; mainland-China endpoint: `alibaba-cn`) |
-| **Alibaba Cloud (Coding Plan)** | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) (provider: `alibaba-coding-plan`, alias: `alibaba_coding`; mainland-China endpoint: `alibaba-coding-plan-cn`) — separate billing SKU, different endpoint |
-| **Alibaba Cloud (Token Plan)** | `ALIBABA_TOKEN_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-token-plan`; mainland-China endpoint: `alibaba-token-plan-cn`) — Model Studio flat-token tier |
+| **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
+| **Alibaba Cloud (Coding Plan)** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
-| **Tencent TokenPlan** | `TOKENPLAN_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenplan`, aliases: `tokenplan`, `tencent-lkeap`; Anthropic Messages endpoint) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
-| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously. The model list refreshes automatically from OpenCode's live catalog, so rotating free promotions appear (and delisted ones disappear) without a Hermes update |
+| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
@@ -257,10 +253,6 @@ hermes chat --provider fireworks --model accounts/fireworks/models/kimi-k2p6
 hermes chat --provider novita --model moonshotai/kimi-k2.5
 # Requires: NOVITA_API_KEY in ~/.hermes/.env
 
-# Ramp Router (model IDs come from your account's live catalog)
-hermes chat --provider router --model gpt-5.4-mini
-# Requires: RAMP_ROUTER_API_KEY in ~/.hermes/.env
-
 # z.ai / ZhipuAI GLM
 hermes chat --provider zai --model glm-5
 # Requires: GLM_API_KEY in ~/.hermes/.env
@@ -289,13 +281,9 @@ hermes chat --provider alibaba --model qwen3.5-plus
 hermes chat --provider xiaomi --model mimo-v2-pro
 # Requires: XIAOMI_API_KEY in ~/.hermes/.env
 
-# Tencent TokenHub (Hy4 preview)
-hermes chat --provider tencent-tokenhub --model hy4-preview
+# Tencent TokenHub (Hy3 Preview)
+hermes chat --provider tencent-tokenhub --model hy3-preview
 # Requires: TOKENHUB_API_KEY in ~/.hermes/.env
-
-# Tencent TokenPlan (Hy4 preview via Anthropic Messages endpoint)
-hermes chat --provider tencent-tokenplan --model hy4-preview
-# Requires: TOKENPLAN_API_KEY in ~/.hermes/.env
 
 # Arcee AI (Trinity models)
 hermes chat --provider arcee --model trinity-large-thinking
@@ -309,10 +297,6 @@ hermes chat --provider meta-ai --model muse-spark-1.2
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
-
-# Nebius Token Factory
-hermes chat --provider nebius --model deepseek-ai/DeepSeek-V4-Pro
-# Requires: NEBIUS_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -1301,7 +1285,7 @@ Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accept
 
 #### Command-minted credentials (`key_cmd`)
 
-Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names a command that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart:
+Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names an **argv-only executable command** that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart. Hermes never invokes a shell for `key_cmd`.
 
 ```yaml
 providers:
@@ -1311,7 +1295,9 @@ providers:
     key_cmd: "my-auth-cli print-token --profile prod"
 ```
 
-Works with any helper that prints a token — `databricks auth token`, `gcloud auth print-access-token`, `az account get-access-token`, `vault read`, or Claude Code-style `apiKeyHelper` scripts.
+Works with any executable helper that prints a token — `databricks auth token`, `gcloud auth print-access-token`, `az account get-access-token`, or `vault read`. Do not wrap a helper in `cmd.exe /c`, `powershell -Command`, `pwsh -c`, `sh -c`, or `bash -c`; shell launchers and shell operators are rejected. Replace shell syntax with explicit executable arguments instead.
+
+On Windows, `key_cmd` uses native command-line quoting. Backslashes are preserved as path separators unless they precede a double quote. Quote an executable or argument only when it contains spaces, for example: `"C:\Program Files\my-auth.exe" --config C:\Users\me\config.json`. Use double quotes (not POSIX single-quote syntax) for grouped arguments; escape embedded double quotes with the native backslash rules.
 
 The command must print **only** the token on stdout: either bare, or as JSON with an `access_token` field (`expires_in` is honored; absolute `expiry`/`expiresOn` ISO timestamps too). Multi-line output is rejected rather than guessed at. If no expiry is advertised, the token is re-minted on a bounded window.
 
@@ -1350,8 +1336,6 @@ extra_body:
   chat_template_kwargs:
     enable_thinking: false
 ```
-
-The configured `extra_body` follows the provider everywhere: it is merged at agent construction, **survives every gateway turn** (including turns where `/fast` layers `service_tier`/`speed` overrides on top — those merge over your `extra_body` rather than replacing it), and is **re-derived on `/model` switches** — switching to a named custom provider applies its `extra_body`, and switching away clears it so it never leaks to another provider.
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
@@ -1603,7 +1587,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `tencent-tokenplan`, `nebius-token-factory`, `router`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).


### PR DESCRIPTION
Successor to #98837 (closed after force-push, cannot be reopened — same branch, new head 40c120be0).

## Summary
Fixes #98831 — independent report preserved (reframed to honest trusted-operator boundary, see #98831).
Hostile-writer arbitrary executable tracked in #98910.

## Relation to #97217
Landing = this PR (superset of #97217). Upon merge, #97217 superseded with credit preserved. See #97217 comment.

## Changes
- Native argv + shell=False, reject shell ops, block shells/busybox, 25 wrappers, LOLBins, limits, allow = in exe path, pre-effect _mint tests with caplog.

Head: 40c120be0 (all 163002695@noreply provenance). Tests: 50 passed, 3 skipped.

Fixes #98831
Related #98910
Supersedes #97217
