### PR TITLE
fix(billing): preserve configured provider identity on custom-provider billing records

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3434,6 +3434,38 @@ def switch_model(
             )
 
 
+def billing_provider_identity(agent) -> str:
+    """Routable provider identity for billing/display records.
+
+    All user-defined ``providers:`` entries resolve to the *billing class*
+    ``custom`` at runtime (hermes_cli/runtime_provider.py). Writing that bare
+    class into ``billing_provider`` loses which configured provider actually
+    served the session — the dashboard then shows "custom" instead of the
+    configured name (GitHub #98739), and resume can't re-route. The configured
+    identity is preserved on the agent as ``requested_provider`` (mirrored
+    from the resolved runtime's ``requested_provider`` field). Prefer it
+    whenever the active provider is the bare class; built-in providers pass
+    through unchanged.
+    """
+    provider = (getattr(agent, "provider", "") or "").strip()
+    if provider.lower() != "custom":
+        return provider
+    requested = (getattr(agent, "requested_provider", "") or "").strip()
+    if requested and requested.lower() not in {"custom", "auto", ""}:
+        return requested
+    # Last resort: the live main runtime's requested_provider (set by
+    # resolve_runtime_provider / set_runtime_main for custom providers).
+    try:
+        from agent.auxiliary_client import _runtime_main_value
+
+        runtime_requested = str(_runtime_main_value("requested_provider") or "").strip()
+        if runtime_requested.lower() not in {"custom", "auto", ""}:
+            return runtime_requested
+    except Exception:
+        pass
+    return provider
+
+
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
                  tool_call_id: Optional[str] = None, messages: list = None,
                  pre_tool_block_checked: bool = False,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.agent_runtime_helpers import billing_provider_identity
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 agent._session_db.queue_token_counts(
                     agent.session_id,
                     model=agent.model,
-                    billing_provider=agent.provider,
+                    billing_provider=billing_provider_identity(agent),
                     billing_base_url=agent.base_url,
                     billing_mode="subscription_included",
                     api_call_count=1,
@@ -228,7 +229,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 if cost_result.amount_usd is not None else None,
                 cost_status=cost_result.status,
                 cost_source=cost_result.source,
-                billing_provider=agent.provider,
+                billing_provider=billing_provider_identity(agent),
                 billing_base_url=agent.base_url,
                 billing_mode="subscription_included"
                 if cost_result.status == "included" else None,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -39,6 +39,7 @@ from agent.conversation_compression import (
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.agent_runtime_helpers import billing_provider_identity
 from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
@@ -4459,7 +4460,7 @@ def run_conversation(
                                 estimated_cost_usd=_cost_delta,
                                 cost_status=cost_result.status,
                                 cost_source=cost_result.source,
-                                billing_provider=agent.provider,
+                                billing_provider=billing_provider_identity(agent),
                                 billing_base_url=agent.base_url,
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,

--- a/tests/agent/test_billing_provider_identity.py
+++ b/tests/agent/test_billing_provider_identity.py
@@ -1,0 +1,60 @@
+"""billing_provider_identity: routable provider identity for billing records.
+
+Regression tests for GitHub #98739: automatic fallback to a user-defined
+``providers:`` entry wrote the bare billing class ``custom`` into
+``billing_provider`` (conversation_loop / codex_runtime), so the dashboard
+showed "custom" instead of the configured provider name. The manual /model
+switch path already propagated the configured ID.
+"""
+
+from agent.agent_runtime_helpers import billing_provider_identity
+
+
+class _Agent:
+    """Minimal stand-in with just the attributes the helper reads."""
+
+    def __init__(self, provider="", requested_provider=""):
+        self.provider = provider
+        self.requested_provider = requested_provider
+
+
+def test_builtin_provider_passthrough():
+    """Built-in providers are returned unchanged, requested_provider ignored."""
+    agent = _Agent(provider="zai", requested_provider="something-else")
+    assert billing_provider_identity(agent) == "zai"
+
+
+def test_custom_class_prefers_requested_provider():
+    """Bare 'custom' with a configured identity resolves to that identity."""
+    agent = _Agent(provider="custom", requested_provider="my-custom-provider")
+    assert billing_provider_identity(agent) == "my-custom-provider"
+
+
+def test_custom_class_with_no_identity_stays_custom():
+    """Anonymous custom endpoints (OPENAI_BASE_URL) have no ID to preserve.
+
+    The helper must not invent one — bare 'custom' is the honest record.
+    """
+    agent = _Agent(provider="custom", requested_provider="")
+    assert billing_provider_identity(agent) == "custom"
+
+
+def test_custom_class_ignores_non_routable_requested_values():
+    """'custom'/'auto'/blank on requested_provider are not identities."""
+    for requested in ("custom", "auto", "  ", None):
+        agent = _Agent(provider="custom", requested_provider=requested)
+        assert billing_provider_identity(agent) == "custom"
+
+
+def test_requested_provider_case_and_whitespace_normalized():
+    agent = _Agent(provider=" Custom ", requested_provider="  My-Provider ")
+    assert billing_provider_identity(agent) == "My-Provider"
+
+
+def test_missing_attributes_tolerated():
+    """Agents without the attrs (tests, bare objects) don't crash."""
+
+    class _Bare:
+        pass
+
+    assert billing_provider_identity(_Bare()) == ""


### PR DESCRIPTION
Fixes #98739

## Problem

User-defined `providers:` entries (named custom providers) all resolve to the *billing class* `custom` at runtime. The automatic-fallback and runtime billing write sites recorded `agent.provider` verbatim, so sessions served by a named custom provider were recorded as bare `"custom"` — the dashboard shows a generic "custom" instead of the configured provider name, and the record can't be re-routed on resume.

The manual `/model` switch path already propagates the configured identity; only the fallback/runtime path was wrong.

## Fix

Add `billing_provider_identity(agent)` in `agent/agent_runtime_helpers.py`:

- Built-in providers pass through unchanged.
- When the active provider is the bare class `custom`, prefer `agent.requested_provider` (the configured identity mirrored from `resolve_runtime_provider`), then the live main runtime's `requested_provider`, and only fall back to bare `"custom"` when no identity exists (anonymous `OPENAI_BASE_URL`-style endpoints, where `"custom"` is the honest record).

Wire it into the billing call sites:
- `agent/conversation_loop.py` (`queue_token_counts`)
- `agent/codex_runtime.py` (both write sites)

## Tests

New `tests/agent/test_billing_provider_identity.py` (6 cases): built-in passthrough, configured-identity preference, anonymous-endpoint fallback, non-routable requested values (`custom`/`auto`/blank) ignored, whitespace/case normalization, missing-attribute tolerance.

Verification:
- New tests pass (6/6).
- Targeted subset (billing / codex_runtime / conversation_loop / token_count / fallback): 250 passed, 1 skipped.
- Full `tests/agent/` run with the change: 180 failed, 5621 passed — identical failure set to a clean `main` baseline run (180 failed, 5615 passed); zero new failures introduced, all pre-existing/environmental.