### PR TITLE
perf(desktop): cache and defer mermaid renders to prevent transcript stalls

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -1,30 +1,14 @@
 'use client'
 
-import mermaid from 'mermaid'
 import { useEffect, useState } from 'react'
 
 import { Zoomable } from '@/components/ui/zoomable'
 import { copySvgAsPng, normalizeSvgSize } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
 
+import { nextPaint, renderMermaidSvg } from './mermaid-render-cache'
 import type { RichFenceProps } from './types'
 import { useIsDark } from './use-is-dark'
-
-let lastTheme: 'dark' | 'default' | null = null
-
-// Re-initialise only on first use / theme flip. `securityLevel: 'strict'` makes
-// mermaid sanitise label HTML and drop click handlers, so the rendered SVG is
-// safe to inject.
-function ensureInit(dark: boolean) {
-  const theme = dark ? 'dark' : 'default'
-
-  if (theme === lastTheme) {
-    return
-  }
-
-  mermaid.initialize({ fontFamily: 'inherit', securityLevel: 'strict', startOnLoad: false, theme })
-  lastTheme = theme
-}
 
 function SourcePreview({ code, muted }: { code: string; muted?: boolean }) {
   return (
@@ -39,9 +23,11 @@ function SourcePreview({ code, muted }: { code: string; muted?: boolean }) {
   )
 }
 
-// Lazy chunk (pulls in mermaid). Renders ```mermaid fences as diagrams; shows
-// the source while the message streams (partial syntax throws) and falls back
-// to source on parse failure.
+// Lazy chunk (the heavy mermaid runtime is imported inside the render cache's
+// deferred callback). Renders ```mermaid fences as diagrams; shows the source
+// while the message streams (partial syntax throws) and falls back to source on
+// parse failure. Completed diagrams are cached per (source, theme) so remounts
+// reuse the SVG instead of re-running parse/layout.
 export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
   const isDark = useIsDark()
   const [svg, setSvg] = useState('')
@@ -58,12 +44,17 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
 
     void (async () => {
       try {
-        ensureInit(isDark)
-        const id = `mmd-${Math.random().toString(36).slice(2)}`
-        const result = await mermaid.render(id, code)
+        // Let the source fallback paint first; the mermaid runtime import and
+        // parse/layout happen only after that frame.
+        await nextPaint()
+
+        const { svg: rendered } = await renderMermaidSvg(
+          code,
+          isDark ? 'dark' : 'default'
+        )
 
         if (!cancelled) {
-          setSvg(normalizeSvgSize(result.svg))
+          setSvg(normalizeSvgSize(rendered))
         }
       } catch {
         if (!cancelled) {

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.test.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The cache module must never pull the real mermaid runtime into the test
+// bundle: tests drive the deferred-import seam with a stubbed renderer.
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn()
+  }
+}))
+
+import { default as mermaidStub } from 'mermaid'
+
+import {
+  cachedMermaidSvgCount,
+  nextPaint,
+  renderMermaidSvg,
+  resetMermaidRenderCacheForTests
+} from './mermaid-render-cache'
+
+const render = vi.mocked(mermaidStub.render)
+const initialize = vi.mocked(mermaidStub.initialize)
+
+beforeEach(() => {
+  resetMermaidRenderCacheForTests()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const okSvg = (tag: string) => `<svg data-tag="${tag}"></svg>`
+
+describe('renderMermaidSvg', () => {
+  it('renders uncached source and caches the completed SVG', async () => {
+    render.mockResolvedValueOnce({ svg: okSvg('one') } as never)
+
+    const first = await renderMermaidSvg('graph TD;A-->B', 'default')
+
+    expect(first.svg).toBe(okSvg('one'))
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(cachedMermaidSvgCount()).toBe(1)
+  })
+
+  it('reuses the cached SVG on remount instead of re-rendering', async () => {
+    render.mockResolvedValueOnce({ svg: okSvg('one') } as never)
+    await renderMermaidSvg('graph TD;A-->B', 'default')
+    render.mockClear()
+
+    const second = await renderMermaidSvg('graph TD;A-->B', 'default')
+
+    expect(second.svg).toBe(okSvg('one'))
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('shares one in-flight render between identical concurrent requests', async () => {
+    let release: (svg: string) => void = () => {}
+
+    const gate = new Promise<string>((resolve) => {
+      release = resolve
+    })
+
+    render.mockImplementationOnce(async () => ({ svg: await gate } as never))
+
+    const first = renderMermaidSvg('graph TD;A-->B', 'dark')
+    const second = renderMermaidSvg('graph TD;A-->B', 'dark')
+    release(okSvg('shared'))
+
+    await expect(first).resolves.toEqual({ svg: okSvg('shared') })
+    await expect(second).resolves.toEqual({ svg: okSvg('shared') })
+    expect(render).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches light and dark themes separately', async () => {
+    render.mockResolvedValueOnce({ svg: okSvg('light') } as never)
+    render.mockResolvedValueOnce({ svg: okSvg('dark') } as never)
+
+    await renderMermaidSvg('graph TD;A-->B', 'default')
+    await renderMermaidSvg('graph TD;A-->B', 'dark')
+
+    expect(render).toHaveBeenCalledTimes(2)
+
+    await expect(renderMermaidSvg('graph TD;A-->B', 'default')).resolves.toEqual({
+      svg: okSvg('light')
+    })
+    await expect(renderMermaidSvg('graph TD;A-->B', 'dark')).resolves.toEqual({
+      svg: okSvg('dark')
+    })
+  })
+
+  it('does not poison the cache when a render fails', async () => {
+    render.mockRejectedValueOnce(new Error('parse error') as never)
+
+    await expect(renderMermaidSvg('not a diagram', 'default')).rejects.toThrow(
+      'parse error'
+    )
+    expect(cachedMermaidSvgCount()).toBe(0)
+
+    render.mockResolvedValueOnce({ svg: okSvg('retry') } as never)
+    await expect(renderMermaidSvg('not a diagram', 'default')).resolves.toEqual({
+      svg: okSvg('retry')
+    })
+  })
+
+  it('serializes uncached renders instead of starting them together', async () => {
+    const order: string[] = []
+
+    const slow = (tag: string, ms: number) => {
+      let release!: (svg: string) => void
+
+      const gate = new Promise<string>((resolve) => {
+        release = resolve
+      })
+
+      render.mockImplementationOnce(async () => {
+        order.push(`start:${tag}`)
+        const svg = await gate
+        order.push(`end:${tag}`)
+
+        return { svg } as never
+      })
+      // Resolve on the next microtask unless explicitly released.
+      queueMicrotask(() => release(okSvg(tag)))
+      void ms
+
+      return gate
+    }
+
+    slow('a', 0)
+    slow('b', 0)
+
+    const first = renderMermaidSvg('graph TD;A-->A', 'default')
+    const second = renderMermaidSvg('graph TD;B-->B', 'default')
+    await Promise.all([first, second])
+
+    expect(order).toEqual([
+      'start:a',
+      'end:a',
+      'start:b',
+      'end:b'
+    ])
+  })
+
+  it('evicts the oldest entry once the cache passes its bound', async () => {
+    for (let i = 0; i < 66; i++) {
+      render.mockResolvedValueOnce({ svg: okSvg(`svg-${i}`) } as never)
+      await renderMermaidSvg(`graph TD;N${i}-->N${i}`, 'default')
+    }
+
+    expect(cachedMermaidSvgCount()).toBeLessThanOrEqual(64)
+
+    render.mockClear()
+    render.mockResolvedValue({ svg: okSvg('re-rendered') } as never)
+    const oldest = await renderMermaidSvg('graph TD;N0-->N0', 'default')
+    const newest = await renderMermaidSvg('graph TD;N65-->N65', 'default')
+    expect(oldest.svg).not.toBe(okSvg('svg-0'))
+    expect(newest.svg).toBe(okSvg('svg-65'))
+    // Only the evicted oldest entry re-rendered; the newest survived.
+    expect(render).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('nextPaint', () => {
+  it('resolves without requestAnimationFrame (node fallback)', async () => {
+    const raf = globalThis.requestAnimationFrame
+    // @ts-expect-error exercise the timer fallback branch
+    delete globalThis.requestAnimationFrame
+
+    try {
+      await expect(nextPaint()).resolves.toBeUndefined()
+    } finally {
+      if (raf) {
+        globalThis.requestAnimationFrame = raf
+      }
+    }
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.ts
@@ -1,0 +1,135 @@
+// Render cache for mermaid diagrams. Transcript remounts (history reloads,
+// file previews, tab switches) used to re-run mermaid.parse+layout for every
+// fence; with several diagrams that froze the renderer for noticeable stretches.
+// Completed SVGs are kept per (source, theme) and reused across mounts, in-flight
+// renders for identical pairs are shared, misses are serialized so diagrams do
+// not monopolise one event-loop turn, and the heavy mermaid runtime is imported
+// inside the render callback — after the source fallback has painted.
+
+type Theme = 'dark' | 'default'
+
+interface CacheEntry {
+  svg: string
+}
+
+const MAX_CACHED_SVGS = 64
+
+const completed = new Map<string, CacheEntry>()
+const inFlight = new Map<string, Promise<string>>()
+
+// Serialized misses: one diagram renders at a time, next starts only after the
+// previous settled. This keeps a transcript full of diagrams from turning into
+// one long uninterruptible block of layout work.
+let queueTail: Promise<void> = Promise.resolve()
+
+export function resetMermaidRenderCacheForTests(): void {
+  completed.clear()
+  inFlight.clear()
+  queueTail = Promise.resolve()
+}
+
+export function cachedMermaidSvgCount(): number {
+  return completed.size
+}
+
+function cacheKey(source: string, theme: Theme): string {
+  // JSON-encoded pair cannot collide across different (source, theme) combos.
+  return JSON.stringify([theme, source])
+}
+
+function evictIfNeeded(): void {
+  while (completed.size > MAX_CACHED_SVGS) {
+    // Map preserves insertion order; the oldest entry is the least recently
+    // inserted render. Re-insertion on cache hit would be needed for true LRU;
+    // transcript diagrams are re-read far more often than they are added, so
+    // FIFO keeps the common case (scroll back through history) fully cached.
+    const oldest = completed.keys().next().value
+
+    if (oldest === undefined) {
+      return
+    }
+
+    completed.delete(oldest)
+  }
+}
+
+async function runSerialized<T>(task: () => Promise<T>): Promise<T> {
+  const run = queueTail.then(task, task)
+  queueTail = run.then(
+    () => undefined,
+    () => undefined
+  )
+
+  return run
+}
+
+export interface MermaidRenderResult {
+  svg: string
+}
+
+async function renderUncached(source: string, theme: Theme): Promise<string> {
+  // The import stays inside the render path on purpose: the lazy embed chunk
+  // stays lightweight and the mermaid runtime is only evaluated once a diagram
+  // actually needs rendering, after the source fallback has painted.
+  const { default: mermaid } = await import('mermaid')
+  mermaid.initialize({
+    fontFamily: 'inherit',
+    securityLevel: 'strict',
+    startOnLoad: false,
+    theme
+  })
+  const id = `mmd-${Math.random().toString(36).slice(2)}`
+  const result = await mermaid.render(id, source)
+
+  return result.svg
+}
+
+export function renderMermaidSvg(
+  source: string,
+  theme: Theme
+): Promise<MermaidRenderResult> {
+  const key = cacheKey(source, theme)
+
+  const hit = completed.get(key)
+
+  if (hit) {
+    return Promise.resolve(hit)
+  }
+
+  const existing = inFlight.get(key)
+
+  if (existing) {
+    return existing.then((svg) => ({ svg }))
+  }
+
+  const render = runSerialized(() => renderUncached(source, theme))
+    .then((svg) => {
+      completed.set(key, { svg })
+      evictIfNeeded()
+      inFlight.delete(key)
+
+      return svg
+    })
+    .catch((error: unknown) => {
+      // Failed entries never enter the cache, so a transient parse error (or a
+      // partially streamed diagram re-rendered after an edit) can retry.
+      inFlight.delete(key)
+      throw error
+    })
+
+  inFlight.set(key, render)
+
+  return render.then((svg) => ({ svg }))
+}
+
+// The embed defers the first uncached render by one frame so the source
+// fallback paints before the CPU-heavy mermaid chunk is imported and parsed.
+export function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve())
+    } else {
+      setTimeout(resolve, 0)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
Closes #98951.

`mermaid.render()` ran directly in a mount effect with no cache and no deduplication, so every transcript remount re-ran parse/layout for each diagram, and several fences started CPU-heavy renders in the same task — the source preview painted, then the renderer stalled until every SVG landed.

## Change
- New `mermaid-render-cache.ts`: completed SVGs cached per `(source, resolved theme)` and reused across remounts; identical concurrent requests share one in-flight promise; cache misses are **serialized** (one diagram at a time) and **deferred** until after the next paint so the source fallback paints first and multiple diagrams cannot monopolise one event-loop turn.
- The heavy mermaid runtime import moved from the embed module into the deferred render callback, keeping the lazy embed chunk lightweight.
- Bounded cache (64 entries, FIFO eviction — insertion order); failed renders never enter the cache, so transient parse errors can retry.
- Preserved: strict security level, streaming source fallback, parse-failure fallback, zoom/copy behavior, theme-specific output (`initialize` called with the resolved theme per render).

## Acceptance criteria mapping
- [x] source fallback paints before the heavy runtime import — `nextPaint()` defers the first uncached render by one frame
- [x] repeated mounts reuse one render — per-`(source, theme)` completed cache
- [x] concurrent identical requests share one in-flight render — `inFlight` map
- [x] light/dark cached separately — theme is part of the cache key
- [x] failed renders do not poison the cache — failures bypass `completed`, entry removed from `inFlight`
- [x] explicit cache upper bound — 64 entries with FIFO eviction
- [x] uncached renders deferred and serialized — `runSerialized` queue + `nextPaint`
- [x] unit tests cover cache/dedup — 8 tests: cache reuse, in-flight sharing, theme separation, failure retry, serialization order, eviction bound, rAF fallback
- [x] typecheck, lint, UI tests pass locally

## Test plan
- `npx vitest run src/components/assistant-ui/embeds/mermaid-render-cache.test.ts --project ui` — 8/8 pass
- `npx vitest run --project ui` — 6756 passed; 4 failures are pre-existing on clean `main` (verified via `git stash`: 2 billing settings + `fallback-model` clamp + `renderRpcResult` usage formatting)
- `tsc -p . --noEmit` clean, `eslint` clean after `--fix`