### PR TITLE
fix(agent): route OpenCode aux clients by per-model API mode (#98799)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6487,6 +6487,33 @@ def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optio
         return model_name
 
 
+def _opencode_family_api_mode(provider: str, model: Optional[str]) -> Optional[str]:
+    """Per-model API mode for OpenCode Zen/Go family providers, or None.
+
+    OpenCode mixes API surfaces by model (``gpt-*``/``grok-*``/``muse-spark*``
+    → ``/v1/responses``, ``minimax-*``/``qwen*``/``claude-*`` →
+    ``/v1/messages``, the rest → ``/v1/chat/completions``). The provider
+    name alone — built-in ``opencode-go``/``opencode-zen`` or a custom
+    family entry like ``opencode-go-bridge`` (#85589) — says nothing about
+    the wire format, so auxiliary resolution must derive the transport from
+    the resolved model exactly like the main agent's runtime resolution
+    (``hermes_cli/runtime_provider.py``) does (#98799).
+    """
+    try:
+        from hermes_cli.models import (
+            opencode_model_api_mode,
+            opencode_provider_family,
+        )
+    except Exception:
+        return None
+    try:
+        if opencode_provider_family(provider) is None:
+            return None
+        return opencode_model_api_mode(provider, model) or None
+    except Exception:
+        return None
+
+
 def resolve_provider_client(
     provider: str,
     model: str = None,
@@ -6932,6 +6959,21 @@ def resolve_provider_client(
                     or "gpt-4o-mini",
                     provider,
                 )
+                # OpenCode family entries (opencode-go-bridge, #85589) serve
+                # mixed API surfaces per model — the entry's declared api_mode
+                # was persisted for whichever model was configured at save
+                # time and is stale for any other. Re-derive per model like
+                # the registry branch above (#98799).
+                _oc_entry_mode = _opencode_family_api_mode(provider, final_model)
+                if _oc_entry_mode and not api_mode:
+                    entry_api_mode = _oc_entry_mode
+                    try:
+                        from hermes_cli.models import normalize_opencode_base_url
+                        custom_base = normalize_opencode_base_url(
+                            provider, _oc_entry_mode, custom_base
+                        )
+                    except Exception:
+                        pass
                 # anthropic_messages talks to the /anthropic surface directly;
                 # OpenAI-wire paths (chat_completions / codex_responses) need the
                 # /v1 equivalent.  Rewrite only on the OpenAI-wire path so the
@@ -7119,6 +7161,21 @@ def resolve_provider_client(
         default_model = _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
 
+        # OpenCode Zen/Go mix API surfaces per model. Derive the transport
+        # from the resolved model (the same table the main agent's runtime
+        # resolution uses) so Responses-only models (gpt-5.6-luna, grok-4.5)
+        # get the Responses adapter and Anthropic-wire models (minimax, qwen)
+        # land on /v1/messages instead of every auxiliary call going to
+        # /chat/completions (#98799).
+        _oc_mode = _opencode_family_api_mode(provider, final_model)
+        if _oc_mode:
+            api_mode = _oc_mode
+            try:
+                from hermes_cli.models import normalize_opencode_base_url
+                base_url = normalize_opencode_base_url(provider, _oc_mode, base_url)
+            except Exception:
+                pass
+
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
@@ -7184,7 +7241,13 @@ def resolve_provider_client(
         # Anthropic-wire endpoints (Kimi Coding Plan api.kimi.com/coding,
         # /anthropic-suffixed gateways) so named providers like kimi-coding
         # land on the right transport without needing per-provider branches.
-        client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
+        # Pass the api-mode-normalized base URL only for OpenCode family
+        # providers (anthropic-wire models carry the /v1-stripped URL the
+        # Anthropic SDK expects, #98799). Every other provider keeps the raw
+        # registry URL — its /anthropic suffix is what the wrap heuristics
+        # key on (e.g. minimax).
+        _wrap_base = base_url if _oc_mode else raw_base_url
+        client = _wrap_if_needed(client, final_model, _wrap_base, api_key)
 
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/tests/agent/test_auxiliary_opencode_routing.py
+++ b/tests/agent/test_auxiliary_opencode_routing.py
@@ -1,0 +1,214 @@
+"""OpenCode Go/Zen auxiliary clients must honor per-model API routing (#98799).
+
+``resolve_provider_client()`` builds auxiliary clients (compression, title
+generation, vision, embeddings, session search) through its API-key
+registry branch. OpenCode Go and Zen mix API surfaces per model —
+``gpt-5.6-luna``/``grok-*``/``muse-spark*`` are served via ``/v1/responses``,
+``minimax-*``/``qwen*``/``claude-*`` via ``/v1/messages``, everything else
+via ``/v1/chat/completions`` — but the registry branch never consulted
+``opencode_model_api_mode()``, so every auxiliary request went to
+``/chat/completions`` and Responses-only models failed with HTTP 500
+(#98799). The main-agent path (``hermes_cli/runtime_provider.py``)
+re-derives the mode per model; auxiliary must match.
+
+These tests drive the real ``resolve_provider_client`` with a real
+``OPENCODE_GO_API_KEY`` env credential and mock only the OpenAI SDK
+constructor, so the full production resolution path (registry lookup,
+credential resolution, base-URL handling, wrap decision) runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.auxiliary_client import (
+    AnthropicAuxiliaryClient,
+    CodexAuxiliaryClient,
+    resolve_provider_client,
+)
+
+GO_BASE = "https://opencode.ai/zen/go/v1"
+ZEN_BASE = "https://opencode.ai/zen/v1"
+
+
+@pytest.fixture(autouse=True)
+def _opencode_env(monkeypatch, tmp_path):
+    """Isolate credential env and give opencode-go a key so the registry
+    branch is reachable without touching the real environment."""
+    for key in (
+        "OPENCODE_GO_API_KEY", "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_BASE_URL", "OPENCODE_ZEN_BASE_URL",
+        "OPENAI_API_KEY", "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "go-test-key")
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "zen-test-key")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def _fake_openai_factory():
+    """Mock the OpenAI SDK constructor; capture base_url per constructed client."""
+    constructed = []
+
+    def _factory(**kwargs):
+        client = MagicMock()
+        client.api_key = kwargs.get("api_key", "")
+        client.base_url = kwargs.get("base_url", "")
+        client._construction_kwargs = kwargs
+        constructed.append(client)
+        return client
+
+    return _factory, constructed
+
+
+class TestOpenCodeGoResponsesModels:
+    """Layer 1: Responses-only models on Go must get CodexAuxiliaryClient."""
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-luna", "grok-4.5", "muse-spark"])
+    def test_go_responses_model_wraps_codex(self, model):
+        factory, constructed = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-go", model)
+        assert resolved == model, "model must pass through unchanged"
+        assert isinstance(client, CodexAuxiliaryClient), (
+            f"{model} on Go is Responses-only; plain chat.completions 500s (#98799)"
+        )
+        # Underlying OpenAI client keeps the /v1 base (SDK appends /responses).
+        assert str(client.base_url).rstrip("/") == GO_BASE
+
+    def test_go_responses_model_async_mode(self):
+        """async consumers (web_extract, session_search) get the async codex wrapper."""
+        from agent.auxiliary_client import AsyncCodexAuxiliaryClient
+
+        factory, _ = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client(
+                "opencode-go", "gpt-5.6-luna", async_mode=True
+            )
+        assert isinstance(client, AsyncCodexAuxiliaryClient)
+
+
+class TestOpenCodeGoAnthropicModels:
+    """Layer 2: anthropic_messages models on Go must get AnthropicAuxiliaryClient."""
+
+    @pytest.mark.parametrize("model", ["minimax-m2.7", "qwen3.7-max"])
+    def test_go_anthropic_model_wraps_anthropic(self, model):
+        factory, _ = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-go", model)
+        assert resolved == model
+        assert isinstance(client, AnthropicAuxiliaryClient), (
+            f"{model} on Go is Anthropic-wire; chat.completions 404s (#98799)"
+        )
+        # Anthropic SDK appends /v1/messages itself — base must be /v1-stripped.
+        assert str(client.base_url).rstrip("/") == "https://opencode.ai/zen/go"
+
+
+class TestOpenCodeGoChatCompletionsModels:
+    """Layer 3: chat_completions models on Go stay plain — no regression."""
+
+    @pytest.mark.parametrize("model", ["glm-5", "kimi-k2.5", "deepseek-v4-flash"])
+    def test_go_chat_model_stays_plain(self, model):
+        factory, constructed = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-go", model)
+        assert resolved == model
+        assert not isinstance(client, (CodexAuxiliaryClient, AnthropicAuxiliaryClient)), (
+            f"{model} on Go is chat_completions; wrapping would break it"
+        )
+        assert constructed, "underlying OpenAI client must be constructed"
+        assert constructed[0].base_url.rstrip("/") == GO_BASE
+
+
+class TestOpenCodeZenParity:
+    """Layer 4: opencode-zen (and zen-hosted opencode-free) get the same routing."""
+
+    @pytest.mark.parametrize("model,wrapper", [
+        ("claude-sonnet-4-6", AnthropicAuxiliaryClient),
+        ("gpt-5.2", CodexAuxiliaryClient),
+    ])
+    def test_zen_models_routed_per_model(self, model, wrapper):
+        factory, _ = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-zen", model)
+        assert resolved == model
+        assert isinstance(client, wrapper), (
+            f"{model} on Zen must resolve to {wrapper.__name__}"
+        )
+
+
+class TestOpenCodeCustomFamilyProvider:
+    """Layer 5: custom providers extending a family slug (opencode-go-bridge,
+    #85589) must re-derive api_mode per model, not trust the entry's stale
+    declared api_mode."""
+
+    def test_custom_family_entry_derives_mode_from_model(self, monkeypatch):
+        factory, _ = _fake_openai_factory()
+        entry = {
+            "name": "opencode-go-bridge",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "bridge-key",
+            "api_mode": "chat_completions",  # stale: persisted for glm-5
+            "model": "gpt-5.6-luna",  # target model needs Responses
+        }
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda name: dict(entry) if name == "opencode-go-branch" or name == entry["name"] else None,
+        )
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-go-bridge", "gpt-5.6-luna")
+        assert resolved == "gpt-5.6-luna"
+        assert isinstance(client, CodexAuxiliaryClient), (
+            "custom family provider must re-derive api_mode per model (#98799, #85589)"
+        )
+
+
+class TestOpenCodeBaseUrlOverrides:
+    """Layer 6: base-URL env overrides must not be mangled by /v1 handling."""
+
+    def test_go_env_base_url_override_untouched(self, monkeypatch):
+        """A custom proxy override keeps its URL exactly (no opencode.ai
+        /v1 re-suffix) while still wrapping for Responses models."""
+        monkeypatch.setenv("OPENCODE_GO_BASE_URL", "https://proxy.example/go")
+        factory, constructed = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("opencode-go", "gpt-5.6-luna")
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert constructed[0].base_url.rstrip("/") == "https://proxy.example/go"
+
+
+class TestOpenCodeAuxRoutingIntegration:
+    """End-to-end through the task-level resolver — the exact repro from the
+    issue: auxiliary.compression.provider=opencode-go + gpt-5.6-luna."""
+
+    def test_compression_task_resolution_routes_responses(self):
+        factory, _ = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client(
+                "opencode-go", "gpt-5.6-luna", task="compression"
+            )
+        assert resolved == "gpt-5.6-luna"
+        assert isinstance(client, CodexAuxiliaryClient)
+
+
+class TestOpenCodeNoRegressionOtherProviders:
+    """Guard: non-OpenCode registry providers keep their existing behavior."""
+
+    def test_zai_unchanged_by_opencode_fix(self, monkeypatch):
+        monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+        factory, constructed = _fake_openai_factory()
+        with patch("agent.auxiliary_client.OpenAI", side_effect=factory), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, resolved = resolve_provider_client("zai", "glm-4.5-flash")
+        assert resolved == "glm-4.5-flash"
+        assert not isinstance(client, (CodexAuxiliaryClient, AnthropicAuxiliaryClient))


### PR DESCRIPTION
## What

`resolve_provider_client()` in `agent/auxiliary_client.py` never applied Hermes' own `opencode_model_api_mode()` per-model routing table when building auxiliary clients. OpenCode Go/Zen mix API surfaces per model — `gpt-5.6-luna`/`grok-*`/`muse-spark*` are served via `/v1/responses`, `minimax-*`/`qwen*`/`claude-*` via `/v1/messages`, everything else via `/v1/chat/completions` — so auxiliary tasks on OpenCode Go/Zen always built a plain Chat Completions client, and Responses-only models failed with HTTP 500 (the exact repro in #98799: `auxiliary.compression.provider: opencode-go` + `gpt-5.6-luna`).

The main-conversation path already re-derives api_mode per model (`hermes_cli/runtime_provider.py`); this PR brings the auxiliary path to parity.

## How

- New helper `_opencode_family_api_mode(provider, model)` derives the transport for any OpenCode-family provider (built-in `opencode-go`/`opencode-zen`/`opencode-free` and custom family entries like `opencode-bridge` per #85589) by reusing `hermes_cli.models.opencode_model_api_mode` + `opencode_provider_family` — the same single-owner table the main runtime uses, not a re-implementation.
- **Registry branch**: after `final_model` is resolved, derive `api_mode` per model and normalize the base URL symmetrically via `normalize_opencode_base_url` (Anthropic-wire models get the `/v1`-stripped URL the Anthropic SDK expects; previously-stripped URLs self-heal `/v1` on OpenAI-wire modes).
- **Named-custom branch** (custom family entries, #85589): the entry's declared `api_mode` is stale for any model other than the one configured at save time — re-derive per model (explicit task-level `api_mode` overrides still win).
- `_wrap_base` passes the api-mode-normalized URL to the wrap heuristics only for OpenCode-family providers; every other provider keeps the raw registry URL (its `/anthropic` suffix is what the wrap heuristics key on, e.g. minimax).

## Verification

- **RED on upstream/main @ 4f22543509**: 11 failed / 4 passed — `gpt-5.6-luna`/`grok-4.5`/`muse-spark` on Go resolved to plain chat.completions (the #98799 500s); `minimax-m2.7`/`qwen3.7-max` missing Anthropic wrap (404s); custom family entry `opencode-go-bridge` trusted stale `api_mode`; zen parity cases missing.
- **GREEN after fix**: 15/15 new production-path tests in `tests/agent/test_auxiliary_opencode_routing.py` (real `resolve_provider_client` driven end-to-end, only the OpenAI SDK constructor mocked; covers all 6 issue layers incl. async mode, env base-URL override untouched, non-OpenCode regression guard).
- **Nearby suites**: 229/229 passed across the aux sibling suites (`test_auxiliary_named_custom_providers.py`, `test_auxiliary_transport_autodetect.py`, `test_minimax_auxiliary_url.py`, `test_auxiliary_client.py` and 4 more). Two `test_auxiliary_main_first.py` vision-custom tests fail identically when co-run with `test_auxiliary_client.py` on **pristine upstream/main** (inter-file state contamination, pre-existing — verified in a fresh worktree, not caused by this change).
- `git rev-list --left-right --count upstream/main...HEAD` = `0 1`; `git diff --check` clean; no new dependencies.

## Competitor analysis

No open PR addresses #98799 (issue-number + keyword + topic-overlap + same-author searches at review time and publish time — all empty). A claim comment by @kokhlo exists on the issue (Aug 30 19:58Z) but no PR has materialized; crediting the claim here.

Fixes #98799

Auto-published by Moonsong via Path B automated pipeline.