### PR TITLE
fix(honcho): skip prewarm when resuming stored sessions

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -544,8 +544,16 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Query-aware base retrieval starts with the first substantive message.
         # Generic dialectic prewarm is incompatible with latest-message rewriting.
+        # Only a context load that positively identified an empty session may
+        # prewarm. Resumes, summary-only context, cache hits, and context-load
+        # failures all skip paid startup work until the first real user turn.
         if self._recall_mode in {"context", "hybrid"}:
-            if self._query_rewriter is None or not self._query_rewrite_enabled:
+            if not getattr(session, "metadata", {}).get("confirmed_new", False):
+                logger.debug(
+                    "Honcho dialectic prewarm skipped for session not confirmed new: %s",
+                    self._session_key,
+                )
+            elif self._query_rewriter is None or not self._query_rewrite_enabled:
                 _prewarm_query = (
                     "Summarize what you know about this user. "
                     "Focus on preferences, current projects, and working style."

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -370,17 +370,18 @@ class HonchoSessionManager:
 
     def _get_or_create_honcho_session(
         self, session_id: str, user_peer: Any, assistant_peer: Any
-    ) -> tuple[Any, list]:
+    ) -> tuple[Any, list | None]:
         """
         Get or create a Honcho session with peers configured.
 
         Returns:
-            Tuple of (honcho_session, existing_messages).
+            Tuple of (honcho_session, existing_messages). ``None`` means the
+            session was not positively identified as empty.
         """
         with self._cache_lock:
             if session_id in self._sessions_cache:
                 logger.debug("Honcho session '%s' retrieved from cache", session_id)
-                return self._sessions_cache[session_id], []
+                return self._sessions_cache[session_id], None
 
         self._authed_call("session setup", lambda: self._sdk_session(session_id))
 
@@ -446,7 +447,7 @@ class HonchoSessionManager:
             )
 
         # Load existing messages via context() - single call for messages + metadata
-        existing_messages = []
+        existing_messages = None
         if not auth_dead:
             try:
                 ctx = self._authed_call(
@@ -455,7 +456,9 @@ class HonchoSessionManager:
                         summary=True, tokens=self._context_tokens
                     ),
                 )
-                existing_messages = ctx.messages or []
+                context_messages = ctx.messages or []
+                if context_messages or not getattr(ctx, "summary", None):
+                    existing_messages = context_messages
 
                 # Verify chronological ordering
                 if existing_messages and len(existing_messages) > 1:
@@ -475,8 +478,10 @@ class HonchoSessionManager:
                         "Honcho session '%s' retrieved (%d existing messages)",
                         session_id, len(existing_messages),
                     )
-                else:
+                elif existing_messages == []:
                     logger.info("Honcho session '%s' created (new)", session_id)
+                else:
+                    logger.info("Honcho session '%s' retrieved (summary only)", session_id)
             except HonchoAuthError:
                 logger.warning(
                     "Honcho session '%s' loaded without server context: auth failed",
@@ -635,7 +640,7 @@ class HonchoSessionManager:
         )
 
         local_messages = []
