### PR TITLE
fix(electron): adopt served dashboard token before readiness probe (boot 401 loop)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12119,9 +12119,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   entry.port = port
 
   const baseUrl = `http://127.0.0.1:${port}`
-  await Promise.race([waitForHermes(baseUrl, token), startFailed])
-  ready = true
 
+  // Adopt the token the backend actually serves BEFORE the readiness probe.
+  // The backend regenerates its session token at serve time; the spawn env pin
+  // (HERMES_DASHBOARD_SESSION_TOKEN) does not always survive the spawn (see
+  // dashboard-token.ts). Probing /api/health with the stale spawn token yields
+  // a 401 that wedges boot in an infinite repair loop (the symptom Arthur hit:
+  // "Desktop boot failed: 401 Unauthorized" repeating through repair 1/3..3/3).
+  // Adopting first lets the credentialed probe use the served token.
   const authToken = await adoptServedDashboardToken(baseUrl, token, {
     childAlive: () => child.exitCode === null && !child.killed,
     label: `Hermes backend for profile "${profile}"`,
@@ -12129,6 +12134,8 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   })
 
   entry.token = authToken
+  await Promise.race([waitForHermes(baseUrl, authToken), startFailed])
+  ready = true
 
   // Verify the WebSocket session token before declaring backend ready.
   // HTTP /api/status can pass while WS auth fails (separate transport, separate guards).


### PR DESCRIPTION
## Summary
Fixes the Electron desktop "keeps crashing / boot loop" failure: the local backend starts (`HERMES_BACKEND_READY`) but the desktop's `/api/health` readiness probe returns **401 Unauthorized**, boot fails, the renderer requests repair, restarts the backend, and the cycle repeats forever (repair 1/3 → 2/3 → 3/3 → 1/3).

### Root cause
The desktop pins `HERMES_DASHBOARD_SESSION_TOKEN` into the spawned backend's env, but the backend **regenerates its own session token at serve time** (documented in `dashboard-token.ts` — "the env pin did not survive the spawn"). The boot sequence probed `/api/health` with the **stale spawn token *before* adopting the served token**, so the credentialed probe was rejected. `adoptServedDashboardToken` (which would have adopted the live token) ran *after* the probe and was never reached.

### Fix
Reorder `apps/desktop/electron/main.ts` so `adoptServedDashboardToken` runs first and `waitForHermes` probes with the token the backend actually serves. Pure statement reorder — no API/signature change.

### Verification
- `tsc --noEmit -p tsconfig.electron.json` passes (exit 0).
- Logic matches the codebase's own documented contract (`dashboard-token.ts`).

## Scope
Electron main-process boot only. The running app must be rebuilt to pick this up (it ships bundled in `app.asar`); this is a source fix for the upstream build, not a patch to the installed binary.

🤖 Generated with [Hermes](https://github.com/NousResearch/hermes-agent)