### PR TITLE
feat(cron): expose persisted job results for polling clients

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -487,21 +487,53 @@ def get_job_results(
     job_id: str,
     *,
     after: Optional[str] = None,
+    before: Optional[str] = None,
     limit: int = _DEFAULT_JOB_RESULTS,
 ) -> Dict[str, Any]:
-    """Return the newest saved output files for ``job_id``, newest first.
+    """Return saved output files for ``job_id``, newest first, bounded by ``limit``.
 
-    Built for polling clients: pass the previous response's ``next_after``
-    (or the newest item's ``cursor``) back in as ``after`` to fetch only
-    output files strictly newer than that cursor — deduplication is exact
-    because cursors are the run's timestamp-based output filename, which is
-    monotonically increasing per job.
+    Two cursors serve two different purposes and must not be conflated:
+
+    - ``after`` is the client's **high-water mark** — "I have already seen
+      everything up to and including this cursor." Only files strictly
+      newer than ``after`` (``name > after``) are ever considered. It stays
+      fixed for the whole polling *round* (it does not advance while a
+      client pages backwards through one round's results).
+    - ``before`` is an **intra-round paging cursor** — "give me the next,
+      older slice of the files I haven't finished walking yet." Only files
+      strictly older than ``before`` (``name < before``) are considered.
+      Pass the previous response's ``next_before`` back in to keep walking
+      older results within the same round; omit it (or pass ``None``) to
+      start (or restart) at the newest unseen file.
+
+    A full polling round therefore looks like: call with ``after=<last
+    high-water mark>`` and no ``before``; if ``has_more`` is true, keep
+    calling with the same ``after`` and ``before=<previous next_before>``
+    until ``has_more`` is false. Every file strictly newer than the
+    starting ``after`` is visited exactly once across that walk — newest
+    first, no gaps, no duplicates — because each page's range is the
+    half-open interval ``(after, before)`` and consecutive pages tile that
+    interval without overlap.
+
+    Response fields:
+
+    - ``next_after`` — the cursor of the single newest file matching
+      ``after`` in the store *right now*, independent of ``before``/paging
+      position. Stable across every page of the same round: capture it
+      once (from any page) and use it as ``after`` for the *next* round's
+      first call. ``None`` (or the original ``after``) when nothing newer
+      than ``after`` exists.
+    - ``next_before`` — the cursor of the oldest file returned in *this*
+      page, to pass back as ``before`` for the next page of the same
+      round. ``None`` whenever ``has_more`` is false (nothing older left
+      to page to in this round).
 
     Raises ``ValueError`` for a malformed/path-escaping ``job_id`` (see
-    ``_job_output_dir``) so callers can turn that into a 400, never a leak
-    outside the cron output sandbox. A missing output directory (job has
-    never produced output, or was pruned to zero) is not an error — it
-    yields an empty result set.
+    ``_job_output_dir``) or a malformed/path-escaping ``after``/``before``
+    cursor, so callers can turn that into a 400, never a leak outside the
+    cron output sandbox. A missing output directory (job has never
+    produced output, or was pruned to zero) is not an error — it yields an
+    empty result set.
     """
     job_output_dir = _job_output_dir(job_id)
     try:
@@ -510,23 +542,40 @@ def get_job_results(
         clamped_limit = _DEFAULT_JOB_RESULTS
     clamped_limit = max(1, min(clamped_limit, _MAX_JOB_RESULTS))
 
-    cursor = str(after).strip() if after else ""
-    if cursor and ("/" in cursor or "\\" in cursor or cursor in {".", ".."}):
-        raise ValueError(f"Invalid cursor: {after!r}")
+    def _validate_cursor(value: Optional[str], label: str) -> str:
+        text = str(value).strip() if value else ""
+        if text and ("/" in text or "\\" in text or text in {".", ".."}):
+            raise ValueError(f"Invalid {label}: {value!r}")
+        return text
+
+    after_cursor = _validate_cursor(after, "cursor")
+    before_cursor = _validate_cursor(before, "before cursor")
 
     try:
-        files = sorted(
+        all_files = sorted(
             (f for f in job_output_dir.glob("*.md") if f.is_file()),
             key=lambda f: f.name,
             reverse=True,
         )
     except OSError:
-        files = []
+        all_files = []
 
-    if cursor:
-        files = [f for f in files if f.name > cursor]
+    # Files newer than the high-water mark — the full unseen set for this
+    # round. This does NOT get filtered by ``before``, so its head is a
+    # stable "true newest" regardless of where a paging walk currently is.
+    files_after = (
+        [f for f in all_files if f.name > after_cursor] if after_cursor else all_files
+    )
+    next_after = files_after[0].name if files_after else (after or None)
+
+    files = (
+        [f for f in files_after if f.name < before_cursor]
+        if before_cursor
+        else files_after
+    )
 
     page = files[:clamped_limit]
+    has_more = len(files) > clamped_limit
     results = []
     for f in page:
         try:
@@ -538,8 +587,9 @@ def get_job_results(
     return {
         "job_id": job_id,
         "results": results,
-        "has_more": len(files) > clamped_limit,
-        "next_after": results[0]["cursor"] if results else (after or None),
+        "has_more": has_more,
+        "next_after": next_after,
+        "next_before": page[-1].name if has_more else None,
     }
 
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -476,6 +476,73 @@ def _job_output_dir(job_id: str) -> Path:
     return _current_cron_store().output_dir / text
 
 
+# Hard ceiling on results returned per poll — a client-supplied ``limit`` is
+# clamped into (0, _MAX_JOB_RESULTS] so a single request can't be made to walk
+# an unbounded number of saved output files.
+_MAX_JOB_RESULTS = 100
+_DEFAULT_JOB_RESULTS = 20
+
+
+def get_job_results(
+    job_id: str,
+    *,
+    after: Optional[str] = None,
+    limit: int = _DEFAULT_JOB_RESULTS,
+) -> Dict[str, Any]:
+    """Return the newest saved output files for ``job_id``, newest first.
+
+    Built for polling clients: pass the previous response's ``next_after``
+    (or the newest item's ``cursor``) back in as ``after`` to fetch only
+    output files strictly newer than that cursor — deduplication is exact
+    because cursors are the run's timestamp-based output filename, which is
+    monotonically increasing per job.
+
+    Raises ``ValueError`` for a malformed/path-escaping ``job_id`` (see
+    ``_job_output_dir``) so callers can turn that into a 400, never a leak
+    outside the cron output sandbox. A missing output directory (job has
+    never produced output, or was pruned to zero) is not an error — it
+    yields an empty result set.
+    """
+    job_output_dir = _job_output_dir(job_id)
+    try:
+        clamped_limit = int(limit)
+    except (TypeError, ValueError):
+        clamped_limit = _DEFAULT_JOB_RESULTS
+    clamped_limit = max(1, min(clamped_limit, _MAX_JOB_RESULTS))
+
+    cursor = str(after).strip() if after else ""
+    if cursor and ("/" in cursor or "\\" in cursor or cursor in {".", ".."}):
+        raise ValueError(f"Invalid cursor: {after!r}")
+
+    try:
+        files = sorted(
+            (f for f in job_output_dir.glob("*.md") if f.is_file()),
+            key=lambda f: f.name,
+            reverse=True,
+        )
+    except OSError:
+        files = []
+
+    if cursor:
+        files = [f for f in files if f.name > cursor]
+
+    page = files[:clamped_limit]
+    results = []
+    for f in page:
+        try:
+            content = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        results.append({"cursor": f.name, "content": content})
+
+    return {
+        "job_id": job_id,
+        "results": results,
+        "has_more": len(files) > clamped_limit,
+        "next_after": results[0]["cursor"] if results else (after or None),
+    }
+
+
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
     """Normalize legacy/single-skill and multi-skill inputs into a unique ordered list."""
     if skills is None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6690,19 +6690,34 @@ class APIServerAdapter(BasePlatformAdapter):
         Read-only, bounded, and cursor-based so a client can poll for new
         cron output without re-downloading everything each time:
 
-        - ``after=<cursor>`` — only return results strictly newer than the
-          given cursor (the ``cursor`` value from a previously returned
-          result, or the ``next_after`` from a previous response). Exact
-          dedup: cursors are the run's timestamp-based output filename,
-          which increases monotonically per job.
+        - ``after=<cursor>`` — the client's high-water mark. Only results
+          strictly newer than this cursor are ever considered, for the
+          whole polling round. Pass the ``next_after`` from a previous
+          *round's* response (any page of it — ``next_after`` is stable
+          across pages of the same round) back in to start the next round.
+        - ``before=<cursor>`` — intra-round paging cursor. Only results
+          strictly older than this cursor are considered. Pass the
+          previous page's ``next_before`` back in to keep walking older
+          results within the same round (same ``after``); omit it to get
+          the newest unseen page. Cursors are the run's timestamp-based
+          output filename, which increases monotonically per job, so
+          ``(after, before)`` is an exact, gap-free, duplicate-free
+          half-open window.
         - ``limit=<n>`` — clamped to (0, 100], default 20.
+
+        A full poll of everything newer than a high-water mark: call with
+        ``after`` set and no ``before``; while the response's ``has_more``
+        is true, call again with the same ``after`` and
+        ``before=<previous next_before>``. ``next_before`` is ``null``
+        once ``has_more`` is false.
 
         Never touches anything outside the job's own output directory: the
         job_id is validated by ``_check_job_id`` (12-hex format) before
         this handler runs, and ``get_job_results`` re-validates the id as a
-        safe single path component and rejects a cursor containing a path
-        separator. A job with no output directory yet (never run, or fully
-        pruned) returns an empty result list rather than an error.
+        safe single path component and rejects an ``after``/``before``
+        cursor containing a path separator. A job with no output directory
+        yet (never run, or fully pruned) returns an empty result list
+        rather than an error.
         """
         auth_err = self._check_auth(request)
         if auth_err:
@@ -6721,6 +6736,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
         after = request.query.get("after") or None
+        before = request.query.get("before") or None
         raw_limit = request.query.get("limit")
         try:
             limit = (
@@ -6735,7 +6751,7 @@ class APIServerAdapter(BasePlatformAdapter):
         limit = max(1, min(limit, self._MAX_JOB_RESULTS_LIMIT))
 
         try:
-            page = _cron_get_results(job_id, after=after, limit=limit)
+            page = _cron_get_results(job_id, after=after, before=before, limit=limit)
             return web.json_response(page)
         except ValueError as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=400)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1418,6 +1418,7 @@ try:
         pause_job as _cron_pause,
         resume_job as _cron_resume,
         trigger_job as _cron_trigger,
+        get_job_results as _cron_get_results,
     )
     from cron.scheduler import (
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
@@ -1433,6 +1434,7 @@ except ImportError:
     _cron_pause = None
     _cron_resume = None
     _cron_trigger = None
+    _cron_get_results = None
 
     class _CronSchedulerRegistrationError(RuntimeError):
         pass
@@ -2259,6 +2261,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/api/jobs", self._handle_list_jobs),
             ("POST", "/api/jobs", self._handle_create_job),
             ("GET", "/api/jobs/{job_id}", self._handle_get_job),
+            ("GET", "/api/jobs/{job_id}/results", self._handle_get_job_results),
             ("PATCH", "/api/jobs/{job_id}", self._handle_update_job),
             ("DELETE", "/api/jobs/{job_id}", self._handle_delete_job),
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
@@ -3426,6 +3429,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "method": "GET",
                     "path": "/v1/artifacts/download/{artifact_id}",
                 },
+                "job_results": {"method": "GET", "path": "/api/jobs/{job_id}/results"},
             },
         })
 
