### PR TITLE
fix(bluebubbles): drop self-echo of a failed send by text, not just GUID/isFromMe

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
 from datetime import datetime
@@ -166,6 +167,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    # Window in which an inbound webhook record matching text we just sent to
+    # the same chat is treated as a self-echo rather than a new user message.
+    _SELF_ECHO_WINDOW_SECONDS = 10.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
@@ -203,10 +207,38 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # (chat_guid, text) -> monotonic send time. Populated on every outbound
+        # attempt (success or failure) so a server-written echo of a failed send
+        # can still be recognized even though no GUID was ever returned for it.
+        self._recent_sent_texts: "OrderedDict[tuple, float]" = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
     # ------------------------------------------------------------------
+
+    def _remember_sent_text(self, chat_guid: Optional[str], text: str) -> None:
+        if not chat_guid or not text:
+            return
+        self._recent_sent_texts[(chat_guid, text)] = time.monotonic()
+        while len(self._recent_sent_texts) > 200:
+            self._recent_sent_texts.popitem(last=False)
+
+    def _pop_recent_self_echo(self, chat_guid: Optional[str], text: str) -> bool:
+        """Drop a recently-sent text echoed back through the webhook.
+
+        Catches the case a robust ``isFromMe``/GUID check cannot: BlueBubbles
+        writes an outbound row to chat.db (and fires a webhook for it) even
+        when the send API call itself failed, so no GUID was ever captured for
+        it and the row's isFromMe/handle fields can't be trusted.
+        """
+        if not chat_guid or not text:
+            return False
+        key = (chat_guid, text)
+        sent_at = self._recent_sent_texts.get(key)
+        if sent_at is None:
+            return False
+        del self._recent_sent_texts[key]
+        return (time.monotonic() - sent_at) <= self._SELF_ECHO_WINDOW_SECONDS
 
     def _api_url(self, path: str) -> str:
         sep = "&" if "?" in path else "?"
@@ -576,6 +608,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 payload["method"] = "private-api"
                 payload["selectedMessageGuid"] = reply_to
                 payload["partIndex"] = 0
+            # Recorded before the call completes: BlueBubbles can write the
+            # outbound row to chat.db (and fire a webhook for it) even when
+            # this request itself errors out, so the echo must still be
+            # recognizable.
+            self._remember_sent_text(guid, chunk)
             try:
                 res = await self._api_post("/api/v1/message/text", payload)
                 data = res.get("data") or {}
@@ -1033,6 +1070,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.json_response({"error": "missing message fields"}, status=400)
 
         session_chat_id = chat_guid or chat_identifier
+        # A send that fails at the BlueBubbles API layer can still be written
+        # to chat.db by Messages.app, producing a webhook record whose
+        # isFromMe/handle fields are unreliable (see is_from_me check above).
+        # Recognize it here by matching text we sent to this chat moments ago.
+        if self._pop_recent_self_echo(session_chat_id, text):
+            return web.Response(text="ok")
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -116,6 +116,83 @@ class TestBlueBubblesMentionGating:
         assert handled == []
 
 
+class TestBlueBubblesFailedSendEchoGuard:
+    """A send that errors at the BlueBubbles API layer can still be written to
+    chat.db by Messages.app (e.g. the account's iMessage send failed but the
+    local send attempt was recorded), producing a webhook echo whose
+    isFromMe/handle fields can't be trusted. No GUID is ever returned for a
+    failed call, so GUID-based dedupe can't catch it; the adapter must
+    recognize the echo by the text it just attempted to send.
+    """
+
+    @pytest.mark.asyncio
+    async def test_echo_of_a_failed_send_is_dropped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;+15555550100"
+
+        async def failing_api_post(path, payload):
+            raise httpx.HTTPStatusError(
+                "500 Message Send Error", request=None, response=None
+            )
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", failing_api_post)
+
+        result = await adapter.send("+15555550100", "Looks like a pocket-text.")
+        assert result.success is False
+
+        # BlueBubbles still writes the row and fires a webhook for it, with a
+        # spoofed handle and isFromMe unset — the exact shape from the report.
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "server-written-guid",
+                "text": "Looks like a pocket-text.",
+                "handle": {"address": "+15555550100"},
+                "chatGuid": "iMessage;-;+15555550100",
+                "error": 22,
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_unrelated_inbound_text_still_dispatches(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "inbound-1",
+                "text": "hey are you there?",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;+15555550100",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        assert handled[0].text == "hey are you there?"
+
+
 class TestBlueBubblesWebhookParsing:
 
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):


