### PR TITLE
feat(kanban): consolidate browser task deep links and history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19601,6 +19601,7 @@
         "@vitejs/plugin-react": "6.0.3",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint-plugin-react-refresh": "0.5.3",
+        "jsdom": "29.1.1",
         "three": "0.180.0",
         "typescript": "6.0.3",
         "vite": "8.2.0",

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -328,6 +328,47 @@
     } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
   }
 
+  function buildKanbanTaskUrl(board, taskId) {
+    const url = new URL(window.location.href);
+    if (board) url.searchParams.set("board", board);
+    else url.searchParams.delete("board");
+    url.searchParams.delete("task_id");
+    if (taskId) url.searchParams.set("task", taskId);
+    else url.searchParams.delete("task");
+    return url;
+  }
+
+  function copyTextWithTextarea(text) {
+    const el = document.createElement("textarea");
+    el.value = text;
+    el.setAttribute("readonly", "readonly");
+    el.style.position = "fixed";
+    el.style.left = "-9999px";
+    document.body.appendChild(el);
+    el.select();
+    try {
+      if (typeof document.execCommand !== "function") {
+        throw new Error("Copy command is not available");
+      }
+      const copied = document.execCommand("copy");
+      if (!copied) throw new Error("Copy command was not accepted");
+    } catch (e) {
+      return Promise.reject(e);
+    } finally {
+      document.body.removeChild(el);
+    }
+    return Promise.resolve();
+  }
+
+  function copyTextToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text).catch(function () {
+        return copyTextWithTextarea(text);
+      });
+    }
+    return copyTextWithTextarea(text);
+  }
+
   function withBoard(url, board) {
     // Always append ?board=<slug> when we have one picked — including
     // "default". Omitting the param would fall through to the backend's
@@ -3539,6 +3580,7 @@
     const [homeChannels, setHomeChannels] = useState([]);
     const [homeBusy, setHomeBusy] = useState({});
     const boardSlug = props.boardSlug;
+    const [linkCopied, setLinkCopied] = useState(false);
 
     const load = useCallback(function () {
       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug))
@@ -3565,6 +3607,16 @@
       window.addEventListener("keydown", onKey);
       return function () { window.removeEventListener("keydown", onKey); };
     }, [props.onClose, editing]);
+
+    const handleCopyLink = function () {
+      const link = buildKanbanTaskUrl(boardSlug, props.taskId).toString();
+      copyTextToClipboard(link)
+        .then(function () {
+          setLinkCopied(true);
+          setTimeout(function () { setLinkCopied(false); }, 1800);
+        })
+        .catch(function (e) { setErr(String(e.message || e)); });
+    };
 
     const handleComment = function () {
       const body = newComment.trim();
@@ -3804,12 +3856,20 @@
       },
         h("div", { className: "hermes-kanban-drawer-head" },
           h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
-          h("button", {
-            type: "button",
-            onClick: props.onClose,
-            className: "hermes-kanban-drawer-close",
-            title: tx(t, "close", "Close (Esc)"),
-          }, "×"),
+          h("div", { className: "hermes-kanban-drawer-actions" },
+            h("button", {
+              type: "button",
+              onClick: handleCopyLink,
+              className: "hermes-kanban-drawer-linkcopy",
+              title: tx(t, "copyTaskLink", "Copy link to this task"),
+            }, linkCopied ? tx(t, "copied", "Copied") : tx(t, "copyLink", "Copy link")),
+            h("button", {
+              type: "button",
+              onClick: props.onClose,
+              className: "hermes-kanban-drawer-close",
+              title: tx(t, "close", "Close (Esc)"),
+            }, "×"),
+          ),
         ),
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -22,6 +22,7 @@
     Badge, Button, Input, Label, Select, SelectOption,
   } = SDK.components;
   const { useState, useEffect, useCallback, useMemo, useRef } = SDK.hooks;
+  const useHostNavigate = SDK.hooks.useNavigate;
   const { cn, timeAgo } = SDK.utils;
 
   // Newer host dashboards expose a DS-styled Checkbox on the plugin SDK.
@@ -324,19 +325,33 @@
     return `${url.pathname}${params.toString() ? `?${params}` : ""}${url.hash}`;
   }
 
-  function replaceKanbanUrl(board, taskId) {
+  function hostRouterLocation(location) {
+    const basePath = String(SDK.basePath || "").replace(/\/+$/, "");
+    if (!basePath) return location;
+    if (location === basePath) return "/";
+    if (location.indexOf(`${basePath}/`) === 0) return location.slice(basePath.length);
+    return location;
+  }
+
+  function replaceKanbanUrl(navigate, board, taskId) {
     try {
       const next = buildKanbanLocation(board, taskId);
       const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      if (next !== current) window.history.replaceState(window.history.state, "", next);
+      if (next !== current) {
+        if (navigate) navigate(hostRouterLocation(next), { replace: true });
+        else window.history.replaceState(null, "", next);
+      }
     } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
   }
 
-  function pushKanbanUrl(board, taskId) {
+  function pushKanbanUrl(navigate, board, taskId) {
     try {
       const next = buildKanbanLocation(board, taskId);
       const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      if (next !== current) window.history.pushState(window.history.state, "", next);
+      if (next !== current) {
+        if (navigate) navigate(hostRouterLocation(next));
+        else window.history.pushState(null, "", next);
+      }
     } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
   }
 
@@ -683,13 +698,18 @@
 
   function KanbanPage() {
     const { t } = useI18n();
+    // Static feature detection keeps older dashboard hosts compatible while
+    // production hosts route every write through BrowserRouter.
+    const hostNavigate = useHostNavigate ? useHostNavigate() : null;
     const kanbanDialogs = useKanbanDialogs(t);
     const initialUrlSelectionRef = useRef(null);
     if (initialUrlSelectionRef.current === null) {
       initialUrlSelectionRef.current = readKanbanUrlSelection();
     }
     const [board, setBoard] = useState(() =>
-      initialUrlSelectionRef.current.board || readSelectedBoard() || null);
+      initialUrlSelectionRef.current.board
+        || (initialUrlSelectionRef.current.task ? null : readSelectedBoard())
+        || null);
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
     const [showBoardSettings, setShowBoardSettings] = useState(false);
@@ -744,6 +764,7 @@
     const navigationGenerationRef = useRef(0);
     const locatorRequestGenerationRef = useRef(0);
     const detailRequestGenerationRef = useRef(0);
+    const taskLookupRequestRef = useRef(null);
     const navigationSourceRef = useRef("initial");
     // Increment for both committed selections and synchronous transitions.
     // The request generation prevents A -> B -> A from accepting the first
@@ -763,8 +784,8 @@
       setPendingTaskIsBoardQualified(false);
       setDeepLinkNotice(null);
       setSelectedTaskId(taskId);
-      pushKanbanUrl(board, taskId);
-    }, [board]);
+      pushKanbanUrl(hostNavigate, board, taskId);
+    }, [board, hostNavigate]);
 
     const closeTask = useCallback(function () {
       navigationGenerationRef.current += 1;
@@ -774,8 +795,8 @@
       setPendingTaskIsBoardQualified(false);
       setDeepLinkNotice(null);
       setSelectedTaskId(null);
-      pushKanbanUrl(board, null);
-    }, [board]);
+      pushKanbanUrl(hostNavigate, board, null);
+    }, [board, hostNavigate]);
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -846,7 +867,13 @@
             boardRequestGenerationRef.current += 1;
             setBoard(resolvedBoard);
             writeSelectedBoard(resolvedBoard);
-            if (navigationSourceRef.current !== "pop") replaceKanbanUrl(resolvedBoard, null);
+            // An unqualified task is authoritative until its global lookup
+            // settles. Do not let a stored/current-board bootstrap turn it
+            // into a board-qualified link or discard it in the interim.
+            if (navigationSourceRef.current !== "pop"
+                && !pendingTaskId && !selectedTaskId) {
+              replaceKanbanUrl(hostNavigate, resolvedBoard, null);
+            }
             return;
           }
           if (!boards.some(function (item) { return item.slug === requestedBoard; })) {
@@ -863,20 +890,22 @@
             currentBoardRef.current = fallbackBoard;
             boardRequestGenerationRef.current += 1;
             setBoard(fallbackBoard);
-            replaceKanbanUrl(fallbackBoard, null);
+            if (navigationSourceRef.current !== "pop") {
+              replaceKanbanUrl(hostNavigate, fallbackBoard, null);
+            }
             return;
           }
           writeSelectedBoard(requestedBoard);
           if (initialUrlSelectionRef.current.legacyTask
               && navigationSourceRef.current !== "pop") {
-            replaceKanbanUrl(requestedBoard, pendingTaskId || selectedTaskId);
+            replaceKanbanUrl(hostNavigate, requestedBoard, pendingTaskId || selectedTaskId);
           } else if (!pendingTaskId && !selectedTaskId
               && navigationSourceRef.current !== "pop") {
-            replaceKanbanUrl(requestedBoard, null);
+            replaceKanbanUrl(hostNavigate, requestedBoard, null);
           }
         })
         .catch(function () { /* non-fatal */ });
-    }, [board, pendingTaskId, selectedTaskId]);
+    }, [board, pendingTaskId, selectedTaskId, hostNavigate]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
 
@@ -947,8 +976,10 @@
       };
     }, [loadBoard]);
 
-    // Resolve against the selected board first. Only a miss uses the global
-    // locator, whose ambiguity response prevents opening an arbitrary match.
+    // Board-qualified links may use visible board data directly. Task-only
+    // links always use the global locator so duplicate ids stay ambiguous.
+    // The request is keyed to navigation identity and shared across board-data
+    // refreshes; WebSocket reloads must never fan out an all-board scan.
     useEffect(function () {
       const requestedTaskId = pendingTaskId;
       if (!requestedTaskId || !boardData || !board) return undefined;
@@ -967,16 +998,44 @@
       };
       if (task && pendingTaskIsBoardQualified) {
         setPendingTaskId(null);
+        setPendingTaskIsBoardQualified(false);
+        if (task.status === "archived") {
+          setSelectedTaskId(null);
+          setDeepLinkNotice(`Card ${requestedTaskId} is archived.`);
+          if (navigationSourceRef.current !== "pop") {
+            replaceKanbanUrl(hostNavigate, requestedBoard, null);
+          }
+          return undefined;
+        }
         setSelectedTaskId(task.id);
         setDeepLinkNotice(null);
-        if (navigationSourceRef.current !== "pop") replaceKanbanUrl(requestedBoard, task.id);
+        if (navigationSourceRef.current !== "pop") {
+          replaceKanbanUrl(hostNavigate, requestedBoard, task.id);
+        }
         return undefined;
       }
 
       const lookupUrl = pendingTaskIsBoardQualified
         ? withBoard(`${API}/tasks/${encodeURIComponent(requestedTaskId)}`, requestedBoard)
         : `${API}/tasks/locate/${encodeURIComponent(requestedTaskId)}`;
-      SDK.fetchJSON(lookupUrl)
+      const lookupKey = [
+        navigationGeneration,
+        requestedBoard,
+        requestedTaskId,
+        pendingTaskIsBoardQualified ? "qualified" : "global",
+      ].join(":");
+      let lookupRequest = taskLookupRequestRef.current;
+      if (!lookupRequest || lookupRequest.key !== lookupKey) {
+        lookupRequest = { key: lookupKey, promise: SDK.fetchJSON(lookupUrl) };
+        taskLookupRequestRef.current = lookupRequest;
+        const clearRequest = function () {
+          if (taskLookupRequestRef.current === lookupRequest) {
+            taskLookupRequestRef.current = null;
+          }
+        };
+        lookupRequest.promise.then(clearRequest, clearRequest);
+      }
+      lookupRequest.promise
         .then(function (result) {
           if (!isCurrent()) return;
           const targetBoard = pendingTaskIsBoardQualified ? requestedBoard : (result && result.board);
@@ -991,9 +1050,11 @@
             setPendingTaskId(null);
             setPendingTaskIsBoardQualified(false);
             setSelectedTaskId(requestedTaskId);
-            setDeepLinkNotice(`Card ${requestedTaskId} is outside the current filters.`);
+            setDeepLinkNotice(task
+              ? null
+              : `Card ${requestedTaskId} is outside the current filters.`);
             if (navigationSourceRef.current !== "pop") {
-              replaceKanbanUrl(requestedBoard, requestedTaskId);
+              replaceKanbanUrl(hostNavigate, requestedBoard, requestedTaskId);
             }
             return;
           }
@@ -1004,6 +1065,10 @@
           boardRequestGenerationRef.current += 1;
           setBoard(targetBoard);
           writeSelectedBoard(targetBoard);
+          // Reuse the successful global locator. Once the target board loads,
+          // visible data or the board-qualified detail endpoint completes the
+          // open without another global request.
+          setPendingTaskIsBoardQualified(true);
           setSelectedTaskId(null);
           setDeepLinkNotice(null);
           setSearch("");
@@ -1013,19 +1078,30 @@
         })
         .catch(function (err) {
           if (!isCurrent()) return;
-          setPendingTaskId(null);
-          setPendingTaskIsBoardQualified(false);
           setSelectedTaskId(null);
           const message = String(err && err.message ? err.message : err);
-          setDeepLinkNotice(message.includes("ambiguous")
+          const isAmbiguous = message.includes("409:") || message.includes("ambiguous");
+          const isArchived = message.includes("is archived");
+          const isMissing = message.includes("404:") || message.includes("task not found");
+          if (!isAmbiguous && !isArchived && !isMissing) {
+            setDeepLinkNotice(
+              `Could not load card ${requestedTaskId}. The link was kept; retry by refreshing.`,
+            );
+            return;
+          }
+          setPendingTaskId(null);
+          setPendingTaskIsBoardQualified(false);
+          setDeepLinkNotice(isAmbiguous
             ? `Card ${requestedTaskId} is ambiguous across active boards.`
-            : message.includes("is archived")
+            : isArchived
               ? `Card ${requestedTaskId} is archived.`
               : `Card ${requestedTaskId} was not found or is archived.`);
-          replaceKanbanUrl(requestedBoard, null);
+          if (navigationSourceRef.current !== "pop") {
+            replaceKanbanUrl(hostNavigate, requestedBoard, null);
+          }
         });
       return function () { cancelled = true; };
-    }, [board, boardData, pendingTaskId, pendingTaskIsBoardQualified]);
+    }, [board, boardData, pendingTaskId, pendingTaskIsBoardQualified, hostNavigate]);
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
@@ -1463,14 +1539,14 @@
       setPendingTaskIsBoardQualified(false);
       setSelectedTaskId(null);
       setDeepLinkNotice(null);
