### PR TITLE
feat(review): add strict automatic checkpoint runner

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2002,6 +2002,13 @@ def run_conversation(
     # turn's flush must not be reported against this turn.
     agent._compression_adoption_failed = False
 
+    # An enabled review runtime owns final-surface delivery for this turn.
+    # Streaming deltas are buffered until the matching checkpoint passes;
+    # disabled or absent runtimes preserve the ordinary byte path.
+    from agent.review_checkpoints import configure_review_output_hold
+
+    configure_review_output_hold(agent)
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -2014,6 +2021,8 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    _review_plan_attempt = 0
+    _review_final_attempt = 0
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
     # overflow/413 retry handlers, and the post-tool compaction gate. The
@@ -7578,6 +7587,113 @@ def run_conversation(
                     failed = True
                     break
 
+                # Review the persisted action bundle before any handler can
+                # run. A REVISE result is represented as ordinary tool
+                # results, one per call, so strict assistant(tool_calls) →
+                # tool alternation remains valid without a synthetic user
+                # message or an executed side effect.
+                from agent.review_checkpoints import (
+                    discard_review_output,
+                    release_review_output,
+                    review_tool_checkpoint,
+                )
+
+                _review_decision = review_tool_checkpoint(
+                    agent,
+                    turn_id=turn_id,
+                    attempt=_review_plan_attempt,
+                    user_message=original_user_message or user_message,
+                    assistant_content=turn_content,
+                    tool_calls=list(assistant_message.tool_calls or []),
+                )
+                _review_action = _review_decision.action
+                _review_summary = (
+                    (_review_decision.result.summary if _review_decision.result else "")
+                    or _review_decision.reason
+                    or "No reviewer explanation was available."
+                )
+
+                if _review_action == "continue":
+                    if not release_review_output(agent):
+                        _review_action = "block"
+                        _review_summary = (
+                            "The held candidate exceeded the safe output buffer."
+                        )
+                    elif _review_decision.reason:
+                        agent._emit_status(
+                            "⚠️ Review unavailable; continuing under the configured "
+                            f"failure policy ({_review_decision.reason})"
+                        )
+
+                if _review_action != "continue":
+                    discard_review_output(agent)
+                    if _review_action == "revise":
+                        _review_tool_text = (
+                            "Review checkpoint requested a revised plan before "
+                            f"execution. No tool ran. {_review_summary}"
+                        )
+                    elif _review_action == "ask_user":
+                        _review_tool_text = (
+                            "Review checkpoint needs the user's decision before "
+                            f"execution. No tool ran. {_review_summary}"
+                        )
+                    elif _review_action == "cancelled":
+                        _review_tool_text = (
+                            "Review checkpoint was cancelled before execution. "
+                            f"No tool ran. {_review_summary}"
+                        )
+                    else:
+                        _review_tool_text = (
+                            "Review checkpoint blocked this planned action before "
+                            f"execution. No tool ran. {_review_summary}"
+                        )
+
+                    for _review_tc in assistant_message.tool_calls or []:
+                        append_message(messages, {
+                            "role": "tool",
+                            "name": _review_tc.function.name,
+                            "tool_call_id": coalesce_tool_call_id(_review_tc),
+                            "content": _review_tool_text,
+                        })
+                    agent._session_messages = messages
+                    try:
+                        agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception:
+                        logger.warning(
+                            "review checkpoint closure flush failed (session=%s)",
+                            getattr(agent, "session_id", None) or "none",
+                            exc_info=True,
+                        )
+
+                    if _review_action == "revise":
+                        _review_plan_attempt += 1
+                        final_response = None
+                        agent._emit_status(
+                            "↻ Reviewer requested a revised plan; no tool ran"
+                        )
+                        continue
+
+                    if _review_action == "ask_user":
+                        final_response = (
+                            "Review checkpoint needs your decision before the "
+                            f"planned action can run. {_review_summary}"
+                        )
+                    elif _review_action == "cancelled":
+                        final_response = (
+                            "Review checkpoint was cancelled before the planned "
+                            f"action could run. {_review_summary}"
+                        )
+                    else:
+                        final_response = (
+                            "Review checkpoint blocked the planned action before "
+                            f"any tool ran. {_review_summary}"
+                        )
+                    _turn_exit_reason = f"review_plan_{_review_action}"
+                    failed = True
+                    break
+
                 # A UI must never observe an assistant/tool-call row that is
                 # still only an ephemeral in-memory projection. Emit interim
                 # commentary only after the canonical SessionDB append above.
@@ -8550,6 +8666,69 @@ def run_conversation(
                     )
                     final_response = None
                     continue
+
+                # All ordinary completion/verification gates have accepted the
+                # candidate. Review it once more before any final surface or
+                # durable assistant row receives it. Automatic final-answer
+                # rewriting would require a synthetic conversation turn, so a
+                # REVISE verdict is surfaced as a controlled stop instead.
+                from agent.review_checkpoints import (
+                    discard_review_output,
+                    release_review_output,
+                    review_final_checkpoint,
+                )
+
+                _review_decision = review_final_checkpoint(
+                    agent,
+                    turn_id=turn_id,
+                    attempt=_review_final_attempt,
+                    user_message=original_user_message or user_message,
+                    final_response=final_response,
+                )
+                _review_action = _review_decision.action
+                _review_summary = (
+                    (_review_decision.result.summary if _review_decision.result else "")
+                    or _review_decision.reason
+                    or "No reviewer explanation was available."
+                )
+                if _review_action == "continue":
+                    if not release_review_output(agent):
+                        _review_action = "block"
+                        _review_summary = (
+                            "The held candidate exceeded the safe output buffer."
+                        )
+                    elif _review_decision.reason:
+                        agent._emit_status(
+                            "⚠️ Review unavailable; continuing under the configured "
+                            f"failure policy ({_review_decision.reason})"
+                        )
+
+                if _review_action != "continue":
+                    discard_review_output(agent)
+                    if _review_action == "revise":
+                        _review_final_attempt += 1
+                        final_response = (
+                            "Review checkpoint requested changes to the candidate "
+                            f"answer. {_review_summary}"
+                        )
+                    elif _review_action == "ask_user":
+                        final_response = (
+                            "Review checkpoint needs your decision before this "
+                            f"candidate answer can be released. {_review_summary}"
+                        )
+                    elif _review_action == "cancelled":
+                        final_response = (
+                            "Review checkpoint was cancelled before the candidate "
+                            f"answer could be released. {_review_summary}"
+                        )
+                    else:
+                        final_response = (
+                            "Review checkpoint blocked the candidate answer. "
+                            f"{_review_summary}"
+                        )
+                    _turn_exit_reason = f"review_final_{_review_action}"
+                    failed = True
+                    break
 
                 append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2131,8 +2131,15 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
-        entry, pending_refresh = self._select_under_lock()
+    def select(self, *, auth_type: Optional[str] = None) -> Optional[PooledCredential]:
+        """Select an available entry, optionally constrained to one auth type.
+
+        The filter is a hard eligibility boundary, not a preference: when no
+        matching entry is available this returns ``None`` instead of selecting
+        another credential kind. Existing callers that omit ``auth_type`` keep
+        the prior pool behavior unchanged.
+        """
+        entry, pending_refresh = self._select_under_lock(auth_type=auth_type)
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
         if entry is not None:
@@ -2141,15 +2148,17 @@ class CredentialPool:
         # If no entry was available but we just refreshed some, re-select
         # now that the refreshed entries are back in the pool.
         if pending_refresh:
-            entry, _ = self._select_under_lock()
+            entry, _ = self._select_under_lock(auth_type=auth_type)
             if entry is not None:
                 self._unmatched_rotation_streak = 0
         return entry
 
-    def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_under_lock(
+        self, *, auth_type: Optional[str] = None
+    ) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Run selection under the lock, returning entry + pending refreshes."""
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(auth_type=auth_type)
 
     def _refresh_pending_entries(self, pending: List[tuple]) -> None:
         """Refresh deferred single-use-token entries outside the lock.
@@ -2348,13 +2357,22 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_unlocked(
+        self,
+        *,
+        refresh: bool = True,
+        auth_type: Optional[str] = None,
+    ) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Select the best available credential entry.
 
         Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
         single-use-token entries that must be refreshed outside the lock.
         """
         available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
+        if auth_type is not None:
+            available = [
+                entry for entry in available if entry.auth_type == auth_type
+            ]
         if not available:
             self._current_id = None
             self._log_no_available_entries()

--- a/agent/review_backend.py
+++ b/agent/review_backend.py
@@ -1,0 +1,248 @@
+"""Trusted exact-route backend adapter for automatic review checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any, Callable, Mapping
+
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    PooledCredential,
+    load_pool,
+)
+from agent.review_runner import ResolvedReviewRoute
+
+
+_SUPPORTED_SUBSCRIPTION_PROVIDERS = frozenset({"openai-codex", "anthropic"})
+_JSON_FENCE_RE = re.compile(
+    r"^\s*```(?:json)?\s*(.*?)\s*```\s*$",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class _SubscriptionCredentialHandle:
+    """Backend-only credential lease whose repr never contains token material."""
+
+    provider: str
+    entry_id: str
+    entry: PooledCredential = field(repr=False, compare=False)
+
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return "default"
+
+
+def resolve_subscription_review_route(
+    *,
+    provider: str,
+    model: str,
+    credential_policy: str,
+    fallback_policy: str,
+    pool_loader: Callable[[str], Any] = load_pool,
+    profile_name: Callable[[], str] = _active_profile_name,
+) -> ResolvedReviewRoute:
+    """Resolve one qualifying OAuth pool entry without another auth path."""
+
+    provider = str(provider or "").strip().lower()
+    model = str(model or "").strip()
+    if credential_policy != "subscription_oauth_only":
+        raise RuntimeError("unsupported review credential policy")
+    if fallback_policy != "none":
+        raise RuntimeError("review fallback must be disabled")
+    if provider not in _SUPPORTED_SUBSCRIPTION_PROVIDERS:
+        raise RuntimeError("provider does not expose a supported subscription route")
+    if not model:
+        raise RuntimeError("an exact review model is required")
+
+    pool = pool_loader(provider)
+    entry = pool.select(auth_type=AUTH_TYPE_OAUTH)
+    if entry is None:
+        raise RuntimeError("subscription OAuth credential is unavailable")
+    if entry.auth_type != AUTH_TYPE_OAUTH:
+        raise RuntimeError("selected credential is not subscription OAuth")
+    if entry.provider != provider or not entry.runtime_api_key:
+        raise RuntimeError("selected subscription OAuth route is unusable")
+
+    handle = _SubscriptionCredentialHandle(
+        provider=provider,
+        entry_id=entry.id,
+        entry=entry,
+    )
+    return ResolvedReviewRoute(
+        profile=str(profile_name() or "default"),
+        provider=provider,
+        model=model,
+        credential_kind="subscription_oauth",
+        credential_handle=handle,
+    )
+
+
+def _build_exact_subscription_client(
+    *,
+    provider: str,
+    model: str,
+    entry: PooledCredential,
+    timeout: float,
+) -> Any:
+    """Build one provider client directly; this function contains no fallback."""
+
+    token = entry.runtime_api_key
+    if not token or entry.auth_type != AUTH_TYPE_OAUTH:
+        raise RuntimeError("subscription OAuth credential is unavailable")
+
+    if provider == "openai-codex":
+        from agent.auxiliary_client import (
+            CodexAuxiliaryClient,
+            _CODEX_AUX_BASE_URL,
+            _codex_cloudflare_headers,
+            _create_openai_client,
+            _pool_runtime_base_url,
+        )
+
+        base_url = (
+            _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL)
+            or _CODEX_AUX_BASE_URL
+        )
+        client = _create_openai_client(
+            api_key=token,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=0,
+            default_headers=_codex_cloudflare_headers(
+                token,
+                base_url=base_url,
+            ),
+        )
+        return CodexAuxiliaryClient(client, model)
+
+    if provider == "anthropic":
+        from agent.anthropic_adapter import build_anthropic_client
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            _ANTHROPIC_DEFAULT_BASE_URL,
+            _pool_runtime_base_url,
+        )
+
+        base_url = (
+            _pool_runtime_base_url(entry, _ANTHROPIC_DEFAULT_BASE_URL)
+            or _ANTHROPIC_DEFAULT_BASE_URL
+        )
+        client = build_anthropic_client(token, base_url, timeout=timeout)
+        return AnthropicAuxiliaryClient(
+            client,
+            model,
+            token,
+            base_url,
+            is_oauth=True,
+        )
+
+    raise RuntimeError("unsupported subscription review provider")
+
+
+def _message_content(response: Any) -> str:
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise RuntimeError("review provider returned no choices")
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        raise RuntimeError("review provider returned no message")
+    if getattr(message, "tool_calls", None):
+        raise RuntimeError("review provider attempted a tool call")
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("review provider returned no JSON content")
+    return content.strip()
+
+
+def _parse_payload(content: str) -> Mapping[str, Any]:
+    match = _JSON_FENCE_RE.match(content)
+    if match is not None:
+        content = match.group(1).strip()
+    try:
+        payload = json.loads(content)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError("review provider returned invalid JSON") from error
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("review provider JSON must be an object")
+    return payload
+
+
+def _usage(response: Any) -> dict[str, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return {"input_tokens": 0, "output_tokens": 0}
+    input_tokens = getattr(
+        usage,
+        "prompt_tokens",
+        getattr(usage, "input_tokens", 0),
+    )
+    output_tokens = getattr(
+        usage,
+        "completion_tokens",
+        getattr(usage, "output_tokens", 0),
+    )
+    return {
+        "input_tokens": int(input_tokens or 0),
+        "output_tokens": int(output_tokens or 0),
+    }
+
+
+def complete_subscription_review(
+    *,
+    credential_handle: object,
+    provider: str,
+    model: str,
+    messages: list[dict[str, str]],
+    tools: list[Any],
+    tool_choice: str,
+    timeout: float,
+    idempotency_key: str,
+    client_factory: Callable[..., Any] = _build_exact_subscription_client,
+) -> Mapping[str, Any]:
+    """Perform exactly one no-tools completion against the resolved route."""
+
+    if tools or tool_choice != "none":
+        raise RuntimeError("review completion does not permit tools")
+    if not isinstance(credential_handle, _SubscriptionCredentialHandle):
+        raise RuntimeError("invalid review credential handle")
+    provider = str(provider or "").strip().lower()
+    model = str(model or "").strip()
+    if (
+        provider != credential_handle.provider
+        or credential_handle.entry.provider != provider
+        or not model
+    ):
+        raise RuntimeError("review route does not match credential handle")
+    if credential_handle.entry.auth_type != AUTH_TYPE_OAUTH:
+        raise RuntimeError("review credential is not subscription OAuth")
+    if not idempotency_key:
+        raise RuntimeError("review checkpoint idempotency key is required")
+
+    client = client_factory(
+        provider=provider,
+        model=model,
+        entry=credential_handle.entry,
+        timeout=timeout,
+    )
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0,
+        )
+        payload = dict(_parse_payload(_message_content(response)))
+        payload["usage"] = _usage(response)
+        payload["request_id"] = str(getattr(response, "id", "") or "")
+        return payload
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()

