### PR TITLE
fix(memory): scope honcho observation flags per session

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -183,11 +183,19 @@ class HonchoSessionManager:
         self._observation_mode: str = (
             config.observation_mode if config else "directional"
         )
-        # Per-peer observation booleans (granular, from config)
+        # Per-peer observation booleans (granular, from config). These stay a
+        # config snapshot: server-synced values live in _session_observation
+        # keyed by honcho session id, so one session's sync can never retune
+        # the recall routing of another served by the same manager (#98936).
         self._user_observe_me: bool = config.user_observe_me if config else True
         self._user_observe_others: bool = config.user_observe_others if config else True
         self._ai_observe_me: bool = config.ai_observe_me if config else True
         self._ai_observe_others: bool = config.ai_observe_others if config else True
+        # honcho session id → observation flags synced from the server during
+        # session setup. Whole-dict entries are assigned in one statement, so
+        # lock-free reads observe either the old or the new snapshot, never a
+        # partial one.
+        self._session_observation: dict[str, dict[str, bool]] = {}
         self._message_max_chars: int = (
             config.message_max_chars if config else 25000
         )
@@ -368,6 +376,34 @@ class HonchoSessionManager:
                     return self._peers_cache.setdefault(peer_id, peer)
             # Client rebuilt mid-resolve — drop the stale object and retry.
 
+    def _observation_flags(
+        self, honcho_session_id: str
+    ) -> tuple[bool, bool, bool, bool]:
+        """Observation flags for one session.
+
+        Server-synced values if the session completed setup, else the config
+        snapshot defaults. Per-session scoping is what keeps recall routing
+        honest when one manager serves sessions with diverging configs (#98936).
+        """
+        synced = self._session_observation.get(honcho_session_id)
+        if synced is not None:
+            return (
+                synced["user_observe_me"],
+                synced["user_observe_others"],
+                synced["ai_observe_me"],
+                synced["ai_observe_others"],
+            )
+        return (
+            self._user_observe_me,
+            self._user_observe_others,
+            self._ai_observe_me,
+            self._ai_observe_others,
+        )
+
+    def _ai_observes_others(self, session: HonchoSession) -> bool:
+        """Whether the AI peer observes other peers, for this session's routing."""
+        return self._observation_flags(session.honcho_session_id)[3]
+
     def _get_or_create_honcho_session(
         self, session_id: str, user_peer: Any, assistant_peer: Any
     ) -> tuple[Any, list]:
@@ -385,17 +421,25 @@ class HonchoSessionManager:
         self._authed_call("session setup", lambda: self._sdk_session(session_id))
 
         # Configure per-peer observation from granular booleans.
-        # These map 1:1 to Honcho's SessionPeerConfig toggles.
+        # These map 1:1 to Honcho's SessionPeerConfig toggles. Read per-session
+        # so a session that already synced its server config keeps those
+        # values instead of re-applying the manager-wide defaults.
+        (
+            user_observe_me,
+            user_observe_others,
+            ai_observe_me,
+            ai_observe_others,
+        ) = self._observation_flags(session_id)
         auth_dead = False
         try:
             from honcho.session import SessionPeerConfig
             user_config = SessionPeerConfig(
-                observe_me=self._user_observe_me,
-                observe_others=self._user_observe_others,
+                observe_me=user_observe_me,
+                observe_others=user_observe_others,
             )
             ai_config = SessionPeerConfig(
-                observe_me=self._ai_observe_me,
-                observe_others=self._ai_observe_others,
+                observe_me=ai_observe_me,
+                observe_others=ai_observe_others,
             )
             peer_entries = [(user_peer, user_config), (assistant_peer, ai_config)]
 
@@ -406,8 +450,10 @@ class HonchoSessionManager:
 
             # Sync back: server-side config (set via Honcho UI) wins over
             # local defaults. Read the effective config after add_peers.
