### PR TITLE
fix(codex): honor run budgets and prevent false terminal success

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1027,7 +1027,7 @@ def init_agent(
     # (agent.run_budget_seconds) further below. None = feature fully off:
     # no clock reads, no injection, no stale-timeout capping.
     agent.run_budget_seconds = _normalize_run_budget_seconds(run_budget_seconds)
-    # Wall-clock start of the CURRENT run_conversation turn. Set by
+    # Monotonic start of the CURRENT run_conversation turn. Set by
     # turn_context.prepare_turn when a run budget is active; None otherwise.
     agent._run_budget_started_at = None
     # One-shot latch for the 80% wrap-up notice (reset each turn).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -772,8 +772,29 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    # A native app-server turn encompasses Codex's complete agent/tool loop,
+    # so the conversation run budget is also this call's hard deadline.  Pass
+    # the remaining budget rather than the configured original value: turn
+    # setup and persistence have already consumed part of the same run.
+    #
+    # Provider ``request_timeout_seconds`` is deliberately not reused here.
+    # It bounds one provider HTTP request, while an app-server turn may contain
+    # many provider requests and tool executions owned by the Codex process.
+    # Without a run budget Hermes therefore waits for protocol completion;
+    # explicit interrupts, subprocess death, and the post-tool quiet watchdog
+    # still terminate unhealthy turns.
+    turn_timeout = None
+    run_budget = getattr(agent, "run_budget_seconds", None)
+    run_started_at = getattr(agent, "_run_budget_started_at", None)
+    if run_budget is not None and run_started_at is not None:
+        elapsed = max(0.0, time.time() - run_started_at)
+        turn_timeout = max(0.0, float(run_budget) - elapsed)
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            turn_timeout=turn_timeout,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -783,12 +783,9 @@ def run_codex_app_server_turn(
     # Without a run budget Hermes therefore waits for protocol completion;
     # explicit interrupts, subprocess death, and the post-tool quiet watchdog
     # still terminate unhealthy turns.
-    turn_timeout = None
-    run_budget = getattr(agent, "run_budget_seconds", None)
-    run_started_at = getattr(agent, "_run_budget_started_at", None)
-    if run_budget is not None and run_started_at is not None:
-        elapsed = max(0.0, time.time() - run_started_at)
-        turn_timeout = max(0.0, float(run_budget) - elapsed)
+    from agent.run_budget import remaining_run_budget_seconds
+
+    turn_timeout = remaining_run_budget_seconds(agent)
 
     try:
         turn = agent._codex_session.run_turn(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -204,15 +204,15 @@ def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) 
     Dormant unless ``agent.run_budget_seconds`` is set AND the turn stamped
     ``_run_budget_started_at`` (see ``turn_context.prepare_conversation_turn``).
     """
+    from agent.run_budget import elapsed_run_budget_seconds
+
     budget = getattr(agent, "run_budget_seconds", None)
-    if not budget:
-        return False
     if getattr(agent, "_run_budget_wrapup_injected", False):
         return False
-    started = getattr(agent, "_run_budget_started_at", None)
-    if not started:
+    elapsed = elapsed_run_budget_seconds(agent)
+    if elapsed is None:
         return False
-    if (time.time() - started) < 0.8 * float(budget):
+    if elapsed < 0.8 * float(budget):
         return False
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
@@ -232,7 +232,7 @@ def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) 
             logger.info(
                 "Run budget wrap-up notice injected (budget=%.0fs, elapsed=%.0fs)",
                 float(budget),
-                time.time() - started,
+                elapsed,
             )
             return True
     return False

--- a/agent/run_budget.py
+++ b/agent/run_budget.py
@@ -1,0 +1,46 @@
+"""Monotonic helpers for the optional per-conversation run budget."""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any, Optional
+
+
+def _finite_seconds(value: Any) -> Optional[float]:
+    """Return a finite numeric duration, rejecting bools and duck types."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    seconds = float(value)
+    return seconds if math.isfinite(seconds) else None
+
+
+def elapsed_run_budget_seconds(
+    agent: Any,
+    *,
+    now: Optional[float] = None,
+) -> Optional[float]:
+    """Return monotonic elapsed time for an active, well-typed run budget."""
+    budget = _finite_seconds(getattr(agent, "run_budget_seconds", None))
+    started_at = _finite_seconds(getattr(agent, "_run_budget_started_at", None))
+    if budget is None or budget <= 0 or started_at is None:
+        return None
+    current = time.monotonic() if now is None else _finite_seconds(now)
+    if current is None:
+        return None
+    return max(0.0, current - started_at)
+
+
+def remaining_run_budget_seconds(
+    agent: Any,
+    *,
+    now: Optional[float] = None,
+) -> Optional[float]:
+    """Return the bounded remaining budget, or ``None`` when inactive."""
+    budget = _finite_seconds(getattr(agent, "run_budget_seconds", None))
+    if budget is None or budget <= 0:
+        return None
+    elapsed = elapsed_run_budget_seconds(agent, now=now)
+    if elapsed is None:
+        return None
+    return max(0.0, budget - elapsed)

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 import threading
@@ -91,6 +92,7 @@ class TurnResult:
 # normal completion path fires. Mirrors openclaw beta.8 fix.
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 _FINAL_ANSWER_COMPLETION_GRACE_SECONDS = 5.0
+_APPROVAL_CANCEL_JOIN_SECONDS = 0.25
 
 
 def _bounded_request_timeout(
@@ -292,6 +294,16 @@ class _ServerRequestRouting:
     auto_approve_apply_patch: bool = False
 
 
+@dataclass
+class _TurnEventState:
+    """Mutable projection/terminal state shared by every notification path."""
+
+    turn_complete: bool = False
+    final_answer_completion_deadline: Optional[float] = None
+    completed_final_answer_text: Optional[str] = None
+    last_tool_completion_at: Optional[float] = None
+
+
 class CodexAppServerSession:
     """One Codex thread per Hermes session, lifetime owned by AIAgent.
 
@@ -332,6 +344,8 @@ class CodexAppServerSession:
         self._interrupt_event = threading.Event()
         self._active_turn_id: Optional[str] = None
         self._active_turn_lock = threading.Lock()
+        self._approval_wait_lock = threading.Lock()
+        self._approval_cancel_events: set[threading.Event] = set()
         # Pending file-change items, keyed by item id. Populated on
         # item/started for fileChange items; consumed by the approval
         # bridge when codex sends item/fileChange/requestApproval. The
@@ -412,6 +426,9 @@ class CodexAppServerSession:
         if self._closed:
             return
         self._closed = True
+        with self._approval_wait_lock:
+            for cancel_event in self._approval_cancel_events:
+                cancel_event.set()
         with self._active_turn_lock:
             self._active_turn_id = None
         if self._client is not None:
@@ -434,6 +451,9 @@ class CodexAppServerSession:
         """Idempotent: signal the active turn loop to issue turn/interrupt
         and unwind. Called by AIAgent's _interrupt_requested path."""
         self._interrupt_event.set()
+        with self._approval_wait_lock:
+            for cancel_event in self._approval_cancel_events:
+                cancel_event.set()
 
     def request_steer(self, text: str) -> bool:
         """Append user guidance to the active Codex turn via ``turn/steer``."""
@@ -502,6 +522,96 @@ class CodexAppServerSession:
         return f"{base}\ncodex stderr (last {len(tail)} lines):\n{redacted}"
 
     # ---------- per-turn ----------
+
+    def _apply_turn_notification(
+        self,
+        note: dict,
+        *,
+        result: TurnResult,
+        projector: CodexEventProjector,
+        state: _TurnEventState,
+        deadline: Optional[float],
+    ) -> bool:
+        """Apply one active-turn notification through the canonical path.
+
+        Returns ``False`` for foreign or deadline-late notifications.  Both
+        ordinary polling and approval pre-drain call this method, so projection,
+        watchdog state, and terminal status can never diverge by queue path.
+        """
+        assert self._client is not None
+        method = note.get("method", "")
+        if not _notification_belongs_to_turn(
+            note,
+            thread_id=self._thread_id,
+            turn_id=result.turn_id,
+        ):
+            logger.debug("ignoring foreign codex notification: method=%s", method)
+            return False
+
+        now = time.monotonic()
+        if deadline is not None and now >= deadline:
+            logger.debug("ignoring codex notification received at/after deadline: %s", method)
+            return False
+
+        if self._on_event is not None:
+            try:
+                self._on_event(note)
+            except Exception:  # pragma: no cover - display callback
+                logger.debug("on_event callback raised", exc_info=True)
+
+        _apply_token_usage_notification(result, note)
+        _apply_compaction_notification(result, note)
+        self._track_pending_file_change(note)
+
+        projection = projector.project(note)
+        is_protocol_final = _is_completed_final_answer_item(note)
+        if is_protocol_final and projection.final_text:
+            state.final_answer_completion_deadline = (
+                now + _FINAL_ANSWER_COMPLETION_GRACE_SECONDS
+            )
+            state.completed_final_answer_text = projection.final_text
+        if projection.messages:
+            result.projected_messages.extend(projection.messages)
+        if projection.is_tool_iteration:
+            result.tool_iterations += 1
+            state.last_tool_completion_at = now
+        elif projection.messages or projection.final_text is not None:
+            state.last_tool_completion_at = None
+
+        if projection.final_text is not None:
+            if is_protocol_final or state.completed_final_answer_text is None:
+                result.final_text = projection.final_text
+            if _has_turn_aborted_marker(projection.final_text):
+                result.final_text = projection.final_text
+                state.turn_complete = True
+                result.interrupted = True
+                result.error = result.error or "codex reported turn_aborted"
+
+        if method == "turn/completed":
+            state.turn_complete = True
+            turn = (note.get("params") or {}).get("turn") or {}
+            turn_status = turn.get("status")
+            if turn_status == "interrupted":
+                result.interrupted = True
+            elif turn_status and turn_status != "completed":
+                err_obj = turn.get("error")
+                err_msg = (
+                    _format_responses_error(err_obj, str(turn_status))
+                    if err_obj
+                    else f"turn ended status={turn_status}"
+                )
+                stderr_blob = "\n".join(self._client.stderr_tail(40))
+                hint = _classify_oauth_failure(err_msg, stderr_blob)
+                if hint is not None:
+                    result.error = hint
+                    result.should_retire = True
+                elif err_obj:
+                    result.error = self._format_error_with_stderr(
+                        f"turn ended status={turn_status}", err_msg
+                    )
+                else:
+                    result.error = err_msg
+        return True
 
     def run_turn(
         self,
@@ -615,26 +725,15 @@ class CodexAppServerSession:
         result.turn_id = (ts.get("turn") or {}).get("id")
         with self._active_turn_lock:
             self._active_turn_id = result.turn_id
-        turn_complete = False
-        # A completed phase=final_answer item is protocol-grounded terminal
-        # output, but allow the normal turn/completed notification and trailing
-        # bookkeeping a short window to arrive before using the compatibility
-        # fallback. This also keeps that fallback reachable for no-budget turns.
-        final_answer_completion_deadline: Optional[float] = None
-        completed_final_answer_text: Optional[str] = None
-        # Post-tool watchdog state. last_tool_completion_at is set whenever
-        # a tool-shaped item completes; if no further notification arrives
-        # within post_tool_quiet_timeout and the turn hasn't completed, we
-        # fast-fail and retire the session.
-        last_tool_completion_at: Optional[float] = None
+        state = _TurnEventState()
 
         while (
             (deadline is None or time.monotonic() < deadline)
             and (
-                final_answer_completion_deadline is None
-                or time.monotonic() < final_answer_completion_deadline
+                state.final_answer_completion_deadline is None
+                or time.monotonic() < state.final_answer_completion_deadline
             )
-            and not turn_complete
+            and not state.turn_complete
         ):
             if self._interrupt_event.is_set():
                 self._issue_interrupt(result.turn_id)
@@ -662,9 +761,9 @@ class CodexAppServerSession:
             # signal and codex has been silent past the quiet timeout, give
             # up on this turn instead of waiting for the outer deadline.
             if (
-                last_tool_completion_at is not None
-                and (time.monotonic() - last_tool_completion_at)
-                    > post_tool_quiet_timeout
+                state.last_tool_completion_at is not None
+                and (time.monotonic() - state.last_tool_completion_at)
+                    >= post_tool_quiet_timeout
             ):
                 self._issue_interrupt(result.turn_id)
                 result.interrupted = True
@@ -688,182 +787,80 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
-                    if not _notification_belongs_to_turn(
+                    self._apply_turn_notification(
                         pending,
-                        thread_id=self._thread_id,
-                        turn_id=result.turn_id,
-                    ):
-                        logger.debug(
-                            "ignoring foreign codex notification while draining "
-                            "server request: method=%s",
-                            pending.get("method"),
+                        result=result,
+                        projector=projector,
+                        state=state,
+                        deadline=deadline,
+                    )
+                    if state.turn_complete:
+                        break
+                approval_deadline = deadline
+                if state.final_answer_completion_deadline is not None:
+                    approval_deadline = (
+                        state.final_answer_completion_deadline
+                        if approval_deadline is None
+                        else min(
+                            approval_deadline,
+                            state.final_answer_completion_deadline,
                         )
-                        continue
-                    # Mirror the main notification-handling block below so
-                    # display events surface and stay in step with projector
-                    # state. Without this, item/started / item/completed
-                    # events drained as part of the approval-roundtrip
-                    # preamble are projected into messages but never reach
-                    # the tool-progress display, silently hiding tool
-                    # bubbles around approvals.
-                    if self._on_event is not None:
-                        try:
-                            self._on_event(pending)
-                        except Exception:  # pragma: no cover - display callback
-                            logger.debug(
-                                "on_event callback raised", exc_info=True
-                            )
-                    _apply_token_usage_notification(result, pending)
-                    _apply_compaction_notification(result, pending)
-                    self._track_pending_file_change(pending)
-                    proj = projector.project(pending)
-                    is_protocol_final = _is_completed_final_answer_item(pending)
-                    if is_protocol_final and proj.final_text:
-                        final_answer_completion_deadline = (
-                            time.monotonic()
-                            + _FINAL_ANSWER_COMPLETION_GRACE_SECONDS
-                        )
-                        completed_final_answer_text = proj.final_text
-                    if proj.messages:
-                        result.projected_messages.extend(proj.messages)
-                    if proj.is_tool_iteration:
-                        result.tool_iterations += 1
-                        last_tool_completion_at = time.monotonic()
-                    if proj.final_text is not None:
-                        if is_protocol_final or completed_final_answer_text is None:
-                            result.final_text = proj.final_text
-                        if _has_turn_aborted_marker(proj.final_text):
-                            result.final_text = proj.final_text
-                            turn_complete = True
-                            result.interrupted = True
-                            result.error = (
-                                result.error
-                                or "codex reported turn_aborted"
-                            )
-                self._handle_server_request(sreq)
-                # Activity counts as live signal — reset the post-tool
-                # quiet timer so an approval round-trip doesn't trip it.
-                last_tool_completion_at = None
+                    )
+                if state.last_tool_completion_at is not None:
+                    watchdog_deadline = (
+                        state.last_tool_completion_at + post_tool_quiet_timeout
+                    )
+                    approval_deadline = (
+                        watchdog_deadline
+                        if approval_deadline is None
+                        else min(approval_deadline, watchdog_deadline)
+                    )
+                self._handle_server_request(
+                    sreq,
+                    deadline=approval_deadline,
+                )
                 continue
 
-            note = self._client.take_notification(
-                timeout=notification_poll_timeout
-            )
+            now = time.monotonic()
+            wait_timeout = notification_poll_timeout
+            if deadline is not None:
+                wait_timeout = min(wait_timeout, max(0.0, deadline - now))
+            if state.final_answer_completion_deadline is not None:
+                wait_timeout = min(
+                    wait_timeout,
+                    max(0.0, state.final_answer_completion_deadline - now),
+                )
+            if state.last_tool_completion_at is not None:
+                watchdog_remaining = (
+                    state.last_tool_completion_at
+                    + post_tool_quiet_timeout
+                    - now
+                )
+                wait_timeout = min(wait_timeout, max(0.0, watchdog_remaining))
+            note = self._client.take_notification(timeout=wait_timeout)
             if note is None:
                 continue
-
-            method = note.get("method", "")
-            if not _notification_belongs_to_turn(
+            self._apply_turn_notification(
                 note,
-                thread_id=self._thread_id,
-                turn_id=result.turn_id,
-            ):
-                logger.debug(
-                    "ignoring foreign codex notification: method=%s", method
-                )
-                continue
-
-            if self._on_event is not None:
-                try:
-                    self._on_event(note)
-                except Exception:  # pragma: no cover - display callback
-                    logger.debug("on_event callback raised", exc_info=True)
-
-            _apply_token_usage_notification(result, note)
-            _apply_compaction_notification(result, note)
-
-            # Track in-progress fileChange items so the approval bridge
-            # can surface a real change summary when codex requests
-            # approval (the approval params themselves don't carry the
-            # changeset). Quirk #4 fix.
-            self._track_pending_file_change(note)
-
-            # Project into messages
-            projection = projector.project(note)
-            is_protocol_final = _is_completed_final_answer_item(note)
-            if is_protocol_final and projection.final_text:
-                final_answer_completion_deadline = (
-                    time.monotonic()
-                    + _FINAL_ANSWER_COMPLETION_GRACE_SECONDS
-                )
-                completed_final_answer_text = projection.final_text
-            if projection.messages:
-                result.projected_messages.extend(projection.messages)
-            if projection.is_tool_iteration:
-                result.tool_iterations += 1
-                # Arm/refresh the post-tool quiet watchdog whenever a
-                # tool-shaped item completes.
-                last_tool_completion_at = time.monotonic()
-            else:
-                # Any non-tool projected activity (assistant message,
-                # status update, etc.) means codex is still producing
-                # output — clear the quiet timer so we don't fast-fail.
-                if projection.messages or projection.final_text is not None:
-                    last_tool_completion_at = None
-            if projection.final_text is not None:
-                # Codex can emit multiple agentMessage items in one turn
-                # (e.g. commentary then final). Once the protocol identifies
-                # a final_answer, later commentary cannot replace its payload.
-                if is_protocol_final or completed_final_answer_text is None:
-                    result.final_text = projection.final_text
-                # Some codex builds tear a turn down by emitting a
-                # `<turn_aborted>` marker in the agent message text and
-                # never sending turn/completed. Treat the marker itself
-                # as terminal so we don't burn the full deadline.
-                if _has_turn_aborted_marker(projection.final_text):
-                    result.final_text = projection.final_text
-                    turn_complete = True
-                    result.interrupted = True
-                    result.error = (
-                        result.error or "codex reported turn_aborted"
-                    )
-
-            if method == "turn/completed":
-                turn_complete = True
-                turn_status = (
-                    (note.get("params") or {}).get("turn") or {}
-                ).get("status")
-                if turn_status == "interrupted":
-                    result.interrupted = True
-                elif turn_status and turn_status != "completed":
-                    err_obj = (
-                        (note.get("params") or {}).get("turn") or {}
-                    ).get("error")
-                    err_msg = (
-                        _format_responses_error(err_obj, str(turn_status))
-                        if err_obj
-                        else f"turn ended status={turn_status}"
-                    )
-                    # If the turn failed for an auth/refresh reason,
-                    # rewrite the error into a re-auth hint AND mark
-                    # the session for retirement.
-                    stderr_blob = "\n".join(
-                        self._client.stderr_tail(40)
-                    )
-                    hint = _classify_oauth_failure(err_msg, stderr_blob)
-                    if hint is not None:
-                        result.error = hint
-                        result.should_retire = True
-                    elif err_obj:
-                        result.error = self._format_error_with_stderr(
-                            f"turn ended status={turn_status}", err_msg
-                        )
-                    else:
-                        result.error = err_msg
+                result=result,
+                projector=projector,
+                state=state,
+                deadline=deadline,
+            )
 
         if (
-            turn_complete
+            state.turn_complete
             and not result.interrupted
             and result.error is None
-            and completed_final_answer_text
+            and state.completed_final_answer_text
         ):
-            result.final_text = completed_final_answer_text
+            result.final_text = state.completed_final_answer_text
 
         if (
-            not turn_complete
+            not state.turn_complete
             and not result.interrupted
-            and final_answer_completion_deadline is not None
-            and completed_final_answer_text
+            and state.final_answer_completion_deadline is not None
+            and state.completed_final_answer_text
             and result.error is None
         ):
             logger.warning(
@@ -872,10 +869,10 @@ class CodexAppServerSession:
                 "accepting the protocol-marked final text as the terminal "
                 "response"
             )
-            result.final_text = completed_final_answer_text
-            turn_complete = True
+            result.final_text = state.completed_final_answer_text
+            state.turn_complete = True
 
-        if not turn_complete and not result.interrupted:
+        if not state.turn_complete and not result.interrupted:
             # Hit the deadline. Issue interrupt to stop wasted compute, and
             # tell the caller to retire the session — a turn that never
             # finished is a strong sign codex is wedged in a way the next
@@ -1100,7 +1097,107 @@ class CodexAppServerSession:
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
 
-    def _handle_server_request(self, req: dict) -> None:
+    def _approval_callback_kwargs(
+        self,
+        *,
+        deadline: Optional[float],
+        cancel_event: threading.Event,
+    ) -> dict[str, Any]:
+        """Pass cooperative controls only when a duck-typed callback accepts them."""
+        callback = self._approval_callback
+        if callback is None:
+            return {}
+        try:
+            signature = inspect.signature(callback)
+        except (TypeError, ValueError):
+            return {}
+        accepts_any = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+        kwargs: dict[str, Any] = {}
+        if accepts_any or "deadline" in signature.parameters:
+            kwargs["deadline"] = deadline
+        if accepts_any or "cancel_event" in signature.parameters:
+            kwargs["cancel_event"] = cancel_event
+        return kwargs
+
+    def _wait_for_approval_decision(
+        self,
+        decide: Callable[[threading.Event], str],
+        *,
+        deadline: Optional[float],
+    ) -> str:
+        """Run a possibly blocking prompt while retaining turn cancellation."""
+        cancel_event = threading.Event()
+        done = threading.Event()
+        outcome: dict[str, str] = {}
+
+        def run_callback() -> None:
+            try:
+                outcome["decision"] = decide(cancel_event)
+            except Exception:
+                logger.exception("codex approval decision failed")
+                outcome["decision"] = "decline"
+            finally:
+                done.set()
+                with self._approval_wait_lock:
+                    self._approval_cancel_events.discard(cancel_event)
+
+        with self._approval_wait_lock:
+            self._approval_cancel_events.add(cancel_event)
+        worker = threading.Thread(
+            target=run_callback,
+            name="codex-approval-callback",
+            daemon=True,
+        )
+        worker.start()
+
+        def cancellation_requested(*, now: Optional[float] = None) -> bool:
+            client = self._client
+            return (
+                self._interrupt_event.is_set()
+                or client is None
+                or not client.is_alive()
+                or (
+                    deadline is not None
+                    and (time.monotonic() if now is None else now) >= deadline
+                )
+            )
+
+        def decline_after_cancellation() -> str:
+            cancel_event.set()
+            # Cooperative callbacks (including the CLI prompt) should be gone
+            # before the turn returns.  Keep the wait bounded for legacy
+            # callbacks that do not accept ``cancel_event``.
+            worker.join(timeout=_APPROVAL_CANCEL_JOIN_SECONDS)
+            if worker.is_alive():
+                logger.warning(
+                    "codex approval callback did not stop after cancellation"
+                )
+            return "decline"
+
+        while not done.is_set():
+            now = time.monotonic()
+            if cancellation_requested(now=now):
+                return decline_after_cancellation()
+            wait_timeout = 0.01
+            if deadline is not None:
+                wait_timeout = min(wait_timeout, max(0.0, deadline - now))
+            done.wait(wait_timeout)
+
+        # A callback result that arrived on the deadline boundary is late and
+        # must not approve work after the whole-turn budget expired.
+        if cancellation_requested():
+            return decline_after_cancellation()
+        return outcome.get("decision", "decline")
+
+    def _handle_server_request(
+        self,
+        req: dict,
+        *,
+        deadline: Optional[float] = None,
+    ) -> None:
         """Translate a codex server request (approval) into Hermes' approval
         flow, then send the response.
 
@@ -1118,18 +1215,46 @@ class CodexAppServerSession:
         rid = req.get("id")
         params = req.get("params") or {}
 
+        def respond(payload: dict) -> None:
+            client = self._client
+            if client is None:
+                return
+            try:
+                client.respond(rid, payload)
+            except Exception:
+                if client.is_alive():
+                    raise
+                logger.debug(
+                    "codex exited before server-request response could be sent",
+                    exc_info=True,
+                )
+
         if method == "item/commandExecution/requestApproval":
-            decision = self._decide_exec_approval(params)
-            self._client.respond(rid, {"decision": decision})
+            decision = self._wait_for_approval_decision(
+                lambda cancel_event: self._decide_exec_approval(
+                    params,
+                    deadline=deadline,
+                    cancel_event=cancel_event,
+                ),
+                deadline=deadline,
+            )
+            respond({"decision": decision})
         elif method == "item/fileChange/requestApproval":
-            decision = self._decide_apply_patch_approval(params)
-            self._client.respond(rid, {"decision": decision})
+            decision = self._wait_for_approval_decision(
+                lambda cancel_event: self._decide_apply_patch_approval(
+                    params,
+                    deadline=deadline,
+                    cancel_event=cancel_event,
+                ),
+                deadline=deadline,
+            )
+            respond({"decision": decision})
         elif method == "item/permissions/requestApproval":
             # Codex sometimes asks to escalate permissions mid-turn. We
             # always decline — the user already chose their permission
             # profile in ~/.codex/config.toml and surprise escalations
             # shouldn't be silently accepted.
-            self._client.respond(rid, {"decision": "decline"})
+            respond({"decision": "decline"})
         elif method == "mcpServer/elicitation/request":
             # Codex's MCP layer asks the user for structured input on
             # behalf of an MCP server (e.g. tool-call confirmation,
@@ -1141,15 +1266,9 @@ class CodexAppServerSession:
             # codex's own auth flow.
             server_name = params.get("serverName") or ""
             if server_name == "hermes-tools":
-                self._client.respond(
-                    rid,
-                    {"action": "accept", "content": None, "_meta": None},
-                )
+                respond({"action": "accept", "content": None, "_meta": None})
             else:
-                self._client.respond(
-                    rid,
-                    {"action": "decline", "content": None, "_meta": None},
-                )
+                respond({"action": "decline", "content": None, "_meta": None})
         else:
             # Unknown server request — codex can extend this surface. Reject
             # cleanly so codex doesn't hang waiting for us.
@@ -1158,7 +1277,13 @@ class CodexAppServerSession:
                 rid, code=-32601, message=f"Unsupported method: {method}"
             )
 
-    def _decide_exec_approval(self, params: dict) -> str:
+    def _decide_exec_approval(
+        self,
+        params: dict,
+        *,
+        deadline: Optional[float] = None,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> str:
         """Decide a Codex exec approval request.
 
         This is protocol-level routing only — it carries NO Hermes
@@ -1184,8 +1309,15 @@ class CodexAppServerSession:
             description += f" — {reason}"
         if self._approval_callback is not None:
             try:
+                callback_cancel_event = cancel_event or threading.Event()
                 choice = self._approval_callback(
-                    command, description, allow_permanent=False
+                    command,
+                    description,
+                    allow_permanent=False,
+                    **self._approval_callback_kwargs(
+                        deadline=deadline,
+                        cancel_event=callback_cancel_event,
+                    ),
                 )
                 return _approval_choice_to_codex_decision(choice)
             except Exception:
@@ -1193,7 +1325,13 @@ class CodexAppServerSession:
                 return "decline"
         return "decline"  # fail-closed when no callback wired
 
-    def _decide_apply_patch_approval(self, params: dict) -> str:
+    def _decide_apply_patch_approval(
+        self,
+        params: dict,
+        *,
+        deadline: Optional[float] = None,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> str:
         """Decide a Codex apply_patch approval request.
 
         Protocol-level routing only; Hermes approval-mode/timeout
@@ -1229,10 +1367,15 @@ class CodexAppServerSession:
                 else "apply_patch"
             )
             try:
+                callback_cancel_event = cancel_event or threading.Event()
                 choice = self._approval_callback(
                     command_label,
                     description,
                     allow_permanent=False,
+                    **self._approval_callback_kwargs(
+                        deadline=deadline,
+                        cancel_event=callback_cancel_event,
+                    ),
                 )
                 return _approval_choice_to_codex_decision(choice)
             except Exception:

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -92,6 +92,23 @@ class TurnResult:
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 
 
+def _is_completed_final_answer_item(note: dict) -> bool:
+    """Whether *note* is protocol-grounded terminal assistant output.
+
+    A completed ``agentMessage`` alone is not terminal: Codex uses the same
+    item type for commentary/progress.  Newer app-server builds distinguish
+    the terminal item with ``phase=final_answer``; that is the only safe
+    compatibility signal when ``turn/completed`` is missing.
+    """
+    if note.get("method") != "item/completed":
+        return False
+    item = (note.get("params") or {}).get("item") or {}
+    return (
+        item.get("type") == "agentMessage"
+        and item.get("phase") == "final_answer"
+    )
+
+
 def _notification_scope_ids(
     note: dict,
 ) -> tuple[Optional[str], Optional[str]]:
@@ -471,13 +488,18 @@ class CodexAppServerSession:
         self,
         user_input: Any,
         *,
-        turn_timeout: float = 600.0,
+        turn_timeout: Optional[float] = None,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
         into Hermes' messages shape.
+
+        turn_timeout: optional hard wall-clock cap for the whole native Codex
+        turn. ``None`` waits for protocol completion without an arbitrary cap;
+        explicit interrupts, subprocess failure, and the post-tool watchdog
+        remain active.
 
         post_tool_quiet_timeout: if codex emits a tool completion and then
         goes quiet for this many seconds without emitting another item or
@@ -559,15 +581,23 @@ class CodexAppServerSession:
         result.turn_id = (ts.get("turn") or {}).get("id")
         with self._active_turn_lock:
             self._active_turn_id = result.turn_id
-        deadline = time.monotonic() + turn_timeout
+        deadline = (
+            time.monotonic() + max(0.0, turn_timeout)
+            if turn_timeout is not None
+            else None
+        )
         turn_complete = False
+        saw_completed_final_answer = False
         # Post-tool watchdog state. last_tool_completion_at is set whenever
         # a tool-shaped item completes; if no further notification arrives
         # within post_tool_quiet_timeout and the turn hasn't completed, we
         # fast-fail and retire the session.
         last_tool_completion_at: Optional[float] = None
 
-        while time.monotonic() < deadline and not turn_complete:
+        while (
+            (deadline is None or time.monotonic() < deadline)
+            and not turn_complete
+        ):
             if self._interrupt_event.is_set():
                 self._issue_interrupt(result.turn_id)
                 result.interrupted = True
@@ -649,6 +679,8 @@ class CodexAppServerSession:
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)
+                    if _is_completed_final_answer_item(pending):
+                        saw_completed_final_answer = True
                     if proj.messages:
                         result.projected_messages.extend(proj.messages)
                     if proj.is_tool_iteration:
@@ -703,6 +735,8 @@ class CodexAppServerSession:
 
             # Project into messages
             projection = projector.project(note)
+            if _is_completed_final_answer_item(note):
+                saw_completed_final_answer = True
             if projection.messages:
                 result.projected_messages.extend(projection.messages)
             if projection.is_tool_iteration:
@@ -760,13 +794,14 @@ class CodexAppServerSession:
         if (
             not turn_complete
             and not result.interrupted
+            and saw_completed_final_answer
             and result.final_text
             and result.error is None
         ):
             logger.warning(
                 "codex app-server turn reached deadline after a completed "
-                "assistant message but before turn/completed; accepting "
-                "the assistant text as the terminal response"
+                "final_answer item but before turn/completed; accepting the "
+                "protocol-marked final text as the terminal response"
             )
             turn_complete = True
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -95,6 +95,29 @@ _FINAL_ANSWER_COMPLETION_GRACE_SECONDS = 5.0
 _APPROVAL_CANCEL_JOIN_SECONDS = 0.25
 
 
+class _ApprovalCancelEvent(threading.Event):
+    """Cancellation event that can also wake a cooperative blocking prompt."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._waker_lock = threading.Lock()
+        self._wakers: list[Callable[[], None]] = []
+
+    def add_waker(self, waker: Callable[[], None]) -> None:
+        with self._waker_lock:
+            if not self.is_set():
+                self._wakers.append(waker)
+                return
+        waker()
+
+    def set(self) -> None:
+        super().set()
+        with self._waker_lock:
+            wakers, self._wakers = self._wakers, []
+        for waker in wakers:
+            waker()
+
+
 def _bounded_request_timeout(
     deadline: Optional[float], default_timeout: float
 ) -> float:
@@ -796,6 +819,9 @@ class CodexAppServerSession:
                     )
                     if state.turn_complete:
                         break
+                if state.turn_complete:
+                    self._decline_server_request(sreq)
+                    break
                 approval_deadline = deadline
                 if state.final_answer_completion_deadline is not None:
                     approval_deadline = (
@@ -1129,7 +1155,7 @@ class CodexAppServerSession:
         deadline: Optional[float],
     ) -> str:
         """Run a possibly blocking prompt while retaining turn cancellation."""
-        cancel_event = threading.Event()
+        cancel_event = _ApprovalCancelEvent()
         done = threading.Event()
         outcome: dict[str, str] = {}
 
@@ -1167,10 +1193,18 @@ class CodexAppServerSession:
 
         def decline_after_cancellation() -> str:
             cancel_event.set()
-            # Cooperative callbacks (including the CLI prompt) should be gone
-            # before the turn returns.  Keep the wait bounded for legacy
-            # callbacks that do not accept ``cancel_event``.
-            worker.join(timeout=_APPROVAL_CANCEL_JOIN_SECONDS)
+            callback = self._approval_callback
+            callback_fn = getattr(callback, "__func__", callback)
+            cooperative = bool(
+                getattr(callback_fn, "_codex_cooperative_cancel", False)
+            )
+            # The marked CLI callback is cancellation-wakeable, so its worker
+            # must be fully reaped before returning. Keep legacy/third-party
+            # callbacks bounded because accepting cancel_event does not prove
+            # that they actually cooperate with it.
+            worker.join(
+                timeout=None if cooperative else _APPROVAL_CANCEL_JOIN_SECONDS
+            )
             if worker.is_alive():
                 logger.warning(
                     "codex approval callback did not stop after cancellation"
@@ -1191,6 +1225,39 @@ class CodexAppServerSession:
         if cancellation_requested():
             return decline_after_cancellation()
         return outcome.get("decision", "decline")
+
+    def _decline_server_request(self, req: dict) -> None:
+        """Resolve a removed request without consulting authorization policy."""
+        client = self._client
+        if client is None:
+            return
+        request_id = req.get("id")
+        method = req.get("method", "")
+        try:
+            if method in {
+                "item/commandExecution/requestApproval",
+                "item/fileChange/requestApproval",
+                "item/permissions/requestApproval",
+            }:
+                client.respond(request_id, {"decision": "decline"})
+            elif method == "mcpServer/elicitation/request":
+                client.respond(
+                    request_id,
+                    {"action": "decline", "content": None, "_meta": None},
+                )
+            else:
+                client.respond_error(
+                    request_id,
+                    code=-32601,
+                    message=f"Unsupported method: {method}",
+                )
+        except Exception:
+            if client.is_alive():
+                raise
+            logger.debug(
+                "codex exited before terminal request could be declined",
+                exc_info=True,
+            )
 
     def _handle_server_request(
         self,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -90,6 +90,19 @@ class TurnResult:
 # items when an interrupt or upstream error tears the turn down before the
 # normal completion path fires. Mirrors openclaw beta.8 fix.
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
+_FINAL_ANSWER_COMPLETION_GRACE_SECONDS = 5.0
+
+
+def _bounded_request_timeout(
+    deadline: Optional[float], default_timeout: float
+) -> float:
+    """Cap one startup request by an optional whole-turn deadline."""
+    if deadline is None:
+        return default_timeout
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("codex app-server turn deadline expired")
+    return min(default_timeout, remaining)
 
 
 def _is_completed_final_answer_item(note: dict) -> bool:
@@ -329,10 +342,11 @@ class CodexAppServerSession:
 
     # ---------- lifecycle ----------
 
-    def ensure_started(self) -> str:
+    def ensure_started(self, *, deadline: Optional[float] = None) -> str:
         """Spawn the subprocess, do the initialize handshake, and start a
         thread. Returns the codex thread id. Idempotent — repeated calls
-        return the same thread id."""
+        return the same thread id. When supplied, ``deadline`` bounds the
+        startup RPCs by the caller's absolute monotonic deadline."""
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
@@ -343,6 +357,7 @@ class CodexAppServerSession:
             client_name="hermes",
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
+            timeout=_bounded_request_timeout(deadline, 10.0),
         )
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
@@ -360,7 +375,11 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
-        result = self._client.request("thread/start", params, timeout=15)
+        result = self._client.request(
+            "thread/start",
+            params,
+            timeout=_bounded_request_timeout(deadline, 15.0),
+        )
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
         # tolerance fix so future codex drops/renames don't KeyError us
@@ -497,9 +516,9 @@ class CodexAppServerSession:
         into Hermes' messages shape.
 
         turn_timeout: optional hard wall-clock cap for the whole native Codex
-        turn. ``None`` waits for protocol completion without an arbitrary cap;
-        explicit interrupts, subprocess failure, and the post-tool watchdog
-        remain active.
+        turn. ``None`` waits without an arbitrary whole-turn cap; explicit
+        interrupts, subprocess failure, the post-tool watchdog, and the short
+        completion grace after a protocol-marked final answer remain active.
 
         post_tool_quiet_timeout: if codex emits a tool completion and then
         goes quiet for this many seconds without emitting another item or
@@ -513,8 +532,18 @@ class CodexAppServerSession:
         # the caller can render — instead of bubbling raw codex exceptions
         # up to AIAgent.run_conversation.
         result = TurnResult()
+        deadline = (
+            time.monotonic() + max(0.0, turn_timeout)
+            if turn_timeout is not None
+            else None
+        )
+        if deadline is not None and time.monotonic() >= deadline:
+            result.interrupted = True
+            result.error = f"turn timed out after {turn_timeout}s"
+            self._interrupt_event.clear()
+            return result
         try:
-            self.ensure_started()
+            self.ensure_started(deadline=deadline)
         except (CodexAppServerError, TimeoutError) as exc:
             result.error = self._format_error_with_stderr(
                 "codex app-server startup failed", exc
@@ -534,6 +563,11 @@ class CodexAppServerSession:
             result.interrupted = True
             self._interrupt_event.clear()
             return result
+        if deadline is not None and time.monotonic() >= deadline:
+            result.interrupted = True
+            result.error = f"turn timed out after {turn_timeout}s"
+            self._interrupt_event.clear()
+            return result
         projector = CodexEventProjector()
 
         user_input_text = _coerce_turn_input_text(user_input)
@@ -547,7 +581,7 @@ class CodexAppServerSession:
                     "threadId": self._thread_id,
                     "input": [{"type": "text", "text": user_input_text}],
                 },
-                timeout=10,
+                timeout=_bounded_request_timeout(deadline, 10.0),
             )
         except CodexAppServerError as exc:
             # Classify auth/refresh failures so the user gets a clear
@@ -581,13 +615,13 @@ class CodexAppServerSession:
         result.turn_id = (ts.get("turn") or {}).get("id")
         with self._active_turn_lock:
             self._active_turn_id = result.turn_id
-        deadline = (
-            time.monotonic() + max(0.0, turn_timeout)
-            if turn_timeout is not None
-            else None
-        )
         turn_complete = False
-        saw_completed_final_answer = False
+        # A completed phase=final_answer item is protocol-grounded terminal
+        # output, but allow the normal turn/completed notification and trailing
+        # bookkeeping a short window to arrive before using the compatibility
+        # fallback. This also keeps that fallback reachable for no-budget turns.
+        final_answer_completion_deadline: Optional[float] = None
+        completed_final_answer_text: Optional[str] = None
         # Post-tool watchdog state. last_tool_completion_at is set whenever
         # a tool-shaped item completes; if no further notification arrives
         # within post_tool_quiet_timeout and the turn hasn't completed, we
@@ -596,6 +630,10 @@ class CodexAppServerSession:
 
         while (
             (deadline is None or time.monotonic() < deadline)
+            and (
+                final_answer_completion_deadline is None
+                or time.monotonic() < final_answer_completion_deadline
+            )
             and not turn_complete
         ):
             if self._interrupt_event.is_set():
@@ -679,16 +717,23 @@ class CodexAppServerSession:
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)
-                    if _is_completed_final_answer_item(pending):
-                        saw_completed_final_answer = True
+                    is_protocol_final = _is_completed_final_answer_item(pending)
+                    if is_protocol_final and proj.final_text:
+                        final_answer_completion_deadline = (
+                            time.monotonic()
+                            + _FINAL_ANSWER_COMPLETION_GRACE_SECONDS
+                        )
+                        completed_final_answer_text = proj.final_text
                     if proj.messages:
                         result.projected_messages.extend(proj.messages)
                     if proj.is_tool_iteration:
                         result.tool_iterations += 1
                         last_tool_completion_at = time.monotonic()
                     if proj.final_text is not None:
-                        result.final_text = proj.final_text
+                        if is_protocol_final or completed_final_answer_text is None:
+                            result.final_text = proj.final_text
                         if _has_turn_aborted_marker(proj.final_text):
+                            result.final_text = proj.final_text
                             turn_complete = True
                             result.interrupted = True
                             result.error = (
@@ -735,8 +780,13 @@ class CodexAppServerSession:
 
             # Project into messages
             projection = projector.project(note)
-            if _is_completed_final_answer_item(note):
-                saw_completed_final_answer = True
+            is_protocol_final = _is_completed_final_answer_item(note)
+            if is_protocol_final and projection.final_text:
+                final_answer_completion_deadline = (
+                    time.monotonic()
+                    + _FINAL_ANSWER_COMPLETION_GRACE_SECONDS
+                )
+                completed_final_answer_text = projection.final_text
             if projection.messages:
                 result.projected_messages.extend(projection.messages)
             if projection.is_tool_iteration:
@@ -752,13 +802,16 @@ class CodexAppServerSession:
                     last_tool_completion_at = None
             if projection.final_text is not None:
                 # Codex can emit multiple agentMessage items in one turn
-                # (e.g. partial then final). Take the last one as canonical.
-                result.final_text = projection.final_text
+                # (e.g. commentary then final). Once the protocol identifies
+                # a final_answer, later commentary cannot replace its payload.
+                if is_protocol_final or completed_final_answer_text is None:
+                    result.final_text = projection.final_text
                 # Some codex builds tear a turn down by emitting a
                 # `<turn_aborted>` marker in the agent message text and
                 # never sending turn/completed. Treat the marker itself
                 # as terminal so we don't burn the full deadline.
                 if _has_turn_aborted_marker(projection.final_text):
+                    result.final_text = projection.final_text
                     turn_complete = True
                     result.interrupted = True
                     result.error = (
@@ -770,39 +823,56 @@ class CodexAppServerSession:
                 turn_status = (
                     (note.get("params") or {}).get("turn") or {}
                 ).get("status")
-                if turn_status and turn_status not in {"completed", "interrupted"}:
+                if turn_status == "interrupted":
+                    result.interrupted = True
+                elif turn_status and turn_status != "completed":
                     err_obj = (
                         (note.get("params") or {}).get("turn") or {}
                     ).get("error")
-                    if err_obj:
-                        err_msg = _format_responses_error(err_obj, str(turn_status))
-                        # If the turn failed for an auth/refresh reason,
-                        # rewrite the error into a re-auth hint AND mark
-                        # the session for retirement.
-                        stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
+                    err_msg = (
+                        _format_responses_error(err_obj, str(turn_status))
+                        if err_obj
+                        else f"turn ended status={turn_status}"
+                    )
+                    # If the turn failed for an auth/refresh reason,
+                    # rewrite the error into a re-auth hint AND mark
+                    # the session for retirement.
+                    stderr_blob = "\n".join(
+                        self._client.stderr_tail(40)
+                    )
+                    hint = _classify_oauth_failure(err_msg, stderr_blob)
+                    if hint is not None:
+                        result.error = hint
+                        result.should_retire = True
+                    elif err_obj:
+                        result.error = self._format_error_with_stderr(
+                            f"turn ended status={turn_status}", err_msg
                         )
-                        hint = _classify_oauth_failure(err_msg, stderr_blob)
-                        if hint is not None:
-                            result.error = hint
-                            result.should_retire = True
-                        else:
-                            result.error = self._format_error_with_stderr(
-                                f"turn ended status={turn_status}", err_msg
-                            )
+                    else:
+                        result.error = err_msg
+
+        if (
+            turn_complete
+            and not result.interrupted
+            and result.error is None
+            and completed_final_answer_text
+        ):
+            result.final_text = completed_final_answer_text
 
         if (
             not turn_complete
             and not result.interrupted
-            and saw_completed_final_answer
-            and result.final_text
+            and final_answer_completion_deadline is not None
+            and completed_final_answer_text
             and result.error is None
         ):
             logger.warning(
-                "codex app-server turn reached deadline after a completed "
-                "final_answer item but before turn/completed; accepting the "
-                "protocol-marked final text as the terminal response"
+                "codex app-server turn ended its completion wait after a "
+                "completed final_answer item but before turn/completed; "
+                "accepting the protocol-marked final text as the terminal "
+                "response"
             )
+            result.final_text = completed_final_answer_text
             turn_complete = True
 
         if not turn_complete and not result.interrupted:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -682,11 +682,11 @@ def build_turn_context(
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
     agent.iteration_budget = IterationBudget(agent.max_iterations)
 
-    # Wall-clock run budget: per-run_conversation clock. Only stamped when a
+    # Monotonic run budget: per-run_conversation clock. Only stamped when a
     # budget is configured so the default path stays clock-free; the wrap-up
     # latch resets each turn (one notice per run, not per session).
     if getattr(agent, "run_budget_seconds", None):
-        agent._run_budget_started_at = time.time()
+        agent._run_budget_started_at = time.monotonic()
     else:
         agent._run_budget_started_at = None
     agent._run_budget_wrapup_injected = False

--- a/cli.py
+++ b/cli.py
@@ -16302,6 +16302,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 prompt_deadline = min(prompt_deadline, deadline)
             response_queue = queue.Queue()
 
+            if cancel_event is not None:
+                add_waker = getattr(cancel_event, "add_waker", None)
+                if add_waker is not None:
+                    add_waker(lambda: response_queue.put_nowait("deny"))
+
             self._approval_state = {
                 "command": command,
                 "description": description,
@@ -16373,6 +16378,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return "timeout"
         finally:
             self._approval_lock.release()
+
+    setattr(_approval_callback, "_codex_cooperative_cancel", True)
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
                           allow_session: bool = True,

--- a/cli.py
+++ b/cli.py
@@ -16257,7 +16257,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
                            allow_session: bool = True,
-                           smart_denied: bool = False) -> str:
+                           smart_denied: bool = False,
+                           deadline: Optional[float] = None,
+                           cancel_event: Optional[threading.Event] = None) -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
@@ -16275,8 +16277,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """
         import time as _time
 
-        with self._approval_lock:
-            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 300))
+        timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 300))
+
+        # A Codex app-server turn can expire or die while this prompt is open.
+        # Acquire the shared modal lock cooperatively so cancellation is not
+        # hidden behind another approval prompt.  Ordinary (non-Codex) callers
+        # retain the legacy behavior where their own timeout starts only after
+        # the preceding prompt releases the lock.
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                return "deny"
+            lock_wait = 0.05
+            if deadline is not None:
+                remaining = deadline - _time.monotonic()
+                if remaining <= 0:
+                    return "timeout"
+                lock_wait = min(lock_wait, remaining)
+            if self._approval_lock.acquire(timeout=lock_wait):
+                break
+
+        try:
+            prompt_deadline = _time.monotonic() + timeout
+            if deadline is not None:
+                prompt_deadline = min(prompt_deadline, deadline)
             response_queue = queue.Queue()
 
             self._approval_state = {
@@ -16291,7 +16314,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 "selected": 0,
                 "response_queue": response_queue,
             }
-            self._approval_deadline = _time.monotonic() + timeout
+            self._approval_deadline = prompt_deadline
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms
@@ -16302,8 +16325,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             _last_countdown_refresh = _time.monotonic()
             while True:
+                if cancel_event is not None and cancel_event.is_set():
+                    self._approval_state = None
+                    self._approval_deadline = 0
+                    self._paint_now()
+                    return "deny"
+                remaining = self._approval_deadline - _time.monotonic()
+                if remaining <= 0:
+                    break
                 try:
-                    result = response_queue.get(timeout=1)
+                    result = response_queue.get(timeout=min(1.0, remaining))
+                    if cancel_event is not None and cancel_event.is_set():
+                        self._approval_state = None
+                        self._approval_deadline = 0
+                        self._paint_now()
+                        return "deny"
                     self._approval_state = None
                     self._approval_deadline = 0
                     self._paint_now()
@@ -16335,6 +16371,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 "⚠", "Approval", command, "timed out (no response)",
             )
             return "timeout"
+        finally:
+            self._approval_lock.release()
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
                           allow_session: bool = True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1539,9 +1539,10 @@ class AIAgent:
         # (or env var) still wins untouched.
         run_budget = getattr(self, "run_budget_seconds", None)
         if run_budget and not self._stale_timeout_is_explicit():
-            started = getattr(self, "_run_budget_started_at", None)
-            if started:
-                remaining = float(run_budget) - (time.time() - started)
+            from agent.run_budget import remaining_run_budget_seconds
+
+            remaining = remaining_run_budget_seconds(self)
+            if remaining is not None:
                 deadline_cap = max(60.0, remaining * 0.5)
                 if deadline_cap < timeout:
                     timeout = deadline_cap

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -74,6 +75,13 @@ def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
 def test_normalize_run_budget_seconds(raw, expected):
     from agent.agent_init import _normalize_run_budget_seconds
     assert _normalize_run_budget_seconds(raw) == expected
+
+
+def test_remaining_budget_ignores_duck_typed_mock_attributes():
+    """Unconfigured mock agents must not enter numeric budget arithmetic."""
+    from agent.run_budget import remaining_run_budget_seconds
+
+    assert remaining_run_budget_seconds(MagicMock()) is None
 
 
 # ── constructor / config plumbing ─────────────────────────────────────────
@@ -135,7 +143,7 @@ def test_active_budget_caps_implicit_reasoning_floor(monkeypatch, tmp_path):
     base, implicit = agent._resolved_api_call_stale_timeout_base()
     assert base == 600.0 and implicit is False
 
-    agent._run_budget_started_at = time.time() - 800
+    agent._run_budget_started_at = time.monotonic() - 800
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 60.0
 
 
@@ -148,7 +156,7 @@ def test_active_budget_cap_half_remaining(monkeypatch, tmp_path):
         model="deepseek/deepseek-v4-pro",
         run_budget_seconds=900,
     )
-    agent._run_budget_started_at = time.time() - 100  # remaining ~800 -> cap ~400
+    agent._run_budget_started_at = time.monotonic() - 100  # remaining ~800 -> cap ~400
     timeout = agent._compute_non_stream_stale_timeout({"input": "hi"})
     assert 395.0 <= timeout <= 400.0
 
@@ -161,7 +169,7 @@ def test_active_budget_never_raises_timeout(monkeypatch, tmp_path):
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
     agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
-    agent._run_budget_started_at = time.time() - 10
+    agent._run_budget_started_at = time.monotonic() - 10
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 90.0
 
 
@@ -170,7 +178,7 @@ def test_explicit_provider_config_wins_over_budget_cap(monkeypatch, tmp_path):
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: 1800.0)
     agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
-    agent._run_budget_started_at = time.time() - 800
+    agent._run_budget_started_at = time.monotonic() - 800
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1800.0
 
 
@@ -180,7 +188,7 @@ def test_explicit_env_var_wins_over_budget_cap(monkeypatch, tmp_path):
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
     agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
     monkeypatch.setenv("HERMES_API_CALL_STALE_TIMEOUT", "1200")
-    agent._run_budget_started_at = time.time() - 800
+    agent._run_budget_started_at = time.monotonic() - 800
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1200.0
 
 
@@ -219,7 +227,7 @@ def _tool_messages():
 
 def test_wrapup_not_injected_when_unset():
     from agent.conversation_loop import _maybe_inject_run_budget_wrapup
-    agent = _StubAgent(budget=None, started=time.time() - 10_000)
+    agent = _StubAgent(budget=None, started=time.monotonic() - 10_000)
     messages = _tool_messages()
     assert _maybe_inject_run_budget_wrapup(agent, messages) is False
     assert messages == _tool_messages()
@@ -227,18 +235,21 @@ def test_wrapup_not_injected_when_unset():
 
 def test_wrapup_not_injected_before_threshold():
     from agent.conversation_loop import _maybe_inject_run_budget_wrapup
-    agent = _StubAgent(budget=900, started=time.time() - 100)  # 11% elapsed
+    agent = _StubAgent(budget=900, started=time.monotonic() - 100)  # 11% elapsed
     messages = _tool_messages()
     assert _maybe_inject_run_budget_wrapup(agent, messages) is False
     assert agent._run_budget_wrapup_injected is False
 
 
-def test_wrapup_injected_once_after_threshold():
+def test_wrapup_injected_once_after_threshold(monkeypatch):
     from agent.conversation_loop import (
         RUN_BUDGET_WRAPUP_NOTICE,
         _maybe_inject_run_budget_wrapup,
     )
-    agent = _StubAgent(budget=900, started=time.time() - 800)  # 89% elapsed
+    now = time.monotonic()
+    agent = _StubAgent(budget=900, started=now - 800)  # 89% elapsed
+    # Simulate an unrelated wall-clock correction; budget accounting is monotonic.
+    monkeypatch.setattr("agent.conversation_loop.time.time", lambda: -1_000_000.0)
     messages = _tool_messages()
     assert _maybe_inject_run_budget_wrapup(agent, messages) is True
     assert agent._run_budget_wrapup_injected is True
@@ -265,7 +276,7 @@ def test_wrapup_retries_when_no_tool_message_yet():
         RUN_BUDGET_WRAPUP_NOTICE,
         _maybe_inject_run_budget_wrapup,
     )
-    agent = _StubAgent(budget=900, started=time.time() - 800)
+    agent = _StubAgent(budget=900, started=time.monotonic() - 800)
     messages = [{"role": "user", "content": "do the task"}]
     assert _maybe_inject_run_budget_wrapup(agent, messages) is False
     assert agent._run_budget_wrapup_injected is False
@@ -291,7 +302,7 @@ def test_wrapup_multimodal_tool_content():
         RUN_BUDGET_WRAPUP_NOTICE,
         _maybe_inject_run_budget_wrapup,
     )
-    agent = _StubAgent(budget=900, started=time.time() - 800)
+    agent = _StubAgent(budget=900, started=time.monotonic() - 800)
     messages = [
         {"role": "user", "content": "task"},
         {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
@@ -315,7 +326,7 @@ def test_turn_clock_stamped_only_with_budget(monkeypatch, tmp_path):
     # Mirror the turn_context.prepare block (unit-level: run the same logic).
     for agent in (agent_with,):
         if getattr(agent, "run_budget_seconds", None):
-            agent._run_budget_started_at = time.time()
+            agent._run_budget_started_at = time.monotonic()
         else:
             agent._run_budget_started_at = None
         agent._run_budget_wrapup_injected = False

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -186,6 +186,59 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    def test_exhausted_turn_budget_does_not_start_client(self):
+        created = []
+
+        def client_factory(**kwargs):
+            created.append(kwargs)
+            return FakeClient(**kwargs)
+
+        result = CodexAppServerSession(
+            cwd="/tmp",
+            client_factory=client_factory,
+        ).run_turn("hi", turn_timeout=0.0)
+
+        assert created == []
+        assert result.interrupted is True
+        assert result.error and "timed out" in result.error
+        assert result.should_retire is False
+
+    def test_turn_budget_includes_startup_and_turn_start(self, monkeypatch):
+        client = FakeClient()
+        clock = {"now": 0.0}
+        request_timeouts = []
+        original_initialize = client.initialize
+        original_request = client.request
+
+        def initialize(**kwargs):
+            request_timeouts.append(("initialize", kwargs.get("timeout")))
+            clock["now"] += 3.0
+            return original_initialize(**kwargs)
+
+        def request(method, params=None, timeout=30.0):
+            request_timeouts.append((method, timeout))
+            clock["now"] += 3.0
+            return original_request(method, params, timeout)
+
+        monkeypatch.setattr(client, "initialize", initialize)
+        monkeypatch.setattr(client, "request", request)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(client).run_turn(
+            "hi",
+            turn_timeout=7.0,
+            notification_poll_timeout=0.0,
+        )
+
+        assert request_timeouts[:3] == [
+            ("initialize", pytest.approx(7.0)),
+            ("thread/start", pytest.approx(4.0)),
+            ("turn/start", pytest.approx(1.0)),
+        ]
+        assert request_timeouts[3:] == [("turn/interrupt", 5)]
+        assert result.interrupted is True
+        assert result.error and "timed out" in result.error
+
     def test_explicit_interrupt_remains_terminal_without_a_deadline(self):
         client = FakeClient()
         session = make_session(client)
@@ -220,6 +273,31 @@ class TestRunTurn:
                    for m in r.projected_messages)
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
+
+    @pytest.mark.parametrize(
+        "status, expected_interrupted, expected_error",
+        [
+            ("interrupted", True, None),
+            ("failed", False, "status=failed"),
+        ],
+    )
+    def test_non_success_completion_status_is_not_success(
+        self, status, expected_interrupted, expected_error
+    ):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": status, "error": None},
+        )
+
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.interrupted is expected_interrupted
+        if expected_error is None:
+            assert result.error is None
+        else:
+            assert result.error and expected_error in result.error
 
 
 
@@ -777,6 +855,98 @@ class TestSessionRetirement:
         assert r.error is None
         assert r.should_retire is False
         assert not any(method == "turn/interrupt" for method, _ in client.requests)
+
+    def test_protocol_final_answer_without_completion_recovers_without_budget(
+        self, monkeypatch
+    ):
+        """No-budget turns still recover a protocol-marked final answer."""
+        client = FakeClient()
+        clock = {"now": 0.0, "final_sent": False}
+
+        def take_notification(timeout: float = 0.0):
+            clock["now"] += 1.0
+            if not clock["final_sent"]:
+                clock["final_sent"] = True
+                return {
+                    "method": "item/completed",
+                    "params": {
+                        "item": {
+                            "type": "agentMessage",
+                            "id": "m1",
+                            "text": "done",
+                            "phase": "final_answer",
+                        },
+                        "threadId": "thread-fake-001",
+                        "turnId": "turn-fake-001",
+                    },
+                }
+            if clock["now"] > 30.0:
+                raise AssertionError("no-budget final answer waited forever")
+            return None
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        r = make_session(client).run_turn(
+            "hi",
+            notification_poll_timeout=0.0,
+        )
+
+        assert r.final_text == "done"
+        assert r.interrupted is False
+        assert r.error is None
+        assert r.should_retire is False
+        assert not any(method == "turn/interrupt" for method, _ in client.requests)
+
+    def test_protocol_final_answer_is_not_replaced_by_later_commentary(
+        self, monkeypatch
+    ):
+        client = FakeClient()
+        clock = {"now": 0.0}
+        notifications = [
+            {
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "final-1",
+                        "text": "actual final",
+                        "phase": "final_answer",
+                    },
+                    "threadId": "thread-fake-001",
+                    "turnId": "turn-fake-001",
+                },
+            },
+            {
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "commentary-1",
+                        "text": "late commentary",
+                        "phase": "commentary",
+                    },
+                    "threadId": "thread-fake-001",
+                    "turnId": "turn-fake-001",
+                },
+            },
+        ]
+
+        def take_notification(timeout: float = 0.0):
+            clock["now"] += 1.0
+            return notifications.pop(0) if notifications else None
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(client).run_turn(
+            "hi",
+            notification_poll_timeout=0.0,
+        )
+
+        assert result.final_text == "actual final"
+        assert result.interrupted is False
+        assert result.error is None
 
     def test_progress_messages_can_continue_past_ten_minutes_before_completion(
         self, monkeypatch

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -186,6 +186,18 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    def test_explicit_interrupt_remains_terminal_without_a_deadline(self):
+        client = FakeClient()
+        session = make_session(client)
+        session.request_interrupt()
+
+        result = session.run_turn("hi")
+
+        assert result.interrupted is True
+        assert result.error is None
+        assert result.should_retire is False
+        assert not any(method == "turn/start" for method, _ in client.requests)
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
@@ -704,14 +716,22 @@ class TestSessionRetirement:
 
 
 
-    def test_final_agent_message_without_turn_completed_is_recovered(self):
-        """A completed assistant item is still a usable terminal response when
-        codex omits turn/completed and then goes quiet.
+    @pytest.mark.parametrize("phase", [None, "commentary"])
+    def test_nonfinal_agent_message_without_turn_completed_times_out(self, phase):
+        """An agentMessage item is not proof that the whole turn completed.
+
+        Codex may emit several completed agentMessage items as interim progress
+        while it continues working.  Without ``turn/completed`` the adapter
+        must interrupt and retire instead of promoting the latest text to a
+        successful terminal response.
         """
         client = FakeClient()
+        item = {"type": "agentMessage", "id": "m1", "text": "done"}
+        if phase is not None:
+            item["phase"] = phase
         client.queue_notification(
             "item/completed",
-            item={"type": "agentMessage", "id": "m1", "text": "done"},
+            item=item,
             threadId="t",
             turnId="tu1",
         )
@@ -722,13 +742,95 @@ class TestSessionRetirement:
             notification_poll_timeout=0.01,
         )
         assert r.final_text == "done"
-        assert r.interrupted is False
-        assert r.error is None
-        assert r.should_retire is False
+        assert r.interrupted is True
+        assert r.error and "timed out" in r.error
+        assert r.should_retire is True
         assert any(
             msg["role"] == "assistant" and msg.get("content") == "done"
             for msg in r.projected_messages
         )
+        assert any(method == "turn/interrupt" for method, _ in client.requests)
+
+    def test_protocol_final_answer_without_turn_completed_is_recovered(self):
+        """The explicit final_answer phase preserves the legacy fallback."""
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "agentMessage",
+                "id": "m1",
+                "text": "done",
+                "phase": "final_answer",
+            },
+            threadId="t",
+            turnId="tu1",
+        )
+
+        r = make_session(client).run_turn(
+            "hi",
+            turn_timeout=0.05,
+            notification_poll_timeout=0.01,
+        )
+
+        assert r.final_text == "done"
+        assert r.interrupted is False
+        assert r.error is None
+        assert r.should_retire is False
+        assert not any(method == "turn/interrupt" for method, _ in client.requests)
+
+    def test_progress_messages_can_continue_past_ten_minutes_before_completion(
+        self, monkeypatch
+    ):
+        """A caller-granted long deadline must not retain the old 600s cutoff."""
+        client = FakeClient()
+        clock = {"now": 0.0, "progress_sent": False, "complete_sent": False}
+
+        def take_notification(timeout: float = 0.0):
+            clock["now"] += 100.0
+            if not clock["progress_sent"]:
+                clock["progress_sent"] = True
+                return {
+                    "method": "item/completed",
+                    "params": {
+                        "item": {
+                            "type": "agentMessage",
+                            "id": "progress-1",
+                            "text": "Still working",
+                            "phase": "commentary",
+                        },
+                        "threadId": "thread-fake-001",
+                        "turnId": "turn-fake-001",
+                    },
+                }
+            if clock["now"] >= 700.0 and not clock["complete_sent"]:
+                clock["complete_sent"] = True
+                return {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-fake-001",
+                        "turn": {
+                            "id": "turn-fake-001",
+                            "status": "completed",
+                            "error": None,
+                        },
+                    },
+                }
+            return None
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        r = make_session(client).run_turn(
+            "long task",
+            turn_timeout=1200.0,
+            notification_poll_timeout=0.0,
+        )
+
+        assert clock["now"] >= 700.0
+        assert r.final_text == "Still working"
+        assert r.interrupted is False
+        assert r.error is None
+        assert r.should_retire is False
         assert not any(method == "turn/interrupt" for method, _ in client.requests)
 
 
@@ -753,7 +855,6 @@ class TestSessionRetirement:
         ):
             r = s.run_turn(
                 "tool then silence",
-                turn_timeout=5.0,
                 notification_poll_timeout=0.0,
                 post_tool_quiet_timeout=0.15,
             )
@@ -895,4 +996,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -313,6 +313,7 @@ class TestRunTurn:
     ):
         """Every scoped notification takes the same terminal-status path."""
         client = FakeClient()