--- a/agent/review_checkpoints.py
+++ b/agent/review_checkpoints.py
@@ -1,0 +1,515 @@
+"""Session-scoped state machine for bounded automatic review checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+from functools import partial
+import json
+from typing import Any, Callable
+
+from agent.review_runner import ReviewRequest, ReviewResult
+
+
+@dataclass(frozen=True)
+class ReviewCheckpointConfig:
+    """Behavior that the session owner explicitly enables."""
+
+    enabled: bool = False
+    max_revisions: int = 2
+    failure_policy: str = "continue"
+
+
+@dataclass(frozen=True)
+class ReviewCheckpointDecision:
+    """A core-loop action derived from one review result."""
+
+    action: str
+    result: ReviewResult | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ReviewCheckpointRoute:
+    """Exact auxiliary route selected by the user for this session."""
+
+    provider: str
+    model: str
+    require_distinct_from_main: bool = True
+    timeout_seconds: float = 60.0
+
+
+@dataclass
+class _InFlight:
+    done: threading.Event
+
+
+class ReviewCheckpointController:
+    """Own idempotency, cancellation, and verdict transitions for one session."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        config: ReviewCheckpointConfig,
+        run_review: Callable[[ReviewRequest], ReviewResult],
+        emit: Callable[[dict], None] | None = None,
+    ) -> None:
+        if not session_id.strip():
+            raise ValueError("session_id is required")
+        if config.max_revisions < 0:
+            raise ValueError("max_revisions must be non-negative")
+        if config.failure_policy not in {"continue", "block"}:
+            raise ValueError("failure_policy must be 'continue' or 'block'")
+        if not callable(run_review):
+            raise ValueError("run_review must be callable")
+
+        self.session_id = session_id
+        self.config = config
+        self._run_review = run_review
+        self._emit = emit
+        self._lock = threading.RLock()
+        self._completed: dict[str, ReviewCheckpointDecision] = {}
+        self._inflight: dict[str, _InFlight] = {}
+        self._cancelled: set[str] = set()
+
+    def cancel(self, checkpoint_id: str) -> None:
+        """Cancel a checkpoint; an already returned late result stays discarded."""
+
+        if not checkpoint_id:
+            return
+        with self._lock:
+            if checkpoint_id in self._completed:
+                return
+            self._cancelled.add(checkpoint_id)
+            if checkpoint_id not in self._inflight:
+                self._completed[checkpoint_id] = self._cancelled_decision(
+                    checkpoint_id
+                )
+
+    def evaluate(self, request: ReviewRequest) -> ReviewCheckpointDecision:
+        """Evaluate once, sharing one billed call across duplicate checkpoint IDs."""
+
+        if not self.config.enabled:
+            return ReviewCheckpointDecision(action="continue")
+        if request.session_id != self.session_id:
+            return ReviewCheckpointDecision(
+                action="block",
+                reason="session_mismatch",
+            )
+
+        with self._lock:
+            cached = self._completed.get(request.checkpoint_id)
+            if cached is not None:
+                return cached
+            if request.checkpoint_id in self._cancelled:
+                decision = self._cancelled_decision(request.checkpoint_id)
+                self._completed[request.checkpoint_id] = decision
+                return decision
+            pending = self._inflight.get(request.checkpoint_id)
+            if pending is None:
+                pending = _InFlight(done=threading.Event())
+                self._inflight[request.checkpoint_id] = pending
+                owner = True
+            else:
+                owner = False
+
+        if not owner:
+            pending.done.wait()
+            with self._lock:
+                return self._completed[request.checkpoint_id]
+
+        try:
+            try:
+                result = self._run_review(request)
+            except Exception:
+                result = ReviewResult(
+                    checkpoint_id=request.checkpoint_id,
+                    status="unavailable",
+                    summary="Review runner failed before producing a safe result.",
+                    unavailable_reason="runner_error",
+                )
+
+            if not isinstance(result, ReviewResult):
+                result = ReviewResult(
+                    checkpoint_id=request.checkpoint_id,
+                    status="unavailable",
+                    summary="Review runner returned an invalid result.",
+                    unavailable_reason="invalid_review_result",
+                )
+            elif result.checkpoint_id != request.checkpoint_id:
+                result = ReviewResult(
+                    checkpoint_id=request.checkpoint_id,
+                    status="unavailable",
+                    summary="Review result did not match the active checkpoint.",
+                    unavailable_reason="checkpoint_mismatch",
+                )
+
+            with self._lock:
+                cancelled = request.checkpoint_id in self._cancelled
+            decision = (
+                self._cancelled_decision(request.checkpoint_id)
+                if cancelled
+                else self._decision_for(request, result)
+            )
+        finally:
+            with self._lock:
+                # Keep a safe terminal object even if an unexpected mapping bug
+                # occurs, so duplicate waiters never hang or trigger a second call.
+                if "decision" not in locals():
+                    decision = ReviewCheckpointDecision(
+                        action=self.config.failure_policy,
+                        result=ReviewResult(
+                            checkpoint_id=request.checkpoint_id,
+                            status="unavailable",
+                            unavailable_reason="controller_error",
+                        ),
+                        reason="controller_error",
+                    )
+                self._completed[request.checkpoint_id] = decision
+                current = self._inflight.pop(request.checkpoint_id, None)
+                if current is not None:
+                    current.done.set()
+
+        self._emit_decision(request, decision)
+        return decision
+
+    @staticmethod
+    def _cancelled_decision(checkpoint_id: str) -> ReviewCheckpointDecision:
+        result = ReviewResult(
+            checkpoint_id=checkpoint_id,
+            status="cancelled",
+            unavailable_reason="cancelled",
+        )
+        return ReviewCheckpointDecision(
+            action="cancelled",
+            result=result,
+            reason="cancelled",
+        )
+
+    def _decision_for(
+        self,
+        request: ReviewRequest,
+        result: ReviewResult,
+    ) -> ReviewCheckpointDecision:
+        if result.status != "completed":
+            return ReviewCheckpointDecision(
+                action=self.config.failure_policy,
+                result=result,
+                reason=result.unavailable_reason or result.status,
+            )
+        if result.verdict == "PASS":
+            return ReviewCheckpointDecision(action="continue", result=result)
+        if result.verdict == "REVISE":
+            if request.attempt < self.config.max_revisions:
+                return ReviewCheckpointDecision(action="revise", result=result)
+            return ReviewCheckpointDecision(
+                action="ask_user",
+                result=result,
+                reason="revision_limit_reached",
+            )
+        if result.verdict == "ASK_USER":
+            return ReviewCheckpointDecision(action="ask_user", result=result)
+        if result.verdict == "BLOCK":
+            return ReviewCheckpointDecision(action="block", result=result)
+        return ReviewCheckpointDecision(
+            action=self.config.failure_policy,
+            result=result,
+            reason="invalid_verdict",
+        )
+
+    def _emit_decision(
+        self,
+        request: ReviewRequest,
+        decision: ReviewCheckpointDecision,
+    ) -> None:
+        if self._emit is None:
+            return
+        result = decision.result
+        event = {
+            "checkpoint_id": request.checkpoint_id,
+            "session_id": self.session_id,
+            "phase": request.phase,
+            "attempt": request.attempt,
+            "action": decision.action,
+            "status": result.status if result is not None else "skipped",
+            "verdict": result.verdict if result is not None else None,
+            "reason": decision.reason,
+            "actual_route": (
+                dict(result.actual_route)
+                if result is not None and result.actual_route is not None
+                else None
+            ),
+            "failure_policy": self.config.failure_policy,
+        }
+        try:
+            self._emit(event)
+        except Exception:
+            # Observability must not change checkpoint semantics.
+            pass
+
+
+class ReviewCheckpointRuntime:
+    """Build bounded requests and delegate state transitions to the controller."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        route: ReviewCheckpointRoute,
+        controller: ReviewCheckpointController,
+    ) -> None:
+        if not route.provider.strip() or not route.model.strip():
+            raise ValueError("an exact review provider and model are required")
+        if route.timeout_seconds <= 0:
+            raise ValueError("review timeout must be positive")
+        if controller.session_id != session_id:
+            raise ValueError("runtime and controller sessions must match")
+        self.session_id = session_id
+        self.route = route
+        self.controller = controller
+
+    @property
+    def enabled(self) -> bool:
+        return self.controller.config.enabled
+
+    def evaluate(
+        self,
+        *,
+        checkpoint_id: str,
+        phase: str,
+        attempt: int,
+        objective: str,
+        constraints: tuple[str, ...],
+        candidate: dict[str, Any],
+        main_provider: str,
+        main_model: str,
+    ) -> ReviewCheckpointDecision:
+        request = ReviewRequest(
+            checkpoint_id=checkpoint_id,
+            session_id=self.session_id,
+            phase=phase,
+            attempt=attempt,
+            objective=objective,
+            constraints=constraints,
+            candidate=candidate,
+            provider=self.route.provider,
+            model=self.route.model,
+            main_provider=main_provider,
+            main_model=main_model,
+            require_distinct_from_main=self.route.require_distinct_from_main,
+            timeout_seconds=self.route.timeout_seconds,
+        )
+        return self.controller.evaluate(request)
+
+    def cancel(self, checkpoint_id: str) -> None:
+        self.controller.cancel(checkpoint_id)
+
+
+def create_review_checkpoint_runtime(
+    *,
+    session_id: str,
+    provider: str,
+    model: str,
+    enabled: bool = True,
+    max_revisions: int = 2,
+    failure_policy: str = "continue",
+    require_distinct_from_main: bool = True,
+    timeout_seconds: float = 60.0,
+    emit: Callable[[dict], None] | None = None,
+    run_review_fn: Callable[[ReviewRequest], ReviewResult] | None = None,
+) -> ReviewCheckpointRuntime:
+    """Create the trusted per-session runtime used by core checkpoint seams."""
+
+    if run_review_fn is None:
+        from agent.review_backend import (
+            complete_subscription_review,
+            resolve_subscription_review_route,
+        )
+        from agent.review_runner import run_review
+
+        run_review_fn = partial(
+            run_review,
+            resolve_route=resolve_subscription_review_route,
+            complete=complete_subscription_review,
+        )
+    config = ReviewCheckpointConfig(
+        enabled=enabled,
+        max_revisions=max_revisions,
+        failure_policy=failure_policy,
+    )
+    controller = ReviewCheckpointController(
+        session_id=session_id,
+        config=config,
+        run_review=run_review_fn,
+        emit=emit,
+    )
+    return ReviewCheckpointRuntime(
+        session_id=session_id,
+        route=ReviewCheckpointRoute(
+            provider=provider,
+            model=model,
+            require_distinct_from_main=require_distinct_from_main,
+            timeout_seconds=timeout_seconds,
+        ),
+        controller=controller,
+    )
+
+
+def _objective_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()[:8_000] or "Review the current turn"
+    return "Review the current turn"
+
+
+def _argument_keys(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw or "{}")
+        except (TypeError, ValueError):
+            return []
+    if isinstance(raw, dict):
+        return sorted(str(key) for key in raw)[:100]
+    return []
+
+
+def review_tool_checkpoint(
+    agent: Any,
+    *,
+    turn_id: str,
+    attempt: int,
+    user_message: Any,
+    assistant_content: str,
+    tool_calls: list[Any],
+) -> ReviewCheckpointDecision:
+    """Review an action bundle immediately before its handlers may execute."""
+
+    runtime = getattr(agent, "review_checkpoint_runtime", None)
+    if not isinstance(runtime, ReviewCheckpointRuntime) or not runtime.enabled:
+        return ReviewCheckpointDecision(action="continue")
+
+    from agent.tool_result_classification import tool_may_have_side_effect
+
+    actions = []
+    for tool_call in tool_calls:
+        function = getattr(tool_call, "function", None)
+        name = str(getattr(function, "name", "") or "")
+        actions.append({
+            "tool": name,
+            "effect": "state_change" if tool_may_have_side_effect(name) else "read",
+            "argument_keys": _argument_keys(getattr(function, "arguments", None)),
+            "redacted_arguments": {},
+        })
+    return runtime.evaluate(
+        checkpoint_id=f"{turn_id}:plan:{attempt}",
+        phase="plan",
+        attempt=attempt,
+        objective=_objective_text(user_message),
+        constraints=("Do not execute tools during review.",),
+        candidate={
+            "summary": str(assistant_content or "")[:16_000],
+            "actions": actions,
+        },
+        main_provider=str(getattr(agent, "provider", "") or ""),
+        main_model=str(getattr(agent, "model", "") or ""),
+    )
+
+
+def review_final_checkpoint(
+    agent: Any,
+    *,
+    turn_id: str,
+    attempt: int,
+    user_message: Any,
+    final_response: str,
+    evidence: list[str] | None = None,
+) -> ReviewCheckpointDecision:
+    """Review a candidate answer before any final-response surface receives it."""
+
+    runtime = getattr(agent, "review_checkpoint_runtime", None)
+    if not isinstance(runtime, ReviewCheckpointRuntime) or not runtime.enabled:
+        return ReviewCheckpointDecision(action="continue")
+    return runtime.evaluate(
+        checkpoint_id=f"{turn_id}:final:{attempt}",
+        phase="final",
+        attempt=attempt,
+        objective=_objective_text(user_message),
+        constraints=("Review only the candidate answer and bounded evidence.",),
+        candidate={
+            "summary": str(final_response or "")[:32_000],
+            "evidence": [str(item)[:2_000] for item in (evidence or [])[:20]],
+        },
+        main_provider=str(getattr(agent, "provider", "") or ""),
+        main_model=str(getattr(agent, "model", "") or ""),
+    )
+
+
+def configure_review_output_hold(agent: Any) -> bool:
+    """Enable candidate buffering only while this session's runtime is enabled."""
+
+    runtime = getattr(agent, "review_checkpoint_runtime", None)
+    enabled = isinstance(runtime, ReviewCheckpointRuntime) and runtime.enabled
+    agent._review_hold_output = enabled
+    agent._review_held_stream_chunks = []
+    agent._review_held_stream_chars = 0
+    agent._review_held_stream_overflow = False
+    agent._review_release_interim_once = False
+    return enabled
+
+
+def discard_review_output(agent: Any) -> None:
+    """Discard a candidate that did not pass its checkpoint."""
+
+    agent._review_held_stream_chunks = []
+    agent._review_held_stream_chars = 0
+    agent._review_held_stream_overflow = False
+    agent._review_release_interim_once = False
+
+
+def release_review_output(agent: Any) -> bool:
+    """Release already-scrubbed candidate deltas after a checkpoint passes."""
+
+    if not getattr(agent, "_review_hold_output", False):
+        return True
+    if getattr(agent, "_review_held_stream_overflow", False):
+        discard_review_output(agent)
+        return False
+
+    held = list(getattr(agent, "_review_held_stream_chunks", []) or [])
+    callbacks = [
+        callback
+        for callback in (
+            getattr(agent, "stream_delta_callback", None),
+            getattr(agent, "_stream_callback", None),
+        )
+        if callback is not None
+    ]
+    for chunk in held:
+        delivered = False
+        for callback in callbacks:
+            try:
+                callback(chunk)
+                delivered = True
+            except Exception:
+                pass
+        try:
+            from agent.plugin_stream_hooks import enqueue_plugin_stream_hook
+
+            enqueue_plugin_stream_hook(
+                "on_stream_delta",
+                **agent._stream_hook_base_payload(),
+                delta=chunk,
+                kind="text",
+            )
+        except Exception:
+            pass
+        if delivered:
+            try:
+                agent._record_streamed_assistant_text(chunk)
+            except Exception:
+                pass
+
+    agent._review_held_stream_chunks = []
+    agent._review_held_stream_chars = 0
+    agent._review_release_interim_once = True
+    return True