-      pushKanbanUrl(nextSlug, null);
+      pushKanbanUrl(hostNavigate, nextSlug, null);
       // Reset filters so stale search/tenant/assignee don't persist across boards.
       setSearch("");
       setTenantFilter("");
       setAssigneeFilter("");
       setIncludeArchived(false);
       clearSelected();
-    }, [board, clearSelected]);
+    }, [board, clearSelected, hostNavigate]);
 
     const createNewBoard = useCallback(function (payload) {
       return SDK.fetchJSON(`${API}/boards`, {

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -301,40 +301,53 @@
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
-  // A task drawer is shareable as /kanban?board=<slug>&task=<id>.  Keep
-  // localStorage as the fallback for ordinary visits, but let an explicit URL
-  // win so links are stable across browsers and dashboard sessions.
+  // A task drawer is shareable as /kanban?board=<slug>&task=<id>. Task-only
+  // and task_id links remain accepted as input and are normalized after resolve.
   function readKanbanUrlSelection() {
     try {
       const params = new URLSearchParams(window.location.search);
       const board = (params.get("board") || "").trim() || null;
-      const task = (params.get("task") || "").trim() || null;
-      return { board: board, task: task };
-    } catch (_e) { return { board: null, task: null }; }
+      const canonicalTask = (params.get("task") || "").trim() || null;
+      const legacyTask = (params.get("task_id") || "").trim() || null;
+      return { board: board, task: canonicalTask || legacyTask, legacyTask: !!legacyTask };
+    } catch (_e) { return { board: null, task: null, legacyTask: false }; }
+  }
+
+  function buildKanbanLocation(board, taskId) {
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    params.delete("board");
+    params.delete("task");
+    params.delete("task_id");
+    if (board) params.append("board", board);
+    if (taskId) params.append("task", taskId);
+    return `${url.pathname}${params.toString() ? `?${params}` : ""}${url.hash}`;
   }
 
   function replaceKanbanUrl(board, taskId) {
     try {
-      const url = new URL(window.location.href);
-      const params = url.searchParams;
-      // The default board is intentionally implicit in the public URL.
-      if (board && board !== "default") params.set("board", board);
-      else params.delete("board");
-      if (taskId) params.set("task", taskId);
-      else params.delete("task");
-      const next = `${url.pathname}${params.toString() ? `?${params}` : ""}${url.hash}`;
+      const next = buildKanbanLocation(board, taskId);
       const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
       if (next !== current) window.history.replaceState(window.history.state, "", next);
     } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
   }
 
+  function pushKanbanUrl(board, taskId) {
+    try {
+      const next = buildKanbanLocation(board, taskId);
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (next !== current) window.history.pushState(window.history.state, "", next);
+    } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
+  }
+
   function buildKanbanTaskUrl(board, taskId) {
     const url = new URL(window.location.href);
-    if (board) url.searchParams.set("board", board);
-    else url.searchParams.delete("board");
-    url.searchParams.delete("task_id");
-    if (taskId) url.searchParams.set("task", taskId);
-    else url.searchParams.delete("task");
+    const profile = url.searchParams.get("profile");
+    url.search = "";
+    if (profile) url.searchParams.append("profile", profile);
+    if (board) url.searchParams.append("board", board);
+    url.searchParams.append("task", taskId);
+    url.hash = "";
     return url;
   }
 
@@ -675,13 +688,8 @@
     if (initialUrlSelectionRef.current === null) {
       initialUrlSelectionRef.current = readKanbanUrlSelection();
     }
-    const initialTaskRef = useRef(initialUrlSelectionRef.current.task);
-    const initialTaskResolvedRef = useRef(!initialUrlSelectionRef.current.task);
     const [board, setBoard] = useState(() =>
-      initialUrlSelectionRef.current.board
-      // `task` without `board` is the compact deep-link form for default;
-      // it must not inherit a different board from this browser's storage.
-      || (initialUrlSelectionRef.current.task ? "default" : readSelectedBoard() || null));
+      initialUrlSelectionRef.current.board || readSelectedBoard() || null);
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
     const [showBoardSettings, setShowBoardSettings] = useState(false);
@@ -706,10 +714,11 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
-    const [deepLinkTaskId] = useState(function () {
-      return initialUrlSelectionRef.current.task || "";
-    });
     const [deepLinkNotice, setDeepLinkNotice] = useState(null);
+    const [pendingTaskId, setPendingTaskId] = useState(initialUrlSelectionRef.current.task);
+    const [pendingTaskIsBoardQualified, setPendingTaskIsBoardQualified] = useState(
+      !!initialUrlSelectionRef.current.board,
+    );
     const [selectedTaskId, setSelectedTaskId] = useState(null);
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
@@ -732,23 +741,40 @@
     // selected slug separately so a response for a board we have since left
     // cannot repaint the grid after a fallback or board switch.
     const currentBoardRef = useRef(board);
+    const navigationGenerationRef = useRef(0);
+    const locatorRequestGenerationRef = useRef(0);
+    const detailRequestGenerationRef = useRef(0);
+    const navigationSourceRef = useRef("initial");
     // Increment for both committed selections and synchronous transitions.
     // The request generation prevents A -> B -> A from accepting the first
     // A response after the newer A request has started.
     const boardRequestGenerationRef = useRef(0);
+    const boardListRequestGenerationRef = useRef(0);
     useEffect(function () {
       currentBoardRef.current = board;
       boardRequestGenerationRef.current += 1;
     }, [board]);
 
     const openTask = useCallback(function (taskId) {
+      navigationGenerationRef.current += 1;
+      detailRequestGenerationRef.current += 1;
+      navigationSourceRef.current = "user";
+      setPendingTaskId(null);
+      setPendingTaskIsBoardQualified(false);
+      setDeepLinkNotice(null);
       setSelectedTaskId(taskId);
-      replaceKanbanUrl(board, taskId);
+      pushKanbanUrl(board, taskId);
     }, [board]);
 
     const closeTask = useCallback(function () {
+      navigationGenerationRef.current += 1;
+      detailRequestGenerationRef.current += 1;
+      navigationSourceRef.current = "user";
+      setPendingTaskId(null);
+      setPendingTaskIsBoardQualified(false);
+      setDeepLinkNotice(null);
       setSelectedTaskId(null);
-      replaceKanbanUrl(board, null);
+      pushKanbanUrl(board, null);
     }, [board]);
 
     // --- load config once ---------------------------------------------------
@@ -769,6 +795,7 @@
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
       const requestedBoard = board;
+      if (!requestedBoard) return Promise.resolve();
       const requestGeneration = ++boardRequestGenerationRef.current;
       const isCurrentRequest = function () {
         return currentBoardRef.current === requestedBoard
@@ -797,72 +824,110 @@
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
       const requestedBoard = board;
-      return SDK.fetchJSON(withBoard(`${API}/boards`, requestedBoard))
+      const requestGeneration = ++boardListRequestGenerationRef.current;
+      const navigationGeneration = navigationGenerationRef.current;
+      return SDK.fetchJSON(`${API}/boards`)
         .then(function (data) {
-          if (currentBoardRef.current !== requestedBoard) return;
+          if (boardListRequestGenerationRef.current !== requestGeneration
+              || navigationGenerationRef.current !== navigationGeneration
+              || currentBoardRef.current !== requestedBoard) return;
           const boards = (data && data.boards) || [];
           const storedBoard = readSelectedBoard();
           setBoardList(boards);
-          if (!storedBoard && !board && data && data.current) {
-            currentBoardRef.current = data.current;
+          if (!requestedBoard) {
+            const storedIsActive = storedBoard && boards.some(function (item) {
+              return item.slug === storedBoard;
+            });
+            const currentIsActive = data && data.current && boards.some(function (item) {
+              return item.slug === data.current;
+            });
+            const resolvedBoard = storedIsActive ? storedBoard : (currentIsActive ? data.current : "default");
+            currentBoardRef.current = resolvedBoard;
             boardRequestGenerationRef.current += 1;
-            setBoard(data.current);
+            setBoard(resolvedBoard);
+            writeSelectedBoard(resolvedBoard);
+            if (navigationSourceRef.current !== "pop") replaceKanbanUrl(resolvedBoard, null);
             return;
           }
-          // If the stored slug isn't in the list any longer (board was
-          // deleted in the CLI while dashboard was open), fall back to
-          // default so the UI doesn't hang on a 404.
-          if (board && board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
-            // Do not leave a stale task id paired with the fallback board.
-            initialTaskRef.current = null;
-            initialTaskResolvedRef.current = true;
+          if (!boards.some(function (item) { return item.slug === requestedBoard; })) {
+            const fallbackBoard = (storedBoard && boards.some(function (item) {
+              return item.slug === storedBoard;
+            })) ? storedBoard : "default";
+            navigationGenerationRef.current += 1;
+            setPendingTaskId(null);
+            setPendingTaskIsBoardQualified(false);
             setSelectedTaskId(null);
+            setDeepLinkNotice(`Board ${requestedBoard} was not found or is archived. Showing ${fallbackBoard}.`);
             setBoardData(null);
             setLoading(true);
-            // An explicit URL is a one-off navigation, not a preference.
-            // Keep an existing local choice intact when that URL is invalid.
-            const fallbackBoard = initialUrlSelectionRef.current.board
-              ? (boards.find(function (b) { return b.slug === storedBoard; }) || {}).slug || "default"
-              : "default";
             currentBoardRef.current = fallbackBoard;
             boardRequestGenerationRef.current += 1;
             setBoard(fallbackBoard);
-            if (!initialUrlSelectionRef.current.board) writeSelectedBoard(fallbackBoard);
+            replaceKanbanUrl(fallbackBoard, null);
+            return;
+          }
+          writeSelectedBoard(requestedBoard);
+          if (initialUrlSelectionRef.current.legacyTask
+              && navigationSourceRef.current !== "pop") {
+            replaceKanbanUrl(requestedBoard, pendingTaskId || selectedTaskId);
+          } else if (!pendingTaskId && !selectedTaskId
+              && navigationSourceRef.current !== "pop") {
+            replaceKanbanUrl(requestedBoard, null);
           }
         })
         .catch(function () { /* non-fatal */ });
-    }, [board]);
+    }, [board, pendingTaskId, selectedTaskId]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
 
-    // Resolve /kanban?task=<id> without requiring callers to know the board.
-    // The auth gate preserves the full path+query in its `next` parameter, so
-    // this runs unchanged after an OAuth/password round trip.
+    function applyHistoryBoard(targetBoard, targetTask, taskIsBoardQualified, navigationGeneration) {
+      if (navigationGenerationRef.current !== navigationGeneration) return;
+      if (targetBoard !== currentBoardRef.current) {
+        setBoardData(null);
+        cursorRef.current = 0;
+        setLoading(true);
+        setSearch("");
+        setTenantFilter("");
+        setAssigneeFilter("");
+        setIncludeArchived(false);
+      }
+      currentBoardRef.current = targetBoard;
+      boardRequestGenerationRef.current += 1;
+      setBoard(targetBoard);
+      setPendingTaskId(targetTask || null);
+      setPendingTaskIsBoardQualified(!!taskIsBoardQualified);
+    }
+
+    // History entries can be created outside this plugin. Back/Forward should
+    // re-read them without creating or rewriting another history entry.
     useEffect(function () {
-      if (!deepLinkTaskId) return;
-      SDK.fetchJSON(`${API}/tasks/locate/${encodeURIComponent(deepLinkTaskId)}`)
-        .then(function (result) {
-          const targetBoard = result && result.board;
-          const targetTask = result && result.task && result.task.id;
-          if (!targetBoard || !targetTask) throw new Error("invalid task lookup response");
-          if (targetBoard !== board) {
-            setBoardData(null);
-            cursorRef.current = 0;
-            setLoading(true);
-            setBoard(targetBoard);
-            writeSelectedBoard(targetBoard);
-            setSearch("");
-            setTenantFilter("");
-            setAssigneeFilter("");
-            setIncludeArchived(false);
-          }
-          openTask(targetTask);
-        })
-        .catch(function () {
-          setDeepLinkNotice(`Card ${deepLinkTaskId} was not found or is archived.`);
-          replaceKanbanUrl(board, null);
-        });
-    }, []);  // deep-link input is immutable for this page load
+      function onPopState() {
+        const selection = readKanbanUrlSelection();
+        const navigationGeneration = ++navigationGenerationRef.current;
+        locatorRequestGenerationRef.current += 1;
+        detailRequestGenerationRef.current += 1;
+        navigationSourceRef.current = "pop";
+        setPendingTaskId(null);
+        setSelectedTaskId(null);
+        setDeepLinkNotice(null);
+        if (selection.board) {
+          applyHistoryBoard(selection.board, selection.task, true, navigationGeneration);
+          return;
+        }
+        if (!selection.task) {
+          applyHistoryBoard(readSelectedBoard() || "default", null, false, navigationGeneration);
+          return;
+        }
+        applyHistoryBoard(
+          currentBoardRef.current || readSelectedBoard() || "default",
+          selection.task,
+          false,
+          navigationGeneration,
+        );
+      }
+      window.addEventListener("popstate", onPopState);
+      return function () { window.removeEventListener("popstate", onPopState); };
+    }, []);
 
     const scheduleReload = useCallback(function () {
       if (reloadTimerRef.current) return;
@@ -882,40 +947,85 @@
       };
     }, [loadBoard]);
 