+        approval_calls = []
         client.queue_server_request(
             "item/commandExecution/requestApproval",
             request_id="approval-1",
@@ -327,10 +328,13 @@ class TestRunTurn:
 
         result = make_session(
             client,
-            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+            approval_callback=lambda *args, **kwargs: (
+                approval_calls.append((args, kwargs)) or "once"
+            ),
         ).run_turn("hi", turn_timeout=0.05, notification_poll_timeout=0.0)
 
-        assert client.responses == [("approval-1", {"decision": "accept"})]
+        assert approval_calls == []
+        assert client.responses == [("approval-1", {"decision": "decline"})]
         assert result.interrupted is expected_interrupted
         assert result.should_retire is False
         if expected_error is None:
@@ -779,14 +783,20 @@ class TestServerRequestRouting:
 
 
 
-    def test_routing_auto_approve_bypass(self):
+    def test_routing_auto_approve_bypass(self, monkeypatch):
         client = FakeClient()
         client.queue_server_request("item/commandExecution/requestApproval", request_id="r1",
                                     command="ls", cwd="/")
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        original_respond = client.respond
+
+        def respond(request_id, result):
+            original_respond(request_id, result)
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
+
+        monkeypatch.setattr(client, "respond", respond)
         # No callback, but routing says auto-approve. Should approve.
         s = make_session(client, request_routing=_ServerRequestRouting(
             auto_approve_exec=True))
@@ -927,6 +937,55 @@ class TestServerRequestRouting:
         assert result.error and "exited unexpectedly" in result.error
         assert client.responses == [("approval-1", {"decision": "decline"})]
 
+    def test_process_death_joins_real_cli_approval_and_clears_modal(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from cli import HermesCLI
+
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="sleep 300",
+            cwd="/tmp",
+        )
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._approval_state = None
+        cli._approval_deadline = 0
+        cli._approval_lock = threading.Lock()
+        cli._paint_now = MagicMock()
+        cli._persist_prompt_summary = MagicMock()
+        cli._app = SimpleNamespace(invalidate=MagicMock())
+
+        holder = {}
+        session = make_session(client, approval_callback=cli._approval_callback)
+        run_thread = threading.Thread(
+            target=lambda: holder.setdefault(
+                "result",
+                session.run_turn("hi", notification_poll_timeout=0.0),
+            )
+        )
+        run_thread.start()
+        deadline = time.monotonic() + 0.5
+        while cli._approval_state is None and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert cli._approval_state is not None
+
+        client._closed = True
+        run_thread.join(0.75)
+
+        assert not run_thread.is_alive()
+        assert cli._approval_state is None
+        assert not any(
+            thread.is_alive() and thread.name == "codex-approval-callback"
+            for thread in threading.enumerate()
+        )
+        result = holder["result"]
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert client.responses == [("approval-1", {"decision": "decline"})]
+
 
 
 # ---- enriched approval prompts ----
@@ -943,13 +1002,13 @@ class TestApprovalPromptEnrichment:
             "item/commandExecution/requestApproval", request_id="r1",
             command="ls",  # no cwd
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["description"] = description
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
             return "once"
         s = make_session(client, approval_callback=cb)
         s.run_turn("hi", turn_timeout=1.0)
@@ -977,14 +1036,14 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="add and update files",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
             captured["description"] = description
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
             return "once"
         s = make_session(client, approval_callback=cb)
         s.run_turn("hi", turn_timeout=1.0)
@@ -1005,13 +1064,13 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="apply some changes",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
             return "once"
         s = make_session(client, approval_callback=cb)
         s.run_turn("hi", turn_timeout=1.0)

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,6 +7,7 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import threading
 import time
 from unittest.mock import patch
 from typing import Any, Optional
@@ -298,6 +299,112 @@ class TestRunTurn:
             assert result.error is None
         else:
             assert result.error and expected_error in result.error
+
+    @pytest.mark.parametrize(
+        "status, expected_interrupted, expected_error",
+        [
+            ("completed", False, None),
+            ("interrupted", True, None),
+            ("failed", False, "status=failed"),
+        ],
+    )
+    def test_completion_in_approval_predrain_is_terminal(
+        self, status, expected_interrupted, expected_error
+    ):
+        """Every scoped notification takes the same terminal-status path."""
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="pwd",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": status, "error": None},
+        )
+
+        result = make_session(
+            client,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+        ).run_turn("hi", turn_timeout=0.05, notification_poll_timeout=0.0)
+
+        assert client.responses == [("approval-1", {"decision": "accept"})]
+        assert result.interrupted is expected_interrupted
+        assert result.should_retire is False
+        if expected_error is None:
+            assert result.error is None
+        else:
+            assert result.error and expected_error in result.error
+        assert not any(method == "turn/interrupt" for method, _ in client.requests)
+
+    def test_completion_in_approval_predrain_terminates_without_budget(
+        self, monkeypatch
+    ):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="pwd",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        empty_polls = {"count": 0}
+        original_take = client.take_notification
+
+        def take_notification(timeout=0.0):
+            note = original_take(timeout)
+            if note is None:
+                empty_polls["count"] += 1
+                if empty_polls["count"] > 3:
+                    raise AssertionError("pre-drained completion did not terminate turn")
+            return note
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+
+        result = make_session(
+            client,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+        ).run_turn("hi", notification_poll_timeout=0.0)
+
+        assert result.interrupted is False
+        assert result.error is None
+        assert result.should_retire is False
+
+    def test_late_completion_after_deadline_is_rejected(self, monkeypatch):
+        client = FakeClient()
+        clock = {"now": 0.0}
+
+        def take_notification(timeout=0.0):
+            clock["now"] = 0.03
+            return {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-fake-001",
+                    "turn": {
+                        "id": "turn-fake-001",
+                        "status": "completed",
+                        "error": None,
+                    },
+                },
+            }
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(client).run_turn(
+            "hi", turn_timeout=0.01, notification_poll_timeout=1.0
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "timed out" in result.error
+        assert any(method == "turn/interrupt" for method, _ in client.requests)
 
 
 
@@ -686,6 +793,140 @@ class TestServerRequestRouting:
         s.run_turn("hi", turn_timeout=1.0)
         assert ("r1", {"decision": "accept"}) in client.responses
 
+    def test_approval_callback_cannot_cross_turn_deadline(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="sleep 300",
+            cwd="/tmp",
+        )
+        clock = {"now": 0.0}
+        entered = threading.Event()
+        exited = threading.Event()
+
+        def callback(
+            command,
+            description,
+            *,
+            allow_permanent=True,
+            deadline=None,
+            cancel_event=None,
+        ):
+            entered.set()
+            clock["now"] = 0.03
+            assert deadline == pytest.approx(0.02)
+            if cancel_event is not None:
+                cancel_event.wait(0.1)
+            exited.set()
+            return "once"
+
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(client, approval_callback=callback).run_turn(
+            "hi", turn_timeout=0.02, notification_poll_timeout=0.0
+        )
+
+        assert entered.is_set()
+        assert exited.wait(0.1)
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "timed out" in result.error
+        assert client.responses == [("approval-1", {"decision": "decline"})]
+
+    def test_explicit_interrupt_unblocks_pending_approval(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="sleep 300",
+            cwd="/tmp",
+        )
+        entered = threading.Event()
+        exited = threading.Event()
+
+        def callback(
+            command,
+            description,
+            *,
+            allow_permanent=True,
+            deadline=None,
+            cancel_event=None,
+        ):
+            entered.set()
+            assert cancel_event is not None
+            cancel_event.wait(1.0)
+            exited.set()
+            return "deny"
+
+        session = make_session(client, approval_callback=callback)
+        holder = {}
+        run_thread = threading.Thread(
+            target=lambda: holder.setdefault(
+                "result", session.run_turn("hi", notification_poll_timeout=0.0)
+            )
+        )
+        run_thread.start()
+        assert entered.wait(0.5)
+
+        session.request_interrupt()
+        run_thread.join(0.5)
+
+        assert not run_thread.is_alive()
+        assert exited.is_set()
+        result = holder["result"]
+        assert result.interrupted is True
+        assert result.should_retire is False
+        assert client.responses == [("approval-1", {"decision": "decline"})]
+
+    def test_process_death_unblocks_pending_approval(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="sleep 300",
+            cwd="/tmp",
+        )
+        entered = threading.Event()
+        exited = threading.Event()
+
+        def callback(
+            command,
+            description,
+            *,
+            allow_permanent=True,
+            deadline=None,
+            cancel_event=None,
+        ):
+            entered.set()
+            assert cancel_event is not None
+            cancel_event.wait(1.0)
+            exited.set()
+            return "deny"
+
+        holder = {}
+        run_thread = threading.Thread(
+            target=lambda: holder.setdefault(
+                "result",
+                make_session(client, approval_callback=callback).run_turn(
+                    "hi", notification_poll_timeout=0.0
+                ),
+            )
+        )
+        run_thread.start()
+        assert entered.wait(0.5)
+
+        client._closed = True
+        run_thread.join(0.5)
+
+        assert not run_thread.is_alive()
+        assert exited.is_set()
+        result = holder["result"]
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "exited unexpectedly" in result.error
+        assert client.responses == [("approval-1", {"decision": "decline"})]
+
 
 
 # ---- enriched approval prompts ----
@@ -1068,6 +1309,118 @@ class TestSessionRetirement:
         assert r.final_text == "tool finished"
         assert r.should_retire is False
         assert r.interrupted is False
+
+    @pytest.mark.parametrize("turn_timeout", [None, 1.0])
+    def test_approval_does_not_disarm_post_tool_watchdog(
+        self, monkeypatch, turn_timeout
+    ):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="echo hi",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution",
+                "id": "ex1",
+                "command": "echo hi",
+                "cwd": "/tmp",
+                "status": "completed",
+                "aggregatedOutput": "hi",
+                "exitCode": 0,
+                "commandActions": [],
+            },
+            threadId="t",
+            turnId="tu1",
+        )
+        clock = {"now": 0.0, "empty_polls": 0}
+        original_take = client.take_notification
+
+        def take_notification(timeout=0.0):
+            note = original_take(timeout)
+            if note is None:
+                clock["now"] += 0.05
+                clock["empty_polls"] += 1
+                if clock["empty_polls"] > 30:
+                    raise AssertionError("approval permanently disarmed watchdog")
+            return note
+
+        monkeypatch.setattr(client, "take_notification", take_notification)
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(
+            client,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True),
+        ).run_turn(
+            "tool, approval, silence",
+            turn_timeout=turn_timeout,
+            notification_poll_timeout=0.0,
+            post_tool_quiet_timeout=0.1,
+        )
+
+        assert result.tool_iterations == 1
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "silent" in result.error
+        assert client.responses == [("approval-1", {"decision": "accept"})]
+
+    def test_post_tool_watchdog_can_expire_during_approval(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="approval-1",
+            command="echo hi",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution",
+                "id": "ex1",
+                "command": "echo hi",
+                "cwd": "/tmp",
+                "status": "completed",
+                "aggregatedOutput": "hi",
+                "exitCode": 0,
+                "commandActions": [],
+            },
+            threadId="t",
+            turnId="tu1",
+        )
+        clock = {"now": 0.0}
+        exited = threading.Event()
+
+        def callback(
+            command,
+            description,
+            *,
+            allow_permanent=True,
+            deadline=None,
+            cancel_event=None,
+        ):
+            assert deadline == pytest.approx(0.1)
+            assert cancel_event is not None
+            clock["now"] = 0.11
+            cancel_event.wait(0.1)
+            exited.set()
+            return "once"
+
+        monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock["now"])
+
+        result = make_session(client, approval_callback=callback).run_turn(
+            "tool, approval, silence",
+            notification_poll_timeout=0.0,
+            post_tool_quiet_timeout=0.1,
+        )
+
+        assert exited.wait(0.1)
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "silent" in result.error
+        assert client.responses == [("approval-1", {"decision": "decline"})]
 
 
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -73,6 +73,113 @@ class TestApiModeAccepted:
 
 
 class TestRunConversationCodexPath:
