### PR TITLE
feat(feishu): add JoaoMarcos44's privileged card auth fix from PR #96088

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2792,8 +2792,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        # DM approval cards: skip group policy check — chat_id mismatch below provides sufficient security.
+        # _allow_group_message is designed for group chat policy (allowlist/blacklist) and rejects all DM clicks
+        # when group_policy="allowlist" (the default).
+        if not open_id:
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2852,8 +2854,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        # DM update prompt cards: skip group policy check — chat_id mismatch below provides sufficient security.
+        if not open_id:
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2768,15 +2768,47 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
-        """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
+    def _is_interactive_operator_authorized(
+        self, open_id: str, user_id: str = "", chat_id: str = "",
+    ) -> bool:
+        """Return whether this card-action operator may answer gated prompts.
+
+        Privileged card clicks (exec approvals, update prompts) answer a
+        different question than ``_allow_group_message``: not "may this person
+        talk to the bot here?" but "may this person authorize a dangerous
+        action?". Both must hold, so the gate is the intersection of:
+
+        1. **Operator identity** — membership of ``admins ∪ allowed_group_users``
+           (or the ``*`` wildcard). ``group_policy`` deliberately has no say
+           here: ``open`` means "anyone may chat", never "anyone may approve a
+           dangerous command".
+        2. **Chat lock** — when the card's chat has an explicit ``group_rules``
+           entry, that rule still applies (a ``disabled`` channel, an
+           ``admin_only`` channel, or a per-chat blacklist must not resolve
+           approvals). Chats without an explicit rule impose no extra lock, so
+           DM cards are never gated by the group default policy.
+
+        Both ``open_id`` and ``user_id`` are matched, because allowlists may be
+        configured with either identifier. With no operator configured at all
+        (no admins, no allowlist — the pairing-mode/single-user default) there
+        is no privilege boundary to escalate across, so only the chat lock
+        applies; that keeps unconfigured installs usable instead of
+        dead-locking every approval.
+        """
+        ids = {v for v in (str(open_id or "").strip(), str(user_id or "").strip()) if v}
+        if not ids:
             return False
-        allowed_ids = set(self._admins) | set(self._allowed_group_users)
-        if not allowed_ids:
+        operators = set(self._admins) | set(self._allowed_group_users)
+        if operators and "*" not in operators and not (ids & operators):
+            return False
+        chat = str(chat_id or "").strip()
+        if not chat or chat not in self._group_rules:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        sender_id = SimpleNamespace(
+            open_id=str(open_id or "").strip() or None,
+            user_id=str(user_id or "").strip() or None,
+        )
+        return self._allow_group_message(sender_id, chat, is_bot=False)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2792,10 +2824,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        # DM approval cards: skip group policy check — chat_id mismatch below provides sufficient security.
-        # _allow_group_message is designed for group chat policy (allowlist/blacklist) and rejects all DM clicks
-        # when group_policy="allowlist" (the default).
-        if not open_id:
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(
+            open_id, operator_user_id, str(state.get("chat_id", "") or ""),
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2821,6 +2853,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=operator_user_id,
                 chat_id=chat_id,
             ),
         ):
@@ -2854,8 +2887,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        # DM update prompt cards: skip group policy check — chat_id mismatch below provides sufficient security.
-        if not open_id:
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(
+            open_id, operator_user_id, str(state.get("chat_id", "") or ""),
+        ):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2878,6 +2913,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 answer,
                 user_name,
                 open_id=open_id,
+                user_id=operator_user_id,
                 chat_id=callback_chat_id,
             ),
         ):
@@ -2900,6 +2936,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2907,7 +2944,9 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        if not self._is_interactive_operator_authorized(
+            open_id, user_id, str(state.get("chat_id", "") or "")
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")
@@ -2954,6 +2993,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Persist an update prompt answer for the detached update process."""
@@ -2961,11 +3001,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
+        if not self._is_interactive_operator_authorized(
+            open_id, user_id, str(state.get("chat_id", "") or "")
+        ):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id or "<unknown>", prompt_id)
+            return
         expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -447,3 +447,236 @@ class TestResolveUpdatePrompt:
         assert 1 not in adapter._update_prompt_state
 
 
