### PR TITLE
feat(gateway): make the local STT fallback configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -966,6 +966,7 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    stt_local_fallback: bool = True  # Whether cloud/plugin STT failures may fall back to local Whisper
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1210,6 +1211,13 @@ class GatewayConfig:
                 if isinstance(data.get("stt"), dict)
                 else None
             )
+        stt_local_fallback = data.get("stt_local_fallback")
+        if stt_local_fallback is None:
+            stt_local_fallback = (
+                data.get("stt", {}).get("local_fallback")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -1324,6 +1332,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            stt_local_fallback=_coerce_bool(stt_local_fallback, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25929,7 +25929,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = await asyncio.to_thread(
                     transcribe_audio, path, None, "gateway",
                 )
-                if not result.get("success"):
+                if (
+                    not result.get("success")
+                    and getattr(self.config, "stt_local_fallback", True)
+                ):
                     fallback = await asyncio.to_thread(
                         transcribe_audio_local_fallback,
                         path,

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -16,6 +16,29 @@ def test_gateway_config_stt_disabled_from_dict_nested():
     assert config.stt_enabled is False
 
 
+def test_gateway_config_stt_local_fallback_defaults_to_true():
+    assert GatewayConfig.from_dict({}).stt_local_fallback is True
+
+
+def test_gateway_config_stt_local_fallback_disabled_from_dict_nested():
+    config = GatewayConfig.from_dict({"stt": {"local_fallback": False}})
+    assert config.stt_local_fallback is False
+
+
+def test_load_gateway_config_bridges_stt_local_fallback_from_config_yaml(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"stt": {"local_fallback": False}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert load_gateway_config().stt_local_fallback is False
+
+
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()


### PR DESCRIPTION
When a cloud/plugin STT provider fails, the gateway always falls back to local Whisper. On a small VPS that fallback is the most expensive thing the process can do — a local Whisper run costs several GB of RAM — so a transient provider error can turn a voice note into a memory spike. With a cloud provider configured (Groq, in our case) the desired behaviour on failure is to fail, not to quietly spend the box.

This adds `stt.local_fallback` (also accepted as top-level `stt_local_fallback`), **defaulting to `true`, so current behaviour is unchanged**. Setting it to `false` skips `transcribe_audio_local_fallback`.

Tested: `tests/gateway/test_stt_config.py` — 7 passed on current `main`, including three new cases (default true, nested dict, and the `config.yaml` bridge). In production on a five-instance fleet.