### PR TITLE
fix(slack): treat native streams as the final message

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1120,6 +1120,11 @@ class SlackAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
+    # Native chat.startStream/appendStream/stopStream IS the final message.
+    # Telegram-shaped drafts clear and a later send() posts history; Slack
+    # must not do that or users see the streamed reply plus a duplicate
+    # chat.postMessage. Keep one stream per turn across tool boundaries.
+    draft_stream_is_message = True
     # Slack's typing indicator is a text status line (assistant.threads
     # .setStatus), so the gateway feeds it live per-tool phrases.
     supports_status_text = True

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -18,11 +18,13 @@ Behaviour contract:
   * disconnect(): dangling streams sealed.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 from plugins.platforms.slack.adapter import SlackAdapter
 
 
@@ -228,3 +230,52 @@ class TestDisconnectCleanup:
         await adapter.disconnect()
         client.chat_stopStream.assert_awaited()
         assert not adapter._active_streams
+
+
+class TestStreamIsTheMessage:
+    """Slack's native stream IS the final message (unlike Telegram drafts).
+
+    Without this flag the stream consumer treats Slack like Telegram: it
+    bumps draft_id at every tool boundary (sealing one stream and opening
+    another) and later posts a real chat.postMessage. Users see the
+    streamed reply, then a second copy with mrkdwn auto-links.
+    """
+
+    def test_adapter_declares_draft_stream_is_message(self):
+        adapter, _ = _make_adapter()
+        assert SlackAdapter.draft_stream_is_message is True
+        assert adapter.draft_stream_is_message is True
+        consumer = GatewayStreamConsumer(
+            adapter, "D1", StreamConsumerConfig(chat_type="channel"),
+        )
+        assert consumer._stream_is_message() is True
+
+    @pytest.mark.asyncio
+    async def test_tool_boundary_does_not_post_duplicate_final(self):
+        adapter, client = _make_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto",
+            chat_type="channel",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+        )
+        consumer = GatewayStreamConsumer(
+            adapter, "C1", cfg, metadata=META,
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("This looks like a briefing.")
+        await asyncio.sleep(0.05)
+        consumer.on_segment_break()
+        await asyncio.sleep(0.05)
+        consumer.on_delta(" Adam — use something.cdr.xyz")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=5.0)
+
+        assert client.chat_startStream.await_count == 1
+        client.chat_stopStream.assert_awaited()
+        client.chat_postMessage.assert_not_awaited()
+        # Stream is sealed, so _active_streams is empty — one start, one stop.
+        assert "C1" not in adapter._active_streams


### PR DESCRIPTION
## Problem

Slack users see the same Hermes reply twice: a streamed copy (raw markdown, `streaming_state: completed`), then a second `chat.postMessage` ~1–2s later with `format_message` applied (URLs auto-linked). The gateway then logs `Suppressing normal final send … content_delivered=True`, so this is **not** issue #25256 (that guard is working).

Reproduced 2026-08-30 in a Slack thread that called a tool mid-turn (skill load). Two bot messages, 1.64s apart, same body.

## Cause

`GatewayStreamConsumer` only treats a native stream as *the* message when the adapter sets `draft_stream_is_message`. The **relay** Slack path already does (`platform == "slack"`). Native `SlackAdapter` did not.

Without the flag the consumer uses Telegram draft semantics:

- bump `draft_id` at every tool boundary → `send_draft` seals stream A and `startStream`s stream B
- turn-final `send()` is a real history message

On Slack, `chat.startStream` **is** the final message. After a tool boundary the intercept in `_try_finalize_stream` often misses, so users get stream B **plus** a formatted `postMessage`.

Closed PR #96655 tried this flag and was withdrawn as opened by accident pending confirmation. The duplicate is confirmed.

Related but different: #94444 (finalize/`send_draft` race), #98231 (stuck-cursor tail).

## Approach

Set `SlackAdapter.draft_stream_is_message = True` so the consumer keeps **one** stream per turn across tool boundaries. Existing `send()` → `_try_finalize_stream` → `chat.stopStream` (no `postMessage`) remains the seal path.

No change to Telegram drafts.

## Tests

- `test_adapter_declares_draft_stream_is_message`
- `test_tool_boundary_does_not_post_duplicate_final` — preamble, `on_segment_break`, final text → exactly one `startStream`, a `stopStream`, zero `postMessage`

Sabotage: commenting out the flag makes both tests fail (`startStream` count 2). Restored, 24/24 in `test_slack_native_streaming.py` and 12/12 in `test_stream_consumer_draft.py`.

## Risk

Low. One class attribute. If a Slack workspace lacks Agents & AI Apps, native streaming already falls back to edit-based streaming (`_native_stream_unsupported`).

## Exclusions

Does not change keep-alive, task cards, or `rich_messages`. Does not restart a running gateway; operators need a gateway restart to pick this up.
