### PR TITLE
fix(gateway): drain detached hygiene workers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -390,20 +390,27 @@ async def run_codex_hygiene_compaction(
     loop = asyncio.get_running_loop()
     compressor = getattr(agent, "context_compressor", None)
     count_before = getattr(compressor, "compression_count", 0)
+    worker_future = loop.run_in_executor(
+        None,
+        # Keep the caller's multiplexed profile secret scope and HERMES_HOME
+        # override in the worker. The default executor does not propagate
+        # ContextVars on the Python runtimes Hermes currently ships.
+        copy_context().run,
+        lambda: agent._compress_context(
+            history,
+            "",
+            approx_tokens=approx_tokens,
+        ),
+    )
+    track_worker = getattr(gateway, "_track_deferred_agent_worker", None)
+    if callable(track_worker):
+        # ``wait_for`` only cancels the asyncio wrapper; the executor thread
+        # keeps running. Keep it visible to gateway shutdown until the real
+        # worker finishes, just like the detached local-compressor path.
+        track_worker(worker_future, agent)
     try:
         await asyncio.wait_for(
-            # copy_context().run: keep the caller's profile secret scope /
-            # HERMES_HOME override in the worker (multiplex_profiles) — same
-            # class as the detached-agent hygiene path below.
-            loop.run_in_executor(
-                None,
-                copy_context().run,
-                lambda: agent._compress_context(
-                    history,
-                    "",
-                    approx_tokens=approx_tokens,
-                ),
-            ),
+            asyncio.shield(worker_future),
             timeout=max(float(timeout_seconds), 1.0),
         )
     except asyncio.TimeoutError:
@@ -9227,6 +9234,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agent_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
+            + self._active_deferred_agent_worker_count()
         )
 
     def _active_cron_job_count(self) -> int:
@@ -9279,6 +9287,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.debug("Failed interrupting api_server runs during shutdown: %s", exc)
             return 0
+
+    def _active_deferred_agent_worker_count(self) -> int:
+        """Count executor workers that outlived their owning gateway turn.
+
+        A timed-out hygiene compression keeps running in its executor thread.
+        Some paths defer agent cleanup; the live Codex path keeps its cached
+        agent. In both cases the turn can finish before the worker does, so
+        ``_running_agents`` no longer represents it. Count the worker itself.
+        """
+        workers = getattr(self, "_deferred_agent_workers", None)
+        if not isinstance(workers, dict):
+            return 0
+        return sum(1 for future in list(workers) if not future.done())
+
+    def _track_deferred_agent_worker(
+        self,
+        future: asyncio.Future,
+        agent: Any,
+    ) -> None:
+        """Expose an executor worker to drain/interrupt until it really exits."""
+        workers = getattr(self, "_deferred_agent_workers", None)
+        if workers is None:
+            workers = {}
+            self._deferred_agent_workers = workers
+        workers[future] = agent
+
+        def _discard_worker(done_future: asyncio.Future) -> None:
+            workers.pop(done_future, None)
+            # Some tracked workers intentionally outlive the coroutine that
+            # started them and therefore have no later waiter. Consume their
+            # terminal exception so asyncio does not emit an unhandled-future
+            # warning after the worker eventually unwinds (#98973).
+            if not done_future.cancelled():
+                try:
+                    done_future.exception()
+                except Exception:
+                    pass
+
+        future.add_done_callback(_discard_worker)
+
+    def _interrupt_deferred_agent_workers(self, reason: str) -> int:
+        """Request cancellation of detached executor-backed agent work."""
+        workers = getattr(self, "_deferred_agent_workers", None)
+        if not isinstance(workers, dict):
+            return 0
+        interrupted = 0
+        seen: set[int] = set()
+        for future, agent in list(workers.items()):
+            if future.done() or agent is None or id(agent) in seen:
+                continue
+            seen.add(id(agent))
+            try:
+                request_hard_interrupt(agent, reason)
+                interrupted += 1
+            except Exception as exc:
+                logger.debug(
+                    "Failed interrupting deferred agent worker during shutdown: %s",
+                    exc,
+                )
+        return interrupted
 
     # ── scale-to-zero idle detection / dormant-quiesce (Phase 0) ──────────────
     # The gateway-side BEHAVIOUR that consumes the relay scale-to-zero primitives
