### PR TITLE
fix(desktop): retry a failed unpin instead of resurrecting the pin

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -292,6 +292,31 @@ describe('watchSessionPins remote pull', () => {
     expect(patch).toHaveBeenCalledWith('failed', true, undefined)
   })
 
+  it('keeps the unpin and retries when the write itself fails', async () => {
+    // Adopt a server-side pin first, so it's held locally and mirrored.
+    $sessions.set([row('stuck', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('stuck')
+    patch.mockClear()
+
+    // The user unpins, but the PATCH fails.
+    patch.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    $pinnedSessionIds.set([])
+    await flush()
+    await flush()
+    patch.mockClear()
+
+    // The PATCH never landed, so the next refresh still says pinned=true —
+    // but that's OUR undelivered intent, not a remote decision. The unpin
+    // must stay and the next reconcile retries it instead of resurrecting
+    // the pin.
+    $sessions.set([row('stuck', { pinned: true })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('stuck')
+    expect(patch).toHaveBeenCalledWith('stuck', false, undefined)
+  })
+
   it('does not oscillate when two profiles share a session id with conflicting pins', async () => {
     // The cross-profile list can hold the same durable id twice with opposite
     // `pinned` flags (copied/imported profile DBs). A profile-blind pull would

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -235,7 +235,14 @@ function reconcileInner(): void {
     if (!current.has(id)) {
       mirrored.delete(id)
       pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+      void writePin(id, false, profileFor(id)).catch(() => {
+        // The PATCH never landed, so the server still holds the pin — dropping
+        // the id entirely would let the next pull adopt that stale row as a
+        // foreign pin and resurrect what the user just unpinned. Keeping it
+        // mirrored holds the unpin pending and retries the write on the next
+        // reconcile, the same retry a failed pin push already gets.
+        mirrored.add(id)
+      })
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an asymmetric failure-handling bug in the session-pin sync layer. When the `pinned=false` PATCH behind an unpin failed (network error, bridge hiccup), the id was dropped from the pin mirror entirely. With no mirror entry and no write guard left standing, the next session-list refresh adopted the server's still-stale `pinned=true` row as a *foreign* pin — the session the user had just unpinned came straight back in the Pinned section, and the unpin never retried. From the user's side this reads as "cannot unpin": the row drops to the bottom of the pinned list instead of leaving it (reported in #38858).

A failed `pinned=true` push already gets a retry (the pin path puts the id back in `pending`); this PR gives the unpin path the same treatment by re-marking the id as mirrored on write failure, so the next reconcile retries the PATCH and the write guard fences the stale row until the server catches up.

## Related Issue

Fixes #38858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-pin-sync.ts` — on a failed unpin PATCH, keep the id in `mirrored` instead of dropping it, so a later reconcile re-issues the write and the pull pass does not resurrect the pin from the stale server row.
- `apps/desktop/src/store/session-pin-sync.test.ts` — added `keeps the unpin and retries when the write itself fails`, the unpin counterpart of the existing failed-pin-write test.

## How to Test

1. `cd apps/desktop && npx vitest run src/store/session-pin-sync.test.ts` — should pass 23 tests, including the new one.
2. On this branch without the fix (test-only), the new test fails: after a rejected `pinned=false` PATCH, the next refresh carrying `pinned=true` re-adds the id to `$pinnedSessionIds` (`expected [ 'stuck' ] to not include 'stuck'`). Observed result: red before the `session-pin-sync.ts` change, green after.
3. `npm run test:ui` — Observed result: 683 files / 6753 tests passed. `npm run check:lint` — Observed result: 0 errors (typecheck + eslint clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (JS-only change, desktop workspace; full `test:ui` suite run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (store-level logic, no platform surface touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Vitest output for the new test before/after the fix:

```
# before the fix (test-only worktree)
× keeps the unpin and retries when the write itself fails
AssertionError: expected [ 'stuck' ] to not include 'stuck'

# after the fix
✓ keeps the unpin and retries when the write itself fails
 Test Files  1 passed (1)   Tests  23 passed (23)
```