-    // Resolve a deep-linked task only after the board data is available.  The
-    // board payload intentionally omits archived cards, so validate a missing
-    // card through the authenticated detail endpoint before clearing it.
+    // Resolve against the selected board first. Only a miss uses the global
+    // locator, whose ambiguity response prevents opening an arbitrary match.
     useEffect(function () {
-      const initialTaskId = initialTaskRef.current;
-      if (!initialTaskId || !boardData) return;
+      const requestedTaskId = pendingTaskId;
+      if (!requestedTaskId || !boardData || !board) return undefined;
       const task = boardData.columns.reduce(function (found, column) {
-        return found || column.tasks.find(function (item) { return item.id === initialTaskId; });
+        return found || column.tasks.find(function (item) { return item.id === requestedTaskId; });
       }, null);
       const requestedBoard = board;
+      const navigationGeneration = navigationGenerationRef.current;
+      const requestGeneration = ++detailRequestGenerationRef.current;
       let cancelled = false;
-      const resolve = function (resolvedTaskId) {
-        if (cancelled || currentBoardRef.current !== requestedBoard || initialTaskRef.current !== initialTaskId) return;
-        initialTaskRef.current = null;
-        initialTaskResolvedRef.current = true;
-        setSelectedTaskId(resolvedTaskId);
-        replaceKanbanUrl(requestedBoard, resolvedTaskId);
+      const isCurrent = function () {
+        return !cancelled
+          && detailRequestGenerationRef.current === requestGeneration
+          && navigationGenerationRef.current === navigationGeneration
+          && currentBoardRef.current === requestedBoard;
       };
-      if (task) {
-        resolve(task.id);
-        return;
+      if (task && pendingTaskIsBoardQualified) {
+        setPendingTaskId(null);
+        setSelectedTaskId(task.id);
+        setDeepLinkNotice(null);
+        if (navigationSourceRef.current !== "pop") replaceKanbanUrl(requestedBoard, task.id);
+        return undefined;
       }
-      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(initialTaskId)}`, requestedBoard))
-        .then(function (data) { resolve(data && data.task ? initialTaskId : null); })
-        .catch(function () { resolve(null); });
-      return function () { cancelled = true; };
-    }, [board, boardData]);
 
-    // Board-only links and normal board changes are canonicalized too.  Wait
-    // for an initial task link to be validated so this never drops `task`
-    // before the first board response arrives.
-    useEffect(function () {
-      if (initialTaskResolvedRef.current) replaceKanbanUrl(board, selectedTaskId);
-    }, [board, selectedTaskId]);
+      const lookupUrl = pendingTaskIsBoardQualified
+        ? withBoard(`${API}/tasks/${encodeURIComponent(requestedTaskId)}`, requestedBoard)
+        : `${API}/tasks/locate/${encodeURIComponent(requestedTaskId)}`;
+      SDK.fetchJSON(lookupUrl)
+        .then(function (result) {
+          if (!isCurrent()) return;
+          const targetBoard = pendingTaskIsBoardQualified ? requestedBoard : (result && result.board);
+          const targetTask = result && result.task && result.task.id;
+          if (!targetBoard || targetTask !== requestedTaskId) {
+            throw new Error("invalid task lookup response");
+          }
+          if (targetBoard === requestedBoard) {
+            if (result.task.status === "archived") {
+              throw new Error(`Card ${requestedTaskId} is archived.`);
+            }
+            setPendingTaskId(null);
+            setPendingTaskIsBoardQualified(false);
+            setSelectedTaskId(requestedTaskId);
+            setDeepLinkNotice(`Card ${requestedTaskId} is outside the current filters.`);
+            if (navigationSourceRef.current !== "pop") {
+              replaceKanbanUrl(requestedBoard, requestedTaskId);
+            }
+            return;
+          }
+          setBoardData(null);
+          cursorRef.current = 0;
+          setLoading(true);
+          currentBoardRef.current = targetBoard;
+          boardRequestGenerationRef.current += 1;
+          setBoard(targetBoard);
+          writeSelectedBoard(targetBoard);
+          setSelectedTaskId(null);
+          setDeepLinkNotice(null);
+          setSearch("");
+          setTenantFilter("");
+          setAssigneeFilter("");
+          setIncludeArchived(false);
+        })
+        .catch(function (err) {
+          if (!isCurrent()) return;
+          setPendingTaskId(null);
+          setPendingTaskIsBoardQualified(false);
+          setSelectedTaskId(null);
+          const message = String(err && err.message ? err.message : err);
+          setDeepLinkNotice(message.includes("ambiguous")
+            ? `Card ${requestedTaskId} is ambiguous across active boards.`
+            : message.includes("is archived")
+              ? `Card ${requestedTaskId} is archived.`
+              : `Card ${requestedTaskId} was not found or is archived.`);
+          replaceKanbanUrl(requestedBoard, null);
+        });
+      return function () { cancelled = true; };
+    }, [board, boardData, pendingTaskId, pendingTaskIsBoardQualified]);
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
@@ -1335,6 +1445,10 @@
     // --- board switching ----------------------------------------------------
     const switchBoard = useCallback(function (nextSlug) {
       if (!nextSlug || nextSlug === board) return;
+      navigationGenerationRef.current += 1;
+      locatorRequestGenerationRef.current += 1;
+      detailRequestGenerationRef.current += 1;
+      navigationSourceRef.current = "user";
       // Optimistic UI: clear the current grid + show loading, reset the
       // event cursor so the WS reopens aligned to the new board's
       // latest_event_id on the next loadBoard.
@@ -1345,8 +1459,11 @@
       boardRequestGenerationRef.current += 1;
       setBoard(nextSlug);
       writeSelectedBoard(nextSlug);
+      setPendingTaskId(null);
+      setPendingTaskIsBoardQualified(false);
       setSelectedTaskId(null);
-      replaceKanbanUrl(nextSlug, null);
+      setDeepLinkNotice(null);
+      pushKanbanUrl(nextSlug, null);
       // Reset filters so stale search/tenant/assignee don't persist across boards.
       setSearch("");
       setTenantFilter("");
@@ -1536,6 +1653,7 @@
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
+          key: `${board}:${selectedTaskId}`,
           taskId: selectedTaskId,
           boardSlug: board,
           onClose: closeTask,
@@ -3933,7 +4051,6 @@
           uploadBusy: uploadBusy,
           uploadErr: uploadErr,
           onOpenTask: function (taskId) {
-            props.onClose();
             if (props.onOpenTask) props.onOpenTask(taskId);
           },
                     requestDialog: props.requestDialog,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -706,6 +706,10 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
+    const [deepLinkTaskId] = useState(function () {
+      return initialUrlSelectionRef.current.task || "";
+    });
+    const [deepLinkNotice, setDeepLinkNotice] = useState(null);
     const [selectedTaskId, setSelectedTaskId] = useState(null);
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
@@ -830,6 +834,35 @@
     }, [board]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
+
+    // Resolve /kanban?task=<id> without requiring callers to know the board.
+    // The auth gate preserves the full path+query in its `next` parameter, so
+    // this runs unchanged after an OAuth/password round trip.
+    useEffect(function () {
+      if (!deepLinkTaskId) return;
+      SDK.fetchJSON(`${API}/tasks/locate/${encodeURIComponent(deepLinkTaskId)}`)
+        .then(function (result) {
+          const targetBoard = result && result.board;
+          const targetTask = result && result.task && result.task.id;
+          if (!targetBoard || !targetTask) throw new Error("invalid task lookup response");
+          if (targetBoard !== board) {
+            setBoardData(null);
+            cursorRef.current = 0;
+            setLoading(true);
+            setBoard(targetBoard);
+            writeSelectedBoard(targetBoard);
+            setSearch("");
+            setTenantFilter("");
+            setAssigneeFilter("");
+            setIncludeArchived(false);
+          }
+          openTask(targetTask);
+        })
+        .catch(function () {
+          setDeepLinkNotice(`Card ${deepLinkTaskId} was not found or is archived.`);
+          replaceKanbanUrl(board, null);
+        });
+    }, []);  // deep-link input is immutable for this page load
 
     const scheduleReload = useCallback(function () {
       if (reloadTimerRef.current) return;
@@ -1473,6 +1506,10 @@
          onSelectAllVisible: selectAllVisible,
          onDelete: deleteSelected,
        }) : null,
+        deepLinkNotice ? h("div", {
+          className: "text-xs text-muted-foreground border border-border bg-muted/40 px-3 py-2",
+          role: "status",
+        }, deepLinkNotice) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
         h(KanbanDialogs, {
           dialogProps: kanbanDialogs.dialogProps,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -301,6 +301,33 @@
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
+  // A task drawer is shareable as /kanban?board=<slug>&task=<id>.  Keep
+  // localStorage as the fallback for ordinary visits, but let an explicit URL
+  // win so links are stable across browsers and dashboard sessions.
+  function readKanbanUrlSelection() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const board = (params.get("board") || "").trim() || null;
+      const task = (params.get("task") || "").trim() || null;
+      return { board: board, task: task };
+    } catch (_e) { return { board: null, task: null }; }
+  }
+
+  function replaceKanbanUrl(board, taskId) {
+    try {
+      const url = new URL(window.location.href);
+      const params = url.searchParams;
+      // The default board is intentionally implicit in the public URL.
+      if (board && board !== "default") params.set("board", board);
+      else params.delete("board");
+      if (taskId) params.set("task", taskId);
+      else params.delete("task");
+      const next = `${url.pathname}${params.toString() ? `?${params}` : ""}${url.hash}`;
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (next !== current) window.history.replaceState(window.history.state, "", next);
+    } catch (_e) { /* URL/history unavailable (for example, an embedded preview) */ }
+  }
+
   function withBoard(url, board) {
     // Always append ?board=<slug> when we have one picked — including
     // "default". Omitting the param would fall through to the backend's
@@ -603,7 +630,17 @@
   function KanbanPage() {
     const { t } = useI18n();
     const kanbanDialogs = useKanbanDialogs(t);
-    const [board, setBoard] = useState(() => readSelectedBoard() || null);
+    const initialUrlSelectionRef = useRef(null);
+    if (initialUrlSelectionRef.current === null) {
+      initialUrlSelectionRef.current = readKanbanUrlSelection();
+    }
+    const initialTaskRef = useRef(initialUrlSelectionRef.current.task);
+    const initialTaskResolvedRef = useRef(!initialUrlSelectionRef.current.task);
+    const [board, setBoard] = useState(() =>
+      initialUrlSelectionRef.current.board
+      // `task` without `board` is the compact deep-link form for default;
+      // it must not inherit a different board from this browser's storage.
+      || (initialUrlSelectionRef.current.task ? "default" : readSelectedBoard() || null));
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
     const [showBoardSettings, setShowBoardSettings] = useState(false);
@@ -646,6 +683,28 @@
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
     const wsClosedRef = useRef(false);
+    // Fetches are not abortable through every dashboard SDK host.  Keep the
+    // selected slug separately so a response for a board we have since left
+    // cannot repaint the grid after a fallback or board switch.
+    const currentBoardRef = useRef(board);
+    // Increment for both committed selections and synchronous transitions.
+    // The request generation prevents A -> B -> A from accepting the first
+    // A response after the newer A request has started.
+    const boardRequestGenerationRef = useRef(0);
+    useEffect(function () {
+      currentBoardRef.current = board;
+      boardRequestGenerationRef.current += 1;
+    }, [board]);
+
+    const openTask = useCallback(function (taskId) {
+      setSelectedTaskId(taskId);
+      replaceKanbanUrl(board, taskId);
+    }, [board]);
+
+    const closeTask = useCallback(function () {
+      setSelectedTaskId(null);
+      replaceKanbanUrl(board, null);
+    }, [board]);
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -664,30 +723,44 @@
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
+      const requestedBoard = board;
+      const requestGeneration = ++boardRequestGenerationRef.current;
+      const isCurrentRequest = function () {
+        return currentBoardRef.current === requestedBoard
+          && boardRequestGenerationRef.current === requestGeneration;
+      };
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
-      return SDK.fetchJSON(withBoard(url, board))
+      return SDK.fetchJSON(withBoard(url, requestedBoard))
         .then(function (data) {
+          if (!isCurrentRequest()) return;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
         })
         .catch(function (err) {
+          if (!isCurrentRequest()) return;
           setError(String(err && err.message ? err.message : err));
         })
-        .finally(function () { setLoading(false); });
+        .finally(function () {
+          if (isCurrentRequest()) setLoading(false);
+        });
     }, [tenantFilter, includeArchived, board]);
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
-      return SDK.fetchJSON(withBoard(`${API}/boards`, board))
+      const requestedBoard = board;
+      return SDK.fetchJSON(withBoard(`${API}/boards`, requestedBoard))
         .then(function (data) {
+          if (currentBoardRef.current !== requestedBoard) return;
           const boards = (data && data.boards) || [];
           const storedBoard = readSelectedBoard();
           setBoardList(boards);
           if (!storedBoard && !board && data && data.current) {
+            currentBoardRef.current = data.current;
+            boardRequestGenerationRef.current += 1;
             setBoard(data.current);
             return;
           }
@@ -695,8 +768,21 @@
           // deleted in the CLI while dashboard was open), fall back to
           // default so the UI doesn't hang on a 404.
           if (board && board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
-            setBoard("default");
-            writeSelectedBoard("default");
+            // Do not leave a stale task id paired with the fallback board.
+            initialTaskRef.current = null;
+            initialTaskResolvedRef.current = true;
+            setSelectedTaskId(null);
+            setBoardData(null);
+            setLoading(true);
+            // An explicit URL is a one-off navigation, not a preference.
+            // Keep an existing local choice intact when that URL is invalid.
+            const fallbackBoard = initialUrlSelectionRef.current.board
+              ? (boards.find(function (b) { return b.slug === storedBoard; }) || {}).slug || "default"
+              : "default";
+            currentBoardRef.current = fallbackBoard;
+            boardRequestGenerationRef.current += 1;
+            setBoard(fallbackBoard);
+            if (!initialUrlSelectionRef.current.board) writeSelectedBoard(fallbackBoard);
           }
         })
         .catch(function () { /* non-fatal */ });
@@ -721,6 +807,41 @@
         }
       };
     }, [loadBoard]);
+
+    // Resolve a deep-linked task only after the board data is available.  The
+    // board payload intentionally omits archived cards, so validate a missing
+    // card through the authenticated detail endpoint before clearing it.
+    useEffect(function () {
+      const initialTaskId = initialTaskRef.current;
+      if (!initialTaskId || !boardData) return;
+      const task = boardData.columns.reduce(function (found, column) {
+        return found || column.tasks.find(function (item) { return item.id === initialTaskId; });
+      }, null);
+      const requestedBoard = board;
+      let cancelled = false;
+      const resolve = function (resolvedTaskId) {
+        if (cancelled || currentBoardRef.current !== requestedBoard || initialTaskRef.current !== initialTaskId) return;
+        initialTaskRef.current = null;
+        initialTaskResolvedRef.current = true;
+        setSelectedTaskId(resolvedTaskId);
+        replaceKanbanUrl(requestedBoard, resolvedTaskId);
+      };
+      if (task) {
+        resolve(task.id);
+        return;
+      }
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(initialTaskId)}`, requestedBoard))
+        .then(function (data) { resolve(data && data.task ? initialTaskId : null); })
+        .catch(function () { resolve(null); });
+      return function () { cancelled = true; };
+    }, [board, boardData]);
+
+    // Board-only links and normal board changes are canonicalized too.  Wait
+    // for an initial task link to be validated so this never drops `task`
+    // before the first board response arrives.
+    useEffect(function () {
+      if (initialTaskResolvedRef.current) replaceKanbanUrl(board, selectedTaskId);
+    }, [board, selectedTaskId]);
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
@@ -1146,8 +1267,12 @@
       setBoardData(null);
       cursorRef.current = 0;
       setLoading(true);