@@ -6674,6 +6678,67 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
+        except Exception as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+    _MAX_JOB_RESULTS_LIMIT = 100
+    _DEFAULT_JOB_RESULTS_LIMIT = 20
+
+    async def _handle_get_job_results(self, request: "web.Request") -> "web.Response":
+        """GET /api/jobs/{job_id}/results — poll a job's newest saved outputs.
+
+        Read-only, bounded, and cursor-based so a client can poll for new
+        cron output without re-downloading everything each time:
+
+        - ``after=<cursor>`` — only return results strictly newer than the
+          given cursor (the ``cursor`` value from a previously returned
+          result, or the ``next_after`` from a previous response). Exact
+          dedup: cursors are the run's timestamp-based output filename,
+          which increases monotonically per job.
+        - ``limit=<n>`` — clamped to (0, 100], default 20.
+
+        Never touches anything outside the job's own output directory: the
+        job_id is validated by ``_check_job_id`` (12-hex format) before
+        this handler runs, and ``get_job_results`` re-validates the id as a
+        safe single path component and rejects a cursor containing a path
+        separator. A job with no output directory yet (never run, or fully
+        pruned) returns an empty result list rather than an error.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        cron_err = self._check_jobs_available()
+        if cron_err:
+            return cron_err
+        job_id, id_err = self._check_job_id(request)
+        if id_err:
+            return id_err
+        try:
+            job = _cron_get(job_id)
+            if not job:
+                return web.json_response({"error": "Job not found"}, status=404)
+        except Exception as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+        after = request.query.get("after") or None
+        raw_limit = request.query.get("limit")
+        try:
+            limit = (
+                self._DEFAULT_JOB_RESULTS_LIMIT
+                if raw_limit is None
+                else int(raw_limit)
+            )
+        except (TypeError, ValueError):
+            return web.json_response(
+                {"error": "limit must be an integer"}, status=400,
+            )
+        limit = max(1, min(limit, self._MAX_JOB_RESULTS_LIMIT))
+
+        try:
+            page = _cron_get_results(job_id, after=after, limit=limit)
+            return web.json_response(page)
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1224,6 +1224,7 @@ class TestGetJobResults:
         assert page["results"] == []
         assert page["has_more"] is False
         assert page["next_after"] is None
+        assert page["next_before"] is None
 
     def test_returns_newest_first_bounded_by_limit(self, tmp_cron_dir):
         from cron.jobs import get_job_results
@@ -1239,7 +1240,11 @@ class TestGetJobResults:
         # Newest content first.
         assert page["results"][0]["content"] == "run 4"
         assert page["results"][1]["content"] == "run 3"
+        # next_after is the true newest cursor regardless of paging position.
         assert page["next_after"] == page["results"][0]["cursor"]
+        # next_before is the oldest cursor on *this* page — pass it back as
+        # `before` to keep paging older results within the same round.
+        assert page["next_before"] == page["results"][1]["cursor"]
 
     def test_after_cursor_returns_only_newer_results(self, tmp_cron_dir):
         """A polling client passes the last-seen cursor back in via `after` and
