### PR TITLE
fix(desktop): dial remote gateway WebSocket from the main process

### DIFF
--- a/apps/desktop/electron/gateway-node-socket.test.ts
+++ b/apps/desktop/electron/gateway-node-socket.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  httpsOriginFromGatewayWsUrl,
+  isAllowedGatewayWsUrl,
+  parseGatewayWsUrl,
+  shouldDialGatewayFromMain
+} from './gateway-node-socket'
+
+test('parseGatewayWsUrl accepts ws(s) /api/ws and rejects everything else', () => {
+  assert.equal(parseGatewayWsUrl('wss://gw.example.com/api/ws?ticket=t')?.hostname, 'gw.example.com')
+  assert.equal(parseGatewayWsUrl('ws://127.0.0.1:9/api/ws')?.port, '9')
+  assert.equal(parseGatewayWsUrl('https://gw.example.com/api/ws'), null)
+  assert.equal(parseGatewayWsUrl('wss://gw.example.com/api/status'), null)
+  assert.equal(parseGatewayWsUrl('not a url'), null)
+})
+
+test('shouldDialGatewayFromMain is only for non-loopback gateway sockets', () => {
+  assert.equal(shouldDialGatewayFromMain('wss://hermes.example.com/api/ws?ticket=t'), true)
+  assert.equal(shouldDialGatewayFromMain('ws://127.0.0.1:52515/api/ws?token=t'), false)
+  assert.equal(shouldDialGatewayFromMain('ws://localhost:9/api/ws'), false)
+})
+
+test('isAllowedGatewayWsUrl allowlists saved remote hosts', () => {
+  const hosts = ['gw.example.com']
+
+  assert.equal(isAllowedGatewayWsUrl('wss://gw.example.com/api/ws?ticket=a', hosts), true)
+  assert.equal(isAllowedGatewayWsUrl('wss://evil.example/api/ws?ticket=a', hosts), false)
+  assert.equal(isAllowedGatewayWsUrl('ws://127.0.0.1:9/api/ws', hosts), true)
+})
+
+test('httpsOriginFromGatewayWsUrl matches the dashboard scheme/host', () => {
+  assert.equal(
+    httpsOriginFromGatewayWsUrl('wss://gw.example.com/api/ws?ticket=a'),
+    'https://gw.example.com'
+  )
+  assert.equal(httpsOriginFromGatewayWsUrl('ws://127.0.0.1:9/api/ws'), 'http://127.0.0.1:9')
+})

