### PR TITLE
fix(install): recognize almalinux distro ID and RHEL-family gcc-toolset-12

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -795,17 +795,42 @@ check_git() {
 # Best-effort like install_system_packages: warns and lets the caller decide
 # whether to proceed rather than aborting the whole install (unlike git,
 # which is hard-required much earlier for clone_repo).
+
+# RHEL 8-family systems (AlmaLinux/Rocky/CentOS/RHEL 8) ship GCC 8.5 as the
+# default g++, which predates the -std=gnu++20 flag name node-gyp passes when
+# building node-pty (it only recognizes the pre-standardization -std=gnu++2a
+# alias). GCC 11+ (e.g. gcc-toolset-12) is required. Other distros' g++/
+# clang++ are recent enough that mere presence has always been sufficient.
+cxx_compiler_ok() {
+    case "$DISTRO" in
+        rhel|centos|rocky|alma|almalinux)
+            command -v g++ &> /dev/null || return 1
+            local gxx_major
+            gxx_major="$(g++ -dumpversion 2>/dev/null | cut -d. -f1)"
+            case "$gxx_major" in ''|*[!0-9]*) return 1 ;; esac
+            [ "$gxx_major" -ge 11 ]
+            ;;
+        *)
+            command -v g++ &> /dev/null || command -v clang++ &> /dev/null
+            ;;
+    esac
+}
+
 check_cxx_compiler() {
     log_info "Checking for a C++ compiler (needed to build native Node modules like node-pty)..."
 
-    if command -v g++ &> /dev/null || command -v clang++ &> /dev/null; then
+    if cxx_compiler_ok; then
         log_success "C++ compiler found"
         HAS_CXX_COMPILER=true
         return 0
     fi
 
     HAS_CXX_COMPILER=false
-    log_warn "No C++ compiler found"
+    if [ "$OS" = "linux" ] && command -v g++ &> /dev/null; then
+        log_warn "System GCC is too old to build node-pty (needs GCC 11+ for -std=gnu++20)"
+    else
+        log_warn "No C++ compiler found"
+    fi
 
     case "$OS" in
         macos)
@@ -851,8 +876,16 @@ check_cxx_compiler() {
                     log_info "Installing base-devel via pacman..."
                     $sudo_cmd pacman -S --noconfirm base-devel >/dev/null 2>&1 || true
                     ;;
+                rhel|centos|rocky|alma|almalinux)
+                    log_info "Installing gcc-toolset-12 via dnf (RHEL 8's default GCC is too old for C++20)..."
+                    $sudo_cmd dnf install -y gcc-toolset-12 >/dev/null 2>&1 || true
+                    if [ -f /opt/rh/gcc-toolset-12/enable ]; then
+                        # shellcheck disable=SC1091
+                        . /opt/rh/gcc-toolset-12/enable
+                    fi
+                    ;;
             esac
-            if command -v g++ &> /dev/null || command -v clang++ &> /dev/null; then
+            if cxx_compiler_ok; then
                 log_success "C++ compiler installed"
                 HAS_CXX_COMPILER=true
                 return 0
@@ -869,6 +902,10 @@ check_cxx_compiler() {
                 ubuntu|debian) log_info "  sudo apt install build-essential" ;;
                 fedora)        log_info "  sudo dnf install gcc-c++" ;;
                 arch)          log_info "  sudo pacman -S base-devel" ;;
+                rhel|centos|rocky|alma|almalinux)
+                    log_info "  sudo dnf install gcc-toolset-12"
+                    log_info "  scl enable gcc-toolset-12 bash   # then re-run the installer in this shell"
+                    ;;
                 *)             log_info "  Install a C++ compiler (g++/gcc-c++) via your package manager" ;;
             esac
             ;;
@@ -2541,7 +2578,7 @@ install_node_deps() {
                         log_warn "Playwright browser installation failed — browser tools will not work."
                     }
                     ;;
-                fedora|rhel|centos|rocky|alma)
+                fedora|rhel|centos|rocky|alma|almalinux)
                     log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
                     log_info "Install Chromium system dependencies manually before using browser tools:"
                     log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"

