### PR TITLE
fix(desktop): take keyboard focus when the terminal pane is revealed

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { setTerminalTakeover } from '@/app/right-sidebar/store'
+import { focusRevealedTerminal } from '@/app/right-sidebar/terminal/reveal-focus'
 import { closeActiveTerminal, createTerminal, cycleTerminal } from '@/app/right-sidebar/terminal/terminals'
 import { appViewForPath, isOverlayView } from '@/app/routes'
 import {
@@ -253,7 +254,19 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.showFiles': showFiles,
     'view.showBrowser': openBrowserTab,
     'view.toggleHud': () => toggleHud(hudTargetSessionId()),
-    'view.showTerminal': () => togglePaneVisible('terminal'),
+    'view.showTerminal': () => {
+      // The unhide direction is also the terminal's only focus affordance,
+      // and nothing else on the reveal path focuses xterm (the keep-alive
+      // terminals never re-run their activation effect), so it must claim
+      // keyboard focus itself.
+      const revealed = !isPaneVisible('terminal')
+
+      togglePaneVisible('terminal')
+
+      if (revealed) {
+        focusRevealedTerminal()
+      }
+    },
     // Create first so the pane's open-effect ensure sees a non-empty set and
     // doesn't also spawn one — net effect is exactly one fresh terminal.
     'view.newTerminal': () => {

--- a/apps/desktop/src/app/right-sidebar/terminal/reveal-focus.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/reveal-focus.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { focusRevealedTerminal } from './reveal-focus'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+function installRaf() {
+  const frames: FrameRequestCallback[] = []
+  let nextId = 1
+
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.push(callback)
+
+    return nextId++
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+
+  // Run every frame scheduled so far, once — new rAF calls made while flushing
+  // land in the NEXT drain, exactly like real frames.
+  return () => frames.splice(0).forEach(callback => callback(0))
+}
+
+function mountTerminal(visible: boolean): HTMLTextAreaElement {
+  const host = document.createElement('div')
+
+  host.dataset.terminal = ''
+
+  if (!visible) {
+    host.className = 'invisible pointer-events-none'
+  }
+
+  const textarea = document.createElement('textarea')
+
+  textarea.className = 'xterm-helper-textarea'
+  host.appendChild(textarea)
+  document.body.appendChild(host)
+
+  return textarea
+}
+
+describe('focusRevealedTerminal', () => {
+  it('focuses the visible terminal once the reveal settles', () => {
+    const frame = installRaf()
+    const hidden = mountTerminal(false)
+    const visible = mountTerminal(true)
+
+    focusRevealedTerminal()
+    frame()
+
+    expect(document.activeElement).toBe(visible)
+    expect(document.activeElement).not.toBe(hidden)
+  })
+
+  it('re-asserts focus when another surface steals it back', () => {
+    const frame = installRaf()
+    const visible = mountTerminal(true)
+
+    focusRevealedTerminal()
+    frame()
+    expect(document.activeElement).toBe(visible)
+
+    // The composer (or any autofocus effect) wins focus after the reveal.
+    visible.blur()
+    expect(document.activeElement).not.toBe(visible)
+
+    frame()
+    expect(document.activeElement).toBe(visible)
+  })
+
+  it('stops once focus sits inside the terminal', () => {
+    const frame = installRaf()
+    const visible = mountTerminal(true)
+    const focusSpy = vi.spyOn(visible, 'focus')
+
+    focusRevealedTerminal()
+    frame()
+    frame()
+    frame()
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('gives up quietly when no terminal is on screen', () => {
+    const frame = installRaf()
+
+    focusRevealedTerminal()
+    frame()
+    frame()
+    frame()
+
+    expect(document.activeElement).toBe(document.body)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/reveal-focus.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/reveal-focus.ts
@@ -1,0 +1,44 @@
+import { isFocusWithin } from '@/lib/keybinds/combo'
+
+const TERMINAL_FOCUS_SCOPE = '[data-terminal]'
+
+// The on-screen instance's container carries `visible`; keep-alive tabs sit on
+// `invisible`, so this never targets an off-screen terminal. xterm's hidden
+// textarea is its real keyboard input — the same query the clipboard helper
+// uses to reach it.
+const FOCUS_TARGET = `${TERMINAL_FOCUS_SCOPE}:not(.invisible) .xterm-helper-textarea`
+
+/** Frames to keep trying after a reveal. The pane layout settles over a couple
+ *  of frames (slot rect chase, theme repaint), so a focus() issued sooner can
+ *  land before the host is focusable; three frames covers that without turning
+ *  into a focus fight with surfaces the user deliberately focuses later. */
+const REVEAL_FOCUS_ATTEMPTS = 3
+
+/**
+ * Take keyboard focus for the active terminal once its pane has been revealed.
+ *
+ * Revealing the pane (Ctrl+`) restores the layout, but nothing on that path
+ * focuses xterm: the terminals stay mounted while hidden (VS Code-style
+ * keep-alive), so the `[active, status]` focus effect never re-runs and focus
+ * stays wherever the user came from — usually the composer. Ctrl+` is also the
+ * terminal's only focus affordance, so the reveal has to claim focus itself:
+ * try over the next few animation frames and stop as soon as focus sits inside
+ * the terminal scope.
+ */
+export function focusRevealedTerminal(): void {
+  scheduleFocusAttempt(REVEAL_FOCUS_ATTEMPTS)
+}
+
+function scheduleFocusAttempt(attempts: number): void {
+  window.requestAnimationFrame(() => {
+    if (isFocusWithin(TERMINAL_FOCUS_SCOPE)) {
+      return
+    }
+
+    document.querySelector<HTMLTextAreaElement>(FOCUS_TARGET)?.focus()
+
+    if (attempts > 1) {
+      scheduleFocusAttempt(attempts - 1)
+    }
+  })
+}


### PR DESCRIPTION
## What does this PR do?

Pressing Ctrl+` reveals the terminal pane but leaves keyboard focus wherever it was — usually the chat composer — so keystrokes keep landing in the composer instead of the shell. The user has to click inside the pane to start typing.

Root cause: nothing on the reveal path focuses xterm. `view.showTerminal` toggles the pane layout only, and the terminal instances stay mounted while hidden (VS Code-style keep-alive), so the `[active, status]` effect in `use-terminal-session.ts` that focuses the active terminal never re-runs on reveal. Since Ctrl+` is both the show/hide toggle and the terminal's only focus affordance, the reveal itself now claims focus: `focusRevealedTerminal()` focuses the on-screen terminal's xterm textarea over the next few animation frames (the pane layout settles over a couple of frames), stops as soon as focus sits inside `[data-terminal]`, and re-asserts once if an autofocus surface steals focus back. The hide direction is untouched, and a reveal that finds focus already inside the terminal is a no-op.

## Related Issue

Fixes #98955

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/terminal/reveal-focus.ts` (new): `focusRevealedTerminal()` — a bounded (3-frame) animation-frame loop that focuses the visible terminal's `.xterm-helper-textarea` (the same element the clipboard helper targets) when focus is not already inside `[data-terminal]`, using the existing `isFocusWithin` primitive.
- `apps/desktop/src/app/hooks/use-keybinds.ts`: the `view.showTerminal` handler now calls `focusRevealedTerminal()` only on the reveal direction (`!isPaneVisible(terminal)` before toggling); the hide direction and all other keybinds are unchanged.

## How to Test

1. Focus the chat composer, press Ctrl+` — the terminal pane is revealed and typing goes straight to the shell (no click needed).
2. Press Ctrl+` to hide, then Ctrl+` again — focus lands in the terminal again each cycle; hiding is unaffected.
3. Unit tests: `cd apps/desktop && npx vitest run --project ui src/app/right-sidebar/terminal/reveal-focus.test.ts` — Observed result: 4 passed (visible-instance targeting, re-assert after focus theft, stop-when-focused, quiet no-op with no terminal mounted).
4. Full desktop suite: `npm run test:ui` — Observed result: 684 files / 6756 tests passed; `eslint`, `tsc` typecheck, and `prettier --check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (TS-only change — verified via the desktop suites above instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (the activation path is platform-independent renderer code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A