### PR TITLE
docs(config): show ignored Telegram threads example

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1216,6 +1216,7 @@ platform_toolsets:
 #     # Default false; ordinary messages, replies, and regex wake words stay blocked.
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
+#     # ignored_threads: [31, "42"]  # Telegram forum topics where the bot never responds
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in


### PR DESCRIPTION
## Summary

- Add a commented `telegram.ignored_threads` example to `cli-config.yaml.example`.
- Show both numeric and quoted Telegram forum topic IDs alongside the existing group-gating settings.

This makes the recently documented setting discoverable from the bundled configuration example.

## Tests

- `git diff --check`
- Comment-only YAML example change; no parsed YAML nodes changed.