--- a/tests/test_install_sh_almalinux.py
+++ b/tests/test_install_sh_almalinux.py
@@ -1,0 +1,96 @@
+"""Regression tests for AlmaLinux 8 install support (#98938).
+
+RHEL 8-family systems (AlmaLinux/Rocky/CentOS/RHEL 8) ship GCC 8.5, which
+predates the -std=gnu++20 flag name node-gyp passes when building node-pty —
+the build fails even though a compiler is technically present. Separately,
+`/etc/os-release`'s `ID` on AlmaLinux is the literal string `almalinux`, not
+`alma`, so the RPM-family case patterns in install.sh must match both.
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function_body(source: str, name: str) -> str:
+    m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", source, re.MULTILINE | re.DOTALL)
+    assert m, f"could not extract {name}() from install.sh"
+    return m.group(0)
+
+
+def test_playwright_deps_branch_matches_almalinux() -> None:
+    text = INSTALL_SH.read_text()
+    assert "fedora|rhel|centos|rocky|alma|almalinux)" in text
+
+
+def test_check_cxx_compiler_has_rhel_family_gcc_toolset_branch() -> None:
+    text = INSTALL_SH.read_text()
+
+    body = _extract_function_body(text, "check_cxx_compiler")
+    assert "rhel|centos|rocky|alma|almalinux" in body
+    assert "gcc-toolset-12" in body
+
+
+def _run_cxx_compiler_ok(distro: str, *, gxx_present: bool, gxx_major: str) -> dict:
+    """Source cxx_compiler_ok() from install.sh with a stubbed g++ and run it."""
+    src = INSTALL_SH.read_text()
+    body = _extract_function_body(src, "cxx_compiler_ok")
+
+    if gxx_present:
+        gxx_stub = f"""
+g++() {{
+    if [ "$1" = "-dumpversion" ]; then echo {gxx_major!r}; else :; fi
+}}
+"""
+    else:
+        gxx_stub = ""
+
+    harness = f"""
+set -u
+DISTRO={distro!r}
+command() {{
+    if [ "$1" = "-v" ] && [ "$2" = "g++" ]; then
+        {"return 0" if gxx_present else "return 1"}
+    fi
+    if [ "$1" = "-v" ] && [ "$2" = "clang++" ]; then
+        return 1
+    fi
+    builtin command "$@"
+}}
+
+{gxx_stub}
+
+{body}
+
+cxx_compiler_ok
+echo "RC=$?"
+"""
+    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True)
+    rc = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("RC="):
+            rc = int(line.split("=", 1)[1])
+    return {"rc": rc, "stderr": proc.stderr}
+
+
+def test_almalinux_with_old_gcc_is_not_ok() -> None:
+    """AlmaLinux 8's default GCC 8 must be treated as insufficient."""
+    r = _run_cxx_compiler_ok("almalinux", gxx_present=True, gxx_major="8")
+    assert r["rc"] == 1, r
+
+
+def test_almalinux_with_gcc_toolset_12_is_ok() -> None:
+    """Once gcc-toolset-12 (GCC 12) is on PATH, the check must pass."""
+    r = _run_cxx_compiler_ok("almalinux", gxx_present=True, gxx_major="12")
+    assert r["rc"] == 0, r
+
+
+def test_ubuntu_only_checks_presence_not_version() -> None:
+    """Non-RHEL distros keep the old presence-only behavior (no regression)."""
+    r = _run_cxx_compiler_ok("ubuntu", gxx_present=True, gxx_major="8")
+    assert r["rc"] == 0, r


### PR DESCRIPTION
## What does this PR do?

Fixes two related install failures on AlmaLinux 8 (RHEL 8-family) reported in #98938:

1. **`check_cxx_compiler()` never checked compiler *version*, only presence.** AlmaLinux 8's default `g++` is 8.5, which predates the `-std=gnu++20` flag name node-gyp passes when building `node-pty` (GCC recognized this C++20 support only under the pre-standardization `-std=gnu++2a` alias until GCC 11). Because `g++` is technically present, the old code returned success immediately and never warned — the failure only surfaced later, deep inside `npm install`, with a cryptic `g++: error: unrecognized command line option '-std=gnu++20'`.
2. **The Playwright-deps `case "$DISTRO"` branch matched `alma` but not `almalinux`.** `/etc/os-release`'s `ID` on AlmaLinux is the literal string `almalinux`, so the RPM-family branch (which prints the correct `dnf install ... nss atk at-spi2-core ...` package list) was never reached; it fell through to the generic unknown-distro message instead.