--- a/agent/review_runner.py
+++ b/agent/review_runner.py
@@ -1,0 +1,282 @@
+"""Bounded, transport-agnostic review checkpoint runner.
+
+This module intentionally does not resolve credentials or call a provider on
+its own.  A trusted backend supplies both operations.  The runner's job is to
+enforce the review contract around one exact, no-tools completion call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any
+
+
+_MAX_PACKET_BYTES = 64 * 1024
+_VALID_PHASES = frozenset({"plan", "recovery", "final"})
+_VALID_VERDICTS = frozenset({"PASS", "REVISE", "ASK_USER", "BLOCK"})
+_REDACTED = "[REDACTED]"
+_SECRET_KEY_PARTS = (
+    "api_key",
+    "authorization",
+    "cookie",
+    "password",
+    "secret",
+    "token",
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
+_KEY_RE = re.compile(r"\b(?:sk|pk)-[A-Za-z0-9_-]{8,}\b")
+
+
+@dataclass(frozen=True)
+class ReviewRequest:
+    """A bounded checkpoint packet plus an exact requested review route."""
+
+    checkpoint_id: str
+    session_id: str
+    phase: str
+    objective: str
+    constraints: tuple[str, ...]
+    candidate: Mapping[str, Any]
+    provider: str
+    model: str
+    main_provider: str
+    main_model: str
+    attempt: int = 0
+    credential_policy: str = "subscription_oauth_only"
+    fallback_policy: str = "none"
+    require_distinct_from_main: bool = True
+    timeout_seconds: float = 45.0
+
+
+@dataclass(frozen=True)
+class ResolvedReviewRoute:
+    """Sanitized route provenance plus a backend-owned opaque credential."""
+
+    profile: str
+    provider: str
+    model: str
+    credential_kind: str
+    credential_handle: object = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class ReviewResult:
+    """Outcome safe to return to the caller or display in the shell."""
+
+    checkpoint_id: str
+    status: str
+    verdict: str | None = None
+    summary: str = ""
+    feedback: tuple[Any, ...] = ()
+    actual_route: Mapping[str, str] | None = None
+    usage: Mapping[str, Any] | None = None
+    unavailable_reason: str | None = None
+
+
+def _actual_route(route: ResolvedReviewRoute) -> dict[str, str]:
+    return {
+        "profile": route.profile,
+        "provider": route.provider,
+        "model": route.model,
+        "credential_kind": route.credential_kind,
+    }
+
+
+def _unavailable(
+    request: ReviewRequest,
+    reason: str,
+    *,
+    summary: str = "",
+    status: str = "unavailable",
+    actual_route: Mapping[str, str] | None = None,
+) -> ReviewResult:
+    return ReviewResult(
+        checkpoint_id=request.checkpoint_id,
+        status=status,
+        summary=summary,
+        actual_route=actual_route,
+        unavailable_reason=reason,
+    )
+
+
+def _is_secret_key(key: object) -> bool:
+    normalized = str(key).casefold().replace("-", "_")
+    return any(part in normalized for part in _SECRET_KEY_PARTS)
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _REDACTED if _is_secret_key(key) else _redact(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _safe_error(error: Exception) -> str:
+    message = str(error).replace("\r", " ").replace("\n", " ")[:300]
+    message = _BEARER_RE.sub("Bearer [REDACTED]", message)
+    return _KEY_RE.sub(_REDACTED, message)
+
+
+def _validate_request(request: ReviewRequest) -> str | None:
+    if request.credential_policy != "subscription_oauth_only":
+        return "unsupported_policy"
+    if request.fallback_policy != "none":
+        return "unsupported_policy"
+    if (
+        not request.checkpoint_id.strip()
+        or not request.session_id.strip()
+        or request.phase not in _VALID_PHASES
+        or not request.objective.strip()
+        or not request.provider.strip()
+        or not request.model.strip()
+        or request.attempt < 0
+        or request.timeout_seconds <= 0
+    ):
+        return "invalid_request"
+    return None
+
+
+def _build_messages(request: ReviewRequest) -> tuple[list[dict[str, str]], int]:
+    packet = _redact({
+        "checkpoint_id": request.checkpoint_id,
+        "session_id": request.session_id,
+        "phase": request.phase,
+        "attempt": request.attempt,
+        "objective": request.objective,
+        "constraints": request.constraints,
+        "candidate": request.candidate,
+    })
+    serialized = json.dumps(
+        packet,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Review the bounded checkpoint packet. Do not execute actions "
+                "or request tools. Return only one JSON object, with no markdown "
+                "or surrounding text, using this exact shape: "
+                '{"verdict":"PASS|REVISE|ASK_USER|BLOCK",'
+                '"summary":"short explanation","feedback":[]}. '
+                "The verdict must be exactly PASS, REVISE, ASK_USER, or BLOCK."
+            ),
+        },
+        {"role": "user", "content": serialized},
+    ]
+    return messages, len(serialized.encode("utf-8"))
+
+
+def run_review(
+    request: ReviewRequest,
+    *,
+    resolve_route: Callable[..., ResolvedReviewRoute],
+    complete: Callable[..., Mapping[str, Any]],
+) -> ReviewResult:
+    """Run one strict review completion, or return a truthful unavailable state."""
+
+    invalid_reason = _validate_request(request)
+    if invalid_reason is not None:
+        return _unavailable(request, invalid_reason)
+
+    messages, packet_bytes = _build_messages(request)
+    if packet_bytes > _MAX_PACKET_BYTES:
+        return _unavailable(request, "packet_too_large")
+
+    try:
+        route = resolve_route(
+            provider=request.provider,
+            model=request.model,
+            credential_policy=request.credential_policy,
+            fallback_policy=request.fallback_policy,
+        )
+    except Exception as error:
+        return _unavailable(
+            request,
+            "route_unavailable",
+            summary=f"Review route unavailable: {_safe_error(error)}",
+        )
+
+    attestation = _actual_route(route)
+    if route.credential_kind != "subscription_oauth":
+        return _unavailable(
+            request,
+            "credential_policy_mismatch",
+            actual_route=attestation,
+        )
+    if route.provider != request.provider or route.model != request.model:
+        return _unavailable(
+            request,
+            "route_mismatch",
+            actual_route=attestation,
+        )
+    if request.require_distinct_from_main and (
+        route.provider == request.main_provider and route.model == request.main_model
+    ):
+        return _unavailable(
+            request,
+            "review_route_matches_main",
+            actual_route=attestation,
+        )
+
+    try:
+        response = complete(
+            credential_handle=route.credential_handle,
+            provider=route.provider,
+            model=route.model,
+            messages=messages,
+            tools=[],
+            tool_choice="none",
+            timeout=request.timeout_seconds,
+            idempotency_key=request.checkpoint_id,
+        )
+    except TimeoutError as error:
+        return _unavailable(
+            request,
+            "timeout",
+            status="timed_out",
+            summary=_safe_error(error),
+            actual_route=attestation,
+        )
+    except Exception as error:
+        return _unavailable(
+            request,
+            "completion_failed",
+            summary=_safe_error(error),
+            actual_route=attestation,
+        )
+
+    if not isinstance(response, Mapping) or response.get("verdict") not in _VALID_VERDICTS:
+        return _unavailable(
+            request,
+            "invalid_response",
+            actual_route=attestation,
+        )
+
+    feedback = response.get("feedback", ())
+    if not isinstance(feedback, Sequence) or isinstance(feedback, (str, bytes)):
+        feedback = ()
+    usage = response.get("usage")
+    if not isinstance(usage, Mapping):
+        usage = None
+
+    return ReviewResult(
+        checkpoint_id=request.checkpoint_id,
+        status="completed",
+        verdict=str(response["verdict"]),
+        summary=str(response.get("summary", "")),
+        feedback=tuple(feedback),
+        actual_route=attestation,
+        usage=dict(usage) if usage is not None else None,
+    )

--- a/run_agent.py
+++ b/run_agent.py
@@ -6617,6 +6617,27 @@ class AIAgent:
 
     def _reset_stream_delivery_tracking(self) -> None:
         """Reset tracking for text delivered during the current model response."""
+        if getattr(self, "_review_hold_output", False):
+            # A fresh provider attempt owns a fresh candidate. Discard any
+            # partial bytes and scrubber tails from the previous/retried
+            # attempt; a reviewed PASS path releases its buffer explicitly
+            # before another request can begin.
+            for scrubber_name in (
+                "_stream_think_scrubber",
+                "_stream_context_scrubber",
+            ):
+                scrubber = getattr(self, scrubber_name, None)
+                if scrubber is not None:
+                    try:
+                        scrubber.flush()
+                    except Exception:
+                        pass
+            self._current_streamed_assistant_text = ""
+            self._review_held_stream_chunks = []
+            self._review_held_stream_chars = 0
+            self._review_held_stream_overflow = False
+            self._review_release_interim_once = False
+            return
         # Flush any benign partial-tag tail held by the think scrubber
         # first (#17924): an innocent '<' at the end of the stream that
         # turned out not to be a tag prefix should reach the UI.  Then
@@ -6784,6 +6805,8 @@ class AIAgent:
 
     def _fire_streamed_codex_commentary(self, text: str) -> None:
         """Deliver a completed live Codex commentary message immediately."""
+        if getattr(self, "_review_hold_output", False):
+            return
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(text, str):
             return
@@ -6813,6 +6836,11 @@ class AIAgent:
         """
         if not isinstance(assistant_msg, dict):
             return