-            # Note: observation booleans are manager-scoped, not per-session.
-            # Last session init wins. Fine for CLI; gateway should scope per-session.
+            # Observation booleans are scoped per session: manager-level
+            # fields stay as the config snapshot, and each session's sync is
+            # stored under its own id so the last initialization can no
+            # longer retune every other session the manager serves (#98936).
             try:
                 def _read_server_configs() -> tuple[Any, Any]:
                     sdk_session = self._sdk_session(session_id)
@@ -419,18 +465,29 @@ class HonchoSessionManager:
                 server_user, server_ai = self._authed_call(
                     "peer configuration read", _read_server_configs
                 )
+                synced = {
+                    "user_observe_me": user_observe_me,
+                    "user_observe_others": user_observe_others,
+                    "ai_observe_me": ai_observe_me,
+                    "ai_observe_others": ai_observe_others,
+                }
                 if server_user.observe_me is not None:
-                    self._user_observe_me = server_user.observe_me
+                    synced["user_observe_me"] = server_user.observe_me
                 if server_user.observe_others is not None:
-                    self._user_observe_others = server_user.observe_others
+                    synced["user_observe_others"] = server_user.observe_others
                 if server_ai.observe_me is not None:
-                    self._ai_observe_me = server_ai.observe_me
+                    synced["ai_observe_me"] = server_ai.observe_me
                 if server_ai.observe_others is not None:
-                    self._ai_observe_others = server_ai.observe_others
+                    synced["ai_observe_others"] = server_ai.observe_others
+                self._session_observation[session_id] = synced
                 logger.debug(
-                    "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
-                    self._user_observe_me, self._user_observe_others,
-                    self._ai_observe_me, self._ai_observe_others,
+                    "Honcho observation synced from server for session '%s': "
+                    "user(me=%s,others=%s) ai(me=%s,others=%s)",
+                    session_id,
+                    synced["user_observe_me"],
+                    synced["user_observe_others"],
+                    synced["ai_observe_me"],
+                    synced["ai_observe_others"],
                 )
             except HonchoAuthError:
                 raise
@@ -919,7 +976,7 @@ class HonchoSessionManager:
             level = self._default_reasoning_level()
 
         def _chat_once() -> str:
-            if self._ai_observe_others:
+            if self._ai_observes_others(session):
                 # AI peer can observe other peers — use assistant as observer.
                 ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                 if target_peer_id == session.assistant_peer_id:
@@ -1429,7 +1486,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             return session.assistant_peer_id, session.assistant_peer_id
 
-        if self._ai_observe_others:
+        if self._ai_observes_others(session):
             return session.assistant_peer_id, target_peer_id
 
         return target_peer_id, None
@@ -1574,7 +1631,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(session.assistant_peer_id)
-        elif self._ai_observe_others:
+        elif self._ai_observes_others(session):
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(target_peer_id)
         else:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,5 +1,7 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
+import sys
+import threading
 import time
 
 from datetime import datetime
@@ -1244,6 +1246,7 @@ class TestSetPeerCardNoneGuard:
         mgr._cache = {}
         mgr._sessions_cache = {}
         mgr._config = cfg
+        mgr._session_observation = {}
         return mgr
 
     def test_returns_none_when_peer_resolves_to_none(self):
@@ -1286,6 +1289,7 @@ class TestGetSessionContextFallback:
         mgr._dialectic_reasoning_level = "low"
         mgr._dialectic_max_input_chars = 10000
         mgr._ai_observe_others = True