+    @pytest.mark.parametrize(
+        "budget,expected_timeout",
+        [(None, None), (10800.0, 10800.0)],
+    )
+    def test_run_budget_controls_app_server_turn_deadline(
+        self, monkeypatch, budget, expected_timeout
+    ):
+        """Native turns are unbounded by default and use the run's hard cap."""
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured.update(kwargs)
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-budget-1",
+                thread_id="thread-budget-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-budget-1",
+        )
+        agent = _make_codex_agent(run_budget_seconds=budget)
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("long task")
+
+        assert result["completed"] is True
+        if expected_timeout is None:
+            assert captured["turn_timeout"] is None
+        else:
+            assert expected_timeout - 1.0 <= captured["turn_timeout"] <= expected_timeout
+
+    def test_provider_request_timeout_is_not_a_whole_native_turn_cap(
+        self, monkeypatch
+    ):
+        """Provider HTTP timeouts and native multi-request turns have different scope."""
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured.update(kwargs)
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-provider-timeout-1",
+                thread_id="thread-provider-timeout-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-provider-timeout-1",
+        )
+        agent = _make_codex_agent()
+        monkeypatch.setattr(agent, "_resolved_api_call_timeout", lambda: 5.0)
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("multi-step task")
+
+        assert result["completed"] is True
+        assert captured["turn_timeout"] is None
+
+    def test_app_server_receives_remaining_run_budget(self, monkeypatch):
+        """Turn setup time is deducted from the caller's hard run budget."""
+        import agent.codex_runtime as codex_runtime
+        import agent.conversation_loop as conversation_loop
+
+        captured = {}
+        original_build_turn_context = conversation_loop.build_turn_context
+
+        def build_turn_context_with_elapsed_budget(agent, *args, **kwargs):
+            context = original_build_turn_context(agent, *args, **kwargs)
+            agent._run_budget_started_at = 100.0
+            return context
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured.update(kwargs)
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-effective-budget-1",
+                thread_id="thread-effective-budget-1",
+            )
+
+        monkeypatch.setattr(
+            conversation_loop,
+            "build_turn_context",
+            build_turn_context_with_elapsed_budget,
+        )
+        monkeypatch.setattr(codex_runtime.time, "time", lambda: 107.5)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-effective-budget-1",
+        )
+        agent = _make_codex_agent(run_budget_seconds=30.0)
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("bounded task")
+
+        assert result["completed"] is True
+        assert captured["turn_timeout"] == pytest.approx(22.5)
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests
@@ -629,8 +736,10 @@ class TestSessionRetirementOnRunAgent:
 
         def fake_run_turn(self, user_input, **kwargs):
             return TurnResult(
-                final_text="",
-                projected_messages=[],
+                final_text="Still working",
+                projected_messages=[
+                    {"role": "assistant", "content": "Still working"}
+                ],
                 tool_iterations=0,
                 interrupted=True,
                 error="turn timed out after 600.0s",
@@ -655,7 +764,9 @@ class TestSessionRetirementOnRunAgent:
         assert closes["count"] == 1
         assert getattr(agent, "_codex_session", "MISSING") is None
         # Partial result was still returned (caller still sees the error)
+        assert result["completed"] is False
         assert result["partial"] is True
+        assert result["final_response"] == "Still working"
         assert result["error"] == "turn timed out after 600.0s"
 
     def test_normal_turn_keeps_session(self, fake_session):

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -165,7 +165,9 @@ class TestRunConversationCodexPath:
             "build_turn_context",
             build_turn_context_with_elapsed_budget,
         )
