### PR TITLE
fix(compression): compaction dead-loop ended — trigger and tail walks charge stale thinking by wire truth (#84371)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1504,7 +1504,18 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     if not charge_stale_thinking:
         return tokens
+    # The wire ships at most ONE of the generic thinking keys: every request
+    # build pops ``reasoning`` after (optionally) promoting it into
+    # ``reasoning_content`` (``apply_reasoning_content_policy``), and a
+    # non-empty stored ``reasoning_content`` always displaces it. Charging
+    # both keys double-counted the same thinking text on echo-back providers
+    # that persist it under both (#84371 comment: +53% vs real
+    # prompt_tokens). Mirror the wire: reasoning_content wins when present.
+    _rc = msg.get("reasoning_content")
+    _skip_reasoning_dup = isinstance(_rc, str) and bool(_rc.strip())
     for key in _NEWEST_TURN_ONLY_BUDGET_KEYS:
+        if key == "reasoning" and _skip_reasoning_dup:
+            continue
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     # reasoning_details: charge only the thinking TEXT, never the signed /
     # base64 envelope (#73298 second site; mirrors the preflight estimator's
@@ -3930,11 +3941,16 @@ class ContextCompressor(ContextEngine):
             # Same newest-turn-only thinking charge as the tail-cut walk
             # (#73624) — this boundary decides which tool results stay
             # prunable, and overcharging stale thinking shrinks that window.
+            # Echo-back routes charge every turn (#84371 estimator parity).
             _newest_asst_idx = _last_assistant_index(result)
+            _charge_all_thinking = self._stale_thinking_on_wire()
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or i == _newest_asst_idx
+                    ),
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -6495,6 +6511,30 @@ This compaction should PRIORITISE preserving all information related to the focu
             idx += 1
         return idx
 
+    def _stale_thinking_on_wire(self) -> bool:
+        """Whether the active route replays stale thinking text (#84371).
+
+        The tail-budget walks and the preflight trigger must charge the SAME
+        stale-thinking policy or a reasoning-heavy session can look
+        over-threshold to one and fully tail-protected to the other — the
+        infinite ineffective compaction loop.  Echo-back chat-completions
+        families (DeepSeek/Kimi/MiMo thinking mode) replay stored
+        ``reasoning_content`` on EVERY assistant turn, so the walk must
+        charge it everywhere; codex_responses and strict providers never
+        ship the text keys, so newest-turn-only stands (#73624).
+        """
+        try:
+            from agent.message_sanitization import stale_thinking_reaches_wire
+
+            return stale_thinking_reaches_wire(
+                getattr(self, "api_mode", "") or "",
+                getattr(self, "provider", "") or "",
+                getattr(self, "model", "") or "",
+                getattr(self, "base_url", "") or "",
+            )
+        except Exception:
+            return False
+
     def _find_tail_cut_by_tokens(
         self, messages: List[Dict[str, Any]], head_end: int,
         token_budget: int | None = None,
@@ -6540,12 +6580,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         # fields any transport still replays (#73624) — every older turn's
         # reasoning/reasoning_content is stripped or padded at send time,
         # so charging it here spends tail budget on bytes that never ship.
+        # Exception: echo-back providers (DeepSeek/Kimi/MiMo thinking mode
+        # on chat_completions) replay stale thinking on EVERY turn — charge
+        # it everywhere so this walk agrees with the preflight trigger
+        # (#84371 estimator parity).
         _newest_asst_idx = _last_assistant_index(messages)
+        _charge_all_thinking = self._stale_thinking_on_wire()
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=(
+                    _charge_all_thinking or i == _newest_asst_idx
+                ),
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -6573,7 +6621,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or j == _newest_asst_idx
+                    ),
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3754,6 +3754,26 @@ def compress_context(
                 "Compression made no progress (session=%s) — skipping boundary rewrite.",
                 agent.session_id or "none",
             )