@@ -11370,25 +11438,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_active_count = self._running_agent_count()
         last_cron_count = self._active_cron_job_count()
         last_api_count = self._active_api_run_count()
+        last_deferred_count = self._active_deferred_agent_worker_count()
         last_status_at = 0.0
 
         def _maybe_update_status(force: bool = False) -> None:
-            nonlocal last_active_count, last_cron_count, last_api_count, last_status_at
+            nonlocal last_active_count, last_cron_count, last_api_count
+            nonlocal last_deferred_count, last_status_at
             now = asyncio.get_running_loop().time()
             active_count = self._running_agent_count()
             cron_count = self._active_cron_job_count()
             api_count = self._active_api_run_count()
+            deferred_count = self._active_deferred_agent_worker_count()
             if (
                 force
                 or active_count != last_active_count
                 or cron_count != last_cron_count
                 or api_count != last_api_count
+                or deferred_count != last_deferred_count
                 or (now - last_status_at) >= 1.0
             ):
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_cron_count = cron_count
                 last_api_count = api_count
+                last_deferred_count = deferred_count
                 last_status_at = now
 
         # Cron jobs run on the scheduler's own thread pool, outside
@@ -11397,7 +11470,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # or a cron job's tool work gets killed with zero warning the
         # instant it's the only active thing running (#60432).
         # API-server / desk sessions have the same structural gap (#63529).
-        if not self._running_agents and last_cron_count == 0 and last_api_count == 0:
+        if (
+            not self._running_agents
+            and last_cron_count == 0
+            and last_api_count == 0
+            and last_deferred_count == 0
+        ):
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -11418,7 +11496,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         def _still_draining() -> bool:
             now = loop.time()
             if (
-                len(self._running_agents) or self._active_api_run_count()
+                len(self._running_agents)
+                or self._active_api_run_count()
+                or self._active_deferred_agent_worker_count()
             ) and now < deadline:
                 return True
             return bool(self._active_cron_job_count()) and now < cron_deadline
@@ -11434,6 +11514,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             bool(len(self._running_agents))
             or bool(self._active_cron_job_count())
             or bool(self._active_api_run_count())
+            or bool(self._active_deferred_agent_worker_count())
         )
         _maybe_update_status(force=True)
         return snapshot, timed_out
@@ -11453,6 +11534,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         interrupted_api = self._interrupt_api_server_runs(reason)
         if interrupted_api:
             logger.debug("Interrupted %d api_server run(s) during shutdown", interrupted_api)