+# ===========================================================================
+# DM card-action security regression tests (PR #94485)
+#
+# PR #94485 replaced _allow_group_message with a bare "if not open_id" check
+# on DM approval/update-prompt cards, relying on the downstream chat_id
+# mismatch check to provide security.  These tests verify that the downstream
+# chat_id gate correctly accepts legitimate DM clicks and rejects
+# cross-chat / non-participant clicks.
+# ===========================================================================
+
+
+class TestDmApprovalCardSecurity:
+    """Verify DM approval card button security after _allow_group_message removal."""
+
+    def _make_dm_event(self, approval_id: int = 1, open_id: str = "ou_dm_user",
+                       chat_id: str = "oc_dm_chat", action: str = "approve_once"):
+        """Build a minimal card-action event with context.open_chat_id set to a DM ID."""
+        return _make_card_action_data(
+            {"hermes_action": action, "approval_id": approval_id},
+            chat_id=chat_id, open_id=open_id,
+        )
+
+    def test_dm_participant_can_approve(self, _patch_callback_card_types):
+        """Positive: the user who received the card in a DM clicks it — should succeed."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        approval_id = 10
+        adapter._approval_state[approval_id] = {
+            "session_key": "sess-dm-10",
+            "message_id": "msg_dm_10",
+            "chat_id": "oc_dm_chat",        # original DM chat
+        }
+        data = self._make_dm_event(
+            approval_id=approval_id,
+            open_id="ou_dm_user",
+            chat_id="oc_dm_chat",           # same DM chat
+        )
+        adapter._sender_name_cache["ou_dm_user"] = ("DM User", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert "Approved once" in response.card.data["header"]["title"]["content"]
+
+    def test_dm_user_clicking_from_different_chat_rejected(self, _patch_callback_card_types):
+        """Negative: same user, but callback originates from a different chat (e.g. card forwarded to group)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        approval_id = 11
+        adapter._approval_state[approval_id] = {
+            "session_key": "sess-dm-11",
+            "message_id": "msg_dm_11",
+            "chat_id": "oc_dm_chat",        # card sent in DM
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": approval_id},
+            chat_id="oc_forwarded_group",   # forwarded to group — DIFFERENT chat_id
+            open_id="ou_dm_user",           # same user
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None           # rejected — no inline card
+        mock_submit.assert_not_called()
+        assert approval_id in adapter._approval_state   # state preserved
+
+    def test_empty_open_id_rejected(self, _patch_callback_card_types):
+        """Negative: operator has no open_id — must be rejected at the open_id check."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[12] = {
+            "session_key": "sess-dm-12",
+            "message_id": "msg_dm_12",
+            "chat_id": "oc_dm_chat",
+        }
+        # Build event with empty/open_id=empty via raw namespace manipulation
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 12},
+            open_id="",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert 12 in adapter._approval_state
+
+    def test_different_user_same_dm_chat_rejected_by_chat_id(self, _patch_callback_card_types):
+        """Negative: a different user in the same DM group/chat should fail the chat_id check
+        if the card was NOT sent to that chat (i.e. the card was sent in a one-on-one DM and
+        someone else intercepts it in a group)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        approval_id = 13
+        adapter._approval_state[approval_id] = {
+            "session_key": "sess-dm-13",
+            "message_id": "msg_dm_13",
+            "chat_id": "oc_bobs_dm",           # card sent in Bob's one-on-one with bot
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": approval_id},
+            chat_id="oc_bobs_dm",               # same DM chat
+            open_id="ou_mallory",               # DIFFERENT user
+        )
+        # Allow mallory to have a valid open_id — the open_id check passes.
+        # But the chat_id check should NOT reject here because chat_ids match.
+        # This tests the edge case: same chat, different user.
+        # With the current code, this WILL succeed (chat_id matches). That's acceptable
+        # because in a 1:1 DM only that user can interact with the card.
+        # We verify the card is returned — this is intentional behavior.
+        adapter._sender_name_cache["ou_mallory"] = ("Mallory", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        # In a 1:1 DM, the chat_id uniquely identifies the conversation, so
+        # only the DM participant can reach this code path with a matching chat_id.
+        assert response is not None
+        assert response.card is not None
+
+    def test_card_forwarded_to_group_different_chat_rejected(self, _patch_callback_card_types):
+        """Negative: card originally sent to DM, user forwards it to a group and clicks —
+        callback_chat_id (group) != expected_chat_id (DM) → rejected."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        approval_id = 14
+        adapter._approval_state[approval_id] = {
+            "session_key": "sess-dm-14",
+            "message_id": "msg_dm_14",
+            "chat_id": "oc_12345",              # original DM chat
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": approval_id},
+            chat_id="oc_group5678",             # forwarded to group
+            open_id="ou_original_user",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert approval_id in adapter._approval_state
+
+
+class TestDmUpdatePromptCardSecurity:
+    """Verify DM update-prompt card button security after _allow_group_message removal."""
+
+    def test_dm_participant_can_confirm(self, _patch_callback_card_types):
+        """Positive: DM participant confirms update prompt."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        prompt_id = 20
+        adapter._update_prompt_state[prompt_id] = {
+            "session_key": "sess-up-dm-20",
+            "message_id": "msg_up_dm_20",
+            "chat_id": "oc_dm_chat",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": prompt_id},
+            chat_id="oc_dm_chat", open_id="ou_dm_user",
+        )
+        adapter._sender_name_cache["ou_dm_user"] = ("DM User", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+
+    def test_dm_user_clicking_from_different_chat_rejected(self, _patch_callback_card_types):
+        """Negative: same user, different callback chat (forwarded) — rejected by chat_id check."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        prompt_id = 21
+        adapter._update_prompt_state[prompt_id] = {
+            "session_key": "sess-up-dm-21",
+            "message_id": "msg_up_dm_21",
+            "chat_id": "oc_dm_chat",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": prompt_id},
+            chat_id="oc_forwarded_group",   # different chat
+            open_id="ou_dm_user",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert prompt_id in adapter._update_prompt_state
+
+    def test_empty_open_id_rejected_on_update_prompt(self, _patch_callback_card_types):
+        """Negative: operator has no open_id on update prompt card."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._update_prompt_state[22] = {
+            "session_key": "sess-up-dm-22",
+            "message_id": "msg_up_dm_22",
+            "chat_id": "oc_dm_chat",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 22},
+            open_id="",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert 22 in adapter._update_prompt_state
+
+


### PR DESCRIPTION
This PR cherry-picks @JoaoMarcos44's commit from PR #96088 (feishu privileged card authorization fix) and links it to my own DM approval card fix PR #95156.

## Credits
- Original fix by: [@JoaoMarcos44](https://github.com/JoaoMarcos44)
- Original PR: #96088
- Authorship preserved via cherry-pick with original author metadata

## Relationship
This PR's commit is linked to PR #95156 (my DM approval card fix). Together they address the same root cause:
- **#95156**: Fixes DM approval card unresponsive by adding `open_id` check
- **This PR**: Adds Joao's more comprehensive `_is_interactive_operator_authorized()` function that properly handles both DM and group card authorization

Both PRs fix `_allow_group_message()` misuse as a DM authorization gate.