+        if getattr(self, "_review_hold_output", False):
+            if getattr(self, "_review_release_interim_once", False):
+                self._review_release_interim_once = False
+            else:
+                return
         commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
         undelivered_parts: List[str] = []
         pending_keys: set[str] = set()
@@ -7020,6 +7048,21 @@ class AIAgent:
             ):
                 text = text.lstrip("\n")
         if not text:
+            return
+        if getattr(self, "_review_hold_output", False):
+            held = getattr(self, "_review_held_stream_chunks", None)
+            if not isinstance(held, list):
+                held = []
+                self._review_held_stream_chunks = held
+            current_chars = int(
+                getattr(self, "_review_held_stream_chars", 0) or 0
+            )
+            next_chars = current_chars + len(text)
+            if next_chars <= 2_000_000:
+                held.append(text)
+                self._review_held_stream_chars = next_chars
+            else:
+                self._review_held_stream_overflow = True
             return
         callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
         delivered = False

--- a/tests/agent/test_credential_pool_auth_filter.py
+++ b/tests/agent/test_credential_pool_auth_filter.py
@@ -1,0 +1,64 @@
+"""Credential pools must support policy-filtered selection without fallback."""
+
+from agent.credential_pool import (
+    AUTH_TYPE_API_KEY,
+    AUTH_TYPE_OAUTH,
+    CredentialPool,
+    PooledCredential,
+)
+
+
+def _entry(entry_id, auth_type, priority):
+    return PooledCredential(
+        provider="openai-codex",
+        id=entry_id,
+        label=entry_id,
+        auth_type=auth_type,
+        priority=priority,
+        source="manual",
+        access_token=f"token-{entry_id}",
+    )
+
+
+def test_select_auth_type_skips_higher_priority_api_key():
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            _entry("api", AUTH_TYPE_API_KEY, 0),
+            _entry("oauth", AUTH_TYPE_OAUTH, 1),
+        ],
+    )
+
+    selected = pool.select(auth_type=AUTH_TYPE_OAUTH)
+
+    assert selected is not None
+    assert selected.id == "oauth"
+    assert selected.auth_type == AUTH_TYPE_OAUTH
+    assert pool.current().id == "oauth"
+
+
+def test_select_auth_type_returns_none_instead_of_falling_back():
+    pool = CredentialPool(
+        "openai-codex",
+        [_entry("api", AUTH_TYPE_API_KEY, 0)],
+    )
+
+    selected = pool.select(auth_type=AUTH_TYPE_OAUTH)
+
+    assert selected is None
+    assert pool.current() is None
+
+
+def test_unfiltered_select_preserves_existing_behavior():
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            _entry("api", AUTH_TYPE_API_KEY, 0),
+            _entry("oauth", AUTH_TYPE_OAUTH, 1),
+        ],
+    )
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "api"

