### PR TITLE
feat(cron): include copyable job and run ids in deliveries

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3116,9 +3116,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
+        execution_id = job.get("execution_id", "")
+        identifiers = f"job_id={job_id}"
+        if execution_id:
+            identifiers += f"\nrun_id={execution_id}"
         delivery_content = (
             f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
+            f"```text\n{identifiers}\n```\n"
             f"-------------\n\n"
             f"{content}\n\n"
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
@@ -7151,6 +7155,10 @@ def _run_one_job_body(
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+        # Keep the durable execution identifier attached to the in-memory job
+        # throughout output wrapping and delivery.  This lets every cron
+        # notification identify both the recurring job and this exact run.
+        job["execution_id"] = execution_id
     delivery_attempted = False
     delivery_error = None
     # Durable failure-incident bookkeeping for this run (see cron.incidents):

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -217,6 +217,13 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     import cron.scheduler as scheduler
 
     events = []
+    delivered_jobs = []
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda job_id, *, source: {"id": "exec-3", "job_id": job_id, "source": source},
+        raising=False,
+    )
     monkeypatch.setattr(
         scheduler,
         "mark_execution_running",
@@ -236,11 +243,16 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
         lambda job, *, defer_agent_teardown=None, **_kw: (True, "output", "response", None),
     )
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
-    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, *_args, **_kwargs: delivered_jobs.append(dict(job)),
+    )
     monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
 
-    assert scheduler.run_one_job({"id": "job-3", "execution_id": "exec-3"}) is True
+    assert scheduler.run_one_job({"id": "job-3"}) is True
     assert events[0] == ("running", "exec-3")
+    assert delivered_jobs[0]["execution_id"] == "exec-3"
     assert events[-1][0:2] == ("finish", "exec-3")
     assert events[-1][2]["success"] is True
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -367,6 +367,7 @@ class TestDeliverResultWrapping:
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
             job = {
                 "id": "test-job",
+                "execution_id": "test-run-123",
                 "name": "daily-report",
                 "deliver": "origin",
                 "origin": {"platform": "telegram", "chat_id": "123"},
@@ -376,7 +377,7 @@ class TestDeliverResultWrapping:
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
+        assert "```text\njob_id=test-job\nrun_id=test-run-123\n```" in sent_content
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content


### PR DESCRIPTION
A cron delivery currently carries `(job_id: ...)` as prose, and never the execution id. When a scheduled job misbehaves, the first thing you need is both identifiers in a form you can paste straight into `hermes cron` — on a phone, out of a Telegram message, without retyping.

This renders them in a fenced block:

```text
job_id=<id>
run_id=<execution id>
```

and attaches the execution id to the in-memory job so the run id survives output wrapping and delivery.

Tested: `tests/cron/test_execution_ledger.py` and `tests/cron/test_scheduler.py` — 122 passed on current `main`.