@@ -1263,6 +1268,7 @@ class TestGetJobResults:
         next_page = get_job_results("polljob2", after=cursor)
         assert [r["content"] for r in next_page["results"]] == ["run 1"]
         assert next_page["has_more"] is False
+        assert next_page["next_before"] is None
 
     def test_limit_is_clamped(self, tmp_cron_dir):
         from cron.jobs import get_job_results, _MAX_JOB_RESULTS
@@ -1285,6 +1291,8 @@ class TestGetJobResults:
         for bad_cursor in ("../escape.md", "a/b.md", ".", ".."):
             with pytest.raises(ValueError):
                 get_job_results("cursorjob", after=bad_cursor)
+            with pytest.raises(ValueError):
+                get_job_results("cursorjob", before=bad_cursor)
 
     def test_content_preserved_exactly(self, tmp_cron_dir):
         """Result content must round-trip byte-for-byte for chat rendering."""
@@ -1293,6 +1301,63 @@ class TestGetJobResults:
         save_job_output("exactjob", text)
         page = get_job_results("exactjob")
         assert page["results"][0]["content"] == text
+
+    def test_before_cursor_pages_intra_round_without_gaps_or_duplicates(self, tmp_cron_dir):
+        """The bug this whole feature exists to avoid: a client polling with
+        `after=next_after` from a page that had `has_more=True` must be able
+        to retrieve the *older* remaining unseen files, not get stuck. Walk a
+        real store with more files than `limit` using the `before` cursor and
+        prove the full walk is exactly the unseen set, in order, no repeats."""
+        from cron.jobs import get_job_results
+        import time as _time
+
+        n = 7
+        for i in range(n):
+            save_job_output("pagingjob", f"run {i}")
+            _time.sleep(1.01)
+
+        # First round: nothing seen yet.
+        seen_cursors: list = []
+        seen_contents: list = []
+        before = None
+        first_next_after = None
+        pages_fetched = 0
+        while True:
+            page = get_job_results("pagingjob", limit=3, before=before)
+            pages_fetched += 1
+            if first_next_after is None:
+                first_next_after = page["next_after"]
+            else:
+                # next_after must be stable across every page of the round.
+                assert page["next_after"] == first_next_after
+            seen_cursors.extend(r["cursor"] for r in page["results"])
+            seen_contents.extend(r["content"] for r in page["results"])
+            if not page["has_more"]:
+                assert page["next_before"] is None
+                break
+            before = page["next_before"]
+            assert pages_fetched <= n  # guard against infinite loop on a bug
+
+        # No gaps, no duplicates: exactly every saved run, newest first.
+        assert seen_contents == [f"run {n - 1 - i}" for i in range(n)]
+        assert len(seen_cursors) == len(set(seen_cursors)) == n
+
+        # Second round: poll again using the high-water mark from round one.
+        # With nothing new produced, the round must be immediately empty and
+        # never resurface anything already delivered.
+        round_two_after = first_next_after
+        empty_page = get_job_results("pagingjob", after=round_two_after, limit=3)
+        assert empty_page["results"] == []
+        assert empty_page["has_more"] is False
+        assert empty_page["next_before"] is None
+
+        # A new run lands after round one finished; round two must surface
+        # only that one new file, not re-walk anything from round one.
+        _time.sleep(1.01)
+        save_job_output("pagingjob", "run new")
+        round_two_page = get_job_results("pagingjob", after=round_two_after, limit=3)
+        assert [r["content"] for r in round_two_page["results"]] == ["run new"]
+        assert round_two_page["has_more"] is False
 
 
 class TestCronOutputRetention:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1214,6 +1214,87 @@ class TestSaveJobOutput:
         assert "test123" in str(output_file)
 
 
