### PR TITLE
fix(compression): attempt lifecycle — worker teardown, durable backoff, supersession, no false auto-reset (#97488, #96775)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3000,6 +3000,17 @@ class ContextCompressor(ContextEngine):
         except Exception as exc:
             logger.debug("compression failure cooldown clear failed (non-sqlite): %s", exc)
 
+    def _compression_cancelled(self) -> bool:
+        """Read the host-owned cooperative cancellation signal, if installed."""
+        cancelled_check = getattr(self, "_compression_cancelled_check", None)
+        if not callable(cancelled_check):
+            return False
+        try:
+            return bool(cancelled_check())
+        except Exception:
+            logger.debug("compression cancellation check failed", exc_info=True)
+            return False
+
     def update_model(
         self,
         model: str,
@@ -4805,6 +4816,8 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         placeholder.
         """
         prompt_started_at = time.monotonic()
+        if self._compression_cancelled():
+            raise AuxiliaryExplicitCancellation()
         now = prompt_started_at
         if now < self._summary_failure_cooldown_until:
             logger.debug(
@@ -5183,6 +5196,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                     effective_aux_context=_aux_context,
                     phase_timings=_latency_info,
                 )
+            if self._compression_cancelled():
+                raise AuxiliaryExplicitCancellation()
             # ``_validate_llm_response`` only guarantees ``choices[0].message``
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2950,13 +2950,23 @@ class ContextCompressor(ContextEngine):
             self._cooldown_persist_failed = True
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
-    def record_timeout_failure(self, error: str) -> None:
+    def record_timeout_failure(self, error: str, failure_kind: str = "timeout") -> None:
         """Record a consecutive timeout/stall failure using the shared ladder.
 
         Used by the summary-LLM exception handler, the host-level
         ``compress_context`` timeout wrapper, and stall-interrupted
         pre-commit cancellation (#62452, #96775).
+
+        The persisted error is prefixed with the attempt identity —
+        ``backoff:<failure_kind>:strategy=<tail_mode>`` — so the durable row
+        (``sessions.compression_failure_cooldown_until`` +
+        ``compression_failure_error`` in state.db) records WHICH strategy
+        failed and WHY, and a gateway restart rebuilds the same backoff
+        decision from ``bind_session_state()`` (#96775/#97488).
         """
+        strategy = getattr(self, "tail_mode", None) or "unknown"
+        kind = failure_kind or "timeout"
+        stamped = f"backoff:{kind}:strategy={strategy}: {error}"
         _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
         self._consecutive_timeout_failures = (
             getattr(self, "_consecutive_timeout_failures", 0) + 1
@@ -2965,7 +2975,7 @@ class ContextCompressor(ContextEngine):
             min(self._consecutive_timeout_failures,
                 len(_TIMEOUT_COOLDOWN_LADDER)) - 1
         ]
-        self._record_compression_failure_cooldown(float(cooldown), error)
+        self._record_compression_failure_cooldown(float(cooldown), stamped)
 
     def _clear_compression_failure_cooldown(self) -> None:
         # #76354 review F4: fence check BEFORE cooldown-clear. A late worker

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2920,9 +2920,16 @@ class ContextCompressor(ContextEngine):
         cooldown_seconds: float,
         error: Optional[str],
     ) -> None:
-        cooldown_until = time.time() + cooldown_seconds
-        self._summary_failure_cooldown_until = time.monotonic() + cooldown_seconds
+        now_mono = time.monotonic()
+        new_mono = now_mono + float(cooldown_seconds)
+        # Never shorten a longer live deadline (#96775). A later stall or
+        # timeout records the latest error text but keeps the later of the
+        # two clocks.
+        if new_mono > self._summary_failure_cooldown_until:
+            self._summary_failure_cooldown_until = new_mono
         self._last_summary_error = error
+        remaining = max(0.0, self._summary_failure_cooldown_until - time.monotonic())
+        cooldown_until = time.time() + remaining
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
@@ -2944,12 +2951,11 @@ class ContextCompressor(ContextEngine):
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
     def record_timeout_failure(self, error: str) -> None:
-        """Record a consecutive timeout failure using the shared cooldown ladder.
+        """Record a consecutive timeout/stall failure using the shared ladder.
 
-        Used by both the summary-LLM exception handler (inline at line ~3714)
-        and the host-level ``compress_context`` timeout wrapper in
-        ``run_compress_context_with_progress_timeout``. Avoids re-implementing
-        the ladder at each call site (#62452).
+        Used by the summary-LLM exception handler, the host-level
+        ``compress_context`` timeout wrapper, and stall-interrupted
+        pre-commit cancellation (#62452, #96775).
         """
         _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
         self._consecutive_timeout_failures = (

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1645,34 +1645,36 @@ def run_compress_context_with_progress_timeout(
         # so a NEW compressor can acquire the lock immediately (no ABA: the
         # DB release is holder-scoped).
         handled_exit = True
-        # #97488 teardown: give the cancelled worker a bounded grace to
-        # actually exit before this host moves on. The worker checks the
-        # poison fence between provider phases, so a cooperative worker
-        # exits quickly; an uninterruptible provider call is orphaned behind
-        # the fence after the grace elapses (its late result is discarded and
-        # cannot touch session state).
-        worker_exited = _join_cancelled_worker(
-            future,
-            min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
-        )
-        if worker_exited:
-            # The worker provably exited: no in-flight provider call can
-            # outlive this attempt, so the total-ceiling lease retention is
-            # no longer needed and a retry cannot overlap anything.
-            fence.allow_cancelled_lock_release()
-        else:
-            logger.warning(
-                "Cancelled compression worker did not exit within %.1fs "
-                "grace — orphaning it behind the poison fence (late result "
-                "will be discarded)%s",
+        # #97488 teardown (total-ceiling path only): give the cancelled
+        # worker a bounded grace to actually exit before this host moves on.
+        # The worker checks the poison fence between provider phases, so a
+        # cooperative worker exits quickly; an uninterruptible provider call
+        # is orphaned behind the fence after the grace elapses (its late
+        # result is discarded and cannot touch session state). The
+        # idle-stall path intentionally skips the join: its worker is by
+        # definition silent/hung, the stall-fallback retry below needs a
+        # prompt host return (pinned by the #76354 S3 latency contract), and
+        # the fence poison + attempt-generation supersession already protect
+        # state against its late unwind.
+        if total_exhausted:
+            worker_exited = _join_cancelled_worker(
+                future,
                 min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
-                (
-                    "; retaining the session compression lease until it "
-                    "exits so no new attempt overlaps it"
-                    if total_exhausted
-                    else ""
-                ),
             )
+            if worker_exited:
+                # The worker provably exited: no in-flight provider call can
+                # outlive this attempt, so the total-ceiling lease retention
+                # is no longer needed and a retry cannot overlap anything.
+                fence.allow_cancelled_lock_release()
+            else:
+                logger.warning(
+                    "Cancelled compression worker did not exit within %.1fs "
+                    "grace — orphaning it behind the poison fence (late "
+                    "result will be discarded); retaining the session "
+                    "compression lease until it exits so no new attempt "
+                    "overlaps it",
+                    min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+                )
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -637,7 +637,7 @@ class CompressionCommitFence:
     fully complete before the caller proceeds.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, total_ceiling_seconds: float | None = None) -> None:
         self._lock = threading.Lock()
         self._cancelled = False
         self._commit_started = False
@@ -672,6 +672,18 @@ class CompressionCommitFence:
         # a SLOW-but-alive summary model from a HUNG one, so slow models are
         # not killed by a fixed wall-clock deadline while tokens are moving.
         self._last_progress = time.monotonic()
+        self._progress_observed = False
+        self._deadline: float | None = None
+        self._retain_cancelled_lock_until_worker_done = False
+        if total_ceiling_seconds is not None:
+            self.set_total_ceiling_seconds(total_ceiling_seconds)
+
+    def set_total_ceiling_seconds(self, seconds: float) -> None:
+        """Arm the wall-clock deadline shared by the host and worker."""
+        seconds = float(seconds)
+        if seconds <= 0:
+            raise ValueError("total compression ceiling must be positive")
+        self._deadline = time.monotonic() + seconds
 
     def touch_progress(self) -> None:
         """Record forward progress (e.g. a streamed summary token arriving).
@@ -681,6 +693,17 @@ class CompressionCommitFence:
         CPython, so no lock is needed.
         """
         self._last_progress = time.monotonic()
+        self._progress_observed = True
+
+    @property
+    def progress_observed(self) -> bool:
+        """Whether semantic provider progress was reported for this attempt."""
+        return self._progress_observed
+
+    @property
+    def deadline_exceeded(self) -> bool:
+        deadline = self._deadline
+        return deadline is not None and time.monotonic() >= deadline
 
     def seconds_since_progress(self) -> float:
         """Seconds since the worker last reported forward progress."""
@@ -723,7 +746,7 @@ class CompressionCommitFence:
         """Atomically admit commit unless a hard cancellation already won."""
         self._lock.acquire()
         if (
-            self._cancelled
+            self.is_cancelled
             or self._admission_revoked
             or (cancel_event is not None and bool(cancel_event.is_set()))
         ):
@@ -771,7 +794,11 @@ class CompressionCommitFence:
     @property
     def is_cancelled(self) -> bool:
         """True after cancellation won before the commit boundary."""
-        return self._cancelled or self._admission_revoked
+        return self._cancelled or self._admission_revoked or self.deadline_exceeded
+
+    def retain_compression_lock_until_worker_done(self) -> None:
+        """Prevent a timed-out live worker from overlapping a retry."""
+        self._retain_cancelled_lock_until_worker_done = True
 
     def revoke_commit_admission(self) -> None:
         """Revoke FUTURE commit admission without blocking on the fence lock.
@@ -830,7 +857,7 @@ class CompressionCommitFence:
         the durable lock and making its cancellation cleanup callable.
         """
         self._lock.acquire()
-        if self._cancelled or self._admission_revoked:
+        if self.is_cancelled or self._admission_revoked:
             self._lock.release()
             return False
         return True
@@ -868,6 +895,8 @@ class CompressionCommitFence:
         publication is retained and fulfilled synchronously when the worker
         publishes the hook.
         """
+        if self._retain_cancelled_lock_until_worker_done:
+            return
         with self._lock_release_guard:
             self._cancelled_lock_release_requested = True
             release = self._cancelled_lock_release
@@ -1244,9 +1273,10 @@ def run_compress_context_with_progress_timeout(
             return system_prompt_fallback()
         return system_prompt_fallback
 
-    fence = fence if fence is not None else CompressionCommitFence()
     ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
     idle = float(idle_timeout_seconds)
+    fence = fence if fence is not None else CompressionCommitFence()
+    fence.set_total_ceiling_seconds(ceiling)
     # Sync mirror of gateway session-hygiene's run_in_executor(None, ...) +
     # wait_for loop (gateway/run.py): offload compress_context onto the shared
     # daemon pool, poll with an inactivity budget + total ceiling, then
@@ -1347,6 +1377,15 @@ def run_compress_context_with_progress_timeout(
         # F6: a not-yet-started future must not linger as a stale queued job.
         # cancel() is a no-op for a running worker (fence handles that path).
         future.cancel()
+
+        total_exhausted = (
+            time.monotonic() - wait_started >= ceiling or fence.deadline_exceeded
+        )
+        if total_exhausted:
+            # A total-ceiling candidate can still be unwinding a healthy
+            # provider call. Keep its session lease until that worker exits so
+            # another automatic attempt cannot overlap the unchanged source.
+            fence.retain_compression_lock_until_worker_done()
 
         cancelled: Optional[bool] = None
         while cancelled is None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1316,6 +1316,10 @@ def run_compress_context_with_progress_timeout(
         # (worker slot freed late). Check the fence BEFORE any expensive
         # summary work so a stale job never burns an LLM call; its return
         # value is discarded by the already-departed host.
+        if worker_fence.deadline_exceeded:
+            raise concurrent.futures.TimeoutError(
+                "compression deadline expired before worker start"
+            )
         if worker_fence.is_cancelled:
             logger.info(
                 "Skipping stale compression job: fence cancelled before start"
@@ -1362,7 +1366,11 @@ def run_compress_context_with_progress_timeout(
             except concurrent.futures.TimeoutError:
                 waited = time.monotonic() - wait_started
                 since_progress = fence.seconds_since_progress()
-                if since_progress < idle and waited < ceiling:
+                if (
+                    not fence.deadline_exceeded
+                    and since_progress < idle
+                    and waited < ceiling
+                ):
                     logger.info(
                         "Context compression still streaming after %.0fs "
                         "(last progress %.1fs ago) — extending wait "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -909,6 +909,12 @@ class CompressionCommitFence:
 DEFAULT_CONTEXT_TIMEOUT_SECONDS = 120.0
 DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS = 600.0
 
+# Distinct from ``explicit_interrupt``: a /stop that arrived after the summary
+# stream had already crossed the no-progress stall window (#96775). Ordinary
+# early /stop stays cooldown-neutral; this class arms the durable backoff so
+# the next automatic turn does not re-enter the same stalled strategy.
+STALL_INTERRUPTED_FAILURE_CLASS = "stall_interrupted"
+
 # Shared daemon pool for sync compress_context timeout wraps — analogous to
 # asyncio's default executor used by gateway session hygiene's
 # ``loop.run_in_executor(None, ...)``, but daemon so a fence-cancelled hung
@@ -1028,6 +1034,101 @@ def resolve_context_compression_timeouts(
     if idle > 0:
         ceiling = max(ceiling, idle)
     return idle, ceiling
+
+
+def compression_attempt_stalled(
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    idle_timeout_seconds: Optional[float] = None,
+) -> bool:
+    """Return whether a pre-commit cancel landed after the stall window.
+
+    An ordinary early ``/stop`` must stay cooldown-neutral. When the fence
+    (or, without a fence, the attempt clock) has already sat idle for the
+    configured compression inactivity budget, the interrupt is a stalled
+    attempt — the same condition the host timeout uses — and the next
+    automatic turn must not blindly retry that strategy (#96775).
+    """
+    idle = idle_timeout_seconds
+    if idle is None:
+        idle, _ceiling = resolve_context_compression_timeouts()
+    try:
+        idle = float(idle)
+    except (TypeError, ValueError):
+        return False
+    if idle <= 0:
+        return False
+    if commit_fence is not None:
+        try:
+            return float(commit_fence.seconds_since_progress()) >= idle
+        except Exception:
+            return False
+    try:
+        return (time.monotonic() - float(started_at)) >= idle
+    except (TypeError, ValueError):
+        return False
+
+
+def _stall_source_fingerprint(
+    agent: Any,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> str:
+    """Identity of the stalled source context + summary strategy."""
+    compressor = getattr(agent, "context_compressor", None)
+    model = (
+        getattr(compressor, "summary_model", None)
+        or getattr(agent, "model", None)
+        or ""
+    )
+    n_messages = len(messages) if isinstance(messages, list) else 0
+    try:
+        tokens = int(approx_tokens or 0)
+    except (TypeError, ValueError):
+        tokens = 0
+    return f"msgs={n_messages}:tokens={tokens}:model={model}"
+
+
+def _record_stall_interrupted_backoff(
+    agent: Any,
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> bool:
+    """Persist a stall-interrupted cooldown after snapshot restore.
+
+    Must run *after* ``_restore_compressor_attempt_state`` so rollback cannot
+    wipe the new row. Returns True when the stall backoff was recorded.
+    """
+    if not compression_attempt_stalled(
+        commit_fence=commit_fence, started_at=started_at
+    ):
+        return False
+    compressor = getattr(agent, "context_compressor", None)
+    record = getattr(compressor, "record_timeout_failure", None)
+    if not callable(record):
+        return False
+    error = (
+        f"{STALL_INTERRUPTED_FAILURE_CLASS}:"
+        f"{_stall_source_fingerprint(agent, messages, approx_tokens)}"
+    )
+    try:
+        record(error)
+    except Exception:
+        logger.debug(
+            "stall-interrupted compression cooldown persist failed",
+            exc_info=True,
+        )
+        return False
+    logger.info(
+        "Recorded stall-interrupted compression backoff (session=%s, %s)",
+        getattr(agent, "session_id", None) or "none",
+        error,
+    )
+    return True
 
 
 def resolve_compression_fallback_route() -> Optional[dict]:
@@ -3716,6 +3817,15 @@ def compress_context(
             and messages != messages_before_compression
         ):
             messages[:] = copy.deepcopy(messages_before_compression)
+        # Record after restore so rollback cannot wipe a stall backoff, and
+        # while the lease is still held so the next turn cannot race it.
+        _stall_backoff = _record_stall_interrupted_backoff(
+            agent,
+            commit_fence=commit_fence,
+            started_at=_attempt_started_at,
+            messages=messages,
+            approx_tokens=approx_tokens,
+        )
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression cancelled")
             _activity_heartbeat = None
@@ -3725,7 +3835,11 @@ def compress_context(
             started_at=_attempt_started_at,
             commit_status="aborted",
             split_status="aborted",
-            failure_class="explicit_interrupt",
+            failure_class=(
+                STALL_INTERRUPTED_FAILURE_CLASS
+                if _stall_backoff
+                else "explicit_interrupt"
+            ),
         )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:
@@ -3870,6 +3984,13 @@ def compress_context(
                     agent.session_id or "none",
                 )
                 agent._last_compaction_in_place = False
+                _stall_backoff = _record_stall_interrupted_backoff(
+                    agent,
+                    commit_fence=commit_fence,
+                    started_at=_attempt_started_at,
+                    messages=messages,
+                    approx_tokens=approx_tokens,
+                )
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:
                     _existing_sp = agent._build_system_prompt(system_message)
@@ -3878,7 +3999,11 @@ def compress_context(
                     started_at=_attempt_started_at,
                     commit_status="aborted",
                     split_status="aborted",
-                    failure_class="commit_fence_cancelled",
+                    failure_class=(
+                        STALL_INTERRUPTED_FAILURE_CLASS
+                        if _stall_backoff
+                        else "commit_fence_cancelled"
+                    ),
                 )
                 _release_lock()
                 return messages, _existing_sp

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1102,6 +1102,7 @@ def _retry_compression_on_fallback_chain(
     idle_timeout_seconds: float,
     total_ceiling_seconds: float,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
+    on_timeout_cause: Optional[Callable[[bool, bool], None]] = None,
     telemetry_agent: Any = None,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
 ) -> Optional[Tuple[list, str]]:
@@ -1176,6 +1177,7 @@ def _retry_compression_on_fallback_chain(
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=ceiling,
                 on_commit_overrun=on_commit_overrun,
+                on_timeout_cause=on_timeout_cause,
                 fence=retry_fence,
                 telemetry_agent=telemetry_agent,
                 stall_fallback=False,
@@ -1213,6 +1215,7 @@ def run_compress_context_with_progress_timeout(
     idle_timeout_seconds: float,
     total_ceiling_seconds: float,
     on_timeout: Optional[Callable[[float, float, float], None]] = None,
+    on_timeout_cause: Optional[Callable[[bool, bool], None]] = None,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     fence: Optional[CompressionCommitFence] = None,
     telemetry_agent: Any = None,
@@ -1247,7 +1250,10 @@ def run_compress_context_with_progress_timeout(
 
     ``system_prompt_fallback`` may be a string or a zero-arg callable resolved
     only on the timeout path, so successful compression never pays for (or
-    fails on) an eager prompt rebuild.
+    fails on) an eager prompt rebuild. ``on_timeout_cause`` receives whether
+    the total ceiling expired and whether provider progress was observed before
+    ``on_timeout`` runs, allowing hosts to report the timeout accurately while
+    preserving the existing three-argument timeout callback contract.
 
     ``stall_fallback`` (default on) makes an aborted stall attempt the
     configured ``auxiliary.compression.fallback_chain`` once — pinned onto a
@@ -1395,6 +1401,15 @@ def run_compress_context_with_progress_timeout(
             # another automatic attempt cannot overlap the unchanged source.
             fence.retain_compression_lock_until_worker_done()
 
+        if on_timeout_cause is not None:
+            try:
+                on_timeout_cause(total_exhausted, fence.progress_observed)
+            except Exception:
+                logger.debug(
+                    "compress_context timeout-cause callback failed",
+                    exc_info=True,
+                )
+
         cancelled: Optional[bool] = None
         while cancelled is None:
             # F1: ``begin_commit`` retains the fence lock until
@@ -1493,6 +1508,7 @@ def run_compress_context_with_progress_timeout(
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=ceiling,
                 on_commit_overrun=on_commit_overrun,
+                on_timeout_cause=on_timeout_cause,
                 telemetry_agent=telemetry_agent,
                 new_fence=new_fence,
             )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -800,6 +800,16 @@ class CompressionCommitFence:
         """Prevent a timed-out live worker from overlapping a retry."""
         self._retain_cancelled_lock_until_worker_done = True
 
+    def allow_cancelled_lock_release(self) -> None:
+        """Undo :meth:`retain_compression_lock_until_worker_done`.
+
+        Called by the host after a bounded-grace join confirmed the timed-out
+        worker actually exited: the overlap hazard is gone, so the durable
+        lease may be released normally and a fallback/retry attempt can
+        proceed against a genuinely quiescent session.
+        """
+        self._retain_cancelled_lock_until_worker_done = False
+
     def revoke_commit_admission(self) -> None:
         """Revoke FUTURE commit admission without blocking on the fence lock.
 
@@ -930,6 +940,47 @@ _compress_timeout_executor_lock = threading.Lock()
 # silent unbounded future.result(). Clamped down to the ceiling for tiny test
 # ceilings so overrun reporting stays observable at test timescales.
 _COMMIT_OVERRUN_WAIT_SLICE_SECONDS = 30.0
+
+# Bounded grace given to a fence-cancelled compression worker to actually
+# exit before the host moves on (#97488). A worker that exits inside the
+# grace window proves no provider call is still in flight, so the durable
+# lease can be released safely even on the total-ceiling path. A worker that
+# does NOT exit is orphaned behind the poison fence (its late result cannot
+# commit) and, on the total-ceiling path, keeps the holder-qualified lease
+# retained so a new attempt cannot overlap the unchanged session.
+_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS = 5.0
+
+
+def _join_cancelled_worker(future: Any, grace_seconds: float) -> bool:
+    """Best-effort bounded join of a fence-cancelled compression worker.
+
+    Returns True when the worker future settled (result, exception, or
+    pre-start cancellation) within ``grace_seconds`` — i.e. the worker thread
+    provably exited and cannot be holding a provider call open. Returns
+    False for a worker that is still running; the caller must treat it as an
+    orphan behind the poison fence.
+    """
+    try:
+        grace = max(float(grace_seconds), 0.0)
+    except (TypeError, ValueError):
+        grace = 0.0
+    try:
+        future.result(timeout=grace)
+        return True
+    except concurrent.futures.TimeoutError:
+        return False
+    except concurrent.futures.CancelledError:
+        # Never started; nothing can be in flight.
+        return True
+    except Exception:
+        # The worker raised — it exited. The exception is intentionally
+        # swallowed here: the host already chose the fallback result, and the
+        # fence prevents the failed attempt from touching session state.
+        logger.debug(
+            "cancelled compression worker exited with an exception",
+            exc_info=True,
+        )
+        return True
 
 # Bounded admission for the shared compress-timeout pool (#76354 review F6).
 # The stdlib executor queue is unbounded: with all four workers wedged in hung
@@ -1116,7 +1167,7 @@ def _record_stall_interrupted_backoff(
         f"{_stall_source_fingerprint(agent, messages, approx_tokens)}"
     )
     try:
-        record(error)
+        record(error, failure_kind="stall_interrupted")
     except Exception:
         logger.debug(
             "stall-interrupted compression cooldown persist failed",
@@ -1594,6 +1645,34 @@ def run_compress_context_with_progress_timeout(
         # so a NEW compressor can acquire the lock immediately (no ABA: the
         # DB release is holder-scoped).
         handled_exit = True
+        # #97488 teardown: give the cancelled worker a bounded grace to
+        # actually exit before this host moves on. The worker checks the
+        # poison fence between provider phases, so a cooperative worker
+        # exits quickly; an uninterruptible provider call is orphaned behind
+        # the fence after the grace elapses (its late result is discarded and
+        # cannot touch session state).
+        worker_exited = _join_cancelled_worker(
+            future,
+            min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+        )
+        if worker_exited:
+            # The worker provably exited: no in-flight provider call can
+            # outlive this attempt, so the total-ceiling lease retention is
+            # no longer needed and a retry cannot overlap anything.
+            fence.allow_cancelled_lock_release()
+        else:
+            logger.warning(
+                "Cancelled compression worker did not exit within %.1fs "
+                "grace — orphaning it behind the poison fence (late result "
+                "will be discarded)%s",
+                min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+                (
+                    "; retaining the session compression lease until it "
+                    "exits so no new attempt overlaps it"
+                    if total_exhausted
+                    else ""
+                ),
+            )
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()
@@ -1773,6 +1852,63 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     """
     _sig = getattr(agent, "_compression_skipped_due_to_lock", None)
     return _sig is True or isinstance(_sig, str)
+
+
+def compression_blocked_transiently(agent: Any) -> bool:
+    """Type-pinned read of the transient-block signal (#97488).
+
+    ``agent._compression_blocked_transient`` is set by ``compress_context``
+    when an automatic pass no-ops because a TRANSIENT compressor guard is
+    active — a summary-failure cooldown (e.g. one just recorded by the host
+    ceiling timeout) or a structural no-op backoff — and cleared to ``None``
+    at the entry of every call.
+
+    Consumers (the overflow-recovery loops in ``conversation_loop``) must
+    treat such a no-op as a temporary defer, NOT as evidence the session is
+    incompressible: counting it toward ``compression_exhausted`` lets a real
+    upstream ``context_length_exceeded`` auto-reset (wipe) a session whose
+    compression was merely cooling down (#97488). The permanent
+    ``ineffective`` breaker intentionally does NOT set this signal — a
+    genuinely incompressible session must still be able to exhaust.
+
+    Type-pinned for the same reason as :func:`compression_skipped_due_to_lock`
+    (MagicMock auto-attribute hijack).
+    """
+    _sig = getattr(agent, "_compression_blocked_transient", None)
+    return isinstance(_sig, str) and bool(_sig)
+
+
+def _mark_compression_blocked_transient(agent: Any, compressor: Any) -> None:
+    """Publish the transient-block signal when the active guard is transient.
+
+    Reads the compressor's own block reason so the transient/permanent
+    classification lives in one place (``_compression_block_reason``):
+    ``cooldown:*`` and ``structural_backoff:*`` are timed guards that lapse
+    on their own; ``ineffective`` is the permanent breaker and stays
+    unmarked so exhaustion semantics are preserved.
+    """
+    reason_fn = getattr(compressor, "_compression_block_reason", None)
+    reason = None
+    if callable(reason_fn):
+        try:
+            reason = reason_fn()
+        except Exception:
+            logger.debug("compression block-reason read failed", exc_info=True)
+    if isinstance(reason, str) and (
+        reason.startswith("cooldown") or reason.startswith("structural_backoff")
+    ):
+        logger.info(
+            "Skipping automatic compression re-entry: transient guard "
+            "active (%s, session=%s, last failure: %s) — will retry after "
+            "the backoff lapses; /compress forces an immediate retry",
+            reason,
+            getattr(agent, "session_id", None) or "none",
+            getattr(compressor, "_last_summary_error", None) or "unknown",
+        )
+        try:
+            agent._compression_blocked_transient = reason
+        except Exception:
+            pass
 
 
 def _adopt_live_compression_child(
@@ -2966,6 +3102,10 @@ def compress_context(
     # second clear before lock acquisition below stays for the same reason
     # it was added in #69870 and is simply idempotent now.
     agent._compression_skipped_due_to_lock = None
+    # Transient-block signal (#97488): cleared with the same per-attempt
+    # rule; set by the breaker gates below when a TRANSIENT guard (cooldown /
+    # structural backoff) no-ops this pass.
+    agent._compression_blocked_transient = None
 
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
@@ -3038,6 +3178,7 @@ def compress_context(
             None,
         )
         if callable(blocked) and blocked(agent.context_compressor):
+            _mark_compression_blocked_transient(agent, agent.context_compressor)
             existing_prompt = getattr(agent, "_cached_system_prompt", None)
             if not existing_prompt:
                 existing_prompt = agent._build_system_prompt(system_message)
@@ -3496,6 +3637,7 @@ def compress_context(
             None,
         )
         if callable(blocked) and blocked(compressor):
+            _mark_compression_blocked_transient(agent, compressor)
             _release_lock()
             existing_prompt = getattr(agent, "_cached_system_prompt", None)
             if not existing_prompt:
@@ -3960,6 +4102,47 @@ def compress_context(
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
+            _release_lock()
+            return messages, _existing_sp
+
+        # Supersession guard (#97488): a NEWER attempt claiming this
+        # compressor (via _claim_compressor_attempt) supersedes this one —
+        # this attempt's late candidate must be discarded, never committed
+        # over the newer attempt's state. Checked for fenceless callers too:
+        # the fence poison alone cannot see a successor that minted its own
+        # fresh fence.
+        _attempt_superseded = not _compressor_attempt_is_current(
+            agent.context_compressor, _attempt_generation
+        )
+        if _attempt_superseded:
+            logger.warning(
+                "Discarding late compression candidate: attempt generation "
+                "%s was superseded by a newer attempt (current: %s) "
+                "(session=%s).",
+                _attempt_generation,
+                getattr(
+                    agent.context_compressor,
+                    "_compression_attempt_generation",
+                    None,
+                ),
+                agent.session_id or "none",
+            )
+            if (
+                messages_before_compression is not None
+                and messages != messages_before_compression
+            ):
+                messages[:] = copy.deepcopy(messages_before_compression)
+            agent._last_compaction_in_place = False
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            _emit_compression_attempt_telemetry(
+                agent,
+                started_at=_attempt_started_at,
+                commit_status="aborted",
+                split_status="aborted",
+                failure_class="attempt_superseded",
+            )
             _release_lock()
             return messages, _existing_sp
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    compression_blocked_transiently,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
@@ -1513,38 +1514,57 @@ def _compression_deferred_result(
     agent,
     messages: List[Dict],
     api_call_count: int,
+    reason: str = "lock",
 ) -> Dict[str, Any]:
-    """Build the soft turn result for a lock-contended compression defer.
+    """Build the soft turn result for a transiently-deferred compression.
 
-    Another path (a sibling turn, a background review fork, a manual
-    ``/compress``) holds this session's compression lock, so every
-    compression pass this turn no-oped and the request still does not fit.
-    This is a TEMPORARY condition — the lock winner is actively shrinking
-    the same session — so the turn must end as a soft defer
+    Two transient shapes funnel here, and BOTH must end as a soft defer
     (``compression_deferred``), never as ``compression_exhausted``: the
-    gateway auto-resets (wipes) the session on exhaustion (#9893/#35809),
-    which would destroy a session that the concurrent compressor is about
-    to make healthy again.
+    gateway auto-resets (wipes) the session on exhaustion (#9893/#35809).
+
+    * ``reason="lock"`` — another path (a sibling turn, a background review
+      fork, a manual ``/compress``) holds this session's compression lock,
+      so every compression pass this turn no-oped and the request still does
+      not fit. The lock winner is actively shrinking the same session.
+    * ``reason="transient_block"`` — the compressor is in a timed transient
+      guard (summary-failure cooldown / structural backoff, e.g. one just
+      recorded by the host ceiling timeout, #97488). The no-op says nothing
+      about compressibility; treating it as exhaustion falsely auto-reset
+      sessions whose compression was merely cooling down.
 
     ``failed`` stays False so the gateway persists the user turn (transient
     branch) and retry-next-message semantics apply.
     """
-    holder = getattr(agent, "_compression_skipped_due_to_lock", None)
-    logger.info(
-        "turn deferred: compression lock held by another path "
-        "(session=%s holder=%s) — not counting as compression exhaustion",
-        agent.session_id or "none",
-        holder if isinstance(holder, str) else "unconfirmed",
-    )
+    if reason == "transient_block":
+        block = getattr(agent, "_compression_blocked_transient", None)
+        logger.info(
+            "turn deferred: compression transiently blocked (%s) "
+            "(session=%s) — not counting as compression exhaustion",
+            block if isinstance(block, str) else "unknown guard",
+            agent.session_id or "none",
+        )
+        _final = (
+            "Context compression is temporarily paused after a recent "
+            "failed attempt. Please retry in a moment — compression will "
+            "resume automatically (or run /compress to force a retry now)."
+        )
+    else:
+        holder = getattr(agent, "_compression_skipped_due_to_lock", None)
+        logger.info(
+            "turn deferred: compression lock held by another path "
+            "(session=%s holder=%s) — not counting as compression exhaustion",
+            agent.session_id or "none",
+            holder if isinstance(holder, str) else "unconfirmed",
+        )
+        _final = (
+            "Context compression is already running for this session. "
+            "Please retry in a moment — your next message will be processed "
+            "once the concurrent compression finishes."
+        )
     try:
         agent._flush_status_buffer()
     except Exception:
         pass
-    _final = (
-        "Context compression is already running for this session. "
-        "Please retry in a moment — your next message will be processed "
-        "once the concurrent compression finishes."
-    )
     return {
         "final_response": _final,
         "messages": messages,
@@ -2816,16 +2836,21 @@ def run_conversation(
                 approx_tokens=request_pressure_tokens,
                 task_id=effective_task_id,
             )
-            if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
-                # #69870 lock-skip: another path holds this session's
-                # compression lock, so this pass no-oped. That is a temporary
-                # DEFER, not evidence about compressibility — refund the
-                # attempt (it must not burn the shared overflow-recovery
-                # budget toward compression_exhausted → gateway auto-reset,
-                # #9893/#35809) and leave the insufficient-progress blocker
-                # unarmed. Proceed with the current request: if it truly does
-                # not fit, the provider's 413/overflow handler returns the
-                # soft compression_deferred result with that stronger signal.
+            if messages is _pre_api_input and (
+                compression_skipped_due_to_lock(agent)
+                or compression_blocked_transiently(agent)
+            ):
+                # #69870 lock-skip / #97488 transient-block: this pass
+                # no-oped for a TEMPORARY reason (another path holds the
+                # compression lock, or a timed cooldown/backoff guard is
+                # active). That is a temporary DEFER, not evidence about
+                # compressibility — refund the attempt (it must not burn the
+                # shared overflow-recovery budget toward
+                # compression_exhausted → gateway auto-reset, #9893/#35809)
+                # and leave the insufficient-progress blocker unarmed.
+                # Proceed with the current request: if it truly does not
+                # fit, the provider's 413/overflow handler returns the soft
+                # compression_deferred result with that stronger signal.
                 compression_attempts -= 1
                 _last_preflight_pressure = None
                 if pending_moa_prepared_request is _moa_prepared_request:
@@ -5803,6 +5828,18 @@ def run_conversation(
                         return _compression_deferred_result(
                             agent, messages, api_call_count
                         )
+                    if messages is _overflow_input and compression_blocked_transiently(agent):
+                        # #97488 transient-block: compression no-oped because a
+                        # timed guard (host-timeout cooldown / structural
+                        # backoff) is active — a temporary defer, not evidence
+                        # of incompressibility. Never classify it as
+                        # compression_exhausted (gateway auto-reset).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count,
+                            reason="transient_block",
+                        )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -5960,6 +5997,15 @@ def run_conversation(
                                 agent._persist_session(messages, conversation_history)
                                 return _compression_deferred_result(
                                     agent, messages, api_call_count
+                                )
+                            if messages is _overflow_input and compression_blocked_transiently(agent):
+                                # #97488: timed transient guard — defer, never
+                                # exhaustion (gateway auto-reset).
+                                compression_attempts -= 1
+                                agent._persist_session(messages, conversation_history)
+                                return _compression_deferred_result(
+                                    agent, messages, api_call_count,
+                                    reason="transient_block",
                                 )
                             conversation_history = conversation_history_after_compression(
                                 agent, messages, conversation_history
@@ -6120,6 +6166,17 @@ def run_conversation(
                         agent._persist_session(messages, conversation_history)
                         return _compression_deferred_result(
                             agent, messages, api_call_count
+                        )
+                    if messages is _overflow_input and compression_blocked_transiently(agent):
+                        # #97488 transient-block: a timed guard (host-timeout
+                        # cooldown / structural backoff) no-oped this pass —
+                        # defer softly, never compression_exhausted (which
+                        # would auto-reset the session).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count,
+                            reason="transient_block",
                         )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -288,6 +288,32 @@ def hygiene_compaction_recovered(
     )
 
 
+def _hygiene_compression_timeout_message(
+    *,
+    total_exhausted: bool,
+    elapsed: float,
+    idle_timeout: float,
+    progress_observed: bool,
+) -> str:
+    """Describe the host timeout that actually ended hygiene compression."""
+    if total_exhausted:
+        progress = (
+            " after summary output was observed" if progress_observed else ""
+        )
+        return (
+            "⚠️ Context compression reached its total ceiling after "
+            f"{elapsed:.1f}s{progress}. No messages were dropped — continuing "
+            "without compression. Run /compress to retry or /reset for a clean "
+            "session."
+        )
+    return (
+        f"⚠️ Context compression timed out after {idle_timeout:.1f}s with no "
+        "output from the summary model. No messages were dropped — continuing "
+        "without compression. Run /compress to retry, /reset for a clean "
+        "session, or check your auxiliary.compression model configuration."
+    )
+
+
 def _record_hygiene_cooldown(
     gateway,
     session_id: str,
@@ -20581,7 +20607,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
                                     loop = asyncio.get_running_loop()
-                                    _hyg_commit_fence = CompressionCommitFence()
+                                    _hyg_commit_fence = CompressionCommitFence(
+                                        total_ceiling_seconds=_hyg_total_ceiling_seconds
+                                    )
                                     _hyg_future = loop.run_in_executor(
                                         None,
                                         lambda: _hyg_agent._compress_context(
@@ -20609,10 +20637,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # from the start of this wait slice —
                                             # otherwise silence can approach 2x
                                             # the configured timeout.
-                                            _slice = max(
-                                                _hyg_timeout_seconds
-                                                - _hyg_commit_fence.seconds_since_progress(),
-                                                0.005,
+                                            _hyg_waited = (
+                                                time.monotonic() - _hyg_wait_started
+                                            )
+                                            _slice = min(
+                                                max(
+                                                    _hyg_timeout_seconds
+                                                    - _hyg_commit_fence.seconds_since_progress(),
+                                                    0.005,
+                                                ),
+                                                max(
+                                                    _hyg_total_ceiling_seconds
+                                                    - _hyg_waited,
+                                                    0.005,
+                                                ),
                                             )
                                             # Bounded turn-hold (#TKT-0029): cap
                                             # this slice at the remaining
@@ -20786,6 +20824,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                 )
                                             raise
                                     except asyncio.TimeoutError:
+                                        _hyg_waited = time.monotonic() - _hyg_wait_started
+                                        _hyg_total_exhausted = (
+                                            _hyg_waited >= _hyg_total_ceiling_seconds
+                                            or _hyg_commit_fence.deadline_exceeded
+                                        )
+                                        if _hyg_total_exhausted:
+                                            # The worker cooperatively checks this
+                                            # deadline between digest calls. Keep
+                                            # its lease until it exits so an
+                                            # unchanged session cannot overlap a
+                                            # retry. Inactivity timeouts retain the
+                                            # established release behavior for a
+                                            # provider call that may never return.
+                                            _hyg_commit_fence.retain_compression_lock_until_worker_done()
                                         _cancelled = None
                                         while _cancelled is None:
                                             # #76354 F1: a hung commit retains the
@@ -20813,13 +20865,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
-                                            # #76354 F4: release the timed-out
-                                            # worker's durable lease via the
-                                            # holder-qualified hook so the next
-                                            # compressor can acquire the lock
-                                            # immediately (no ABA against a new
-                                            # holder — release is holder-scoped).
-                                            _hyg_commit_fence.release_cancelled_compression_lock()
+                                            # Cleanup follows worker completion;
+                                            # its holder-qualified lease remains
+                                            # live until then to exclude retries.
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,
                                                 _hyg_agent,
@@ -20833,12 +20881,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                     session_key,
                                                     _hyg_failure_cooldown_seconds,
                                                 )
+                                                _timeout_reason = (
+                                                    "session hygiene compression total "
+                                                    "ceiling exhausted"
+                                                    if _hyg_total_exhausted
+                                                    else "session hygiene compression "
+                                                    "timed out with no output from the "
+                                                    "summary model"
+                                                )
                                                 _record_hygiene_cooldown(
                                                     self, session_entry.session_id,
                                                     _hyg_cooldown,
-                                                    "session hygiene compression "
-                                                    "timed out with no output from "
-                                                    "the summary model",
+                                                    _timeout_reason,
                                                 )
                                             from agent.session_activity import (
                                                 ActivityProvenance,
@@ -20850,24 +20904,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                 "hygiene compression timeout "
                                                 "activity stamp failed",
                                             )
-                                            logger.warning(
-                                                "Session hygiene compression for session %s "
-                                                "made no progress for %.1fs "
-                                                "(total wait %.1fs, ceiling %.1fs); "
-                                                "continuing without compression",
-                                                session_entry.session_id,
-                                                _hyg_commit_fence.seconds_since_progress(),
-                                                time.monotonic() - _hyg_wait_started,
-                                                _hyg_total_ceiling_seconds,
+                                            _hyg_elapsed = (
+                                                time.monotonic() - _hyg_wait_started
                                             )
+                                            if _hyg_total_exhausted:
+                                                logger.warning(
+                                                    "Session hygiene compression for session %s "
+                                                    "reached its total ceiling after %.1fs "
+                                                    "(progress observed=%s); continuing without "
+                                                    "compression",
+                                                    session_entry.session_id,
+                                                    _hyg_elapsed,
+                                                    _hyg_commit_fence.progress_observed,
+                                                )
+                                            else:
+                                                logger.warning(
+                                                    "Session hygiene compression for session %s "
+                                                    "made no progress for %.1fs (total wait "
+                                                    "%.1fs, ceiling %.1fs); continuing without "
+                                                    "compression",
+                                                    session_entry.session_id,
+                                                    _hyg_commit_fence.seconds_since_progress(),
+                                                    _hyg_elapsed,
+                                                    _hyg_total_ceiling_seconds,
+                                                )
                                             _timeout_msg = (
-                                                "⚠️ Context compression timed out "
-                                                f"after {_hyg_timeout_seconds:.1f}s "
-                                                "with no output from the summary model. "
-                                                "No messages were dropped — continuing without "
-                                                "compression. Run /compress to retry, /reset for "
-                                                "a clean session, or check your "
-                                                "auxiliary.compression model configuration."
+                                                _hygiene_compression_timeout_message(
+                                                    total_exhausted=_hyg_total_exhausted,
+                                                    elapsed=_hyg_elapsed,
+                                                    idle_timeout=_hyg_timeout_seconds,
+                                                    progress_observed=(
+                                                        _hyg_commit_fence.progress_observed
+                                                    ),
+                                                )
                                             )
                                             try:
                                                 _adapter = self._adapter_for_source(source)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20865,9 +20865,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
-                                            # Cleanup follows worker completion;
-                                            # its holder-qualified lease remains
-                                            # live until then to exclude retries.
+                                            # Release an inactivity-timed-out
+                                            # worker's holder-qualified lease
+                                            # promptly. Total-ceiling attempts
+                                            # retained it above, so this is a
+                                            # no-op until worker cleanup there.
+                                            _hyg_commit_fence.release_cancelled_compression_lock()
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,
                                                 _hyg_agent,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7438,10 +7438,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return
 
         def _do(conn):
+            # Merge-max with any longer live deadline so a later shorter
+            # write cannot reopen the thrash window (#96775). The error
+            # column always takes the latest diagnostic.
             conn.execute(
-                "UPDATE sessions SET compression_failure_cooldown_until = ?, "
+                "UPDATE sessions SET compression_failure_cooldown_until = CASE "
+                "WHEN compression_failure_cooldown_until IS NOT NULL "
+                " AND compression_failure_cooldown_until > ? "
+                "THEN compression_failure_cooldown_until ELSE ? END, "
                 "compression_failure_error = ? WHERE id = ?",
-                (cooldown_until, error, session_id),
+                (cooldown_until, cooldown_until, error, session_id),
             )
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8179,15 +8179,35 @@ class AIAgent:
                         )
                         return system_message or ""
 
+                timeout_cause = {
+                    "total_exhausted": False,
+                    "progress_observed": False,
+                }
+
+                def _on_timeout_cause(total_exhausted, progress_observed):
+                    timeout_cause["total_exhausted"] = total_exhausted
+                    timeout_cause["progress_observed"] = progress_observed
+
                 def _on_timeout(idle, waited, since_progress):
-                    logger.warning(
-                        "Context compression made no progress for %.1fs "
-                        "(total wait %.1fs, ceiling %.1fs); continuing without "
-                        "compression",
-                        since_progress,
-                        waited,
-                        total_ceiling,
-                    )
+                    total_exhausted = timeout_cause["total_exhausted"]
+                    progress_observed = timeout_cause["progress_observed"]
+                    if total_exhausted:
+                        logger.warning(
+                            "Context compression reached its total ceiling "
+                            "after %.1fs (progress observed=%s); continuing "
+                            "without compression",
+                            waited,
+                            progress_observed,
+                        )
+                    else:
+                        logger.warning(
+                            "Context compression made no progress for %.1fs "
+                            "(total wait %.1fs, ceiling %.1fs); continuing "
+                            "without compression",
+                            since_progress,
+                            waited,
+                            total_ceiling,
+                        )
                     touch = getattr(self, "_touch_activity", None)
                     if callable(touch):
                         try:
@@ -8207,10 +8227,14 @@ class AIAgent:
                         record = getattr(compressor, "record_timeout_failure", None)
                         if callable(record):
                             try:
-                                record(
-                                    "host compress_context timeout "
+                                reason = (
+                                    "host compress_context total ceiling "
+                                    "exhausted"
+                                    if total_exhausted
+                                    else "host compress_context timeout "
                                     "(no summary progress)"
                                 )
+                                record(reason)
                             except Exception:
                                 logger.debug(
                                     "failed to record compress_context timeout "
@@ -8219,13 +8243,27 @@ class AIAgent:
                                 )
                     emit = getattr(self, "_emit_warning", None)
                     if callable(emit):
-                        emit(
-                            "⚠ Context compression timed out "
-                            f"after {idle:.1f}s with no output from the summary "
-                            "model. No messages were dropped — continuing without "
-                            "compression. Run /compress to retry, /new for a clean "
-                            "session, or check auxiliary.compression."
-                        )
+                        if total_exhausted:
+                            progress = (
+                                " after summary output was observed"
+                                if progress_observed
+                                else ""
+                            )
+                            emit(
+                                "⚠ Context compression reached its total ceiling "
+                                f"after {waited:.1f}s{progress}. No messages were "
+                                "dropped — continuing without compression. Run "
+                                "/compress to retry or /new for a clean session."
+                            )
+                        else:
+                            emit(
+                                "⚠ Context compression timed out "
+                                f"after {idle:.1f}s with no output from the summary "
+                                "model. No messages were dropped — continuing "
+                                "without compression. Run /compress to retry, /new "
+                                "for a clean session, or check "
+                                "auxiliary.compression."
+                            )
 
                 def _on_commit_overrun(waited, ceiling):
                     # Commit-phase ceiling breach: the SessionDB mutation is in
@@ -8259,6 +8297,7 @@ class AIAgent:
                     idle_timeout_seconds=idle_timeout,
                     total_ceiling_seconds=total_ceiling,
                     on_timeout=_on_timeout,
+                    on_timeout_cause=_on_timeout_cause,
                     on_commit_overrun=_on_commit_overrun,
                     fence=active_fence,
                     telemetry_agent=self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8234,7 +8234,14 @@ class AIAgent:
                                     else "host compress_context timeout "
                                     "(no summary progress)"
                                 )
-                                record(reason)
+                                record(
+                                    reason,
+                                    failure_kind=(
+                                        "ceiling_exhausted"
+                                        if total_exhausted
+                                        else "stalled"
+                                    ),
+                                )
                             except Exception:
                                 logger.debug(
                                     "failed to record compress_context timeout "

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -70,7 +70,10 @@ class TestRunCompressContextWithProgressTimeout:
             messages=original,
             system_prompt_fallback="fallback-prompt",
             idle_timeout_seconds=0.05,
-            total_ceiling_seconds=0.2,
+            # Leave enough total budget for a busy Windows runner to start the
+            # daemon worker; this case exercises inactivity cancellation, not
+            # the separate total-ceiling path.
+            total_ceiling_seconds=2.0,
             on_timeout=lambda idle, waited, since: warnings.append(
                 (idle, waited, since)
             ),

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -8,12 +8,14 @@ for the owned wrapper used when callers do not pass a ``commit_fence``.
 
 from __future__ import annotations
 
+import concurrent.futures
 import threading
 import time
 from unittest.mock import MagicMock
 
 import pytest
 
+import agent.conversation_compression as cc
 from agent.conversation_compression import (
     CompressionCommitFence,
     resolve_context_compression_timeouts,
@@ -46,6 +48,46 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
+    def test_deadline_before_worker_start_uses_timeout_fallback(self, monkeypatch):
+        original = [{"role": "user", "content": "keep-me"}]
+        worker = MagicMock()
+        fallback = MagicMock(return_value="fallback-prompt")
+        timeouts = []
+
+        class _ExpiredBeforeStartExecutor:
+            def submit(self, fn, fence):
+                fence._deadline = time.monotonic() - 1.0
+                future = concurrent.futures.Future()
+                try:
+                    future.set_result(fn(fence))
+                except BaseException as exc:
+                    future.set_exception(exc)
+                return future
+
+        monkeypatch.setattr(
+            cc,
+            "_get_compress_timeout_executor",
+            _ExpiredBeforeStartExecutor,
+        )
+
+        result_msgs, result_prompt = run_compress_context_with_progress_timeout(
+            worker=worker,
+            messages=original,
+            system_prompt_fallback=fallback,
+            idle_timeout_seconds=1.0,
+            total_ceiling_seconds=1.0,
+            on_timeout=lambda idle, waited, since: timeouts.append(
+                (idle, waited, since)
+            ),
+            stall_fallback=False,
+        )
+
+        worker.assert_not_called()
+        fallback.assert_called_once_with()
+        assert result_msgs is original
+        assert result_prompt == "fallback-prompt"
+        assert len(timeouts) == 1
+
     def test_silent_worker_times_out_and_preserves_messages(self):
         original = [{"role": "user", "content": "keep-me"}]
         started = threading.Event()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -483,6 +483,73 @@ class TestCompressContextForwarderOwnsTimeout:
             provenance=ActivityProvenance.AGENT_COMPRESSION_TIMEOUT,
         )
 
+    def test_owned_total_ceiling_reports_progress_accurately(self, monkeypatch):
+        from run_agent import AIAgent
+        from agent.context_compressor import ContextCompressor
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "s1"
+        agent._cached_system_prompt = "sys"
+        agent._emit_warning = MagicMock()
+        agent._touch_activity = MagicMock()
+        agent._build_system_prompt = MagicMock(return_value="sys")
+        agent._conversation_root_id = MagicMock(return_value=None)
+        agent.context_compressor = MagicMock()
+        agent.context_compressor._consecutive_timeout_failures = 0
+        agent.context_compressor.record_timeout_failure = (
+            ContextCompressor.record_timeout_failure.__get__(
+                agent.context_compressor, MagicMock
+            )
+        )
+        agent.context_compressor._record_compression_failure_cooldown = MagicMock()
+
+        release = threading.Event()
+
+        def streaming_compress(agent_obj, messages, system_message, **kwargs):
+            fence = kwargs["commit_fence"]
+            while not fence.deadline_exceeded:
+                fence.touch_progress()
+                time.sleep(0.005)
+            release.wait(timeout=2)
+            return messages, "sys"
+
+        monkeypatch.setattr(
+            "agent.conversation_compression.compress_context",
+            streaming_compress,
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (0.05, 0.15),
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_compression_fallback_route",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "agent.portal_tags.get_conversation_context",
+            lambda: object(),
+        )
+
+        original = [{"role": "user", "content": "stay"}]
+        try:
+            out_msgs, out_prompt = AIAgent._compress_context(
+                agent, original, "sys"
+            )
+        finally:
+            release.set()
+
+        assert out_msgs is original
+        assert out_prompt == "sys"
+        warning = agent._emit_warning.call_args.args[0]
+        assert "total ceiling" in warning
+        assert "summary output was observed" in warning
+        assert "no output" not in warning
+        cooldown_error = (
+            agent.context_compressor._record_compression_failure_cooldown
+            .call_args.args[1]
+        )
+        assert "total ceiling exhausted" in cooldown_error
+
     def test_fallback_prompt_resolved_lazily_on_timeout(self, monkeypatch):
         """Eager prompt rebuild must not run before compression starts."""
         from run_agent import AIAgent

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -1,0 +1,279 @@
+"""Attempt-lifecycle regression tests for #97488 / #96775.
+
+Pins the three attempt-level lifecycle guarantees added after PR #98628
+collapsed lean compaction to one auxiliary request per attempt:
+
+1. A ceiling/idle-timeout host TEARS DOWN its worker: a cooperative worker is
+   joined within the bounded grace (releasing the lease normally), while an
+   uninterruptible worker is orphaned behind the poison fence — its late
+   result is discarded and, on the total-ceiling path, the durable lease is
+   retained until it exits so no new attempt overlaps the unchanged session.
+2. A failed/stalled/cancelled attempt records a durable per-session backoff
+   (strategy + failure kind stamped into the state.db cooldown row) that
+   SURVIVES a gateway restart; the next automatic turn skips the same
+   strategy inside the window, and a successful compression clears it.
+3. Late results from a superseded attempt are discarded, never committed
+   over newer state (generation counter), and a transiently-blocked no-op is
+   reported as a soft defer — never compression_exhausted (false auto-reset).
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    _claim_compressor_attempt,
+    compress_context,
+    compression_blocked_transiently,
+    run_compress_context_with_progress_timeout,
+)
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str, db: SessionDB | None = None):
+    if db is None:
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1_000
+    return db, agent
+
+
+def _messages():
+    return [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+
+class TestWorkerTeardownOnCeiling:
+    def test_cooperative_worker_joined_within_grace(self):
+        """A worker that exits promptly after cancel is joined; the lease is
+        released normally (no retention) — the sabotage check for this test
+        is removing the `_join_cancelled_worker` call, which makes
+        `worker_done_when_host_returned` False."""
+        original = [{"role": "user", "content": "keep"}]
+        worker_done = threading.Event()
+
+        def cooperative_worker(fence: CompressionCommitFence):
+            # Poll the poison fence like the production worker does between
+            # provider phases; exit as soon as cancellation is visible.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if fence.is_cancelled:
+                    break
+                fence_idle = fence.seconds_since_progress()
+                assert fence_idle >= 0  # precondition: fence clock live
+                time.sleep(0.01)
+            worker_done.set()
+            return (original, "late")
+
+        fence = CompressionCommitFence()
+        msgs, prompt = run_compress_context_with_progress_timeout(
+            worker=cooperative_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.15,
+            fence=fence,
+            stall_fallback=False,
+        )
+        # The bounded-grace join must have reaped the cooperative worker
+        # BEFORE the host returned.
+        assert worker_done.is_set(), (
+            "host returned before tearing down a cooperative cancelled "
+            "worker — bounded-grace join missing (#97488)"
+        )
+        assert prompt == "fallback"
+        # Teardown proved quiescence, so the lease must NOT stay retained.
+        assert fence._retain_cancelled_lock_until_worker_done is False
+
+    def test_uninterruptible_worker_is_orphaned_with_lease_retained(self):
+        """A worker stuck in an uninterruptible provider call is orphaned:
+        the host returns after the grace, the poison fence discards its late
+        result, and on the total-ceiling path the durable lease release hook
+        does NOT fire while the worker is alive (no overlap window)."""
+        original = [{"role": "user", "content": "keep"}]
+        release = threading.Event()
+        worker_finished = threading.Event()
+        lock_released: list[float] = []
+
+        def stuck_worker(fence: CompressionCommitFence):
+            # Continuous progress so only the TOTAL ceiling can expire
+            # (the #97488 'last progress 0.0s ago' shape).
+            while not release.wait(timeout=0.02):
+                fence.touch_progress()
+            worker_finished.set()
+            if not fence.begin_commit():
+                return (original, "")
+            try:
+                return ([{"role": "assistant", "content": "late"}], "late")
+            finally:
+                fence.finish_commit()
+
+        fence = CompressionCommitFence()
+        fence.register_cancelled_lock_release(
+            lambda: lock_released.append(time.monotonic())
+        )
+        msgs, prompt = run_compress_context_with_progress_timeout(
+            worker=stuck_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.1,
+            total_ceiling_seconds=0.3,
+            fence=fence,
+            stall_fallback=False,
+        )
+        # Precondition: the worker is genuinely still running.
+        assert not worker_finished.is_set()
+        assert msgs is original and prompt == "fallback"
+        # Total-ceiling path: lease retained until the worker exits, so no
+        # new attempt can overlap the unchanged session.
+        assert not lock_released, (
+            "durable lease released while the timed-out worker was still "
+            "alive — overlap window reopened (#97488)"
+        )
+        release.set()
+        assert worker_finished.wait(timeout=2)
+        # Late result was fence-poisoned, never adopted.
+        assert msgs == [{"role": "user", "content": "keep"}]
+
+
+class TestDurableAttemptBackoff:
+    def test_backoff_row_records_strategy_and_kind(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_KIND")
+        agent.context_compressor.record_timeout_failure(
+            "host ceiling exhausted", failure_kind="ceiling_exhausted"
+        )
+        row = db.get_compression_failure_cooldown("BACKOFF_KIND")
+        assert row is not None, "backoff must persist to state.db"
+        assert row["remaining_seconds"] > 0
+        assert "backoff:ceiling_exhausted:strategy=lean" in (row["error"] or "")
+
+    def test_backoff_blocks_same_strategy_reentry_next_turn(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_REENTRY")
+        agent.context_compressor.record_timeout_failure(
+            "stall", failure_kind="stalled"
+        )
+        # Precondition: over threshold, so only the backoff can block.
+        assert 500_000 >= agent.context_compressor.threshold_tokens
+        should, reason = agent.context_compressor.should_compress_info(500_000)
+        assert should is False
+        assert reason and reason.startswith("cooldown"), (
+            "next-turn re-entry of the same strategy must be skipped inside "
+            "the backoff window (#96775)"
+        )
+
+    def test_backoff_survives_simulated_gateway_restart(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_RESTART")
+        agent.context_compressor.record_timeout_failure(
+            "stall before restart", failure_kind="stall_interrupted"
+        )
+        # Precondition: row is durable in this DB file.
+        assert db.get_compression_failure_cooldown("BACKOFF_RESTART")
+        # Simulated restart: brand-new SessionDB handle + brand-new agent
+        # objects rebuilt from the same state.db file.
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        _db2, agent2 = _build_agent(tmp_path, "BACKOFF_RESTART", db=db2)
+        cooldown = agent2.context_compressor.get_active_compression_failure_cooldown(
+            refresh=True
+        )
+        assert cooldown is not None, (
+            "backoff must survive a gateway restart via state.db (#96775)"
+        )
+        assert "stall_interrupted" in (cooldown["error"] or "")
+        should, reason = agent2.context_compressor.should_compress_info(500_000)
+        assert should is False and reason.startswith("cooldown")
+
+    def test_success_clears_backoff(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_CLEAR")
+        compressor = agent.context_compressor
+        compressor.record_timeout_failure("stall", failure_kind="stalled")
+        assert db.get_compression_failure_cooldown("BACKOFF_CLEAR")
+        # What a successful compression does on commit:
+        compressor._clear_compression_failure_cooldown()
+        assert db.get_compression_failure_cooldown("BACKOFF_CLEAR") is None
+        assert compressor.should_compress_info(500_000)[0] is True
+
+
+class TestSupersessionDiscardsLateResults:
+    def test_superseded_attempt_candidate_never_commits(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "SUPERSEDE")
+        live = _messages()
+        original = copy.deepcopy(live)
+
+        def compress_and_get_superseded(messages, **_kwargs):
+            # While this attempt's summary was in flight, a NEWER attempt
+            # claimed the compressor (what a retry/fallback does).
+            _claim_compressor_attempt(agent.context_compressor)
+            return [{"role": "assistant", "content": "stale summary"}]
+
+        agent.context_compressor.compress = compress_and_get_superseded
+        out, _prompt = compress_context(
+            agent, live, "sys", approx_tokens=500_000
+        )
+        assert out == original, (
+            "late candidate from a superseded attempt must be discarded, "
+            "never committed over newer state (#97488)"
+        )
+        assert live == original
+        # Session stayed writable and unrotated.
+        assert db.get_compression_lock_holder("SUPERSEDE") is None
+        db.append_message("SUPERSEDE", "assistant", "still writable")
+
+
+class TestTransientBlockIsNotExhaustion:
+    def test_cooldown_blocked_noop_sets_transient_signal(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "TRANSIENT_SIGNAL")
+        agent.context_compressor.record_timeout_failure(
+            "host ceiling", failure_kind="ceiling_exhausted"
+        )
+        live = _messages()
+        before = copy.deepcopy(live)
+        out, _ = compress_context(agent, live, "sys", approx_tokens=500_000)
+        # Preconditions: the pass no-oped and it was NOT a lock skip.
+        assert out == before
+        assert getattr(agent, "_compression_skipped_due_to_lock", None) is None
+        assert compression_blocked_transiently(agent) is True, (
+            "a cooldown-blocked no-op must be distinguishable from "
+            "exhaustion or the gateway falsely auto-resets (#97488)"
+        )
+
+    def test_signal_cleared_per_attempt_and_not_set_when_unblocked(
+        self, tmp_path: Path
+    ):
+        db, agent = _build_agent(tmp_path, "TRANSIENT_CLEAR")
+        # Stale signal from a previous pass must not leak.
+        agent._compression_blocked_transient = "cooldown:999"
+        agent.context_compressor.compress = lambda messages, **kw: list(messages)
+        live = _messages()
+        compress_context(agent, live, "sys", approx_tokens=500_000)
+        assert compression_blocked_transiently(agent) is False
+
+    def test_type_pinned_against_magicmock_agents(self):
+        from unittest.mock import MagicMock
+
+        mock_agent = MagicMock()
+        # MagicMock auto-attributes are truthy but not str.
+        assert compression_blocked_transiently(mock_agent) is False

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -69,23 +69,29 @@ def _messages():
 
 class TestWorkerTeardownOnCeiling:
     def test_cooperative_worker_joined_within_grace(self):
-        """A worker that exits promptly after cancel is joined; the lease is
-        released normally (no retention) — the sabotage check for this test
-        is removing the `_join_cancelled_worker` call, which makes
-        `worker_done_when_host_returned` False."""
+        """A worker that exits promptly after cancel is joined on the
+        total-ceiling path; the lease is released normally (no retention) —
+        the sabotage check for this test is removing the
+        `_join_cancelled_worker` call, which makes
+        `worker_done.is_set()` False when the host returns."""
         original = [{"role": "user", "content": "keep"}]
         worker_done = threading.Event()
 
         def cooperative_worker(fence: CompressionCommitFence):
-            # Poll the poison fence like the production worker does between
-            # provider phases; exit as soon as cancellation is visible.
+            # Continuous progress (the #97488 'last progress 0.0s ago'
+            # shape) so only the TOTAL ceiling expires; poll the poison
+            # fence like the production worker does between provider phases.
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
                 if fence.is_cancelled:
                     break
-                fence_idle = fence.seconds_since_progress()
-                assert fence_idle >= 0  # precondition: fence clock live
+                fence.touch_progress()
                 time.sleep(0.01)
+            # Cooperative-but-not-instant exit: the unwind after seeing the
+            # poison takes real time (rollback, telemetry). Long enough that
+            # a host WITHOUT the bounded-grace join returns first; far
+            # inside the 5s grace for a host WITH it.
+            time.sleep(0.08)
             worker_done.set()
             return (original, "late")
 
@@ -94,8 +100,8 @@ class TestWorkerTeardownOnCeiling:
             worker=cooperative_worker,
             messages=original,
             system_prompt_fallback="fallback",
-            idle_timeout_seconds=0.05,
-            total_ceiling_seconds=0.15,
+            idle_timeout_seconds=0.1,
+            total_ceiling_seconds=0.2,
             fence=fence,
             stall_fallback=False,
         )
@@ -105,7 +111,11 @@ class TestWorkerTeardownOnCeiling:
             "host returned before tearing down a cooperative cancelled "
             "worker — bounded-grace join missing (#97488)"
         )
-        assert prompt == "fallback"
+        # Whichever return path won the race (fallback via join, or the
+        # worker's own return adopted inside the final wait slice), the
+        # transcript must be unchanged.
+        assert msgs == [{"role": "user", "content": "keep"}]
+        assert prompt in ("fallback", "late")
         # Teardown proved quiescence, so the lease must NOT stay retained.
         assert fence._retain_cancelled_lock_until_worker_done is False
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -820,6 +820,27 @@ def test_commit_fence_waits_for_an_active_commit() -> None:
     assert result["cancelled"] is False
 
 
+def test_total_deadline_cancellation_retains_lock_until_worker_cleanup() -> None:
+    """A total-ceiling timeout must exclude retries while its worker is alive."""
+    from agent.conversation_compression import CompressionCommitFence
+
+    released = threading.Event()
+    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
+    fence.register_cancelled_lock_release(released.set)
+    fence.retain_compression_lock_until_worker_done()
+
+    now = time.monotonic()
+    with patch(
+        "agent.conversation_compression.time.monotonic",
+        return_value=now + 2.0,
+    ):
+        assert fence.is_cancelled
+        assert fence.try_cancel_before_commit() is True
+    fence.release_cancelled_compression_lock()
+
+    assert not released.is_set()
+
+
 def test_delayed_contender_adopts_unique_rotated_child(tmp_path: Path) -> None:
     """A stale agent must continue on the winner's compacted child transcript."""
     db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -457,6 +457,7 @@ class TestF6ExecutorSaturation:
             assert returned is messages
             # The cancelled attempt must not leave the durable lock held.
             assert db.get_compression_lock_holder(session_id) is None
+            db.close()
 
 
 class TestS3IdleChargedFromLastProgress:
@@ -480,6 +481,7 @@ class TestS3IdleChargedFromLastProgress:
                 system_prompt_fallback="fb",
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=5.0,
+                stall_fallback=False,
             )
         finally:
             elapsed = time.monotonic() - t0

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -44,13 +44,15 @@ def _drain_admission_slots():
 
 
 class TestF1CommitOverrunWhileHung:
-    def test_overrun_warning_fires_while_commit_still_blocked(self):
+    def test_overrun_warning_fires_while_commit_still_blocked(self, monkeypatch):
         """The warning + on_commit_overrun fire DURING the hang, not after.
 
         The fake commit is event-gated and is NOT released until after the
         assertions on the callback/log have been made while the worker
         thread is still blocked inside the commit boundary.
         """
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        monkeypatch.setattr(cc, "_get_compress_timeout_executor", lambda: executor)
         original = [{"role": "user", "content": "a"}]
         compressed = [{"role": "assistant", "content": "late"}]
         entered = threading.Event()
@@ -86,8 +88,8 @@ class TestF1CommitOverrunWhileHung:
                 worker=worker,
                 messages=original,
                 system_prompt_fallback="fallback",
-                idle_timeout_seconds=0.05,
-                total_ceiling_seconds=0.05,
+                idle_timeout_seconds=1.0,
+                total_ceiling_seconds=1.0,
                 on_commit_overrun=on_overrun,
             )
 
@@ -124,13 +126,14 @@ class TestF1CommitOverrunWhileHung:
                     "expected the overrun WARNING while the commit was "
                     f"still blocked; got: {[r.getMessage() for r in records]}"
                 )
-                assert overruns and overruns[0][1] == pytest.approx(0.05)
+                assert overruns and overruns[0][1] == pytest.approx(1.0)
             finally:
                 release.set()
             t.join(timeout=5)
             assert not t.is_alive()
         finally:
             comp_logger.removeHandler(handler)
+            executor.shutdown(wait=True)
         assert done["result"] == (compressed, "committed-late")
         _drain_admission_slots()
 

--- a/tests/agent/test_compression_stall_interrupt_96775.py
+++ b/tests/agent/test_compression_stall_interrupt_96775.py
@@ -171,7 +171,7 @@ class TestStallInterruptedBackoff:
         assert db.get_compression_lock_holder("STALL_AUX_CANCEL") is None
         state = db.get_compression_failure_cooldown("STALL_AUX_CANCEL")
         assert state is not None
-        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(state["error"])
         assert "msgs=20" in str(state["error"])
         assert agent.context_compressor.should_compress(50_000) is False
 
@@ -222,7 +222,7 @@ class TestStallInterruptedBackoff:
         assert live == original
         state = db.get_compression_failure_cooldown("STALL_FENCE_CANCEL")
         assert state is not None
-        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(state["error"])
         assert agent.context_compressor.should_compress(50_000) is False
         db.append_message("STALL_FENCE_CANCEL", "user", "next turn")
 
@@ -339,7 +339,7 @@ class TestStallInterruptedBackoff:
         after = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
         assert after is not None
         assert float(after["cooldown_until"]) >= prior_until - 1.0
-        assert str(after["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(after["error"])
 
 
 def test_session_db_cooldown_write_does_not_shorten_longer_deadline(

--- a/tests/agent/test_compression_stall_interrupt_96775.py
+++ b/tests/agent/test_compression_stall_interrupt_96775.py
@@ -1,0 +1,359 @@
+"""Stall-interrupted preflight compression must persist a durable backoff.
+
+#96775: an explicit /stop after the summary stream has already crossed the
+no-progress stall window restores the original transcript but must record a
+stall-specific cooldown so the next automatic turn does not re-enter the
+same strategy. An ordinary early /stop stays cooldown-neutral.
+
+Native Codex app-server compaction is a sibling path (#75364) and is not
+covered here. Stall classification reads the commit fence's progress clock,
+not Chat Completions vs Responses frame shapes.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.conversation_compression import (
+    STALL_INTERRUPTED_FAILURE_CLASS,
+    CompressionCommitFence,
+    compress_context,
+    compression_attempt_stalled,
+)
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str = "STALL_INTERRUPT_96775"):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1_000
+    return db, agent
+
+
+def _messages():
+    return [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+
+def _age_fence(fence: CompressionCommitFence, idle_seconds: float) -> None:
+    fence._last_progress = time.monotonic() - float(idle_seconds)
+
+
+class TestStallClassificationIsFenceIdle:
+    def test_fresh_fence_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_idle_fence_is_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+
+    def test_recent_progress_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic() - 5.0,
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_chat_and_responses_share_the_fence_clock(self):
+        """Transport-agnostic: both APIs tick the same fence or they don't."""
+        chat_fence = CompressionCommitFence()
+        responses_fence = CompressionCommitFence()
+        _age_fence(chat_fence, 2.0)
+        responses_fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=chat_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+        assert compression_attempt_stalled(
+            commit_fence=responses_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+
+class TestEarlyStopStaysNeutral:
+    def test_explicit_interrupt_before_stall_does_not_arm_cooldown(
+        self, tmp_path: Path
+    ):
+        db, agent = _build_agent(tmp_path, "EARLY_STOP_96775")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _early_stop(messages, **_kwargs):
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _early_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("EARLY_STOP_96775") is None
+        assert db.get_compression_failure_cooldown("EARLY_STOP_96775") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+        db.append_message("EARLY_STOP_96775", "assistant", "still writable")
+
+
+class TestStallInterruptedBackoff:
+    def test_aux_explicit_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_AUX_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+        compress_calls = {"n": 0}
+
+        def _stalled_then_stop(messages, **_kwargs):
+            compress_calls["n"] += 1
+            _age_fence(fence, 2.0)
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("STALL_AUX_CANCEL") is None
+        state = db.get_compression_failure_cooldown("STALL_AUX_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert "msgs=20" in str(state["error"])
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        compress_calls["n"] = 0
+        again, _ = compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert again == original
+        assert compress_calls["n"] == 0
+
+        db.append_message("STALL_AUX_CANCEL", "assistant", "still writable")
+
+    def test_commit_fence_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _summary_then_cancel(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _summary_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        state = db.get_compression_failure_cooldown("STALL_FENCE_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert agent.context_compressor.should_compress(50_000) is False
+        db.append_message("STALL_FENCE_CANCEL", "user", "next turn")
+
+    def test_commit_fence_cancel_with_fresh_progress_stays_neutral(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FRESH_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _healthy_then_cancel(messages, **_kwargs):
+            fence.touch_progress()
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _healthy_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert db.get_compression_failure_cooldown("FRESH_FENCE_CANCEL") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+
+    def test_manual_force_bypasses_stall_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FORCE_BYPASS_STALL")
+        original = _messages()
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        forced_calls = {"n": 0}
+
+        def _forced(messages, **kwargs):
+            forced_calls["n"] += 1
+            assert kwargs.get("force") is True
+            return messages
+
+        agent.context_compressor.compress = _forced
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert forced_calls["n"] == 1
+
+    def test_stall_backoff_merges_with_longer_active_deadline(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "MERGE_MAX_STALL")
+        agent.context_compressor._record_compression_failure_cooldown(
+            900.0, "prior timeout"
+        )
+        before = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert before is not None
+        prior_until = float(before["cooldown_until"])
+
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        # force=True so the pre-existing cooldown does not skip the attempt
+        # before the stall-interrupt restore/merge path can run.
+        compress_context(
+            agent,
+            _messages(),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=fence,
+        )
+
+        after = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert after is not None
+        assert float(after["cooldown_until"]) >= prior_until - 1.0
+        assert str(after["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+
+
+def test_session_db_cooldown_write_does_not_shorten_longer_deadline(
+    tmp_path: Path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("merge-max", source="cli")
+    later = time.time() + 900.0
+    sooner = time.time() + 60.0
+    db.record_compression_failure_cooldown("merge-max", later, "timeout")
+    db.record_compression_failure_cooldown(
+        "merge-max", sooner, STALL_INTERRUPTED_FAILURE_CLASS
+    )
+    row = db.get_compression_failure_cooldown("merge-max")
+    assert row is not None
+    assert float(row["cooldown_until"]) >= later - 1.0
+    assert row["error"] == STALL_INTERRUPTED_FAILURE_CLASS

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import pytest
 import time
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import (
@@ -23,6 +24,60 @@ class StubProviderError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+
+
+def test_lean_chunk_digests_stop_after_host_cancellation(compressor, monkeypatch):
+    """A cancelled total-deadline candidate must not dispatch another digest."""
+    import agent.context_compressor as context_compressor_module
+
+    cancelled = False
+    calls = 0
+
+    def fake_call_llm(**_kwargs):
+        nonlocal cancelled, calls
+        calls += 1
+        cancelled = True
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="digest"))]
+        )
+
+    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_CHUNK_CHARS", 20)
+    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_MAX_CHUNKS", 8)
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+    compressor._compression_cancelled_check = lambda: cancelled
+
+    result = compressor._build_chunk_digests(
+        [{"role": "tool", "content": "x" * 200, "tool_call_id": "call-1"}]
+    )
+
+    assert calls == 1
+    assert "Segment 2/" not in result
+
+
+def test_lean_chunk_digests_do_not_start_after_deadline(compressor, monkeypatch):
+    """The shared compaction deadline is checked before the first digest."""
+    import agent.context_compressor as context_compressor_module
+    from agent.conversation_compression import CompressionCommitFence
+
+    calls = 0
+
+    def fake_call_llm(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("digest request started after total deadline")
+
+    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
+    compressor._compression_cancelled_check = lambda: fence.is_cancelled
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    with patch(
+        "agent.conversation_compression.time.monotonic",
+        return_value=time.monotonic() + 2.0,
+    ):
+        assert compressor._build_chunk_digests(
+            [{"role": "user", "content": "late digest"}]
+        ) == ""
+    assert calls == 0
 
 
 @pytest.fixture()

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -26,60 +26,6 @@ class StubProviderError(Exception):
         self.response = response
 
 
-def test_lean_chunk_digests_stop_after_host_cancellation(compressor, monkeypatch):
-    """A cancelled total-deadline candidate must not dispatch another digest."""
-    import agent.context_compressor as context_compressor_module
-
-    cancelled = False
-    calls = 0
-
-    def fake_call_llm(**_kwargs):
-        nonlocal cancelled, calls
-        calls += 1
-        cancelled = True
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content="digest"))]
-        )
-
-    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_CHUNK_CHARS", 20)
-    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_MAX_CHUNKS", 8)
-    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
-    compressor._compression_cancelled_check = lambda: cancelled
-
-    result = compressor._build_chunk_digests(
-        [{"role": "tool", "content": "x" * 200, "tool_call_id": "call-1"}]
-    )
-
-    assert calls == 1
-    assert "Segment 2/" not in result
-
-
-def test_lean_chunk_digests_do_not_start_after_deadline(compressor, monkeypatch):
-    """The shared compaction deadline is checked before the first digest."""
-    import agent.context_compressor as context_compressor_module
-    from agent.conversation_compression import CompressionCommitFence
-
-    calls = 0
-
-    def fake_call_llm(**_kwargs):
-        nonlocal calls
-        calls += 1
-        raise AssertionError("digest request started after total deadline")
-
-    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
-    compressor._compression_cancelled_check = lambda: fence.is_cancelled
-    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
-
-    with patch(
-        "agent.conversation_compression.time.monotonic",
-        return_value=time.monotonic() + 2.0,
-    ):
-        assert compressor._build_chunk_digests(
-            [{"role": "user", "content": "late digest"}]
-        ) == ""
-    assert calls == 0
-
-
 @pytest.fixture()
 def compressor():
     """Create a ContextCompressor with mocked dependencies."""

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -506,6 +506,7 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
 
     worker_started = threading.Event()
     release_worker = threading.Event()
+    lease_released = threading.Event()
     cleanup_done = threading.Event()
     fake_db = MagicMock()
     # The DB-backed cooldown check calls this before compressing; a bare
@@ -531,8 +532,10 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         def _compress_context(
             self, messages, *_args, commit_fence=None, **_kwargs
         ):
+            if commit_fence is not None:
+                commit_fence.register_cancelled_lock_release(lease_released.set)
             worker_started.set()
-            assert release_worker.wait(timeout=2)
+            assert release_worker.wait(timeout=10)
             if commit_fence is not None and not commit_fence.begin_commit():
                 return (messages, None)
             try:
@@ -630,8 +633,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
+    assert lease_released.is_set()
     # Event/state assertions prove the host returned before the detached
-    # worker's two-second wait completed without a scheduler-sensitive clock
+    # worker's event-gated wait completed without a scheduler-sensitive clock
     # bound: cleanup runs only when that worker actually exits.
     SlowCompressAgent.last_instance.close.assert_not_called()
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -149,6 +149,22 @@ class TestSessionHygieneThresholds:
         assert approx_tokens < huge_model_threshold
 
 
+def test_hygiene_total_ceiling_warning_reports_elapsed_and_progress():
+    from gateway.run import _hygiene_compression_timeout_message
+
+    warning = _hygiene_compression_timeout_message(
+        total_exhausted=True,
+        elapsed=600.4,
+        idle_timeout=30.0,
+        progress_observed=True,
+    )
+
+    assert "total ceiling after 600.4s" in warning
+    assert "summary output was observed" in warning
+    assert "30.0s" not in warning
+    assert "no output" not in warning
+
+
 class TestSessionHygieneWarnThreshold:
     """Test the post-compression warning threshold (95% of context)."""
 
@@ -600,16 +616,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         message_id="1",
     )
 
-    started = time.monotonic()
     result = await runner._handle_message(event)
-    elapsed = time.monotonic() - started
 
     assert result == "ok"
-    # Loose wall-clock bound per flake policy: this asserts the handler did
-    # NOT block on the hygiene-compression timeout path (which would take
-    # multiple seconds), not a precise latency. 0.15s missed by ~1-8ms on
-    # busy CI shards twice on 2026-07-23.
-    assert elapsed < 2.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
     # Cooldown must be persisted to the state DB (survives restart, #74136),
@@ -621,6 +630,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
+    # Event/state assertions prove the host returned before the detached
+    # worker's two-second wait completed without a scheduler-sensitive clock
+    # bound: cleanup runs only when that worker actually exits.
     SlowCompressAgent.last_instance.close.assert_not_called()
 
     release_worker.set()


### PR DESCRIPTION
## Summary
Compaction attempts are now contained: a total-ceiling timeout tears down (or poison-orphans) its worker so late results never commit, failed/stalled attempts arm a durable backoff that survives gateway restarts, superseded attempts are discarded, and a cooldown-blocked no-op no longer counts as `compression_exhausted` — ending the false session auto-resets.

The last open piece of the "attempts run 10+ minutes, fail or hit commit_fence_cancelled, and retry against unchanged context" report.

## Changes
- Salvaged @fangliquanflq's #97512 (all 6 commits, authorship preserved): fence carries the wall-clock total deadline (expired fence = poisoned), ceiling attempts retain the lease until worker cleanup, accurate ceiling-vs-stall reporting
- Salvaged @HexLab98's #96784 (both commits): stall-interrupted /stop records a durable backoff, merge-max SQL on the cooldown deadline
- #97671 not carried — its mechanism targeted the digest loop deleted by #98628 (its author concurs on the PR)
- Our follow-ups: bounded 5s worker teardown w/ poison-orphan fallback (#97488), `backoff:<kind>:strategy=<mode>` stamped into the existing state.db cooldown row (no schema change; survives restarts; success clears), generation-counter supersession, transient-block signal so cooldown ≠ exhaustion (kills the false auto-reset)

## Validation
Probes before/after: worker outliving host + lease released while worker alive → fixed; immediate same-strategy re-entry after stall → blocked, survives simulated restart (new SessionDB + agent on same state.db). 4 sabotage-verified contracts. 293 targeted tests green.

Fixes #97488. Fixes #96775. Composes with the #84371 branch's structural backoff (classified transient by design).

## Infographic

![Attempt lifecycle contained](https://v3b.fal.media/files/b/0aa87c2d/soQEPfuvE8fbKGwo1mKsU_DtIUnah3.png)
