### PR TITLE
fix(state): decode errors now reach the heal path and fail loud in TUI (residual #98924 surfaces)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12380,15 +12380,21 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
 
     try:
         return _open_probed()
-    except sqlite3.DatabaseError as exc:
+    except (sqlite3.DatabaseError, UnicodeDecodeError) as exc:
         message = str(exc).lower()
         stale_schema = "no such table" in message or "no such column" in message
-        if not stale_schema and not is_malformed_schema_error(exc):
+        if not stale_schema and not (
+            # UnicodeDecodeError = pysqlite could not decode SQLite's own
+            # error message because corrupt file bytes were embedded in it
+            # (#98924). The one-writable-open heal is the only repair path,
+            # so route it through the same dispatch as malformed schema.
+            is_malformed_schema_error(exc) or isinstance(exc, UnicodeDecodeError)
+        ):
             raise
         SessionDB(db_path=db_path, read_only=False).close()
         try:
             return _open_probed()
-        except sqlite3.DatabaseError as still_stale:
+        except (sqlite3.DatabaseError, UnicodeDecodeError) as still_stale:
             message = str(still_stale).lower()
             if "no such table" not in message and "no such column" not in message:
                 raise

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -494,7 +494,7 @@ class SessionSchemaMixin:
         """Body of :meth:`_recover_stale_fts`; caller holds rebuild authority."""
         try:
             trigram_status = self._fts_table_probe(cursor, "messages_fts_trigram")
-        except sqlite3.DatabaseError:
+        except (sqlite3.DatabaseError, UnicodeDecodeError):
             # A corrupt vtable may fail even a LIMIT 0 probe. It still needs
             # to be included in the drop-and-recreate recovery below.
             trigram_status = True

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -628,6 +628,36 @@ class TestWebServerEndpoints:
 
         assert opens == [True]
 
+    def test_decode_error_triggers_writable_heal(self, tmp_path, monkeypatch):
+        """UnicodeDecodeError — pysqlite failing to decode SQLite's own error
+        message over corrupt file bytes (#98924) — must route through the
+        same one-writable-open heal as malformed schema."""
+        import hermes_state
+        from hermes_cli import web_server
+
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"not-empty")
+        opens = []
+
+        class _OkDB:
+            _conn = None
+
+            def close(self):
+                pass
+
+        def scripted_open(*_args, **kwargs):
+            opens.append(kwargs.get("read_only", False))
+            if opens == [True]:
+                raise UnicodeDecodeError("utf-8", b"\x81", 0, 1, "invalid start byte")
+            return _OkDB()
+
+        monkeypatch.setattr(hermes_state, "SessionDB", scripted_open)
+
+        db = web_server._open_session_db_at_path(db_path, read_only=True)
+
+        assert isinstance(db, _OkDB)
+        assert opens == [True, False, True]
+
     def test_get_sessions_zero_byte_store_returns_empty_list(self):
         from hermes_constants import get_hermes_home
 

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -840,3 +840,42 @@ def test_repair_honors_configured_delete_mode(tmp_path, monkeypatch):
 
     assert report["repaired"] is True
     assert _mode_of(db_path) == "delete"