+class TestGetJobResults:
+    """Bounded, cursor-based polling over a job's saved output files."""
+
+    def test_no_output_dir_returns_empty(self, tmp_cron_dir):
+        """A job that never produced output must not error — just empty results."""
+        from cron.jobs import get_job_results
+        page = get_job_results("nooutputjob")
+        assert page["results"] == []
+        assert page["has_more"] is False
+        assert page["next_after"] is None
+
+    def test_returns_newest_first_bounded_by_limit(self, tmp_cron_dir):
+        from cron.jobs import get_job_results
+        for i in range(5):
+            save_job_output("polljob", f"run {i}")
+            # Ensure distinct, increasing timestamps in the filename.
+            import time as _time
+            _time.sleep(1.01)
+
+        page = get_job_results("polljob", limit=2)
+        assert len(page["results"]) == 2
+        assert page["has_more"] is True
+        # Newest content first.
+        assert page["results"][0]["content"] == "run 4"
+        assert page["results"][1]["content"] == "run 3"
+        assert page["next_after"] == page["results"][0]["cursor"]
+
+    def test_after_cursor_returns_only_newer_results(self, tmp_cron_dir):
+        """A polling client passes the last-seen cursor back in via `after` and
+        must get only results strictly newer than it — never a repeat of
+        anything already delivered, and nothing at all if the job hasn't
+        produced new output since."""
+        from cron.jobs import get_job_results
+        import time as _time
+
+        save_job_output("polljob2", "run 0")
+        first_page = get_job_results("polljob2")
+        assert [r["content"] for r in first_page["results"]] == ["run 0"]
+        cursor = first_page["next_after"]
+
+        # No new output yet: polling again with the same cursor yields nothing.
+        assert get_job_results("polljob2", after=cursor)["results"] == []
+
+        # A new run lands; polling with the old cursor surfaces only the new one.
+        _time.sleep(1.01)
+        save_job_output("polljob2", "run 1")
+        next_page = get_job_results("polljob2", after=cursor)
+        assert [r["content"] for r in next_page["results"]] == ["run 1"]
+        assert next_page["has_more"] is False
+
+    def test_limit_is_clamped(self, tmp_cron_dir):
+        from cron.jobs import get_job_results, _MAX_JOB_RESULTS
+        save_job_output("clampjob", "one run")
+        page = get_job_results("clampjob", limit=999999)
+        # Clamp doesn't error and the ceiling constant caps what would be requested.
+        assert len(page["results"]) <= _MAX_JOB_RESULTS
+        page_zero = get_job_results("clampjob", limit=0)
+        assert len(page_zero["results"]) >= 1  # clamps up to at least 1, not to 0
+
+    def test_rejects_path_escaping_job_id(self, tmp_cron_dir):
+        from cron.jobs import get_job_results
+        for bad_id in ("../escape", "a/b", "..", ".", "/etc/passwd"):
+            with pytest.raises(ValueError):
+                get_job_results(bad_id)
+
+    def test_rejects_path_escaping_cursor(self, tmp_cron_dir):
+        from cron.jobs import get_job_results
+        save_job_output("cursorjob", "content")
+        for bad_cursor in ("../escape.md", "a/b.md", ".", ".."):
+            with pytest.raises(ValueError):
+                get_job_results("cursorjob", after=bad_cursor)
+
+    def test_content_preserved_exactly(self, tmp_cron_dir):
+        """Result content must round-trip byte-for-byte for chat rendering."""
+        from cron.jobs import get_job_results
+        text = "# Heading\n\nSome **markdown** with emoji 🎉 and unicode café.\n"
+        save_job_output("exactjob", text)
+        page = get_job_results("exactjob")
+        assert page["results"][0]["content"] == text
+
+
 class TestCronOutputRetention:
     """Per-run cron output must self-prune so long deploys don't fill the disk (#52383)."""
 

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -224,6 +224,7 @@ class TestGetJobResults:
             "results": [{"cursor": "2026-01-02_00-00-00.md", "content": "hi"}],
             "has_more": False,
             "next_after": "2026-01-02_00-00-00.md",
