### PR TITLE
perf(desktop): cache and defer Mermaid rendering

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { initialize, renderMermaid } = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  renderMermaid: vi.fn(async () => ({
+    svg: '<svg id="shared"><title>Request flow</title><desc>A sends data to B</desc><defs><marker id="arrow" /></defs><path marker-end="url(#arrow)" /></svg>'
+  }))
+}))
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize,
+    render: renderMermaid
+  }
+}))
+
+vi.mock('./use-is-dark', () => ({ useIsDark: () => false }))
+
+import MermaidRenderer from './mermaid-embed'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('MermaidRenderer', () => {
+  it('reuses one render while isolating each mounted SVG in an image resource', async () => {
+    const { container } = render(
+      <>
+        <MermaidRenderer code="graph TD; A-->B" />
+        <MermaidRenderer code="graph TD; A-->B" />
+      </>
+    )
+
+    await waitFor(() => expect(container.querySelectorAll('img')).toHaveLength(2))
+
+    const images = [...container.querySelectorAll('img')]
+    expect(renderMermaid).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('svg#shared')).toBeNull()
+    expect(images[0]?.src).toMatch(/^data:image\/svg\+xml/)
+    expect(images[1]?.src).toBe(images[0]?.src)
+    expect(images.map(image => image.alt)).toEqual([
+      'Request flow — A sends data to B',
+      'Request flow — A sends data to B'
+    ])
+    expect(decodeURIComponent(images[0]?.src.split(',')[1] ?? '')).toContain('marker-end="url(#arrow)"')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -1,21 +1,23 @@
 'use client'
 
-import mermaid from 'mermaid'
+import type { Mermaid as MermaidApi } from 'mermaid'
 import { useEffect, useState } from 'react'
 
 import { Zoomable } from '@/components/ui/zoomable'
 import { copySvgAsPng, normalizeSvgSize } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
 
+import { createMermaidRenderCache, createRetryableLoader } from './mermaid-render-cache'
 import type { RichFenceProps } from './types'
 import { useIsDark } from './use-is-dark'
 
 let lastTheme: 'dark' | 'default' | null = null
+const loadMermaid = createRetryableLoader<MermaidApi>(() => import('mermaid').then(module => module.default))
 
 // Re-initialise only on first use / theme flip. `securityLevel: 'strict'` makes
 // mermaid sanitise label HTML and drop click handlers, so the rendered SVG is
 // safe to inject.
-function ensureInit(dark: boolean) {
+function ensureInit(mermaid: MermaidApi, dark: boolean) {
   const theme = dark ? 'dark' : 'default'
 
   if (theme === lastTheme) {
@@ -25,6 +27,18 @@ function ensureInit(dark: boolean) {
   mermaid.initialize({ fontFamily: 'inherit', securityLevel: 'strict', startOnLoad: false, theme })
   lastTheme = theme
 }
+
+const renderCache = createMermaidRenderCache({
+  maxEntries: 32,
+  render: async (code, theme) => {
+    const mermaid = await loadMermaid()
+    ensureInit(mermaid, theme === 'dark')
+    const id = `mmd-${Math.random().toString(36).slice(2)}`
+    const result = await mermaid.render(id, code)
+
+    return normalizeSvgSize(result.svg)
+  }
+})
 
 function SourcePreview({ code, muted }: { code: string; muted?: boolean }) {
   return (
@@ -37,6 +51,16 @@ function SourcePreview({ code, muted }: { code: string; muted?: boolean }) {
       {code}
     </pre>
   )
+}
+
+function svgAccessibleText(svg: string): string {
+  const document = new DOMParser().parseFromString(svg, 'image/svg+xml')
+
+  const text = [document.querySelector('title')?.textContent, document.querySelector('desc')?.textContent]
+    .map(value => value?.trim())
+    .filter((value): value is string => Boolean(value))
+
+  return text.join(' — ') || 'Mermaid diagram'
 }
 
 // Lazy chunk (pulls in mermaid). Renders ```mermaid fences as diagrams; shows
@@ -53,17 +77,17 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
     }
 
     let cancelled = false
+    const controller = new AbortController()
 
     setFailed(false)
+    setSvg('')
 
     void (async () => {
       try {
-        ensureInit(isDark)
-        const id = `mmd-${Math.random().toString(36).slice(2)}`
-        const result = await mermaid.render(id, code)
+        const rendered = await renderCache.render(code, isDark ? 'dark' : 'default', controller.signal)
 
         if (!cancelled) {
-          setSvg(normalizeSvgSize(result.svg))
+          setSvg(rendered)
         }
       } catch {
         if (!cancelled) {
@@ -75,6 +99,7 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
 
     return () => {
       cancelled = true
+      controller.abort()
     }
   }, [code, isDark, streaming])
 
@@ -90,6 +115,9 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
     return <SourcePreview code={code} muted />
   }
 
+  const imageSrc = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  const imageAlt = svgAccessibleText(svg)
+
   // Click to open the diagram full-screen with pan/zoom + copy-as-PNG. The
   // overlay keeps the diagram's natural width (capped to the viewport) so it
   // renders before any zoom; the inline version stays capped at 33dvh.
@@ -98,16 +126,12 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
       label="Open diagram"
       onCopy={() => copySvgAsPng(svg)}
       overlay={
-        <div
-          className="[&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[80vh] [&_svg]:max-w-[85vw]"
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
+        <img alt={imageAlt} className="mx-auto h-auto max-h-[80vh] max-w-[85vw]" draggable={false} src={imageSrc} />
       }
     >
-      <div
-        className="overflow-hidden p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[33dvh] [&_svg]:max-w-full"
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
+      <div className="overflow-hidden p-3">
+        <img alt={imageAlt} className="mx-auto h-auto max-h-[33dvh] max-w-full" draggable={false} src={imageSrc} />
+      </div>
     </Zoomable>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.test.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMermaidRenderCache, createRetryableLoader } from './mermaid-render-cache'
+
+const flushTasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('createMermaidRenderCache', () => {
+  it('shares in-flight work and reuses the completed SVG', async () => {
+    let release!: (svg: string) => void
+    const render = vi.fn(() => new Promise<string>(resolve => (release = resolve)))
+    const defer = vi.fn(async () => undefined)
+    const cache = createMermaidRenderCache({ defer, maxEntries: 8, render })
+
+    const first = cache.render('graph TD; A-->B', 'dark')
+    const concurrent = cache.render('graph TD; A-->B', 'dark')
+    await flushTasks()
+
+    expect(first).toBe(concurrent)
+    expect(defer).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(1)
+
+    release('<svg>dark</svg>')
+    await expect(first).resolves.toBe('<svg>dark</svg>')
+
+    const cached = cache.render('graph TD; A-->B', 'dark')
+    expect(cached).toBe(first)
+    await expect(cached).resolves.toBe('<svg>dark</svg>')
+    expect(render).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches themes separately and serializes cache misses', async () => {
+    const releases: Array<(svg: string) => void> = []
+    let active = 0
+    let maxActive = 0
+
+    const render = vi.fn(
+      (_code: string, theme: 'dark' | 'default') =>
+        new Promise<string>(resolve => {
+          active += 1
+          maxActive = Math.max(maxActive, active)
+          releases.push(svg => {
+            active -= 1
+            resolve(`${svg}-${theme}`)
+          })
+        })
+    )
+
+    const cache = createMermaidRenderCache({
+      defer: async () => undefined,
+      maxEntries: 8,
+      render,
+      yieldToMainThread: async () => undefined
+    })
+
+    const dark = cache.render('sequenceDiagram\nA->>B: hello', 'dark')
+    const light = cache.render('sequenceDiagram\nA->>B: hello', 'default')
+    await flushTasks()
+
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(maxActive).toBe(1)
+
+    releases[0]('<svg>first</svg>')
+    await dark
+    await flushTasks()
+
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(maxActive).toBe(1)
+
+    releases[1]('<svg>second</svg>')
+    await expect(light).resolves.toBe('<svg>second</svg>-default')
+  })
+
+  it('removes failed work so a later mount can retry', async () => {
+    const render = vi
+      .fn<(code: string, theme: 'dark' | 'default') => Promise<string>>()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce('<svg>retry</svg>')
+
+    const cache = createMermaidRenderCache({ defer: async () => undefined, maxEntries: 8, render })
+
+    await expect(cache.render('flowchart LR; A-->B', 'dark')).rejects.toThrow('temporary failure')
+    await expect(cache.render('flowchart LR; A-->B', 'dark')).resolves.toBe('<svg>retry</svg>')
+    expect(render).toHaveBeenCalledTimes(2)
+  })
+
+  it('evicts the least recently used result at the configured bound', async () => {
+    const render = vi.fn(async (code: string, theme: 'dark' | 'default') => `<svg>${theme}:${code}</svg>`)
+    const cache = createMermaidRenderCache({ defer: async () => undefined, maxEntries: 2, render })
+
+    await cache.render('A', 'dark')
+    await cache.render('B', 'dark')
+    await cache.render('A', 'dark')
+    await cache.render('C', 'dark')
+    await cache.render('B', 'dark')
+
+    expect(render.mock.calls.map(([code]) => code)).toEqual(['A', 'B', 'C', 'B'])
+  })
+
+  it('keeps in-flight work deduplicated when the completed-cache bound is exceeded', async () => {
+    const render = vi.fn(async (code: string) => `<svg>${code}</svg>`)
+    const cache = createMermaidRenderCache({ defer: async () => undefined, maxEntries: 2, render })
+
+    const firstA = cache.render('A', 'dark')
+
+    const all = Promise.all([firstA, cache.render('B', 'dark'), cache.render('C', 'dark'), cache.render('A', 'dark')])
+
+    await all
+    expect(render.mock.calls.map(([code]) => code)).toEqual(['A', 'B', 'C'])
+  })
+
+  it('admits misses in parallel but keeps Mermaid rendering serialized', async () => {
+    const admissions: Array<() => void> = []
+
+    const defer = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          admissions.push(resolve)
+        })
+    )
+
+    let active = 0
+    let maxActive = 0
+
+    const render = vi.fn(async (code: string) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await Promise.resolve()
+      active -= 1
+
+      return `<svg>${code}</svg>`
+    })
+
+    const cache = createMermaidRenderCache({ defer, maxEntries: 8, render })
+
+    const pending = [cache.render('A', 'dark'), cache.render('B', 'dark'), cache.render('C', 'dark')]
+    await flushTasks()
+
+    expect(defer).toHaveBeenCalledTimes(3)
+    expect(render).not.toHaveBeenCalled()
+
+    admissions.forEach(admit => admit())
+    await Promise.all(pending)
+
+    expect(render.mock.calls.map(([code]) => code)).toEqual(['A', 'B', 'C'])
+    expect(maxActive).toBe(1)
+  })
+
+  it('yields a task between CPU-heavy Mermaid renders', async () => {
+    const releaseYields: Array<() => void> = []
+
+    const yieldToMainThread = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          releaseYields.push(resolve)
+        })
+    )
+
+    const render = vi.fn(async (code: string) => `<svg>${code}</svg>`)
+
+    const cache = createMermaidRenderCache({
+      defer: async () => undefined,
+      maxEntries: 8,
+      render,
+      yieldToMainThread
+    })
+
+    const first = cache.render('A', 'dark')
+    const second = cache.render('B', 'dark')
+
+    await first
+    await flushTasks()
+    expect(render.mock.calls.map(([code]) => code)).toEqual(['A'])
+    expect(yieldToMainThread).toHaveBeenCalledTimes(1)
+
+    releaseYields.shift()?.()
+    await second
+    expect(render.mock.calls.map(([code]) => code)).toEqual(['A', 'B'])
+  })
+
+  it('cancels unobserved work before it enters the Mermaid render mutex', async () => {
+    const defer = vi.fn(
+      (signal?: AbortSignal) =>
+        new Promise<void>((resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+        })
+    )
+
+    const render = vi.fn(async () => '<svg>stale</svg>')
+    const cache = createMermaidRenderCache({ defer, maxEntries: 8, render })
+    const controller = new AbortController()
+
+    const stale = cache.render('stale', 'dark', controller.signal)
+    controller.abort()
+
+    await expect(stale).rejects.toMatchObject({ name: 'AbortError' })
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('starts fresh work when the same key remounts immediately after cancellation', async () => {
+    let attempt = 0
+
+    const defer = vi.fn((signal?: AbortSignal) => {
+      attempt += 1
+
+      if (attempt > 1) {
+        return Promise.resolve()
+      }
+
+      return new Promise<void>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    })
+
+    const render = vi.fn(async () => '<svg>fresh</svg>')
+    const cache = createMermaidRenderCache({ defer, maxEntries: 8, render })
+    const controller = new AbortController()
+
+    const stale = cache.render('strict-mode', 'dark', controller.signal)
+    controller.abort()
+    const remounted = cache.render('strict-mode', 'dark')
+
+    await expect(stale).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(remounted).resolves.toBe('<svg>fresh</svg>')
+    expect(render).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createRetryableLoader', () => {
+  it('shares a load attempt but retries after a transient rejection', async () => {
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('chunk unavailable'))
+      .mockResolvedValueOnce('mermaid')
+
+    const get = createRetryableLoader(load)
+
+    const first = get()
+    expect(get()).toBe(first)
+    await expect(first).rejects.toThrow('chunk unavailable')
+    await expect(get()).resolves.toBe('mermaid')
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-render-cache.ts
@@ -1,0 +1,239 @@
+export type MermaidTheme = 'dark' | 'default'
+
+interface MermaidRenderCacheOptions {
+  defer?: (signal?: AbortSignal) => Promise<void>
+  maxEntries: number
+  render: (code: string, theme: MermaidTheme) => Promise<string>
+  yieldToMainThread?: () => Promise<void>
+}
+
+interface MermaidRenderCache {
+  render: (code: string, theme: MermaidTheme, signal?: AbortSignal) => Promise<string>
+}
+
+interface PendingRender {
+  controller: AbortController
+  observers: number
+  promise: Promise<string>
+  uncancellable: boolean
+}
+
+function abortError(): DOMException {
+  return new DOMException('Mermaid render cancelled', 'AbortError')
+}
+
+function deferUntilIdle(signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError())
+
+      return
+    }
+
+    let idleId: number | undefined
+    let timerId: ReturnType<typeof setTimeout> | undefined
+
+    const cleanup = () => {
+      signal?.removeEventListener('abort', onAbort)
+    }
+
+    const finish = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onAbort = () => {
+      if (idleId !== undefined && typeof cancelIdleCallback === 'function') {
+        cancelIdleCallback(idleId)
+      }
+
+      if (timerId !== undefined) {
+        clearTimeout(timerId)
+      }
+
+      cleanup()
+      reject(abortError())
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+
+    if (typeof requestIdleCallback === 'function') {
+      idleId = requestIdleCallback(finish, { timeout: 100 })
+    } else {
+      timerId = setTimeout(finish, 0)
+    }
+  })
+}
+
+function yieldTask(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function observePending(entry: PendingRender, signal?: AbortSignal): Promise<string> {
+  if (!signal) {
+    entry.uncancellable = true
+
+    return entry.promise
+  }
+
+  if (signal.aborted) {
+    return Promise.reject(abortError())
+  }
+
+  entry.observers += 1
+
+  return new Promise((resolve, reject) => {
+    let observing = true
+
+    const release = () => {
+      if (!observing) {
+        return
+      }
+
+      observing = false
+      signal.removeEventListener('abort', onAbort)
+      entry.observers -= 1
+
+      if (entry.observers === 0 && !entry.uncancellable) {
+        entry.controller.abort()
+      }
+    }
+
+    const onAbort = () => {
+      release()
+      reject(abortError())
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    entry.promise.then(
+      value => {
+        if (!observing) {
+          return
+        }
+
+        release()
+        resolve(value)
+      },
+      error => {
+        if (!observing) {
+          return
+        }
+
+        release()
+        reject(error)
+      }
+    )
+  })
+}
+
+export function createRetryableLoader<T>(load: () => Promise<T>): () => Promise<T> {
+  let current: Promise<T> | null = null
+
+  return () => {
+    if (current) {
+      return current
+    }
+
+    const attempt = load()
+    current = attempt
+    void attempt.catch(() => {
+      if (current === attempt) {
+        current = null
+      }
+    })
+
+    return attempt
+  }
+}
+
+export function createMermaidRenderCache({
+  defer = deferUntilIdle,
+  maxEntries,
+  render: renderSvg,
+  yieldToMainThread = yieldTask
+}: MermaidRenderCacheOptions): MermaidRenderCache {
+  if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+    throw new Error('Mermaid render cache must contain at least one entry')
+  }
+
+  const completed = new Map<string, Promise<string>>()
+  const inFlight = new Map<string, PendingRender>()
+  let renderMutex = Promise.resolve()
+
+  return {
+    render(code, theme, signal) {
+      if (signal?.aborted) {
+        return Promise.reject(abortError())
+      }
+
+      const key = JSON.stringify([theme, code])
+      const cached = completed.get(key)
+
+      if (cached) {
+        completed.delete(key)
+        completed.set(key, cached)
+
+        return cached
+      }
+
+      const existing = inFlight.get(key)
+
+      if (existing?.controller.signal.aborted) {
+        inFlight.delete(key)
+      } else if (existing) {
+        return observePending(existing, signal)
+      }
+
+      const controller = new AbortController()
+      const admitted = defer(controller.signal)
+
+      const promise = admitted.then(() => {
+        const rendered = renderMutex.then(() => {
+          if (controller.signal.aborted) {
+            throw abortError()
+          }
+
+          return renderSvg(code, theme)
+        })
+
+        renderMutex = rendered.then(yieldToMainThread, yieldToMainThread).then(
+          () => undefined,
+          () => undefined
+        )
+
+        return rendered
+      })
+
+      const entry: PendingRender = { controller, observers: 0, promise, uncancellable: false }
+      inFlight.set(key, entry)
+
+      void promise.then(
+        () => {
+          if (inFlight.get(key) !== entry) {
+            return
+          }
+
+          inFlight.delete(key)
+          completed.set(key, promise)
+
+          while (completed.size > maxEntries) {
+            const oldest = completed.keys().next().value
+
+            if (oldest === undefined) {
+              break
+            }
+
+            completed.delete(oldest)
+          }
+        },
+        () => {
+          if (inFlight.get(key) === entry) {
+            inFlight.delete(key)
+          }
+        }
+      )
+
+      return observePending(entry, signal)
+    }
+  }
+}

--- a/apps/desktop/src/components/assistant-ui/embeds/registry.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/registry.tsx
@@ -6,8 +6,9 @@ import { RichBoundary } from './rich-boundary'
 import type { RichFenceProps } from './types'
 
 // Root renderer for fenced code blocks: a language → lazy-renderer table. Each
-// renderer is its own split chunk (mermaid pulls in the mermaid lib, svg pulls
-// in DOMPurify), loaded only when a block of that language actually appears.
+// renderer is split and loaded only when a block of that language appears. The
+// Mermaid renderer defers its heavier runtime import until after its source
+// fallback has had a chance to paint.
 const LAZY_FENCE: Record<string, LazyExoticComponent<ComponentType<RichFenceProps>>> = {
   mermaid: lazy(() => import('./mermaid-embed')),
   svg: lazy(() => import('./svg-embed'))


### PR DESCRIPTION
## Summary

- defer the heavy Mermaid runtime until the source fallback gets a paint/idle opportunity
- deduplicate in-flight renders and retain completed SVGs in a 32-entry source/theme LRU
- overlap idle admission, then serialize Mermaid's global initialize/render section with a main-thread yield between diagrams
- cancel stale deferred/queued work when every observing component unmounts
- retry transient Mermaid chunk-load failures instead of memoizing a rejected import
- isolate cached SVG copies in image resources so duplicate mounts do not reuse DOM IDs

## Problem

The desktop embed eagerly evaluated Mermaid and rendered every completed fence again after remounts. Several diagrams could monopolize the renderer main thread before the transcript became responsive.

## Implementation

`createMermaidRenderCache` now keeps in-flight and completed work separate:

- identical pending source/theme requests share one render even beyond the LRU bound
- completed results are retained with bounded least-recently-used eviction
- idle admission occurs before entering a serialized Mermaid mutex, which yields a task between diagrams
- abort signals drop work that no mounted component still observes
- failures are removed so future mounts can retry

The embed's dynamic import is also retryable. Cached SVG text is displayed through `data:image/svg+xml` resources, retaining zoom/copy support while isolating each mounted copy's internal IDs.

## Verification

- `npx vitest run --project ui src/components/assistant-ui/embeds/mermaid-render-cache.test.ts src/components/assistant-ui/embeds/mermaid-embed.test.tsx` — 11 tests passed
- Regression sabotage: disabling the cache hit path failed the focused cache test as expected; restoring it passed
- `npm run test:ui -w apps/desktop` — 685 files / 6,763 tests passed
- `npm run check:lint -w apps/desktop` — passed (0 errors; existing repository warnings only)
- `npm run build -w apps/desktop` — passed
- `git diff --check` — passed
- Production bundle keeps the 2.97 MB Mermaid runtime in a separate nested dynamic chunk; the lightweight Mermaid embed chunk is 12.51 kB

## Risk / compatibility

- cache entries include the resolved light/dark theme
- Mermaid initialization and rendering stay serialized because Mermaid configuration is global
- `securityLevel: 'strict'`, source fallback, parse-failure fallback, zoom, and copy-as-PNG behavior remain intact
- cached SVG copies are ID-isolated, while Mermaid-generated title/description text is retained as image alt text
- completed SVG retention is explicitly capped at 32 entries
- one unusually large Mermaid render can still form a long main-thread task; this change prevents duplicate/back-to-back work but does not move Mermaid itself off-thread

## Related work

#98967 was opened independently while this change was under review. This implementation additionally isolates reused SVG IDs, retries failed runtime loads, cancels stale work, preserves in-flight deduplication beyond the completed-cache bound, and yields between CPU-heavy renders.

## Scope

Desktop renderer only. No backend, protocol, persistence, dependency, or configuration changes.

Closes #98951