--- a/apps/desktop/electron/gateway-node-socket.ts
+++ b/apps/desktop/electron/gateway-node-socket.ts
@@ -1,0 +1,118 @@
+/**
+ * Main-process (Node/undici) WebSocket for remote Hermes gateways.
+ *
+ * "Test remote" already dials `/api/ws` with `globalThis.WebSocket` in the
+ * main process and succeeds. The renderer uses Chromium's WebSocket from a
+ * `file://` page — different Origin, HTTP/2 Extended CONNECT, and system
+ * proxy — so Test can pass while boot still shows "Could not connect to
+ * Hermes gateway". Chat must use the same Node socket the probe uses.
+ */
+
+export function parseGatewayWsUrl(raw: unknown): URL | null {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(raw)
+    const path = parsed.pathname.replace(/\/+$/, '') || '/'
+
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+      return null
+    }
+
+    if (!path.endsWith('/api/ws')) {
+      return null
+    }
+
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function isLoopbackGatewayHost(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase()
+
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1'
+}
+
+/** Remote (non-loopback) `/api/ws` URLs should leave Chromium and dial from main. */
+export function shouldDialGatewayFromMain(raw: unknown): boolean {
+  const parsed = parseGatewayWsUrl(raw)
+
+  return Boolean(parsed && !isLoopbackGatewayHost(parsed.hostname))
+}
+
+export function isAllowedGatewayWsUrl(raw: unknown, allowedHosts: string[]): boolean {
+  const parsed = parseGatewayWsUrl(raw)
+
+  if (!parsed) {
+    return false
+  }
+
+  if (isLoopbackGatewayHost(parsed.hostname)) {
+    return true
+  }
+
+  const host = parsed.hostname.trim().toLowerCase()
+
+  return allowedHosts.some(allowed => allowed.trim().toLowerCase() === host)
+}
+
+export function httpsOriginFromGatewayWsUrl(raw: unknown): string | null {
+  const parsed = parseGatewayWsUrl(raw)
+
+  if (!parsed) {
+    return null
+  }
+
+  return `${parsed.protocol === 'wss:' ? 'https:' : 'http:'}//${parsed.host}`
+}
+
+type NodeWebSocketLike = {
+  addEventListener: (type: string, listener: (event: any) => void) => void
+  close: () => void
+  send: (data: string) => void
+}
+
+type NodeWebSocketCtor = new (url: string, options?: { headers?: Record<string, string> }) => NodeWebSocketLike
+
+export function openNodeGatewaySocket(
+  wsUrl: string,
+  options: {
+    WebSocketImpl: NodeWebSocketCtor
+    headers?: Record<string, string>
+    onClose: (code: number, reason: string) => void
+    onError: () => void
+    onMessage: (data: string) => void
+    onOpen: () => void
+  }
+): { close: () => void; send: (data: string) => void } {
+  const headers = options.headers && Object.keys(options.headers).length > 0 ? options.headers : undefined
+  const socket = headers
+    ? new options.WebSocketImpl(wsUrl, { headers })
+    : new options.WebSocketImpl(wsUrl)
+
+  socket.addEventListener('open', () => options.onOpen())
+  socket.addEventListener('message', event => {
+    options.onMessage(typeof event?.data === 'string' ? event.data : String(event?.data ?? ''))
+  })
+  socket.addEventListener('close', event => {
+    options.onClose(Number(event?.code) || 1005, String(event?.reason || ''))
+  })
+  socket.addEventListener('error', () => options.onError())
+
+  return {
+    close: () => {
+      try {
+        socket.close()
+      } catch {
+        // already closed
+      }
+    },
+    send: data => {
+      socket.send(data)
+    }
+  }
+}

--- a/apps/desktop/electron/gateway-proxy-bypass.test.ts
+++ b/apps/desktop/electron/gateway-proxy-bypass.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  chromiumProxyBypassListForGatewayUrls,
+  collectRemoteGatewayHosts,
+  hostnameFromGatewayUrl,
+  proxyBypassRulesForGatewayUrls,
+  scutilProxyIsEnabled
+} from './gateway-proxy-bypass'
+
+test('hostnameFromGatewayUrl extracts https hosts and drops loopback', () => {
+  assert.equal(hostnameFromGatewayUrl('https://gw.example.com'), 'gw.example.com')
+  assert.equal(hostnameFromGatewayUrl('https://gw.example.com:9119/chat'), 'gw.example.com')
+  assert.equal(hostnameFromGatewayUrl('hermes.example.com'), 'hermes.example.com')
+  assert.equal(hostnameFromGatewayUrl('http://127.0.0.1:8642'), null)
+  assert.equal(hostnameFromGatewayUrl('http://localhost'), null)
+  assert.equal(hostnameFromGatewayUrl(''), null)
+  assert.equal(hostnameFromGatewayUrl('ftp://files.example.com'), null)
+})
+
+test('collectRemoteGatewayHosts de-dupes and ignores junk', () => {
+  assert.deepEqual(
+    collectRemoteGatewayHosts([
+      'https://gw.example.com',
+      'https://GW.example.com/app',
+      null,
+      'http://127.0.0.1:9',
+      'https://other.example.com'
+    ]),
+    ['gw.example.com', 'other.example.com']
+  )
+})
+
+test('proxyBypassRulesForGatewayUrls prefixes <local> and returns null when empty', () => {
+  assert.equal(proxyBypassRulesForGatewayUrls([]), null)
+  assert.equal(proxyBypassRulesForGatewayUrls(['http://localhost']), null)
+  assert.equal(
+    proxyBypassRulesForGatewayUrls(['https://gw.example.com']),
+    '<local>,gw.example.com'
+  )
+})
+
+test('chromiumProxyBypassListForGatewayUrls is host-only for the command line', () => {
+  assert.equal(chromiumProxyBypassListForGatewayUrls([]), null)
+  assert.equal(
+    chromiumProxyBypassListForGatewayUrls(['https://gw.example.com']),
+    'gw.example.com'
+  )
+})
+
+test('scutilProxyIsEnabled follows Enable flags, not leftover Server/Port', () => {
+  assert.equal(
+    scutilProxyIsEnabled(`
+HTTPEnable : 0
+HTTPProxy : 127.0.0.1
+HTTPPort : 7892
+HTTPSEnable : 0
+SOCKSEnable : 0
+ProxyAutoConfigEnable : 0
+`),
+    false
+  )
+  assert.equal(scutilProxyIsEnabled('HTTPEnable : 1\nHTTPProxy : 127.0.0.1'), true)
+  assert.equal(scutilProxyIsEnabled('ProxyAutoConfigEnable : 1'), true)
+})