+            "next_before": None,
         }
         mock_results = MagicMock(return_value=page)
         async with TestClient(TestServer(app)) as cli:
@@ -234,15 +235,18 @@ class TestGetJobResults:
                 assert resp.status == 200
                 data = await resp.json()
                 assert data == page
-                mock_results.assert_called_once_with(VALID_JOB_ID, after=None, limit=20)
+                mock_results.assert_called_once_with(
+                    VALID_JOB_ID, after=None, before=None, limit=20,
+                )
 
     @pytest.mark.asyncio
     async def test_get_job_results_passes_after_and_limit(self, adapter):
-        """?after=<cursor>&limit=<n> forwards through, with limit clamped."""
+        """?after=<cursor>&before=<cursor>&limit=<n> forwards through, with limit clamped."""
         app = _create_app(adapter)
         mock_get = MagicMock(return_value=SAMPLE_JOB)
         mock_results = MagicMock(return_value={
-            "job_id": VALID_JOB_ID, "results": [], "has_more": False, "next_after": None,
+            "job_id": VALID_JOB_ID, "results": [], "has_more": False,
+            "next_after": None, "next_before": None,
         })
         async with TestClient(TestServer(app)) as cli:
             with patch(f"{_MOD}._CRON_AVAILABLE", True), \
@@ -250,11 +254,18 @@ class TestGetJobResults:
                  patch(f"{_MOD}._cron_get_results", mock_results):
                 resp = await cli.get(
                     f"/api/jobs/{VALID_JOB_ID}/results",
-                    params={"after": "2026-01-01_00-00-00.md", "limit": "9999"},
+                    params={
+                        "after": "2026-01-01_00-00-00.md",
+                        "before": "2026-01-03_00-00-00.md",
+                        "limit": "9999",
+                    },
                 )
                 assert resp.status == 200
                 mock_results.assert_called_once_with(
-                    VALID_JOB_ID, after="2026-01-01_00-00-00.md", limit=100,
+                    VALID_JOB_ID,
+                    after="2026-01-01_00-00-00.md",
+                    before="2026-01-03_00-00-00.md",
+                    limit=100,
                 )
 
     @pytest.mark.asyncio