--- a/tests/agent/test_review_backend.py
+++ b/tests/agent/test_review_backend.py
@@ -1,0 +1,246 @@
+"""Exact subscription-OAuth backend adapter for the review runner."""
+
+from __future__ import annotations
+
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.credential_pool import AUTH_TYPE_API_KEY, AUTH_TYPE_OAUTH, PooledCredential
+from agent.review_backend import (
+    complete_subscription_review,
+    resolve_subscription_review_route,
+)
+
+
+def _entry(auth_type=AUTH_TYPE_OAUTH):
+    return PooledCredential(
+        provider="openai-codex",
+        id="credential-1",
+        label="ChatGPT subscription",
+        auth_type=auth_type,
+        priority=0,
+        source="device_code",
+        access_token="private-oauth-token",
+    )
+
+
+class _Pool:
+    def __init__(self, entry):
+        self.entry = entry
+        self.calls = []
+
+    def select(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.entry
+
+
+def _resolve(pool):
+    return resolve_subscription_review_route(
+        provider="openai-codex",
+        model="gpt-review",
+        credential_policy="subscription_oauth_only",
+        fallback_policy="none",
+        pool_loader=lambda provider: pool,
+        profile_name=lambda: "work",
+    )
+
+
+def test_resolver_selects_only_oauth_and_returns_sanitized_handle():
+    pool = _Pool(_entry())
+
+    route = _resolve(pool)
+
+    assert pool.calls == [{"auth_type": AUTH_TYPE_OAUTH}]
+    assert route.profile == "work"
+    assert route.provider == "openai-codex"
+    assert route.model == "gpt-review"
+    assert route.credential_kind == "subscription_oauth"
+    assert "private-oauth-token" not in repr(route.credential_handle)
+
+
+def test_resolver_rejects_api_key_even_if_pool_violates_filter():
+    with pytest.raises(RuntimeError, match="subscription OAuth"):
+        _resolve(_Pool(_entry(AUTH_TYPE_API_KEY)))
+
+
+def test_resolver_does_not_fallback_when_no_oauth_entry_exists():
+    with pytest.raises(RuntimeError, match="unavailable"):
+        _resolve(_Pool(None))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"provider": "openrouter"},
+        {"model": ""},
+        {"credential_policy": "any"},
+        {"fallback_policy": "auto"},
+    ],
+)
+def test_resolver_requires_supported_exact_subscription_route(overrides):
+    kwargs = {
+        "provider": "openai-codex",
+        "model": "gpt-review",
+        "credential_policy": "subscription_oauth_only",
+        "fallback_policy": "none",
+        "pool_loader": lambda provider: _Pool(_entry()),
+        "profile_name": lambda: "default",
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(RuntimeError):
+        resolve_subscription_review_route(**kwargs)
+
+
+def _response(content, *, tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=SimpleNamespace(prompt_tokens=12, completion_tokens=4),
+        id="request-1",
+    )
+
+
+class _Completions:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+def _complete(response):
+    pool = _Pool(_entry())
+    route = _resolve(pool)
+    completions = _Completions(response)
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=completions),
+        close=MagicMock(),
+    )
+    factory_calls = []
+
+    def factory(**kwargs):
+        factory_calls.append(kwargs)
+        return client
+
+    call = partial(complete_subscription_review, client_factory=factory)
+    return route, completions, factory_calls, client, call
+
+
+def test_completion_calls_exact_model_once_without_tool_schema():
+    route, completions, factory_calls, client, complete = _complete(_response(
+        '{"verdict":"PASS","summary":"good","feedback":[]}'
+    ))
+
+    result = complete(
+        credential_handle=route.credential_handle,
+        provider="openai-codex",
+        model="gpt-review",
+        messages=[{"role": "user", "content": "review"}],
+        tools=[],
+        tool_choice="none",
+        timeout=30,
+        idempotency_key="checkpoint-1",
+    )
+
+    assert result["verdict"] == "PASS"
+    assert result["usage"] == {"input_tokens": 12, "output_tokens": 4}
+    assert result["request_id"] == "request-1"
+    assert len(factory_calls) == 1
+    assert factory_calls[0]["provider"] == "openai-codex"
+    assert factory_calls[0]["model"] == "gpt-review"
+    assert factory_calls[0]["timeout"] == 30
+    assert len(completions.calls) == 1
+    assert completions.calls[0]["model"] == "gpt-review"
+    assert "tools" not in completions.calls[0]
+    assert "tool_choice" not in completions.calls[0]
+    client.close.assert_called_once_with()
+
+
+def test_completion_rejects_any_requested_or_returned_tool_call():
+    route, completions, _, client, complete = _complete(_response(
+        '{"verdict":"PASS","summary":"good","feedback":[]}',
+        tool_calls=[SimpleNamespace(id="tool-1")],
+    ))
+
+    with pytest.raises(RuntimeError, match="tool"):
+        complete(
+            credential_handle=route.credential_handle,
+            provider="openai-codex",
+            model="gpt-review",
+            messages=[],
+            tools=[],
+            tool_choice="none",
+            timeout=30,
+            idempotency_key="checkpoint-1",
+        )
+    assert len(completions.calls) == 1
+    client.close.assert_called_once_with()
+
+    with pytest.raises(RuntimeError, match="tool"):
+        complete(
+            credential_handle=route.credential_handle,
+            provider="openai-codex",
+            model="gpt-review",
+            messages=[],
+            tools=[{"type": "function"}],
+            tool_choice="none",
+            timeout=30,
+            idempotency_key="checkpoint-2",
+        )
+    assert len(completions.calls) == 1
+
+
+def test_completion_rejects_route_swap_before_client_creation():
+    route, completions, factory_calls, _, complete = _complete(_response("{}"))
+
+    with pytest.raises(RuntimeError, match="route"):
+        complete(
+            credential_handle=route.credential_handle,
+            provider="anthropic",
+            model="gpt-review",
+            messages=[],
+            tools=[],
+            tool_choice="none",
+            timeout=30,
+            idempotency_key="checkpoint-1",
+        )
+
+    assert factory_calls == []
+    assert completions.calls == []
+
+
+def test_completion_accepts_json_fence_but_rejects_invalid_payload():
+    route, _, _, _, complete = _complete(_response(
+        '```json\n{"verdict":"REVISE","summary":"fix","feedback":["test"]}\n```'
+    ))
+    result = complete(
+        credential_handle=route.credential_handle,
+        provider="openai-codex",
+        model="gpt-review",
+        messages=[],
+        tools=[],
+        tool_choice="none",
+        timeout=30,
+        idempotency_key="checkpoint-1",
+    )
+    assert result["verdict"] == "REVISE"
+
+    route, _, _, client, complete = _complete(_response("not json"))
+    with pytest.raises(RuntimeError, match="JSON"):
+        complete(
+            credential_handle=route.credential_handle,
+            provider="openai-codex",
+            model="gpt-review",
+            messages=[],
+            tools=[],
+            tool_choice="none",
+            timeout=30,
+            idempotency_key="checkpoint-2",
+        )
+    client.close.assert_called_once_with()

