### PR TITLE
fix(responses): preserve valid replay item graphs (#97427)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -691,6 +691,7 @@ def _chat_messages_to_responses_input(
                         item_id = raw_item.get("id")
                         if (
                             not is_github_responses
+                            and not has_codex_reasoning
                             and isinstance(item_id, str)
                             and item_id.strip()
                         ):
@@ -976,11 +977,19 @@ def _preflight_codex_input_items(
     )
     normalized: List[Dict[str, Any]] = []
     seen_ids: set = set()
+    reasoning_requires_anonymous_message = False
     for idx, item in enumerate(raw_items):
         if not isinstance(item, dict):
             raise ValueError(f"Codex Responses input[{idx}] must be an object.")
 
         item_type = item.get("type")
+        # Only an immediately following assistant message can belong to the
+        # de-identified reasoning chain.  A tool call/output, user item, or
+        # other Responses item closes that turn, so later assistant messages
+        # retain their independent IDs for cache reuse.
+        if reasoning_requires_anonymous_message and item_type not in {"reasoning", "message"}:
+            reasoning_requires_anonymous_message = False
+
         if item_type == "function_call":
             call_id = item.get("call_id")
             name = item.get("name")
@@ -1083,6 +1092,12 @@ def _preflight_codex_input_items(
                 else:
                     reasoning_item["summary"] = []
                 normalized.append(reasoning_item)
+                # A store-less replay strips the reasoning ID above.  The
+                # next assistant message belongs to that reasoning chain, so
+                # its server-issued ID must be stripped too; otherwise the
+                # API rejects the message for referencing a missing reasoning
+                # item (#97427).
+                reasoning_requires_anonymous_message = True
             continue
 
         if item_type == "compaction":
@@ -1131,6 +1146,7 @@ def _preflight_codex_input_items(
             item_id = item.get("id")
             if (
                 not is_github_responses
+                and not reasoning_requires_anonymous_message
                 and isinstance(item_id, str)
                 and item_id.strip()
             ):
@@ -1141,6 +1157,7 @@ def _preflight_codex_input_items(
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()
             normalized.append(normalized_item)
+            reasoning_requires_anonymous_message = False
             continue
 
         role = item.get("role")

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -302,6 +302,119 @@ _OVERSIZED_ITEM_ID = "x" * 408
 _VALID_ITEM_ID = "msg_abc123"
 
 
+def test_chat_replay_drops_message_id_paired_with_encrypted_reasoning():
+    """A store-less replay must not retain the message's server ID after
+    its required reasoning ID has been removed (#97427)."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "I'll inspect that.",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_required_by_msg",
+                    "encrypted_content": "opaque-reasoning",
+                    "summary": [],
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "id": _VALID_ITEM_ID,
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "I'll inspect that."}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning_item = next(item for item in items if item.get("type") == "reasoning")
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert "id" not in reasoning_item
+    assert "id" not in message_item
+    assert message_item["phase"] == "commentary"
+    assert message_item["content"] == [{"type": "output_text", "text": "I'll inspect that."}]
+
+
+def test_chat_replay_keeps_short_message_id_without_encrypted_reasoning():
+    """Message IDs still participate in cache reuse when no reasoning item
+    has been de-identified for the same assistant turn."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Plain answer.",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "id": _VALID_ITEM_ID,
+                    "content": [{"type": "output_text", "text": "Plain answer."}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert message_item["id"] == _VALID_ITEM_ID
+
+
+def test_preflight_drops_only_message_id_following_replayed_reasoning():
+    """The final wire validation must preserve the same graph invariant as
+    history conversion without discarding unrelated cache IDs."""
+    items = _preflight_codex_input_items(
+        [
+            {"type": "reasoning", "id": "rs_required_by_msg", "encrypted_content": "opaque"},
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "id": "msg_requires_reasoning",
+                "content": [{"type": "output_text", "text": "Tool plan."}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "id": "msg_independent",
+                "content": [{"type": "output_text", "text": "Plain answer."}],
+            },
+        ]
+    )
+
+    message_items = [item for item in items if item.get("type") == "message"]
+    assert "id" not in message_items[0]
+    assert message_items[1]["id"] == "msg_independent"
+
+
+def test_preflight_keeps_message_id_after_reasoning_tool_round():
+    """A reasoning item followed by a tool round has no paired assistant
+    message, so a later assistant message must keep its independent ID."""
+    items = _preflight_codex_input_items(
+        [
+            {"type": "reasoning", "id": "rs_for_tool", "encrypted_content": "opaque"},
+            {"type": "function_call", "call_id": "call_1", "name": "pwd", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "/workspace"},
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "id": "msg_after_tool_round",
+                "content": [{"type": "output_text", "text": "The directory is ready."}],
+            },
+        ]
+    )
+
+    message_item = next(item for item in items if item.get("type") == "message")
+    assert message_item["id"] == "msg_after_tool_round"
+
+
 # The codex app-server overflows the Responses 64-char call_id limit for
 # MCP-routed tools, e.g. codex_mcp__hermes-tools__web_search_exec-<uuid> (#73492).
 _OVERSIZED_CALL_ID = "codex_mcp__hermes-tools__web_search_exec-" + "0" * 43


### PR DESCRIPTION
Fixes #97427.

When replaying encrypted reasoning with `store: false`, the server-side reasoning ID is intentionally omitted. This change also omits the paired assistant-message ID, preventing the API from rejecting an incomplete replay graph.

It preserves short message IDs for turns without replayed encrypted reasoning and for messages after a reasoning-to-tool round, retaining cache reuse where the graph is independent.

Tests cover:
- paired reasoning/message replay
- plain assistant-message replay
- direct preflight normalization
- a reasoning → tool-call → tool-output → independent-message boundary

Validation:
- `uv run --extra dev pytest tests/agent/test_codex_responses_adapter.py -q`
- `uv run --extra dev ruff check agent/codex_responses_adapter.py tests/agent/test_codex_responses_adapter.py`