+
+
+# ── #98924 companion: recovery surface beyond the probe fix (#98935) ───────
+
+# The probe itself is fixed in #98935; this test must not depend on it.
+def test_fts_recovery_includes_vtables_that_raise_decode_errors(tmp_path):
+    """Drop-and-recreate recovery must include corrupt vtables whose probe
+    raises UnicodeDecodeError, not only sqlite3.DatabaseError (#98924)."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="searchable needle")
+    cursor = db._conn.cursor()
+
+    original_probe = db._fts_table_probe
+
+    def _decode_boom(probe_cursor, table_name):
+        if table_name == "messages_fts_trigram":
+            raise UnicodeDecodeError("utf-8", b"\x81", 0, 1, "invalid start byte")
+        return original_probe(probe_cursor, table_name)
+
+    db._fts_table_probe = _decode_boom
+    try:
+        assert db._recover_stale_fts(cursor, legacy=False) is True
+    finally:
+        db.close()
+
+    check = sqlite3.connect(str(db_path))
+    try:
+        names = {
+            row[0]
+            for row in check.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts%'"
+            )
+        }
+    finally:
+        check.close()
+    assert "messages_fts" in names
+    assert "messages_fts_trigram" in names

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14254,6 +14254,61 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     assert server._db_error == "locking protocol"
 
 
+def test_ensure_session_db_row_false_when_store_unavailable(monkeypatch):
+    """Store unavailable → False, so prompt.submit can fail the send loudly
+    instead of streaming into a store that will never save it (#98924)."""
+    fake_mod = types.ModuleType("hermes_state")
+
+    class _BrokenSessionDB:
+        def __init__(self):
+            raise RuntimeError("utf-8 boom")
+
+    fake_mod.SessionDB = _BrokenSessionDB
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    assert server._ensure_session_db_row({"session_key": "k1"}) is False
+
+
+def test_ensure_session_db_row_true_when_row_persisted(monkeypatch):
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, **_kwargs):
+            created.append(key)
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    assert server._ensure_session_db_row({"session_key": "k1", "cwd": "/tmp"}) is True
+    assert created == ["k1"]
+
+
+def test_prompt_submit_fails_loudly_when_store_unavailable(monkeypatch):
+    """A send with no persistable store must fail the RPC with a real error
+    (desktop maps it to a toast) instead of streaming the message into a
+    store that will never save it (#98924)."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {}})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_db_error", "utf-8 decode failure")
+
+    server._sessions["lost-sid"] = _session()
+    try:
+        resp = server.handle_request(
+            {
+                "id": "lost",
+                "method": "prompt.submit",
+                "params": {"session_id": "lost-sid", "text": "will vanish"},
+            }
+        )
+    finally:
+        server._sessions.pop("lost-sid", None)
+
+    assert resp["error"]["code"] == 5072
+    assert "session storage unavailable" in resp["error"]["message"]
+
+
 @pytest.mark.real_agent_prewarm
 def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     class _FakeWorker:

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -839,7 +839,17 @@ def _(rid, params: dict) -> dict:
     # Disk-full must fail the RPC (not stream silently): desktop maps the error
     # string to a "disk full" toast so the user knows why the send vanished.
     try:
-        _ensure_session_db_row(session)
+        if _ensure_session_db_row(session) is False:
+            # Store unavailable: failing the RPC is the only user-visible
+            # signal — same principle as the disk-full path above (#98924).
+            # _db_error carries the SessionDB open failure for the toast.
+            return _err(
+                rid,
+                5072,
+                "session storage unavailable: "
+                f"{_db_error or 'state.db could not be opened'} — the message "
+                "was not saved; repair state.db and try again",
+            )
         # A branch becomes real here: copy its parent's transcript into the row so it
         # resumes with full context (the agent won't persist the seed itself).
         _persist_branch_seed(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3788,13 +3788,17 @@ def _register_session_cwd(session: dict | None) -> None:
         pass
 
 
-def _ensure_session_db_row(session: dict) -> None:
+def _ensure_session_db_row(session: dict) -> bool:
     """Idempotently persist the session's DB row on first real activity.
 
     Called from prompt.submit so a row only exists once the user actually sends
     a message — abandoned drafts never leave an empty "Untitled" session behind.
     Uses INSERT OR IGNORE under the hood, so re-calls (and the AIAgent's own
     lazy create) are no-ops.