--- a/tests/agent/test_review_checkpoint_controller.py
+++ b/tests/agent/test_review_checkpoint_controller.py
@@ -1,0 +1,283 @@
+"""Session-state contract for automatic review checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import threading
+
+import pytest
+
+from agent.review_checkpoints import (
+    ReviewCheckpointConfig,
+    ReviewCheckpointController,
+)
+from agent.review_runner import ReviewRequest, ReviewResult
+
+
+def _request(**overrides):
+    request = ReviewRequest(
+        checkpoint_id="turn-1:plan:0",
+        session_id="session-1",
+        phase="plan",
+        objective="Make the requested change",
+        constraints=("Keep the core cache-safe",),
+        candidate={"summary": "Edit one file after focused tests"},
+        provider="openai-codex",
+        model="gpt-review",
+        main_provider="openai-codex",
+        main_model="gpt-economy",
+    )
+    return replace(request, **overrides)
+
+
+def _result(verdict="PASS", **overrides):
+    result = ReviewResult(
+        checkpoint_id="turn-1:plan:0",
+        status="completed",
+        verdict=verdict,
+        summary=f"Reviewer returned {verdict}.",
+        actual_route={
+            "profile": "default",
+            "provider": "openai-codex",
+            "model": "gpt-review",
+            "credential_kind": "subscription_oauth",
+        },
+    )
+    return replace(result, **overrides)
+
+
+def _runner(result):
+    def run(request):
+        run.calls.append(request)
+        return replace(result, checkpoint_id=request.checkpoint_id)
+
+    run.calls = []
+    return run
+
+
+def test_disabled_controller_has_zero_review_calls_and_no_behavioral_effect():
+    run = _runner(_result())
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=False),
+        run_review=run,
+    )
+
+    decision = controller.evaluate(_request())
+
+    assert decision.action == "continue"
+    assert decision.result is None
+    assert run.calls == []
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected_action"),
+    [
+        ("PASS", "continue"),
+        ("REVISE", "revise"),
+        ("ASK_USER", "ask_user"),
+        ("BLOCK", "block"),
+    ],
+)
+def test_completed_verdicts_map_to_explicit_actions(verdict, expected_action):
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=_runner(_result(verdict)),
+    )
+
+    decision = controller.evaluate(_request())
+
+    assert decision.action == expected_action
+    assert decision.result.verdict == verdict
+
+
+def test_revision_count_is_bounded_and_escalates_to_user():
+    run = _runner(_result("REVISE"))
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True, max_revisions=2),
+        run_review=run,
+    )
+
+    first = controller.evaluate(_request(attempt=0))
+    second = controller.evaluate(_request(checkpoint_id="turn-1:plan:1", attempt=1))
+    exhausted = controller.evaluate(_request(checkpoint_id="turn-1:plan:2", attempt=2))
+
+    assert first.action == "revise"
+    assert second.action == "revise"
+    assert exhausted.action == "ask_user"
+    assert exhausted.reason == "revision_limit_reached"
+    assert len(run.calls) == 3
+
+
+def test_unavailable_is_visible_and_fail_open_by_default():
+    events = []
+    run = _runner(_result(
+        verdict=None,
+        status="unavailable",
+        unavailable_reason="route_unavailable",
+    ))
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=run,
+        emit=events.append,
+    )
+
+    decision = controller.evaluate(_request())
+
+    assert decision.action == "continue"
+    assert decision.reason == "route_unavailable"
+    assert events[-1]["status"] == "unavailable"
+    assert events[-1]["failure_policy"] == "continue"
+
+
+def test_unavailable_can_be_configured_to_block():
+    run = _runner(_result(
+        verdict=None,
+        status="timed_out",
+        unavailable_reason="timeout",
+    ))
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True, failure_policy="block"),
+        run_review=run,
+    )
+
+    decision = controller.evaluate(_request())
+
+    assert decision.action == "block"
+    assert decision.reason == "timeout"
+
+
+def test_replayed_checkpoint_id_returns_cached_decision_without_second_call():
+    run = _runner(_result("PASS"))
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=run,
+    )
+
+    first = controller.evaluate(_request())
+    replay = controller.evaluate(_request())
+
+    assert replay is first
+    assert len(run.calls) == 1
+
+
+def test_cancelled_inflight_checkpoint_discards_late_result():
+    entered = threading.Event()
+    release = threading.Event()
+    decisions = []
+
+    def slow_run(request):
+        entered.set()
+        assert release.wait(timeout=5)
+        return replace(_result("PASS"), checkpoint_id=request.checkpoint_id)
+
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=slow_run,
+    )
+    worker = threading.Thread(
+        target=lambda: decisions.append(controller.evaluate(_request())),
+        daemon=True,
+    )
+    worker.start()
+    assert entered.wait(timeout=5)
+
+    controller.cancel("turn-1:plan:0")
+    release.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert decisions[0].action == "cancelled"
+    assert decisions[0].result.status == "cancelled"
+    assert controller.evaluate(_request()) is decisions[0]
+
+
+def test_concurrent_duplicate_waits_for_owner_and_bills_once():
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+    decisions = []
+
+    def slow_run(request):
+        calls.append(request)
+        entered.set()
+        assert release.wait(timeout=5)
+        return replace(_result("PASS"), checkpoint_id=request.checkpoint_id)
+
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=slow_run,
+    )
+    workers = [
+        threading.Thread(
+            target=lambda: decisions.append(controller.evaluate(_request())),
+            daemon=True,
+        )
+        for _ in range(2)
+    ]
+    workers[0].start()
+    assert entered.wait(timeout=5)
+    workers[1].start()
+    release.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(calls) == 1
+    assert len(decisions) == 2
+    assert decisions[0] is decisions[1]
+
+
+def test_session_mismatch_is_rejected_before_runner_call():
+    run = _runner(_result())
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=run,
+    )
+
+    decision = controller.evaluate(_request(session_id="session-2"))
+
+    assert decision.action == "block"
+    assert decision.reason == "session_mismatch"
+    assert run.calls == []
+
+
+def test_events_expose_sanitized_state_not_request_or_credential_objects():
+    events = []
+    controller = ReviewCheckpointController(
+        session_id="session-1",
+        config=ReviewCheckpointConfig(enabled=True),
+        run_review=_runner(_result("PASS")),
+        emit=events.append,
+    )
+
+    controller.evaluate(_request(candidate={"api_key": "must-not-leak"}))
+
+    serialized = str(events)
+    assert "must-not-leak" not in serialized
+    assert "credential_handle" not in serialized
+    assert events[-1]["actual_route"]["credential_kind"] == "subscription_oauth"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        ReviewCheckpointConfig(enabled=True, max_revisions=-1),
+        ReviewCheckpointConfig(enabled=True, failure_policy="retry"),
+    ],
+)
+def test_invalid_controller_config_fails_fast(config):
+    with pytest.raises(ValueError):
+        ReviewCheckpointController(
+            session_id="session-1",
+            config=config,
+            run_review=_runner(_result()),
+        )

--- a/tests/agent/test_review_checkpoint_runtime.py
+++ b/tests/agent/test_review_checkpoint_runtime.py
@@ -1,0 +1,127 @@
+"""Core-facing request builders for plan and final review checkpoints."""
+
+from types import SimpleNamespace
+
+from agent.review_checkpoints import (
+    create_review_checkpoint_runtime,
+    review_final_checkpoint,
+    review_tool_checkpoint,
+)
+from agent.review_runner import ReviewResult
+
+
+def _runtime(calls, *, enabled=True):
+    def run(request):
+        calls.append(request)
+        return ReviewResult(
+            checkpoint_id=request.checkpoint_id,
+            status="completed",
+            verdict="PASS",
+        )
+
+    return create_review_checkpoint_runtime(
+        session_id="session-1",
+        provider="openai-codex",
+        model="gpt-review",
+        enabled=enabled,
+        run_review_fn=run,
+    )
+
+
+def _agent(runtime):
+    return SimpleNamespace(
+        review_checkpoint_runtime=runtime,
+        provider="openai-codex",
+        model="gpt-economy",
+    )
+
+
+def _tool(name, arguments):
+    return SimpleNamespace(
+        function=SimpleNamespace(name=name, arguments=arguments)
+    )
+
+
+def test_tool_checkpoint_sends_names_effects_and_argument_keys_not_values():
+    calls = []
+    decision = review_tool_checkpoint(
+        _agent(_runtime(calls)),
+        turn_id="turn-1",
+        attempt=0,
+        user_message="Update the file",
+        assistant_content="I will inspect then update it.",
+        tool_calls=[
+            _tool("read_file", '{"path":"C:/private/secret.txt"}'),
+            _tool("write_file", '{"path":"C:/private/secret.txt","content":"secret"}'),
+        ],
+    )
+
+    assert decision.action == "continue"
+    request = calls[0]
+    assert request.phase == "plan"
+    assert request.checkpoint_id == "turn-1:plan:0"
+    assert request.provider == "openai-codex"
+    assert request.model == "gpt-review"
+    assert request.main_model == "gpt-economy"
+    assert request.candidate["actions"] == [
+        {
+            "tool": "read_file",
+            "effect": "read",
+            "argument_keys": ["path"],
+            "redacted_arguments": {},
+        },
+        {
+            "tool": "write_file",
+            "effect": "state_change",
+            "argument_keys": ["content", "path"],
+            "redacted_arguments": {},
+        },
+    ]
+    assert "C:/private" not in str(request.candidate)
+    assert '"secret"' not in str(request.candidate)
+
+
+def test_final_checkpoint_holds_bounded_candidate_and_evidence():
+    calls = []
+    decision = review_final_checkpoint(
+        _agent(_runtime(calls)),
+        turn_id="turn-1",
+        attempt=1,
+        user_message="Finish the task",
+        final_response="Completed safely.",
+        evidence=["36 tests passed"],
+    )
+
+    assert decision.action == "continue"
+    request = calls[0]
+    assert request.phase == "final"
+    assert request.attempt == 1
+    assert request.candidate == {
+        "summary": "Completed safely.",
+        "evidence": ["36 tests passed"],
+    }
+
+
+def test_disabled_runtime_is_zero_call_noop_at_both_seams():
+    calls = []
+    agent = _agent(_runtime(calls, enabled=False))
+
+    plan = review_tool_checkpoint(
+        agent,
+        turn_id="turn-1",
+        attempt=0,
+        user_message="Do it",
+        assistant_content="",
+        tool_calls=[_tool("write_file", "{}")],
+    )
+    final = review_final_checkpoint(
+        agent,
+        turn_id="turn-1",
+        attempt=0,
+        user_message="Do it",
+        final_response="Done",
+    )
+
+    assert plan.action == "continue"
+    assert final.action == "continue"
+    assert calls == []

--- a/tests/agent/test_review_output_hold.py
+++ b/tests/agent/test_review_output_hold.py
@@ -1,0 +1,64 @@
+"""Advisor-enabled sessions must not stream candidates before review."""
+
+from unittest.mock import MagicMock
+
+from agent.review_checkpoints import (
+    discard_review_output,
+    release_review_output,
+)
+from run_agent import AIAgent
+
+
+def _agent():
+    agent = AIAgent.__new__(AIAgent)
+    agent._review_hold_output = True
+    agent._review_held_stream_chunks = []
+    agent._review_held_stream_chars = 0
+    agent._review_held_stream_overflow = False
+    agent._review_release_interim_once = False
+    agent._stream_needs_break = False
+    agent._stream_think_scrubber = None
+    agent._stream_context_scrubber = None
+    agent._current_streamed_assistant_text = ""
+    agent._stream_writer_tls = None
+    agent._stream_writer_token = 0
+    agent._stream_callback = None
+    agent.stream_delta_callback = MagicMock()
+    agent._strip_think_blocks = lambda text: text
+    agent._record_streamed_assistant_text = MagicMock()
+    agent._stream_hook_base_payload = lambda: {}
+    return agent
+
+
+def test_candidate_delta_is_held_until_release():
+    agent = _agent()
+
+    agent._fire_stream_delta("candidate answer")
+
+    agent.stream_delta_callback.assert_not_called()
+    assert agent._review_held_stream_chunks == ["candidate answer"]
+
+    assert release_review_output(agent) is True
+    agent.stream_delta_callback.assert_called_once_with("candidate answer")
+    agent._record_streamed_assistant_text.assert_called_once_with("candidate answer")
+    assert agent._review_held_stream_chunks == []
+
+
+def test_rejected_candidate_is_discarded_without_surface_delivery():
+    agent = _agent()
+    agent._fire_stream_delta("candidate answer")
+
+    discard_review_output(agent)
+
+    agent.stream_delta_callback.assert_not_called()
+    assert agent._review_held_stream_chunks == []
+
+
+def test_overflow_fails_closed_for_candidate_release():
+    agent = _agent()
+    agent._review_held_stream_chunks = ["partial"]
+    agent._review_held_stream_overflow = True
+
+    assert release_review_output(agent) is False
+    agent.stream_delta_callback.assert_not_called()
+    assert agent._review_held_stream_chunks == []

--- a/tests/agent/test_review_runner.py
+++ b/tests/agent/test_review_runner.py
@@ -1,0 +1,240 @@
+"""Behavior contract for the proposed bounded review runner.
+
+The runner is deliberately transport-agnostic.  A trusted backend resolver
+owns credentials and returns only an opaque handle plus sanitized provenance;
+the runner enforces route and payload invariants around exactly one no-tools
+completion call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from agent.review_runner import (
+    ReviewRequest,
+    ResolvedReviewRoute,
+    run_review,
+)
+
+
+def _request(**overrides):
+    request = ReviewRequest(
+        checkpoint_id="cp-1",
+        session_id="session-1",
+        phase="plan",
+        objective="Ship the reviewed change",
+        constraints=("Keep the core cache-safe",),
+        candidate={"summary": "Run the focused tests, then edit one file"},
+        provider="openai-codex",
+        model="gpt-review",
+        main_provider="openai-codex",
+        main_model="gpt-economy",
+    )
+    return replace(request, **overrides)
+
+
+def _route(**overrides):
+    route = ResolvedReviewRoute(
+        profile="default",
+        provider="openai-codex",
+        model="gpt-review",
+        credential_kind="subscription_oauth",
+        credential_handle=object(),
+    )
+    return replace(route, **overrides)
+
+
+def _complete_ok(**payload_overrides):
+    payload = {
+        "verdict": "PASS",
+        "summary": "Plan is bounded and testable.",
+        "feedback": [],
+        "usage": {"input_tokens": 24, "output_tokens": 9},
+    }
+    payload.update(payload_overrides)
+
+    def complete(**kwargs):
+        complete.calls.append(kwargs)
+        return payload
+
+    complete.calls = []
+    return complete
+
+
+def test_subscription_route_runs_once_without_tools_and_attests_actual_route():
+    complete = _complete_ok()
+    resolve_calls = []
+
+    def resolve(**kwargs):
+        resolve_calls.append(kwargs)
+        return _route()
+
+    result = run_review(_request(), resolve_route=resolve, complete=complete)
+
+    assert result.status == "completed"
+    assert result.verdict == "PASS"
+    assert result.actual_route == {
+        "profile": "default",
+        "provider": "openai-codex",
+        "model": "gpt-review",
+        "credential_kind": "subscription_oauth",
+    }
+    assert resolve_calls == [{
+        "provider": "openai-codex",
+        "model": "gpt-review",
+        "credential_policy": "subscription_oauth_only",
+        "fallback_policy": "none",
+    }]
+    assert len(complete.calls) == 1
+    assert complete.calls[0]["tools"] == []
+    assert complete.calls[0]["tool_choice"] == "none"
+    assert complete.calls[0]["idempotency_key"] == "cp-1"
+    system_prompt = complete.calls[0]["messages"][0]["content"]
+    assert "Return only one JSON object" in system_prompt
+    assert '"verdict":"PASS|REVISE|ASK_USER|BLOCK"' in system_prompt
+
+
+def test_api_key_route_is_rejected_before_any_model_call():
+    complete = _complete_ok()
+
+    result = run_review(
+        _request(),
+        resolve_route=lambda **_: _route(credential_kind="api_key"),
+        complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "credential_policy_mismatch"
+    assert complete.calls == []
+
+
+def test_requested_and_actual_provider_model_must_match_exactly():
+    complete = _complete_ok()
+
+    result = run_review(
+        _request(),
+        resolve_route=lambda **_: _route(model="gpt-fallback"),
+        complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "route_mismatch"
+    assert complete.calls == []
+
+
+def test_same_actual_route_as_main_is_rejected_when_distinct_is_required():
+    complete = _complete_ok()
+
+    result = run_review(
+        _request(main_model="gpt-review"),
+        resolve_route=lambda **_: _route(),
+        complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "review_route_matches_main"
+    assert complete.calls == []
+
+
+def test_route_resolution_failure_is_truthful_and_does_not_fallback():
+    complete = _complete_ok()
+
+    def unavailable(**_):
+        raise RuntimeError("subscription quota exhausted")
+
+    result = run_review(
+        _request(), resolve_route=unavailable, complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "route_unavailable"
+    assert "quota exhausted" in result.summary
+    assert complete.calls == []
+
+
+def test_invalid_verdict_is_rejected_instead_of_treated_as_pass():
+    complete = _complete_ok(verdict="ALLOW")
+
+    result = run_review(
+        _request(), resolve_route=lambda **_: _route(), complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "invalid_response"
+    assert result.verdict is None
+
+
+def test_completion_failure_does_not_retry_or_change_route():
+    calls = []
+
+    def complete(**kwargs):
+        calls.append(kwargs)
+        raise TimeoutError("review timed out")
+
+    result = run_review(
+        _request(), resolve_route=lambda **_: _route(), complete=complete,
+    )
+
+    assert result.status == "timed_out"
+    assert result.unavailable_reason == "timeout"
+    assert len(calls) == 1
+
+
+def test_packet_redacts_secret_shaped_fields_before_completion():
+    complete = _complete_ok()
+    request = _request(candidate={
+        "summary": "Call the provider",
+        "api_key": "secret-api-key",
+        "nested": {"authorization": "Bearer secret-token"},
+        "safe": "visible",
+    })
+
+    result = run_review(
+        request, resolve_route=lambda **_: _route(), complete=complete,
+    )
+
+    assert result.status == "completed"
+    serialized_messages = str(complete.calls[0]["messages"])
+    assert "secret-api-key" not in serialized_messages
+    assert "secret-token" not in serialized_messages
+    assert "[REDACTED]" in serialized_messages
+    assert "visible" in serialized_messages
+
+
+def test_oversized_packet_is_rejected_before_resolution():
+    complete = _complete_ok()
+    resolve_calls = []
+
+    def resolve(**kwargs):
+        resolve_calls.append(kwargs)
+        return _route()
+
+    result = run_review(
+        _request(candidate={"summary": "x" * 70_000}),
+        resolve_route=resolve,
+        complete=complete,
+    )
+
+    assert result.status == "unavailable"
+    assert result.unavailable_reason == "packet_too_large"
+    assert resolve_calls == []
+    assert complete.calls == []
+
+
+def test_request_requires_exact_route_and_supported_policies():
+    complete = _complete_ok()
+
+    missing_model = run_review(
+        _request(model=""),
+        resolve_route=lambda **_: _route(),
+        complete=complete,
+    )
+    wrong_policy = run_review(
+        _request(credential_policy="any"),
+        resolve_route=lambda **_: _route(),
+        complete=complete,
+    )
+
+    assert missing_model.unavailable_reason == "invalid_request"
+    assert wrong_policy.unavailable_reason == "unsupported_policy"
+    assert complete.calls == []

--- a/tests/run_agent/test_review_checkpoint_loop.py
+++ b/tests/run_agent/test_review_checkpoint_loop.py
@@ -1,0 +1,175 @@
+"""End-to-end ordering contract for plan and final review checkpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.review_checkpoints import create_review_checkpoint_runtime
+from agent.review_runner import ReviewResult
+from run_agent import AIAgent
+from tests.run_agent.test_run_agent import (
+    _make_tool_defs,
+    _mock_response,
+    _mock_tool_call,
+)
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            session_id="review-loop-session",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="economy-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance.client = MagicMock()
+    instance._cached_system_prompt = "stable test prompt"
+    instance._use_prompt_caching = False
+    instance._session_db = None
+    instance._session_json_enabled = False
+    instance.save_trajectories = False
+    instance.compression_enabled = False
+    instance.tool_delay = 0
+    return instance
+
+
+def _install(agent, verdicts, review_calls, *, enabled=True):
+    verdict_iter = iter(verdicts)
+
+    def run(request):
+        review_calls.append(request)
+        verdict = next(verdict_iter)
+        return ReviewResult(
+            checkpoint_id=request.checkpoint_id,
+            status="completed",
+            verdict=verdict,
+            summary=f"Reviewer returned {verdict}.",
+        )
+
+    agent.review_checkpoint_runtime = create_review_checkpoint_runtime(
+        session_id=agent.session_id,
+        provider="openai-codex",
+        model="gpt-review",
+        enabled=enabled,
+        run_review_fn=run,
+    )
+
+
+def _run(agent, message, handle):
+    with (
+        patch("run_agent.handle_function_call", side_effect=handle),
+        patch.object(agent, "_flush_messages_to_session_db", return_value=True),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        return agent.run_conversation(message)
+
+
+def test_plan_block_happens_before_tool_handler(agent):
+    review_calls = []
+    _install(agent, ["BLOCK"], review_calls)
+    tool = _mock_tool_call("web_search", '{"query":"private"}', call_id="c1")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I will search.",
+        finish_reason="tool_calls",
+        tool_calls=[tool],
+    )
+    handler = MagicMock(return_value="must not run")
+
+    result = _run(agent, "search", handler)
+
+    handler.assert_not_called()
+    assert [request.phase for request in review_calls] == ["plan"]
+    assert "blocked the planned action" in result["final_response"]
+    assert result["completed"] is False
+
+
+def test_plan_revise_closes_tool_protocol_and_replans_without_execution(agent):
+    review_calls = []
+    _install(agent, ["REVISE", "PASS"], review_calls)
+    tool = _mock_tool_call("web_search", "{}", call_id="c1")
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="I will search.",
+            finish_reason="tool_calls",
+            tool_calls=[tool],
+        ),
+        _mock_response(content="Replanned safely.", finish_reason="stop"),
+    ]
+    handler = MagicMock(return_value="must not run")
+
+    result = _run(agent, "search", handler)
+
+    handler.assert_not_called()
+    assert result["final_response"] == "Replanned safely."
+    assert [request.phase for request in review_calls] == ["plan", "final"]
+    tool_results = [
+        message for message in result["messages"] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 1
+    assert "requested a revised plan" in tool_results[0]["content"]
+
+
+def test_final_block_holds_candidate_before_final_surface(agent):
+    review_calls = []
+    _install(agent, ["BLOCK"], review_calls)
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Unreviewed candidate",
+        finish_reason="stop",
+    )
+    surface = MagicMock()
+    agent.stream_delta_callback = surface
+
+    result = _run(agent, "answer", MagicMock())
+
+    surface.assert_not_called()
+    assert [request.phase for request in review_calls] == ["final"]
+    assert "blocked the candidate answer" in result["final_response"]
+    assert "Unreviewed candidate" not in result["final_response"]
+    assert result["completed"] is False
+
+
+def test_final_pass_publishes_original_candidate(agent):
+    review_calls = []
+    _install(agent, ["PASS"], review_calls)
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Reviewed candidate",
+        finish_reason="stop",
+    )
+
+    result = _run(agent, "answer", MagicMock())
+
+    assert result["final_response"] == "Reviewed candidate"
+    assert [request.phase for request in review_calls] == ["final"]
+    assert result["completed"] is True
+
+
+def test_disabled_runtime_preserves_normal_tool_execution(agent):
+    review_calls = []
+    _install(agent, [], review_calls, enabled=False)
+    tool = _mock_tool_call("web_search", "{}", call_id="c1")
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[tool]),
+        _mock_response(content="Normal result", finish_reason="stop"),
+    ]
+    handler = MagicMock(return_value="search result")
+
+    result = _run(agent, "search", handler)
+
+    handler.assert_called_once()
+    assert review_calls == []
+    assert result["final_response"] == "Normal result"


### PR DESCRIPTION
## What does this PR do?

This is a draft reference implementation for the architecture proposed in
#98493. It adds opt-in, session-scoped review checkpoints that can gate a tool
plan before execution and hold a candidate final answer until a separate,
explicitly selected reviewer returns a structured verdict.

The reviewer is deliberately smaller and less privileged than the existing
manual `/review` subagent: one bounded request, no tools, exact provider/model,
subscription OAuth only, no route fallback, and sanitized route attestation.
The existing `/review` behavior remains unchanged.

This draft intentionally does not add Desktop UI or configuration plumbing. It
is meant to make the core ordering, credential, caching, and session-state
contracts concrete for maintainer review before any surface adopts them.

## Related Issue

Related to #98493. This draft does not close the issue; the issue is still the
architecture decision point.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `agent/review_runner.py`, a bounded transport-independent runner that
  redacts secret-shaped input and accepts only strict JSON
  `PASS|REVISE|ASK_USER|BLOCK` results.
- Add `agent/review_backend.py`, which resolves only exact `openai-codex` or
  `anthropic` subscription-OAuth routes, performs one no-tools completion, and
  never falls back to another credential, provider, or model.
- Add `agent/review_checkpoints.py`, a per-session controller with idempotency,
  bounded revisions, cancellation/late-result handling, explicit fail-open or
  fail-block behavior, and sanitized events.
- Add a hard `auth_type` eligibility filter to `CredentialPool.select()` while
  preserving existing behavior for callers that omit the filter.
- Gate persisted tool-call bundles before tool handlers run. `REVISE` closes
  each tool call with a normal tool-result row and replans without a synthetic
  user message or a side effect.
- Hold streamed candidate output until final `PASS`; rejected candidates never
  reach stream or interim surfaces. Disabled mode leaves the ordinary path
  unchanged and makes zero review calls.
- Close per-review provider clients on both success and failure.

## How to Test

1. Run the focused checkpoint and existing review suite:

   ```bash
   scripts/run_tests.sh \
     tests/run_agent/test_review_checkpoint_loop.py \
     tests/agent/test_review_output_hold.py \
     tests/agent/test_review_checkpoint_runtime.py \
     tests/agent/test_review_checkpoint_controller.py \
     tests/agent/test_review_backend.py \
     tests/agent/test_review_runner.py \
     tests/agent/test_credential_pool_auth_filter.py \
     tests/agent/test_review_engine.py -q
   ```

   Result on rebased head `4116137ff`: **76 passed, 0 failed**.

2. Run Ruff and ty against the touched/new modules. Both pass on the same head.
3. A synthetic live smoke test on Windows 11 used an existing Hermes login and
   attested `openai-codex / gpt-5.6-sol / subscription_oauth`; it returned
   `PASS` with 158 input and 29 output tokens. No project or conversation data
   was sent.

The full repository wrapper was also attempted locally. It could not provide a
clean all-suite receipt because the environment lacked the optional ACP package
and exposed unrelated Windows sandbox/path failures. Those failures do not
touch this diff; the upstream CI matrix should provide the authoritative full
suite and cross-platform result.

## Behavioral Notes for Review

- Plan `REVISE` is automatic and cache-safe because it uses normal tool-result
  rows.
- Final `REVISE` currently returns a controlled stop rather than injecting a
  synthetic user turn. A first-class final-revision channel should be an
  explicit maintainer decision.
- `require_distinct_from_main` proves route separation, not that one model is
  objectively stronger.
- The renderer never receives a token or raw credential object.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings included; user docs deferred until the public surface is accepted
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config key is exposed in this draft
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python; no new filesystem, shell, or process behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the reviewer has no tools

## Screenshots / Logs

No UI is included. The key behavior is covered by executable tests, including
pre-handler blocking and withheld final-stream delivery.