-        monkeypatch.setattr(codex_runtime.time, "time", lambda: 107.5)
+        monkeypatch.setattr(codex_runtime.time, "monotonic", lambda: 107.5)
+        # A wall-clock correction must not alter the run's remaining budget.
+        monkeypatch.setattr(codex_runtime.time, "time", lambda: 10_000.0)
         monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
         monkeypatch.setattr(
             CodexAppServerSession,


### PR DESCRIPTION
## Summary

Fix Codex app-server turns being forcibly terminalized after a hardcoded 600 seconds and incorrectly returning interim assistant/progress text as successful final output.

The change:

- propagates the caller's monotonic run budget through the entire native app-server turn, including startup and `turn/start`;
- defines no-budget behavior without an arbitrary whole-turn cutoff;
- accepts missing-`turn/completed` compatibility only for protocol-grounded `final_answer` items, snapshotting canonical text so later commentary cannot replace it;
- returns explicit partial/error state and retires/interupts on real deadlines rather than promoting arbitrary text;
- preserves post-tool silence, explicit interrupt, process-death, provider-timeout, and session-retirement semantics;
- makes approval waits deadline/interrupt/process-death aware;
- prevents terminal pre-drain from authorizing a queued request;
- makes the real CLI approval modal cancellation-wakeable and guarantees cooperative worker/modal cleanup before return;
- keeps unknown non-cooperative third-party callbacks bounded.

## Reproduction

Multiple native Codex app-server sessions launched with `--run-budget 10800` or `14400` ended at exactly 600 seconds with:

```text
codex app-server turn reached deadline after a completed assistant message but before turn/completed; accepting the assistant text as the terminal response
```

The accepted text was an interim progress message and the CLI exited code 0. The defect also reproduced while implementing this fix.

Related upstream context:

- #58432 reported missing `turn/completed` after assistant text.
- #58433 was closed unmerged; equivalent permissive fallback later landed but covered only a single apparently-final message.
- #79230 makes hardcoded timeouts configurable but does not propagate CLI run budget or prevent interim-text false success.

This PR addresses the combined deadline, event-classification, and approval-lifecycle bug class.

## Verification

Final remediation and independent review evidence includes:

- 1,886 expanded approval/CLI/runtime tests passed; 8 Windows-only skipped.
- 460 transport/runtime tests passed during remediation.
- Independent review: 441/441 transport/runtime and 118/118 changed base-path tests passed.
- Terminal completed/interrupted/failed pre-drain cases: 5/5 passed.
- Real CLI process-death, interrupt, deadline, active-approval, late-response, lock-contention, and callback-reentrancy reproductions passed.
- Non-cooperative callback remained bounded at approximately 0.300 seconds.
- Ruff, `py_compile`, and `git diff --check` passed.
- Exact candidate independently reviewed and approved: `44c7ff3aafe37a28495ddf6d5f7afd57cda51688`.

A broader unrelated test can be environment-sensitive when `/tmp` resolves inside a Git workspace; no failure implicated this diff.

## Deployment

No live gateway was restarted or modified while developing or reviewing this change.