### PR TITLE
fix(cli): surface real errors when memory provider discovery fails

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -7,6 +7,7 @@ the provider's config schema. Writes config to config.yaml + .env.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import sys
@@ -14,6 +15,8 @@ import shlex
 
 from hermes_constants import get_hermes_home
 from hermes_cli.secret_prompt import masked_secret_prompt
+
+logger = logging.getLogger(__name__)
 
 _CANCELLED = -1
 
@@ -206,19 +209,37 @@ def _get_available_providers() -> list:
 
     Returns list of (name, description, provider_instance) tuples.
     """
-    try:
-        from plugins.memory import discover_memory_providers, load_memory_provider
-        raw = discover_memory_providers()
-    except Exception:
-        raw = []
+    providers, _ = _scan_providers()
+    return providers
+
+
+def _scan_providers() -> tuple[list, list[str]]:
+    """Discover providers, keeping failures visible instead of masking them.
+
+    Returns ``(providers, skipped)``: the loadable ``(name, setup_hint,
+    provider)`` tuples plus one human-readable reason per discovered
+    provider that was dropped. A discovery crash (broken import of
+    ``plugins.memory`` itself, missing bridge dependency) is re-raised
+    after being logged — the wizard used to flatten it into "no plugins
+    detected", sending users to reinstall plugins that were already
+    installed and working.
+    """
+    from plugins.memory import discover_memory_providers, load_memory_provider
+
+    raw = discover_memory_providers()
 
     results = []
+    skipped: list[str] = []
     for name, desc, available in raw:
         try:
             provider = load_memory_provider(name)
             if not provider:
+                skipped.append(f"{name}: provider module did not expose an instance")
                 continue
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to load memory provider '%s': %s", name, exc)
+            logger.debug("Provider load traceback", exc_info=True)
+            skipped.append(f"{name}: {exc}")
             continue
 
         schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
@@ -234,7 +255,7 @@ def _get_available_providers() -> list:
             setup_hint = "local"
 
         results.append((name, setup_hint, provider))
-    return results
+    return results, skipped
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +266,14 @@ def cmd_setup_provider(provider_name: str) -> None:
     """Run memory setup for a specific provider, skipping the picker."""
     from hermes_cli.config import load_config, save_config
 
-    providers = _get_available_providers()
+    try:
+        providers, skipped = _scan_providers()
+    except Exception as exc:
+        print("\n  Failed to discover memory provider plugins:")
+        print(f"    {exc}")
+        print("\n  Fix the error above before running setup again.\n")
+        return
+
     match = None
     for name, desc, provider in providers:
         if name == provider_name:
@@ -254,7 +282,12 @@ def cmd_setup_provider(provider_name: str) -> None:
 
     if not match:
         print(f"\n  Memory provider '{provider_name}' not found.")
-        print("  Run 'hermes memory setup' to see available providers.\n")
+        if skipped:
+            print(f"  {len(skipped)} installed provider(s) could not be loaded:")
+            for reason in skipped:
+                print(f"    - {reason}")
+        else:
+            print("  Run 'hermes memory setup' to see available providers.\n")
         return
 
     name, _, provider = match
@@ -283,12 +316,30 @@ def cmd_setup(args) -> None:
     """Interactive memory provider setup wizard."""
     from hermes_cli.config import load_config, save_config
 
-    providers = _get_available_providers()
+    try:
+        providers, skipped = _scan_providers()
+    except Exception as exc:
+        print("\n  Failed to discover memory provider plugins:")
+        print(f"    {exc}")
+        print("\n  Fix the error above before running setup again.\n")
+        return
 
     if not providers:
-        print("\n  No memory provider plugins detected.")
-        print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
+        if skipped:
+            print("\n  No memory provider plugins could be loaded.")
+            print("  The following installed plugins failed:")
+            for reason in skipped:
+                print(f"    - {reason}")
+            print()
+        else:
+            print("\n  No memory provider plugins detected.")
+            print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
         return
+
+    if skipped:
+        print(f"\n  ⚠ {len(skipped)} installed provider(s) could not be loaded:")
+        for reason in skipped:
+            print(f"    - {reason}")
 
     # Build picker items
     items = []

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,35 +1,42 @@
+"""Tests for `hermes memory setup` provider discovery failure reporting.
+
+`_scan_providers` used to collapse every failure into an empty list, so a
+broken `plugins.memory` import or a provider whose load raised was reported
+as "No memory provider plugins detected" — advising a reinstall of plugins
+that were already installed and discovered. These tests pin the three
+outcomes the wizard must distinguish: discovery crashed, providers dropped
+at load, and genuinely nothing installed.
+"""
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 import hermes_cli.memory_setup as memory_setup
 from hermes_cli.memory_setup import _CANCELLED, _curses_select
 
 
+class FakeProvider:
+    def __init__(self):
+        self.save_config = MagicMock()
 
-
-
-
+    def get_config_schema(self):
+        return [{
+            "key": "mode",
+            "description": "Mode",
+            "default": "one",
+            "choices": ["one", "two"],
+        }]
 
 
 def test_cmd_setup_generic_choice_cancel_writes_nothing(tmp_path, monkeypatch):
-    class ChoiceProvider:
-        def __init__(self):
-            self.save_config = MagicMock()
-
-        def get_config_schema(self):
-            return [{
-                "key": "mode",
-                "description": "Mode",
-                "default": "one",
-                "choices": ["one", "two"],
-            }]
-
-    provider = ChoiceProvider()
+    provider = FakeProvider()
     selections = iter([0, _CANCELLED])
     save_config = MagicMock()
     install_dependencies = MagicMock()
 
-    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [("fake", "local", provider)])
+    monkeypatch.setattr(memory_setup, "_scan_providers", lambda: ([("fake", "local", provider)], []))
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(selections))
     monkeypatch.setattr(memory_setup, "_install_dependencies", install_dependencies)
     monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: tmp_path)
@@ -44,20 +51,142 @@ def test_cmd_setup_generic_choice_cancel_writes_nothing(tmp_path, monkeypatch):
     assert not (tmp_path / ".env").exists()
 
 
-# _write_env_vars's CR/LF-stripping, denylist, and plain-value-roundtrip
-# behavior is covered by tests/hermes_cli/test_memory_setup_env_denylist.py,
-# which exercises the current save_env_value-routed signature
-# (env_writes, hermes_home=None) \u2014 these three tests pinned the prior direct
-# Path.write_text(env_path, env_writes) signature/implementation and were
-# removed along with it (#60587).
+# ---------------------------------------------------------------------------
+# Discovery failure reporting
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_setup_reports_discovery_crash_instead_of_empty(capsys, monkeypatch):
+    """A plugins.memory import failure must surface the real error, not the
+    install-a-plugin advice — the plugins are installed and discovered."""
+    def boom():
+        raise ModuleNotFoundError("No module named 'yaml'")
+
+    monkeypatch.setattr(memory_setup, "_scan_providers", boom)
+
+    memory_setup.cmd_setup(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Failed to discover memory provider plugins" in out
+    assert "No module named 'yaml'" in out
+    assert "Install a plugin" not in out
+
+
+def test_cmd_setup_reports_dropped_providers_when_none_load(capsys, monkeypatch):
+    """Every discovered provider failing to load is a broken-install report
+    naming each failure, not "no plugins detected"."""
+    monkeypatch.setattr(
+        memory_setup,
+        "_scan_providers",
+        lambda: ([], ["mem0: cannot import name 'X'", "honcho: boom"]),
+    )
+
+    memory_setup.cmd_setup(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "No memory provider plugins could be loaded" in out
+    assert "mem0: cannot import name 'X'" in out
+    assert "honcho: boom" in out
+    assert "Install a plugin" not in out
+
+
+def test_cmd_setup_lists_skipped_providers_alongside_picker(capsys, monkeypatch):
+    """A partial failure must not hide the dropped provider from the user
+    even when others load fine."""
+    provider = FakeProvider()
+    monkeypatch.setattr(memory_setup, "_scan_providers", lambda: ([("fake", "local", provider)], ["mem0: boom"]))
+    monkeypatch.setattr(memory_setup, "_curses_select", lambda *a, **k: _CANCELLED)
+
+    memory_setup.cmd_setup(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "1 installed provider(s) could not be loaded" in out
+    assert "mem0: boom" in out
+    assert "Cancelled" in out
+
+
+def test_cmd_setup_provider_reports_discovery_crash(capsys, monkeypatch):
+    """`hermes memory setup <name>` hits the same wall and must not claim
+    the provider is merely not found."""
+    def boom():
+        raise ImportError("cannot import name 'X' from 'some.dep'")
+
+    monkeypatch.setattr(memory_setup, "_scan_providers", boom)
+
+    memory_setup.cmd_setup_provider("mem0")
+
+    out = capsys.readouterr().out
+    assert "Failed to discover memory provider plugins" in out
+    assert "cannot import name 'X'" in out
+    assert "not found" not in out
+
+
+def test_cmd_setup_provider_names_dropped_provider(capsys, monkeypatch):
+    """When the requested provider was discovered but its load failed, the
+    not-found message must point at the load failure, not at the picker."""
+    monkeypatch.setattr(
+        memory_setup,
+        "_scan_providers",
+        lambda: ([("other", "local", FakeProvider())], ["mem0: cannot import name 'X'"]),
+    )
+
+    memory_setup.cmd_setup_provider("mem0")
+
+    out = capsys.readouterr().out
+    assert "Memory provider 'mem0' not found" in out
+    assert "could not be loaded" in out
+    assert "mem0: cannot import name 'X'" in out
+
+
+def test_scan_providers_collects_load_failure_reasons(monkeypatch):
+    """The scan itself records why each provider was dropped and keeps going."""
+    import plugins.memory as pm
+
+    good = FakeProvider()
+
+    def fake_load(name):
+        if name == "broken":
+            raise ImportError("cannot import name 'X' from 'some.dep'")
+        if name == "empty":
+            return None
+        return good
+
+    monkeypatch.setattr(pm, "discover_memory_providers", lambda: [
+        ("good", "a good provider", True),
+        ("broken", "raises on load", True),
+        ("empty", "module exposes no instance", True),
+    ], raising=False)
+    monkeypatch.setattr(pm, "load_memory_provider", fake_load, raising=False)
+
+    providers, skipped = memory_setup._scan_providers()
+
+    assert [name for name, _, _ in providers] == ["good"]
+    assert skipped == [
+        "broken: cannot import name 'X' from 'some.dep'",
+        "empty: provider module did not expose an instance",
+    ]
+
+
+def test_scan_providers_propagates_discovery_crash(monkeypatch):
+    """An import failure of plugins.memory itself must propagate so callers
+    can report it — it is not "no plugins detected"."""
+    import builtins
+    real_import = builtins.__import__
+
+    def broken_import(name, *args, **kwargs):
+        if name == "plugins.memory":
+            raise ModuleNotFoundError("No module named 'yaml'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_import)
+
+    with pytest.raises(ModuleNotFoundError):
+        memory_setup._scan_providers()
 
 
 # ---------------------------------------------------------------------------
 # _provider_pip_dependencies — mode-aware dep expansion (#70636)
 # ---------------------------------------------------------------------------
-
-
-
 
 
 def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeypatch):
@@ -121,3 +250,4 @@ def test_cmd_status_memory_tool_gate_enabled(capsys, monkeypatch):
     assert "Memory tool:        enabled ✓" in captured
     assert "Memory injection:   enabled ✓" in captured
     assert "User profile:       disabled ✗" in captured
+


### PR DESCRIPTION
### Summary

`hermes memory setup` reported **"No memory provider plugins detected. Install a plugin to ~/.hermes/plugins/ and try again."** whenever provider *discovery failed* — a broken `plugins.memory` import (e.g. `ModuleNotFoundError: No module named 'yaml'`), a missing bridge dependency — because `_get_available_providers()` collapsed every exception into an empty list. The message steers users to reinstall plugins that are already installed and discovered; the real exception was never logged, printed, or re-raised. `hermes memory setup <provider>` hits the same wall and surfaces a third misleading message ("provider not found").

Fixes #98920

### Changes

- New `_scan_providers()` returns `(providers, skipped)` instead of flattening failures away: discovery crashes propagate to the caller, and each provider that fails to load is recorded as `"<name>: <reason>"` (logged via `logger.warning`, traceback at debug).
- `cmd_setup` distinguishes three outcomes: discovery crashed → prints the actual exception and advises fixing it; all providers dropped → lists each failure ("No memory provider plugins could be loaded"); genuinely nothing installed → keeps the old install-a-plugin advice. A partial failure prints a `⚠ N installed provider(s) could not be loaded` block before the picker.
- `cmd_setup_provider` reports discovery crashes and names dropped providers in the not-found message.
- `_get_available_providers()` is retained (single tuple) for `cmd_status`, whose existing tests pin that contract.

### Testing

- `tests/hermes_cli/test_memory_setup.py`: 6 new tests pin the three outcomes in both the wizard and the provider-arg path, plus `_scan_providers` reason collection and crash propagation.
- Full local run: **39 passed** across `test_memory_setup.py`, `test_memory_setup_provider_arg.py`, `test_memory_setup_env_denylist.py`, `test_memory_status.py`, `test_memory_status_env_hint.py`.
- RED check: the 6 new tests fail against unpatched `main` (8 failed / 3 passed), pass with this change (11/11).