### PR TITLE
fix(desktop): render all 11 auxiliary task slots in Settings

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -1,7 +1,30 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ar } from '@/i18n/ar'
+import { en } from '@/i18n/en'
+import { ja } from '@/i18n/ja'
+import type { Translations } from '@/i18n/types'
+import { zh } from '@/i18n/zh'
+import { zhHant } from '@/i18n/zh-hant'
+
+const SHIPPED_LOCALES: readonly [string, Translations][] = [
+  ['en', en],
+  ['ja', ja],
+  ['zh', zh],
+  ['zh-hant', zhHant],
+  ['ar', ar]
+]
+
+// Locale tag for assertion messages — clearer failures than "[Object object]".
+function localeName(locale: Translations): string {
+  return SHIPPED_LOCALES.find(([, bundle]) => bundle === locale)?.[0] ?? 'unknown'
+}
 
 // Radix Select calls scrollIntoView on its items when the content opens; jsdom
 // doesn't implement it (nor hasPointerCapture / releasePointerCapture), so stub
@@ -324,6 +347,47 @@ describe('ModelSettings', () => {
 
     expect(await screen.findByText('Vision')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
+  })
+
+  it('renders every backend auxiliary slot, including the three that were UI-invisible', async () => {
+    await renderModelSettings()
+
+    // 8 slots rendered before #98978; the pinned inventory is 11.
+    expect(await screen.findAllByRole('button', { name: 'Set to main' })).toHaveLength(11)
+    expect(await screen.findByText('Triage specifier')).toBeTruthy()
+    expect(await screen.findByText('Kanban decomposer')).toBeTruthy()
+    expect(await screen.findByText('Profile describer')).toBeTruthy()
+  })
+
+  it('keeps AUX_TASKS in lockstep with the backend slot list', async () => {
+    // The backend tuple is the source of truth (served by GET /api/model/auxiliary);
+    // a hardcoded frontend list that misses a slot makes that slot editable only
+    // via raw config.yaml (#98978). Parse web_server.py instead of importing it —
+    // the desktop test runner has no Python interpreter contract.
+    const webServer = await fs.readFile(
+      path.join(__dirname, '..', '..', '..', '..', '..', 'hermes_cli', 'web_server.py'),
+      'utf8'
+    )
+
+    const match = webServer.match(/_AUX_TASK_SLOTS[^=]*=\s*\(([^)]*)\)/)
+    expect(match).toBeTruthy()
+    const backendSlots = [...match![1].matchAll(/"([a-z_]+)"/g)].map(m => m[1])
+
+    const { AUX_TASKS } = await import('./model-settings')
+    expect(AUX_TASKS.map(meta => meta.key)).toEqual(backendSlots)
+  })
+
+  it('labels every auxiliary slot in all shipped locales', async () => {
+    const { AUX_TASKS } = await import('./model-settings')
+
+    for (const locale of [en, ja, zh, zhHant, ar]) {
+      const tasks = locale.settings.model.tasks
+
+      for (const meta of AUX_TASKS) {
+        expect(tasks[meta.key]?.label, `${localeName(locale)}: ${meta.key}`).toBeTruthy()
+        expect(tasks[meta.key]?.hint, `${localeName(locale)}: ${meta.key}`).toBeTruthy()
+      }
+    }
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -102,12 +102,13 @@ function isProviderReady(p?: ModelOptionProvider): boolean {
 
 // Mirrors `_AUX_TASK_SLOTS` in hermes_cli/web_server.py. Friendly labels and
 // hints make the assignments readable; raw task keys (vision, mcp, …) are
-// opaque to most users.
+// opaque to most users. The drift test parses the backend tuple and pins this
+// list to it, so a slot added server-side can't stay unreachable here again.
 interface AuxTaskMeta {
   key: string
 }
 
-const AUX_TASKS: readonly AuxTaskMeta[] = [
+export const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'vision' },
   { key: 'compression' },
   { key: 'skills_hub' },
@@ -115,6 +116,9 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'mcp' },
   { key: 'title_generation' },
   { key: 'review' },
+  { key: 'triage_specifier' },
+  { key: 'kanban_decomposer' },
+  { key: 'profile_describer' },
   { key: 'curator' }
 ]
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -900,6 +900,18 @@ export const ar = defineLocale({
           label: 'المراجعة',
           hint: 'وكيل المراجعة الفرعي /review'
         },
+        triage_specifier: {
+          label: 'مُحدِّد الفرز',
+          hint: 'تحويل أفكار فرز كانبان إلى مواصفات'
+        },
+        kanban_decomposer: {
+          label: 'مُفكِّك كانبان',
+          hint: 'تفكيك مهام كانبان إلى مخطط'
+        },
+        profile_describer: {
+          label: 'واصف الملفات الشخصية',
+          hint: 'توليد أوصاف الملفات الشخصية'
+        },
         curator: {
           label: 'المنسّق',
           hint: 'مراجعة استخدام المهارات'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1108,6 +1108,9 @@ export const en: Translations = {
         mcp: { label: 'MCP', hint: 'MCP tool routing' },
         title_generation: { label: 'Title gen', hint: 'Session titles' },
         review: { label: 'Review', hint: '/review reviewer subagent' },
+        triage_specifier: { label: 'Triage specifier', hint: 'Kanban triage specs' },
+        kanban_decomposer: { label: 'Kanban decomposer', hint: 'Kanban task graph' },
+        profile_describer: { label: 'Profile describer', hint: 'Profile descriptions' },
         curator: { label: 'Curator', hint: 'Skill-usage review' }
       }
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1012,6 +1012,9 @@ export const ja = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP ツールルーティング' },
         title_generation: { label: 'タイトル生成', hint: 'セッションタイトル' },
         review: { label: 'レビュー', hint: '/review レビューサブエージェント' },
+        triage_specifier: { label: 'トリアージ仕様化', hint: 'カンバントリアージの仕様への展開' },
+        kanban_decomposer: { label: 'カンバン分解', hint: 'カンバンのタスクグラフ分解' },
+        profile_describer: { label: 'プロファイル記述', hint: 'プロファイル概要の生成' },
         curator: { label: 'キュレーター', hint: 'スキル使用レビュー' }
       }
     },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -977,6 +977,9 @@ export const zhHant = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '標題生成', hint: '工作階段標題' },
         review: { label: '評審', hint: '/review 評審子代理' },