-        for msg in existing_messages:
+        for msg in existing_messages or []:
             role = "assistant" if msg.peer_id == assistant_peer_id else "user"
             local_messages.append({
                 "role": role,
@@ -650,6 +655,7 @@ class HonchoSessionManager:
             assistant_peer_id=assistant_peer_id,
             honcho_session_id=honcho_session_id,
             messages=local_messages,
+            metadata={"confirmed_new": existing_messages == []},
         )
 
         # Write to cache under lock — only one writer wins

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
 import time
+import pytest
 
 from datetime import datetime
 from types import SimpleNamespace
@@ -107,6 +108,76 @@ class TestFormatMigrationTranscript:
 
 
 class TestManagerCacheOps:
+    @staticmethod
+    def _load_session_with_context(*, messages=None, summary="", context_error=None):
+        sdk_session = MagicMock()
+        sdk_session.get_peer_configuration.return_value = SimpleNamespace(
+            observe_me=None,
+            observe_others=None,
+        )
+        if context_error is not None:
+            sdk_session.context.side_effect = context_error
+        else:
+            sdk_session.context.return_value = SimpleNamespace(
+                messages=messages or [],
+                summary=summary,
+            )
+        manager = HonchoSessionManager()
+        manager._sdk_session = MagicMock(return_value=sdk_session)
+        manager._authed_call = MagicMock(side_effect=lambda _label, operation: operation())
+        return manager._get_or_create_honcho_session(
+            "stored-session",
+            MagicMock(),
+            MagicMock(),
+        )
+
+    @pytest.mark.parametrize(
+        ("messages", "summary", "context_error", "confirmed_new"),
+        [
+            ([], "", None, True),
+            ([], "Existing summary", None, False),
+            ([MagicMock()], "", None, False),
+            ([], "", RuntimeError("temporary failure"), False),
+        ],
+        ids=["empty", "summary-only", "messages", "context-failure"],
+    )
+    def test_only_successful_empty_context_is_confirmed_new(
+        self, messages, summary, context_error, confirmed_new
+    ):
+        _, loaded = self._load_session_with_context(
+            messages=messages,
+            summary=summary,
+            context_error=context_error,
+        )
+
+        assert (loaded == []) == confirmed_new
+
+    def test_get_or_create_exposes_confirmed_new_metadata(self):
+        manager = HonchoSessionManager()
+        manager._resolve_user_peer_id = MagicMock(return_value="user")
+        manager._get_or_create_peer = MagicMock()
+        manager._get_or_create_honcho_session = MagicMock(
+            return_value=(MagicMock(), [])
+        )
+
+        session = manager.get_or_create("test-session")
+
+        assert session.metadata["confirmed_new"] is True
+
+    def test_cached_sdk_session_is_not_confirmed_new(self):
+        manager = HonchoSessionManager()
+        cached = MagicMock()
+        manager._sessions_cache["stored-session"] = cached
+
+        session, messages = manager._get_or_create_honcho_session(
+            "stored-session",
+            MagicMock(),
+            MagicMock(),
+        )
+
+        assert session is cached
+        assert messages is None
+
     def test_delete_cached_session(self):
         mgr = HonchoSessionManager()
         session = HonchoSession(
@@ -921,7 +992,11 @@ class TestSessionStartDialecticPrewarm:
     consumed by turn 1 — no duplicate .chat() and no dead-cache orphaning."""
 
     @staticmethod
-    def _make_provider(cfg_extra=None, dialectic_result="prewarm synthesis"):
+    def _make_provider(
+        cfg_extra=None,
+        dialectic_result="prewarm synthesis",
+        confirmed_new=True,
+    ):
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
@@ -931,7 +1006,9 @@ class TestSessionStartDialecticPrewarm:
         cfg = HonchoClientConfig(**defaults)
         provider = HonchoMemoryProvider()
         mock_manager = MagicMock()
-        mock_manager.get_or_create.return_value = MagicMock(messages=[])
+        mock_manager.get_or_create.return_value = MagicMock(
+            metadata={"confirmed_new": confirmed_new},
+        )
         mock_manager.get_prefetch_context.return_value = None
         mock_manager.pop_context_result.return_value = None
         mock_manager.dialectic_query.return_value = dialectic_result
@@ -951,6 +1028,27 @@ class TestSessionStartDialecticPrewarm:
         with p._prefetch_lock:
             assert p._prefetch_result == "prewarm synthesis"
         assert p._last_dialectic_turn == 0
+
+    def test_unconfirmed_session_does_not_prewarm(self):
+        p = self._make_provider(confirmed_new=False)
+
+        assert getattr(p._manager, "dialectic_query").call_count == 0
+        assert p._prefetch_thread is None
+
+    def test_resumed_session_runs_dialectic_on_first_new_user_turn(self):
+        """Skipping resume-time prewarm must defer—not disable—normal dialectic work."""
+        p = self._make_provider(confirmed_new=False)
+        p._session_key = "test-resumed"
+        p._base_context_cache = ""
+        p._turn_count = 1
+
+        result = p.prefetch("what should we work on next?")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=3.0)
+            result = result or p._consume_pending_dialectic()
+
+        assert getattr(p._manager, "dialectic_query").call_count == 1
+        assert "prewarm synthesis" in result
 
 
     def test_turn1_consumes_prewarm_without_duplicate_dialectic(self):


### PR DESCRIPTION
## What does this PR do?

Prevents Honcho's startup dialectic prewarm from running unless session context was loaded successfully and confirmed empty.

A fresh Hermes runtime can reconnect to an existing Honcho session. Previously, every runtime initialization could launch paid dialectic work before a new user turn. Existing messages, summary-only context, SDK cache hits, and failed context loads now skip startup prewarm. The first substantive user turn still follows the normal dialectic path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve the existing session-loader API while distinguishing confirmed-empty context from unknown/resumed context.
- Prewarm only sessions explicitly marked `confirmed_new`.
- Cover empty, message-backed, summary-only, cached, and context-failure initialization, plus first-turn dialectic after a skipped prewarm.

## How to Test

```bash
python -m pytest tests/honcho_plugin \
  tests/test_honcho_startup_fail_open.py \
  tests/test_honcho_client_config.py \
  tests/test_honcho_session_context.py \
  tests/test_honcho_client_concurrency.py -q

ruff check plugins/memory/honcho/__init__.py \
  plugins/memory/honcho/session.py \
  tests/honcho_plugin/test_session.py
```

Local result: **372 passed**; Ruff passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS; self-hosted Honcho

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public behavior or configuration added
- [x] `cli-config.yaml.example` — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; provider lifecycle code is shared across surfaces
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — behavior is covered by regression tests.
