### PR TITLE
fix(mcp): keep application errors out of transport breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,45 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_application_errors_do_not_trip_transport_breaker(monkeypatch, tmp_path):
+    """Completed RPCs with ``isError`` keep the transport breaker closed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    responses = [True, True, True, False]
+    call_count = {"n": 0}
+
+    async def _call_tool(*a, **kw):
+        is_error = responses.pop(0)
+        call_count["n"] += 1
+        result = MagicMock()
+        result.is_error = is_error
+        block = MagicMock()
+        block.text = "invalid_input" if is_error else "ok"
+        result.content = [block]
+        result.structured_content = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            parsed = json.loads(handler({}))
+            assert parsed.get("error") == "invalid_input", parsed
+
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+
+        parsed = json.loads(handler({}))
+        assert parsed.get("result") == "ok", parsed
+        assert call_count["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6167,12 +6167,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     ):
                         # Dead children but stale server.session, so the
                         # transport-down path above never fired — signal the
-                        # server task to respawn and return a clean
-                        # reconnecting error. No explicit _bump_server_error:
-                        # the error return flows through the handler's JSON
-                        # parse, which already bumps once.
+                        # server task to respawn and raise a transport error so
+                        # the handler's exception path records one breaker
+                        # strike.
                         if _signal_reconnect(server):
-                            return tool_error(
+                            raise TimeoutError(
                                 f"MCP server '{server_name}' stdio subprocess is "
                                 f"dead and reconnect was requested. Do NOT retry "
                                 f"immediately — give it a few seconds to respawn."
@@ -6372,15 +6371,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # A completed tools/call round-trip proves the MCP transport is
+            # healthy even when the tool returns ``isError`` (validation,
+            # operation-not-found, domain conflict, etc.).  Those application
+            # failures must not open the server-unreachable circuit breaker.
+            # Transport/session exceptions still flow through the exception
+            # path below and count as breaker strikes.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Summary
- reset the MCP transport breaker after any completed `tools/call` round-trip, including `isError` application results
- keep genuine dead-stdio failures on the exception path so they still count as transport strikes
- add regression coverage proving repeated validation errors do not block the next healthy call

## Test plan
- `uv run --extra dev python -m pytest -q tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_tool_session_expired.py` (122 passed)
- `uv run --extra dev ruff check tools/mcp_tool.py tests/tools/test_mcp_circuit_breaker.py`