## Related Issue

Fixes #98938

## Changes Made

- `scripts/install.sh`:
  - Added `cxx_compiler_ok()`: on `rhel|centos|rocky|alma|almalinux`, requires `g++ -dumpversion` to report major version >= 11 (not just presence); all other distros keep the previous presence-only check (no behavior change there).
  - `check_cxx_compiler()` now uses `cxx_compiler_ok()` for both the initial check and the post-install-attempt check, and gains an RHEL-family branch that installs `gcc-toolset-12` via `dnf` and sources `/opt/rh/gcc-toolset-12/enable` (when present) so the newer compiler is on `PATH` for the rest of the same install run. The manual-install fallback message also gains an RHEL-family case pointing at `gcc-toolset-12` + `scl enable`.
  - Playwright deps branch: `fedora|rhel|centos|rocky|alma)` → `fedora|rhel|centos|rocky|alma|almalinux)`.
- `tests/test_install_sh_almalinux.py` (new): asserts both case patterns are present, and drives the extracted `cxx_compiler_ok()` function in a stubbed shell to prove AlmaLinux + GCC 8 is rejected, AlmaLinux + GCC 12 is accepted, and non-RHEL distros (e.g. Ubuntu) keep the old presence-only behavior.

## How to Test

1. `python3 -m pytest tests/test_install_sh_almalinux.py -v` — all 5 pass.
2. Confirm the tests actually catch the bug: `git checkout HEAD~1 -- scripts/install.sh && python3 -m pytest tests/test_install_sh_almalinux.py -v` — all 5 fail (`cxx_compiler_ok` doesn't exist yet / `almalinux` isn't in the Playwright case pattern), then `git checkout HEAD -- scripts/install.sh` restores the fix.
3. `bash -n scripts/install.sh` — syntax OK. `shellcheck --severity=error scripts/install.sh` — no errors.
4. Full install.sh regression suite: `python3 -m pytest tests/test_install_sh_*.py -q` → `50 passed, 1 skipped` (unchanged pass count from before this PR, i.e. no regressions).

### Real output

```
$ python3 -m pytest tests/test_install_sh_almalinux.py -v
tests/test_install_sh_almalinux.py::test_playwright_deps_branch_matches_almalinux PASSED
tests/test_install_sh_almalinux.py::test_check_cxx_compiler_has_rhel_family_gcc_toolset_branch PASSED
tests/test_install_sh_almalinux.py::test_almalinux_with_old_gcc_is_not_ok PASSED
tests/test_install_sh_almalinux.py::test_almalinux_with_gcc_toolset_12_is_ok PASSED
tests/test_install_sh_almalinux.py::test_ubuntu_only_checks_presence_not_version PASSED
5 passed in 0.16s

$ git checkout HEAD~1 -- scripts/install.sh && python3 -m pytest tests/test_install_sh_almalinux.py -v
FAILED ... assert 'fedora|rhel|centos|rocky|alma|almalinux)' in '...'
FAILED ... assert 'rhel|centos|rocky|alma|almalinux' in '...'
FAILED ... could not extract cxx_compiler_ok() from install.sh
FAILED ... could not extract cxx_compiler_ok() from install.sh
FAILED ... could not extract cxx_compiler_ok() from install.sh
5 failed in 0.17s
$ git checkout HEAD -- scripts/install.sh   # restored

$ python3 -m pytest tests/test_install_sh_*.py -q
..................................................s
50 passed, 1 skipped in 6.00s
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #51622, #51674 — neither matches `almalinux` or touches `check_cxx_compiler`)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/test_install_sh_*.py -q` and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not tested on a real AlmaLinux 8 host (no such host available in this environment); verified via `bash -n`, `shellcheck`, and a stubbed-shell unit test of the extracted function instead.

### AI-assistance disclosure

This PR was prepared with the assistance of an AI coding agent (Claude), which read the issue, wrote the fix and the regression test, and verified the test fails without the fix and passes with it. A human reviewed the diff before it was pushed.
