### PR TITLE
fix(checkpoints): snapshot V4A patch targets

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -35,6 +35,7 @@ from agent.display import (
 from agent.message_sanitization import coalesce_tool_call_id
 from agent.tool_dispatch_helpers import (
     _NEVER_PARALLEL_TOOLS,
+    _extract_file_mutation_targets,
     _is_destructive_command,
     _is_multimodal_tool_result,
     _multimodal_text_summary,
@@ -86,8 +87,8 @@ def _ensure_file_checkpoint(
     effective_task_id: str,
 ) -> None:
     """Checkpoint the same workspace path that the file tool will mutate."""
-    file_path = function_args.get("path", "")
-    if not file_path:
+    file_paths = _extract_file_mutation_targets(function_name, function_args)
+    if not file_paths:
         return
 
     # File tools resolve relative paths against the task's live/session cwd,
@@ -96,9 +97,17 @@ def _ensure_file_checkpoint(
     # discover the project root.
     from tools.file_tools import _resolve_path_for_task
 
-    resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
-    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
-    agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+    checkpointed_work_dirs = set()
+    for file_path in file_paths:
+        resolved_path = _resolve_path_for_task(
+            file_path,
+            effective_task_id or "default",
+        )
+        work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
+        if work_dir in checkpointed_work_dirs:
+            continue
+        agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+        checkpointed_work_dirs.add(work_dir)
 
 
 def _budget_for_agent(agent) -> BudgetConfig:

--- a/tests/agent/test_tool_executor_checkpoint_paths.py
+++ b/tests/agent/test_tool_executor_checkpoint_paths.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 from agent.tool_executor import _ensure_file_checkpoint
-from tools.checkpoint_manager import CheckpointManager
+from tools.checkpoint_manager import CheckpointManager, _run_git, _store_path
 
 
 def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
@@ -38,3 +38,108 @@ def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
 
     assert manager.list_checkpoints(str(workspace_cwd))
     assert manager.list_checkpoints(str(process_cwd)) == []
+
+
+def test_v4a_patch_checkpoint_preserves_pre_edit_content(tmp_path, monkeypatch):
+    workspace_cwd = tmp_path / "workspace"
+    workspace_cwd.mkdir()
+    baseline = workspace_cwd / "baseline.py"
+    baseline.write_text("VALUE = 1\n")
+    sibling = workspace_cwd / "sibling.py"
+    sibling.write_text("SIBLING = 1\n")
+    checkpoint_base = tmp_path / "checkpoints"
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace_cwd))
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        checkpoint_base,
+    )
+
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+    _ensure_file_checkpoint(
+        agent,
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                "*** Update File: baseline.py\n"
+                "@@\n"
+                "-VALUE = 1\n"
+                "+VALUE = 2\n"
+                "*** Update File: sibling.py\n"
+                "@@\n"
+                "-SIBLING = 1\n"
+                "+SIBLING = 2\n"
+                "*** End Patch\n"
+            ),
+        },
+        "session",
+    )
+
+    checkpoints = manager.list_checkpoints(str(workspace_cwd))
+    assert len(checkpoints) == 1
+    assert checkpoints[0]["reason"] == "before patch"
+
+    baseline.write_text("VALUE = 2\n")
+    ok, content, error = _run_git(
+        ["show", f"{checkpoints[0]['hash']}:baseline.py"],
+        _store_path(checkpoint_base),
+        str(workspace_cwd),
+    )
+    assert ok, error
+    assert content == "VALUE = 1"
+
+    ok, content, error = _run_git(
+        ["show", f"{checkpoints[0]['hash']}:sibling.py"],
+        _store_path(checkpoint_base),
+        str(workspace_cwd),
+    )
+    assert ok, error
+    assert content == "SIBLING = 1"
+
+
+def test_v4a_patch_checkpoints_each_target_workspace(tmp_path, monkeypatch):
+    left_workspace = tmp_path / "left"
+    right_workspace = tmp_path / "right"
+    for workspace, value in ((left_workspace, 1), (right_workspace, 2)):
+        workspace.mkdir()
+        (workspace / "pyproject.toml").write_text("[project]\n")
+        (workspace / "baseline.py").write_text(f"VALUE = {value}\n")
+    checkpoint_base = tmp_path / "checkpoints"
+
+    monkeypatch.setenv("TERMINAL_CWD", str(left_workspace))
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        checkpoint_base,
+    )
+
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+    _ensure_file_checkpoint(
+        agent,
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Update File: {left_workspace / 'baseline.py'}\n"
+                f"*** Update File: {right_workspace / 'baseline.py'}\n"
+                "*** End Patch\n"
+            ),
+        },
+        "session",
+    )
+
+    for workspace, value in ((left_workspace, 1), (right_workspace, 2)):
+        checkpoints = manager.list_checkpoints(str(workspace))
+        assert len(checkpoints) == 1
+        assert checkpoints[0]["reason"] == "before patch"
+        ok, content, error = _run_git(
+            ["show", f"{checkpoints[0]['hash']}:baseline.py"],
+            _store_path(checkpoint_base),
+            str(workspace),
+        )
+        assert ok, error
+        assert content == f"VALUE = {value}"


### PR DESCRIPTION
## What does this PR do?

Creates checkpoints for V4A `patch` mode before any target file is mutated. V4A calls carry paths inside the patch payload rather than a top-level `path`, so the previous interceptor returned without snapshotting.

The fix reuses the existing file-mutation target extractor, resolves each target through the same task-aware path pipeline as the file tool, and checkpoints each distinct workspace once.

## Related Issue

Fixes #98907

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/tool_executor.py` to checkpoint all V4A patch targets, deduplicated by resolved workspace.
- Add real checkpoint-store tests proving pre-edit content is recoverable for multiple files in one workspace and for targets across separate workspaces.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_tool_executor_checkpoint_paths.py tests/agent/test_tool_dispatch_helpers.py tests/run_agent/test_file_mutation_verifier.py`.
2. Confirm all 63 tests pass.
3. Temporarily restore the old top-level `path` lookup and confirm `test_v4a_patch_checkpoint_preserves_pre_edit_content` fails with zero checkpoints.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. The canonical full runner completed but the local dev-only environment reported 225 unrelated failures across optional integrations and platform-dependent tests; the affected canonical subset passes 63/63.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] Config example update: N/A
- [x] Contribution/architecture docs update: N/A
- [x] Cross-platform impact considered; paths continue through the existing task-aware and canonical checkpoint path resolvers.
- [x] Tool schema update: N/A

## Verification

- RED: new recoverability test failed against the pre-fix implementation (`0` checkpoints observed).
- GREEN: canonical affected suite: `63 passed, 0 failed`.
- Ruff: passed for both changed files.
- `git diff --check`: passed.
- Independent Claude Max review: APPROVE after multi-file same-workspace and cross-workspace coverage was added.
