### PR TITLE
fix(kanban): keep protocol breaker blocked

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4452,8 +4452,7 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` requires an explicit unblock.
 
     A ``blocked`` status can come from two very different sources:
 
@@ -4463,30 +4462,36 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       should stay blocked until an operator unblocks it.  The block tool
       emits a ``"blocked"`` event row in ``task_events``.
 
-    * **Circuit-breaker** — ``_record_task_failure`` tripped after
-      repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
+    * **Circuit-breaker** — ``_record_task_failure`` tripped after repeated
+      failures and emitted ``"gave_up"``. Ordinary failures can recover
+      automatically when conditions change, but a protocol-violation breaker
+      has already exhausted its separate retry budget and must stay blocked.
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
-
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    ``unblocked`` is the durable operator-approval barrier: only explicit
+    blocks or threshold-crossing protocol ``gave_up`` events after the latest
+    unblock are sticky. Other circuit-breaker and legacy blocked rows retain
+    the pre-#28712 auto-recovery behavior.
     """
-    row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
-        "ORDER BY id DESC LIMIT 1",
+    rows = conn.execute(
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked', 'gave_up') "
+        "ORDER BY id DESC",
         (task_id,),
-    ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    )
+    for row in rows:
+        if row["kind"] == "unblocked":
+            return False
+        if row["kind"] == "blocked":
+            return True
+        try:
+            payload = json.loads(row["payload"]) if row["payload"] else {}
+            violations = int(payload["protocol_violations"])
+            limit = int(payload["protocol_violation_limit"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if violations >= limit:
+            return True
+    return False
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
@@ -4531,9 +4536,8 @@ def recompute_ready(
     blocked purely by a parent dependency unblocks itself when the
     parent completes), *except* in two cases:
 
-    1. The most recent block event was a worker-initiated
-       ``kanban_block`` — those stay blocked until an explicit
-       ``kanban_unblock`` (#28712).
+    1. A worker-initiated ``kanban_block`` or an exhausted protocol-violation
+       breaker occurred after the latest explicit ``kanban_unblock``.
 
     2. The task's ``consecutive_failures`` has reached the effective
        failure limit.  This prevents infinite retry loops when a task
@@ -4562,10 +4566,9 @@ def recompute_ready(
             task_id = row["id"]
             cur_status = row["status"]
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for explicit human intervention — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
+                # Explicit handoffs and exhausted protocol-only retry budgets
+                # require operator approval. ``unblock_task`` emits the durable
+                # barrier that makes a later retry eligible again.
                 continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -176,6 +176,31 @@ def test_non_protocol_failures_keep_existing_retry_semantics(
         assert kb.claim_task(conn, retryable) is not None
 
 
+def test_ordinary_gave_up_recovers_when_failure_limit_increases(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ordinary breaker", assignee="worker")
+        assert kb.claim_task(conn, tid) is not None
+        assert kb._record_task_failure(
+            conn,
+            tid,
+            "temporary worker failure",
+            outcome="spawn_failed",
+            failure_limit=1,
+            release_claim=True,
+            end_run=True,
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        gave_up = next(e for e in kb.list_events(conn, tid) if e.kind == "gave_up")
+        assert {"protocol_violations", "protocol_violation_limit"}.isdisjoint(
+            gave_up.payload or {}
+        )
+        assert kb.recompute_ready(conn, failure_limit=2) == 1
+        assert kb.get_task(conn, tid).status == "ready"
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -13,10 +13,11 @@ These tests pin down:
 
 * Worker / operator-initiated blocks are sticky and survive
   ``recompute_ready``.
-* Circuit-breaker blocks (``gave_up`` event, status flipped via
-  ``_record_task_failure``) still auto-recover — the original intent
-  of #40c1decb3 is preserved.
-* An explicit ``kanban_unblock`` clears the sticky state.
+* Ordinary circuit-breaker blocks (``gave_up`` without protocol-breaker
+  metadata) still auto-recover — the original intent of #40c1decb3 is
+  preserved.
+* A protocol breaker that exhausts its violation-only budget stays blocked.
+* An explicit ``kanban_unblock`` clears either sticky state.
 * The full block → promote → crash → ``gave_up`` loop is broken after
   this fix: subsequent ticks leave the task blocked.
 
@@ -79,8 +80,100 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
 
 
 # ---------------------------------------------------------------------------
-# Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
+# Protocol-breaker blocks are sticky; ordinary failures keep retry semantics
 # ---------------------------------------------------------------------------
+
+
+def _drive_protocol_violation(
+    conn, task_id: str, pid: int, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reap one clean worker exit without a terminal kanban call."""
+    import hermes_cli.kanban_db as live_kb
+
+    host = live_kb._claimer_id().split(":", 1)[0]
+    claimed = live_kb.claim_task(conn, task_id, claimer=f"{host}:test")
+    assert claimed is not None
+    live_kb._set_worker_pid(conn, task_id, pid)
+    live_kb._record_worker_exit(pid, 0)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(live_kb, "_pid_alive", lambda _pid: False)
+    assert task_id in live_kb.detect_crashed_workers(conn)
+
+
+def test_protocol_breaker_stays_blocked_until_explicit_unblock(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three clean protocol exits trip a sticky breaker.
+
+    A later dispatcher tick must neither promote nor spawn the task.  An
+    explicit operator unblock is still allowed to start a fresh attempt.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="protocol breaker", assignee="worker")
+
+        for attempt in range(kb._PROTOCOL_VIOLATION_FAILURE_LIMIT):
+            _drive_protocol_violation(conn, tid, 81000 + attempt, monkeypatch)
+            expected = (
+                "blocked"
+                if attempt + 1 == kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+                else "ready"
+            )
+            assert kb.get_task(conn, tid).status == expected
+
+        gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
+        assert len(gave_up) == 1
+        assert (gave_up[0].payload or {})["protocol_violations"] == 3
+        assert (gave_up[0].payload or {})["protocol_violation_limit"] == 3
+
+        before_tick = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS id FROM task_events WHERE task_id = ?",
+            (tid,),
+        ).fetchone()["id"]
+        spawn_calls = []
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *args, **kwargs: spawn_calls.append((args, kwargs)),
+            reconcile_orphans=False,
+        )
+
+        assert result.promoted == 0
+        assert result.spawned == []
+        assert spawn_calls == []
+        tick_kinds = {
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? AND id > ?",
+                (tid, before_tick),
+            )
+        }
+        assert tick_kinds.isdisjoint({"promoted", "claimed", "spawned"})
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.claim_task(conn, tid, claimer="operator-approved-retry") is not None
+
+
+def test_non_protocol_failures_keep_existing_retry_semantics(
+    kanban_home: Path,
+) -> None:
+    """The protocol guard must not make unrelated transient failures sticky."""
+    with kb.connect() as conn:
+        retryable = kb.create_task(conn, title="transient", assignee="worker")
+        assert kb.claim_task(conn, retryable) is not None
+        assert not kb._record_task_failure(
+            conn,
+            retryable,
+            "temporary worker failure",
+            outcome="spawn_failed",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+        )
+        task = kb.get_task(conn, retryable)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+        assert kb.claim_task(conn, retryable) is not None
 
 
 


### PR DESCRIPTION
## Summary

- Keep protocol-breaker `gave_up` tasks blocked across recompute and dispatch ticks.
- Preserve explicit operator unblock as the approval boundary for retry.
- Preserve existing retry behavior for unrelated transient failures below the configured budget.

## Root cause

The protocol breaker trips after three clean worker exits without a terminal kanban action, while the general dispatcher failure limit defaults to five. Because the protocol path recorded `gave_up` with only one consecutive failure, `recompute_ready()` could immediately promote the task again.

The fix reuses the existing sticky-block event scan. A threshold-crossing protocol-breaker `gave_up` event is sticky until a newer explicit `unblocked` event appears. Ordinary `gave_up` events retain their existing failure-budget behavior.

## Validation

- Red proof on upstream source with the regression test added:
  - `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q`
  - `3 passed, 1 failed`; dispatch incorrectly reported `promoted == 1`
- Green focused proof:
  - `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q`
  - `4 passed`
- Adjacent kanban regression suite:
  - `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q`
  - `82 passed, 2 skipped` (platform-only skips on macOS)
- `.venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py`
  - `All checks passed!`
- `git diff --check`
  - passed

The full repository suite is not claimed as green: a macOS run encountered unrelated live-process, port-collision, and platform-assumption failures before being stopped. The focused and adjacent kanban suites above completed cleanly.

## Scope

- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_blocked_sticky.py`