+    Returns False only when the store is unavailable (no openable state.db);
+    prompt.submit turns that into an RPC error so a send fails loudly with a
+    toast instead of streaming into a store that will never save it (#98924).
+    Every other outcome — no key, best-effort attempt, success — is True.
 
     A cwd the user *chose* is always persisted. When they made no explicit
     choice the launch directory stands in, and whether that is meaningful
@@ -3824,13 +3828,13 @@ def _ensure_session_db_row(session: dict) -> None:
             db = SessionDB(db_path=Path(profile_home) / "state.db")
         except Exception:
             logger.debug("failed to open profile db for session row", exc_info=True)
-            return
+            return False
         close_db = True
     else:
         db = _get_db()
         close_db = False
     if db is None:
-        return
+        return False
     # The session's own model/effort/fast pick — the composer override shipped on
     # session.create, or a restored /model switch — must own the row's model +
     # model_config. The agent isn't built yet at first prompt.submit, so derive
@@ -3943,6 +3947,7 @@ def _ensure_session_db_row(session: dict) -> None:
                 db.close()
             except Exception:
                 pass
+    return True
 
 
 def _persist_branch_seed(session: dict) -> None:


### PR DESCRIPTION
## What does this PR do?

`_fts_table_probe` catching `UnicodeDecodeError` (#98935) fixes the probe itself, but #98924 describes three surfaces and that PR covers only one. When pysqlite fails to UTF-8-decode SQLite's *own error message* (a corrupt store puts non-UTF-8 file bytes into the message, e.g. a damaged `sqlite_master` name row re-quoted as `malformed database schema (…)`), `cursor.execute()` raises a **raw `UnicodeDecodeError`** — a `ValueError`, not `sqlite3.Error` — which every `except sqlite3.DatabaseError` guard in the read path misses.

This PR closes the remaining two surfaces plus the same-class gap in FTS recovery. It is intentionally disjoint from #98935 (no probe changes) so the two can land in either order:

1. **Web heal never fired (Failure 1 in the issue).** `_open_session_db_at_path` advertises a one-writable-open heal, but both its catches were typed `sqlite3.DatabaseError`, so a decode error escaped *after* `SessionDB(read_only=True)` init raised — 500s on every poll with the documented repair path skipped. Both catches now include `UnicodeDecodeError` and dispatch it to the heal. (Deliberately *not* routed through `is_malformed_schema_error` — that classifier stays fail-closed for repair dispatch elsewhere.)
2. **FTS drop-and-recreate skipped decode-corrupt vtables.** `_recover_stale_fts_locked`'s comment already says "a corrupt vtable may fail even a LIMIT 0 probe", but its catch was `sqlite3.DatabaseError`-only — same class of gap as the probe.
3. **TUI silent message loss (Failure 2 in the issue).** `_ensure_session_db_row` silently returned when the store could not open, so `prompt.submit` streamed the turn while persisting nothing — the issue's "17 minutes of conversation vanished with no surface indication". It now returns `False` on store unavailability and `prompt.submit` fails the RPC with code **5072**, mirroring the existing disk-full/5070 convention (desktop maps the error string to a toast). `session.create` remains silent per its pinned degraded-mode contract (`test_session_create_continues_when_state_db_is_unavailable`).

Root-cause note (verified by live repro): invalid UTF-8 in `messages.content` alone does **not** make the probe's `SELECT … LIMIT 0` raise — `LIMIT 0` fetches no rows. The `execute()`-time `UnicodeDecodeError` comes from pysqlite decoding the SQLite error message itself, i.e. schema-area corruption. That is why the heal dispatch (surface 1) matters even with the probe fixed.

## Related Issue

Fixes #98924 (surfaces not covered by #98935)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py` — widen both heal catches in `_open_session_db_at_path` to `(sqlite3.DatabaseError, UnicodeDecodeError)`; decode errors dispatch to the one-writable-open heal
- `hermes_state_schema.py` — `_recover_stale_fts_locked` catches `(sqlite3.DatabaseError, UnicodeDecodeError)` so corrupt vtables are included in drop-and-recreate
- `tui_gateway/server.py` — `_ensure_session_db_row` returns `bool` (`False` = store unavailable, launch- and profile-open paths)
- `tui_gateway/methods_prompt.py` — `prompt.submit` returns RPC error 5072 `session storage unavailable: …` when the row cannot be persisted because the store is down
- Tests: heal dispatch (`tests/hermes_cli/test_web_server.py`), FTS recovery with decode-corrupt vtable (`tests/test_state_db_malformed_repair.py`), store-unavailable contract + 5072 send-failure (`tests/test_tui_gateway_server.py`)

## How to Test

1. Repro the mechanism (without #98935, or on `main` + this PR's test): build a store, flip one byte of an FTS-related name cell in `sqlite_master`, then `SessionDB(db_path, read_only=True)` — init raises `UnicodeDecodeError` on `main`.
2. With this PR, the decode error reaching `_open_session_db_at_path` triggers the writable heal attempt instead of bypassing it: `pytest tests/hermes_cli/test_web_server.py -k "decode_error_triggers_writable_heal or generic_corruption_does_not_trigger_writable_heal"` — 2 passed. (`generic_corruption…` pins that unscoped `SQLITE_CORRUPT` still does *not* escalate to writes.)
3. `pytest tests/test_state_db_malformed_repair.py -q` — 24 passed (incl. recovery including a vtable whose probe raises `UnicodeDecodeError`).
4. `pytest tests/test_tui_gateway_server.py -k "ensure_session_db_row or get_db_degrades or prompt_submit_fails_loudly"` — 11 passed; the 5072 test asserts a send with no persistable store fails the RPC with `session storage unavailable` instead of returning `{"status":"streaming"}`.

Tested on macOS 15 (darwin 25.6.0, arm64, Python 3.11). The probe itself is unchanged here — #98935's regression test covers that layer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #98935 covers the probe; this PR is scoped to the surfaces it does not touch
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted suites: `tests/hermes_cli/test_web_server.py`, `tests/test_state_db_malformed_repair.py`, `tests/test_tui_gateway_server.py` (store/session subsets) — all pass; a combined run shows one pre-existing unrelated failure (`test_gui_surface_toolsets` toolset-set drift) reproducible on `main` without this patch
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (Darwin 25.6.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated on changed functions)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (sqlite3/pysqlite exception semantics, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
