### PR TITLE
fix(gateway): keep auto-TTS output under Hermes home

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,7 +15,6 @@ import re
 import socket as _socket
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -23,6 +22,7 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from hermes_constants import get_hermes_home
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -252,13 +252,11 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
-    audio_path = os.path.join(
-        tempfile.gettempdir(),
-        "hermes_voice",
-        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
+    audio_path = get_hermes_home() / "tmp" / "hermes_voice" / (
+        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}"
     )
-    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-    return audio_path
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    return str(audio_path)
 
 
 def utf16_len(s: str) -> int:

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -12,10 +12,12 @@ voice bubble). The fix passes an explicit output path from
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agent.file_safety import is_write_denied
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -79,9 +81,40 @@ def _hold_typing():
 
 
 @pytest.mark.parametrize(
+    ("platform", "suffix"),
+    [(Platform.TELEGRAM, ".ogg"), (Platform.DISCORD, ".mp3")],
+)
+def test_output_path_is_safe_hermes_temp_path(
+    platform, suffix, tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(hermes_home))
+
+    path = Path(build_auto_tts_output_path(platform))
+
+    assert path.parent == hermes_home / "tmp" / "hermes_voice"
+    assert path.suffix == suffix
+    assert path.parent.is_dir()
+    assert is_write_denied(str(path)) is False
+
+
+def test_output_paths_are_uuid_unique(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    first = build_auto_tts_output_path(Platform.TELEGRAM)
+    second = build_auto_tts_output_path(Platform.TELEGRAM)
+
+    assert first != second
+
+
+@pytest.mark.parametrize(
     "platform", [Platform.DISCORD, Platform.SLACK, "irc", None]
 )
-def test_output_path_is_mp3_for_non_opus_platforms(platform):
+def test_output_path_is_mp3_for_non_opus_platforms(
+    platform, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     path = build_auto_tts_output_path(platform)
     assert path.endswith(".mp3"), path
 
@@ -116,8 +149,22 @@ async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
 
 
 @pytest.mark.asyncio
-async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
+async def test_base_auto_tts_cleans_up_safe_output_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _DummyAdapter(Platform.TELEGRAM)
+
+    requested, _ = await _run_auto_tts(adapter, Platform.TELEGRAM)
+
+    assert len(requested) == 1
+    assert not Path(requested[0]).exists()
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_skips_playback_when_tool_reports_failure(
+    tmp_path, monkeypatch
+):
     """A success=False tool result must not deliver a stale/partial file."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     adapter = _DummyAdapter(Platform.TELEGRAM)
     adapter._keep_typing = _hold_typing()
     adapter._should_auto_tts_for_chat = lambda _chat_id: True


### PR DESCRIPTION
`build_auto_tts_output_path` writes voice replies into `tempfile.gettempdir()`, outside the Hermes home. Anything the agent produces should live under `HERMES_HOME` so it stays inside the write-safe root, survives a `/tmp` sweep mid-turn, and is reachable when the gateway and the tooling do not share a `/tmp` (containers, sandboxes).

This moves the path to `HERMES_HOME/tmp/hermes_voice/` and keeps the existing `.ogg`/`.mp3` selection and UUID uniqueness untouched.

Tested: `tests/gateway/test_base_auto_tts_output_format.py` — 9 passed on current `main`. Running in production on a five-instance fleet since 2026-08-16.