### PR DESCRIPTION
## What & why

Fixes #98909.

The BlueBubbles adapter's self-message filter (`_handle_webhook`) only
guards against `isFromMe`/`fromMe`/`is_from_me` being truthy on the webhook
record. That misses a specific failure mode: when the send API call itself
errors (e.g. a 500 from BlueBubbles because the account's iMessage send
failed at the Apple layer), Messages.app can still write the outbound row to
`chat.db` and BlueBubbles still fires a `new-message`/`updated-message`
webhook for it. In that failure mode:

- the row's `isFromMe` flag is unreliable/absent, so the existing check
  doesn't trip, and
- no message GUID was ever returned to the adapter (the API call errored
  before a response body existed), so GUID-based dedupe can't help either, and
- the row's `handle` is the chat participant, spoofing the sender as the
  allowlisted contact.

The agent then re-ingests its own reply as a new inbound user message and
replies again, looping indefinitely (the reporter saw dozens of self-replies,
including internal status lines, until the gateway was hard-stopped).

## The fix

`send()` now remembers the `(chat_guid, text)` it is about to attempt,
*before* the API call resolves — so the record survives even if the call
raises. `_handle_webhook` checks incoming text against this short window
(10s) and drops any match, regardless of what `isFromMe`/`handle`/GUID the
record claims. This is additive to (and independent of) the existing
`isFromMe` check and doesn't touch normal inbound message handling.

Two other open PRs (#46974, #59398) address the more common BlueBubbles
self-chat echo case (successful sends echoed back with `isFromMe` unset),
but both rely on `isFromMe`/GUID matching captured from a *successful*
send response, so neither catches this failed-send path — there is no GUID
to match in that response.

## How to test

```
python3 -m pytest tests/gateway/test_bluebubbles.py -q
```

Result: `25 passed`.

Added `TestBlueBubblesFailedSendEchoGuard` with two cases:
- `test_echo_of_a_failed_send_is_dropped`: drives a real `send()` call whose
  `_api_post` raises (simulating the BlueBubbles 500), then feeds back a
  webhook record shaped like the report (`updated-message`, no `isFromMe`,
  handle spoofed to the chat participant, matching text) — asserts the
  agent does not re-dispatch it.
- `test_unrelated_inbound_text_still_dispatches`: an ordinary inbound message
  with no prior matching send is still dispatched normally.

Confirmed the new test fails without the fix:

```
git checkout HEAD~1 -- gateway/platforms/bluebubbles.py
python3 -m pytest tests/gateway/test_bluebubbles.py::TestBlueBubblesFailedSendEchoGuard -q
# 1 failed, 1 passed — test_echo_of_a_failed_send_is_dropped fails:
# the agent's own reply is re-dispatched as a new MessageEvent.
git checkout HEAD -- gateway/platforms/bluebubbles.py
```

Also ran the full `tests/gateway/` suite (6622 passed, 44 skipped, 2 xfailed,
9 failed) — the 9 failures are pre-existing and unrelated to this change
(Discord/Teams/WeCom optional-dependency gaps, an unrelated session-store
path assertion, and a Telegram polling log assertion), none touch
`bluebubbles.py`.

## Platforms

Logic-only change in the BlueBubbles adapter; no OS-specific code.
