### PR TITLE
fix(delegation): stop async results from losing model provenance

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3540,6 +3540,24 @@ def run_conversation(
 
                 agent._turn_received_provider_response = True
 
+                # Keep provider-reported identity separate from the configured
+                # route. A response model alone is not provider evidence.
+                _delegation_evidence = getattr(
+                    agent, "_delegation_model_evidence", None
+                )
+                if isinstance(_delegation_evidence, dict):
+                    try:
+                        from tools.delegation_model_evidence import (
+                            record_actual_response,
+                        )
+
+                        record_actual_response(_delegation_evidence, response)
+                    except Exception:
+                        logging.debug(
+                            "Failed to record delegated runtime model evidence",
+                            exc_info=True,
+                        )
+
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
                     status = getattr(response, "status", None)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -202,6 +202,95 @@ def test_rich_reinjection_block_is_self_contained():
         assert needle in text, f"missing {needle!r}"
 
 
+def test_completion_without_runtime_reporting_is_explicit_not_question_mark():
+    evt = _make_async_evt(model=None)
+
+    text = format_process_notification(evt)
+
+    assert text is not None
+    assert "Model: ?" not in text
+    assert "Actual: not-reported/not-reported" in text
+
+
+def test_dispatch_persists_sanitized_model_evidence():
+    evidence = [{
+        "selection_source": "task",
+        "requested": {"provider": "openrouter", "model": "requested/model"},
+        "resolved": {"provider": "openrouter", "model": "resolved/model"},
+        "actual": {"provider": "not-reported", "model": "not-reported"},
+    }]
+    res = ad.dispatch_async_delegation_batch(
+        goals=["persist evidence"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="resolved/model",
+        model_evidence=evidence,
+        session_key="owner-session",
+        runner=lambda: {
+            "results": [{
+                "task_index": 0,
+                "status": "completed",
+                "summary": "done",
+                "model_evidence": evidence[0],
+            }],
+        },
+    )
+    evt = _drain_for(res["delegation_id"])
+    assert evt is not None
+    assert evt["model_evidence"] == evidence
+
+    with ad._connect() as conn:
+        task_json, event_json = conn.execute(
+            "SELECT task_json, event_json FROM async_delegations WHERE delegation_id=?",
+            (res["delegation_id"],),
+        ).fetchone()
+    assert json.loads(task_json)["model_evidence"] == evidence
+    assert json.loads(event_json)["model_evidence"] == evidence
+
+
+def test_credential_shaped_model_never_reaches_durable_or_delivered_payloads():
+    secret = "sk-abcdefghijklmnopqrstuvwxyz"
+    raw_evidence = [{
+        "selection_source": "task",
+        "requested": {"provider": secret, "model": secret},
+        "resolved": {"provider": secret, "model": secret},
+        "actual": {"provider": secret, "model": secret},
+    }]
+    res = ad.dispatch_async_delegation_batch(
+        goals=["withhold configured secret"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=secret,
+        model_evidence=raw_evidence,
+        session_key="owner-session",
+        runner=lambda: {
+            "results": [{
+                "task_index": 0,
+                "status": "error",
+                "summary": None,
+                "model": secret,
+                "model_evidence": raw_evidence[0],
+                "error": (secret + " rejected ") * 200,
+            }],
+        },
+    )
+    evt = _drain_for(res["delegation_id"])
+    assert evt is not None
+    rendered = format_process_notification(evt)
+
+    with ad._connect() as conn:
+        task_json, event_json, result_json = conn.execute(
+            "SELECT task_json, event_json, result_json FROM async_delegations "
+            "WHERE delegation_id=?",
+            (res["delegation_id"],),
+        ).fetchone()
+    for payload in (task_json, event_json, result_json, rendered):
+        assert secret not in payload
+    assert len(evt["results"][0]["error"]) <= 1000
+
+
 def test_dispatch_rejected_at_capacity():
     ev = threading.Event()
 

--- a/tests/tools/test_delegation_live_log.py
+++ b/tests/tools/test_delegation_live_log.py
@@ -274,8 +274,8 @@ def test_manifest_includes_model_and_provider():
     assert len(manifest["tasks"]) == 2
 
 
-def test_manifest_model_provider_are_optional_and_default_none():
-    """When not provided, model and provider should be null in the manifest."""
+def test_manifest_model_provider_are_explicit_when_not_reported():
+    """Missing route evidence is explicit rather than an ambiguous null."""
     delegation_id, _writers, _paths = create_live_transcripts(
         [{"goal": "task without model"}]
     )
@@ -285,8 +285,8 @@ def test_manifest_model_provider_are_optional_and_default_none():
             encoding="utf-8"
         )
     )
-    assert manifest["model"] is None
-    assert manifest["provider"] is None
+    assert manifest["model"] == "not-reported"
+    assert manifest["provider"] == "not-reported"
 
 
 def test_no_file_in_the_dispatch_directory_carries_the_raw_key():

--- a/tests/tools/test_delegation_model_evidence.py
+++ b/tests/tools/test_delegation_model_evidence.py
@@ -1,0 +1,98 @@
+"""Behavior contracts for delegation model evidence (#98934)."""
+
+from types import SimpleNamespace
+
+from tools.delegation_model_evidence import (
+    format_model_evidence,
+    make_model_evidence,
+    record_actual_response,
+)
+
+
+def test_runtime_model_without_provider_does_not_claim_actual_provider():
+    evidence = make_model_evidence(
+        requested_provider="openrouter",
+        requested_model="requested/model",
+        resolved_provider="openrouter",
+        resolved_model="resolved/model",
+        selection_source="task",
+    )
+
+    record_actual_response(evidence, SimpleNamespace(model="actual/model"))
+
+    assert evidence["actual"] == {
+        "provider": "not-reported",
+        "model": "actual/model",
+    }
+    assert evidence["substitution"] == {
+        "model": {"resolved": "resolved/model", "actual": "actual/model"}
+    }
+
+
+def test_explicit_runtime_provider_and_model_are_recorded():
+    evidence = make_model_evidence(
+        requested_provider="openrouter",
+        requested_model="requested/model",
+        resolved_provider="openrouter",
+        resolved_model="resolved/model",
+        selection_source="delegation_config",
+    )
+
+    record_actual_response(
+        evidence,
+        SimpleNamespace(
+            model="actual/model",
+            model_extra={"provider": "anthropic"},
+        ),
+    )
+
+    assert evidence["actual"] == {
+        "provider": "anthropic",
+        "model": "actual/model",
+    }
+    assert evidence["substitution"] == {
+        "provider": {"resolved": "openrouter", "actual": "anthropic"},
+        "model": {"resolved": "resolved/model", "actual": "actual/model"},
+    }
+
+
+def test_credential_shaped_identifiers_are_withheld_everywhere():
+    secret_provider = "sk-abcdefghijklmnopqrstuvwxyz"
+    secret_model = "ghp_abcdefghijklmnopqrstuvwxyz"
+    evidence = make_model_evidence(
+        requested_provider=secret_provider,
+        requested_model=secret_model,
+        resolved_provider=secret_provider,
+        resolved_model=secret_model,
+        selection_source="task",
+    )
+    record_actual_response(
+        evidence,
+        SimpleNamespace(model=secret_model, provider=secret_provider),
+    )
+
+    rendered = format_model_evidence(evidence)
+    assert secret_provider not in repr(evidence)
+    assert secret_model not in repr(evidence)
+    assert secret_provider not in rendered
+    assert secret_model not in rendered
+    assert "redacted" in rendered
+
+
+def test_missing_evidence_is_explicit_and_never_renders_question_mark():
+    evidence = make_model_evidence(
+        requested_provider=None,
+        requested_model=None,
+        resolved_provider=None,
+        resolved_model=None,
+        selection_source="parent",
+    )
+
+    rendered = format_model_evidence(evidence)
+
+    assert evidence["actual"] == {
+        "provider": "not-reported",
+        "model": "not-reported",
+    }
+    assert "not-reported" in rendered
+    assert "?" not in rendered

--- a/tests/tools/test_delegation_model_routing.py
+++ b/tests/tools/test_delegation_model_routing.py
@@ -1,0 +1,133 @@
+"""End-to-end delegation model-evidence routing contracts (#98934)."""
+
+import json
+from unittest.mock import MagicMock
+
+import tools.delegate_tool as dt
+
+
+def _parent():
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.model = "parent/model"
+    parent.provider = "parent-provider"
+    parent.base_url = "https://parent.example/v1"
+    parent.api_key = "test-key"
+    parent.session_id = "parent-session"
+    parent._active_children = []
+    parent._active_children_lock = None
+    parent.enabled_toolsets = []
+    parent.disabled_toolsets = []
+    parent._session_db = None
+    parent._interrupt_requested = False
+    return parent
+
+
+def _resolved_creds(cfg, _parent_agent):
+    return {
+        "model": cfg.get("model"),
+        "provider": cfg.get("provider"),
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "request_overrides": None,
+        "max_output_tokens": None,
+        "command": None,
+        "args": None,
+    }
+
+
+def test_model_facing_batch_schema_exposes_per_task_route_overrides():
+    properties = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    task_properties = properties["tasks"]["items"]["properties"]
+
+    assert "model" in task_properties
+    assert "provider" in task_properties
+    assert "model" not in properties
+    assert "provider" not in properties
+
+
+def test_batch_retains_inherited_and_per_task_model_evidence(monkeypatch):
+    parent = _parent()
+    built = []
+
+    def build_child(**kwargs):
+        child = MagicMock()
+        child.model = kwargs.get("model") or parent.model
+        child.provider = kwargs.get("override_provider") or parent.provider
+        child._delegate_role = "leaf"
+        child._subagent_id = f"child-{len(built)}"
+        child._parent_session_id = parent.session_id
+        child._parent_subagent_id = None
+        child._delegate_depth = 1
+        built.append(child)
+        return child
+
+    def run_child(task_index, child=None, **_kwargs):
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "exit_reason": "completed",
+            "model_evidence": child._delegation_model_evidence,
+        }
+
+    monkeypatch.setattr(dt, "_load_config", lambda: {})
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", _resolved_creds)
+    monkeypatch.setattr(dt, "_build_child_preserving_parent_tools", build_child)
+    monkeypatch.setattr(dt, "_run_single_child", run_child)
+    monkeypatch.setattr(
+        "tools.delegation_live_log.create_live_transcripts",
+        lambda *args, **kwargs: (None, [None, None], []),
+    )
+
+    payload = json.loads(
+        dt.delegate_task(
+            tasks=[
+                {
+                    "goal": "Use an explicit route for this sufficiently detailed task",
+                    "provider": "task-provider",
+                    "model": "task/model",
+                },
+                {
+                    "goal": "Inherit the parent route for this other detailed task",
+                },
+            ],
+            parent_agent=parent,
+        )
+    )
+
+    explicit = payload["results"][0]["model_evidence"]
+    inherited = payload["results"][1]["model_evidence"]
+    assert explicit["selection_source"] == "task"
+    assert explicit["requested"] == {
+        "provider": "task-provider",
+        "model": "task/model",
+    }
+    assert explicit["resolved"] == {
+        "provider": "task-provider",
+        "model": "task/model",
+    }
+    assert inherited["selection_source"] == "parent"
+    assert inherited["requested"] == {
+        "provider": "parent-provider",
+        "model": "parent/model",
+    }
+    assert inherited["resolved"] == {
+        "provider": "parent-provider",
+        "model": "parent/model",
+    }
+
+
+def test_top_level_provider_requires_top_level_model():
+    payload = json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": "A sufficiently detailed delegated task goal"}],
+            provider="other-provider",
+            parent_agent=_parent(),
+        )
+    )
+
+    assert "requires 'model'" in payload["error"]

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -244,6 +244,7 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         key: record.get(key)
         for key in (
             "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
+            "model_evidence",
             # Routing origin (scope_id/user_id/user_name): persisted so a
             # restart-recovered completion can reconstruct a full
             # SessionSource — see _capture_routing_origin.
@@ -324,6 +325,31 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def _sanitize_result_payload(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy result diagnostics and model evidence through the durable boundary."""
+    from tools.delegation_model_evidence import (
+        sanitize_diagnostic,
+        sanitize_model_evidence,
+        sanitize_model_identifier,
+    )
+
+    clean = dict(result or {})
+    if "model" in clean:
+        clean["model"] = sanitize_model_identifier(clean.get("model"))
+    if clean.get("model_evidence"):
+        clean["model_evidence"] = sanitize_model_evidence(
+            clean["model_evidence"]
+        )
+    if clean.get("error"):
+        clean["error"] = sanitize_diagnostic(clean["error"])
+    if isinstance(clean.get("results"), list):
+        clean["results"] = [
+            _sanitize_result_payload(item) if isinstance(item, dict) else item
+            for item in clean["results"]
+        ]
+    return clean
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -368,6 +394,7 @@ def recover_abandoned_delegations() -> int:
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
+                "model_evidence": task.get("model_evidence"),
                 "status": "unknown", "summary": None,
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
@@ -765,6 +792,7 @@ def dispatch_async_delegation(
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    model_evidence: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
 
@@ -808,6 +836,11 @@ def dispatch_async_delegation(
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
+    from tools.delegation_model_evidence import (
+        sanitize_model_evidence,
+        sanitize_model_identifier,
+    )
+
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
     record: Dict[str, Any] = {
@@ -816,7 +849,10 @@ def dispatch_async_delegation(
         "context": context,
         "toolsets": list(toolsets) if toolsets else None,
         "role": role,
-        "model": model,
+        "model": sanitize_model_identifier(model),
+        "model_evidence": (
+            sanitize_model_evidence(model_evidence) if model_evidence else None
+        ),
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
@@ -955,10 +991,17 @@ def _push_completion_event(
         )
         return
 
+    result = _sanitize_result_payload(result)
     summary = result.get("summary")
     error = result.get("error")
     dispatched_at = record.get("dispatched_at") or time.time()
     completed_at = record.get("completed_at") or time.time()
+
+    from tools.delegation_model_evidence import sanitize_model_evidence
+
+    _raw_model_evidence = (
+        result.get("model_evidence") or record.get("model_evidence")
+    )
 
     evt = {
         "type": "async_delegation",
@@ -974,6 +1017,10 @@ def _push_completion_event(
         "toolsets": record.get("toolsets"),
         "role": record.get("role"),
         "model": result.get("model") or record.get("model"),
+        "model_evidence": (
+            sanitize_model_evidence(_raw_model_evidence)
+            if _raw_model_evidence else None
+        ),
         "status": status,
         "summary": summary,
         "error": error,
@@ -1028,6 +1075,7 @@ def dispatch_async_delegation_batch(
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    model_evidence: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit.
 
@@ -1049,6 +1097,11 @@ def dispatch_async_delegation_batch(
     ``{"status": "rejected", "error": ...}`` when the async pool is at
     capacity.
     """
+    from tools.delegation_model_evidence import (
+        sanitize_model_evidence,
+        sanitize_model_identifier,
+    )
+
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)
@@ -1063,7 +1116,11 @@ def dispatch_async_delegation_batch(
         "context": context,
         "toolsets": list(toolsets) if toolsets else None,
         "role": role,
-        "model": model,
+        "model": sanitize_model_identifier(model),
+        "model_evidence": (
+            [sanitize_model_evidence(item) for item in model_evidence]
+            if model_evidence else None
+        ),
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
@@ -1172,8 +1229,17 @@ def _push_batch_completion_event(
         )
         return
 
+    combined = _sanitize_result_payload(combined)
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
+    from tools.delegation_model_evidence import sanitize_model_evidence
+
+    _result_evidence = [
+        result.get("model_evidence")
+        for result in (combined.get("results") or [])
+        if isinstance(result, dict) and result.get("model_evidence")
+    ]
+    _raw_model_evidence = _result_evidence or event_record.get("model_evidence")
     evt = {
         "type": "async_delegation",
         "delegation_id": event_record.get("delegation_id"),
@@ -1187,6 +1253,10 @@ def _push_batch_completion_event(
         "toolsets": event_record.get("toolsets"),
         "role": event_record.get("role"),
         "model": event_record.get("model"),
+        "model_evidence": (
+            [sanitize_model_evidence(item) for item in _raw_model_evidence]
+            if _raw_model_evidence else None
+        ),
         "status": status,
         "is_batch": True,
         # The full per-task results list — the formatter renders a

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2594,6 +2594,8 @@ def _run_single_child(
     _raw_sid = getattr(child, "_subagent_id", None)
     _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
     if _subagent_id:
+        from tools.delegation_model_evidence import sanitize_model_identifier
+
         if owner_session_id is None:
             try:
                 from gateway.session_context import get_session_env
@@ -2628,10 +2630,9 @@ def _run_single_child(
                 "delegation_id": (
                     _delegation_id if isinstance(_delegation_id, str) else None
                 ),
-                "model": (
-                    getattr(child, "model", None)
-                    if isinstance(getattr(child, "model", None), str)
-                    else None
+                "model": sanitize_model_identifier(getattr(child, "model", None)),
+                "model_evidence": getattr(
+                    child, "_delegation_model_evidence", None
                 ),
                 "started_at": time.time(),
                 "status": "running",
@@ -2936,6 +2937,9 @@ def _run_single_child(
                 ),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
+                "model_evidence": getattr(
+                    child, "_delegation_model_evidence", None
+                ),
             }
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
@@ -3107,6 +3111,9 @@ def _run_single_child(
         _input_tokens = getattr(child, "session_prompt_tokens", 0)
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
+        from tools.delegation_model_evidence import sanitize_model_identifier
+
+        _reported_model = sanitize_model_identifier(_model)
 
         entry: Dict[str, Any] = {
             "task_index": task_index,
@@ -3114,7 +3121,10 @@ def _run_single_child(
             "summary": summary,
             "api_calls": api_calls,
             "duration_seconds": duration,
-            "model": _model if isinstance(_model, str) else None,
+            "model": _reported_model,
+            "model_evidence": getattr(
+                child, "_delegation_model_evidence", None
+            ),
             "exit_reason": exit_reason,
             # Explicit, parent-visible truncation flag. A subagent that
             # exhausts its per-child iteration budget still returns a summary,
@@ -3269,6 +3279,7 @@ def _run_single_child(
             "files_read": _files_read,
             "files_written": _files_written,
             "output_tail": _output_tail,
+            "model_evidence": entry.get("model_evidence"),
         }
         if _cost_usd is not None:
             try:
@@ -3630,6 +3641,8 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
@@ -3734,13 +3747,13 @@ def delegate_task(
     # ({provider, model, base_url, api_key, api_mode}); the /review engine
     # uses it to route its reviewer subagent onto ``auxiliary.review``
     # without touching the global delegation pin.
-    try:
-        creds = _resolve_delegation_credentials(
-            credentials_cfg if credentials_cfg else cfg, parent_agent
-        )
-    except ValueError as exc:
-        return tool_error(str(exc))
-
+    if provider and not model:
+        return tool_error("'provider' requires 'model' to be set as well.")
+    _base_credentials_cfg = dict(credentials_cfg if credentials_cfg else cfg)
+    if model:
+        _base_credentials_cfg["model"] = model
+    if provider:
+        _base_credentials_cfg["provider"] = provider
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -3785,6 +3798,10 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        if task.get("provider") and not task.get("model"):
+            return tool_error(
+                f"Task {i} 'provider' requires 'model' to be set as well."
+            )
 
     # Batch-only quality gate: catch malformed fan-outs (placeholder goals,
     # unexpanded multi-word template markers, 1-task batches) before any
@@ -3813,6 +3830,36 @@ def delegate_task(
             return tool_error(f"Task {i} output_schema invalid: {schema_err}")
         task_schemas.append(coerced_schema)
 
+    # Resolve each task independently: one fan-out may mix inherited routes
+    # with per-task model/provider overrides.
+    task_creds: List[Dict[str, Any]] = []
+    task_selection_sources: List[str] = []
+    for task in task_list:
+        task_cfg = dict(_base_credentials_cfg)
+        if task.get("model"):
+            task_cfg["model"] = task["model"]
+        if task.get("provider"):
+            task_cfg["provider"] = task["provider"]
+        try:
+            task_creds.append(
+                _resolve_delegation_credentials(task_cfg, parent_agent)
+            )
+        except ValueError as exc:
+            return tool_error(str(exc))
+        if task.get("model") or task.get("provider"):
+            source = "task"
+        elif model or provider:
+            source = "top_level"
+        elif any(
+            _base_credentials_cfg.get(key)
+            for key in ("model", "provider", "base_url", "command")
+        ):
+            source = "delegation_config"
+        else:
+            source = "parent"
+        task_selection_sources.append(source)
+    creds = task_creds[0]
+
     overall_start = time.monotonic()
     results = []
 
@@ -3827,6 +3874,7 @@ def delegate_task(
     # live_paths is empty and delegation proceeds exactly as before.
     from tools.delegation_live_log import (
         create_live_transcripts,
+        update_manifest_model_evidence,
         update_manifest_statuses,
         wrap_progress_callback,
     )
@@ -3863,6 +3911,7 @@ def delegate_task(
     # subagent-lifecycle API).
     children = []
     for i, t in enumerate(task_list):
+        task_cred = task_creds[i]
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
@@ -3882,18 +3931,18 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_cred["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_cred["provider"],
+                override_base_url=task_cred["base_url"],
+                override_api_key=task_cred["api_key"],
+                override_api_mode=task_cred["api_mode"],
+                override_request_overrides=task_cred.get("request_overrides"),
+                override_max_tokens=task_cred.get("max_output_tokens"),
+                override_acp_command=task_cred.get("command"),
+                override_acp_args=task_cred.get("args"),
                 role=effective_role,
             )
         except ValueError as exc:
@@ -3907,6 +3956,25 @@ def delegate_task(
                 child._delegate_output_schema = _task_schema
             except Exception:
                 logger.debug("Could not attach output schema to child %d", i)
+        from tools.delegation_model_evidence import make_model_evidence
+
+        child._delegation_model_evidence = make_model_evidence(
+            requested_provider=(
+                t.get("provider")
+                or provider
+                or _base_credentials_cfg.get("provider")
+                or getattr(parent_agent, "provider", None)
+            ),
+            requested_model=(
+                t.get("model")
+                or model
+                or _base_credentials_cfg.get("model")
+                or getattr(parent_agent, "model", None)
+            ),
+            resolved_provider=getattr(child, "provider", None),
+            resolved_model=getattr(child, "model", None),
+            selection_source=task_selection_sources[i],
+        )
         # Tee the child's progress events into its live transcript log.
         # wrap_progress_callback preserves the inner callback contract
         # (including the _flush attribute) and never lets writer failures
@@ -3923,6 +3991,14 @@ def delegate_task(
         if live_deleg_id:
             setattr(child, "_delegation_id", live_deleg_id)
         children.append((i, t, child))
+
+    update_manifest_model_evidence(
+        live_deleg_id,
+        [
+            getattr(child, "_delegation_model_evidence", {})
+            for _, _, child in children
+        ],
+    )
 
     def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
@@ -4278,6 +4354,10 @@ def delegate_task(
             return tuple(parts), in_tool
 
         _goals = [t["goal"] for t in task_list]
+        _model_evidence = [
+            getattr(_c, "_delegation_model_evidence", None)
+            for _c in _child_agents
+        ]
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
@@ -4286,6 +4366,7 @@ def delegate_task(
             toolsets=None,
             role=top_role,
             model=creds["model"],
+            model_evidence=_model_evidence,
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             origin_session_id=_wake_sid,
@@ -4812,6 +4893,20 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Optional model override for this task. When it "
+                                "belongs to a different provider, set provider."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Optional provider override for this task; "
+                                "requires model."
+                            ),
                         },
                         "output_schema": {
                             "type": "object",

--- a/tools/delegation_live_log.py
+++ b/tools/delegation_live_log.py
@@ -356,12 +356,14 @@ def _write_manifest(delegation_id: str, task_list: List[Dict[str, Any]],
                     paths: List[str], model: Optional[str] = None,
                     provider: Optional[str] = None) -> None:
     try:
+        from tools.delegation_model_evidence import sanitize_model_identifier
+
         manifest = {
             "delegation_id": delegation_id,
             "started": time.strftime("%Y-%m-%d %H:%M:%S"),
             "task_count": len(task_list),
-            "model": model,
-            "provider": provider,
+            "model": sanitize_model_identifier(model),
+            "provider": sanitize_model_identifier(provider),
             "tasks": [
                 {
                     "index": i,
@@ -399,11 +401,39 @@ def update_manifest_statuses(delegation_id: Optional[str],
                 task["status"] = r.get("status", task.get("status"))
                 if r.get("exit_reason"):
                     task["exit_reason"] = r["exit_reason"]
+                if r.get("model_evidence"):
+                    from tools.delegation_model_evidence import sanitize_model_evidence
+
+                    task["model_evidence"] = sanitize_model_evidence(
+                        r["model_evidence"]
+                    )
         manifest["completed"] = time.strftime("%Y-%m-%d %H:%M:%S")
         mp.write_text(json.dumps(manifest, indent=2, ensure_ascii=False),
                       encoding="utf-8")
     except Exception as exc:
         logger.debug("Live transcript manifest update failed: %s", exc)
+
+
+def update_manifest_model_evidence(
+    delegation_id: Optional[str], evidence: List[Dict[str, Any]]
+) -> None:
+    """Persist per-task resolved routes immediately after child construction."""
+    if not delegation_id:
+        return
+    try:
+        from tools.delegation_model_evidence import sanitize_model_evidence
+
+        mp = _manifest_path(delegation_id)
+        manifest = json.loads(mp.read_text(encoding="utf-8"))
+        for task in manifest.get("tasks", []):
+            index = task.get("index")
+            if isinstance(index, int) and 0 <= index < len(evidence):
+                task["model_evidence"] = sanitize_model_evidence(evidence[index])
+        mp.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    except Exception as exc:
+        logger.debug("Live transcript model evidence update failed: %s", exc)
 
 
 def prune_stale_live_dirs(max_age_days: int = LIVE_RETENTION_DAYS) -> int:

--- a/tools/delegation_model_evidence.py
+++ b/tools/delegation_model_evidence.py
@@ -1,0 +1,191 @@
+"""Sanitized requested/resolved/actual model evidence for delegation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+_UNAVAILABLE = "not-reported"
+_MAX_IDENTIFIER_CHARS = 256
+_MAX_DIAGNOSTIC_CHARS = 1000
+_SELECTION_SOURCES = {
+    "task",
+    "top_level",
+    "delegation_config",
+    "parent",
+    "legacy-record",
+}
+
+
+def sanitize_model_identifier(value: Any) -> str:
+    """Return a bounded identifier that cannot carry a credential token."""
+    if not isinstance(value, str) or not value.strip():
+        return _UNAVAILABLE
+    normalized = " ".join(value.split())[:_MAX_IDENTIFIER_CHARS]
+    try:
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(normalized, force=True)
+    except Exception:
+        return "redacted"
+    if redacted != normalized:
+        return "redacted"
+    return normalized
+
+
+def sanitize_diagnostic(value: Any) -> str:
+    """Force-redact and bound free-text evidence diagnostics."""
+    text = str(value or "")[:_MAX_DIAGNOSTIC_CHARS]
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return (redact_sensitive_text(text, force=True) or "")[:_MAX_DIAGNOSTIC_CHARS]
+    except Exception:
+        return "[diagnostic withheld: redaction unavailable]"
+
+
+def make_model_evidence(
+    *,
+    requested_provider: Optional[str],
+    requested_model: Optional[str],
+    resolved_provider: Optional[str],
+    resolved_model: Optional[str],
+    selection_source: str,
+) -> Dict[str, Any]:
+    """Build the dispatch record before any provider response exists."""
+    source = str(selection_source or "parent").strip()[:64] or "parent"
+    if source not in _SELECTION_SOURCES:
+        source = "unknown"
+    return {
+        "selection_source": source,
+        "requested": {
+            "provider": sanitize_model_identifier(requested_provider),
+            "model": sanitize_model_identifier(requested_model),
+        },
+        "resolved": {
+            "provider": sanitize_model_identifier(resolved_provider),
+            "model": sanitize_model_identifier(resolved_model),
+        },
+        "actual": {"provider": _UNAVAILABLE, "model": _UNAVAILABLE},
+    }
+
+
+def sanitize_model_evidence(evidence: Any) -> Dict[str, Any]:
+    """Copy an evidence record through the persistence-boundary sanitizer."""
+    raw = evidence if isinstance(evidence, dict) else {}
+    requested = raw.get("requested") if isinstance(raw.get("requested"), dict) else {}
+    resolved = raw.get("resolved") if isinstance(raw.get("resolved"), dict) else {}
+    actual = raw.get("actual") if isinstance(raw.get("actual"), dict) else {}
+    clean = make_model_evidence(
+        requested_provider=requested.get("provider"),
+        requested_model=requested.get("model"),
+        resolved_provider=resolved.get("provider"),
+        resolved_model=resolved.get("model"),
+        selection_source=str(raw.get("selection_source") or "parent"),
+    )
+    clean["actual"] = {
+        "provider": sanitize_model_identifier(actual.get("provider")),
+        "model": sanitize_model_identifier(actual.get("model")),
+    }
+    _refresh_substitution(clean)
+    return clean
+
+
+def _explicit_response_value(response: Any, *keys: str) -> Optional[str]:
+    """Read only provider-reported fields; never consult the configured route."""
+    containers = [response]
+    if not isinstance(response, dict):
+        for attr in ("model_extra", "metadata"):
+            extra = getattr(response, attr, None)
+            if isinstance(extra, dict):
+                containers.append(extra)
+    else:
+        for key in ("model_extra", "metadata"):
+            extra = response.get(key)
+            if isinstance(extra, dict):
+                containers.append(extra)
+
+    for container in containers:
+        for key in keys:
+            value = (
+                container.get(key)
+                if isinstance(container, dict)
+                else getattr(container, key, None)
+            )
+            if isinstance(value, str) and value.strip():
+                return value
+    return None
+
+
+def _refresh_substitution(evidence: Dict[str, Any]) -> None:
+    resolved = evidence.get("resolved") or {}
+    actual = evidence.get("actual") or {}
+    substitution: Dict[str, Dict[str, str]] = {}
+    for key in ("provider", "model"):
+        before = resolved.get(key)
+        after = actual.get(key)
+        if (
+            before not in (None, _UNAVAILABLE, "redacted")
+            and after not in (None, _UNAVAILABLE, "redacted")
+            and before != after
+        ):
+            substitution[key] = {"resolved": before, "actual": after}
+    if substitution:
+        evidence["substitution"] = substitution
+    else:
+        evidence.pop("substitution", None)
+
+
+def record_actual_response(evidence: Dict[str, Any], response: Any) -> None:
+    """Merge explicit runtime reporting into one evidence record in place."""
+    if not isinstance(evidence, dict):
+        return
+    actual = evidence.setdefault(
+        "actual", {"provider": _UNAVAILABLE, "model": _UNAVAILABLE}
+    )
+    provider = _explicit_response_value(response, "provider", "provider_name")
+    model = _explicit_response_value(response, "model")
+    if provider is not None:
+        actual["provider"] = sanitize_model_identifier(provider)
+    if model is not None:
+        actual["model"] = sanitize_model_identifier(model)
+    _refresh_substitution(evidence)
+
+
+def format_model_evidence(evidence: Any) -> str:
+    """Render evidence without ambiguous question-mark placeholders."""
+    if not isinstance(evidence, dict):
+        evidence = make_model_evidence(
+            requested_provider=None,
+            requested_model=None,
+            resolved_provider=None,
+            resolved_model=None,
+            selection_source="parent",
+        )
+    requested = evidence.get("requested") or {}
+    resolved = evidence.get("resolved") or {}
+    actual = evidence.get("actual") or {}
+
+    def pair(values: Dict[str, Any]) -> str:
+        provider = sanitize_model_identifier(values.get("provider"))
+        model = sanitize_model_identifier(values.get("model"))
+        return f"{provider}/{model}"
+
+    rendered = (
+        f"Requested: {pair(requested)}; "
+        f"Resolved: {pair(resolved)}; "
+        f"Actual: {pair(actual)}; "
+        f"Source: {str(evidence.get('selection_source') or 'parent')[:64]}"
+    )
+    substitution = evidence.get("substitution")
+    if isinstance(substitution, dict) and substitution:
+        parts = []
+        for key in ("provider", "model"):
+            change = substitution.get(key)
+            if isinstance(change, dict):
+                parts.append(
+                    f"{key} {sanitize_model_identifier(change.get('resolved'))}"
+                    f" -> {sanitize_model_identifier(change.get('actual'))}"
+                )
+        if parts:
+            rendered += "; Substitution: " + ", ".join(parts)
+    return rendered

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2977,7 +2977,23 @@ def _format_async_delegation(evt: dict) -> str:
     context = evt.get("context")
     toolsets = evt.get("toolsets")
     role = evt.get("role") or "leaf"
-    model = evt.get("model") or "?"
+    from tools.delegation_model_evidence import (
+        format_model_evidence,
+        make_model_evidence,
+        sanitize_model_evidence,
+    )
+
+    model = evt.get("model")
+    raw_evidence = evt.get("model_evidence")
+
+    def _legacy_evidence():
+        return make_model_evidence(
+            requested_provider=None,
+            requested_model=model,
+            resolved_provider=None,
+            resolved_model=model,
+            selection_source="legacy-record",
+        )
     status = evt.get("status") or "completed"
     summary = evt.get("summary")
     error = evt.get("error")
@@ -3013,8 +3029,21 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append(f"Context you provided: {context}")
         if toolsets:
             lines.append(f"Toolsets: {', '.join(toolsets)}")
-        lines.append(f"Role: {role}   Model: {model}   Total duration: {total_dur}s")
+        lines.append(f"Role: {role}   Total duration: {total_dur}s")
         if error and not results:
+            if isinstance(raw_evidence, list):
+                for idx, item_evidence in enumerate(raw_evidence):
+                    lines.append(
+                        f"Task {idx + 1} model evidence: "
+                        + format_model_evidence(
+                            sanitize_model_evidence(item_evidence)
+                        )
+                    )
+            else:
+                lines.append(
+                    "Model evidence: "
+                    + format_model_evidence(_legacy_evidence())
+                )
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
@@ -3039,6 +3068,16 @@ def _format_async_delegation(evt: dict) -> str:
                 header += ", TRUNCATED: hit max_iterations — work may be incomplete"
             header += ") ---"
             lines.append(header)
+            item_evidence = r.get("model_evidence")
+            if not item_evidence and isinstance(raw_evidence, list) and idx < len(raw_evidence):
+                item_evidence = raw_evidence[idx]
+            lines.append(
+                "Model evidence: "
+                + format_model_evidence(
+                    sanitize_model_evidence(item_evidence)
+                    if item_evidence else _legacy_evidence()
+                )
+            )
             if r_status in ("completed", "success") and r_summary:
                 if r_truncated:
                     lines.append(
@@ -3084,7 +3123,17 @@ def _format_async_delegation(evt: dict) -> str:
         lines.append(f"Context you provided: {context}")
     if toolsets:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
-    lines.append(f"Role: {role}   Model: {model}")
+    lines.append(f"Role: {role}")
+    single_evidence = raw_evidence
+    if isinstance(single_evidence, list):
+        single_evidence = single_evidence[0] if single_evidence else None
+    lines.append(
+        "Model evidence: "
+        + format_model_evidence(
+            sanitize_model_evidence(single_evidence)
+            if single_evidence else _legacy_evidence()
+        )
+    )
     _trunc = " [TRUNCATED: hit max_iterations — work may be incomplete]" if truncated else ""
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s{_trunc}")
     lines.append("--- RESULT ---")


### PR DESCRIPTION
## What does this PR do?

Async delegations now retain requested, resolved, and provider-reported model evidence per task instead of collapsing a batch to one nullable model and rendering `Model: ?`. This gives parent agents and operators an auditable route record while keeping unreported providers explicit and preventing credential-shaped identifiers from reaching durable state or completion output.

### Symptom

A completed background `delegate_task` could render `Model: ?` even after Hermes had resolved the child route. Batch tasks also lost the distinction between inherited and per-task model overrides.

### Impact

Parent-facing completion summaries and live delegation records could not establish which route was requested, which route Hermes resolved, or whether the runtime reported a substitution. Provider-constrained evidence could therefore be treated ambiguously, and configured identifiers were not protected by a dedicated persistence-boundary sanitizer.

### Bug Cause

**Trigger:** `tools/process_registry.py:_format_async_delegation` when an async completion carries no single top-level model.

**Causal chain:**
1. `delegate_task` resolved one credential bundle for the whole fan-out and retained only a nullable model label.
2. Async dispatch, live manifests, and completion events persisted that lossy label without requested/resolved/actual semantics.
3. The parent formatter replaced a missing value with `?`, so per-task route evidence and runtime substitutions could not be audited.

**Why it is wrong:** A configured route is not proof of the provider that served a response. Runtime model reporting must be captured separately, and a missing runtime provider must remain `not-reported` rather than being inferred from the resolved provider.

**Working sibling / contrast:** Provider responses already expose a response model when supported. This change captures that explicit report while refusing to manufacture a provider value from configuration.

**Ruled out:** This is not a provider catalog or cache freshness problem. The failing formatter and persistence records lack evidence fields even when route resolution has already completed, so fresh inventory probing alone cannot repair the lost runtime provenance.

### Fix

- Add per-task `model` and `provider` overrides to the batch task schema and resolve each task independently.
- Build a sanitized evidence record with requested, resolved, actual, selection-source, and substitution fields.
- Capture only explicit response model/provider fields as actual runtime evidence.
- Carry the evidence through live registries, manifests, durable async rows, completion events, and parent summaries.
- Render unavailable evidence as `not-reported`, remove the bare `Model: ?` fallback, force-redact credential-shaped identifiers, and cap diagnostic text at 1,000 characters.

## Related Issue

Fixes #98934

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegation_model_evidence.py` - centralize evidence construction, explicit runtime capture, sanitization, substitution detection, and formatting.
- `tools/delegate_tool.py` - resolve per-task routes and attach evidence to live and completed child records.
- `agent/conversation_loop.py` - capture provider-reported response identity without inferring a provider.
- `tools/async_delegation.py` - sanitize and persist evidence across dispatch, restart recovery, and completion delivery.
- `tools/delegation_live_log.py` - persist sanitized per-task evidence in live manifests.
- `tools/process_registry.py` - render explicit requested/resolved/actual evidence in parent-facing summaries.
- `tests/tools/` - cover per-task overrides, provider evidence gating, substitutions, durable delivery, redaction, diagnostic bounds, and explicit unavailable values.

## How to Test

1. Run the delegation regression suite:

```bash
scripts/run_tests.sh tests/tools/test_*delegat*.py -q
```

Result: 228 passed.

2. Run the focused async/evidence tests:

```bash
scripts/run_tests.sh tests/tools/test_async_delegation.py tests/tools/test_delegation_model_evidence.py tests/tools/test_delegation_model_routing.py -q
```

Result: 33 passed.

3. Run lint on all changed Python files:

```bash
python -m ruff check agent/conversation_loop.py tools/delegate_tool.py tools/async_delegation.py tools/delegation_live_log.py tools/process_registry.py tools/delegation_model_evidence.py tests/tools/test_async_delegation.py tests/tools/test_delegation_live_log.py tests/tools/test_delegation_model_evidence.py tests/tools/test_delegation_model_routing.py
```

Result: all checks passed.

A broader `tests/run_agent/test_run_agent.py` run passed 278 tests; one unrelated Anthropic interrupt test could not construct its client because the optional `anthropic` package is not installed in this Windows environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant delegation suites and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings - no user documentation change is required
- [x] `cli-config.yaml.example` is N/A because this adds no config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this preserves the existing delegation architecture
- [x] I've considered cross-platform impact; the implementation uses platform-neutral Python and existing SQLite/live-log paths
- [x] I've updated the `delegate_task` task schema for the new per-task route overrides

## Screenshots / Logs

N/A - behavior is covered by deterministic unit and persistence tests.