+        triage_specifier: { label: '分類細化', hint: '將看板分類想法整理為規格' },
+        kanban_decomposer: { label: '看板分解器', hint: '分解看板任務圖' },
+        profile_describer: { label: '設定檔描述器', hint: '產生設定檔描述' },
         curator: { label: '策展器', hint: '技能使用審查' }
       }
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1302,6 +1302,9 @@ export const zh: Translations = {
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '标题生成', hint: '会话标题' },
         review: { label: '评审', hint: '/review 评审子智能体' },
+        triage_specifier: { label: '分诊细化', hint: '细化看板分诊想法为规格' },
+        kanban_decomposer: { label: '看板分解器', hint: '分解看板任务图' },
+        profile_describer: { label: '配置档描述器', hint: '生成配置档描述' },
         curator: { label: '维护器', hint: '技能使用审查' }
       }
     },


### PR DESCRIPTION
## Summary

`AUX_TASKS` in `apps/desktop/src/app/settings/model-settings.tsx` hardcoded 8 of the 11 backend `_AUX_TASK_SLOTS` (`hermes_cli/web_server.py`), so `triage_specifier`, `kanban_decomposer` and `profile_describer` were accepted by `POST /api/model/set` (scope=auxiliary), served by `GET /api/model/auxiliary`, honored per-profile — but never rendered. Desktop users could only change them by hand-editing `config.yaml` per profile, which is exactly the silent-cost trap described in #98978 (a stale `kanban_decomposer` pin with `reasoning_effort: high` was undiscoverable from the UI).

- Adds the three slots in the backend's canonical order (before `curator`), so the desktop inventory mirrors the backend exactly.
- Adds labels + hints for all three in every shipped desktop locale (en, ja, zh, zh-hant, ar) — the `Translations` record stays exhaustive.
- Adds a drift test that parses `_AUX_TASK_SLOTS` out of `web_server.py` and pins `AUX_TASKS` to it, plus a locale-completeness test over all 11 slots and a UI test that pins the rendered inventory at 11 rows. A future backend slot can no longer stay UI-invisible silently.

I kept the hardcoded tuple + drift test rather than deriving the list from the `/api/model/auxiliary` payload: the static list keeps deterministic ordering, deep-link `ready` checks (`useDeepLinkHighlight`) and the locale bundle in sync at type-check time, and the drift test closes the gap the issue actually complained about. Happy to switch to payload-derived rendering if maintainers prefer that direction (point 2 of the issue) — the locale work and tests carry over unchanged.

## Testing

```
cd apps/desktop
npx tsc -p . --noEmit                                  # clean
npx vitest run src/app/settings/model-settings.test.tsx --project ui
# Test Files 1 passed (1) · Tests 25 passed (25)
node_modules/.bin/eslint <7 touched files>             # clean
```

Fixes #98978