### PR TITLE
fix(cron): keep delivered output out of run invoker

### DIFF
--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -99,7 +99,9 @@ class TestBackgroundDispatch:
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
-                                     "next_run_at": "2026-08-07T09:00:00"}):
+                                     "next_run_at": "2026-08-07T09:00:00"}), \
+                 patch("tools.cronjob_tools._latest_job_output_excerpt",
+                       return_value="LOCAL JOB PAYLOAD"):
                 res = _try_dispatch_background_run(_job('job-bg-02'))
                 assert res["dispatched"] is True
 
@@ -121,6 +123,145 @@ class TestBackgroundDispatch:
         assert found["status"] == "completed"
         assert "bg run" in (found.get("summary") or "")
         assert "Next scheduled run" in found["summary"]
+        assert "LOCAL JOB PAYLOAD" in found["summary"]
+
+    def test_external_delivery_completion_does_not_echo_job_output(self):
+        """A manual run's completion returns to the invoking session, which may
+        be unrelated to the job's explicit destination. Once the scheduler has
+        delivered externally, the completion must report status without copying
+        the payload into that other session.
+        """
+        import time
+
+        from tools.process_registry import process_registry
+
+        job = {
+            **_job("job-bg-explicit-target"),
+            "deliver": "telegram:170829464:539316",
+        }
+        with _bound_session_key("agent:main:telegram:dm:170829464:581299"):
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                return_value={**job, "fire_claim": {"by": "bg-owner"}},
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ), patch(
+                "tools.cronjob_tools._latest_job_output_excerpt",
+                return_value="PAYLOAD FOR THREAD 539316",
+            ):
+                res = _try_dispatch_background_run(job)
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+
+        assert found is not None
+        assert found["session_key"].endswith(":581299")
+        assert "Delivery target: telegram:170829464:539316" in found["summary"]
+        assert "PAYLOAD FOR THREAD 539316" not in found["summary"]
+
+    def test_completion_uses_claimed_delivery_snapshot(self):
+        """The claimed snapshot governs both execution and completion routing."""
+        import time
+
+        from tools.process_registry import process_registry
+
+        submitted = {**_job("job-bg-claimed-target"), "deliver": "local"}
+        claimed = {
+            **submitted,
+            "deliver": ["telegram:170829464:539316"],
+            "fire_claim": {"by": "bg-owner"},
+        }
+        with _bound_session_key("agent:main:telegram:dm:170829464:581299"):
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ), patch(
+                "tools.cronjob_tools._latest_job_output_excerpt",
+                return_value="CLAIMED SNAPSHOT PAYLOAD",
+            ):
+                res = _try_dispatch_background_run(submitted)
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+
+        assert found is not None
+        assert "Delivery target: telegram:170829464:539316" in found["summary"]
+        assert "CLAIMED SNAPSHOT PAYLOAD" not in found["summary"]
+
+    def test_completion_reports_external_delivery_failure(self):
+        """A completed run must not claim that a failed delivery succeeded."""
+        import time
+
+        from tools.process_registry import process_registry
+
+        job = {**_job("job-bg-delivery-failed"), "deliver": "discord:alerts"}
+        with _bound_session_key("agent:main:discord:channel:invoker"):
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                return_value={**job, "fire_claim": {"by": "bg-owner"}},
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={
+                    "last_status": "ok",
+                    "last_error": None,
+                    "last_delivery_error": "send failed: 502",
+                },
+            ), patch(
+                "tools.cronjob_tools._latest_job_output_excerpt",
+                return_value="EXTERNAL PAYLOAD",
+            ):
+                res = _try_dispatch_background_run(job)
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+
+        assert found is not None
+        assert "Delivery target: discord:alerts" in found["summary"]
+        assert "delivery failed: send failed: 502" in found["summary"]
+        assert "output was delivered" not in found["summary"]
+        assert "EXTERNAL PAYLOAD" not in found["summary"]
 
     def test_failed_run_reports_error_status_in_event(self):
         import time

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1334,29 +1334,36 @@ def _try_dispatch_background_run(
         max_async = 3
 
     started_at = time.time()
-    deliver = job.get("deliver", "local")
+    deliver = _normalize_deliver_param(claimed_job.get("deliver")) or "local"
 
     def _runner() -> Dict[str, Any]:
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
+        delivery_error = str(refreshed.get("last_delivery_error") or "").strip()
+        if deliver == "local":
+            delivery_note = " (output saved locally only)"
+        elif delivery_error:
+            delivery_note = f" (delivery failed: {delivery_error})"
+        else:
+            delivery_note = " (output was delivered there by the job itself)"
         lines = [
             f"Cron job '{job_name}' ({job_id}) finished its manual run.",
             f"Result: {'ok' if res.get('success') else 'FAILED'}"
             + (f" — {res.get('error')}" if res.get("error") else ""),
-            f"Delivery target: {deliver}"
-            + (
-                " (output was delivered there by the job itself)"
-                if deliver != "local"
-                else " (output saved locally only)"
-            ),
+            f"Delivery target: {deliver}{delivery_note}",
         ]
         if refreshed.get("next_run_at"):
             lines.append(f"Next scheduled run: {refreshed['next_run_at']}")
-        excerpt = _latest_job_output_excerpt(job_id)
-        if excerpt:
-            lines.append("--- JOB OUTPUT ---")
-            lines.append(excerpt)
+        # This completion re-enters the session that invoked action='run', not
+        # the job's delivery target. Repeating an externally delivered payload
+        # here leaks it into a second, potentially unrelated chat/thread. Local
+        # jobs have no other user-facing destination, so retain their excerpt.
+        if deliver == "local":
+            excerpt = _latest_job_output_excerpt(job_id)
+            if excerpt:
+                lines.append("--- JOB OUTPUT ---")
+                lines.append(excerpt)
         return {
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),


### PR DESCRIPTION
## Summary

- keep manual `cronjob(action="run")` completions from copying an externally delivered payload into the invoking session
- preserve the output excerpt for `deliver="local"`, where there is no external recipient
- base completion routing on the claimed job snapshot, normalize legacy delivery values, and report `last_delivery_error` instead of claiming a failed delivery succeeded

This salvages the closed, unmerged #97573 from @fangliquanflq. The original commit was cherry-picked and extended after independent review; its Git author attribution is preserved.

## Problem

A manual run captures the invoking session so the background completion can return there. The scheduler separately delivers the job output to the configured destination. The completion previously appended the same saved output unconditionally, so an explicit destination such as Telegram topic A could also leak the payload into the unrelated topic B that invoked the run.

The completion path is platform-independent, so the same duplicate-return behavior applied to other external delivery targets.

## Approach

- append `--- JOB OUTPUT ---` only for canonical `deliver="local"`
- use the `claim_job_for_fire(..., return_job=True)` snapshot for the completion's delivery decision
- normalize legacy list/tuple delivery values before classifying local vs external
- surface `last_delivery_error` in the completion instead of saying the output was delivered
- leave scheduler target resolution, platform adapters, scheduled fires, and session lifecycle unchanged

## Verification

Current-main regression before the fix:

```text
python -m pytest tests/tools/test_cronjob_run_background.py::TestBackgroundDispatch::test_external_delivery_completion_does_not_echo_job_output -q
1 failed
```

The completion for invoking topic `581299` contained the payload intended for explicit topic `539316`.

After the fix, rebased onto `4f22543509d1b91dc45bcb369447126c5eb14fb7`:

```text
python -m pytest tests/tools/test_cronjob_run_background.py tests/tools/test_cronjob_tools.py -q
89 passed

python -m pytest tests/cron/test_scheduler.py -k 'unresolved_target_still_delivered_as_written or explicit_telegram_topic_target_overrides_cron_thread_id' -q
2 passed, 101 deselected

ruff check tools/cronjob_tools.py tests/tools/test_cronjob_run_background.py
All checks passed!

python -m py_compile tools/cronjob_tools.py tests/tools/test_cronjob_run_background.py
git diff origin/main...HEAD --check
```

Focused coverage includes external payload suppression, local excerpt preservation, claimed-snapshot races, legacy list delivery normalization, and failed-delivery reporting.

Closes #97557