--- a/apps/desktop/electron/gateway-proxy-bypass.ts
+++ b/apps/desktop/electron/gateway-proxy-bypass.ts
@@ -1,0 +1,91 @@
+/**
+ * Chromium session proxy bypass for remote Hermes gateways.
+ *
+ * The desktop renderer opens `/api/ws` with Chromium's WebSocket, which honors
+ * the macOS system proxy. Electron's main-process HTTPS (ticket mint, health)
+ * uses a direct agent. When a TUN VPN already captures traffic, leaving the
+ * system proxy on misroutes the upgrade over HTTP/2; a gated gateway then
+ * answers JSON 401 `no_cookie` before the WebSocket handler runs.
+ *
+ * Bypass the saved remote gateway host(s) so renderer sockets take the same
+ * direct/TUN path as the main process.
+ *
+ * Even with the system proxy off, Chromium still prefers RFC 8441 WebSocket
+ * over HTTP/2 (and HTTP/3) to Cloudflare. That handshake is an HTTP request
+ * to `/api/ws` as far as FastAPI's cookie gate is concerned — not a
+ * WebSocket upgrade — so it 401s the same way. `--disable-http2` /
+ * `--disable-quic` (applied in main before `ready`) force HTTP/1.1 Upgrade,
+ * which is what `curl --http1.1` uses when it reaches the WS handler.
+ */
+
+export function hostnameFromGatewayUrl(raw: unknown): string | null {
+  const value = String(raw || '').trim()
+
+  if (!value) {
+    return null
+  }
+
+  try {
+    const href = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`
+    const parsed = new URL(href)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+
+    const host = parsed.hostname.trim().toLowerCase()
+
+    if (!host || host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') {
+      return null
+    }
+
+    return host
+  } catch {
+    return null
+  }
+}
+
+export function collectRemoteGatewayHosts(urls: unknown[]): string[] {
+  const hosts = new Set<string>()
+
+  for (const url of urls) {
+    const host = hostnameFromGatewayUrl(url)
+
+    if (host) {
+      hosts.add(host)
+    }
+  }
+
+  return [...hosts].sort()
+}
+
+export function proxyBypassRulesForGatewayUrls(urls: unknown[]): string | null {
+  const hosts = collectRemoteGatewayHosts(urls)
+
+  if (hosts.length === 0) {
+    return null
+  }
+
+  return ['<local>', ...hosts].join(',')
+}
+
+/** Chromium `--proxy-bypass-list` value (comma-separated hostnames). */
+export function chromiumProxyBypassListForGatewayUrls(urls: unknown[]): string | null {
+  const hosts = collectRemoteGatewayHosts(urls)
+
+  if (hosts.length === 0) {
+    return null
+  }
+
+  return hosts.join(',')
+}
+
+/** True when scutil reports an active HTTP/HTTPS/SOCKS/PAC proxy. */
+export function scutilProxyIsEnabled(scutilOutput: string): boolean {
+  return (
+    /HTTPEnable\s*:\s*1/.test(scutilOutput) ||
+    /HTTPSEnable\s*:\s*1/.test(scutilOutput) ||
+    /SOCKSEnable\s*:\s*1/.test(scutilOutput) ||
+    /ProxyAutoConfigEnable\s*:\s*1/.test(scutilOutput)
+  )
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -125,6 +125,18 @@ import {
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
 import {
+  httpsOriginFromGatewayWsUrl,
+  isAllowedGatewayWsUrl,
+  openNodeGatewaySocket,
+  shouldDialGatewayFromMain
+} from './gateway-node-socket'
+import {
+  chromiumProxyBypassListForGatewayUrls,
+  collectRemoteGatewayHosts,
+  proxyBypassRulesForGatewayUrls,
+  scutilProxyIsEnabled
+} from './gateway-proxy-bypass'
+import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
@@ -8855,8 +8867,102 @@ function installRemoteHeaderRules() {
 
   remoteHeaderRulesInstalled = true
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    applyRemoteRequestHeaders(details, callback, headersForRemoteRequest)
+    const origin =
+      details.resourceType === 'websocket' || /\/api\/ws(?:\?|$)/.test(String(details.url || ''))
+        ? httpsOriginFromGatewayWsUrl(details.url)
+        : null
+
+    applyRemoteRequestHeaders(details, result => {
+      if (!origin) {
+        callback(result)
+
+        return
+      }
+
+      const base =
+        result.requestHeaders && Object.keys(result.requestHeaders).length > 0
+          ? result.requestHeaders
+          : details.requestHeaders
+
+      callback({ requestHeaders: { ...base, Origin: origin } })
+    }, headersForRemoteRequest)
   })
+}
+
+function remoteGatewayUrlsFromDisk() {
+  const urls = []
+
+  try {
+    const remoteUrl = readDesktopConnectionConfig()?.remote?.url
+
+    if (remoteUrl) {
+      urls.push(remoteUrl)
+    }
+  } catch {
+    // connection.json may be missing on a first launch
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(DESKTOP_CONNECTIONS_REGISTRY_PATH, 'utf8'))
+    const entries = Array.isArray(parsed?.connections) ? parsed.connections : []
+
+    for (const entry of entries) {
+      if (entry && entry.kind === 'remote' && entry.url) {
+        urls.push(entry.url)
+      }
+    }
+  } catch {
+    // registry is optional on older installs
+  }
+
+  return urls
+}
+
+// Chromium WebSockets honor the macOS system proxy; main-process HTTPS does not.
+// Bypass saved remote gateway hosts so renderer /api/ws takes the same TUN/direct
+// path as ticket mint (otherwise HTTP/2 proxy upgrades die as 401 no_cookie).
+async function installGatewayProxyBypass() {
+  const rules = proxyBypassRulesForGatewayUrls(remoteGatewayUrlsFromDisk())
+
+  if (!rules) {
+    return
+  }
+
+  // Chat uses Node WebSocket for remote /api/ws; Chromium setProxy is only
+  // needed when the OS proxy is actually on (home FastLink). At the office
+  // with proxy disabled, skip it so Electron does not look like it is
+  // "using a proxy".
+  if (process.platform === 'darwin') {
+    let proxyOn = false
+
+    try {
+      proxyOn = scutilProxyIsEnabled(execFileSync('/usr/sbin/scutil', ['--proxy'], { encoding: 'utf8' }))
+    } catch {
+      proxyOn = false
+    }
+
+    if (!proxyOn) {
+      rememberLog('[proxy] macOS system proxy is off; skipping Chromium setProxy')
+
+      return
+    }
+  }
+
+  const apply = async (sess, label) => {
+    if (!sess || typeof sess.setProxy !== 'function') {
+      return
+    }
+
+    try {
+      await sess.setProxy({ mode: 'system', proxyBypassRules: rules })
+      rememberLog(`[proxy] Chromium bypass ${label}: ${rules}`)
+    } catch (error) {
+      rememberLog(`[proxy] Chromium bypass ${label} failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  await apply(session.defaultSession, 'default')
+  await apply(session.fromPartition(OAUTH_SESSION_PARTITION), 'oauth')
 }
 
 // Validate + normalize the per-profile remote overrides map read from disk.
@@ -14347,6 +14453,93 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))
 })
+
+const nodeGatewaySockets = new Map()
+
+function allowedHostsForNodeGatewayWs() {
+  return collectRemoteGatewayHosts(remoteGatewayUrlsFromDisk())
+}
+
+function emitNodeGatewayWs(sender, payload) {
+  if (sender.isDestroyed()) {
+    return
+  }
+
+  sender.send('hermes:gateway-ws:event', payload)
+}
+
+ipcMain.handle('hermes:gateway-ws:open', (event, url) => {
+  if (!shouldDialGatewayFromMain(url) || !isAllowedGatewayWsUrl(url, allowedHostsForNodeGatewayWs())) {
+    rememberLog(`[gateway-ws] refused ${redactSecrets(String(url || ''))}`)
+
+    return { ok: false, error: 'Gateway WebSocket URL is not allowed.' }
+  }
+
+  if (typeof globalThis.WebSocket !== 'function') {
+    return { ok: false, error: 'WebSocket is not available in this runtime.' }
+  }
+
+  const id = crypto.randomUUID()
+  const sender = event.sender
+  const headers = headersForRemoteRequest(url)
+
+  try {
+    const handle = openNodeGatewaySocket(url, {
+      WebSocketImpl: globalThis.WebSocket,
+      headers,
+      onOpen: () => emitNodeGatewayWs(sender, { id, type: 'open' }),
+      onMessage: data => emitNodeGatewayWs(sender, { id, type: 'message', data }),
+      onClose: (code, reason) => {
+        nodeGatewaySockets.delete(id)
+        rememberLog(`[gateway-ws] node closed ${redactSecrets(String(url))} code=${code}`)
+        emitNodeGatewayWs(sender, { id, type: 'close', code, reason })
+      },
+      onError: () => {
+        nodeGatewaySockets.delete(id)
+        rememberLog(`[gateway-ws] node error ${redactSecrets(String(url))}`)
+        emitNodeGatewayWs(sender, { id, type: 'error' })
+      }
+    })
+
+    nodeGatewaySockets.set(id, handle)
+    rememberLog(`[gateway-ws] node open ${redactSecrets(String(url))}`)
+    sender.once('destroyed', () => {
+      const live = nodeGatewaySockets.get(id)
+
+      if (live) {
+        live.close()
+        nodeGatewaySockets.delete(id)
+      }
+    })
+
+    return { ok: true, id }
+  } catch (error) {
+    rememberLog(
+      `[gateway-ws] node open failed ${redactSecrets(String(url))}: ${error instanceof Error ? error.message : String(error)}`
+    )
+
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+})
+
+ipcMain.on('hermes:gateway-ws:send', (_event, payload) => {
+  const id = payload && typeof payload === 'object' ? payload.id : null
+  const data = payload && typeof payload === 'object' ? payload.data : null
+  const handle = typeof id === 'string' ? nodeGatewaySockets.get(id) : null
+
+  if (handle && typeof data === 'string') {
+    handle.send(data)
+  }
+})
+
+ipcMain.on('hermes:gateway-ws:close', (_event, id) => {
+  const handle = typeof id === 'string' ? nodeGatewaySockets.get(id) : null
+
+  if (handle) {
+    handle.close()
+    nodeGatewaySockets.delete(id)
+  }
+})
 ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
   if (typeof sessionId !== 'string' || !sessionId.trim()) {
     return { ok: false, error: 'invalid-session-id' }
@@ -17328,7 +17521,23 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
-app.whenReady().then(() => {
+{
+  const remoteUrls = remoteGatewayUrlsFromDisk()
+  const chromiumBypass = chromiumProxyBypassListForGatewayUrls(remoteUrls)
+
+  if (chromiumBypass) {
+    app.commandLine.appendSwitch('proxy-bypass-list', chromiumBypass)
+    // Chromium WebSocket to an HTTP/2 peer (Cloudflare) uses RFC 8441 Extended
+    // CONNECT. Gated `/api/ws` is not a public API path, so that request is
+    // JSON 401 `no_cookie` and never reaches the WS handler. Chat now dials
+    // from Node (HTTP/1.1 Upgrade); these switches are a fallback if anything
+    // still uses Chromium WS against the remote host. Must be set before `ready`.
+    app.commandLine.appendSwitch('disable-http2')
+    app.commandLine.appendSwitch('disable-quic')
+  }
+}
+
+app.whenReady().then(async () => {
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()
@@ -17370,6 +17579,7 @@ app.whenReady().then(() => {
   registerMediaProtocol()
   installEmbedReferer()
   installRemoteHeaderRules()
+  await installGatewayProxyBypass()
   registerDeepLinkProtocol()
 
   ensureWslWindowsFonts()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -21,6 +21,17 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
+  gatewayWs: {
+    open: url => ipcRenderer.invoke('hermes:gateway-ws:open', url),
+    send: (id, data) => ipcRenderer.send('hermes:gateway-ws:send', { id, data }),
+    close: id => ipcRenderer.send('hermes:gateway-ws:close', id),
+    subscribe: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:gateway-ws:event', listener)
+
+      return () => ipcRenderer.removeListener('hermes:gateway-ws:event', listener)
+    }
+  },
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.
   getGatewayWsUrlFor: payload => ipcRenderer.invoke('hermes:gateway:ws-url-for', payload),

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,5 +1,6 @@
 import { JsonRpcGatewayClient } from '@hermes/shared'
 
+import { createDesktopGatewaySocket } from '@/lib/desktop-gateway-socket'
 import type { HermesApiRequest } from '@/global'
 
 // Desktop startup fires a burst of read-only data calls (config, profiles,
@@ -32,7 +33,8 @@ export class HermesGateway extends JsonRpcGatewayClient {
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,
       notConnectedErrorMessage: 'Hermes gateway is not connected',
-      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
+      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      socketFactory: url => createDesktopGatewaySocket(url)
     })
   }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -47,6 +47,23 @@ declare global {
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
+      // Remote `/api/ws` is dialed from the main process (Node/undici), the same
+      // transport "Test remote" uses. Chromium's renderer WebSocket is file://
+      // Origin + HTTP/2 CONNECT and is not the path that actually works.
+      gatewayWs?: {
+        close: (id: string) => void
+        open: (url: string) => Promise<{ error?: string; id?: string; ok: boolean }>
+        send: (id: string, data: string) => void
+        subscribe: (
+          callback: (event: {
+            code?: number
+            data?: string
+            id: string
+            reason?: string
+            type: 'close' | 'error' | 'message' | 'open'
+          }) => void
+        ) => () => void
+      }
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false
       // with an error code when the sessionId is empty/invalid. `watch` opens

--- a/apps/desktop/src/lib/desktop-gateway-socket.test.ts
+++ b/apps/desktop/src/lib/desktop-gateway-socket.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createDesktopGatewaySocket, DesktopMainGatewaySocket, type GatewayWsBridge } from './desktop-gateway-socket'
+import { shouldDialGatewayFromMain } from './gateway-ws-target'
+
+describe('shouldDialGatewayFromMain', () => {
+  it('is true for remote wss /api/ws and false for loopback', () => {
+    expect(shouldDialGatewayFromMain('wss://gw.example.com/api/ws?ticket=t')).toBe(true)
+    expect(shouldDialGatewayFromMain('ws://127.0.0.1:52515/api/ws?token=t')).toBe(false)
+  })
+})
+
+describe('DesktopMainGatewaySocket', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('queues events that arrive before open() resolves the id', async () => {
+    const listeners = new Set<(event: any) => void>()
+    const bridge: GatewayWsBridge = {
+      close: vi.fn(),
+      open: vi.fn().mockImplementation(() => new Promise(resolve => {
+        queueMicrotask(() => {
+          for (const listener of listeners) {
+            listener({ id: 'sock-1', type: 'open' })
+          }
+
+          resolve({ ok: true, id: 'sock-1' })
+        })
+      })),
+      send: vi.fn(),
+      subscribe: callback => {
+        listeners.add(callback)
+
+        return () => listeners.delete(callback)
+      }
+    }
+
+    const opened = vi.fn()
+    const socket = new DesktopMainGatewaySocket('wss://gw.example.com/api/ws?ticket=t', bridge)
+    socket.addEventListener('open', opened, { once: true })
+
+    await vi.waitFor(() => {
+      expect(opened).toHaveBeenCalledOnce()
+    })
+    expect(socket.readyState).toBe(1)
+  })
+
+  it('falls back to Chromium WebSocket for loopback URLs', () => {
+    class FakeWs {
+      url: string
+      constructor(url: string) {
+        this.url = url
+      }
+    }
+
+    vi.stubGlobal('WebSocket', FakeWs)
+
+    const socket = createDesktopGatewaySocket('ws://127.0.0.1:9/api/ws?token=t')
+
+    expect(socket).toBeInstanceOf(FakeWs)
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/desktop/src/lib/desktop-gateway-socket.ts
+++ b/apps/desktop/src/lib/desktop-gateway-socket.ts
@@ -1,0 +1,173 @@
+import { shouldDialGatewayFromMain } from './gateway-ws-target'
+
+type GatewayWsEvent =
+  | { data?: string; id: string; type: 'open' }
+  | { data?: string; id: string; type: 'message' }
+  | { code?: number; id: string; reason?: string; type: 'close' }
+  | { id: string; type: 'error' }
+
+export interface GatewayWsBridge {
+  close: (id: string) => void
+  open: (url: string) => Promise<{ error?: string; id?: string; ok: boolean }>
+  send: (id: string, data: string) => void
+  subscribe: (callback: (event: GatewayWsEvent) => void) => () => void
+}
+
+const CONNECTING = 0
+const OPEN = 1
+const CLOSING = 2
+const CLOSED = 3
+
+function gatewayWsBridge(): GatewayWsBridge | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.hermesDesktop?.gatewayWs ?? null
+}
+
+/**
+ * Chromium WebSocket for loopback; Node/undici WebSocket (via main) for remote
+ * gateways — the same transport "Test remote" already proved works.
+ */
+export function createDesktopGatewaySocket(url: string, bridge = gatewayWsBridge()): WebSocket {
+  if (bridge && shouldDialGatewayFromMain(url)) {
+    return new DesktopMainGatewaySocket(url, bridge) as unknown as WebSocket
+  }
+
+  return new WebSocket(url)
+}
+
+export class DesktopMainGatewaySocket {
+  readyState = CONNECTING
+  url: string
+  private readonly listeners = {
+    close: new Set<(event: CloseEvent) => void>(),
+    error: new Set<(event: Event) => void>(),
+    message: new Set<(event: MessageEvent) => void>(),
+    open: new Set<(event: Event) => void>()
+  }
+  private id: string | null = null
+  private readonly pending: GatewayWsEvent[] = []
+  private readonly unsubscribe: () => void
+
+  constructor(
+    url: string,
+    private readonly bridge: GatewayWsBridge
+  ) {
+    this.url = url
+    this.unsubscribe = bridge.subscribe(event => this.dispatch(event))
+    void bridge.open(url).then(
+      result => {
+        if (!result.ok || !result.id) {
+          this.fail()
+
+          return
+        }
+
+        this.id = result.id
+
+        for (const event of this.pending.splice(0)) {
+          this.dispatch(event)
+        }
+      },
+      () => this.fail()
+    )
+  }
+
+  addEventListener(
+    type: keyof DesktopMainGatewaySocket['listeners'],
+    listener: (event: any) => void,
+    options?: { once?: boolean }
+  ): void {
+    const bucket = this.listeners[type]
+
+    if (!bucket) {
+      return
+    }
+
+    const wrapped = options?.once
+      ? (event: any) => {
+          bucket.delete(wrapped)
+          listener(event)
+        }
+      : listener
+
+    bucket.add(wrapped)
+  }
+
+  removeEventListener(type: keyof DesktopMainGatewaySocket['listeners'], listener: (event: any) => void): void {
+    this.listeners[type]?.delete(listener)
+  }
+
+  send(data: string): void {
+    if (this.id && this.readyState === OPEN) {
+      this.bridge.send(this.id, data)
+    }
+  }
+
+  close(): void {
+    if (this.readyState === CLOSED || this.readyState === CLOSING) {
+      return
+    }
+
+    this.readyState = CLOSING
+
+    if (this.id) {
+      this.bridge.close(this.id)
+    }
+  }
+
+  private dispatch(event: GatewayWsEvent): void {
+    if (this.id && event.id !== this.id) {
+      return
+    }
+
+    if (!this.id) {
+      this.pending.push(event)
+
+      return
+    }
+
+    if (event.type === 'open') {
+      this.readyState = OPEN
+      this.emit('open', new Event('open'))
+
+      return
+    }
+
+    if (event.type === 'message') {
+      this.emit('message', { data: event.data ?? '' } as MessageEvent)
+
+      return
+    }
+
+    if (event.type === 'error') {
+      this.readyState = CLOSED
+      this.emit('error', new Event('error'))
+      this.unsubscribe()
+
+      return
+    }
+
+    this.readyState = CLOSED
+    this.emit('close', { code: event.code ?? 1005, reason: event.reason ?? '' } as CloseEvent)
+    this.unsubscribe()
+  }
+
+  private fail(): void {
+    if (this.readyState === CLOSED) {
+      return
+    }
+
+    this.readyState = CLOSED
+    this.emit('error', new Event('error'))
+    this.unsubscribe()
+  }
+
+  private emit(type: keyof DesktopMainGatewaySocket['listeners'], event: any): void {
+    for (const listener of [...this.listeners[type]]) {
+      listener(event)
+    }
+  }
+}

--- a/apps/desktop/src/lib/gateway-ws-target.ts
+++ b/apps/desktop/src/lib/gateway-ws-target.ts
@@ -1,0 +1,23 @@
+export function shouldDialGatewayFromMain(raw: unknown): boolean {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(raw)
+    const host = parsed.hostname.trim().toLowerCase()
+    const path = parsed.pathname.replace(/\/+$/, '') || '/'
+
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+      return false
+    }
+
+    if (!path.endsWith('/api/ws')) {
+      return false
+    }
+
+    return host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]' && host !== '::1'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- Remote chat (`JsonRpcGatewayClient`) was using Chromium's renderer `WebSocket` from a `file://` page. Against Cloudflare that handshake is RFC 8441 HTTP/2 Extended CONNECT; a gated `/api/ws` is not in `PUBLIC_API_PATHS`, so cookie middleware returns JSON `401 no_cookie` and the WS handler never runs. Settings / Test remote already used Node/undici HTTP/1.1 Upgrade and succeeded, which is why HTTP probe showed "Remote Hermes backend is ready" while the overlay said "Could not connect to Hermes gateway".
- Chat now dials non-loopback `/api/ws` from the main process (allowlisted to saved remote hosts) over the same Node socket Test remote uses. Loopback `hermes serve` stays on Chromium.
- Fallback only when a remote gateway is configured: `--disable-http2` / `--disable-quic`, and Chromium `setProxy` bypass for those hosts when the OS system proxy is actually on (skipped when it is off).

## Test plan
- [ ] `npx vitest run electron/gateway-node-socket.test.ts electron/gateway-proxy-bypass.test.ts src/lib/desktop-gateway-socket.test.ts` from `apps/desktop`
- [ ] Remote mode: Settings → Test remote still passes; main chat connects (desktop.log shows `[gateway-ws] node open wss://…/api/ws?ticket=` and the primary socket does not immediately close)
- [ ] Local / loopback backend still uses Chromium WebSocket (no `hermes:gateway-ws:open` for `127.0.0.1`)
- [ ] macOS with system proxy off: log shows `[proxy] macOS system proxy is off; skipping Chromium setProxy`
- [ ] macOS with system HTTP/HTTPS/SOCKS proxy on: Chromium bypass is applied for the saved remote host; chat still connects via Node


Made with [Cursor](https://cursor.com)