### PR TITLE
fix(streaming): re-abort a cancelled attempt when its stream is created

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4064,6 +4064,25 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._stream_diag_capture_response(_diag, response)
             agent._check_openrouter_cache_status(response)
             _writer_token["value"] = claim_stream_writer(agent)
+            if _stream_attempt_was_cancelled(stream_attempt_id):
+                # #98974: the interrupt/stale abort is a one-shot snapshot.
+                # When it fired during create()'s connect/TLS window the pool
+                # had no sockets yet (tcp_force_closed=0), so nothing stopped
+                # this request once the connection came up — on slow
+                # first-token providers the serve kept an inference lane busy
+                # until it finished generating into a dropped consumer.
+                # Response headers prove the socket now exists, so re-run the
+                # shutdown here. It is shutdown-only (never a cross-thread
+                # close), the worker unwinds exactly like it does after a
+                # stale_stream_kill, and a cancel arriving after this check is
+                # still covered by the original abort — the socket is now in
+                # the pool it scans.
+                request_client = attempt_request_client["value"]
+                if request_client is not None:
+                    agent._abort_request_openai_client(
+                        request_client,
+                        reason="cancelled_attempt_late_connect",
+                    )
 
         def _accept_stream_chunk(_chunk: Any) -> bool:
             # A stale-attempt fence can win while Relay is handing an

