### PR TITLE
fix(env): quoted .env credentials read the same in skills and sandboxes as everywhere else

### DIFF
--- a/tests/tools/test_env_parser_parity.py
+++ b/tests/tools/test_env_parser_parity.py
@@ -1,0 +1,71 @@
+"""Parser parity: every core reader of ~/.hermes/.env must agree.
+
+Bug class ported from qwibitai/nanoclaw#3659: two .env parsers, two answers
+for the same file. Hermes' canonical parser (``hermes_cli.config.load_env``)
+reverses the ``\\"``/``\\\\`` escapes its own writer produces and handles
+unpaired quotes conservatively; ``tools.skills_tool.load_env`` used to carry
+a hand-rolled ``value.strip().strip('"\\'')`` loop that did neither — so a
+credential containing ``"`` or ``\\`` (or an unterminated quote) resolved
+differently in skill-requirement checks and sandbox env passthrough than
+everywhere else. skills_tool now delegates to the canonical parser; these
+tests pin the parity contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _load_both(tmp_path, monkeypatch, contents: str):
+    """Return (canonical, skills_tool) parses of the same .env file."""
+    from hermes_cli.config import invalidate_env_cache, load_env
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(contents, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import tools.skills_tool as skills_tool
+
+    invalidate_env_cache()
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            canonical = load_env()
+            skills = skills_tool.load_env()
+    finally:
+        invalidate_env_cache()
+    return canonical, skills
+
+
+def test_escaped_quote_credential_parses_identically(tmp_path, monkeypatch):
+    # The canonical writer (save_env_value) escapes " and \ inside double
+    # quotes. The old skills_tool parser left the backslash in the value.
+    canonical, skills = _load_both(
+        tmp_path, monkeypatch, 'PASS="pa\\"ss"\nSLASH="a\\\\b"\n'
+    )
+    assert canonical["PASS"] == 'pa"ss'
+    assert canonical["SLASH"] == "a\\b"
+    assert skills == canonical
+
+
+def test_unterminated_quote_parses_identically(tmp_path, monkeypatch):
+    # The old skills_tool parser stripped the lone leading quote; the
+    # canonical parser preserves it (not a matched pair).
+    canonical, skills = _load_both(tmp_path, monkeypatch, 'B="unterminated\n')
+    assert skills == canonical
+
+
+def test_ordinary_quoted_values_parse_identically(tmp_path, monkeypatch):
+    canonical, skills = _load_both(
+        tmp_path,
+        monkeypatch,
+        'TZ="America/New_York"\n'
+        "SINGLE='single quoted'\n"
+        "PLAIN=bare\n"
+        "export EXPORTED=fromshell\n"
+        "# comment\n",
+    )
+    assert canonical["TZ"] == "America/New_York"
+    assert canonical["SINGLE"] == "single quoted"
+    assert canonical["PLAIN"] == "bare"
+    assert canonical["EXPORTED"] == "fromshell"
+    assert skills == canonical

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -219,24 +219,20 @@ def _skill_lookup_path_error(name: str) -> Optional[str]:
 
 
 def load_env() -> Dict[str, str]:
-    """Load profile-scoped environment variables from HERMES_HOME/.env."""
-    env_path = get_hermes_home() / ".env"
-    env_vars: Dict[str, str] = {}
-    if not env_path.exists():
-        return env_vars
+    """Load profile-scoped environment variables from HERMES_HOME/.env.
 
-    # utf-8-sig: users hand-edit .env in Notepad, which prepends a BOM that
-    # would otherwise glue U+FEFF onto the first key name (same dialect as
-    # the canonical readers in hermes_cli/config.py).
-    with env_path.open(encoding="utf-8-sig", errors="replace") as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                if line.startswith("export "):
-                    line = line[7:]
-                key, _, value = line.partition("=")
-                env_vars[key.strip()] = value.strip().strip("\"'")
-    return env_vars
+    Delegates to the canonical parser in :mod:`hermes_cli.config` so every
+    reader sees the same values for the same file. This module previously
+    carried its own hand-rolled parser whose quote handling diverged from
+    the canonical one (``value.strip().strip('"\\'')`` strips unpaired
+    quotes and never reverses the ``\\"``/``\\\\`` escapes the canonical
+    writer produces) — so a credential containing ``"`` or ``\\`` worked
+    everywhere except skill-requirement checks and sandbox env passthrough.
+    Same bug class as qwibitai/nanoclaw#3659 (two .env parsers, two answers).
+    """
+    from hermes_cli.config import load_env as _canonical_load_env
+
+    return _canonical_load_env()
 
 
 class SkillReadinessStatus(str, Enum):


### PR DESCRIPTION
## Summary
A credential in `~/.hermes/.env` containing `"` or `\` now resolves to the same value in skill-requirement checks and sandbox env passthrough as everywhere else — `tools.skills_tool.load_env()` delegates to the canonical parser instead of carrying a divergent hand-rolled copy.

Bug class from [qwibitai/nanoclaw#3659](https://github.com/qwibitai/nanoclaw/pull/3659) (weekly NanoClaw PR scout): two `.env` parsers, two answers for the same file. Their incident was a quoted template path silently losing its pick across restart; the identical shape exists here.

## Root cause
`hermes_cli.config.load_env` (canonical) reverses the `\"`/`\\` escapes its own writer `save_env_value` produces and treats unpaired quotes conservatively. `tools/skills_tool.load_env` used `value.strip().strip('"\'')` — which strips unpaired quotes and never reverses escapes. Live repro on main:

| `.env` line | canonical | skills_tool (old) |
|---|---|---|
| `ESCAPED="pa\"ss"` | `pa"ss` | `pa\"ss` |
| `B="unterminated` | `"unterminated` | `unterminated` |

skills_tool's parse feeds `_is_env_var_persisted` (skill readiness/setup prompts) and `register_env_passthrough` (env injection into execute_code/terminal sandboxes) — so an affected credential worked interactively but failed inside skills and sandboxes.

## Changes
- `tools/skills_tool.py`: `load_env()` delegates to `hermes_cli.config.load_env` (also gains its mtime memoization and profile-scoped `HERMES_HOME` resolution). skills_tool already imports from `hermes_cli.config` at module level, so no new coupling.
- `tests/tools/test_env_parser_parity.py`: parity contract tests — escaped-quote credentials, unterminated quote, quoted/`export`-prefixed ordinary values.

## Validation
| | Result |
|---|---|
| Sabotage run (old parser restored) | 2/3 parity tests FAIL — proves tests bite |
| `test_env_parser_parity.py` + `test_env_export_prefix.py` + `test_skills_tool.py` | 48/48 pass |

Not touched (deliberate): `hermes_cli/main.py:_has_any_provider_configured` (boolean presence probe only — quote divergence can't flip its answer for a non-empty value) and memory-plugin env mergers (they parse their own plugin env files, not readers of user credentials).

## Infographic

![One .env file, one parser](https://v3b.fal.media/files/b/0aa87a88/8-Pre7t90G8xc7nVgWzTz_GhL0eH6x.png)