+        mgr._session_observation = {}
 
         session = HonchoSession(
             key="test",
@@ -1314,4 +1318,158 @@ class TestGetSessionContextFallback:
         peer_id, target = fetch_calls[0]
         assert peer_id == "user-peer"
         assert target == "user-peer"
+
+
+# ---------------------------------------------------------------------------
+# Observation flags are scoped per session, not manager-wide (#98936)
+# ---------------------------------------------------------------------------
+
+
+class _FakeServerPeerConfig:
+    """SessionPeerConfig stand-in for both the local build and the server read.
+
+    None means "leave unchanged", mirroring the SDK's optional fields. Doubles
+    as the injected ``honcho.session`` module's SessionPeerConfig so the test
+    runs even without the optional honcho-ai extra installed.
+    """
+
+    def __init__(self, observe_me=None, observe_others=None):
+        self.observe_me = observe_me
+        self.observe_others = observe_others
+
+
+class _FakeSdkSession:
+    """Records add_peers calls and serves per-peer server configs."""
+
+    def __init__(self, server_user_cfg, server_ai_cfg):
+        self.add_peers_calls = []
+        self._server_user_cfg = server_user_cfg
+        self._server_ai_cfg = server_ai_cfg
+
+    def add_peers(self, entries):
+        self.add_peers_calls.append(entries)
+
+    def get_peer_configuration(self, peer):
+        return self._server_user_cfg if peer == "user-peer" else self._server_ai_cfg
+
+    def context(self, summary=True, tokens=None):
+        class _Ctx:
+            messages = []
+
+        return _Ctx()
+
+
+class TestObservationPerSessionScoping:
+    """One session's server sync must not retune another session's routing."""
+
+    def _make_manager(self):
+        from plugins.memory.honcho.session import HonchoSessionManager
+
+        mgr = HonchoSessionManager.__new__(HonchoSessionManager)
+        mgr._cache = {}
+        mgr._sessions_cache = {}
+        mgr._session_observation = {}
+        mgr._cache_lock = threading.RLock()
+        mgr._context_tokens = 1000
+        # Config snapshot defaults — manager fields must stay at these values.
+        mgr._user_observe_me = True
+        mgr._user_observe_others = True
+        mgr._ai_observe_me = True
+        mgr._ai_observe_others = True
+        mgr._authed_call = lambda label, op: op()
+        return mgr
+
+    def _session(self, mgr, key):
+        session = HonchoSession(
+            key=key,
+            honcho_session_id=f"sid-{key}",
+            user_peer_id="user-peer",
+            assistant_peer_id="ai-peer",
+        )
+        mgr._cache[key] = session
+        return session
+
+    def _setup_session(self, mgr, session_id, fake_sdk):
+        fake_module = SimpleNamespace(SessionPeerConfig=_FakeServerPeerConfig)
+        mgr._sdk_session = lambda sid: fake_sdk
+        with patch.dict(sys.modules, {"honcho.session": fake_module}):
+            return mgr._get_or_create_honcho_session(
+                session_id, "user-peer", "ai-peer"
+            )
+
+    def test_sync_back_scopes_flags_per_session(self):
+        """Server flags land under each session's own id; manager snapshot untouched."""
+        mgr = self._make_manager()
+
+        # Session A's server config disables user observe_others...
+        self._setup_session(
+            mgr, "sid-a",
+            _FakeSdkSession(_FakeServerPeerConfig(observe_others=False), _FakeServerPeerConfig()),
+        )
+        # ...session B's server leaves everything at the synced-in defaults.
+        self._setup_session(
+            mgr, "sid-b",
+            _FakeSdkSession(_FakeServerPeerConfig(), _FakeServerPeerConfig()),
+        )
+
+        assert mgr._session_observation["sid-a"]["user_observe_others"] is False
+        assert mgr._session_observation["sid-b"]["user_observe_others"] is True
+        # The config snapshot on the manager must survive both syncs — this is
+        # the regression: last-session-wins used to overwrite it (#98936).
+        assert mgr._user_observe_others is True
+
+    def test_add_peers_reuses_synced_flags_for_existing_session(self):
+        """A re-initialized session re-applies its own synced values, not the defaults."""
+        mgr = self._make_manager()
+
+        fake = _FakeSdkSession(
+            _FakeServerPeerConfig(observe_others=False), _FakeServerPeerConfig()
+        )
+        self._setup_session(mgr, "sid-a", fake)
+
+        # Force the full setup path again (cache cleared, e.g. after re-auth).
+        mgr._sessions_cache = {}
+        fake2 = _FakeSdkSession(
+            _FakeServerPeerConfig(observe_others=False), _FakeServerPeerConfig()
+        )
+        self._setup_session(mgr, "sid-a", fake2)
+
+        user_cfg = fake2.add_peers_calls[0][0][1]
+        assert user_cfg.observe_others is False
+
+    def test_resolve_observer_target_uses_own_session_flags(self):
+        """Recall routing reads each session's flags, so diverging sessions diverge."""
+        mgr = self._make_manager()
+        session_a = self._session(mgr, "a")
+        session_b = self._session(mgr, "b")
+        mgr._session_observation["sid-a"] = {
+            "user_observe_me": True,
+            "user_observe_others": True,
+            "ai_observe_me": True,
+            "ai_observe_others": False,
+        }
+        mgr._session_observation["sid-b"] = {
+            "user_observe_me": True,
+            "user_observe_others": True,
+            "ai_observe_me": True,
+            "ai_observe_others": True,
+        }
+
+        # Without AI cross-observation the target peer queries its own context.
+        assert mgr._resolve_observer_target(session_a, "user") == ("user-peer", None)
+        # With it, the assistant peer observes the user peer.
+        assert mgr._resolve_observer_target(session_b, "user") == ("ai-peer", "user-peer")
+
+    def test_unsynced_session_falls_back_to_config_snapshot(self):
+        """A session that never completed setup routes with the config defaults."""
+        mgr = self._make_manager()
+        session_c = self._session(mgr, "c")
+        mgr._session_observation["sid-other"] = {
+            "user_observe_me": True,
+            "user_observe_others": True,
+            "ai_observe_me": True,
+            "ai_observe_others": False,
+        }
+
+        assert mgr._ai_observes_others(session_c) is True
 


### PR DESCRIPTION
## What does this PR do?

`HonchoSessionManager` kept the four observation booleans (`_user_observe_me`, `_user_observe_others`, `_ai_observe_me`, `_ai_observe_others`) as manager-wide mutable fields, but initialized them from per-session server state: every session setup read that session's `SessionPeerConfig` from the Honcho server and overwrote the shared fields, so the last session to initialize won and its settings applied to every other session the manager served.

The blast radius is not just stale settings: `_ai_observe_others` routes dialectic recall (`ai_peer.chat(target=...)` vs `target_peer.chat(...)`), so a value leaked from another session's initialization silently switched which conclusion collection was read — wrong answers with no error or warning.

This PR keys the server-synced flags by honcho session id in a new `_session_observation` dict:

- The manager-level fields keep their original meaning: a config snapshot, never overwritten by server syncs.
- Session setup (`_get_or_create_honcho_session`) reads per-session values when re-initializing a session that already synced, and stores each sync under its own session id.
- All three recall-routing read sites (`_chat_once`, `_resolve_observer_target`, `_conclusions_scope`) now resolve flags per session via `_ai_observes_others(session)`; a session that never completed setup falls back to the config snapshot, exactly as before.

## Related Issue

Fixes #98936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/session.py`: added `_session_observation: dict[honcho_session_id, flags]` plus `_observation_flags()` / `_ai_observes_others()` helpers; `_get_or_create_honcho_session` now scopes both the add_peers config build and the server sync-back per session; replaced the three manager-wide routing reads with per-session lookups.
- `tests/honcho_plugin/test_session.py`: new `TestObservationPerSessionScoping` covering per-session sync isolation, manager-snapshot preservation, re-initialization reusing synced values, divergent routing for two sessions, and the fallback path; updated the two `__new__`-constructed manager fixtures to set `_session_observation`.

## How to Test

1. `python -m pytest tests/honcho_plugin/ tests/test_honcho_session_context.py tests/test_honcho_client_config.py tests/test_honcho_startup_fail_open.py tests/test_honcho_client_concurrency.py -q` — Observed result: 343 passed, 16 skipped.
2. `python -m ruff check plugins/memory/honcho/session.py tests/honcho_plugin/test_session.py` — Observed result: All checks passed.
3. `TestObservationPerSessionScoping::test_sync_back_scopes_flags_per_session` fails on the previous code (the manager field was clobbered by the first session's sync) and passes with this change; the routing test demonstrates session A routing self-peer while session B routes AI-observer from the same manager.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs