### PR TITLE
fix(commands): include skills in Telegram/Discord menus on Windows

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1090,26 +1090,28 @@ def _collect_gateway_skill_entries(
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs, get_project_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
+        def _dir_prefix(d: str) -> str:
+            """Normalize a directory path and ensure a trailing separator so
+            ``my-skills`` does not also match ``my-skills-extra``.
+            os.path.normpath collapses mixed ``/``/``\\`` separators so
+            Windows backslash paths match the skill paths."""
+            d = os.path.normpath(str(d))
+            return d if d.endswith(os.sep) else d + os.sep
+
+        _skills_dir = _dir_prefix(str(SKILLS_DIR.resolve()))
+        _hub_dir = _dir_prefix(str((SKILLS_DIR / ".hub").resolve()))
         # Build set of allowed directory prefixes: local skills dir + any
         # user-configured ``skills.external_dirs`` + trusted project dirs.
-        # Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
         # Without this widening, external skills are visible in
         # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
         # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
-        )
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_project_skills_dirs()
-        )
+        _allowed_prefixes = [_skills_dir]
+        _allowed_prefixes.extend(_dir_prefix(d) for d in get_external_skills_dirs())
+        _allowed_prefixes.extend(_dir_prefix(d) for d in get_project_skills_dirs())
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
-            skill_path = info.get("skill_md_path", "")
+            skill_path = os.path.normpath(info.get("skill_md_path", ""))
             if not skill_path:
                 continue
             if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):


### PR DESCRIPTION
## Summary

On Windows, the Telegram (and Discord) slash-command menu showed **zero** skills — every installed skill was silently filtered out, regardless of the command-menu cap.

## Root cause

`_collect_gateway_skill_entries()` in `hermes_cli/commands.py` built the allowed-directory prefix set with:

```python
_allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
_allowed_prefixes.extend(str(d).rstrip("/") + "/" for d in get_external_skills_dirs())
_allowed_prefixes.extend(str(d).rstrip("/") + "/" for d in get_project_skills_dirs())
```

On Windows, `SKILLS_DIR.resolve()` returns a backslash path (`C:\...\skills`), so `.rstrip("/")` is a no-op and the appended `/` produces a mixed-separator prefix (`C:\...\skills/`). The comparison

```python
if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
    continue
```

then never matches the backslash-only `skill_md_path`, so **every** skill is skipped. On POSIX the paths and prefixes are already forward-slash and match, which is why this only manifests on Windows.

## Fix

Normalize directories and skill paths with `os.path.normpath` and build the trailing separator from `os.sep`:

```python
def _dir_prefix(d: str) -> str:
    d = os.path.normpath(str(d))
    return d if d.endswith(os.sep) else d + os.sep
```

This is separator-agnostic and preserves the original intent (prefix must end with a separator so `my-skills` does not also match `my-skills-extra`).

## Verification

On Windows, before the fix `telegram_menu_commands()` returned 66 core commands and **0 skills**; after, it returns `66 core + 34 skills = 100` (Telegram's command-menu cap trims the remaining ~206 skills, as designed). The same collector is shared by Discord, so this also fixes Discord skill-command registration.

## Notes

- Single-file change, no new dependencies.
- No behavioral change on POSIX (`os.path.normpath` is a no-op for already-normalized forward-slash paths).