@@ -403,6 +414,87 @@ class TestGetJobResultsRealStore:
                         headers=headers,
                     )
                     assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_before_cursor_pages_beyond_limit_no_gaps_no_duplicates(self, tmp_path):
+        """The bug the `before` cursor exists to fix: a store with more saved
+        results than `limit` must be fully retrievable via HTTP by paging
+        `before=<next_before>` after `after=<original after>` — every file
+        visited exactly once, newest first, nothing skipped and nothing
+        repeated."""
+        import time as _time
+
+        import cron.jobs as cron_jobs
+
+        job_id = "0123456789cd"  # valid 12-hex
+        n = 7
+        limit = 3
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([{
+                "id": job_id,
+                "name": "paging-e2e-job",
+                "schedule": "0 9 * * *",
+                "prompt": "do the thing",
+                "deliver": "local",
+                "enabled": True,
+            }])
+            for i in range(n):
+                cron_jobs.save_job_output(job_id, f"run {i}")
+                _time.sleep(1.01)
+
+            adapter = _make_adapter(api_key="sk-secret")
+            app = _create_app(adapter)
+            headers = {"Authorization": "Bearer sk-secret"}
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                     patch(f"{_MOD}._cron_get", cron_jobs.get_job), \
+                     patch(f"{_MOD}._cron_get_results", cron_jobs.get_job_results):
+                    seen_contents = []
+                    seen_cursors = []
+                    params = {"limit": str(limit)}
+                    pages_fetched = 0
+                    first_next_after = None
+                    while True:
+                        resp = await cli.get(
+                            f"/api/jobs/{job_id}/results", params=params, headers=headers,
+                        )
+                        assert resp.status == 200
+                        data = await resp.json()
+                        pages_fetched += 1
+                        if first_next_after is None:
+                            first_next_after = data["next_after"]
+                        else:
+                            assert data["next_after"] == first_next_after
+                        seen_contents.extend(r["content"] for r in data["results"])
+                        seen_cursors.extend(r["cursor"] for r in data["results"])
+                        if not data["has_more"]:
+                            assert data["next_before"] is None
+                            break
+                        params = {"limit": str(limit), "before": data["next_before"]}
+                        assert pages_fetched <= n
+
+                    assert seen_contents == [f"run {n - 1 - i}" for i in range(n)]
+                    assert len(seen_cursors) == len(set(seen_cursors)) == n
+
+                    # A subsequent round using the high-water mark finds nothing
+                    # until new output lands, and then only the new output.
+                    resp = await cli.get(
+                        f"/api/jobs/{job_id}/results",
+                        params={"after": first_next_after},
+                        headers=headers,
+                    )
+                    assert (await resp.json())["results"] == []
+
+                    _time.sleep(1.01)
+                    cron_jobs.save_job_output(job_id, "run new")
+                    resp = await cli.get(
+                        f"/api/jobs/{job_id}/results",
+                        params={"after": first_next_after},
+                        headers=headers,
+                    )
+                    data = await resp.json()
+                    assert [r["content"] for r in data["results"]] == ["run new"]
 
     @pytest.mark.asyncio
     async def test_missing_output_dir_is_empty_not_error(self, tmp_path):

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -58,6 +58,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)
     app.router.add_post("/api/jobs", adapter._handle_create_job)
     app.router.add_get("/api/jobs/{job_id}", adapter._handle_get_job)
+    app.router.add_get("/api/jobs/{job_id}/results", adapter._handle_get_job_results)
     app.router.add_patch("/api/jobs/{job_id}", adapter._handle_update_job)
     app.router.add_delete("/api/jobs/{job_id}", adapter._handle_delete_job)
     app.router.add_post("/api/jobs/{job_id}/pause", adapter._handle_pause_job)
@@ -206,6 +207,229 @@ class TestGetJob:
                 data = await resp.json()
                 assert data["job"] == SAMPLE_JOB
                 mock_get.assert_called_once_with(VALID_JOB_ID)