+      currentBoardRef.current = nextSlug;
+      boardRequestGenerationRef.current += 1;
       setBoard(nextSlug);
       writeSelectedBoard(nextSlug);
+      setSelectedTaskId(null);
+      replaceKanbanUrl(nextSlug, null);
       // Reset filters so stale search/tenant/assignee don't persist across boards.
       setSearch("");
       setTenantFilter("");
@@ -1283,7 +1408,7 @@
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
         }),
         h(BoardToolbar, {
           board: boardData,
@@ -1328,15 +1453,15 @@
           onMoveSelected: moveSelected,
           onDelete: deleteTask,
           onDeleteSelected: deleteSelected,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
           boardSlug: board,
-          onClose: function () { setSelectedTaskId(null); },
-          onOpenTask: setSelectedTaskId,
+          onClose: closeTask,
+          onOpenTask: openTask,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -386,6 +386,28 @@
 }
 .hermes-kanban-drawer-close:hover { color: var(--color-foreground); }
 
+.hermes-kanban-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hermes-kanban-drawer-linkcopy {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+}
+.hermes-kanban-drawer-linkcopy:hover {
+  color: var(--color-foreground);
+  border-color: var(--color-foreground);
+}
+
 /* Attachment download trigger — styled as a link, rendered as a <button>
    so the click handler can fetch with the session token (#35338). */
 .hermes-kanban-attachment-link {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -136,6 +136,27 @@ def _conn(board: Optional[str] = None):
     return kanban_db.connect(board=board)
 
 
+def _existing_board_conn(board: str) -> Optional[sqlite3.Connection]:
+    """Open an existing board database without creating or migrating it.
+
+    The cross-board locator is a read-only discovery path.  Going through
+    :func:`_conn` here would let ``connect`` recreate a board that was archived
+    after ``list_boards`` returned its snapshot.  SQLite's ``mode=ro`` makes
+    disappearance between path resolution and open a clean miss instead.
+    """
+    path = kanban_db.kanban_db_path(board=board)
+    try:
+        conn = sqlite3.connect(
+            f"{path.resolve().as_uri()}?mode=ro",
+            uri=True,
+        )
+    except sqlite3.OperationalError:
+        return None
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
 # ---------------------------------------------------------------------------
 # Serialization helpers
 # ---------------------------------------------------------------------------
@@ -527,10 +548,16 @@ def locate_task(task_id: str):
     matches = []
     for meta in kanban_db.list_boards(include_archived=False):
         slug = meta["slug"]
-        conn = _conn(board=slug)
+        conn = _existing_board_conn(slug)
+        if conn is None:
+            continue
         try:
             task = kanban_db.get_task(conn, task_id)
-            if task is not None and task.status != "archived":
+            if (
+                task is not None
+                and task.status != "archived"
+                and kanban_db.board_exists(slug)
+            ):
                 matches.append({
                     "board": slug,
                     "task": {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -521,29 +521,34 @@ def get_board(
 def locate_task(task_id: str):
     """Return the active board containing ``task_id``.
 
-    Dashboard links intentionally carry only the globally-random task id so
-    chat integrations do not need to know which board currently owns a card.
-    Archived boards and archived cards are excluded: those links fall back to
-    the normal board with a small not-found notice instead of opening stale
-    work.
+    Task-only compatibility links are accepted only when the id has exactly
+    one match across active boards. Archived boards and cards are excluded.
     """
+    matches = []
     for meta in kanban_db.list_boards(include_archived=False):
         slug = meta["slug"]
         conn = _conn(board=slug)
         try:
             task = kanban_db.get_task(conn, task_id)
             if task is not None and task.status != "archived":
-                return {
+                matches.append({
                     "board": slug,
                     "task": {
                         "id": task.id,
                         "title": task.title,
                         "status": task.status,
                     },
-                }
+                })
         finally:
             conn.close()
-    raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    if not matches:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=f"task id {task_id} is ambiguous across active boards",
+        )
+    return matches[0]
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -514,6 +514,39 @@ def get_board(
 
 
 # ---------------------------------------------------------------------------
+# GET /tasks/locate/:id — resolve a deep link across active boards
+# ---------------------------------------------------------------------------
+
+@router.get("/tasks/locate/{task_id}")
+def locate_task(task_id: str):
+    """Return the active board containing ``task_id``.
+
+    Dashboard links intentionally carry only the globally-random task id so
+    chat integrations do not need to know which board currently owns a card.
+    Archived boards and archived cards are excluded: those links fall back to
+    the normal board with a small not-found notice instead of opening stale
+    work.
+    """
+    for meta in kanban_db.list_boards(include_archived=False):
+        slug = meta["slug"]
+        conn = _conn(board=slug)
+        try:
+            task = kanban_db.get_task(conn, task_id)
+            if task is not None and task.status != "archived":
+                return {
+                    "board": slug,
+                    "task": {
+                        "id": task.id,
+                        "title": task.title,
+                        "status": task.status,
+                    },
+                }
+        finally:
+            conn.close()
+    raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+
+# ---------------------------------------------------------------------------
 # GET /tasks/:id
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -484,7 +484,7 @@ class TestAuthCallbackNext:
         assert r.headers["location"] == "/sessions"
 
     def test_callback_preserves_kanban_task_deep_link(self, gated_app):
-        deep_link = "/kanban?task=t_03dc00df"
+        deep_link = "/kanban?board=ops&task=t_03dc00df"
 
         r = self._drive_oauth_via_login(gated_app, next_path=deep_link)
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -483,6 +483,14 @@ class TestAuthCallbackNext:
         assert r.status_code == 302
         assert r.headers["location"] == "/sessions"
 
+    def test_callback_preserves_kanban_task_deep_link(self, gated_app):
+        deep_link = "/kanban?task=t_03dc00df"
+
+        r = self._drive_oauth_via_login(gated_app, next_path=deep_link)
+
+        assert r.status_code == 302
+        assert r.headers["location"] == deep_link
+
 
     def test_attacker_callback_next_param_is_ignored(self, gated_app):
         """Hardening: even if an attacker crafts a callback URL with a

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -193,6 +193,34 @@ def test_locate_task_excludes_archived_boards(client):
     assert response.status_code == 404
 
 
+def test_locate_task_does_not_recreate_board_archived_after_discovery(
+    client, monkeypatch
+):
+    kb.create_board("retired-during-locate")
+    created = client.post(
+        "/api/plugins/kanban/tasks?board=retired-during-locate",
+        json={"title": "Racing card"},
+    ).json()["task"]
+    plugin_api = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    original_open = plugin_api._existing_board_conn
+    archived_after_discovery = False
+
+    def archive_before_open(board):
+        nonlocal archived_after_discovery
+        if board == "retired-during-locate" and not archived_after_discovery:
+            archived_after_discovery = True
+            kb.remove_board(board, archive=True)
+        return original_open(board)
+
+    monkeypatch.setattr(plugin_api, "_existing_board_conn", archive_before_open)
+
+    response = client.get(f"/api/plugins/kanban/tasks/locate/{created['id']}")
+
+    assert response.status_code == 404
+    assert archived_after_discovery
+    assert not kb.board_dir("retired-during-locate").exists()
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -154,6 +154,45 @@ def test_locate_task_treats_unknown_and_archived_cards_as_not_found(client):
         assert response.status_code == 404
 
 
+def test_locate_task_rejects_ids_duplicated_across_active_boards(client):
+    first = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Default copy"},
+    ).json()["task"]
+    kb.create_board("ops")
+    second = client.post(
+        "/api/plugins/kanban/tasks?board=ops",
+        json={"title": "Ops copy"},
+    ).json()["task"]
+    conn = kb.connect(board="ops")
+    try:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET id = ? WHERE id = ?",
+                (first["id"], second["id"]),
+            )
+    finally:
+        conn.close()
+
+    response = client.get(f"/api/plugins/kanban/tasks/locate/{first['id']}")
+
+    assert response.status_code == 409
+    assert "ambiguous" in response.json()["detail"].lower()
+
+
+def test_locate_task_excludes_archived_boards(client):
+    kb.create_board("retired")
+    created = client.post(
+        "/api/plugins/kanban/tasks?board=retired",
+        json={"title": "Retired card"},
+    ).json()["task"]
+    kb.remove_board("retired", archive=True)
+
+    response = client.get(f"/api/plugins/kanban/tasks/locate/{created['id']}")
+
+    assert response.status_code == 404
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")
@@ -1266,4 +1305,3 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
-

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -116,6 +116,44 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_locate_task_finds_active_card_across_boards(client):
+    kb.create_board("ops")
+    created = client.post(
+        "/api/plugins/kanban/tasks?board=ops",
+        json={"title": "Deep-linked card"},
+    ).json()["task"]
+
+    response = client.get(
+        f"/api/plugins/kanban/tasks/locate/{created['id']}"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "board": "ops",
+        "task": {
+            "id": created["id"],
+            "title": "Deep-linked card",
+            "status": "ready",
+        },
+    }
+
+
+def test_locate_task_treats_unknown_and_archived_cards_as_not_found(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Archived card"},
+    ).json()["task"]
+    archived = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "archived"},
+    )
+    assert archived.status_code == 200
+
+    for task_id in (created["id"], "t_does_not_exist"):
+        response = client.get(f"/api/plugins/kanban/tasks/locate/{task_id}")
+        assert response.status_code == 404
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")
@@ -1228,5 +1266,4 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
-
 

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "@vitejs/plugin-react": "6.0.3",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint-plugin-react-refresh": "0.5.3",
+    "jsdom": "29.1.1",
     "three": "0.180.0",
     "typescript": "6.0.3",
     "vite": "8.2.0",

--- a/web/src/plugins/kanban-dashboard.runtime.test.tsx
+++ b/web/src/plugins/kanban-dashboard.runtime.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
-import React, { act, type ComponentType, type ReactNode } from "react";
+import React, { act, useContext, type ComponentType, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { BrowserRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProfileProvider } from "@/contexts/ProfileProvider";
+import { ProfileContext } from "@/contexts/profile-context";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -54,9 +57,12 @@ function Checkbox({ checked, onCheckedChange, ...props }: Record<string, unknown
 }
 
 class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
+  constructor() { FakeWebSocket.instances.push(this); }
+  emit(data: unknown) { this.onmessage?.({ data: JSON.stringify(data) }); }
   close() {}
 }
 
@@ -71,6 +77,7 @@ Object.assign(window, {
       useRef: React.useRef,
       useContext: React.useContext,
       createContext: React.createContext,
+      useNavigate,
     },
     components: {
       Card: element("section"),
@@ -138,7 +145,7 @@ function detail(
 }
 
 function board(value: BoardFixture) {
-  const statuses = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"];
+  const statuses = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"];
   return {
     columns: statuses.map((status) => ({
       name: status,
@@ -212,7 +219,32 @@ async function renderKanban(path: string) {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
-  await act(async () => root.render(<KanbanPage />));
+  await act(async () => root.render(
+    <BrowserRouter>
+      <KanbanPage />
+    </BrowserRouter>,
+  ));
+}
+
+function ProfileSwitcher() {
+  const { setProfile } = useContext(ProfileContext);
+  return <button onClick={() => setProfile("research")}>Use research profile</button>;
+}
+
+async function renderProductionShell(path: string) {
+  window.history.replaceState({}, "", path);
+  window.__HERMES_PLUGIN_SDK__!.basePath = "/dashboard";
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(
+    <BrowserRouter basename="/dashboard">
+      <ProfileProvider>
+        <KanbanPage />
+        <ProfileSwitcher />
+      </ProfileProvider>
+    </BrowserRouter>,
+  ));
 }
 
 async function click(target: Element) {
@@ -250,7 +282,10 @@ function card(id: string) {
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
+  FakeWebSocket.instances = [];
+  window.__HERMES_PLUGIN_SDK__!.basePath = "";
   window.localStorage.clear();
   document.body.innerHTML = "";
   installApi();
@@ -276,7 +311,11 @@ describe("Kanban browser deep links", () => {
 
     await act(async () => root.unmount());
     root = createRoot(container);
-    await act(async () => root.render(<KanbanPage />));
+    await act(async () => root.render(
+      <BrowserRouter>
+        <KanbanPage />
+      </BrowserRouter>,
+    ));
     await waitForText("Ops task");
   });
 
@@ -288,9 +327,60 @@ describe("Kanban browser deep links", () => {
     expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
     expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("ops");
     expect(window.location.search).toBe("?profile=work&board=ops&task=t_ops");
-    expect(
-      fetchJSON.mock.calls.some(([url]) => String(url).endsWith("/tasks/locate/t_ops")),
-    ).toBe(true);
+    expect(fetchJSON.mock.calls.filter(
+      ([url]) => String(url).endsWith("/tasks/locate/t_ops"),
+    )).toHaveLength(1);
+    expect(container.textContent).not.toContain("outside the current filters");
+  });
+
+  it("keeps router state synchronized through the production profile shell and basename", async () => {
+    await renderProductionShell(
+      "/dashboard/kanban?profile=work&view=compact&board=ops",
+    );
+    await waitForText("Ops task");
+    const push = vi.spyOn(window.history, "pushState");
+
+    await click(card("t_ops"));
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
+    expect(window.location.pathname).toBe("/dashboard/kanban");
+    expect(window.location.search).toBe(
+      "?profile=work&view=compact&board=ops&task=t_ops",
+    );
+    expect(push).toHaveBeenCalledTimes(1);
+
+    const switcher = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Use research profile",
+    );
+    if (!switcher) throw new Error("missing profile switcher");
+    await click(switcher);
+    await vi.waitFor(() => expect(window.location.search).toContain("profile=research"));
+
+    expect(window.location.pathname).toBe("/dashboard/kanban");
+    expect(window.location.search).toContain("view=compact");
+    expect(window.location.search).toContain("board=ops");
+    expect(window.location.search).toContain("task=t_ops");
+    expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
+  });
+
+  it("preserves a task-only target while ignoring a stale stored board", async () => {
+    let resolveLookup!: (value: unknown) => void;
+    const pendingLookup = new Promise((resolve) => { resolveLookup = resolve; });
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "deleted");
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      if (rawUrl.endsWith("/tasks/locate/t_ops")) return pendingLookup;
+      return implementation?.(rawUrl, init);
+    });
+
+    await renderKanban("/kanban?profile=work&task=t_ops");
+    await vi.waitFor(() => expect(fetchJSON.mock.calls.some(
+      ([url]) => String(url).endsWith("/tasks/locate/t_ops"),
+    )).toBe(true));
+    expect(window.location.search).toBe("?profile=work&task=t_ops");
+
+    await act(async () => resolveLookup({ board: "ops", task: opsTask }));
+    await waitForText("Ops task");
+    expect(window.location.search).toBe("?profile=work&board=ops&task=t_ops");
   });
 
   it("canonicalizes legacy task_id and preserves the bare-route localStorage fallback", async () => {
@@ -304,7 +394,11 @@ describe("Kanban browser deep links", () => {
     await act(async () => root.unmount());
     window.history.replaceState({}, "", "/kanban?profile=work");
     root = createRoot(container);
-    await act(async () => root.render(<KanbanPage />));
+    await act(async () => root.render(
+      <BrowserRouter>
+        <KanbanPage />
+      </BrowserRouter>,
+    ));
     await waitForText("Ops task");
     expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
     expect(window.location.search).toBe("?profile=work&board=ops");
@@ -353,6 +447,51 @@ describe("Kanban browser deep links", () => {
     expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).not.toBe("missing");
   });
 
+  it.each([
+    ["invalid board", "/kanban?board=missing&task=t_lost", "Board missing was not found"],
+    ["missing task", "/kanban?board=ops&task=t_lost", "was not found or is archived"],
+    ["archived task", "/kanban?board=default&task=t_archived", "is archived"],
+    ["ambiguous task", "/kanban?task=t_problem", "ambiguous across active boards"],
+  ])("does not write history while traversing a %s destination", async (_kind, path, notice) => {
+    const archived = task("t_archived", "Archived task", "archived");
+    installApi({
+      boards: [
+        { slug: "default", tasks: [defaultTask, archived] },
+        { slug: "ops", tasks: [opsTask] },
+      ],
+      locate: new Map<string, unknown>([
+        ["t_problem", new Error('409: {"detail":"task id is ambiguous across active boards"}')],
+      ]),
+    });
+    window.history.replaceState({}, "", "/kanban?board=default");
+    window.history.pushState({}, "", path);
+    window.history.pushState({}, "", "/kanban?board=ops");
+    await renderKanban("/kanban?board=ops");
+    await waitForText("Ops task");
+    const push = vi.spyOn(window.history, "pushState");
+    const replace = vi.spyOn(window.history, "replaceState");
+
+    const backEvent = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.back();
+    await act(async () => backEvent);
+    await waitForText(notice);
+
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    expect(window.location.search).toBe(new URL(path, window.location.origin).search);
+
+    const forwardEvent = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.forward();
+    await act(async () => forwardEvent);
+    await waitForText("Ops task");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it("opens a board-qualified active task outside the visible columns via detail", async () => {
     const implementation = fetchJSON.getMockImplementation();
     fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
@@ -389,7 +528,87 @@ describe("Kanban browser deep links", () => {
     expect(window.location.search).toBe("?board=default");
   });
 
-  it("uses pushState for user open/close and restores the drawer with Back/Forward", async () => {
+  it.each([
+    ["transport", new Error("Failed to fetch")],
+    ["server", new Error('500: {"detail":"temporary failure"}')],
+    ["corrupt response", { unexpected: true }],
+  ])("keeps a %s lookup failure retryable without changing the URL", async (_kind, failure) => {
+    installApi({ locate: new Map([["t_ops", failure]]) });
+    await renderKanban("/kanban?profile=work&task=t_ops");
+
+    await waitForText("Could not load card t_ops");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?profile=work&task=t_ops");
+    expect(container.textContent).toContain("retry");
+  });
+
+  it("keeps a transient board-qualified detail failure retryable", async () => {
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname.endsWith("/board") && url.searchParams.get("board") === "ops") {
+        return Promise.resolve(board({ slug: "ops", tasks: [] }));
+      }
+      if (rawUrl.includes("/tasks/t_ops?board=ops")) {
+        return Promise.reject(new Error('500: {"detail":"temporary failure"}'));
+      }
+      return implementation?.(rawUrl, init);
+    });
+    await renderKanban("/kanban?board=ops&task=t_ops");
+
+    await waitForText("Could not load card t_ops");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+  });
+
+  it("deduplicates a pending locator across WebSocket board refreshes", async () => {
+    let resolveLookup!: (value: unknown) => void;
+    const pendingLookup = new Promise((resolve) => { resolveLookup = resolve; });
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      if (rawUrl.endsWith("/tasks/locate/t_ops")) return pendingLookup;
+      return implementation?.(rawUrl, init);
+    });
+    await renderKanban("/kanban?task=t_ops");
+    await vi.waitFor(() => expect(fetchJSON.mock.calls.filter(
+      ([url]) => String(url).endsWith("/tasks/locate/t_ops"),
+    )).toHaveLength(1));
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(0));
+    const push = vi.spyOn(window.history, "pushState");
+    const replace = vi.spyOn(window.history, "replaceState");
+
+    await act(async () => {
+      FakeWebSocket.instances.at(-1)?.emit({
+        cursor: 1,
+        events: [{ id: 1, task_id: "t_default" }],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    });
+    expect(fetchJSON.mock.calls.filter(
+      ([url]) => String(url).endsWith("/tasks/locate/t_ops"),
+    )).toHaveLength(1);
+    expect(window.location.search).toBe("?task=t_ops");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(container.textContent).not.toContain("Could not load card");
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("default");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+
+    await act(async () => resolveLookup({ board: "ops", task: opsTask }));
+    await waitForText("Ops task");
+    expect(fetchJSON.mock.calls.filter(
+      ([url]) => String(url).endsWith("/tasks/locate/t_ops"),
+    )).toHaveLength(1);
+    expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
+    expect(container.textContent).not.toContain("outside the current filters");
+    expect(container.textContent).not.toContain("Could not load card");
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("ops");
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses pushState for open/close and performs zero writes across Back/Back/Forward", async () => {
     await renderKanban("/kanban?board=ops");
     await waitForText("Ops task");
     const push = vi.spyOn(window.history, "pushState");
@@ -406,14 +625,34 @@ describe("Kanban browser deep links", () => {
     await click(close);
     expect(push).toHaveBeenCalledTimes(2);
     expect(window.location.search).toBe("?board=ops");
+    push.mockClear();
+    replace.mockClear();
 
-    const backEvent = new Promise((resolve) =>
+    const firstBack = new Promise((resolve) =>
       window.addEventListener("popstate", resolve, { once: true }),
     );
     window.history.back();
-    await act(async () => backEvent);
+    await act(async () => firstBack);
     await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
-    expect(push).toHaveBeenCalledTimes(2);
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+
+    const secondBack = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.back();
+    await act(async () => secondBack);
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).toBeNull());
+    expect(window.location.search).toBe("?board=ops");
+
+    const forward = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.forward();
+    await act(async () => forward);
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it.each(["shade", "Escape"])("pushes board-only history when closing by %s", async (method) => {
@@ -555,7 +794,7 @@ describe("Kanban browser deep links", () => {
     expect(window.location.search).toBe("?board=ops&task=t_ops");
   });
 
-  it("copies the absolute canonical link and exposes fallback failure", async () => {
+  it("copies the actual drawer identity with profile context and exposes fallback failure", async () => {
     const writeText = vi.fn(async () => undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -563,6 +802,9 @@ describe("Kanban browser deep links", () => {
     });
     await renderKanban("/kanban?profile=work&board=ops&task=t_ops&search=ignored");
     await waitForText("Ops task");
+    // Deliberately desynchronize the address bar without notifying the plugin.
+    // Copy Link must use the mounted drawer's props, not these stale URL ids.
+    window.history.replaceState({}, "", "/kanban?profile=work&board=default&task=t_wrong");
     const copy = Array.from(container.querySelectorAll("button")).find((button) =>
       button.textContent?.includes("Copy link"),
     );

--- a/web/src/plugins/kanban-dashboard.runtime.test.tsx
+++ b/web/src/plugins/kanban-dashboard.runtime.test.tsx
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileProvider } from "@/contexts/ProfileProvider";
 import { ProfileContext } from "@/contexts/profile-context";
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
 
 type Task = {
   id: string;
@@ -110,6 +111,7 @@ Object.assign(window, {
 vi.stubGlobal("WebSocket", FakeWebSocket);
 
 // This executes the shipped, hand-authored IIFE and captures its registration.
+// @ts-expect-error TS7016 -- the shipped IIFE intentionally has no TypeScript declarations.
 await import("../../../plugins/kanban/dashboard/dist/index.js");
 
 const defaultTask = task("t_default", "Default task");

--- a/web/src/plugins/kanban-dashboard.runtime.test.tsx
+++ b/web/src/plugins/kanban-dashboard.runtime.test.tsx
@@ -1,0 +1,626 @@
+// @vitest-environment jsdom
+import React, { act, type ComponentType, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Task = {
+  id: string;
+  title: string;
+  status: string;
+  workspace_kind: string;
+  workspace_path: string;
+  skills: string[];
+};
+
+type BoardFixture = { slug: string; tasks: Task[] };
+
+const fetchJSON = vi.fn();
+let KanbanPage: ComponentType<Record<string, never>>;
+
+function element(tag: string) {
+  return function Element({ children, ...props }: Record<string, unknown>) {
+    return React.createElement(tag, props, children as ReactNode);
+  };
+}
+
+function Select({ children, onValueChange, ...props }: Record<string, unknown>) {
+  return (
+    <select
+      {...props}
+      onChange={(event) =>
+        (onValueChange as ((value: string) => void) | undefined)?.(event.currentTarget.value)
+      }
+    >
+      {children as ReactNode}
+    </select>
+  );
+}
+
+function Checkbox({ checked, onCheckedChange, ...props }: Record<string, unknown>) {
+  return (
+    <input
+      {...props}
+      type="checkbox"
+      checked={Boolean(checked)}
+      onChange={(event) =>
+        (onCheckedChange as ((value: boolean) => void) | undefined)?.(
+          event.currentTarget.checked,
+        )
+      }
+    />
+  );
+}
+
+class FakeWebSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  close() {}
+}
+
+Object.assign(window, {
+  __HERMES_PLUGIN_SDK__: {
+    React,
+    hooks: {
+      useState: React.useState,
+      useEffect: React.useEffect,
+      useCallback: React.useCallback,
+      useMemo: React.useMemo,
+      useRef: React.useRef,
+      useContext: React.useContext,
+      createContext: React.createContext,
+    },
+    components: {
+      Card: element("section"),
+      CardContent: element("div"),
+      Badge: element("span"),
+      Button: element("button"),
+      Input: element("input"),
+      Label: element("label"),
+      Select,
+      SelectOption: element("option"),
+      Checkbox,
+      ConfirmDialog: () => null,
+    },
+    fetchJSON,
+    authedFetch: vi.fn(),
+    buildWsUrl: vi.fn(async () => "ws://localhost/events"),
+    utils: {
+      cn: (...values: unknown[]) => values.filter(Boolean).join(" "),
+      timeAgo: () => "now",
+    },
+    useI18n: () => ({ t: { kanban: null }, locale: "en" }),
+  },
+  __HERMES_PLUGINS__: {
+    register: (name: string, component: ComponentType<Record<string, never>>) => {
+      if (name === "kanban") KanbanPage = component;
+    },
+    registerSlot: () => undefined,
+  },
+});
+vi.stubGlobal("WebSocket", FakeWebSocket);
+
+// This executes the shipped, hand-authored IIFE and captures its registration.
+await import("../../../plugins/kanban/dashboard/dist/index.js");
+
+const defaultTask = task("t_default", "Default task");
+const opsTask = task("t_ops", "Ops task");
+
+function task(id: string, title: string, status = "ready"): Task {
+  return {
+    id,
+    title,
+    status,
+    workspace_kind: "scratch",
+    workspace_path: "",
+    skills: [],
+  };
+}
+
+function detail(
+  value: Task,
+  overrides: Partial<{
+    links: { parents: string[]; children: string[] };
+    child_results: Task[];
+  }> = {},
+) {
+  return {
+    task: value,
+    comments: [],
+    events: [],
+    attachments: [],
+    links: { parents: [], children: [] },
+    child_results: [],
+    ...overrides,
+  };
+}
+
+function board(value: BoardFixture) {
+  const statuses = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"];
+  return {
+    columns: statuses.map((status) => ({
+      name: status,
+      tasks: value.tasks.filter((item) => item.status === status),
+    })),
+    tenants: [],
+    assignees: [],
+    latest_event_id: 0,
+  };
+}
+
+function installApi({
+  boards = [
+    { slug: "default", tasks: [defaultTask] },
+    { slug: "ops", tasks: [opsTask] },
+  ],
+  locate = new Map([
+    ["t_default", { board: "default", task: defaultTask }],
+    ["t_ops", { board: "ops", task: opsTask }],
+  ]),
+}: {
+  boards?: BoardFixture[];
+  locate?: Map<string, unknown>;
+} = {}) {
+  fetchJSON.mockImplementation(async (rawUrl: string) => {
+    const url = new URL(rawUrl, window.location.origin);
+    const selectedBoard = url.searchParams.get("board") || "default";
+    if (url.pathname.endsWith("/config")) return { render_markdown: false };
+    if (url.pathname.endsWith("/boards")) {
+      return {
+        current: "default",
+        boards: boards.map((entry) => ({
+          slug: entry.slug,
+          name: entry.slug,
+          total: entry.tasks.length,
+        })),
+      };
+    }
+    if (url.pathname.endsWith("/board")) {
+      const fixture = boards.find((entry) => entry.slug === selectedBoard);
+      if (!fixture) throw new Error("404: board not found");
+      return board(fixture);
+    }
+    if (url.pathname.includes("/tasks/locate/")) {
+      const id = decodeURIComponent(url.pathname.split("/").at(-1) || "");
+      const result = locate.get(id);
+      if (result instanceof Error) throw result;
+      if (!result) throw new Error('404: {"detail":"task not found"}');
+      return result;
+    }
+    if (url.pathname.includes("/tasks/") && !url.pathname.includes("/home-")) {
+      const id = decodeURIComponent(url.pathname.split("/").at(-1) || "");
+      const item = boards
+        .find((entry) => entry.slug === selectedBoard)
+        ?.tasks.find((candidate) => candidate.id === id);
+      if (!item) throw new Error('404: {"detail":"task not found"}');
+      return detail(item);
+    }
+    if (url.pathname.endsWith("/home-channels")) return { home_channels: [] };
+    if (url.pathname.endsWith("/orchestration")) return { enabled: false };
+    if (url.pathname.endsWith("/profiles")) return { profiles: [] };
+    return {};
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderKanban(path: string) {
+  window.history.replaceState({}, "", path);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(<KanbanPage />));
+}
+
+async function click(target: Element) {
+  await act(async () => {
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function navigate(path: string) {
+  await act(async () => {
+    window.history.pushState({}, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+async function selectBoard(slug: string) {
+  const select = Array.from(container.querySelectorAll("select")).find((candidate) =>
+    Array.from(candidate.options).some((option) => option.value === slug),
+  );
+  if (!select) throw new Error(`missing board switcher for ${slug}`);
+  await act(async () => {
+    select.value = slug;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function waitForText(text: string) {
+  await vi.waitFor(() => expect(container.textContent).toContain(text));
+}
+
+function card(id: string) {
+  const target = container.querySelector(`[data-task-id="${id}"]`);
+  if (!target) throw new Error(`missing card ${id}`);
+  return target;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  document.body.innerHTML = "";
+  installApi();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+describe("Kanban browser deep links", () => {
+  it("lets a canonical board+task URL override localStorage and survive refresh", async () => {
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "default");
+    await renderKanban("/kanban?profile=work&board=ops&task=t_ops");
+
+    await waitForText("Ops task");
+    expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
+    expect(window.location.search).toBe("?profile=work&board=ops&task=t_ops");
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("ops");
+    expect(
+      fetchJSON.mock.calls.some(([url]) => String(url).includes("/tasks/locate/")),
+    ).toBe(false);
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await act(async () => root.render(<KanbanPage />));
+    await waitForText("Ops task");
+  });
+
+  it("locates a unique cross-board task, switches boards, and opens it", async () => {
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "default");
+    await renderKanban("/kanban?profile=work&task=t_ops");
+
+    await waitForText("Ops task");
+    expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("ops");
+    expect(window.location.search).toBe("?profile=work&board=ops&task=t_ops");
+    expect(
+      fetchJSON.mock.calls.some(([url]) => String(url).endsWith("/tasks/locate/t_ops")),
+    ).toBe(true);
+  });
+
+  it("canonicalizes legacy task_id and preserves the bare-route localStorage fallback", async () => {
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "ops");
+    await renderKanban("/kanban?profile=work&task_id=t_ops");
+
+    await waitForText("Ops task");
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
+    expect(window.location.search).toBe("?profile=work&board=ops&task=t_ops");
+
+    await act(async () => root.unmount());
+    window.history.replaceState({}, "", "/kanban?profile=work");
+    root = createRoot(container);
+    await act(async () => root.render(<KanbanPage />));
+    await waitForText("Ops task");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?profile=work&board=ops");
+  });
+
+  it.each([
+    ["missing", new Map<string, unknown>(), "not found or is archived"],
+    [
+      "ambiguous",
+      new Map<string, unknown>([
+        ["t_problem", new Error('409: {"detail":"task id is ambiguous across active boards"}')],
+      ]),
+      "ambiguous across active boards",
+    ],
+  ])("cleans up a %s task link without guessing a board", async (_kind, locate, notice) => {
+    installApi({ locate });
+    await renderKanban("/kanban?profile=work&task=t_problem");
+
+    await waitForText(notice);
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?profile=work&board=default");
+  });
+
+  it("rejects an ambiguous task-only link even when one match is visible locally", async () => {
+    installApi({
+      locate: new Map<string, unknown>([
+        ["t_default", new Error('409: {"detail":"task id is ambiguous across active boards"}')],
+      ]),
+    });
+    await renderKanban("/kanban?task=t_default");
+
+    await waitForText("ambiguous across active boards");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(
+      fetchJSON.mock.calls.some(([url]) => String(url).endsWith("/tasks/locate/t_default")),
+    ).toBe(true);
+  });
+
+  it("falls back visibly from an invalid board and removes its task target", async () => {
+    await renderKanban("/kanban?profile=work&board=missing&task=t_lost");
+
+    await waitForText("Board missing was not found or is archived");
+    await waitForText("Default task");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?profile=work&board=default");
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).not.toBe("missing");
+  });
+
+  it("opens a board-qualified active task outside the visible columns via detail", async () => {
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname.endsWith("/board") && url.searchParams.get("board") === "ops") {
+        return Promise.resolve(board({ slug: "ops", tasks: [] }));
+      }
+      return implementation?.(rawUrl, init);
+    });
+
+    await renderKanban("/kanban?board=ops&task=t_ops");
+
+    await waitForText("outside the current filters");
+    await waitForText("Ops task");
+    expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull();
+    expect(
+      fetchJSON.mock.calls.some(([url]) =>
+        String(url).includes("/tasks/t_ops?board=ops"),
+      ),
+    ).toBe(true);
+    expect(
+      fetchJSON.mock.calls.some(([url]) => String(url).includes("/tasks/locate/")),
+    ).toBe(false);
+  });
+
+  it("rejects a board-qualified archived task with a visible notice", async () => {
+    const archived = task("t_archived", "Archived task", "archived");
+    installApi({ boards: [{ slug: "default", tasks: [archived] }] });
+
+    await renderKanban("/kanban?board=default&task=t_archived");
+
+    await waitForText("Card t_archived is archived");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(window.location.search).toBe("?board=default");
+  });
+
+  it("uses pushState for user open/close and restores the drawer with Back/Forward", async () => {
+    await renderKanban("/kanban?board=ops");
+    await waitForText("Ops task");
+    const push = vi.spyOn(window.history, "pushState");
+    const replace = vi.spyOn(window.history, "replaceState");
+
+    await click(card("t_ops"));
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(replace).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+
+    const close = container.querySelector<HTMLButtonElement>(".hermes-kanban-drawer-close");
+    if (!close) throw new Error("missing close button");
+    await click(close);
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(window.location.search).toBe("?board=ops");
+
+    const backEvent = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.back();
+    await act(async () => backEvent);
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).not.toBeNull());
+    expect(push).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["shade", "Escape"])("pushes board-only history when closing by %s", async (method) => {
+    await renderKanban("/kanban?board=ops&task=t_ops");
+    await waitForText("Ops task");
+    const push = vi.spyOn(window.history, "pushState");
+
+    if (method === "shade") {
+      const shade = container.querySelector(".hermes-kanban-drawer-shade");
+      if (!shade) throw new Error("missing drawer shade");
+      await click(shade);
+    } else {
+      await act(async () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+    }
+
+    await vi.waitFor(() => expect(container.querySelector(".hermes-kanban-drawer")).toBeNull());
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("?board=ops");
+  });
+
+  it("pushes a board switch, clears the drawer, and persists the destination", async () => {
+    await renderKanban("/kanban?board=ops&task=t_ops");
+    await waitForText("Ops task");
+    const push = vi.spyOn(window.history, "pushState");
+
+    await selectBoard("default");
+
+    await waitForText("Default task");
+    expect(container.querySelector(".hermes-kanban-drawer")).toBeNull();
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("?board=default");
+    expect(window.localStorage.getItem("hermes.kanban.selectedBoard")).toBe("default");
+  });
+
+  it("suppresses a stale lookup after a newer popstate navigation", async () => {
+    let resolveLookup!: (value: unknown) => void;
+    const pendingLookup = new Promise((resolve) => { resolveLookup = resolve; });
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      if (rawUrl.endsWith("/tasks/locate/t_ops")) return pendingLookup;
+      return implementation?.(rawUrl, init);
+    });
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "default");
+    await renderKanban("/kanban?task=t_ops");
+    await vi.waitFor(() =>
+      expect(fetchJSON.mock.calls.some(([url]) => String(url).endsWith("/tasks/locate/t_ops"))).toBe(true),
+    );
+
+    await act(async () => {
+      window.history.pushState({}, "", "/kanban?board=default&task=t_default");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    await waitForText("Default task");
+    await act(async () => resolveLookup({ board: "ops", task: opsTask }));
+    expect(window.location.search).toBe("?board=default&task=t_default");
+    expect(container.textContent).not.toContain("Ops task");
+  });
+
+  it("suppresses a stale qualified detail after navigating to a newer task", async () => {
+    let resolveDetail!: (value: unknown) => void;
+    const pendingDetail = new Promise((resolve) => { resolveDetail = resolve; });
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      if (rawUrl.includes("/tasks/t_filtered?board=ops")) return pendingDetail;
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname.endsWith("/board") && url.searchParams.get("board") === "ops") {
+        return Promise.resolve(board({ slug: "ops", tasks: [opsTask] }));
+      }
+      return implementation?.(rawUrl, init);
+    });
+    await renderKanban("/kanban?board=ops&task=t_filtered");
+    await vi.waitFor(() =>
+      expect(fetchJSON.mock.calls.some(([url]) => String(url).includes("/tasks/t_filtered"))).toBe(true),
+    );
+
+    await navigate("/kanban?board=ops&task=t_ops");
+    await waitForText("Ops task");
+    await act(async () => resolveDetail(detail(task("t_filtered", "Stale filtered task"))));
+
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+    expect(container.textContent).not.toContain("Stale filtered task");
+  });
+
+  it("lets only the newest A response win in an A-B-A board race", async () => {
+    const oldA = task("t_old_a", "Old A response");
+    const newA = task("t_new_a", "Newest A response");
+    let resolveOldA!: (value: unknown) => void;
+    let resolveNewA!: (value: unknown) => void;
+    const oldAPromise = new Promise((resolve) => { resolveOldA = resolve; });
+    const newAPromise = new Promise((resolve) => { resolveNewA = resolve; });
+    let defaultRequests = 0;
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname.endsWith("/board") && url.searchParams.get("board") === "default") {
+        defaultRequests += 1;
+        return defaultRequests === 1 ? oldAPromise : newAPromise;
+      }
+      return implementation?.(rawUrl, init);
+    });
+    await renderKanban("/kanban?board=ops");
+    await waitForText("Ops task");
+
+    await navigate("/kanban?board=default");
+    await vi.waitFor(() => expect(defaultRequests).toBe(1));
+    await navigate("/kanban?board=ops");
+    await waitForText("Ops task");
+    await navigate("/kanban?board=default");
+    await vi.waitFor(() => expect(defaultRequests).toBe(2));
+    await act(async () => resolveNewA(board({ slug: "default", tasks: [newA] })));
+    await waitForText("Newest A response");
+    await act(async () => resolveOldA(board({ slug: "default", tasks: [oldA] })));
+
+    expect(container.textContent).toContain("Newest A response");
+    expect(container.textContent).not.toContain("Old A response");
+  });
+
+  it("follows task links reached through browser Back and Forward", async () => {
+    window.localStorage.setItem("hermes.kanban.selectedBoard", "default");
+    window.history.replaceState({}, "", "/kanban?board=default&task=t_default");
+    window.history.pushState({}, "", "/kanban?board=ops&task=t_ops");
+    await renderKanban("/kanban?board=ops&task=t_ops");
+    await waitForText("Ops task");
+
+    const backEvent = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.back();
+    await act(async () => backEvent);
+    await waitForText("Default task");
+    expect(window.location.search).toBe("?board=default&task=t_default");
+
+    const forwardEvent = new Promise((resolve) =>
+      window.addEventListener("popstate", resolve, { once: true }),
+    );
+    window.history.forward();
+    await act(async () => forwardEvent);
+    await waitForText("Ops task");
+    expect(window.location.search).toBe("?board=ops&task=t_ops");
+  });
+
+  it("copies the absolute canonical link and exposes fallback failure", async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    await renderKanban("/kanban?profile=work&board=ops&task=t_ops&search=ignored");
+    await waitForText("Ops task");
+    const copy = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Copy link"),
+    );
+    if (!copy) throw new Error("missing copy link button");
+    await click(copy);
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/kanban?profile=work&board=ops&task=t_ops`,
+    );
+    await waitForText("Copied");
+
+    writeText.mockRejectedValueOnce(new Error("clipboard denied"));
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    await click(copy);
+    await vi.waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+
+    writeText.mockRejectedValueOnce(new Error("clipboard denied again"));
+    execCommand.mockReturnValueOnce(false);
+    await click(copy);
+    await waitForText("Copy command was not accepted");
+  });
+
+  it("opens a related child with one task-to-task history entry", async () => {
+    const parent = task("t_parent", "Parent task");
+    const child = task("t_child", "Child task");
+    let resolveChild!: (value: unknown) => void;
+    const pendingChild = new Promise((resolve) => { resolveChild = resolve; });
+    installApi({ boards: [{ slug: "ops", tasks: [parent, child] }] });
+    const implementation = fetchJSON.getMockImplementation();
+    fetchJSON.mockImplementation((rawUrl: string, init?: RequestInit) => {
+      if (rawUrl.includes("/tasks/t_parent?board=ops")) {
+        return Promise.resolve(detail(parent, {
+          links: { parents: [], children: [child.id] },
+          child_results: [child],
+        }));
+      }
+      if (rawUrl.includes("/tasks/t_child?board=ops")) return pendingChild;
+      return implementation?.(rawUrl, init);
+    });
+    await renderKanban("/kanban?board=ops&task=t_parent");
+    await waitForText("Parent task");
+    await waitForText("Child Results");
+    const push = vi.spyOn(window.history, "pushState");
+    const open = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open",
+    );
+    if (!open) throw new Error("missing related-task open button");
+
+    await click(open);
+    const drawer = container.querySelector(".hermes-kanban-drawer");
+    if (!drawer) throw new Error("missing task drawer");
+    expect(drawer.textContent).not.toContain("Parent task");
+    await act(async () => resolveChild(detail(child)));
+    await vi.waitFor(() => expect(drawer.textContent).toContain("Child task"));
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("?board=ops&task=t_child");
+  });
+});

--- a/web/src/plugins/registry.test.ts
+++ b/web/src/plugins/registry.test.ts
@@ -9,7 +9,7 @@
  * Toast/useToast/useConfirmDelete on the plugin SDK". See issue #50547.
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { exposePluginSDK } from "./registry";
+import { exposePluginSDK, SDK_CONTRACT_VERSION } from "./registry";
 
 describe("plugin SDK dialog/toast surface", () => {
   beforeEach(() => {
@@ -42,5 +42,22 @@ describe("plugin SDK dialog/toast surface", () => {
     // Original React hooks still present (no accidental removal).
     expect(typeof sdk.hooks.useState).toBe("function");
     expect(typeof sdk.hooks.useCallback).toBe("function");
+  });
+
+  it("exposes additive router integration without changing the SDK version", () => {
+    exposePluginSDK();
+    const sdk = (globalThis as unknown as {
+      window: {
+        __HERMES_PLUGIN_SDK__: {
+          sdkVersion: string;
+          basePath?: string;
+          hooks: Record<string, unknown>;
+        };
+      };
+    }).window.__HERMES_PLUGIN_SDK__;
+
+    expect(sdk.sdkVersion).toBe(SDK_CONTRACT_VERSION);
+    expect(typeof sdk.basePath).toBe("string");
+    expect(typeof sdk.hooks.useNavigate).toBe("function");
   });
 });

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -17,7 +17,15 @@ import React, {
   useContext,
   createContext,
 } from "react";
-import { api, fetchJSON, authedFetch, buildWsUrl, buildWsAuthParam } from "@/lib/api";
+import { useNavigate } from "react-router";
+import {
+  api,
+  fetchJSON,
+  authedFetch,
+  buildWsUrl,
+  buildWsAuthParam,
+  HERMES_BASE_PATH,
+} from "@/lib/api";
 import { cn, timeAgo, isoTimeAgo } from "@/lib/utils";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -119,6 +127,9 @@ export function exposePluginSDK() {
     // Contract version of the plugin SDK surface (see plugins/sdk.d.ts).
     // Bump on backwards-incompatible changes; additive changes don't need it.
     sdkVersion: SDK_CONTRACT_VERSION,
+    // Deployment prefix used by BrowserRouter. Router navigation accepts
+    // paths relative to this basename, while window.location includes it.
+    basePath: HERMES_BASE_PATH,
     // React core — plugins use these instead of importing react
     React,
     hooks: {
@@ -136,6 +147,10 @@ export function exposePluginSDK() {
       // pendingId) for single-id delete confirmations.
       useToast,
       useConfirmDelete,
+      // Router-aware navigation for plugin-owned URL state. Plugins must use
+      // this instead of calling history.pushState/replaceState directly so
+      // BrowserRouter and sibling providers retain the same location.
+      useNavigate,
     },
 
     // Hermes API client

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -94,6 +94,8 @@ export interface PluginRegistry {
 export interface HermesPluginSDK {
   /** Contract version of this SDK surface (see SDK_CONTRACT_VERSION). */
   readonly sdkVersion: string;
+  /** BrowserRouter deployment basename (empty for root deployments). Added by newer hosts. */
+  basePath?: string;
 
   /** React core — use instead of importing/bundling react. */
   React: typeof import("react").default;
@@ -105,6 +107,8 @@ export interface HermesPluginSDK {
     useRef: typeof import("react").useRef;
     useContext: typeof import("react").useContext;
     createContext: typeof import("react").createContext;
+    /** Router-aware navigation for plugin-owned URL state. Added by newer hosts. */
+    useNavigate?: typeof import("react-router").useNavigate;
     /**
      * Toast feedback. Returns ``{ showToast, toast }`` where ``toast`` is the
      * current visible toast (or null) and ``showToast(message, 'success' | 'error')``


### PR DESCRIPTION
## Summary

This draft consolidates the browser-dashboard portion of #33852 into one coherent URL/history contract:

- canonical `/kanban?board=<slug>&task=<task-id>` links that survive refresh;
- predictable task-only lookup across active boards, including explicit ambiguity handling;
- true Back/Forward navigation (`pushState` for user transitions, `replaceState` only for canonicalization/correction);
- URL synchronization for card open/close, related tasks, and board switching;
- visible, race-safe handling for invalid, missing, archived, filtered, ambiguous, and retryable targets;
- canonical Copy Link behavior;
- direct authentication round-trip preservation;
- behavior-level runtime tests that execute the shipped dashboard plugin IIFE.

This is intentionally a **draft** for early maintainer/contributor collaboration. It is not being presented as ready to merge.

## Why a consolidation draft

The existing browser contributions are valuable but cannot independently satisfy the current acceptance contract:

- #46162 is open/conflicting and provides URL helpers, legacy `task_id`, `popstate`, and Copy Link, but uses replace-only history and source-string tests.
- #75622 is open/conflicting and provides cross-active-board lookup plus auth/API coverage, but lacks full history/navigation behavior and runtime frontend coverage.
- #72083 is closed with its branch deleted; commit `f4819ab3d37d671f73ec32a156aa3a6777454784` provides the strongest validation, fallback, and stale-request foundation, but not correct history or Copy Link.

I cannot update or overwrite another contributor's fork branch, and #72083 is no longer updateable as a PR. This draft therefore preserves the predecessor work as separate authored commits, then applies the independently reviewed corrections on top.

## Provenance and credit

The first three commits retain the predecessor Git authors. They are conflict-resolved/adapted ports rather than patch-identical cherry-picks:

- `32666f160bff7a551cfcebab6bb3de5998ce89c0` — authored by **teknium1**, adapted from #72083 / `f4819ab3...`; PR vehicle/author: **mainframe42**.
- `dc358f20fc1f8257e5dddb07796411f607791a5d` — authored by **Danny Franca**, adapted from #46162 / `867dd5aac259a41d95938512c1fe3be3deed2bb2`.
- `cc5273468abe175fcc0a955033a66a532dc357d5` — authored by **david**, adapted from #75622 / `b3690738757c2b484241c17b0261f04e67356ac3`; PR author: **Brian Spector** (`spector-in-london`).
- `de0e7f38e3f94175713c8f4a452125a6c32944ce` — correction/runtime-test layer.
- `020769acfbf6abbda8003d29b4df87b24cf8ec9c` — independent-review remediation layer.

The draft does not claim the URL helpers, Copy Link, cross-board lookup, auth coverage, or stale-request design as original work.

## Browser behavior

- URL board selection overrides localStorage; bare `/kanban` remains backward compatible.
- Task-only links remain authoritative while lookup is pending and do not get discarded by stale stored-board state.
- IDs duplicated across active boards return an explicit ambiguity response rather than silently selecting the first match.
- A board-qualified active task hidden by client filters still opens through the detail endpoint.
- Archived targets, including archived rows already present in board payloads, fail visibly without opening an active drawer.
- User open/close/related-task/board-switch transitions use router-aware push navigation.
- Initial normalization and terminal corrections use replace navigation, while `popstate` handling performs no feedback history write.
- Router/ProfileProvider state, deployment basenames, `profile`, and unrelated sibling query parameters remain synchronized.
- Board, detail, and locator generations/deduplication prevent stale and A→B→A responses from repainting current state.
- Retryable transport/server/corrupt-response failures preserve the shared URL for retry.
- The locator opens existing board databases read-only and cannot recreate a board archived after enumeration.
- Copy Link uses the actual open drawer's board/task identity and preserves profile context.

## Runtime and backend tests

Behavior-level tests execute `plugins/kanban/dashboard/dist/index.js`, capture the registered component, render it under React/BrowserRouter/ProfileProvider, and drive DOM, history, localStorage, API promises, WebSocket messages, and clipboard behavior. No source-string assertion is used as browser acceptance proof.

Local verification at exact SHA `020769acfbf6abbda8003d29b4df87b24cf8ec9c`:

- `node --check plugins/kanban/dashboard/dist/index.js`
- `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_dashboard_auth_401_reauth.py -q` — **68 passed** (43 plugin + 25 auth)
- focused runtime + SDK registry tests — **33 passed**
- `npm run check --workspace web` — typecheck passed; **37 files / 310 tests passed**; ESLint **0 errors** (26 pre-existing warnings in unchanged files)
- router-integration sabotage: disabling host navigation makes the production-shell regression fail at `kanban-dashboard.runtime.test.tsx:361` because `task=t_ops` is dropped; restored candidate passes.

An independent exact-SHA review approved `020769acfbf6abbda8003d29b4df87b24cf8ec9c` after re-running these gates and checking the prior review findings.

## Desktop coordination and exclusions

#80739 remains the complementary Desktop renderer contribution. This draft:

- changes no `apps/desktop/**` file;
- does not implement or replace Desktop `?task=` consumption;
- does not add external `hermes://` handling;
- does not add notification/comment link emission;
- makes no database schema change.

The pre-existing generic mounted-SPA API-401 `lastLocation` restoration gap is also left out of this focused contribution; direct unauthenticated canonical navigation is covered by the existing same-origin `next` flow and the added regression.

## Review focus

Because this is a public navigation contract, useful early review areas are:

- router/history semantics and basename/profile preservation;
- task-only ambiguity and archive policy;
- async lookup/detail/WebSocket race behavior;
- the plugin SDK's additive router hook exposure;
- whether the runtime harness belongs in the web workspace long-term.

Addresses the browser-dashboard portion of #33852.
