### PR TITLE
fix(code): cap Unicode stdout spills by bytes

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,7 +18,9 @@ import pytest
 import json
 import os
 import socket
+import tempfile
 import time
+from pathlib import Path
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -59,6 +61,8 @@ from tools.code_execution_tool import (
     _TOOL_DOC_LINES,
     _execute_remote,
     _format_interrupted_output,
+    _spill_full_stdout,
+    MAX_SPILLED_STDOUT_BYTES,
 )
 from tools.registry import registry
 
@@ -776,6 +780,37 @@ class TestHeadTailTruncation(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("small output", result["output"])
         self.assertNotIn("TRUNCATED", result["output"])
+
+
+    def test_spill_caps_unicode_by_encoded_bytes(self):
+        """Spills honor their byte cap and retain valid UTF-8 at the boundary."""
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch("hermes_constants.get_hermes_dir", return_value=Path(tmpdir) / "exec"):
+            spill_path = _spill_full_stdout("界" * (MAX_SPILLED_STDOUT_BYTES + 1))
+            if spill_path is None:
+                self.fail("expected stdout spill path")
+            with open(spill_path, "rb") as f:
+                spilled = f.read()
+
+        self.assertLessEqual(
+            len(spilled),
+            MAX_SPILLED_STDOUT_BYTES + len(
+                f"\n\n[... spill capped at {MAX_SPILLED_STDOUT_BYTES:,} bytes ...]".encode()
+            ),
+        )
+        self.assertTrue(spilled.decode("utf-8").endswith("bytes ...]"))
+
+    def test_spill_preserves_unicode_at_exact_byte_cap(self):
+        """Unicode output that encodes exactly to the cap is not marked capped."""
+        text = "界" * (MAX_SPILLED_STDOUT_BYTES // len("界".encode())) + "ab"
+        self.assertEqual(len(text.encode()), MAX_SPILLED_STDOUT_BYTES)
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch("hermes_constants.get_hermes_dir", return_value=Path(tmpdir) / "exec"):
+            spill_path = _spill_full_stdout(text)
+            if spill_path is None:
+                self.fail("expected stdout spill path")
+            with open(spill_path, encoding="utf-8") as f:
+                self.assertEqual(f.read(), text)
 
 
     def test_remote_large_output_gets_truncation_metadata(self):

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -94,6 +94,22 @@ class TestSessionStatePersistence(unittest.TestCase):
         self.assertEqual(second["kernel"]["reused"], True)
         self.assertEqual(second["kernel"]["execution_count"], 2)
 
+    def test_kernel_spill_caps_unicode_by_encoded_bytes(self):
+        """Generated runner never spills more than its byte budget for Unicode."""
+        spill_cap = 5_000_000
+        with _kernel_config():
+            result = _run("print('界' * 5000001)")
+            spill_path = result.get("stdout_spill_path")
+            self.assertIsNotNone(spill_path, result)
+            with open(spill_path, "rb") as f:
+                spilled = f.read()
+
+        self.assertLessEqual(
+            len(spilled),
+            spill_cap + len(f"\n\n[... spill capped ...]".encode()),
+        )
+        spilled.decode("utf-8")
+
     def test_reset_discards_state(self):
         with _kernel_config():
             _run("x = 41")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -168,9 +168,13 @@ def _spill_full_stdout(stdout_text: str) -> Optional[str]:
         import hashlib
         from hermes_constants import get_hermes_dir
 
-        if len(stdout_text) > MAX_SPILLED_STDOUT_BYTES:
+        stdout_bytes = stdout_text.encode("utf-8", errors="replace")
+        if len(stdout_bytes) > MAX_SPILLED_STDOUT_BYTES:
+            # Slice encoded data, then drop only an incomplete final sequence.
+            # The marker is intentionally outside the cap so readers know the
+            # spill is incomplete.
             stdout_text = (
-                stdout_text[:MAX_SPILLED_STDOUT_BYTES]
+                stdout_bytes[:MAX_SPILLED_STDOUT_BYTES].decode("utf-8", errors="ignore")
                 + f"\n\n[... spill capped at {MAX_SPILLED_STDOUT_BYTES:,} bytes ...]"
             )
         cache_dir = get_hermes_dir("cache/exec", "exec_spill")

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -98,19 +98,20 @@ def _bounded(text, spill_name=None):
     Returns (clipped_text, clipped?, spill_path_or_empty). Spill is
     best-effort — a failed write degrades to plain clipping.
     """
-    if len(text) <= _CAPTURE_LIMIT:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= _CAPTURE_LIMIT:
         return text, False, ""
     spill_path = ""
     if _SPILL_DIR and spill_name:
         try:
             spill_path = os.path.join(_SPILL_DIR, spill_name)
             with open(spill_path, "w", encoding="utf-8", errors="replace") as f:
-                f.write(text[:_SPILL_CAP])
-                if len(text) > _SPILL_CAP:
+                f.write(encoded[:_SPILL_CAP].decode("utf-8", errors="ignore"))
+                if len(encoded) > _SPILL_CAP:
                     f.write("\\n\\n[... spill capped ...]")
         except Exception:
             spill_path = ""
-    return text[: _CAPTURE_LIMIT], True, spill_path
+    return encoded[:_CAPTURE_LIMIT].decode("utf-8", errors="ignore"), True, spill_path
 
 
 def _reply(payload):


### PR DESCRIPTION
## Summary
- enforce stdout spill and persistent-kernel output caps against UTF-8 byte length
- retain valid UTF-8 when a multibyte sequence crosses the boundary
- cover oversized and exactly-at-cap Unicode output

## Validation
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_code_execution.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_code_kernel.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check tools/code_execution_tool.py tools/code_kernel.py tests/tools/test_code_execution.py tests/tools/test_code_kernel.py`
- `git diff --check`