+
+
+# ---------------------------------------------------------------------------
+# 10b. test_get_job_results
+# ---------------------------------------------------------------------------
+
+class TestGetJobResults:
+    @pytest.mark.asyncio
+    async def test_get_job_results(self, adapter):
+        """GET /api/jobs/{id}/results returns the newest results page."""
+        app = _create_app(adapter)
+        mock_get = MagicMock(return_value=SAMPLE_JOB)
+        page = {
+            "job_id": VALID_JOB_ID,
+            "results": [{"cursor": "2026-01-02_00-00-00.md", "content": "hi"}],
+            "has_more": False,
+            "next_after": "2026-01-02_00-00-00.md",
+        }
+        mock_results = MagicMock(return_value=page)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                 patch(f"{_MOD}._cron_get", mock_get), \
+                 patch(f"{_MOD}._cron_get_results", mock_results):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/results")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == page
+                mock_results.assert_called_once_with(VALID_JOB_ID, after=None, limit=20)
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_passes_after_and_limit(self, adapter):
+        """?after=<cursor>&limit=<n> forwards through, with limit clamped."""
+        app = _create_app(adapter)
+        mock_get = MagicMock(return_value=SAMPLE_JOB)
+        mock_results = MagicMock(return_value={
+            "job_id": VALID_JOB_ID, "results": [], "has_more": False, "next_after": None,
+        })
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                 patch(f"{_MOD}._cron_get", mock_get), \
+                 patch(f"{_MOD}._cron_get_results", mock_results):
+                resp = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/results",
+                    params={"after": "2026-01-01_00-00-00.md", "limit": "9999"},
+                )
+                assert resp.status == 200
+                mock_results.assert_called_once_with(
+                    VALID_JOB_ID, after="2026-01-01_00-00-00.md", limit=100,
+                )
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_invalid_job_id(self, adapter):
+        """Path-escaping / malformed job_id is rejected with 400 before touching disk."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.get("/api/jobs/../../etc/results")
+                # aiohttp normalizes ".." path segments before routing; either a
+                # 404 (no matching route) or a 400 (rejected job_id) is an
+                # acceptable "never reaches the handler with an escaping id".
+                assert resp.status in (400, 404)
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_job_not_found(self, adapter):
+        """404 when the job itself doesn't exist — never leaks output-dir contents."""
+        app = _create_app(adapter)
+        mock_get = MagicMock(return_value=None)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(f"{_MOD}._cron_get", mock_get):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/results")
+                assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_bad_limit(self, adapter):
+        """Non-integer limit is rejected with 400."""
+        app = _create_app(adapter)
+        mock_get = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(f"{_MOD}._cron_get", mock_get):
+                resp = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/results", params={"limit": "not-a-number"},
+                )
+                assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_cursor_value_error_becomes_400(self, adapter):
+        """A ValueError raised by the store layer (e.g. bad cursor) maps to 400, not 500."""
+        app = _create_app(adapter)
+        mock_get = MagicMock(return_value=SAMPLE_JOB)
+        mock_results = MagicMock(side_effect=ValueError("Invalid cursor: '../evil'"))
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                 patch(f"{_MOD}._cron_get", mock_get), \
+                 patch(f"{_MOD}._cron_get_results", mock_results):
+                resp = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/results", params={"after": "../evil"},
+                )
+                assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_requires_auth(self, auth_adapter):
+        """401 without a valid bearer token when API_SERVER_KEY is configured."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/results")
+                assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_job_results_cron_unavailable(self, adapter):
+        """501 when the cron module isn't available."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", False):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/results")
+                assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# 10c. Real temp-HERMES_HOME end-to-end: real cron store, real job, real
+# saved output files on disk, driven entirely through HTTP — no mocking of
+# _cron_get / _cron_get_results, so this exercises the actual resolution
+# chain (get_cron_output_dir -> job output dir -> API handler -> JSON body).
+# ---------------------------------------------------------------------------
+
+class TestGetJobResultsRealStore:
+    @pytest.mark.asyncio
+    async def test_polls_real_saved_output_end_to_end(self, tmp_path):
+        import time as _time
+
+        import cron.jobs as cron_jobs
+
+        job_id = "0123456789ab"  # valid 12-hex
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([{
+                "id": job_id,
+                "name": "e2e-job",
+                "schedule": "0 9 * * *",
+                "prompt": "do the thing",
+                "deliver": "local",
+                "enabled": True,
+            }])
+            cron_jobs.save_job_output(job_id, "# Run 1\nAll good.")
+            _time.sleep(1.01)
+            cron_jobs.save_job_output(job_id, "# Run 2\nStill good. 🎉")
+
+            adapter = _make_adapter(api_key="sk-secret")
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                     patch(f"{_MOD}._cron_get", cron_jobs.get_job), \
+                     patch(f"{_MOD}._cron_get_results", cron_jobs.get_job_results):
+                    # No auth -> 401, never reaches disk.
+                    resp = await cli.get(f"/api/jobs/{job_id}/results")
+                    assert resp.status == 401
+
+                    headers = {"Authorization": "Bearer sk-secret"}
+
+                    # First page: newest result first, content preserved exactly.
+                    resp = await cli.get(f"/api/jobs/{job_id}/results", headers=headers)
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert len(data["results"]) == 2
+                    assert data["results"][0]["content"] == "# Run 2\nStill good. 🎉"
+                    assert data["results"][1]["content"] == "# Run 1\nAll good."
+                    assert data["has_more"] is False
+
+                    # Cursor-based polling: after the newest cursor, nothing new.
+                    cursor = data["results"][0]["cursor"]
+                    resp = await cli.get(
+                        f"/api/jobs/{job_id}/results",
+                        params={"after": cursor},
+                        headers=headers,
+                    )
+                    assert resp.status == 200
+                    assert (await resp.json())["results"] == []
+
+                    # A new run lands; polling with the old cursor sees only it.
+                    _time.sleep(1.01)
+                    cron_jobs.save_job_output(job_id, "# Run 3")
+                    resp = await cli.get(
+                        f"/api/jobs/{job_id}/results",
+                        params={"after": cursor},
+                        headers=headers,
+                    )
+                    data = await resp.json()
+                    assert [r["content"] for r in data["results"]] == ["# Run 3"]
+
+                    # Path-escaping cursor is rejected (400), not a filesystem read.
+                    resp = await cli.get(
+                        f"/api/jobs/{job_id}/results",
+                        params={"after": "../../../etc/passwd"},
+                        headers=headers,
+                    )
+                    assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_output_dir_is_empty_not_error(self, tmp_path):
+        """A real job with no output directory yet (never run) polls cleanly empty."""
+        import cron.jobs as cron_jobs
+
+        job_id = "aaaaaaaaaaaa"
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([{
+                "id": job_id,
+                "name": "never-run",
+                "schedule": "0 9 * * *",
+                "prompt": "do the thing",
+                "deliver": "local",
+                "enabled": True,
+            }])
+            adapter = _make_adapter()
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True), \
+                     patch(f"{_MOD}._cron_get", cron_jobs.get_job), \
+                     patch(f"{_MOD}._cron_get_results", cron_jobs.get_job_results):
+                    resp = await cli.get(f"/api/jobs/{job_id}/results")
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["results"] == []
+                    assert data["has_more"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -510,6 +510,10 @@ Create a new scheduled job. Body accepts the same shape as `hermes cron` — pro
 
 Fetch a single job's definition and last-run state.
 
+### GET /api/jobs/\{job_id\}/results
+
+Poll a job's newest saved output files (its persisted run results), newest first. Supports `after=<cursor>` (only return results strictly newer than a previously-seen cursor — exact dedup for polling) and `limit=<n>` (clamped to 1-100, default 20). Each result carries a `cursor` (the underlying output filename) and `content` (the raw saved output, safe to render as a chat message). Returns an empty `results` list, not an error, if the job has no saved output yet.
+
 ### PATCH /api/jobs/\{job_id\}
 
 Update fields on an existing job (prompt, schedule, etc.). Partial updates are merged.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -512,7 +512,15 @@ Fetch a single job's definition and last-run state.
 
 ### GET /api/jobs/\{job_id\}/results
 
-Poll a job's newest saved output files (its persisted run results), newest first. Supports `after=<cursor>` (only return results strictly newer than a previously-seen cursor — exact dedup for polling) and `limit=<n>` (clamped to 1-100, default 20). Each result carries a `cursor` (the underlying output filename) and `content` (the raw saved output, safe to render as a chat message). Returns an empty `results` list, not an error, if the job has no saved output yet.
+Poll a job's saved output files (its persisted run results), newest first, in bounded pages. Two cursors, two different jobs:
+
+- `after=<cursor>` — the client's high-water mark. Only results strictly newer than this cursor are ever considered, for the whole polling round. Pass a previous round's `next_after` back in to start the next round.
+- `before=<cursor>` — intra-round paging cursor. Only results strictly older than this cursor are considered. Pass the previous page's `next_before` back in to keep walking older, still-unseen results within the same round (same `after`); omit it to get the newest unseen page.
+- `limit=<n>` — clamped to 1-100, default 20.
+
+To drain everything newer than a high-water mark: call with `after` set and no `before`; while the response's `has_more` is `true`, call again with the same `after` and `before=<previous next_before>`. `next_before` is `null` once `has_more` is `false`. `next_after` is stable across every page of a round (it always reflects the single newest result matching `after`, independent of paging position) — capture it once and use it as `after` for the next round.
+
+Each result carries a `cursor` (the underlying output filename) and `content` (the raw saved output, safe to render as a chat message). Returns an empty `results` list, not an error, if the job has no saved output yet.
 
 ### PATCH /api/jobs/\{job_id\}
 


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/jobs/{job_id}/results` for persisted cron outputs
- provide bounded exact cursor polling with separate high-water (`after`) and intra-round paging (`before`) cursors
- reject path escapes and preserve empty/no-output behavior

## Verification
- `scripts/run_tests.sh tests/cron/test_jobs.py tests/gateway/test_api_server_jobs.py`
- 149 passed

This enables stateless clients to poll cron results without relying on platform `send()` support.