+        interrupted_deferred = self._interrupt_deferred_agent_workers(reason)
+        if interrupted_deferred:
+            logger.debug(
+                "Interrupted %d deferred agent worker(s) during shutdown",
+                interrupted_deferred,
+            )
 
     async def _notify_interrupted_cron_jobs(self, job_ids) -> int:
         """Tell the owner of each just-interrupted cron job that its run died.
@@ -11889,6 +11976,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
             await self._cleanup_agent_resources_off_loop(agent, context=context)
+
+        self._track_deferred_agent_worker(future, agent)
 
         task = asyncio.create_task(_cleanup_when_done())
         tasks = getattr(self, "_deferred_agent_cleanup_tasks", None)
@@ -16079,6 +16168,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "active_agents": self._running_agent_count(),
                     "active_cron_jobs": self._active_cron_job_count(),
                     "active_api_runs": self._active_api_run_count(),
+                    "active_deferred_agent_workers": getattr(
+                        self,
+                        "_active_deferred_agent_worker_count",
+                        lambda: 0,
+                    )(),
                     "restart_drain_timeout": self._restart_drain_timeout,
                     "watchdog_delay_s": resolve_shutdown_watchdog_delay(
                         self._restart_drain_timeout
@@ -16105,6 +16199,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _watchdog_done.set()
 
         async def _stop_impl_body(_kill_tool_subprocesses, _stop_started_at_box) -> None:
+            # Shutdown-path tests and third-party runner doubles may only
+            # implement the older drain-count surface.
+            _deferred_worker_count = getattr(
+                self,
+                "_active_deferred_agent_worker_count",
+                lambda: 0,
+            )
             logger.info(
                 "Stopping gateway%s...",
                 " for restart" if self._restart_requested else "",
@@ -16170,6 +16271,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             _cron_at_start = self._active_cron_job_count()
             _api_at_start = self._active_api_run_count()
+            _deferred_at_start = _deferred_worker_count()
             # In-flight cron work gets its own floor, clamped to the watchdog
             # leash we're already running under so the extra wait can never
             # cost us the post-drain cleanup window (#82161).
@@ -16204,7 +16306,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Shutdown phase: drain done at +%.2fs (drain took %.2fs, "
                 "timed_out=%s, active_at_start=%d, active_now=%d, "
                 "cron_at_start=%d, cron_now=%d, "
-                "api_at_start=%d, api_now=%d)",
+                "api_at_start=%d, api_now=%d, "
+                "deferred_at_start=%d, deferred_now=%d)",
                 _phase_elapsed(),
                 _drain_elapsed,
                 timed_out,
@@ -16214,6 +16317,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._active_cron_job_count(),
                 _api_at_start,
                 self._active_api_run_count(),
+                _deferred_at_start,
+                _deferred_worker_count(),
             )
 
             if not timed_out:
@@ -16233,12 +16338,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s), "
-                    "%d in-flight cron job(s), and %d api_server run(s); "
+                    "%d in-flight cron job(s), %d api_server run(s), and "
+                    "%d deferred agent worker(s); "
                     "interrupting remaining work.",
                     _drain_elapsed,
                     self._running_agent_count(),
                     self._active_cron_job_count(),
                     self._active_api_run_count(),
+                    _deferred_worker_count(),
                 )
                 # Mark forcibly-interrupted sessions as resume_pending BEFORE
                 # interrupting the agents.  This preserves each session's
@@ -16293,7 +16400,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # to stop gets its tool subprocesses killed below before it can
                 # unwind — the exact amputation this interrupt exists to avoid.
                 while (
-                    self._running_agents or self._active_api_run_count()
+                    self._running_agents
+                    or self._active_api_run_count()
+                    or _deferred_worker_count()
                 ) and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
@@ -16308,7 +16417,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # at settle-loop exit, re-signal so a late-materializing
                 # agent gets a cooperative interrupt instead of going
                 # straight to the tool-subprocess kill.
-                if self._running_agents or self._active_api_run_count():
+                if (
+                    self._running_agents
+                    or self._active_api_run_count()
+                    or _deferred_worker_count()
+                ):
                     self._interrupt_running_agents(
                         _INTERRUPT_REASON_GATEWAY_RESTART
                         if self._restart_requested

--- a/tests/gateway/test_hygiene_deferred_work_drain.py
+++ b/tests/gateway/test_hygiene_deferred_work_drain.py
@@ -1,0 +1,150 @@
+"""Shutdown accounting for executor work detached by hygiene timeouts."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.run import run_codex_hygiene_compaction
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_deferred_worker_remains_active_until_executor_future_finishes():
+    runner, _adapter = make_restart_runner()
+    runner._cleanup_agent_resources_off_loop = AsyncMock()
+    worker = asyncio.get_running_loop().create_future()
+    agent = MagicMock()
+
+    runner._defer_agent_cleanup_until_future_done(
+        worker,
+        agent,
+        context="test hygiene timeout",
+    )
+
+    assert runner._active_deferred_agent_worker_count() == 1
+    assert runner._active_work_count() == 1
+
+    worker.set_result(([], None))
+    await asyncio.gather(*runner._deferred_agent_cleanup_tasks)
+
+    assert runner._active_deferred_agent_worker_count() == 0
+    runner._cleanup_agent_resources_off_loop.assert_awaited_once_with(
+        agent,
+        context="test hygiene timeout",
+    )
+
+
+@pytest.mark.asyncio
+async def test_timed_out_codex_hygiene_worker_remains_visible_to_shutdown():
+    runner, _adapter = make_restart_runner()
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingCodexAgent:
+        _codex_session = object()
+        context_compressor = SimpleNamespace(compression_count=0)
+
+        def _compress_context(self, *_args, **_kwargs):
+            started.set()
+            release.wait(timeout=5.0)
+
+    agent = BlockingCodexAgent()
+    runner._agent_cache = {"tg:123": (agent, 0.0)}
+    runner._agent_cache_lock = None
+
+    outcome = await run_codex_hygiene_compaction(
+        runner,
+        "tg:123",
+        "sess-1",
+        auto_mode="hermes",
+        history=[{"role": "user", "content": "hello"}],
+        approx_tokens=100,
+        timeout_seconds=0.01,
+        failure_cooldown_seconds=-1.0,
+    )
+
+    assert started.is_set()
+    assert outcome == "failed:timeout"
+    assert runner._active_deferred_agent_worker_count() == 1
+    with patch("gateway.run.request_hard_interrupt") as interrupt:
+        runner._interrupt_running_agents("gateway shutdown")
+    interrupt.assert_called_once_with(agent, "gateway shutdown")
+
+    release.set()
+    for _ in range(100):
+        if runner._active_deferred_agent_worker_count() == 0:
+            break
+        await asyncio.sleep(0.01)
+    assert runner._active_deferred_agent_worker_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_waits_for_deferred_hygiene_worker():
+    runner, _adapter = make_restart_runner()
+    worker = asyncio.get_running_loop().create_future()
+    runner._deferred_agent_workers = {worker: MagicMock()}
+
+    async def finish_worker():
+        await asyncio.sleep(0.12)
+        worker.set_result(([], None))
+
+    finisher = asyncio.create_task(finish_worker())
+    _snapshot, timed_out = await runner._drain_active_agents(2.0)
+    await finisher
+
+    assert timed_out is False
+    assert _snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_deferred_hygiene_worker_times_out_and_receives_interrupt():
+    runner, _adapter = make_restart_runner()
+    worker = asyncio.get_running_loop().create_future()
+    agent = MagicMock()
+    runner._deferred_agent_workers = {worker: agent}
+
+    _snapshot, timed_out = await runner._drain_active_agents(0.01)
+
+    assert timed_out is True
+    assert _snapshot == {}
+    with patch("gateway.run.request_hard_interrupt") as interrupt:
+        runner._interrupt_running_agents("gateway shutdown")
+    interrupt.assert_called_once_with(agent, "gateway shutdown")
+
+    worker.cancel()
+
+
+@pytest.mark.asyncio
+async def test_stop_interrupts_deferred_worker_before_teardown():
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    worker = asyncio.get_running_loop().create_future()
+
+    class DeferredAgent:
+        def __init__(self):
+            self.interrupts = []
+
+        def hard_interrupt(self, reason):
+            self.interrupts.append(reason)
+            if not worker.done():
+                worker.set_result(([], None))
+
+    agent = DeferredAgent()
+    runner._deferred_agent_workers = {worker: agent}
+    adapter.disconnect = AsyncMock()
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch("cron.scheduler.mark_job_run"),
+        patch("tools.process_registry.process_registry.kill_all", return_value=0),
+        patch("tools.terminal_tool.cleanup_all_environments"),
+        patch("tools.browser_tool.cleanup_all_browsers"),
+    ):
+        await runner.stop()
+
+    assert agent.interrupts == ["Gateway shutting down"]
+    assert worker.done()


### PR DESCRIPTION
## Summary

- retain timed-out executor workers as active gateway work until their real futures finish
- include detached hygiene workers in drain, runtime-status, scale-to-zero, and shutdown-watchdog accounting
- hard-interrupt those agents before adapters and SessionDB teardown, then include them in the cooperative settle window

## Tests

- 166 focused gateway shutdown, drain, hygiene, compression, API, cron, and scale-to-zero tests passed; 2 platform skips
- Ruff passed on the changed production and test files
- git diff --check passed

Closes #98973