### PR TITLE
fix(state): honor _ensure_fts_cjk_schema's never-raises contract

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5119,41 +5119,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
               and leave the stale breadcrumb (#self-heal). The table itself
               stays for a later capable open to rebuild.
         """
-        cjk_present = bool(cursor.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
-            "AND name = 'messages_fts_cjk'"
-        ).fetchone())
+        try:
+            cjk_present = bool(cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'messages_fts_cjk'"
+            ).fetchone())
 
-        if not self._fts_cjk_loaded:
-            if cjk_present:
-                live = [
-                    r[0] for r in cursor.execute(
-                        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
-                        f"AND name IN ({','.join('?' for _ in _FTS_CJK_TRIGGERS)})",
-                        _FTS_CJK_TRIGGERS,
-                    ).fetchall()
-                ]
-                if live:
-                    # Self-heal: this process cannot tokenize, so every
-                    # message INSERT would die inside the cjk trigger.
-                    # Breadcrumb FIRST (crash between the two statements is
-                    # merely conservative), then drop.
-                    logger.warning(
-                        "messages_fts_cjk triggers present but the "
-                        "cjk_unicode61 tokenizer is unavailable (%s) — "
-                        "dropping the cjk triggers so message writes keep "
-                        "working. CJK search falls back to trigram/LIKE; "
-                        "run `hermes sessions optimize-storage` on a host "
-                        "with the extension to rebuild.",
-                        fts5_cjk_so_path(),
-                    )
-                    cursor.execute(
-                        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
-                        "ON CONFLICT(key) DO UPDATE SET value = '1'",
-                        (FTS_CJK_STALE_KEY,),
-                    )
-                    for trig in live:
-                        cursor.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            if not self._fts_cjk_loaded:
+                if cjk_present:
+                    live = [
+                        r[0] for r in cursor.execute(
+                            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                            f"AND name IN ({','.join('?' for _ in _FTS_CJK_TRIGGERS)})",
+                            _FTS_CJK_TRIGGERS,
+                        ).fetchall()
+                    ]
+                    if live:
+                        # Self-heal: this process cannot tokenize, so every
+                        # message INSERT would die inside the cjk trigger.
+                        # Breadcrumb FIRST (crash between the two statements is
+                        # merely conservative), then drop.
+                        logger.warning(
+                            "messages_fts_cjk triggers present but the "
+                            "cjk_unicode61 tokenizer is unavailable (%s) — "
+                            "dropping the cjk triggers so message writes keep "
+                            "working. CJK search falls back to trigram/LIKE; "
+                            "run `hermes sessions optimize-storage` on a host "
+                            "with the extension to rebuild.",
+                            fts5_cjk_so_path(),
+                        )
+                        cursor.execute(
+                            "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                            "ON CONFLICT(key) DO UPDATE SET value = '1'",
+                            (FTS_CJK_STALE_KEY,),
+                        )
+                        for trig in live:
+                            cursor.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                self._fts_cjk_available = False
+                return
+        except sqlite3.OperationalError:
+            # Mirror the tokenizer-loaded except below: the presence check
+            # and self-heal above run before the loaded/not-loaded branch is
+            # even known to be safe, so they need the same never-raises
+            # guarantee the docstring promises for the rest of the method.
+            logger.warning(
+                "messages_fts_cjk presence check failed; CJK search stays on "
+                "trigram/LIKE", exc_info=True,
+            )
             self._fts_cjk_available = False
             return
 

--- a/tests/test_fts_update_of_narrowing.py
+++ b/tests/test_fts_update_of_narrowing.py
@@ -265,6 +265,33 @@ def test_cjk_broad_trigger_is_restored_as_update_of(
         db.close()
 
 
+def test_cjk_ensure_survives_presence_check_failure_when_tokenizer_unloaded(
+    tmp_path: Path,
+):
+    """``_ensure_fts_cjk_schema`` is documented never to raise (#98834).
+
+    The tokenizer-not-loaded branch runs its sqlite_master presence check
+    and self-heal statements before any try/except guards them; a transient
+    sqlite3.OperationalError there (e.g. "database is locked") must degrade
+    to "no cjk index", not propagate.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db._fts_cjk_loaded = False
+        db._fts_cjk_available = True
+
+        class _LockedOnMasterCursor:
+            def execute(self, sql, *args, **kwargs):
+                if "sqlite_master" in sql:
+                    raise sqlite3.OperationalError("database is locked")
+                raise AssertionError(f"unexpected query: {sql}")
+
+        db._ensure_fts_cjk_schema(_LockedOnMasterCursor())
+        assert db._fts_cjk_available is False
+    finally:
+        db.close()
+
+
 def test_legacy_migration_does_not_drop_cjk_trigger(tmp_path: Path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:


### PR DESCRIPTION
## Problem

Fixes #98834.

`SessionDB._ensure_fts_cjk_schema` (`hermes_state.py`) documents itself as
never-raising:

> Never raises; every failure mode degrades to "no cjk index" (trigram/LIKE
> routing keeps working).

The tokenizer-loaded branch honors that with a `try/except
sqlite3.OperationalError`. The tokenizer-**not**-loaded branch does not: its
`sqlite_master` presence check and self-heal statements (dropping stale CJK
triggers so message INSERTs don't fail at trigger time) run completely
unguarded. A transient `sqlite3.OperationalError` there (e.g. "database is
locked") escapes the method, breaking its own contract.

That exception then reaches `_migrate_broad_fts_update_triggers`'s
quarantine-then-reraise handler (`hermes_state_schema.py`), which quarantines
CJK state and then deliberately re-raises to signal a genuine contract
violation. The re-raise propagates out of `_init_schema` → `SessionDB.__init__`,
aborting the whole database open — base FTS never gets a chance to finish
initializing, and the process can hit this on every retry (crash loop).

## Fix

Wrap the tokenizer-not-loaded branch's presence check + self-heal in the same
kind of `sqlite3.OperationalError` guard the tokenizer-loaded branch already
has, so it degrades to "no cjk index" instead of propagating — actually
honoring the docstring's contract instead of only partially implementing it.
`_migrate_broad_fts_update_triggers`'s quarantine-then-reraise handling is left
untouched; it's an intentional, already-tested defense against the ensure
function still somehow violating its contract (see
`test_cjk_ensure_failure_marks_unavailable_and_propagates`), not the bug
itself.

## Test

Added `test_cjk_ensure_survives_presence_check_failure_when_tokenizer_unloaded`
to `tests/test_fts_update_of_narrowing.py`, which forces the presence-check
query to raise `sqlite3.OperationalError` while `_fts_cjk_loaded` is `False`
and asserts `_ensure_fts_cjk_schema` does not raise.

Confirmed it fails without the fix:

```
$ git checkout HEAD~1 -- hermes_state.py   # pre-fix source
$ scripts/run_tests.sh tests/test_fts_update_of_narrowing.py -k cjk_ensure_survives
...
>           db._ensure_fts_cjk_schema(_LockedOnMasterCursor())
hermes_state.py:5122: in _ensure_fts_cjk_schema
    cjk_present = bool(cursor.execute(
E   sqlite3.OperationalError: database is locked
FAILED tests/test_fts_update_of_narrowing.py::test_cjk_ensure_survives_presence_check_failure_when_tokenizer_unloaded
1 failed, 9 deselected in 0.53s
```

And passes with the fix restored:

```
$ git checkout HEAD -- hermes_state.py
$ scripts/run_tests.sh tests/test_fts_update_of_narrowing.py -v
Discovered 1 test files (~10 tests) ...
✓ tests/test_fts_update_of_narrowing.py (10✓, 1.9s)
=== Summary: 1 files, 10 tests passed, 0 failed (100% complete) in 1.9s (8 workers) ===
```

Also ran the broader FTS/state suite (273 tests, 0 failed, 2 skipped):

```
$ scripts/run_tests.sh tests/test_fts_cjk_bigram.py tests/test_fts_update_of_narrowing.py \
    tests/state/test_fts_rebuild_admission.py tests/test_hermes_state.py tests/test_schema_read_probe.py
=== Summary: 5 files, 273 tests passed, 0 failed, 2 skipped (100% complete) in 20.1s (8 workers) ===
```

`tests/state/test_fts_runtime_rebuild.py` has 3 pre-existing failures
(`test_second_corruption_fails_open_and_rebuilds_on_reopen`,
`test_repeated_deferrals_reap_inactive_orphan_then_rebuild`,
`test_legacy_inline_fts_fails_open_and_recovers`); verified identical on
unmodified `upstream/main` — unrelated to this change.

`ruff check` and `ty check` on `hermes_state.py`: no new diagnostics
introduced (`ty` reports the same 85 pre-existing `unresolved-attribute`
findings on `self._conn` elsewhere in the file, none near this change, on
both base and head).

## Note on a related fork PR

The issue body links a tracker (`Sravanjangam/hermes-agent#4`) and a
"forthcoming" PR. That PR (#98904, "atomic CJK FTS migration") was opened and
self-closed by its author within 2 minutes, proposing a SAVEPOINT wrapper
around `_migrate_broad_fts_update_triggers` instead. That approach doesn't
address the actual unguarded code path this PR fixes (the presence check
itself, in the tokenizer-not-loaded branch of `_ensure_fts_cjk_schema`), and
no other open PR from that author targets #98834.

---
Assisted by Claude (Anthropic).