--- a/tests/run_agent/test_request_client_reuse_abort_races.py
+++ b/tests/run_agent/test_request_client_reuse_abort_races.py
@@ -406,3 +406,97 @@ def test_codex_stream_close_failure_on_primary_client_does_not_abort():
     assert final.output_text == "hello"
     assert stream.close_calls == 1
     abort_mock.assert_not_called()
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_cancelled_attempt_reaborts_when_stream_created(monkeypatch):
+    """#98974: the stranger-thread abort is a one-shot snapshot.
+
+    When the interrupt/stale abort fires while ``create()`` is still inside
+    its connect/TLS window, the pool has no sockets yet and the abort is a
+    no-op (``tcp_force_closed=0``). Nothing stops the request once the
+    connection comes up, so a slow-first-token provider keeps an inference
+    lane busy generating into a dropped consumer. When the response headers
+    finally arrive, ``_stream_created`` must re-run the socket shutdown on
+    the owning worker thread.
+    """
+    monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
+    agent = _make_agent()
+
+    def chunks():
+        yield _chunk(content="hello")
+        yield _chunk(finish_reason="stop")
+
+    stream = _FakeStream(chunks)
+    wire = _mock_wire_client(stream)
+    create_calls = {"n": 0}
+    abort_calls = []
+
+    def slow_first_create(**kwargs):
+        create_calls["n"] += 1
+        if create_calls["n"] == 1:
+            # Attempt 1 parks "inside connect": no socket exists in the pool
+            # yet, so the stale detector's abort below finds nothing to shut
+            # down — the exact window from #98974. Park well past two poll
+            # iterations (t.join(timeout=0.3)) so the detector fires while
+            # create() is still pending, deterministically.
+            time.sleep(1.0)
+        return stream
+
+    wire.chat.completions.create.side_effect = slow_first_create
+
+    with patch.object(
+        agent, "_create_request_openai_client", return_value=wire
+    ), patch.object(
+        agent, "_close_request_openai_client"
+    ), patch.object(
+        agent,
+        "_abort_request_openai_client",
+        side_effect=lambda client, *, reason: abort_calls.append(reason),
+    ), patch.object(agent, "_replace_primary_openai_client"):
+        response = agent._interruptible_streaming_api_call(
+            {
+                "model": "test/model",
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        )
+
+    # The late abort fired once the cancelled attempt's stream was created,
+    # after the stale detector's no-op abort had already missed the window.
+    assert "cancelled_attempt_late_connect" in abort_calls
+    assert abort_calls.index("cancelled_attempt_late_connect") > abort_calls.index(
+        "stale_stream_kill"
+    )
+    # The retry attempt still succeeds — the late abort is scoped to the
+    # cancelled attempt, not to the follow-up request.
+    assert response is not None
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_active_attempt_is_not_aborted_when_stream_created():
+    """Fail-safe: a healthy stream must not be socket-aborted at creation."""
+    agent = _make_agent()
+
+    def chunks():
+        yield _chunk(content="hello")
+        yield _chunk(finish_reason="stop")
+
+    stream = _FakeStream(chunks)
+    wire = _mock_wire_client(stream)
+
+    with patch.object(
+        agent, "_create_request_openai_client", return_value=wire
+    ), patch.object(
+        agent, "_close_request_openai_client"
+    ), patch.object(
+        agent, "_abort_request_openai_client"
+    ) as abort_mock:
+        response = agent._interruptible_streaming_api_call(
+            {
+                "model": "test/model",
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        )
+
+    abort_mock.assert_not_called()
+    assert response is not None


### PR DESCRIPTION
## What does this PR do?

The stranger-thread interrupt/stale abort (`_abort_request_openai_client` → `force_close_tcp_sockets`) is a **one-shot snapshot** over the httpx connection pool. When it fires while `create()` is still inside its connect/TLS window, the pool genuinely has no sockets yet, so the abort is a no-op (`tcp_force_closed=0`, the exact WARNING from the issue) — and nothing ever stops the request once the connection comes up. On a slow-first-token self-hosted OpenAI-compatible serve the provider keeps an inference lane busy generating into a dropped consumer until it finishes.

I reproduced the window locally with the real SDK stack (httpx 0.28.1 / httpcore 1.0.9 / openai 2.24.0): while the worker is parked inside connect, `_iter_pool_sockets` finds 0 sockets; once response headers arrive the same client yields exactly 1 socket. The scan itself is sound in every steady state (verified for plain-HTTP TTFB, mid-stream, and TLS) — the gap is purely the connect-window timing.

The fix closes the gap at the first moment the socket provably exists: when relay's `on_stream_created` fires (response headers received) and the attempt was already cancelled, re-run `_abort_request_openai_client` on it. This is:

- **shutdown-only** — never a cross-thread close, so the #29507 FD-recycle invariant is preserved;
- **on the owning worker thread** — the callback runs synchronously where `_open_stream` was called;
- **the same unwind path as `stale_stream_kill`** — the worker sees the forced transport error and exits via the existing cancelled-attempt handling (#6600 swallow, superseded-stream raise);
- **race-free with late cancels** — a cancel arriving *after* this check is still covered by the original abort, because by then the socket is in the pool that abort scans.

## Related Issue

Fixes #98974

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — in `_stream_created` (relay `on_stream_created` callback): when `_stream_attempt_was_cancelled(stream_attempt_id)`, call `agent._abort_request_openai_client(request_client, reason="cancelled_attempt_late_connect")` so the now-existing socket is shut down instead of being missed forever (+19 lines incl. rationale comment).
- `tests/run_agent/test_request_client_reuse_abort_races.py` — two regressions tests (see below).

## How to Test

1. `pytest tests/run_agent/test_request_client_reuse_abort_races.py -q`
2. Observed result: `8 passed` (6 pre-existing + 2 new), stable across repeated runs.
3. Adjacent suites: `pytest tests/agent/test_cascading_interrupt_6600.py tests/run_agent/test_create_openai_client_reuse.py tests/run_agent/test_partial_stream_finish_reason.py tests/agent/test_non_stream_stale_timeout.py tests/agent/test_cron_inline_api_call_62151.py -q` → `32 passed`; `pytest tests/agent/test_relay_llm.py tests/agent/test_auxiliary_relay.py -q` → `44 passed`.
4. New test `test_cancelled_attempt_reaborts_when_stream_created` models the issue window end to end: the first `create()` parks "inside connect" (1s) while `HERMES_STREAM_STALE_TIMEOUT=0.05` fires the detector's abort into an empty pool; when `create()` finally returns, the late `cancelled_attempt_late_connect` abort must fire, ordered after the missed `stale_stream_kill`, and the retry attempt must still succeed.
5. New test `test_active_attempt_is_not_aborted_when_stream_created` is the fail-safe control: a healthy stream is never socket-aborted at creation (`abort_mock.assert_not_called()`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction evidence for the connect-window (the exact `tcp_force_closed=0` condition from the issue log), using the repo's own scan helpers against a live openai-SDK client:

```
PHASE-A (headers+chunk received, parked mid-stream) sockets found: 1
PHASE-B (parked waiting for headers)             sockets found: 1
PHASE-C (TLS, parked mid-stream)                 sockets found: 1  (SSLSocket)
PHASE-D (parked inside connect, request registered) sockets found: 0
force_close_tcp_sockets: 0   ← the logged "no sockets found" condition; the worker is unaffected and the request proceeds once connected
```