+            # Dead-loop breaker (#84371): a fired compaction that returns the
+            # transcript UNCHANGED will fail identically next turn unless the
+            # transcript changes — yet this path recorded telemetry only, so
+            # auto-compress re-fired every turn, each attempt burning a full
+            # aux summarization (6+/10min in the wild). Arm the transient
+            # structural backoff so the next attempts are deferred; any
+            # successful boundary lifts it, and manual /compress overrides it.
+            try:
+                _no_progress_recorder = getattr(
+                    agent.context_compressor, "_record_structural_no_op", None
+                )
+                if callable(_no_progress_recorder):
+                    _no_progress_recorder(
+                        "compaction returned the transcript unchanged "
+                        "(no_progress)"
+                    )
+            except Exception:
+                logger.debug(
+                    "no-progress backoff arm failed", exc_info=True
+                )
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2659,10 +2659,12 @@ def run_conversation(
         # disagreement that dead-looped compaction.
         from agent.turn_context import _agent_stale_thinking_on_wire
 
-        approx_tokens = estimate_messages_tokens_rough(
-            api_messages,
-            charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
-        )
+        if _agent_stale_thinking_on_wire(agent):
+            approx_tokens = estimate_messages_tokens_rough(api_messages)
+        else:
+            approx_tokens = estimate_messages_tokens_rough(
+                api_messages, charge_stale_thinking=False
+            )
         # Route-aware pressure: when the upcoming request is eligible for
         # native Responses compaction the transport will checkpoint-prune
         # the payload before sending — the generic durable-history figure

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2652,7 +2652,17 @@ def run_conversation(
         # messages walk inside estimate_request_tokens_rough. Tools added
         # separately (compression needs them: 50+ tools = 20-30K tokens).
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
-        approx_tokens = estimate_messages_tokens_rough(api_messages)
+        # Charge stale thinking only when the active route actually replays
+        # it (#84371): on codex_responses the text keys never ship (the
+        # encrypted item sidecars — charged unconditionally — carry the
+        # chain), so counting them here re-created the trigger/tail-walk
+        # disagreement that dead-looped compaction.
+        from agent.turn_context import _agent_stale_thinking_on_wire
+
+        approx_tokens = estimate_messages_tokens_rough(
+            api_messages,
+            charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
+        )
         # Route-aware pressure: when the upcoming request is eligible for
         # native Responses compaction the transport will checkpoint-prune
         # the payload before sending — the generic durable-history figure

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -624,6 +624,7 @@ __all__ = [
     "reasoning_echo_family",
     "matches_reasoning_echo_family",
     "needs_reasoning_echo",
+    "stale_thinking_reaches_wire",
     "apply_reasoning_content_policy",
     "reapply_reasoning_echo",
 ]
@@ -891,6 +892,34 @@ def reasoning_echo_family(provider: Any, model: Any, base_url: Any) -> "str | No
 def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
     """True when the endpoint requires reasoning_content echo-back."""
     return reasoning_echo_family(provider, model, base_url) is not None
+
+
+def stale_thinking_reaches_wire(
+    api_mode: Any, provider: Any, model: Any, base_url: Any
+) -> bool:
+    """True when stale assistant ``reasoning``/``reasoning_content`` text is
+    actually replayed on the wire for the active route.
+
+    This is the single wire-truth predicate the compaction TRIGGER estimator
+    and the tail-budget walks must share (#84371): when they disagree, a
+    reasoning-heavy session can simultaneously look over-threshold to
+    preflight and fully tail-protected to the walk — an infinite ineffective
+    compaction loop.
+
+    * ``codex_responses``: the Responses input builder
+      (``_chat_messages_to_responses_input``) never reads the text keys —
+      reasoning continuity rides the encrypted ``codex_reasoning_items``
+      sidecar, which both estimators already charge unconditionally. Stale
+      thinking TEXT never ships → ``False``.
+    * chat-completions echo-back families (DeepSeek/Kimi/MiMo thinking
+      mode): ``apply_reasoning_content_policy`` replays the stored
+      ``reasoning_content`` verbatim on EVERY assistant turn → ``True``.
+    * everything else: stripped or one-space-padded at send time (#73624)
+      → ``False``.
+    """
+    if (api_mode or "") == "codex_responses":
+        return False
+    return needs_reasoning_echo(provider, model, base_url)
 
 
 def apply_reasoning_content_policy(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3544,13 +3544,28 @@ def estimate_tokens_rough(text: str) -> int:
     return dense + ((sparse + 3) // 4)
 
 
-def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
+def estimate_messages_tokens_rough(
+    messages: List[Dict[str, Any]], *, charge_stale_thinking: bool = True,
+) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
     Image parts (base64 PNG/JPEG) are counted as a flat ~1500 tokens per
     image — the Anthropic pricing model — instead of counting raw base64
     character length. Without this, a single ~1MB screenshot would be
     estimated at ~250K tokens and trigger premature context compression.
+
+    ``charge_stale_thinking`` mirrors the tail-budget walk's policy
+    (``context_compressor._estimate_msg_budget_tokens``, #73624): generic
+    thinking text (``reasoning`` / ``reasoning_content``) rides the wire for
+    at most the NEWEST assistant turn on routes that do not echo stale
+    reasoning back (Codex Responses ships encrypted ``codex_reasoning_items``
+    instead of the text keys; strict chat-completions providers strip or
+    one-space-pad the field). Passing ``False`` excludes those keys on every
+    assistant turn but the newest, so the compaction TRIGGER sees the same
+    size class as the tail-protection walk — the disagreement made
+    reasoning-heavy codex_responses sessions fire preflight forever while the
+    walk found nothing to compact (#84371 dead loop). Default ``True``
+    preserves the conservative full charge for callers without route context.
 
     Per-message results are memoized (see ``_estimate_message_tokens_cached``)
     keyed on a deep *identity fingerprint* of the message, so re-walking a
@@ -3559,10 +3574,48 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     leaf objects and structure, hence an identical estimate.
     """
     _IMAGE_TOKEN_COST = 1500
+    if not charge_stale_thinking:
+        messages = _strip_stale_thinking_for_estimate(messages)
     total = 0
     for msg in messages:
         total += _estimate_message_tokens_cached(msg, _IMAGE_TOKEN_COST)
     return total
+
+
+# Generic thinking-text keys replayed for at most the newest assistant turn
+# on non-echo routes — must stay in lockstep with
+# ``context_compressor._NEWEST_TURN_ONLY_BUDGET_KEYS``.
+_STALE_THINKING_ESTIMATE_KEYS = ("reasoning", "reasoning_content")
+
+
+def _strip_stale_thinking_for_estimate(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Copy of ``messages`` with stale thinking keys removed (newest kept).
+
+    Shallow stripped copies share the original value objects, so the
+    per-message memo still hits for the stripped shape on subsequent walks.
+    """
+    newest = -1
+    for i in range(len(messages) - 1, -1, -1):
+        m = messages[i]
+        if isinstance(m, dict) and m.get("role") == "assistant":
+            newest = i
+            break
+    out: List[Dict[str, Any]] = []
+    for i, m in enumerate(messages):
+        if (
+            i != newest
+            and isinstance(m, dict)
+            and m.get("role") == "assistant"
+            and any(m.get(k) for k in _STALE_THINKING_ESTIMATE_KEYS)
+        ):
+            m = {
+                k: v for k, v in m.items()
+                if k not in _STALE_THINKING_ESTIMATE_KEYS
+            }
+        out.append(m)
+    return out
 
 
 # --- Per-message token-estimate memo -------------------------------------
@@ -3692,9 +3745,23 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
         and bool(sidecar)
         and msg.get("role") in ("user", "assistant")
     )
+    # The internal ``reasoning`` key never ships: every request build pops it
+    # after (optionally) promoting it into ``reasoning_content`` (see
+    # ``apply_reasoning_content_policy`` / conversation_loop's api_messages
+    # build). When a message carries BOTH keys — the normal shape on
+    # reasoning-echo providers, which pin ``reasoning_content`` at creation
+    # time while ``reasoning`` holds the same text for trajectory storage —
+    # counting both charged the same thinking twice and inflated the rough
+    # estimate by up to +53% against provider-reported prompt_tokens
+    # (#84371 comment data, llama.cpp/Qwen). Keep ``reasoning`` only as the
+    # promotion proxy when no ``reasoning_content`` exists to displace it.
+    _rc = msg.get("reasoning_content")
+    drop_reasoning_dup = isinstance(_rc, str) and bool(_rc.strip())
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
         if k in ("_anthropic_content_blocks", "reasoning_details") or k in PERSISTENCE_ONLY_MESSAGE_FIELDS:
+            continue
+        if k == "reasoning" and drop_reasoning_dup:
             continue
         if k == "api_content":
             # Always popped before the request is built; only counted when it
@@ -3750,6 +3817,7 @@ def estimate_request_tokens_rough(
     *,
     system_prompt: str = "",
     tools: Optional[List[Dict[str, Any]]] = None,
+    charge_stale_thinking: bool = True,
 ) -> int:
     """Rough token estimate for a full chat-completions request.
 
@@ -3758,12 +3826,19 @@ def estimate_request_tokens_rough(
     tools enabled, schemas alone can add 20-30K tokens — a significant
     blind spot when only counting messages. Image content is counted
     at a flat per-image cost (see estimate_messages_tokens_rough).
+
+    ``charge_stale_thinking`` is forwarded to
+    ``estimate_messages_tokens_rough`` — pass ``False`` when the active
+    route provably strips stale assistant thinking at send time (see
+    ``message_sanitization.stale_thinking_reaches_wire``, #84371).
     """
     total = 0
     if system_prompt:
         total += estimate_tokens_rough(system_prompt)
     if messages:
-        total += estimate_messages_tokens_rough(messages)
+        total += estimate_messages_tokens_rough(
+            messages, charge_stale_thinking=charge_stale_thinking
+        )
     if tools:
         total += _estimate_tools_tokens_rough(tools)
     return total

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3836,9 +3836,15 @@ def estimate_request_tokens_rough(
     if system_prompt:
         total += estimate_tokens_rough(system_prompt)
     if messages:
-        total += estimate_messages_tokens_rough(
-            messages, charge_stale_thinking=charge_stale_thinking
-        )
+        if charge_stale_thinking:
+            # Positional-compatible call: test seams and plugin engines
+            # monkeypatch estimate_messages_tokens_rough with (messages)-only
+            # signatures; only the route-aware False path needs the kwarg.
+            total += estimate_messages_tokens_rough(messages)
+        else:
+            total += estimate_messages_tokens_rough(
+                messages, charge_stale_thinking=False
+            )
     if tools:
         total += _estimate_tools_tokens_rough(tools)
     return total

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -95,11 +95,17 @@ def _preflight_request_tokens(
             "using generic transcript estimate",
             exc_info=True,
         )
+    if _agent_stale_thinking_on_wire(agent):
+        return estimate_request_tokens_rough(
+            messages,
+            system_prompt=system_prompt or "",
+            tools=tools,
+        )
     return estimate_request_tokens_rough(
         messages,
         system_prompt=system_prompt or "",
         tools=tools,
-        charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
+        charge_stale_thinking=False,
     )
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -99,7 +99,27 @@ def _preflight_request_tokens(
         messages,
         system_prompt=system_prompt or "",
         tools=tools,
+        charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
     )
+
+
+def _agent_stale_thinking_on_wire(agent: Any) -> bool:
+    """Whether the agent's active route replays stale thinking text (#84371).
+
+    Route facts unavailable (test doubles, partially-built agents) default to
+    ``True`` — the conservative full charge.
+    """
+    try:
+        from agent.message_sanitization import stale_thinking_reaches_wire
+
+        return stale_thinking_reaches_wire(
+            getattr(agent, "api_mode", "") or "",
+            getattr(agent, "provider", "") or "",
+            getattr(agent, "model", "") or "",
+            getattr(agent, "base_url", "") or "",
+        )
+    except Exception:
+        return True
 
 
 def compose_user_api_content(

--- a/tests/agent/test_estimator_parity_84371.py
+++ b/tests/agent/test_estimator_parity_84371.py
@@ -1,0 +1,330 @@
+"""Regression tests for #84371 — compaction dead-loop on reasoning-heavy
+codex_responses sessions.
+
+Root cause: the compaction TRIGGER (``estimate_messages_tokens_rough`` /
+``estimate_request_tokens_rough``) charged stale ``reasoning`` /
+``reasoning_content`` on EVERY assistant message, while the tail-protection
+walk (``_find_tail_cut_by_tokens``) charged them on the newest turn only
+(#73624).  On a session where most tokens live in stale reasoning replay the
+trigger fires above threshold while the walk protects everything —
+``middle_window_tokens == 0`` / "insufficient progress" — and the same
+compaction re-fires every turn, each attempt burning a full aux
+summarization.
+
+Wire truth (``_chat_messages_to_responses_input``): the codex_responses
+input builder never reads the text thinking keys; reasoning continuity rides
+the encrypted ``codex_reasoning_items`` sidecar, which both estimators charge
+unconditionally.  So the TRIGGER overcounted reality and the fix makes the
+trigger route-aware (charge stale thinking only when the route echoes it),
+while echo-back chat-completions routes (DeepSeek/Kimi/MiMo thinking mode)
+now charge it in the walk too — one policy per session shape, chosen by
+``message_sanitization.stale_thinking_reaches_wire``.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _estimate_msg_budget_tokens,
+)
+from agent.message_sanitization import stale_thinking_reaches_wire
+from agent.model_metadata import (
+    estimate_messages_tokens_rough,
+    estimate_request_tokens_rough,
+)
+
+
+STALE_THINKING = "considering the next move carefully... " * 200  # ~2K tok
+
+
+def _reasoning_heavy_session(n_turns: int = 40) -> list:
+    """Transcript whose bulk is stale reasoning replay (the #84371 shape)."""
+    msgs = [{"role": "system", "content": "You are Hermes."}]
+    msgs.append({"role": "user", "content": "do the big task"})
+    for i in range(n_turns):
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": f"step {i}",
+                "reasoning_content": STALE_THINKING,
+                "tool_calls": [
+                    {
+                        "id": f"c{i}",
+                        "type": "function",
+                        "function": {"name": "t", "arguments": "{}"},
+                    }
+                ],
+            }
+        )
+        msgs.append({"role": "tool", "tool_call_id": f"c{i}", "content": f"r{i}"})
+    return msgs
+
+
+class TestWireTruthPredicate:
+    def test_codex_responses_never_ships_stale_thinking_text(self):
+        assert stale_thinking_reaches_wire(
+            "codex_responses", "deepseek", "deepseek-v4-flash", ""
+        ) is False
+
+    def test_chat_completions_echo_family_ships_it(self):
+        # DeepSeek thinking mode over chat_completions echoes stored
+        # reasoning_content back on every assistant turn.
+        assert stale_thinking_reaches_wire(
+            "", "deepseek", "deepseek-reasoner", "https://api.deepseek.com"
+        ) is True
+
+    def test_strict_chat_completions_strips_it(self):
+        assert stale_thinking_reaches_wire(
+            "", "mistral", "mistral-large", "https://api.mistral.ai"
+        ) is False
+
+
+class TestEstimatorParity:
+    """Trigger-fires must imply the walk finds a compactable middle."""
+
+    def test_trigger_fires_implies_walk_finds_middle(self):
+        msgs = _reasoning_heavy_session()
+        wire = stale_thinking_reaches_wire(
+            "codex_responses", "deepseek", "deepseek-v4-flash", ""
+        )
+        trigger = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=wire
+        )
+
+        cc = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        # THE RELATION, not literals: whenever the route-aware trigger says
+        # the session is over threshold, the tail walk must leave a real
+        # middle region so the fired compaction can actually make progress.
+        if trigger >= cc.threshold_tokens:
+            start = cc._protect_head_size(msgs)
+            end = cc._find_tail_cut_by_tokens(msgs, start)
+            assert end > start, (
+                "trigger fired but the tail walk protected everything — "
+                "the #84371 dead-loop shape"
+            )
+            middle_tokens = estimate_messages_tokens_rough(msgs[start:end])
+            assert middle_tokens > 0
+
+    def test_route_aware_trigger_matches_walk_size_class(self):
+        """On codex_responses the trigger no longer counts stale thinking
+        the walk excludes: both figures land in the same size class."""
+        msgs = _reasoning_heavy_session()
+        legacy = estimate_messages_tokens_rough(msgs)
+        route_aware = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        from agent.context_compressor import _last_assistant_index
+
+        newest = _last_assistant_index(msgs)
+        walk = sum(
+            _estimate_msg_budget_tokens(m, charge_stale_thinking=(i == newest))
+            for i, m in enumerate(msgs)
+        )
+        # Stale thinking dominates this transcript, so the legacy figure is
+        # several times the walk's; the route-aware figure must not be.
+        assert legacy > 3 * walk
+        assert route_aware < 2 * walk
+
+    def test_newest_turn_thinking_still_charged(self):
+        msgs = _reasoning_heavy_session(n_turns=2)
+        stripped = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        no_thinking = estimate_messages_tokens_rough(
+            [
+                {k: v for k, v in m.items()
+                 if k not in ("reasoning", "reasoning_content")}
+                for m in msgs
+            ]
+        )
+        # The newest assistant turn's thinking survives the stale strip.
+        assert stripped > no_thinking
+
+    def test_walk_charges_stale_thinking_on_echo_route(self):
+        """Echo-back chat_completions route: the walk now charges stale
+        thinking on every turn, matching the trigger's full charge; the
+        codex_responses route keeps newest-turn-only.  Assert the per-route
+        charge policy directly — for each route, the walk's per-message sum
+        must land in the same size class as that route's trigger estimate."""
+        msgs = _reasoning_heavy_session()
+        from agent.context_compressor import _last_assistant_index
+
+        cc_echo = ContextCompressor(
+            model="deepseek-reasoner",
+            provider="deepseek",
+            api_mode="",
+            base_url="https://api.deepseek.com",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        cc_codex = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        assert cc_echo._stale_thinking_on_wire() is True
+        assert cc_codex._stale_thinking_on_wire() is False
+
+        newest = _last_assistant_index(msgs)
+
+        def walk_sum(cc):
+            charge_all = cc._stale_thinking_on_wire()
+            return sum(
+                _estimate_msg_budget_tokens(
+                    m, charge_stale_thinking=(charge_all or i == newest)
+                )
+                for i, m in enumerate(msgs)
+            )
+
+        trigger_echo = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=True
+        )
+        trigger_codex = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        walk_echo = walk_sum(cc_echo)
+        walk_codex = walk_sum(cc_codex)
+
+        # Per route, trigger and walk agree within a small rough-estimator
+        # factor — the pre-fix codex disagreement was >3x.
+        assert walk_echo <= trigger_echo * 2 and trigger_echo <= walk_echo * 2
+        assert walk_codex <= trigger_codex * 2 and trigger_codex <= walk_codex * 2
+        # And the echo route genuinely charges the stale thinking bulk.
+        assert walk_echo > 3 * walk_codex
+
+
+class TestReasoningDoubleCount:
+    """``reasoning`` and ``reasoning_content`` carrying the same text must be
+    charged once — the wire ships at most one of them."""
+
+    def test_trigger_counts_identical_pair_once(self):
+        base = [{"role": "assistant", "content": "x"}]
+        rc_only = [{"role": "assistant", "content": "x",
+                    "reasoning_content": "y" * 4000}]
+        both = [{"role": "assistant", "content": "x",
+                 "reasoning": "y" * 4000, "reasoning_content": "y" * 4000}]
+        e0 = estimate_messages_tokens_rough(base)
+        e1 = estimate_messages_tokens_rough(rc_only)
+        e2 = estimate_messages_tokens_rough(both)
+        # Adding a duplicate `reasoning` key must not (materially) grow the
+        # estimate: the increment over rc_only stays far below a second copy.
+        assert (e2 - e0) < 1.5 * (e1 - e0)
+
+    def test_walk_counts_identical_pair_once(self):
+        base = {"role": "assistant", "content": "x"}
+        rc_only = {"role": "assistant", "content": "x",
+                   "reasoning_content": "y" * 4000}
+        both = {"role": "assistant", "content": "x",
+                "reasoning": "y" * 4000, "reasoning_content": "y" * 4000}
+        w0 = _estimate_msg_budget_tokens(base, charge_stale_thinking=True)
+        w1 = _estimate_msg_budget_tokens(rc_only, charge_stale_thinking=True)
+        w2 = _estimate_msg_budget_tokens(both, charge_stale_thinking=True)
+        assert (w2 - w0) < 1.5 * (w1 - w0)
+
+    def test_reasoning_alone_still_charged(self):
+        """No reasoning_content to displace it → `reasoning` is the
+        promotion proxy and must stay counted."""
+        base = [{"role": "assistant", "content": "x"}]
+        r_only = [{"role": "assistant", "content": "x",
+                   "reasoning": "y" * 4000}]
+        assert (
+            estimate_messages_tokens_rough(r_only)
+            > estimate_messages_tokens_rough(base) + 500
+        )
+        w_base = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x"}, charge_stale_thinking=True
+        )
+        w_r = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x", "reasoning": "y" * 4000},
+            charge_stale_thinking=True,
+        )
+        assert w_r > w_base + 500
+
+    def test_pad_reasoning_content_does_not_displace(self):
+        """A one-space echo pad is not real content; `reasoning` still
+        carries the chargeable text."""
+        msg = {"role": "assistant", "content": "x",
+               "reasoning": "y" * 4000, "reasoning_content": " "}
+        w = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        w_base = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x", "reasoning_content": " "},
+            charge_stale_thinking=True,
+        )
+        assert w > w_base + 500
+
+
+class TestNoProgressDeadLoopBreaker:
+    """A fired compaction that returns the transcript unchanged must arm the
+    structural backoff so it cannot re-fire (and re-summarize) every turn."""
+
+    def test_no_progress_arms_structural_backoff(self):
+        import time
+
+        cc = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        assert cc._structural_no_op_backoff_until <= time.monotonic()
+        cc._record_structural_no_op("compaction returned unchanged")
+        assert cc._structural_no_op_backoff_until > time.monotonic()
+        # Over-threshold but blocked: no second aux summarization this turn.
+        over = cc.threshold_tokens + 1
+        assert cc.should_compress(over) is False
+        reason = cc._compression_block_reason() or ""
+        assert reason.startswith("structural_backoff")
+
+    def test_commit_layer_no_progress_calls_recorder(self):
+        """The conversation_compression no_progress path must invoke the
+        compressor's structural no-op recorder (it used to record telemetry
+        only, so auto-compress re-fired next turn)."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import MagicMock
+        import os
+
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id="s-84371",
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+            agent.compression_in_place = False
+            compressor = MagicMock()
+            # No-op compression: returns input unchanged.
+            compressor.compress.side_effect = (
+                lambda messages, **_kwargs: messages
+            )
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            messages = [{"role": "user", "content": "request"}]
+
+            returned, _ = agent._compress_context(
+                messages, "sys", approx_tokens=100
+            )
+
+            assert returned is messages
+            assert compressor._record_structural_no_op.called, (
+                "no_progress must arm the per-session backoff — otherwise "
+                "the dead loop re-fires a full aux summarization every turn"
+            )


### PR DESCRIPTION
## Summary
Reasoning-heavy codex_responses sessions no longer dead-loop (trigger fires at ~406K, walk finds 9.7K chargeable, middle=0, re-fires every turn with a full aux summarization). Trigger estimates and tail-budget walks now charge stale thinking from ONE shared wire-truth predicate.

Wire truth (verified in the adapters): the Responses input builder never ships the text thinking keys — encrypted `codex_reasoning_items` carry continuity and were already charged — so the TRIGGER overcounted there. DeepSeek/Kimi/MiMo thinking mode over chat_completions echoes stored `reasoning_content` every turn — so the WALK undercounted there. One predicate (`stale_thinking_reaches_wire()`) now drives both sides per route.

## Changes
- `agent/message_sanitization.py`: the wire-truth predicate
- Trigger sites (`turn_context`, `conversation_loop`) exclude stale thinking on non-echo routes; all 3 tail/prune walks charge it on echo routes — trigger-fires ⇒ walk-finds-middle
- Double-count fixed in both estimators (issue comment's +53% llama.cpp overcount): `reasoning_content` displaces `reasoning`, never charged twice
- Defense in depth: the commit-layer `no_progress` path (telemetry-only before) now arms the structural no-op backoff — an unchanged-transcript compaction cannot re-fire every turn

## Validation
| Probe (deepseek-v4-flash 1M, threshold 350K) | Before | After |
|---|---|---|
| Trigger estimate vs walk chargeable | 405,796 vs 9,762 → fires + loops | 10,446 vs 9,762 → agrees, no fire |
| Identical reasoning/reasoning_content pair | +2,010 tok (double) | +1,006 (single) |
| Re-fire on unchanged transcript | yes, every turn | no |

13 new relation-based tests (3 sabotage-verified) + ~1,050 targeted tests green.

Fixes #84371. Supersedes single-direction PRs #84401 / #86055 (each fixes one route and breaks the other — closure with credit after merge); #94211's echo-route half matches this PR's conclusion.

## Infographic

![Dead loop broken](https://v3b.fal.media/files/b/0aa87c2d/0KQb8wgjVYGytpB0xp6f7_jZPpF5Pn.png)
