### PR TITLE
fix(kanban): preserve selected board when deleting tasks

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1202,7 +1202,7 @@
        destructive: true,
      }).then(function (r) {
        if (!r.confirmed) return null;
-       return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(taskId)}`, {
+       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {
          method: "DELETE",
        }).then(function () {
          loadBoard();
@@ -1228,7 +1228,7 @@
         const ids = Array.from(selectedIds);
         setSelectedIds(new Set());
         return Promise.all(ids.map(function (id) {
-          return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+          return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(id)}`, board), { method: "DELETE" });
         })).then(function () {
           loadBoard();
         }).catch(function (e) { setError(String(e.message || e)); });

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -190,6 +190,23 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
 
 
+def test_dashboard_task_delete_preserves_selected_board():
+    """Single and bulk deletes must target the browser-selected board."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert (
+        "SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {"
+        in js
+    )
+    assert (
+        "SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(id)}`, board), { method: \"DELETE\" })"
+        in js
+    )
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The kanban dashboard already routes most task calls through `withBoard(...)`, but the confirm-dialog single delete and the bulk delete still hit `${API}/tasks/${id}` without the board. The UI can therefore render tasks from the board the user is looking at and then try to delete them from the CLI's unrelated active board, which surfaces as a misleading 404.

This wraps both remaining call sites, matching what the rest of the file already does.

Tested: `tests/plugins/test_kanban_dashboard_plugin.py` — 39 passed on current `main` (the patch adds a regression test pinning both call sites).