### PR TITLE
fix(a2a): harden replay retry and profile isolation

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -888,6 +888,10 @@ class WebhookAdapter(BasePlatformAdapter):
             try:
                 result = await self._direct_deliver(prompt, delivery)
             except Exception:
+                # A 502 asks the provider to retry. Do not leave the failed
+                # delivery ID in the idempotency cache or that retry would be
+                # acknowledged as a duplicate without another delivery attempt.
+                self._seen_deliveries.pop(delivery_id, None)
                 logger.exception(
                     "[webhook] direct-deliver failed route=%s delivery=%s",
                     route_name,
@@ -908,8 +912,9 @@ class WebhookAdapter(BasePlatformAdapter):
                     },
                     status=200,
                 )
-            # Delivery attempted but target rejected it — surface as 502
-            # with a generic error (don't leak adapter-level detail).
+            # Delivery attempted but target rejected it — surface as 502 and
+            # release the delivery ID so the provider can retry the same event.
+            self._seen_deliveries.pop(delivery_id, None)
             logger.warning(
                 "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
                 route_name,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1145,6 +1145,9 @@ def _auth_file_path() -> Path:
 def _global_auth_file_path() -> Optional[Path]:
     """Return the global-root auth.json when the process is in profile mode.
 
+    Isolated profiles can set ``HERMES_DISABLE_GLOBAL_AUTH_FALLBACK=true`` to
+    prevent inherited root credentials from crossing a trust boundary.
+
     Returns ``None`` when the profile and global root resolve to the same
     directory (classic mode, or custom HERMES_HOME that is not a profile).
     Used by read-only fallback paths so providers authed at the root are
@@ -1152,6 +1155,10 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
+    if is_truthy_value(
+        os.environ.get("HERMES_DISABLE_GLOBAL_AUTH_FALLBACK"), default=False
+    ):
+        return None
     try:
         from hermes_constants import get_default_hermes_root
         global_root = get_default_hermes_root()

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -10,7 +10,7 @@ import threading
 from pathlib import Path
 
 from dotenv import load_dotenv
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, env_var_enabled, fast_safe_load
 
 
 # Env var name suffixes that indicate credential values.  These are the
@@ -478,7 +478,7 @@ def load_hermes_dotenv(
     Behavior:
     - `~/.hermes/.env` overrides stale shell-exported values when present.
     - project `.env` acts as a dev fallback and only fills missing values when
-      the user env exists.
+      the user env exists, unless `HERMES_DISABLE_PROJECT_ENV_FALLBACK=true`.
     - if no user env exists, the project `.env` also overrides stale shell vars.
     - callers that only maintain the installation can set
       ``load_external_secrets=False`` to avoid loading optional secret-manager
@@ -489,6 +489,8 @@ def load_hermes_dotenv(
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
+    if env_var_enabled("HERMES_DISABLE_PROJECT_ENV_FALLBACK"):
+        project_env_path = None
 
     # Normalize safe formatting and remove invalid NUL bytes before parsing.
     if user_env.exists():

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -40,6 +40,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+import uuid
 from collections import deque
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeout
@@ -1201,10 +1202,16 @@ class A2AAdapter(BasePlatformAdapter):
         # Push payload uses the StreamResponse format (same as streaming).
         payload = protocol.status_update(task_id, context_id, state, (reply or "")[:2000])
 
-        signature = security.sign_push_payload(payload)
+        timestamp = str(int(time.time()))
+        delivery_id = uuid.uuid4().hex
+        signature = security.sign_push_payload(
+            payload, timestamp=timestamp, delivery_id=delivery_id
+        )
         headers = {"Content-Type": "application/json"}
         if signature:
             headers["X-A2A-Signature"] = signature
+            headers["X-A2A-Timestamp"] = timestamp
+            headers["X-A2A-Delivery"] = delivery_id
 
         try:
             data = json.dumps(payload).encode("utf-8")

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -347,12 +347,17 @@ class A2AAdapter(BasePlatformAdapter):
         self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
         self.host = security.resolve_bind_host()
         self.agent_name = _default_agent_name()
-        self._advertised_toolsets = [
-            t.strip() for t in (
-                list(extra.get("advertised_toolsets") or [])
-                or os.getenv("A2A_ADVERTISED_TOOLSETS", "").split(",")
-            ) if str(t).strip()
-        ]
+        if "advertised_toolsets" in extra:
+            configured_toolsets = extra.get("advertised_toolsets")
+        elif "A2A_ADVERTISED_TOOLSETS" in os.environ:
+            configured_toolsets = os.environ.get("A2A_ADVERTISED_TOOLSETS", "").split(",")
+        else:
+            configured_toolsets = None
+        self._advertised_toolsets = (
+            [str(t).strip() for t in (configured_toolsets or []) if str(t).strip()]
+            if configured_toolsets is not None
+            else None
+        )
         self._active_profile = _active_profile_name()
         self._agents = self._load_served_agents(extra)
 
@@ -630,7 +635,7 @@ class A2AAdapter(BasePlatformAdapter):
             from tools.registry import registry as tool_registry
             names = tool_registry.get_registered_toolset_names()
             configured = (agent or {}).get("advertised_toolsets") if agent else self._advertised_toolsets
-            allowed = set(configured or []) or None
+            allowed = None if configured is None else set(configured)
             mapping = {
                 n: tool_registry.get_tool_names_for_toolset(n)
                 for n in names

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -265,18 +265,77 @@ def get_push_secret() -> str:
     return get_bearer_token()
 
 
-def sign_push_payload(payload: dict) -> str:
+def _push_signing_bytes(
+    payload: dict,
+    *,
+    timestamp: Optional[str] = None,
+    delivery_id: Optional[str] = None,
+) -> bytes:
+    """Return canonical bytes for legacy or replay-protected push signing."""
+    body = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    if timestamp is None and delivery_id is None:
+        return body
+    if not timestamp or not delivery_id:
+        raise ValueError("timestamp and delivery_id must be provided together")
+    return f"{timestamp}.{delivery_id}.".encode("utf-8") + body
+
+
+def sign_push_payload(
+    payload: dict,
+    *,
+    timestamp: Optional[str] = None,
+    delivery_id: Optional[str] = None,
+) -> str:
     """HMAC-SHA256 sign a push notification payload.
 
-    Returns hex-encoded signature. Empty string if no secret configured.
-    Receivers verify by HMAC-ing the JSON body (sorted keys) with the shared
-    secret and comparing against the X-A2A-Signature header.
+    Legacy callers may sign only the canonical JSON body. Remote callbacks
+    should also pass ``timestamp`` and ``delivery_id``; those values are then
+    covered by the HMAC and allow a receiver to enforce a replay window.
     """
     secret = get_push_secret()
     if not secret:
         return ""
-    body = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    body = _push_signing_bytes(
+        payload, timestamp=timestamp, delivery_id=delivery_id
+    )
     return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def verify_push_payload(
+    payload: dict,
+    signature: str,
+    *,
+    timestamp: str,
+    delivery_id: str,
+    max_age_seconds: int = 300,
+    now: Optional[float] = None,
+    seen_delivery_ids: Optional[set[str]] = None,
+) -> bool:
+    """Verify timestamped push HMAC, age, and optional replay cache.
+
+    ``seen_delivery_ids`` is mutated only after all cryptographic and age checks
+    pass. Receivers sharing it across threads must provide their own lock.
+    """
+    secret = get_push_secret()
+    if not secret or not signature or not timestamp or not delivery_id:
+        return False
+    try:
+        sent_at = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current = time.time() if now is None else float(now)
+    if max_age_seconds < 0 or abs(current - sent_at) > max_age_seconds:
+        return False
+    expected = sign_push_payload(
+        payload, timestamp=timestamp, delivery_id=delivery_id
+    )
+    if not hmac.compare_digest(signature, expected):
+        return False
+    if seen_delivery_ids is not None:
+        if delivery_id in seen_delivery_ids:
+            return False
+        seen_delivery_ids.add(delivery_id)
+    return True
 
 
 # --------------------------------------------------------------------------

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -13,7 +13,7 @@ Peers are resolved from config.yaml under ``a2a_agents``::
     a2a_agents:
       researcher:
         url: "http://localhost:9999"
-        auth: { type: bearer, token: "sk-..." }
+        auth: { type: bearer, token_env: "A2A_RESEARCHER_TOKEN" }
         timeout: 120
         capabilities: [web_search, research]
 
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -35,6 +36,7 @@ from . import protocol, security
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 120
+_A2A_CLIENT_USER_AGENT = "Hermes-A2A-Client/1.0"
 _ORCHESTRATE_MAX_WORKERS = 6  # max parallel peers for fan-out
 
 
@@ -69,9 +71,16 @@ def _resolve_peer(agent: str) -> Optional[dict]:
 
 
 def _auth_header(auth: dict) -> dict:
-    if auth and auth.get("type") == "bearer" and auth.get("token"):
-        return {"Authorization": f"Bearer {auth['token']}"}
-    return {}
+    if not auth or auth.get("type") != "bearer":
+        return {}
+    token_env = str(auth.get("token_env") or "").strip()
+    if token_env:
+        token = os.getenv(token_env, "").strip()
+        if not token:
+            raise ValueError(f"A2A bearer token environment variable is missing: {token_env}")
+        return {"Authorization": f"Bearer {token}"}
+    token = str(auth.get("token") or "").strip()
+    return {"Authorization": f"Bearer {token}"} if token else {}
 
 
 # --------------------------------------------------------------------------
@@ -79,14 +88,20 @@ def _auth_header(auth: dict) -> dict:
 # --------------------------------------------------------------------------
 
 def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
-    req = urllib.request.Request(url, headers=headers, method="GET")
+    request_headers = {"User-Agent": _A2A_CLIENT_USER_AGENT, **headers}
+    req = urllib.request.Request(url, headers=request_headers, method="GET")
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))
 
 
 def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
     data = json.dumps(body).encode("utf-8")
-    hdrs = {"Content-Type": "application/json", "A2A-Version": protocol.PROTOCOL_VERSION, **headers}
+    hdrs = {
+        "Content-Type": "application/json",
+        "A2A-Version": protocol.PROTOCOL_VERSION,
+        "User-Agent": _A2A_CLIENT_USER_AGENT,
+        **headers,
+    }
     req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -57,10 +57,23 @@ def _write(path: Path, payload: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_profile_can_disable_global_credential_pool_fallback(profile_env, monkeypatch):
+    from hermes_cli.auth import read_credential_pool
 
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "glob-1",
+            "label": "global",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "sk-global",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+    monkeypatch.setenv("HERMES_DISABLE_GLOBAL_AUTH_FALLBACK", "true")
 
-
-
+    assert read_credential_pool("openrouter") == []
 
 
 def test_missing_global_auth_file_is_safe(profile_env):
@@ -132,6 +145,18 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 
     _write(profile_env["global"] / "auth.json", _make_auth_store(providers={}))
     _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    assert get_provider_auth_state("nous") is None
+
+
+def test_profile_can_disable_global_provider_state_fallback(profile_env, monkeypatch):
+    from hermes_cli.auth import get_provider_auth_state
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "nous": {"access_token": "nous-global", "refresh_token": "rt-global"},
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+    monkeypatch.setenv("HERMES_DISABLE_GLOBAL_AUTH_FALLBACK", "1")
 
     assert get_provider_auth_state("nous") is None
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -620,3 +620,20 @@ def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch
 
     # The other profile's .env value stands; the process config was not applied.
     assert os.getenv("TERMINAL_ENV") == "docker"
+
+
+def test_disable_project_env_fallback_skips_inaccessible_project_secrets(tmp_path, monkeypatch):
+    """Isolated runtimes must not read or require the checkout-level .env."""
+    home = tmp_path / "edge-home"
+    home.mkdir()
+    project_env = tmp_path / "project.env"
+    project_env.write_text("CORE_ONLY_SECRET=must-not-load\n", encoding="utf-8")
+    project_env.chmod(0)
+
+    monkeypatch.setenv("HERMES_DISABLE_PROJECT_ENV_FALLBACK", "true")
+    monkeypatch.delenv("CORE_ONLY_SECRET", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert loaded == []
+    assert "CORE_ONLY_SECRET" not in os.environ

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -280,6 +280,93 @@ class TestPushSigning:
         monkeypatch.setenv("A2A_BEARER_TOKEN", "bearer-as-push-secret")
         assert security.sign_push_payload({"x": 1})
 
+    def test_timestamped_signature_rejects_replay(self, monkeypatch):
+        monkeypatch.setenv("A2A_PUSH_SECRET", "test-secret-123")
+        payload = {"statusUpdate": {"taskId": "task-1"}}
+        timestamp = "1767225600"
+        delivery_id = "delivery-1"
+        signature = security.sign_push_payload(
+            payload, timestamp=timestamp, delivery_id=delivery_id
+        )
+        seen = set()
+
+        assert security.verify_push_payload(
+            payload,
+            signature,
+            timestamp=timestamp,
+            delivery_id=delivery_id,
+            now=1767225600,
+            seen_delivery_ids=seen,
+        )
+        assert not security.verify_push_payload(
+            payload,
+            signature,
+            timestamp=timestamp,
+            delivery_id=delivery_id,
+            now=1767225600,
+            seen_delivery_ids=seen,
+        )
+
+    def test_timestamped_signature_rejects_expired_delivery(self, monkeypatch):
+        monkeypatch.setenv("A2A_PUSH_SECRET", "test-secret-123")
+        payload = {"statusUpdate": {"taskId": "task-1"}}
+        timestamp = "1767225000"
+        delivery_id = "delivery-expired"
+        signature = security.sign_push_payload(
+            payload, timestamp=timestamp, delivery_id=delivery_id
+        )
+
+        assert not security.verify_push_payload(
+            payload,
+            signature,
+            timestamp=timestamp,
+            delivery_id=delivery_id,
+            now=1767225600,
+            max_age_seconds=300,
+        )
+
+    def test_push_sender_emits_replay_protection_headers(self, monkeypatch):
+        monkeypatch.setenv("A2A_PUSH_SECRET", "test-secret-123")
+        adapter, _base = _make_live_adapter(monkeypatch)
+        adapter.tasks.pop_push_url = lambda _task_id: "https://example.com/callback"
+        monkeypatch.setattr(security, "is_safe_callback_url", lambda _url: True)
+        captured = {}
+
+        class _Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def _urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return _Response()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        adapter._send_push_notification(
+            "task-1", "ctx-1", "done", protocol.STATE_COMPLETED
+        )
+
+        request = captured["request"]
+        timestamp = request.get_header("X-a2a-timestamp")
+        delivery_id = request.get_header("X-a2a-delivery")
+        signature = request.get_header("X-a2a-signature")
+        payload = json.loads(request.data)
+        assert timestamp
+        assert delivery_id
+        assert signature
+        assert security.verify_push_payload(
+            payload,
+            signature,
+            timestamp=timestamp,
+            delivery_id=delivery_id,
+            now=int(timestamp),
+        )
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Anti-loop ping-pong protection

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -645,6 +645,23 @@ class TestDynamicAgentCards:
         card = adapter._build_card()
         assert [s["name"] for s in card["skills"]] == ["webz"]
 
+    def test_explicit_empty_advertised_toolsets_hides_registered_tools(self, monkeypatch):
+        from tools.registry import registry
+        from gateway.config import PlatformConfig
+        from plugins.platforms.a2a.adapter import A2AAdapter
+
+        monkeypatch.setattr(registry, "get_registered_toolset_names",
+                            lambda: ["terminal", "spotify", "todo"])
+        monkeypatch.setattr(registry, "get_tool_names_for_toolset", lambda ts: [ts])
+        monkeypatch.delenv("A2A_ADVERTISED_TOOLSETS", raising=False)
+
+        adapter = A2AAdapter(PlatformConfig(
+            enabled=True,
+            extra={"advertised_toolsets": []},
+        ))
+        card = adapter._build_card()
+        assert [skill["name"] for skill in card["skills"]] == ["general"]
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Capability-based routing (a2a_orchestrate)

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -10,8 +10,7 @@ with a mocked agent handler.
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac
+
 import json
 import os
 import socket
@@ -1248,6 +1247,8 @@ class TestPushNotificationEndToEnd:
                 length = int(self.headers.get("Content-Length", 0))
                 received["body"] = json.loads(self.rfile.read(length).decode())
                 received["signature"] = self.headers.get("X-A2A-Signature", "")
+                received["timestamp"] = self.headers.get("X-A2A-Timestamp", "")
+                received["delivery_id"] = self.headers.get("X-A2A-Delivery", "")
                 self.send_response(200)
                 self.send_header("Content-Length", "0")
                 self.end_headers()
@@ -1281,13 +1282,15 @@ class TestPushNotificationEndToEnd:
             assert su["taskId"] == task["id"]
             assert su["status"]["state"] == "TASK_STATE_COMPLETED"
             assert "ECHO:" in protocol.extract_text(su["status"]["message"])
-            # HMAC signature verifies against the shared secret.
-            expected = hmac.new(
-                b"push-secret-1",
-                json.dumps(payload, sort_keys=True, ensure_ascii=False).encode(),
-                hashlib.sha256,
-            ).hexdigest()
-            assert received["signature"] == expected
+            # HMAC covers body + timestamp + unique delivery id so receivers
+            # can enforce a bounded replay window.
+            assert security.verify_push_payload(
+                payload,
+                received["signature"],
+                timestamp=received["timestamp"],
+                delivery_id=received["delivery_id"],
+                now=int(received["timestamp"]),
+            )
 
             await adapter.disconnect()
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -539,6 +539,49 @@ class TestClientTools:
         assert tools._rpc_url("http://base:3", {"url": "http://legacy:1/"}) == "http://legacy:1/"
         assert tools._rpc_url("http://base:3/", None) == "http://base:3"
 
+    def test_http_post_sets_a2a_client_user_agent(self, monkeypatch):
+        captured = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{}'
+
+        def fake_urlopen(request, timeout):
+            captured["user_agent"] = request.get_header("User-agent")
+            captured["a2a_version"] = request.get_header("A2a-version")
+            return Response()
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        tools._http_post_json("https://peer.example/", {"jsonrpc": "2.0"}, {}, 5)
+
+        assert captured == {
+            "user_agent": "Hermes-A2A-Client/1.0",
+            "a2a_version": protocol.PROTOCOL_VERSION,
+        }
+
+    def test_auth_header_resolves_bearer_token_from_environment(self, monkeypatch):
+        monkeypatch.setenv("A2A_OUTBOUND_EDGE_TOKEN", "secret-from-bws")
+
+        assert tools._auth_header({
+            "type": "bearer",
+            "token_env": "A2A_OUTBOUND_EDGE_TOKEN",
+        }) == {"Authorization": "Bearer secret-from-bws"}
+
+    def test_auth_header_fails_closed_when_token_environment_is_missing(self, monkeypatch):
+        monkeypatch.delenv("A2A_OUTBOUND_EDGE_TOKEN", raising=False)
+
+        with pytest.raises(ValueError, match="A2A_OUTBOUND_EDGE_TOKEN"):
+            tools._auth_header({
+                "type": "bearer",
+                "token_env": "A2A_OUTBOUND_EDGE_TOKEN",
+            })
+
     def test_list_no_peers(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setattr(tools, "_load_config", lambda: {})


### PR DESCRIPTION
## Summary
- bind A2A push signatures to timestamp and delivery ID with replay protection
- release webhook delivery IDs after transient direct-delivery failures so retries are real
- allow isolated profiles to disable fallback to the global auth store
- extend regression coverage for A2A signing and profile auth isolation

## Validation
- `231 passed` across focused A2A, profile-auth, and webhook suites using pytest + pytest-asyncio
- `git diff --check origin/main...HEAD`

## Security intent
These changes support a minimal public-edge profile without inheriting core credentials, while keeping webhook retries idempotent and A2A callbacks replay-resistant.