### PR TITLE
test(skills-hub): raise tools/skills_hub.py coverage from 63% to 84% (ref #36586)

### DIFF
--- a/tests/tools/test_skills_hub_coverage_t1.py
+++ b/tests/tools/test_skills_hub_coverage_t1.py
@@ -1,0 +1,458 @@
+"""Coverage tests for SkillsShSource detail-page parsing + identifier helpers.
+
+Focus ranges (tools/skills_hub.py):
+  _meta_from_search_item      (2036-2070)
+  _fetch_detail_page          (2072-2088)
+  _parse_detail_page          (2090-2125)
+  _extract_repo_slug          (2269-2277)
+  _extract_first_match        (2280-2287)
+  _detail_to_metadata         (2289-2302)
+  _extract_weekly_installs    (2304-2309)
+  _extract_security_audits    (2311-2322)
+  _strip_html                 (2324-2326)
+  _normalize_identifier       (2328-2339)
+  _candidate_identifiers      (2341-2362)
+  _wrap_identifier            (2364-2366)
+
+Deterministic and offline: every network touch is patched (httpx.get,
+_read_index_cache / _write_index_cache), guard branches are exercised, and no
+hard dependency is placed on the external skills.sh HTML or git remote.
+"""
+
+import re
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from tools.skills_hub import GitHubAuth, SkillsShSource
+
+
+class _MockResponse:
+    """Minimal httpx.Response stand-in (status_code + text)."""
+
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+def _detail_html(*, install=True, page_h1=True, prose=True, weekly=True,
+                 security=True):
+    """Build a skills.sh-style detail HTML page that drives every parse regex.
+
+    The ``weekly`` block matches ``_WEEKLY_INSTALLS_RE`` exactly: the pattern
+    expects the literal text ``children\\":\\"<count>\\"`` (two literal
+    backslashes before each quote), which is what a JS-embedded JSON dump looks
+    like in the real page.
+    """
+    parts = ["<html><body>"]
+    if page_h1:
+        parts.append("<h1>Page Title</h1>")
+    if prose:
+        parts.append(
+            '<div class="prose"><h1>Body Heading</h1><p>Summary text.</p></div>'
+        )
+    if install:
+        parts.append(
+            "npx skills add https://github.com/Owner/RepoA --skill my-skill"
+        )
+    if weekly:
+        # Standard JS-embedded JSON escapes: children\":\"1.2k\"
+        parts.append('Weekly Installs ... children\\\":\\\"1.2k\\\"')
+    if security:
+        parts.append(
+            "/security/agent-trust-hub Pass "
+            "/security/socket Warn /security/snyk Fail"
+        )
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# _meta_from_search_item
+# ---------------------------------------------------------------------------
+
+
+class TestMetaFromSearchItem:
+    def _source(self):
+        src = SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+        src.github.trust_level_for = MagicMock(return_value="trusted")
+        return src
+
+    def test_non_dict_item_returns_none(self):
+        assert self._source()._meta_from_search_item("not-a-dict") is None
+        assert self._source()._meta_from_search_item(None) is None
+
+    def test_empty_item_returns_none(self):
+        assert self._source()._meta_from_search_item({}) is None
+
+    def test_valid_item_maps_to_skill_meta(self):
+        meta = self._source()._meta_from_search_item(
+            {
+                "id": "vercel-labs/agent-skills/vercel-react-best-practices",
+                "source": "vercel-labs/agent-skills",
+                "skillId": "vercel-react-best-practices",
+                "name": "Vercel React Best Practices",
+                "installs": 123,
+            }
+        )
+        assert isinstance(meta.name, str)
+        assert meta.name == "Vercel React Best Practices"
+        assert meta.repo == "vercel-labs/agent-skills"
+        assert meta.path == "vercel-react-best-practices"
+        assert meta.source == "skills.sh"
+        assert meta.identifier == (
+            "skills-sh/vercel-labs/agent-skills/vercel-react-best-practices"
+        )
+        assert meta.trust_level == "trusted"
+        assert "123 installs" in meta.description
+        assert "vercel-labs/agent-skills" in meta.description
+        assert meta.extra["installs"] == 123
+        assert meta.extra["detail_url"] == (
+            "https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices"
+        )
+        assert meta.extra["repo_url"] == (
+            "https://github.com/vercel-labs/agent-skills"
+        )
+
+    def test_invalid_canonical_rebuilds_from_repo_and_skill_id(self):
+        # id has fewer than 2 slashes, so the canonical is rebuilt.
+        meta = self._source()._meta_from_search_item(
+            {
+                "id": "vercel-labs/agent-skills",
+                "source": "vercel-labs/agent-skills",
+                "skillId": "my-skill",
+                "name": "My Skill",
+                "installs": 7,
+            }
+        )
+        assert meta is not None
+        assert meta.identifier == "skills-sh/vercel-labs/agent-skills/my-skill"
+        assert meta.repo == "vercel-labs/agent-skills"
+
+    def test_rebuild_fails_when_source_or_skill_id_missing(self):
+        assert self._source()._meta_from_search_item(
+            {"id": "owner/repo", "source": "owner/repo"}
+        ) is None
+        assert self._source()._meta_from_search_item(
+            {"id": "owner/repo", "skillId": "skill"}
+        ) is None
+
+    def test_rebuilt_canonical_with_under_three_parts_returns_none(self):
+        # rebuilt canonical is "x/y" -> only two slash-parts.
+        assert self._source()._meta_from_search_item(
+            {"id": "owner/repo", "source": "x", "skillId": "y"}
+        ) is None
+
+    def test_non_int_installs_produces_no_label(self):
+        meta = self._source()._meta_from_search_item(
+            {
+                "id": "owner/repo/skill",
+                "source": "owner/repo",
+                "skillId": "skill",
+                "installs": "many",
+            }
+        )
+        assert meta.extra["installs"] == "many"
+        assert "· " not in meta.description
+        assert meta.description == "Indexed by skills.sh from owner/repo"
+
+    def test_missing_name_falls_back_to_skill_token(self):
+        meta = self._source()._meta_from_search_item(
+            {"id": "owner/repo/my-skill", "source": "owner/repo", "skillId": "my-skill"}
+        )
+        assert meta.name == "my-skill"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_detail_page
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDetailPage:
+    def _source(self):
+        return SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value={"cached": True})
+    def test_cache_hit_skips_network(self, _mock_read, mock_write, mock_get):
+        detail = self._source()._fetch_detail_page("owner/repo/skill")
+        assert detail == {"cached": True}
+        mock_get.assert_not_called()
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    def test_cache_miss_network_ok_writes_cache(self, _mock_read, mock_write, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, text=_detail_html())
+        detail = self._source()._fetch_detail_page("Owner/RepoA/my-skill")
+        assert detail is not None
+        assert detail["repo"] == "Owner/RepoA"
+        mock_write.assert_called_once()
+        args = mock_write.call_args[0]
+        self_write_key, written = args
+        assert isinstance(self_write_key, str) and self_write_key.startswith("skills_sh_detail_")
+        assert written == detail
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    def test_non_200_returns_none_without_write(self, _mock_read, mock_write, mock_get):
+        mock_get.return_value = _MockResponse(status_code=404, text=_detail_html())
+        assert self._source()._fetch_detail_page("Owner/RepoA/my-skill") is None
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get", side_effect=httpx.HTTPError("boom"))
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    def test_http_error_returns_none(self, _mock_read, mock_write, mock_get):
+        assert self._source()._fetch_detail_page("owner/repo/skill") is None
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    def test_unparseable_identifier_returns_none_without_write(
+        self, _mock_read, mock_write, mock_get
+    ):
+        mock_get.return_value = _MockResponse(status_code=200, text=_detail_html())
+        # "owner/repo" has only two slash-parts -> _parse_detail_page returns None.
+        assert self._source()._fetch_detail_page("owner/repo") is None
+        mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _parse_detail_page
+# ---------------------------------------------------------------------------
+
+
+class TestParseDetailPage:
+    def _source(self):
+        return SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+
+    def test_identifier_with_under_three_parts_returns_none(self):
+        assert self._source()._parse_detail_page("owner/repo", "<html/>") is None
+
+    def test_full_page_parses_every_field(self):
+        detail = self._source()._parse_detail_page(
+            "Owner/RepoA/my-skill", _detail_html()
+        )
+        assert detail["repo"] == "Owner/RepoA"
+        assert detail["install_skill"] == "my-skill"
+        assert detail["page_title"] == "Page Title"
+        assert detail["body_title"] == "Body Heading"
+        assert detail["body_summary"] == "Summary text."
+        assert detail["weekly_installs"] == "1.2k"
+        assert detail["install_command"] == (
+            "npx skills add https://github.com/Owner/RepoA --skill my-skill"
+        )
+        assert detail["repo_url"] == "https://github.com/Owner/RepoA"
+        assert detail["detail_url"] == "https://skills.sh/Owner/RepoA/my-skill"
+        assert detail["security_audits"] == {
+            "agent-trust-hub": "Pass",
+            "socket": "Warn",
+            "snyk": "Fail",
+        }
+
+    def test_page_without_any_matches_returns_defaults(self):
+        detail = self._source()._parse_detail_page("Owner/RepoA/my-skill", "<html></html>")
+        assert detail["repo"] == "Owner/RepoA"
+        assert detail["install_skill"] == "my-skill"
+        assert detail["page_title"] is None
+        assert detail["body_title"] is None
+        assert detail["body_summary"] is None
+        assert detail["weekly_installs"] is None
+        assert detail["install_command"] is None
+        assert detail["security_audits"] == {}
+
+    def test_install_command_absent_keeps_default_repo_and_skill(self):
+        detail = self._source()._parse_detail_page(
+            "Owner/RepoA/my-skill", _detail_html(install=False, page_h1=False,
+                                                prose=False, weekly=False, security=False)
+        )
+        assert detail["install_command"] is None
+        assert detail["repo"] == "Owner/RepoA"
+
+
+# ---------------------------------------------------------------------------
+# _extract_repo_slug
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRepoSlug:
+    def test_strips_github_url_prefix(self):
+        assert SkillsShSource._extract_repo_slug("https://github.com/owner/repo") == "owner/repo"
+
+    def test_passthrough_bare_repo(self):
+        assert SkillsShSource._extract_repo_slug("owner/repo") == "owner/repo"
+
+    def test_deep_path_returns_first_two_segments(self):
+        assert SkillsShSource._extract_repo_slug("owner/repo/extra") == "owner/repo"
+
+    def test_trailing_slash_and_extra_segments_stripped(self):
+        assert (
+            SkillsShSource._extract_repo_slug("https://github.com/owner/repo/extra/")
+            == "owner/repo"
+        )
+
+    def test_single_segment_returns_none(self):
+        assert SkillsShSource._extract_repo_slug("owner") is None
+        assert SkillsShSource._extract_repo_slug("") is None
+        assert SkillsShSource._extract_repo_slug("https://github.com/") is None
+
+    def test_surrounding_whitespace_stripped(self):
+        assert SkillsShSource._extract_repo_slug("  https://github.com/owner/repo  ") == "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# _extract_first_match
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFirstMatch:
+    def test_returns_first_captured_group(self):
+        pat = re.compile(r"<h1[^>]*>(?P<title>.*?)</h1>", re.IGNORECASE | re.DOTALL)
+        assert SkillsShSource._extract_first_match(pat, "<h1>Hello</h1>") == "Hello"
+
+    def test_no_match_returns_none(self):
+        pat = re.compile(r"(?P<h>zzz)")
+        assert SkillsShSource._extract_first_match(pat, "abc") is None
+
+    def test_empty_group_returns_none(self):
+        pat = re.compile(r"(?P<h>a*)")
+        assert SkillsShSource._extract_first_match(pat, "b") is None
+
+    def test_html_in_group_is_stripped(self):
+        pat = re.compile(r"(?P<h><b>bold</b>)")
+        assert SkillsShSource._extract_first_match(pat, "<b>bold</b>") == "bold"
+
+
+# ---------------------------------------------------------------------------
+# _detail_to_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestDetailToMetadata:
+    def _source(self):
+        return SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+
+    def test_none_detail_builds_urls_from_canonical(self):
+        metadata = self._source()._detail_to_metadata("owner/repo/skill", None)
+        assert metadata["detail_url"] == "https://skills.sh/owner/repo/skill"
+        assert metadata["repo_url"] == "https://github.com/owner/repo"
+
+    def test_short_canonical_omits_repo_url(self):
+        metadata = self._source()._detail_to_metadata("solo", None)
+        assert metadata["detail_url"] == "https://skills.sh/solo"
+        assert "repo_url" not in metadata
+
+    def test_detail_truthy_values_copied(self):
+        detail = {
+            "weekly_installs": "1.2k",
+            "install_command": "npx skills add https://github.com/o/r --skill s",
+            "repo_url": "https://github.com/owner/repo",
+            "detail_url": "https://skills.sh/owner/repo/skill",
+            "security_audits": {"socket": "Warn"},
+        }
+        metadata = self._source()._detail_to_metadata("owner/repo/skill", detail)
+        assert metadata["weekly_installs"] == "1.2k"
+        assert metadata["install_command"] == detail["install_command"]
+        assert metadata["repo_url"] == "https://github.com/owner/repo"
+        assert metadata["detail_url"] == "https://skills.sh/owner/repo/skill"
+        assert metadata["security_audits"] == {"socket": "Warn"}
+
+    def test_empty_detail_values_not_copied(self):
+        metadata = self._source()._detail_to_metadata(
+            "owner/repo/skill",
+            {"weekly_installs": "", "security_audits": {}, "install_command": None},
+        )
+        assert "weekly_installs" not in metadata
+        assert "security_audits" not in metadata
+        assert "install_command" not in metadata
+
+
+# ---------------------------------------------------------------------------
+# _extract_weekly_installs / _extract_security_audits / _strip_html
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWeeklyInstalls:
+    def test_matches_count(self):
+        assert SkillsShSource._extract_weekly_installs(_detail_html()) == "1.2k"
+
+    def test_no_match_returns_none(self):
+        assert SkillsShSource._extract_weekly_installs("<html></html>") is None
+
+
+class TestExtractSecurityAudits:
+    def test_extracts_all_audits_with_status(self):
+        html = _detail_html()
+        audits = SkillsShSource._extract_security_audits(html, "Owner/RepoA/my-skill")
+        assert audits == {
+            "agent-trust-hub": "Pass",
+            "socket": "Warn",
+            "snyk": "Fail",
+        }
+
+    def test_no_security_links_returns_empty(self):
+        assert SkillsShSource._extract_security_audits("<html></html>", "o/r/s") == {}
+
+    def test_link_without_status_word_not_recorded(self):
+        html = "<html>/security/socket</html>"
+        assert SkillsShSource._extract_security_audits(html, "o/r/s") == {}
+
+    def test_status_window_is_bounded_to_500_chars(self):
+        # a status word far beyond 500 chars must not be picked up
+        html = "/security/socket " + ("x" * 600) + " Pass"
+        assert SkillsShSource._extract_security_audits(html, "o/r/s") == {}
+
+
+class TestStripHtml:
+    def test_strips_tags(self):
+        assert SkillsShSource._strip_html("<b>bold</b><i>italic</i>") == "bolditalic"
+        assert SkillsShSource._strip_html("no tags here") == "no tags here"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_identifier / _candidate_identifiers / _wrap_identifier
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeIdentifier:
+    def test_strips_all_prefix_aliases(self):
+        assert SkillsShSource._normalize_identifier("skills-sh/o/r/s") == "o/r/s"
+        assert SkillsShSource._normalize_identifier("skills.sh/o/r/s") == "o/r/s"
+        assert SkillsShSource._normalize_identifier("skils-sh/o/r/s") == "o/r/s"
+        assert SkillsShSource._normalize_identifier("skils.sh/o/r/s") == "o/r/s"
+
+    def test_no_prefix_left_unchanged(self):
+        assert SkillsShSource._normalize_identifier("owner/repo/skill") == "owner/repo/skill"
+
+
+class TestCandidateIdentifiers:
+    def test_short_identifier_returns_itself(self):
+        assert SkillsShSource._candidate_identifiers("owner/repo") == ["owner/repo"]
+
+    def test_builds_four_candidate_paths(self):
+        candidates = SkillsShSource._candidate_identifiers("owner/repo/skill")
+        assert candidates == [
+            "owner/repo/skill",
+            "owner/repo/skills/skill",
+            "owner/repo/.agents/skills/skill",
+            "owner/repo/.claude/skills/skill",
+        ]
+
+    def test_leading_slash_in_skill_path_removed(self):
+        candidates = SkillsShSource._candidate_identifiers("owner/repo//skill")
+        assert candidates[0] == "owner/repo/skill"
+        assert len(candidates) == len(set(candidates))
+
+    def test_results_are_dataclass_deduplicated(self):
+        candidates = SkillsShSource._candidate_identifiers("owner/repo/skill")
+        assert len(candidates) == len(set(candidates))
+
+
+class TestWrapIdentifier:
+    def test_prepends_skills_sh_prefix(self):
+        assert SkillsShSource._wrap_identifier("owner/repo/skill") == "skills-sh/owner/repo/skill"

--- a/tests/tools/test_skills_hub_coverage_t2.py
+++ b/tests/tools/test_skills_hub_coverage_t2.py
@@ -1,0 +1,797 @@
+"""Coverage for SkillsShSource sitemap catalog walk + discovery/token helpers.
+
+Executes tools.skills_hub._sitemap_catalog / _featured_skills (the sitemap
+index fetch with the brotli/gzip Accept-Encoding workaround, the per-skill
+sitemap walk, cache read/write, and the fallback to the featured scrape), plus
+_discover_identifier, _resolve_github_meta, _finalize_inspect_meta,
+_matches_skill_tokens and _token_variants.
+
+All tests are deterministic and offline: httpx.get is patched at the module
+level, and _read_index_cache/_write_index_cache are patched the same way the
+ClawHub sitemap-walk tests do it.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+import httpx
+
+from tools.skills_hub import SkillsShSource, GitHubAuth, SkillMeta
+
+
+class _MockResponse:
+    def __init__(self, status_code=200, json_data=None, text="", headers=None):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json_data
+
+
+# Sitemap index: points at two per-skill sitemaps plus one "other" loc that
+# must NOT be collected (it does not contain "sitemap-skills").
+_INDEX_XML = (
+    "<urlset>"
+    "<url><loc>https://www.skills.sh/sitemap-skills-1.xml</loc></url>"
+    "<url><loc>https://www.skills.sh/sitemap-skills-2.xml</loc></url>"
+    "<url><loc>https://www.skills.sh/sitemap-other.xml</loc></url>"
+    "</urlset>"
+)
+
+# Per-skill sitemap #1: canonical skills, one duplicate, and one deeper path
+# that the _SITEMAP_SKILL_RE must reject (extra "/" segment).
+_SKILL_MAP_1 = (
+    "<urlset>"
+    "<url><loc>https://skills.sh/owner1/repo1/skill-a</loc></url>"
+    "<url><loc>https://skills.sh/owner1/repo1/skill-b</loc></url>"
+    "<url><loc>https://skills.sh/owner1/repo1/skill-a</loc></url>"
+    "<url><loc>https://skills.sh/owner1/repo1/sub/skill-a</loc></url>"
+    "</urlset>"
+)
+
+_SKILL_MAP_2 = (
+    "<urlset>"
+    "<url><loc>https://skills.sh/owner2/repo2/skill-c</loc></url>"
+    "</urlset>"
+)
+
+# A sitemap whose locs all fail the per-skill regex -> the walk yields nothing.
+_EMPTY_MAP = (
+    "<urlset>"
+    "<url><loc>https://skills.sh/owner/repo/sub/deep-skill</loc></url>"
+    "<url><loc>https://www.skills.sh/other/page</loc></url>"
+    "</urlset>"
+)
+
+_FEATURED_HTML = (
+    '<a href="/owner5/repo5/skill-d">Skill D</a>'
+    '<a href="/owner5/repo5/skill-d">duplicate</a>'
+    '<a href="/owner6/repo6/skill-e">Skill E</a>'
+    '<a href="/agents/x/y">ignored</a>'
+    '<a href="/_next/x/y">ignored</a>'
+    '<a href="/api/x/y">ignored</a>'
+)
+
+_FEATURED_FALLBACK = SkillMeta(
+    name="featured-fallback",
+    description="fallback",
+    source="skills.sh",
+    identifier="skills-sh/owner/repo/featured-fallback",
+    trust_level="community",
+    repo="owner/repo",
+    path="featured-fallback",
+)
+
+_CACHE_ITEM_A = {
+    "name": "skill-a",
+    "description": "desc-a",
+    "source": "skills.sh",
+    "identifier": "skills-sh/owner/repo/skill-a",
+    "trust_level": "community",
+    "repo": "owner/repo",
+    "path": "skill-a",
+    "tags": [],
+    "extra": {},
+}
+_CACHE_ITEM_B = {
+    "name": "skill-b",
+    "description": "desc-b",
+    "source": "skills.sh",
+    "identifier": "skills-sh/owner/repo/skill-b",
+    "trust_level": "community",
+    "repo": "owner/repo",
+    "path": "skill-b",
+    "tags": [],
+    "extra": {},
+}
+
+
+class TestSkillsShSitemapCatalog(unittest.TestCase):
+    """SkillsShSource._sitemap_catalog + _featured_skills walk behavior."""
+
+    def _src(self):
+        return SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+
+    @staticmethod
+    def _index_only_side_effect():
+        """A side_effect that serves ONLY the sitemap index URL."""
+        def side_effect(url, *args, **kwargs):
+            if url == SkillsShSource.SITEMAP_INDEX_URL:
+                return _MockResponse(status_code=200, text=_INDEX_XML)
+            return _MockResponse(status_code=404)
+        return side_effect
+
+    @staticmethod
+    def _full_walk_side_effect(index_xml=_INDEX_XML, maps=None, featured_html=""):
+        """A side_effect that behaves like the real skills.sh server."""
+        maps = maps or {}
+
+        def side_effect(url, *args, **kwargs):
+            if url == SkillsShSource.SITEMAP_INDEX_URL:
+                return _MockResponse(status_code=200, text=index_xml)
+            if "sitemap-skills" in url:
+                return _MockResponse(status_code=200, text=maps.get(url, _EMPTY_MAP))
+            if url == SkillsShSource.BASE_URL:
+                return _MockResponse(status_code=200, text=featured_html)
+            return _MockResponse(status_code=404)
+        return side_effect
+
+    # ---- cache read block -------------------------------------------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache")
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_cache_hit_returns_skill_metas(
+        self, mock_get, mock_read, mock_write
+    ):
+        """A valid cache read yields SkillMeta objects without any network."""
+        mock_read.return_value = [_CACHE_ITEM_A, _CACHE_ITEM_B]
+
+        results = self._src()._sitemap_catalog(limit=10)
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(m, SkillMeta) for m in results))
+        self.assertEqual(results[0].identifier, "skills-sh/owner/repo/skill-a")
+        self.assertEqual(results[1].name, "skill-b")
+        mock_get.assert_not_called()
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache")
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_cache_hit_zero_limit_returns_all(
+        self, mock_get, mock_read, mock_write
+    ):
+        """limit <= 0 means "no truncation" on the cached list."""
+        mock_read.return_value = [_CACHE_ITEM_A, _CACHE_ITEM_B]
+
+        results = self._src()._sitemap_catalog(limit=0)
+
+        self.assertEqual(len(results), 2)
+        mock_get.assert_not_called()
+        mock_write.assert_not_called()
+
+    # ---- sitemap index fetch / Accept-Encoding workaround -----------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_walk_caches_on_natural_termination(
+        self, mock_get, mock_read, mock_write
+    ):
+        """Happy path: index + per-skill maps dedupe, emit metas, and cache."""
+        maps = {
+            "https://www.skills.sh/sitemap-skills-1.xml": _SKILL_MAP_1,
+            "https://www.skills.sh/sitemap-skills-2.xml": _SKILL_MAP_2,
+        }
+        mock_get.side_effect = self._full_walk_side_effect(maps=maps)
+
+        results = self._src()._sitemap_catalog(limit=10)
+
+        self.assertEqual(len(results), 3)
+        identifiers = {m.identifier for m in results}
+        self.assertEqual(
+            identifiers,
+            {
+                "skills-sh/owner1/repo1/skill-a",
+                "skills-sh/owner1/repo1/skill-b",
+                "skills-sh/owner2/repo2/skill-c",
+            },
+        )
+        # Duplicate canonical and the deeper non-matching path survived dedupe.
+        self.assertEqual(len(results), len(identifiers))
+        self.assertEqual(results[0].source, "skills.sh")
+        self.assertEqual(results[0].extra["detail_url"], "https://skills.sh/owner1/repo1/skill-a")
+        self.assertEqual(results[0].extra["repo_url"], "https://github.com/owner1/repo1")
+
+        # The brotli/gzip Accept-Encoding workaround header is plumbed through.
+        mock_get.assert_any_call(
+            SkillsShSource.SITEMAP_INDEX_URL,
+            timeout=20,
+            follow_redirects=True,
+            headers={"Accept-Encoding": "gzip"},
+        )
+        mock_write.assert_called_once()
+        self.assertEqual(mock_write.call_args.args[0], "skills_sh_sitemap_v1")
+        self.assertEqual(len(mock_write.call_args.args[1]), 3)
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_limit_slices_results(
+        self, mock_get, mock_read, mock_write
+    ):
+        """A positive limit truncates the walked catalog."""
+        maps = {
+            "https://www.skills.sh/sitemap-skills-1.xml": _SKILL_MAP_1,
+            "https://www.skills.sh/sitemap-skills-2.xml": _SKILL_MAP_2,
+        }
+        mock_get.side_effect = self._full_walk_side_effect(maps=maps)
+
+        results = self._src()._sitemap_catalog(limit=1)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].identifier, "skills-sh/owner1/repo1/skill-a")
+
+    @patch.object(SkillsShSource, "_featured_skills", return_value=[_FEATURED_FALLBACK])
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_non_200_index_falls_back_to_featured(
+        self, mock_get, mock_read, mock_write, mock_featured
+    ):
+        """A non-200 sitemap index falls back to the featured scrape."""
+        mock_get.return_value = _MockResponse(status_code=404)
+
+        results = self._src()._sitemap_catalog(limit=5)
+
+        self.assertEqual(results, [_FEATURED_FALLBACK])
+        mock_featured.assert_called_once_with(5)
+        mock_write.assert_not_called()
+
+    @patch.object(SkillsShSource, "_featured_skills", return_value=[_FEATURED_FALLBACK])
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_httpx_error_on_index_falls_back_to_featured(
+        self, mock_get, mock_read, mock_write, mock_featured
+    ):
+        """An httpx.HTTPError on the index fetch falls back to featured."""
+        mock_get.side_effect = httpx.HTTPError("boom")
+
+        results = self._src()._sitemap_catalog(limit=5)
+
+        self.assertEqual(results, [_FEATURED_FALLBACK])
+        mock_featured.assert_called_once_with(5)
+        mock_write.assert_not_called()
+
+    @patch.object(SkillsShSource, "_featured_skills", return_value=[_FEATURED_FALLBACK])
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_no_skill_sitemaps_falls_back_to_featured(
+        self, mock_get, mock_read, mock_write, mock_featured
+    ):
+        """An index without any sitemap-skills loc yields no URLs -> fallback."""
+        mock_get.side_effect = self._full_walk_side_effect(
+            index_xml="<urlset><url><loc>https://www.skills.sh/nonsense.xml</loc></url></urlset>",
+            maps={},
+        )
+
+        results = self._src()._sitemap_catalog(limit=5)
+
+        self.assertEqual(results, [_FEATURED_FALLBACK])
+        mock_featured.assert_called_once_with(5)
+        mock_write.assert_not_called()
+
+    @patch.object(SkillsShSource, "_featured_skills", return_value=[_FEATURED_FALLBACK])
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_skill_map_errors_continue_and_fallback(
+        self, mock_get, mock_read, mock_write, mock_featured
+    ):
+        """Per-skill map failures (HTTPError + non-200) `continue`, not abort."""
+        def side_effect(url, *args, **kwargs):
+            if url == SkillsShSource.SITEMAP_INDEX_URL:
+                return _MockResponse(
+                    status_code=200,
+                    text="<urlset>"
+                    "<url><loc>https://www.skills.sh/sitemap-skills-1.xml</loc></url>"
+                    "<url><loc>https://www.skills.sh/sitemap-skills-2.xml</loc></url>"
+                    "</urlset>",
+                )
+            if "sitemap-skills-1" in url:
+                raise httpx.HTTPError("map 1 exploded")
+            if "sitemap-skills-2" in url:
+                return _MockResponse(status_code=403)
+            return _MockResponse(status_code=404)
+
+        mock_get.side_effect = side_effect
+
+        results = self._src()._sitemap_catalog(limit=5)
+
+        self.assertEqual(results, [_FEATURED_FALLBACK])
+        mock_featured.assert_called_once_with(5)
+        mock_write.assert_not_called()
+
+    @patch.object(SkillsShSource, "_featured_skills", return_value=[_FEATURED_FALLBACK])
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_sitemap_catalog_empty_walk_falls_back_and_does_not_cache(
+        self, mock_get, mock_read, mock_write, mock_featured
+    ):
+        """A walk that yields no skill URLs must NOT poison the sitemap cache."""
+        maps = {"https://www.skills.sh/sitemap-skills-1.xml": _EMPTY_MAP}
+        mock_get.side_effect = self._full_walk_side_effect(maps=maps)
+
+        results = self._src()._sitemap_catalog(limit=5)
+
+        self.assertEqual(results, [_FEATURED_FALLBACK])
+        mock_featured.assert_called_once_with(5)
+        # No sitemap cache write from a fruitless walk.
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_search_empty_query_routes_to_sitemap_catalog(
+        self, mock_get, mock_read, mock_write
+    ):
+        """search("", limit=N) is the bulk dump path -> walks the sitemap."""
+        maps = {
+            "https://www.skills.sh/sitemap-skills-1.xml": _SKILL_MAP_1,
+            "https://www.skills.sh/sitemap-skills-2.xml": _SKILL_MAP_2,
+        }
+        mock_get.side_effect = self._full_walk_side_effect(maps=maps)
+
+        results = self._src().search("", limit=10)
+
+        self.assertEqual(len(results), 3)
+        mock_write.assert_called_once()
+
+    # ---- _featured_skills --------------------------------------------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache")
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_cache_hit_returns_metas(
+        self, mock_get, mock_read, mock_write
+    ):
+        mock_read.return_value = [_CACHE_ITEM_A]
+
+        results = self._src()._featured_skills(limit=10)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].identifier, "skills-sh/owner/repo/skill-a")
+        mock_get.assert_not_called()
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_parses_and_dedupes_and_caches(
+        self, mock_get, mock_read, mock_write
+    ):
+        mock_get.return_value = _MockResponse(status_code=200, text=_FEATURED_HTML)
+
+        results = self._src()._featured_skills(limit=10)
+
+        self.assertEqual(len(results), 2)
+        identifiers = {m.identifier for m in results}
+        self.assertEqual(
+            identifiers,
+            {
+                "skills-sh/owner5/repo5/skill-d",
+                "skills-sh/owner6/repo6/skill-e",
+            },
+        )
+        mock_write.assert_called_once()
+        self.assertEqual(mock_write.call_args.args[0], "skills_sh_featured")
+        self.assertEqual(len(mock_write.call_args.args[1]), 2)
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_limit_breaks(
+        self, mock_get, mock_read, mock_write
+    ):
+        html = '<a href="/owner5/repo5/skill-d">D</a><a href="/owner6/repo6/skill-e">E</a>'
+        mock_get.return_value = _MockResponse(status_code=200, text=html)
+
+        results = self._src()._featured_skills(limit=1)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].identifier, "skills-sh/owner5/repo5/skill-d")
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_non_200_returns_empty(
+        self, mock_get, mock_read, mock_write
+    ):
+        mock_get.return_value = _MockResponse(status_code=500)
+
+        results = self._src()._featured_skills(limit=5)
+
+        self.assertEqual(results, [])
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_httpx_error_returns_empty(
+        self, mock_get, mock_read, mock_write
+    ):
+        mock_get.side_effect = httpx.HTTPError("boom")
+
+        results = self._src()._featured_skills(limit=5)
+
+        self.assertEqual(results, [])
+        mock_write.assert_not_called()
+
+
+def _token_based_source():
+    """A SkillsShSource whose internal GitHubSource is a controllable mock."""
+    src = SkillsShSource(auth=MagicMock(spec=GitHubAuth))
+    src.github = MagicMock()
+    src.github.trust_level_for.return_value = "community"
+    src.github._list_skills_in_repo.return_value = []
+    src.github._find_skill_in_repo_tree.return_value = None
+    src.github.inspect.return_value = None
+    src.github.auth.get_headers.return_value = {}
+    return src
+
+
+class TestSkillsShDiscovery(unittest.TestCase):
+    """_discover_identifier / _resolve_github_meta / _finalize_inspect_meta."""
+
+    def test_discover_identifier_short_identifier_returns_none(self):
+        src = _token_based_source()
+        self.assertIsNone(src._discover_identifier("owner/repo"))
+        self.assertIsNone(src._discover_identifier("just-one"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_base_paths_match_returns_identifier(self, mock_get):
+        src = _token_based_source()
+        meta = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier="owner/repo/skills/foo/my-skill",
+            trust_level="community",
+            path="skills/foo/my-skill",
+        )
+        src.github._list_skills_in_repo.return_value = [meta]
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertEqual(result, "owner/repo/skills/foo/my-skill")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_uses_repo_from_detail_and_token_extras(self, mock_get):
+        src = _token_based_source()
+        meta = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier="custom/repo/my-skill",
+            trust_level="community",
+            path="my-skill",
+        )
+        calls = []
+
+        def list_side(repo, base_path):
+            calls.append((repo, base_path))
+            if repo == "custom/repo" and base_path == "skills/":
+                return [meta]
+            return []
+
+        src.github._list_skills_in_repo.side_effect = list_side
+
+        result = src._discover_identifier(
+            "owner/repo/foo/my-skill",
+            detail={
+                "repo": "custom/repo",
+                "install_skill": "my-skill",
+                "page_title": "My Skill Page",
+                "body_title": "Skill Body",
+            },
+        )
+
+        self.assertEqual(result, "custom/repo/my-skill")
+        # detail.repo overrode the owner/repo default on the first base path.
+        self.assertIn(("custom/repo", "skills/"), calls)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_base_path_exception_continues_to_tree(self, mock_get):
+        src = _token_based_source()
+        src.github._list_skills_in_repo.side_effect = RuntimeError("boom")
+        src.github._find_skill_in_repo_tree.return_value = "owner/repo/tree/path"
+
+        result = src._discover_identifier("owner/repo/foo")
+
+        self.assertEqual(result, "owner/repo/tree/path")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_tree_result_wins(self, mock_get):
+        src = _token_based_source()
+        src.github._find_skill_in_repo_tree.return_value = "owner/repo/deep/path"
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertEqual(result, "owner/repo/deep/path")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_root_listing_direct_inspect_and_skips(self, mock_get):
+        src = _token_based_source()
+        meta = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier="owner/repo/packages/my-skill",
+            trust_level="community",
+            path="packages/my-skill",
+        )
+        src.github.inspect.side_effect = (
+            lambda ident: meta if ident == "owner/repo/packages/my-skill" else None
+        )
+        # Non-dir + dot/underscore + reserved dirs come first so their skip
+        # branches actually run before the matching `packages` dir.
+        entries = [
+            {"type": "file", "name": "README.md"},
+            {"type": "dir", "name": ".hidden"},
+            {"type": "dir", "name": "skills"},
+            {"type": "dir", "name": "_private"},
+            {"type": "dir", "name": "packages"},
+        ]
+        mock_get.return_value = _MockResponse(status_code=200, json_data=entries)
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertEqual(result, "owner/repo/packages/my-skill")
+        # Only the candidate "packages" dir was tried — files, dot/underscore
+        # dirs and the reserved skills dirs were skipped.
+        self.assertEqual(
+            [c.args[0] for c in src.github.inspect.call_args_list],
+            ["owner/repo/packages/my-skill"],
+        )
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_root_listing_list_skills_match(self, mock_get):
+        src = _token_based_source()
+        matching = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier="owner/repo/packages/foo/my-skill",
+            trust_level="community",
+            path="packages/foo/my-skill",
+        )
+
+        def list_side(repo, base_path):
+            if base_path == "packages/":
+                return [matching]
+            return []
+
+        src.github._list_skills_in_repo.side_effect = list_side
+        src.github._find_skill_in_repo_tree.return_value = None
+        src.github.inspect.return_value = None
+        mock_get.return_value = _MockResponse(
+            status_code=200, json_data=[{"type": "dir", "name": "packages"}]
+        )
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertEqual(result, "owner/repo/packages/foo/my-skill")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_root_listing_dir_listing_exception_continues(self, mock_get):
+        """A dir whose skill listing raises is skipped, not fatal."""
+        src = _token_based_source()
+
+        def list_side(repo, base_path):
+            if base_path == "packages/":
+                raise RuntimeError("boom")
+            return []
+
+        src.github._list_skills_in_repo.side_effect = list_side
+        src.github._find_skill_in_repo_tree.return_value = None
+        src.github.inspect.return_value = None
+        mock_get.return_value = _MockResponse(
+            status_code=200, json_data=[{"type": "dir", "name": "packages"}]
+        )
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertIsNone(result)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_root_listing_nothing_found_returns_none(self, mock_get):
+        src = _token_based_source()
+        src.github._find_skill_in_repo_tree.return_value = None
+        src.github.inspect.return_value = None
+        src.github._list_skills_in_repo.return_value = []
+        mock_get.return_value = _MockResponse(
+            status_code=200, json_data=[{"type": "dir", "name": "packages"}]
+        )
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertIsNone(result)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_discover_identifier_root_listing_exception_returns_none(self, mock_get):
+        src = _token_based_source()
+        mock_get.side_effect = RuntimeError("api down")
+
+        result = src._discover_identifier("owner/repo/foo/my-skill")
+
+        self.assertIsNone(result)
+
+    # ---- _resolve_github_meta ----------------------------------------------
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_resolve_github_meta_candidate_inspect_hit(self, mock_get):
+        src = _token_based_source()
+        meta = SkillMeta(
+            name="foo",
+            description="d",
+            source="github",
+            identifier="owner/repo/foo",
+            trust_level="community",
+        )
+        src.github.inspect.side_effect = (
+            lambda ident: meta if ident == "owner/repo/foo" else None
+        )
+
+        result = src._resolve_github_meta("owner/repo/foo")
+
+        self.assertIs(result, meta)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_resolve_github_meta_discovers_then_inspects(self, mock_get):
+        src = _token_based_source()
+        meta = SkillMeta(
+            name="foo",
+            description="d",
+            source="github",
+            identifier="owner/repo/deep/path",
+            trust_level="community",
+        )
+        src.github.inspect.side_effect = (
+            lambda ident: meta if ident == "owner/repo/deep/path" else None
+        )
+        src.github._find_skill_in_repo_tree.return_value = "owner/repo/deep/path"
+
+        result = src._resolve_github_meta("owner/repo/foo")
+
+        self.assertIs(result, meta)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_resolve_github_meta_none(self, mock_get):
+        src = _token_based_source()
+        src.github._find_skill_in_repo_tree.return_value = None
+        src.github.inspect.return_value = None
+        src.github._list_skills_in_repo.return_value = []
+        mock_get.return_value = _MockResponse(status_code=200, json_data=[])
+
+        result = src._resolve_github_meta("owner/repo/foo")
+
+        self.assertIsNone(result)
+
+    # ---- _finalize_inspect_meta ---------------------------------------------
+
+    def _finalize_meta(self):
+        return SkillMeta(
+            name="orig",
+            description="orig desc",
+            source="github",
+            identifier="github/owner/repo/foo",
+            trust_level="trusted",
+            repo="owner/repo",
+            path="foo",
+            extra={"keep": "me"},
+        )
+
+    def test_finalize_inspect_meta_sets_fields_and_merges_extra(self):
+        src = _token_based_source()
+        meta = self._finalize_meta()
+        detail = {"repo": "owner/repo", "install_command": "npx skills add owner/repo"}
+
+        result = src._finalize_inspect_meta(meta, "owner/repo/foo", detail)
+
+        self.assertEqual(result.source, "skills.sh")
+        self.assertEqual(result.identifier, "skills-sh/owner/repo/foo")
+        self.assertEqual(result.trust_level, "community")
+        self.assertEqual(result.description, "orig desc")
+        self.assertEqual(result.extra["keep"], "me")
+        self.assertEqual(result.extra["detail_url"], "https://skills.sh/owner/repo/foo")
+        self.assertEqual(result.extra["repo_url"], "https://github.com/owner/repo")
+        self.assertEqual(result.extra["install_command"], "npx skills add owner/repo")
+
+    def test_finalize_inspect_meta_description_from_body_summary(self):
+        src = _token_based_source()
+        meta = self._finalize_meta()
+        result = src._finalize_inspect_meta(meta, "owner/repo/foo", {"body_summary": "Great skill"})
+        self.assertEqual(result.description, "Great skill")
+
+    def test_finalize_inspect_meta_weekly_installs_description(self):
+        src = _token_based_source()
+        meta = self._finalize_meta()
+        result = src._finalize_inspect_meta(
+            meta, "owner/repo/foo", {"weekly_installs": "1,500"}
+        )
+        self.assertEqual(result.description, "orig desc · 1,500 weekly installs on skills.sh")
+        self.assertEqual(result.extra["weekly_installs"], "1,500")
+
+    def test_finalize_inspect_meta_no_detail(self):
+        src = _token_based_source()
+        meta = self._finalize_meta()
+        result = src._finalize_inspect_meta(meta, "owner/repo/foo", None)
+        self.assertEqual(result.source, "skills.sh")
+        self.assertEqual(result.extra["detail_url"], "https://skills.sh/owner/repo/foo")
+        self.assertEqual(result.description, "orig desc")
+
+
+class TestSkillsShTokenMatching(unittest.TestCase):
+    """_matches_skill_tokens / _token_variants."""
+
+    def test_token_variants_none_and_empty(self):
+        self.assertEqual(SkillsShSource._token_variants(None), set())
+        self.assertEqual(SkillsShSource._token_variants(""), set())
+        self.assertEqual(SkillsShSource._token_variants("  ///  "), set())
+
+    def test_token_variants_html_and_normalization(self):
+        variants = SkillsShSource._token_variants("repo/my_skill")
+        self.assertEqual(
+            variants,
+            {
+                "repo/my_skill",
+                "repo/my-skill",
+                "repo-my_skill",
+                "my_skill",
+                "my-skill",
+            },
+        )
+        self.assertIn("my-skill", SkillsShSource._token_variants("<b>repo/my_skill</b>"))
+        self.assertIn("repo-my-skill", SkillsShSource._token_variants("repo/my-skill"))
+
+    def test_token_variants_underscore_and_slash_fold(self):
+        variants = SkillsShSource._token_variants("owner/repo/my-skill")
+        self.assertEqual(
+            variants,
+            {"owner/repo/my-skill", "owner-repo-my-skill", "my-skill"},
+        )
+
+    def test_matches_skill_tokens_true_and_false(self):
+        meta = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier="owner/repo/skills/foo/my-skill",
+            trust_level="community",
+            path="skills/foo/my-skill",
+        )
+        self.assertTrue(SkillsShSource._matches_skill_tokens(meta, ["my-skill"]))
+        # space variant folds to the dashed token
+        self.assertTrue(SkillsShSource._matches_skill_tokens(meta, ["my skill"]))
+        self.assertFalse(SkillsShSource._matches_skill_tokens(meta, ["unrelated"]))
+
+    def test_matches_skill_tokens_none_identifier(self):
+        meta = SkillMeta(
+            name="my-skill",
+            description="d",
+            source="github",
+            identifier=None,
+            trust_level="community",
+        )
+        self.assertTrue(SkillsShSource._matches_skill_tokens(meta, ["my-skill"]))
+        self.assertFalse(SkillsShSource._matches_skill_tokens(meta, ["other"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_skills_hub_coverage_t3.py
+++ b/tests/tools/test_skills_hub_coverage_t3.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+
+"""Coverage tests for ClawHubSource and LobeHubSource branches in
+tools/skills_hub.py that existing tests do not exercise.
+
+Focus areas (see fix/skills-hub-coverage-36586):
+  * ClawHubSource._normalize_tags / _coerce_skill_payload edge cases
+  * ClawHubSource version-resolution fallbacks / _get_json error paths
+  * ClawHubSource ZIP bundle extraction (unsafe member, large-file, non-text skip)
+  * ClawHubSource owner helpers and 429 retry-after cap in _download_zip
+  * LobeHubSource search / inspect / fetch / _fetch_index / _fetch_agent branches
+
+All tests are deterministic and offline: httpx calls are mocked, cache reads/
+writes are short-circuited, and ZIP bundles are built in-memory.
+"""
+
+import io
+import json
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from tools.skills_hub import ClawHubSource, LobeHubSource, SkillBundle
+
+
+class _MockResponse:
+    """Minimal httpx.Response stand-in with every attribute the code touches."""
+
+    def __init__(self, status_code=200, json_data=None, text="", content=b"", headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+        self.headers = headers or {}
+        self._json_data = json_data
+        self._json_error = None
+
+    def json(self):
+        if self._json_error is not None:
+            raise self._json_error
+        return self._json_data
+
+
+def _make_zip_bytes(members):
+    """Build an in-memory ZIP bundle from ``{name: bytes}``.
+
+    ``members`` values may be ``bytes`` (already-encoded) or ``str`` (utf-8).
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data if isinstance(data, bytes) else data.encode("utf-8"))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._coerce_skill_payload
+# ---------------------------------------------------------------------------
+
+class TestClawHubCoercePayload(unittest.TestCase):
+    def test_non_dict_returns_none(self):
+        for bad in ("string", ["x"], 123, True, None):
+            self.assertIsNone(ClawHubSource._coerce_skill_payload(bad))
+
+    def test_plain_dict_passthrough(self):
+        data = {"slug": "caldav", "tags": ["a"]}
+        self.assertIs(ClawHubSource._coerce_skill_payload(data), data)
+
+    def test_nested_skill_merges_version_and_owner(self):
+        data = {
+            "skill": {"slug": "x", "displayName": "X"},
+            "latestVersion": {"version": "1.2.3"},
+            "owner": {"handle": "alice"},
+        }
+        merged = ClawHubSource._coerce_skill_payload(data)
+        self.assertEqual(merged["slug"], "x")
+        self.assertEqual(merged["latestVersion"], {"version": "1.2.3"})
+        self.assertEqual(merged["owner"], {"handle": "alice"})
+
+    def test_nested_skill_does_not_clobber_existing_version(self):
+        data = {"skill": {"slug": "x", "latestVersion": {"version": "9.9.9"}}, "latestVersion": {"version": "1.0.0"}}
+        merged = ClawHubSource._coerce_skill_payload(data)
+        self.assertEqual(merged["latestVersion"], {"version": "9.9.9"})
+
+    def test_nested_skill_without_version_and_owner(self):
+        merged = ClawHubSource._coerce_skill_payload({"skill": {"slug": "y"}})
+        self.assertEqual(merged, {"slug": "y"})
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._normalize_tags
+# ---------------------------------------------------------------------------
+
+class TestClawHubNormalizeTags(unittest.TestCase):
+    def test_list_coerced_to_str(self):
+        self.assertEqual(ClawHubSource._normalize_tags(["a", 5, "b"]), ["a", "5", "b"])
+
+    def test_dict_excludes_latest(self):
+        self.assertEqual(ClawHubSource._normalize_tags({"latest": "3.0.2", "auto": "3.0.2"}), ["auto"])
+
+    def test_dict_without_latest_returns_all_keys(self):
+        self.assertEqual(ClawHubSource._normalize_tags({"a": "1", "b": "2"}), ["a", "b"])
+
+    def test_other_types_return_empty(self):
+        for bad in ("tag", 5, None, 3.14, (1, 2)):
+            self.assertEqual(ClawHubSource._normalize_tags(bad), [])
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource owner helpers
+# ---------------------------------------------------------------------------
+
+class TestClawHubOwnerHelpers(unittest.TestCase):
+    def test_owner_from_payload_dict_handle(self):
+        self.assertEqual(ClawHubSource._owner_from_payload({"owner": {"handle": " alice "}}), "alice")
+
+    def test_owner_from_payload_string(self):
+        self.assertEqual(ClawHubSource._owner_from_payload({"owner": "bob"}), "bob")
+
+    def test_owner_from_payload_empty_variants(self):
+        self.assertIsNone(ClawHubSource._owner_from_payload(None))
+        self.assertIsNone(ClawHubSource._owner_from_payload({}))
+        self.assertIsNone(ClawHubSource._owner_from_payload({"owner": {}}))
+        self.assertIsNone(ClawHubSource._owner_from_payload({"owner": {"handle": "  "}}))
+        self.assertIsNone(ClawHubSource._owner_from_payload({"owner": " "}))
+
+    def test_owner_matches_no_expected_owner(self):
+        self.assertTrue(ClawHubSource._owner_matches(None, {"slug": "x"}))
+        self.assertTrue(ClawHubSource._owner_matches("", {"slug": "x"}))
+
+    def test_owner_matches_missing_actual(self):
+        self.assertTrue(ClawHubSource._owner_matches("alice", {}))
+        self.assertTrue(ClawHubSource._owner_matches("alice", {"owner": {}}))
+
+    def test_owner_matches_ci_equal(self):
+        self.assertTrue(ClawHubSource._owner_matches("Alice", {"owner": {"handle": "alice"}}))
+
+    def test_owner_matches_mismatch(self):
+        self.assertFalse(ClawHubSource._owner_matches("alice", {"owner": {"handle": "bob"}}))
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._get_json error paths
+# ---------------------------------------------------------------------------
+
+class TestClawHubGetJson(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_none_on_non_200(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=404, json_data={})
+        self.assertIsNone(self.src._get_json("https://x.example/skills/a"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_none_on_http_error(self, mock_get):
+        import httpx
+        mock_get.side_effect = httpx.ConnectError("refused")
+        self.assertIsNone(self.src._get_json("https://x.example/skills/a"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_none_on_json_decode_error(self, mock_get):
+        resp = _MockResponse(status_code=200)
+        resp._json_error = json.JSONDecodeError("bad", "doc", 0)
+        mock_get.return_value = resp
+        self.assertIsNone(self.src._get_json("https://x.example/skills/a"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_json_on_success(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, json_data={"slug": "a"})
+        self.assertEqual(self.src._get_json("https://x.example/skills/a"), {"slug": "a"})
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._resolve_latest_version fallbacks
+# ---------------------------------------------------------------------------
+
+class TestClawHubResolveLatestVersion(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    def test_resolves_from_latest_version_dict(self):
+        self.assertEqual(
+            self.src._resolve_latest_version("s", {"latestVersion": {"version": "3.0.2"}}),
+            "3.0.2",
+        )
+
+    def test_latest_version_dict_without_version_falls_through(self):
+        # No version field -> should fall through to tags, then versions list.
+        self.assertEqual(
+            self.src._resolve_latest_version("s", {"latestVersion": {}}),
+            None,
+        )
+
+    def test_resolves_from_tags_latest(self):
+        self.assertEqual(
+            self.src._resolve_latest_version("s", {"tags": {"latest": "2.1.0", "x": "1"}}),
+            "2.1.0",
+        )
+
+    @patch.object(ClawHubSource, "_get_json")
+    def test_resolves_from_versions_list(self, mock_get_json):
+        mock_get_json.return_value = [{"version": "1.4.0"}, {"version": "1.3.0"}]
+        self.assertEqual(self.src._resolve_latest_version("s", {"slug": "s"}), "1.4.0")
+
+    @patch.object(ClawHubSource, "_get_json")
+    def test_returns_none_when_no_source(self, mock_get_json):
+        mock_get_json.return_value = None
+        self.assertIsNone(self.src._resolve_latest_version("s", {"slug": "s"}))
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._extract_files branches
+# ---------------------------------------------------------------------------
+
+class TestClawHubExtractFiles(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    def test_files_dict_passthrough(self):
+        files = self.src._extract_files({"files": {"SKILL.md": "# x", "ref": "y"}})
+        self.assertEqual(files, {"SKILL.md": "# x", "ref": "y"})
+
+    def test_files_dict_keeps_only_str_values(self):
+        files = self.src._extract_files({"files": {"SKILL.md": "# x", "bin": b"raw"}})
+        self.assertEqual(files, {"SKILL.md": "# x"})
+
+    def test_files_list_uses_inline_content_and_raw_url(self):
+        files = self.src._extract_files({
+            "files": [
+                {"path": "SKILL.md", "content": "inline"},
+                {"name": "ref.md", "rawUrl": "http://files.example/ref"},
+            ]
+        })
+        self.assertEqual(files, {"SKILL.md": "inline"})
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_files_list_fetches_raw_text(self, mock_guarded):
+        mock_guarded.return_value = _MockResponse(status_code=200, text="fetched")
+        files = self.src._extract_files({
+            "files": [{"path": "SKILL.md", "rawUrl": "http://files.example/skill"}]
+        })
+        self.assertEqual(files, {"SKILL.md": "fetched"})
+        mock_guarded.assert_called_once_with("http://files.example/skill", timeout=20)
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_files_list_skips_non_http_raw_url(self, mock_guarded):
+        files = self.src._extract_files({
+            "files": [{"path": "SKILL.md", "rawUrl": "ftp://files.example/skill"}]
+        })
+        self.assertEqual(files, {})
+        mock_guarded.assert_not_called()
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_files_list_skips_failed_raw_fetch(self, mock_guarded):
+        mock_guarded.return_value = None
+        files = self.src._extract_files({
+            "files": [{"path": "SKILL.md", "rawUrl": "http://files.example/skill"}]
+        })
+        self.assertEqual(files, {})
+
+    def test_files_list_skips_missing_path(self):
+        files = self.src._extract_files({"files": [{"content": "no path"}]})
+        self.assertEqual(files, {})
+
+    def test_files_list_skips_non_dict_meta(self):
+        files = self.src._extract_files({"files": ["just a string"]})
+        self.assertEqual(files, {})
+
+    def test_files_list_not_list_returns_empty(self):
+        self.assertEqual(self.src._extract_files({"files": "nope"}), {})
+        self.assertEqual(self.src._extract_files({}), {})
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource._download_zip — ZIP extraction branches
+# ---------------------------------------------------------------------------
+
+class TestClawHubDownloadZip(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    def _zip_with(self, members):
+        return _make_zip_bytes(members)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_happy_path_extracts_text_files(self, mock_get):
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            content=self._zip_with({"SKILL.md": "# Skill\nbody", "references/doc.md": "doc"}),
+        )
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertEqual(files["SKILL.md"], "# Skill\nbody")
+        self.assertEqual(files["references/doc.md"], "doc")
+        mock_get.assert_called_once()
+        call = mock_get.call_args
+        self.assertTrue(call.args[0].endswith("/download"))
+        self.assertEqual(call.kwargs["params"], {"slug": "slug", "version": "1.0.0"})
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_skips_unsafe_member_path(self, mock_get):
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            content=self._zip_with({"SKILL.md": "# ok", "../evil.txt": b"evil"}),
+        )
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertIn("SKILL.md", files)
+        self.assertNotIn("../evil.txt", files)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_skips_large_file(self, mock_get):
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            content=self._zip_with({"SKILL.md": "# ok", "big.bin": b"x" * 600000}),
+        )
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertIn("SKILL.md", files)
+        self.assertNotIn("big.bin", files)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_skips_non_text_file(self, mock_get):
+        # Invalid UTF-8 bytes -> decode raises UnicodeDecodeError -> skipped.
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            content=self._zip_with({"SKILL.md": "# ok", "icon.png": b"\xff\xfe\x00"}),
+        )
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertIn("SKILL.md", files)
+        self.assertNotIn("icon.png", files)
+
+    @patch("tools.skills_hub.time.sleep")
+    @patch("tools.skills_hub.httpx.get")
+    def test_429_caps_retry_after_and_retries(self, mock_get, mock_sleep):
+        mock_get.side_effect = [
+            _MockResponse(status_code=429, headers={"retry-after": "100"}),
+            _MockResponse(status_code=200, content=self._zip_with({"SKILL.md": "# recovered"})),
+        ]
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertEqual(files["SKILL.md"], "# recovered")
+        # Wait is capped at 15s regardless of a 100s Retry-After header.
+        mock_sleep.assert_called_once_with(15)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("tools.skills_hub.time.sleep")
+    @patch("tools.skills_hub.httpx.get")
+    def test_429_invalid_retry_after_uses_default_then_succeeds(self, mock_get, mock_sleep):
+        mock_get.side_effect = [
+            _MockResponse(status_code=429, headers={"retry-after": "not-a-number"}),
+            _MockResponse(status_code=200, content=self._zip_with({"SKILL.md": "# ok"})),
+        ]
+        files = self.src._download_zip("slug", "1.0.0")
+        self.assertEqual(files["SKILL.md"], "# ok")
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_non_200_returns_empty(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=404)
+        self.assertEqual(self.src._download_zip("slug", "1.0.0"), {})
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_bad_zip_returns_empty(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, content=b"not a zip")
+        self.assertEqual(self.src._download_zip("slug", "1.0.0"), {})
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_http_error_returns_empty(self, mock_get):
+        import httpx
+        mock_get.side_effect = httpx.ConnectError("down")
+        self.assertEqual(self.src._download_zip("slug", "1.0.0"), {})
+
+
+# ---------------------------------------------------------------------------
+# ClawHubSource.fetch — end-to-end ZIP download path
+# ---------------------------------------------------------------------------
+
+class TestClawHubFetchZipPath(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_returns_bundle_from_zip(self, mock_get):
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/caldav"):
+                return _MockResponse(
+                    status_code=200,
+                    json_data={"slug": "caldav", "latestVersion": {"version": "1.0.0"}},
+                )
+            if url.endswith("/download"):
+                return _MockResponse(
+                    status_code=200,
+                    content=_make_zip_bytes({"SKILL.md": "# CalDAV Skill"}),
+                )
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+
+        bundle = self.src.fetch("caldav")
+
+        self.assertIsNotNone(bundle)
+        self.assertIsInstance(bundle, SkillBundle)
+        self.assertEqual(bundle.name, "caldav")
+        self.assertEqual(bundle.files["SKILL.md"], "# CalDAV Skill")
+        self.assertEqual(bundle.source, "clawhub")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_returns_none_when_zip_and_fallback_all_missing(self, mock_get):
+        # Detail resolves, ZIP download 404s (empty), version endpoint 404s too.
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/caldav"):
+                return _MockResponse(status_code=200, json_data={"slug": "caldav", "latestVersion": {"version": "1.0.0"}})
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+
+        self.assertIsNone(self.src.fetch("caldav"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_returns_none_when_no_latest_version(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, json_data={"slug": "caldav"})
+        self.assertIsNone(self.src.fetch("caldav"))
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource.search
+# ---------------------------------------------------------------------------
+
+class TestLobeHubSearch(unittest.TestCase):
+    def setUp(self):
+        self.src = LobeHubSource()
+        self._index = {
+            "agents": [
+                {
+                    "identifier": "web-research",
+                    "meta": {"title": "Web Research", "description": "Searches the internet", "tags": ["research", "search"]},
+                },
+                {
+                    "identifier": "code-writer",
+                    "meta": {"title": "Code Writer", "description": "Writes Python", "tags": ["code"]},
+                },
+            ]
+        }
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_search_matches_and_builds_meta(self, mock_fetch_index):
+        mock_fetch_index.return_value = self._index
+        results = self.src.search("research")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].identifier, "lobehub/web-research")
+        self.assertEqual(results[0].name, "web-research")
+        self.assertEqual(results[0].source, "lobehub")
+        self.assertEqual(results[0].tags, ["research", "search"])
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_search_returns_empty_when_no_match(self, mock_fetch_index):
+        mock_fetch_index.return_value = self._index
+        self.assertEqual(self.src.search("nonexistent"), [])
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_search_returns_empty_when_index_missing(self, mock_fetch_index):
+        mock_fetch_index.return_value = None
+        self.assertEqual(self.src.search("research"), [])
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_search_returns_empty_when_agents_not_list(self, mock_fetch_index):
+        mock_fetch_index.return_value = {"agents": "not-a-list"}
+        self.assertEqual(self.src.search("research"), [])
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_search_respects_limit(self, mock_fetch_index):
+        mock_fetch_index.return_value = {
+            "agents": [
+                {"identifier": "a", "meta": {"title": "Research A", "description": "research", "tags": []}},
+                {"identifier": "b", "meta": {"title": "Research B", "description": "research", "tags": []}},
+            ]
+        }
+        results = self.src.search("research", limit=1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].identifier, "lobehub/a")
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource.inspect
+# ---------------------------------------------------------------------------
+
+class TestLobeHubInspect(unittest.TestCase):
+    def setUp(self):
+        self.src = LobeHubSource()
+        self._index = {
+            "agents": [
+                {"identifier": "web-research", "meta": {"title": "Web Research", "description": "Searches", "tags": ["research"]}},
+            ]
+        }
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_inspect_finds_agent(self, mock_fetch_index):
+        mock_fetch_index.return_value = self._index
+        meta = self.src.inspect("lobehub/web-research")
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.identifier, "lobehub/web-research")
+        self.assertEqual(meta.description, "Searches")
+        self.assertEqual(meta.tags, ["research"])
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_inspect_not_found_returns_none(self, mock_fetch_index):
+        mock_fetch_index.return_value = self._index
+        self.assertIsNone(self.src.inspect("lobehub/missing"))
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_inspect_returns_none_when_no_index(self, mock_fetch_index):
+        mock_fetch_index.return_value = None
+        self.assertIsNone(self.src.inspect("lobehub/web-research"))
+
+    @patch.object(LobeHubSource, "_fetch_index")
+    def test_inspect_returns_none_when_agents_not_list(self, mock_fetch_index):
+        mock_fetch_index.return_value = {"agents": "no"}
+        self.assertIsNone(self.src.inspect("lobehub/web-research"))
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource.fetch
+# ---------------------------------------------------------------------------
+
+class TestLobeHubFetch(unittest.TestCase):
+    def setUp(self):
+        self.src = LobeHubSource()
+        self._agent = {
+            "identifier": "web-research",
+            "meta": {"title": "Web Research", "description": "Searches the web", "tags": ["research"]},
+            "config": {"systemRole": "You research the web."},
+        }
+
+    @patch.object(LobeHubSource, "_fetch_agent")
+    def test_fetch_strips_prefix_and_converts(self, mock_fetch_agent):
+        mock_fetch_agent.return_value = self._agent
+        bundle = self.src.fetch("lobehub/web-research")
+        self.assertIsNotNone(bundle)
+        self.assertEqual(bundle.name, "web-research")
+        self.assertEqual(bundle.identifier, "lobehub/web-research")
+        self.assertIn("SKILL.md", bundle.files)
+        self.assertIn("You research the web.", bundle.files["SKILL.md"])
+        mock_fetch_agent.assert_called_once_with("web-research")
+
+    @patch.object(LobeHubSource, "_fetch_agent")
+    def test_fetch_passes_bare_identifier(self, mock_fetch_agent):
+        mock_fetch_agent.return_value = self._agent
+        bundle = self.src.fetch("web-research")
+        self.assertIsNotNone(bundle)
+        mock_fetch_agent.assert_called_once_with("web-research")
+
+    @patch.object(LobeHubSource, "_fetch_agent")
+    def test_fetch_returns_none_when_no_agent_data(self, mock_fetch_agent):
+        mock_fetch_agent.return_value = None
+        self.assertIsNone(self.src.fetch("lobehub/web-research"))
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource._fetch_index
+# ---------------------------------------------------------------------------
+
+class TestLobeHubFetchIndex(unittest.TestCase):
+    def setUp(self):
+        self.src = LobeHubSource()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_success_fetches_and_caches(self, mock_get, _mock_read, mock_write):
+        index = {"agents": [{"identifier": "x"}]}
+        mock_get.return_value = _MockResponse(status_code=200, json_data=index)
+        self.assertEqual(self.src._fetch_index(), index)
+        mock_write.assert_called_once_with("lobehub_index", index)
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_non_200_returns_none(self, mock_get, _mock_read, mock_write):
+        mock_get.return_value = _MockResponse(status_code=500, json_data={})
+        self.assertIsNone(self.src._fetch_index())
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_http_error_returns_none(self, mock_get, _mock_read, mock_write):
+        import httpx
+        mock_get.side_effect = httpx.ConnectError("down")
+        self.assertIsNone(self.src._fetch_index())
+        mock_write.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._read_index_cache")
+    def test_uses_cache_without_http(self, mock_read, mock_get):
+        cached = {"agents": [{"identifier": "cached"}]}
+        mock_read.return_value = cached
+        self.assertEqual(self.src._fetch_index(), cached)
+        mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource._fetch_agent
+# ---------------------------------------------------------------------------
+
+class TestLobeHubFetchAgent(unittest.TestCase):
+    def setUp(self):
+        self.src = LobeHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_success_returns_json(self, mock_get):
+        agent = {"identifier": "x", "meta": {"title": "X"}}
+        mock_get.return_value = _MockResponse(status_code=200, json_data=agent)
+        self.assertEqual(self.src._fetch_agent("x"), agent)
+        self.assertTrue(mock_get.call_args.args[0].endswith("/x.json"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_non_200_returns_none(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=404, json_data={})
+        self.assertIsNone(self.src._fetch_agent("x"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_http_error_returns_none(self, mock_get):
+        import httpx
+        mock_get.side_effect = httpx.ConnectError("down")
+        self.assertIsNone(self.src._fetch_agent("x"))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_json_decode_error_returns_none(self, mock_get):
+        resp = _MockResponse(status_code=200)
+        resp._json_error = json.JSONDecodeError("bad", "doc", 0)
+        mock_get.return_value = resp
+        self.assertIsNone(self.src._fetch_agent("x"))
+
+
+# ---------------------------------------------------------------------------
+# LobeHubSource._convert_to_skill_md — no system-role branch
+# ---------------------------------------------------------------------------
+
+class TestLobeHubConvertSkillMd(unittest.TestCase):
+    def test_no_system_role_uses_placeholder(self):
+        agent_data = {"identifier": "bare", "meta": {"title": "Bare", "description": "d", "tags": ["t"]}}
+        result = LobeHubSource._convert_to_skill_md(agent_data)
+        self.assertIn("(No system role defined)", result)
+        self.assertIn("name: bare", result)
+        self.assertIn("tags: [t]", result)
+
+    def test_non_list_tags_tolerated(self):
+        agent_data = {
+            "identifier": "x",
+            "meta": {"title": "X", "description": "d", "tags": "not-a-list"},
+            "config": {"systemRole": "role"},
+        }
+        result = LobeHubSource._convert_to_skill_md(agent_data)
+        self.assertIn("tags: []", result)
+        self.assertIn("role", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_skills_hub_coverage_t4.py
+++ b/tests/tools/test_skills_hub_coverage_t4.py
@@ -1,0 +1,727 @@
+"""Coverage tests for WellKnownSkillSource, UrlSource, and OptionalSkillSource edge branches.
+
+These complement tests/tools/test_skills_hub.py (which already covers the
+happy/primary paths) by exercising the untested branches:
+
+* WellKnownSkillSource  — _query_to_index_url, _parse_identifier, _parse_index
+  (cache hit / bad HTTP / decode error / non-list), _index_entry not-found,
+  _fetch_text non-200, inspect() end-to-end, fetch() failure branches.
+* UrlSource — _matches rejection branches, _fetch_bytes/_fetch_text non-200,
+  the awaiting_name (name=None) bundle contract, inspect() tag parsing, and
+  _resolve_skill_name's frontmatter / URL-slug / nothing-usable branches.
+* OptionalSkillSource — _list_remote_skill_dirs cache & offline paths,
+  _upstream_pointer(_from_content) validation, _fetch_from_upstream,
+  live-repo content-fetch / missing-SKILL.md failures, upstream-pointer
+  routing through local fetch, and _parse_frontmatter edge cases.
+
+All tests are deterministic and offline: HTTP is patched, no network.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.skills_hub import (
+    OptionalSkillSource,
+    UrlSource,
+    WellKnownSkillSource,
+)
+
+
+# ---------------------------------------------------------------------------
+# WellKnownSkillSource edge branches
+# ---------------------------------------------------------------------------
+
+
+class TestWellKnownSkillSourceEdge:
+    @pytest.fixture(autouse=True)
+    def _neutralize_http_guards(self, monkeypatch):
+        # Keep any path that reaches the real guard from blocking example.com.
+        monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _url: True)
+        monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _url: None)
+
+    def _source(self):
+        return WellKnownSkillSource()
+
+    # -- _query_to_index_url -------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "query, expected",
+        [
+            # Non-HTTP (bare name / slug) — no index URL.
+            ("git-workflow", None),
+            ("", None),
+            # Exact index.json URL passed through.
+            (
+                "https://example.com/.well-known/skills/index.json",
+                "https://example.com/.well-known/skills/index.json",
+            ),
+            # URL already containing the well-known base path.
+            (
+                "https://example.com/.well-known/skills/git-workflow",
+                "https://example.com/.well-known/skills/index.json",
+            ),
+            # Bare origin — append the default base path.
+            (
+                "https://example.com",
+                "https://example.com/.well-known/skills/index.json",
+            ),
+            (
+                "https://example.com/",
+                "https://example.com/.well-known/skills/index.json",
+            ),
+        ],
+    )
+    def test_query_to_index_url(self, query, expected):
+        assert self._source()._query_to_index_url(query) == expected
+
+    # -- search -------------------------------------------------------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    def test_search_returns_empty_when_index_url_none(self, _read, _write):
+        # Non-HTTP query produces no index URL -> early return [].
+        assert self._source().search("git-workflow") == []
+        _read.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_search_returns_empty_when_index_fetch_fails(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(status_code=404)
+        assert self._source().search("https://example.com") == []
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_search_skips_entry_with_non_string_name(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "skills": [
+                    {"name": 123, "description": "numeric name"},
+                    {"name": "good-skill", "description": "ok"},
+                ]
+            },
+        )
+        results = self._source().search("https://example.com")
+        assert [r.name for r in results] == ["good-skill"]
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_search_non_list_files_defaults_to_skill_md(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "skills": [{"name": "git-workflow", "files": "not-a-list"}]
+            },
+        )
+        results = self._source().search("https://example.com")
+        assert results[0].extra["files"] == ["SKILL.md"]
+
+    # -- inspect ------------------------------------------------------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_inspect_reads_frontmatter_and_returns_meta(self, mock_get, _read, _write):
+        def _side_effect(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(
+                    status_code=200,
+                    json=lambda: {
+                        "skills": [
+                            {"name": "my-skill", "description": "entry-desc", "files": ["SKILL.md"]}
+                        ]
+                    },
+                )
+            if url.endswith("/my-skill/SKILL.md"):
+                return MagicMock(
+                    status_code=200,
+                    text="---\nname: actual-name\ndescription: fm-desc\n---\nBody\n",
+                )
+            raise AssertionError(f"unexpected URL: {url}")
+
+        mock_get.side_effect = _side_effect
+        meta = self._source().inspect("well-known:https://example.com/.well-known/skills/my-skill")
+
+        assert meta is not None
+        assert meta.name == "actual-name"
+        assert meta.description == "fm-desc"
+        assert meta.identifier == "well-known:https://example.com/.well-known/skills/my-skill"
+        assert meta.extra["endpoint"] == "https://example.com/.well-known/skills/my-skill"
+
+    def test_inspect_returns_none_for_unparseable_identifier(self):
+        assert self._source().inspect("https://example.com/SKILL.md") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_inspect_returns_none_when_entry_missing(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"skills": [{"name": "other-skill"}]}
+        )
+        assert self._source().inspect("well-known:https://example.com/.well-known/skills/missing") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_inspect_returns_none_when_skill_md_missing(self, mock_get, _read, _write):
+        def _side_effect(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(
+                    status_code=200, json=lambda: {"skills": [{"name": "my-skill"}]}
+                )
+            return MagicMock(status_code=404)  # SKILL.md 404
+
+        mock_get.side_effect = _side_effect
+        assert self._source().inspect("well-known:https://example.com/.well-known/skills/my-skill") is None
+
+    # -- fetch --------------------------------------------------------------
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_rejects_unsafe_skill_name_in_fragment(self, mock_get, _read, _write):
+        # fragment "a/b" fails _validate_skill_name -> warning + None.
+        assert self._source().fetch("well-known:https://example.com/.well-known/skills/index.json#a/b") is None
+        mock_get.assert_not_called()  # never reaches network
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_returns_none_when_entry_missing(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"skills": [{"name": "other-skill"}]}
+        )
+        assert self._source().fetch("well-known:https://example.com/.well-known/skills/missing") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_full_bundle_with_default_files(self, mock_get, _read, _write):
+        body = "---\nname: my-skill\ndescription: d\n---\nBody\n"
+        def _side_effect(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(
+                    status_code=200, json=lambda: {"skills": [{"name": "my-skill"}]}
+                )
+            if url.endswith("/my-skill/SKILL.md"):
+                return MagicMock(status_code=200, text=body)
+            raise AssertionError(f"unexpected URL: {url}")
+
+        mock_get.side_effect = _side_effect
+        bundle = self._source().fetch("well-known:https://example.com/.well-known/skills/my-skill")
+        assert bundle is not None
+        assert bundle.name == "my-skill"
+        assert bundle.files["SKILL.md"] == body
+        assert bundle.source == "well-known"
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_returns_none_when_skill_md_text_missing(self, mock_get, _read, _write):
+        def _side_effect(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(
+                    status_code=200, json=lambda: {"skills": [{"name": "my-skill"}]}
+                )
+            return MagicMock(status_code=500)  # SKILL.md unreachable
+
+        mock_get.side_effect = _side_effect
+        assert self._source().fetch("well-known:https://example.com/.well-known/skills/my-skill") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_returns_none_when_skill_md_not_in_files(self, mock_get, _read, _write):
+        # Entry advertises only a reference file; SKILL.md never lands -> None.
+        def _side_effect(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(
+                    status_code=200,
+                    json=lambda: {"skills": [{"name": "my-skill", "files": ["references/x.md"]}]},
+                )
+            if url.endswith("/my-skill/references/x.md"):
+                return MagicMock(status_code=200, text="ref")
+            raise AssertionError(f"unexpected URL: {url}")
+
+        mock_get.side_effect = _side_effect
+        assert self._source().fetch("well-known:https://example.com/.well-known/skills/my-skill") is None
+
+    # -- _parse_index / _index_entry / _fetch_text --------------------------
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_parse_index_uses_cache_without_http(self, mock_get):
+        cached = {"index_url": "u", "base_url": "https://example.com/.well-known/skills", "skills": [{"name": "s"}]}
+        with patch("tools.skills_hub._read_index_cache", return_value=cached):
+            parsed = self._source()._parse_index("https://example.com/.well-known/skills/index.json")
+        assert parsed == cached
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_parse_index_returns_none_on_non_200(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(status_code=403)
+        assert self._source()._parse_index("https://example.com/.well-known/skills/index.json") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_parse_index_returns_none_on_json_decode_error(self, mock_get, _read, _write):
+        resp = MagicMock(status_code=200)
+        resp.json.side_effect = json.JSONDecodeError("boom", "doc", 0)
+        mock_get.return_value = resp
+        assert self._source()._parse_index("https://example.com/.well-known/skills/index.json") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_parse_index_returns_none_when_skills_not_a_list(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"skills": "not-a-list"})
+        assert self._source()._parse_index("https://example.com/.well-known/skills/index.json") is None
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_parse_index_writes_cache_on_success(self, mock_get, read_cache, write_cache):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"skills": [{"name": "x"}]}
+        )
+        idx = "https://example.com/.well-known/skills/index.json"
+        parsed = self._source()._parse_index(idx)
+        assert parsed["index_url"] == idx
+        assert parsed["base_url"] == "https://example.com/.well-known/skills"
+        assert parsed["skills"] == [{"name": "x"}]
+        write_cache.assert_called_once()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_index_entry_returns_none_when_not_found(self, mock_get, _read, _write):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"skills": [{"name": "other"}]}
+        )
+        assert self._source()._index_entry("https://example.com/.well-known/skills/index.json", "missing") is None
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_text_returns_none_on_non_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=404)
+        assert self._source()._fetch_text("https://example.com/a/SKILL.md") is None
+
+    def test_wrap_identifier(self):
+        assert self._source()._wrap_identifier("https://example.com/.well-known/skills", "git-workflow") == (
+            "well-known:https://example.com/.well-known/skills/git-workflow"
+        )
+
+    # -- _parse_identifier --------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "identifier, expected",
+        [
+            # Non-HTTP raw -> None.
+            ("well-known:git-workflow", None),
+            # index.json without fragment -> None.
+            ("https://example.com/.well-known/skills/index.json", None),
+            # index.json with fragment -> parsed.
+            (
+                "well-known:https://example.com/.well-known/skills/index.json#my-skill",
+                {
+                    "index_url": "https://example.com/.well-known/skills/index.json",
+                    "base_url": "https://example.com/.well-known/skills",
+                    "skill_name": "my-skill",
+                    "skill_url": "https://example.com/.well-known/skills/my-skill",
+                },
+            ),
+            # Bare path without the well-known base -> None.
+            ("https://example.com/SKILL.md", None),
+            # Bare path within base -> parsed.
+            (
+                "https://example.com/.well-known/skills/my-skill",
+                {
+                    "index_url": "https://example.com/.well-known/skills/index.json",
+                    "base_url": "https://example.com/.well-known/skills",
+                    "skill_name": "my-skill",
+                    "skill_url": "https://example.com/.well-known/skills/my-skill",
+                },
+            ),
+            # Full SKILL.md URL -> base stripped, must contain base path.
+            (
+                "https://example.com/.well-known/skills/my-skill/SKILL.md",
+                {
+                    "index_url": "https://example.com/.well-known/skills/index.json",
+                    "base_url": "https://example.com/.well-known/skills",
+                    "skill_name": "my-skill",
+                    "skill_url": "https://example.com/.well-known/skills/my-skill",
+                },
+            ),
+        ],
+    )
+    def test_parse_identifier(self, identifier, expected):
+        assert self._source()._parse_identifier(identifier) == expected
+
+
+# ---------------------------------------------------------------------------
+# UrlSource edge branches
+# ---------------------------------------------------------------------------
+
+
+class TestUrlSourceEdge:
+    @pytest.fixture(autouse=True)
+    def _neutralize_http_guards(self, monkeypatch):
+        monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _url: True)
+        monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _url: None)
+
+    def _source(self):
+        return UrlSource()
+
+    # -- _matches -----------------------------------------------------------
+
+    def test_matches_rejects_non_string(self):
+        assert self._source()._matches(None) is False
+        assert self._source()._matches(123) is False
+
+    def test_matches_rejects_non_http(self):
+        assert self._source()._matches("ftp://example.com/SKILL.md") is False
+        assert self._source()._matches("git-workflow") is False
+
+    def test_matches_rejects_url_without_md_path(self):
+        assert self._source()._matches("https://example.com/index.html") is False
+        assert self._source()._matches("https://example.com/") is False
+
+    # -- _fetch_text / _fetch_bytes -----------------------------------------
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_text_non_200_returns_none(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=404)
+        assert self._source()._fetch_text("https://example.com/a/SKILL.md") is None
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_bytes_non_200_returns_none(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=500)
+        assert self._source()._fetch_bytes("https://example.com/a/x.md") is None
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_bytes_returns_content(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, content=b"bin")
+        assert self._source()._fetch_bytes("https://example.com/a/x.md") == b"bin"
+
+    # -- inspect ------------------------------------------------------------
+
+    def test_inspect_returns_none_for_non_matching_identifier(self):
+        assert self._source().inspect("https://example.com/index.html") is None
+        assert self._source().inspect("not-a-url") is None
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_inspect_reads_tags_from_hermes_metadata(self, mock_get):
+        skill_md = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Has tags.\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    tags: [cli, git]\n"
+            "---\n\n"
+            "Body\n"
+        )
+        mock_get.return_value = MagicMock(status_code=200, text=skill_md)
+        meta = self._source().inspect("https://example.com/my-skill/SKILL.md")
+        assert meta is not None
+        assert meta.name == "my-skill"
+        assert meta.tags == ["cli", "git"]
+        assert meta.extra["awaiting_name"] is False
+
+    # -- fetch --------------------------------------------------------------
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_returns_none_when_not_matching(self, mock_get):
+        assert self._source().fetch("https://example.com/index.html") is None
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_fetch_no_usable_name_yields_awaiting_name_bundle(self, mock_get):
+        # No frontmatter name; URL slug "SKILL" is a sentinel -> name None.
+        mock_get.return_value = MagicMock(status_code=200, text="No frontmatter body.\n")
+        bundle = self._source().fetch("https://example.com/SKILL.md")
+        assert bundle is not None
+        assert bundle.name == ""
+        assert bundle.metadata["awaiting_name"] is True
+        assert bundle.source == "url"
+
+    # -- _resolve_skill_name ------------------------------------------------
+
+    def test_resolve_skill_name_prefers_valid_frontmatter(self):
+        assert UrlSource._resolve_skill_name({"name": "  my-skill  "}, "https://example.com/SKILL.md") == "my-skill"
+
+    def test_resolve_skill_name_uses_url_slug_from_skill_md_parent(self):
+        # Invalid frontmatter name + valid parent slug.
+        assert UrlSource._resolve_skill_name({"name": "bad name"}, "https://example.com/git-workflow/SKILL.md") == "git-workflow"
+
+    def test_resolve_skill_name_uses_url_slug_from_bare_md(self):
+        assert UrlSource._resolve_skill_name({}, "https://example.com/my-skill.md") == "my-skill"
+
+    def test_resolve_skill_name_returns_none_when_nothing_usable(self):
+        assert UrlSource._resolve_skill_name({}, "https://example.com/SKILL.md") is None
+        assert UrlSource._resolve_skill_name({}, "https://example.com/") is None
+
+    def test_resolve_skill_name_ignores_non_string_frontmatter_name(self):
+        # Non-string fm name falls through to URL slug.
+        assert UrlSource._resolve_skill_name({"name": 123}, "https://example.com/git-workflow/SKILL.md") == "git-workflow"
+
+
+# ---------------------------------------------------------------------------
+# OptionalSkillSource edge branches
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalSkillSourceEdge:
+    def _make_source(self, tmp_path, remote_dirs=None):
+        optional_root = tmp_path / "optional-skills"
+        optional_root.mkdir(exist_ok=True)
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+        if remote_dirs is not None:
+            src._remote_dirs = dict.fromkeys(remote_dirs, True)
+        return src
+
+    @staticmethod
+    def _fake_github(tree_entries=(), contents=None):
+        fake = MagicMock()
+        fake._get_repo_tree.return_value = ("main", list(tree_entries))
+        if contents is not None:
+            fake._fetch_file_bytes.side_effect = lambda repo, path: contents.get(path)
+        return fake
+
+    # -- _list_remote_skill_dirs -------------------------------------------
+
+    def test_list_remote_skill_dirs_uses_memory_cache(self, tmp_path):
+        src = self._make_source(tmp_path, ["a/b"])
+        src._github = MagicMock()
+        assert src._list_remote_skill_dirs() == {"a/b": True}
+        src._get_github()._get_repo_tree.assert_not_called()
+
+    def test_list_remote_skill_dirs_index_cache_hit(self, tmp_path):
+        src = self._make_source(tmp_path)  # _remote_dirs is None
+        src._github = MagicMock()
+        with patch("tools.skills_hub._read_index_cache", return_value={"cat/skill": True}):
+            dirs = src._list_remote_skill_dirs()
+        assert dirs == {"cat/skill": True}
+        src._get_github()._get_repo_tree.assert_not_called()
+
+    def test_list_remote_skill_dirs_offline_returns_empty(self, tmp_path):
+        src = self._make_source(tmp_path)
+        src._github = self._fake_github()  # tree -> None by default? set explicitly
+        src._github._get_repo_tree.return_value = None
+        with patch("tools.skills_hub._read_index_cache", return_value=None):
+            assert src._list_remote_skill_dirs() == {}
+
+    def test_list_remote_skill_dirs_writes_cache_from_tree(self, tmp_path):
+        src = self._make_source(tmp_path)
+        entries = [
+            {"type": "blob", "path": "optional-skills/cat/skill/SKILL.md", "mode": "100644"},
+        ]
+        src._github = self._fake_github(entries)
+        with patch("tools.skills_hub._read_index_cache", return_value=None), \
+             patch("tools.skills_hub._write_index_cache") as write_cache:
+            dirs = src._list_remote_skill_dirs()
+        assert dirs == {"cat/skill": True}
+        write_cache.assert_called_once()
+
+    def test_list_remote_skill_dirs_skips_non_blob_and_non_skill_md(self, tmp_path):
+        src = self._make_source(tmp_path)
+        entries = [
+            {"type": "tree", "path": "optional-skills/cat", "mode": "040000"},  # dir
+            {"type": "blob", "path": "optional-skills/cat/skill/README.md", "mode": "100644"},
+        ]
+        src._github = self._fake_github(entries)
+        with patch("tools.skills_hub._read_index_cache", return_value=None):
+            assert src._list_remote_skill_dirs() == {}
+
+    # -- upstream pointers --------------------------------------------------
+
+    def test_upstream_pointer_returns_none_on_missing_skill_md(self, tmp_path):
+        src = self._make_source(tmp_path)
+        empty_dir = src._optional_dir / "empty"
+        empty_dir.mkdir()
+        assert src._upstream_pointer(empty_dir) is None
+
+    def test_upstream_pointer_from_content_bytes_decode_error(self):
+        src = OptionalSkillSource()
+        # Invalid UTF-8 bytes -> None.
+        assert src._upstream_pointer_from_content(b"\xff\xfe\x00") is None
+
+    @pytest.mark.parametrize(
+        "content, expected",
+        [
+            # No metadata dict.
+            ("---\nname: x\n---\nBody", None),
+            # metadata exists but no hermes.
+            ("---\nname: x\nmetadata: {}\n---\nBody", None),
+            # hermes exists but no upstream.
+            ("---\nname: x\nmetadata:\n  hermes: {}\n---\nBody", None),
+            # upstream not a dict.
+            ("---\nname: x\nmetadata:\n  hermes:\n    upstream: nope\n---\nBody", None),
+            # repo missing a slash.
+            (
+                "---\nmetadata:\n  hermes:\n    upstream:\n      repo: owner\n      path: a/b\n---\nBody",
+                None,
+            ),
+            # path missing.
+            (
+                "---\nmetadata:\n  hermes:\n    upstream:\n      repo: owner/repo\n      path: ''\n---\nBody",
+                None,
+            ),
+            # path traversal.
+            (
+                "---\nmetadata:\n  hermes:\n    upstream:\n      repo: owner/repo\n      path: a/../b\n---\nBody",
+                None,
+            ),
+            # valid.
+            (
+                "---\nmetadata:\n  hermes:\n    upstream:\n      repo: pbakaus/impeccable\n      path: .hermes/skills/impeccable\n---\nBody",
+                {"repo": "pbakaus/impeccable", "path": ".hermes/skills/impeccable"},
+            ),
+        ],
+    )
+    def test_upstream_pointer_from_content(self, content, expected):
+        src = OptionalSkillSource()
+        assert src._upstream_pointer_from_content(content) == expected
+
+    # -- _fetch_from_upstream ----------------------------------------------
+
+    def test_fetch_from_upstream_relabels_bundle(self, tmp_path):
+        src = self._make_source(tmp_path)
+        inner = MagicMock()
+        inner.name = "impeccable"
+        inner.files = {"SKILL.md": "body"}
+        inner.metadata = {}
+        inner.source = "github"
+        src._github = MagicMock()
+        src._github.fetch.return_value = inner
+
+        bundle = src._fetch_from_upstream(
+            {"repo": "pbakaus/impeccable", "path": "hermes/skills/impeccable"}, "cat/impeccable"
+        )
+        assert bundle is not None
+        assert bundle.source == "official"
+        assert bundle.identifier == "official/cat/impeccable"
+        assert bundle.trust_level == "trusted"
+        assert bundle.metadata["upstream_repo"] == "pbakaus/impeccable"
+
+    def test_fetch_from_upstream_returns_none_when_inner_fetch_fails(self, tmp_path):
+        src = self._make_source(tmp_path)
+        src._github = MagicMock()
+        src._github.fetch.return_value = None
+        assert src._fetch_from_upstream({"repo": "o/r", "path": "p"}, "cat/skill") is None
+
+    # -- fetch routing (local upstream stub -> _fetch_from_upstream) --------
+
+    def test_fetch_routes_upstream_stub_to_external_repo(self, tmp_path):
+        src = self._make_source(tmp_path)
+        skill_dir = src._optional_dir / "cat" / "impeccable"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: impeccable\nmetadata:\n  hermes:\n    upstream:\n      repo: pbakaus/impeccable\n"
+            "      path: .hermes/skills/impeccable\n---\nBody\n",
+            encoding="utf-8",
+        )
+        inner = MagicMock()
+        inner.name = "impeccable"
+        inner.files = {"SKILL.md": "body"}
+        inner.metadata = {}
+        src._github = MagicMock()
+        src._github.fetch.return_value = inner
+
+        bundle = src.fetch("official/cat/impeccable")
+        assert bundle is not None
+        assert bundle.identifier == "official/cat/impeccable"
+        assert bundle.trust_level == "trusted"
+        src._get_github().fetch.assert_called_once()
+
+    # -- live-repo fallback ------------------------------------------------
+
+    @staticmethod
+    def _entry(rel_dir, extra=()):
+        entries = [{"type": "blob", "path": f"optional-skills/{rel_dir}/SKILL.md", "mode": "100644"}]
+        for p in extra:
+            entries.append({"type": "blob", "path": p, "mode": "100644"})
+        return entries
+
+    def test_fetch_from_live_repo_none_when_content_fetch_fails(self, tmp_path):
+        src = self._make_source(tmp_path, ["cat/skill"])
+        entries = self._entry("cat/skill", ["optional-skills/cat/skill/LICENSE"])
+        src._github = self._fake_github(entries, contents={})  # fetch_file_bytes -> None
+        assert src._fetch_from_live_repo("cat/skill") is None
+
+    def test_fetch_from_live_repo_none_when_skill_md_absent(self, tmp_path):
+        src = self._make_source(tmp_path, ["cat/skill"])
+        # Tree contains only a non-SKILL.md blob under the dir.
+        entries = [{"type": "blob", "path": "optional-skills/cat/skill/LICENSE", "mode": "100644"}]
+        contents = {"optional-skills/cat/skill/LICENSE": b"MIT"}
+        src._github = self._fake_github(entries, contents)
+        assert src._fetch_from_live_repo("cat/skill") is None
+
+    def test_fetch_from_live_repo_routes_upstream_pointer(self, tmp_path):
+        src = self._make_source(tmp_path, ["cat/impeccable"])
+        content = (
+            b"---\nname: impeccable\nmetadata:\n  hermes:\n    upstream:\n"
+            b"      repo: pbakaus/impeccable\n      path: .hermes/skills/impeccable\n---\nBody\n"
+        )
+        entries = self._entry("cat/impeccable")
+        contents = {"optional-skills/cat/impeccable/SKILL.md": content}
+        src._github = self._fake_github(entries, contents)
+        inner = MagicMock()
+        inner.name = "impeccable"
+        inner.files = {"SKILL.md": "body"}
+        inner.metadata = {}
+        src._github.fetch.return_value = inner
+
+        bundle = src._fetch_from_live_repo("cat/impeccable")
+        assert bundle is not None
+        assert bundle.identifier == "official/cat/impeccable"
+        assert bundle.trust_level == "trusted"
+
+    def test_fetch_from_live_repo_empty_rel_returns_none(self, tmp_path):
+        src = self._make_source(tmp_path, ["cat/skill"])
+        src._github = MagicMock()
+        assert src._fetch_from_live_repo("") is None
+        assert src._fetch_from_live_repo("///") is None
+
+    def test_fetch_from_live_repo_normalizes_dot_segments(self, tmp_path):
+        # "cat/./skill" -> parts filters "." -> "cat/skill" matches remote dir.
+        src = self._make_source(tmp_path, ["cat/skill"])
+        entries = self._entry("cat/skill")
+        contents = {"optional-skills/cat/skill/SKILL.md": b"---\nname: skill\n---\nBody"}
+        src._github = self._fake_github(entries, contents)
+        bundle = src._fetch_from_live_repo("cat/./skill")
+        assert bundle is not None
+        assert bundle.identifier == "official/cat/skill"
+
+    # -- _scan_all / _parse_frontmatter ---------------------------------------
+
+    def test_scan_all_skips_skill_with_unreadable_frontmatter(self, tmp_path):
+        src = self._make_source(tmp_path)
+        skill_dir = src._optional_dir / "research" / "bad-skill"
+        skill_dir.mkdir(parents=True)
+        # Invalid UTF-8 -> UnicodeDecodeError -> skipped by _scan_all.
+        (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe\x00\x01")
+        assert src._scan_all() == []
+
+    def test_parse_frontmatter_tolerates_bom(self):
+        src = OptionalSkillSource()
+        assert src._parse_frontmatter("\ufeff---\nname: x\n---\nBody") == {"name": "x"}
+
+    def test_parse_frontmatter_empty_for_no_frontmatter(self):
+        src = OptionalSkillSource()
+        assert src._parse_frontmatter("Just a body text.") == {}
+
+    def test_parse_frontmatter_empty_for_open_frontmatter(self):
+        src = OptionalSkillSource()
+        assert src._parse_frontmatter("---\nname: x\n") == {}
+
+    def test_parse_frontmatter_empty_for_yaml_error(self):
+        src = OptionalSkillSource()
+        assert src._parse_frontmatter("---\nname: [\n---\n") == {}

--- a/tests/tools/test_skills_hub_coverage_t5.py
+++ b/tests/tools/test_skills_hub_coverage_t5.py
@@ -1,0 +1,817 @@
+"""Coverage tests for GitHubSource download / cache / auth helpers.
+
+This file targets uncovered branches in ``tools/skills_hub.py``:
+
+* ``GitHubAuth`` token resolution (``_resolve_token`` / ``_try_gh_cli`` /
+  ``_try_github_app``) — subprocess + secret-scope are mocked; no real gh CLI
+  or token is ever touched.
+* GitHubSource download helpers (``_download_directory``,
+  ``_download_directory_via_tree``, ``_download_directory_recursive``,
+  ``_find_skill_in_repo_tree``) and file helpers (``_fetch_file_content``,
+  ``_fetch_file_bytes``).
+* The SSRF-guarded redirect chain (``_guarded_http_get`` /
+  ``_ssrf_safe_http_get``) and ``_github_get`` retry/backoff.
+* Groupings / cache / metadata helpers (``_get_skillsh_groupings``,
+  ``_parse_skillsh_groupings``, ``_read_cache``, ``_write_cache``,
+  ``_meta_to_dict``).
+
+Everything is deterministic and offline.
+"""
+
+import json
+import subprocess
+import time
+
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+
+from tools.skills_hub import (
+    GitHubAuth,
+    GitHubSource,
+    SkillMeta,
+    _guarded_http_get,
+    _ssrf_safe_http_get,
+)
+
+
+def _source(auth=None):
+    auth = auth or MagicMock(spec=GitHubAuth)
+    auth.get_headers.return_value = {}
+    return GitHubSource(auth=auth)
+
+
+# ---------------------------------------------------------------------------
+# GitHubAuth — token resolution (PAT / gh CLI / GitHub App)
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAuthResolveToken:
+    def test_cached_pat_token_short_circuits(self):
+        auth = GitHubAuth()
+        auth._cached_token = "pat-token"
+        auth._cached_method = "pat"
+
+        with patch("agent.secret_scope.get_secret") as get_secret:
+            assert auth._resolve_token() == "pat-token"
+        get_secret.assert_not_called()
+
+    def test_cached_app_token_returned_while_valid(self):
+        auth = GitHubAuth()
+        auth._cached_token = "app-token"
+        auth._cached_method = "github-app"
+        auth._app_token_expiry = time.time() + 100
+
+        with patch("agent.secret_scope.get_secret") as get_secret:
+            assert auth._resolve_token() == "app-token"
+        get_secret.assert_not_called()
+
+    def test_expired_app_token_re_resolves(self):
+        auth = GitHubAuth()
+        auth._cached_token = "app-token"
+        auth._cached_method = "github-app"
+        auth._app_token_expiry = time.time() - 100  # already expired
+
+        with patch("agent.secret_scope.get_secret", return_value=None), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch("tools.skills_hub.httpx.post") as post:
+            post.return_value = MagicMock(status_code=500)
+            assert auth._resolve_token() is None
+        assert auth._cached_method == "anonymous"
+
+    def test_pat_from_github_token_env(self):
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return "env-token" if name in ("GITHUB_TOKEN", "GH_TOKEN") else None
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret):
+            assert auth._resolve_token() == "env-token"
+        assert auth._cached_method == "pat"
+
+    def test_pat_from_gh_token_env(self):
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return "gh-env-token" if name == "GH_TOKEN" else None
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret):
+            assert auth._resolve_token() == "gh-env-token"
+        assert auth._cached_method == "pat"
+
+    def test_all_methods_fail_becomes_anonymous(self):
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return None
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch("tools.skills_hub.httpx.post") as post:
+            post.return_value = MagicMock(status_code=500)
+            assert auth._resolve_token() is None
+        assert auth._cached_method == "anonymous"
+
+    def test_resolve_token_uses_gh_cli_and_sets_method(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", return_value=None), \
+             patch("tools.skills_hub.subprocess.run", return_value=MagicMock(returncode=0, stdout="gh-token\n")):
+            assert auth._resolve_token() == "gh-token"
+        assert auth._cached_method == "gh-cli"
+        assert auth.is_authenticated() is True
+        assert auth.auth_method() == "gh-cli"
+
+    def test_resolve_token_uses_github_app_when_env_and_cli_fail(self, tmp_path):
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("x", encoding="utf-8")
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {
+                "GITHUB_TOKEN": None,
+                "GH_TOKEN": None,
+                "GITHUB_APP_ID": "1",
+                "GITHUB_APP_PRIVATE_KEY_PATH": str(key_file),
+                "GITHUB_APP_INSTALLATION_ID": "9",
+            }.get(name)
+
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "signed.jwt"
+        resp = MagicMock(status_code=201, json=lambda: {"token": "app-token"})
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch.dict("sys.modules", {"jwt": fake_jwt}), \
+             patch("tools.skills_hub.httpx.post", return_value=resp):
+            assert auth._resolve_token() == "app-token"
+
+        assert auth._cached_method == "github-app"
+        assert auth.is_authenticated() is True
+        assert auth._app_token_expiry > time.time()
+
+
+class TestGitHubAuthTryGhCli:
+    def test_returns_token_on_success(self):
+        auth = GitHubAuth()
+        result = MagicMock(returncode=0, stdout="gh-token\n")
+        with patch("tools.skills_hub.subprocess.run", return_value=result) as run:
+            assert auth._try_gh_cli() == "gh-token"
+        run.assert_called_once()
+        assert run.call_args.args[0] == ["gh", "auth", "token"]
+
+    def test_returns_none_on_nonzero_returncode(self):
+        auth = GitHubAuth()
+        result = MagicMock(returncode=1, stdout="")
+        with patch("tools.skills_hub.subprocess.run", return_value=result):
+            assert auth._try_gh_cli() is None
+
+    def test_returns_none_on_filenotfound(self):
+        auth = GitHubAuth()
+        with patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError):
+            assert auth._try_gh_cli() is None
+
+    def test_returns_none_on_timeout(self):
+        auth = GitHubAuth()
+        with patch("tools.skills_hub.subprocess.run", side_effect=subprocess.TimeoutExpired("gh auth token", 5)):
+            assert auth._try_gh_cli() is None
+
+    def test_returns_none_on_blank_stdout(self):
+        auth = GitHubAuth()
+        result = MagicMock(returncode=0, stdout="   \n")
+        with patch("tools.skills_hub.subprocess.run", return_value=result):
+            assert auth._try_gh_cli() is None
+
+
+class TestGitHubAuthTryGithubApp:
+    def test_returns_none_when_credentials_missing(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", return_value=None):
+            assert auth._try_github_app() is None
+
+    def test_returns_none_on_pyjwt_missing(self):
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {"GITHUB_APP_ID": "1", "GITHUB_APP_PRIVATE_KEY_PATH": "/tmp/k", "GITHUB_APP_INSTALLATION_ID": "2"}.get(name)
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch.dict("sys.modules", {"jwt": None}):
+            assert auth._try_github_app() is None
+
+    def test_returns_none_when_key_file_missing(self, tmp_path):
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {
+                "GITHUB_APP_ID": "1",
+                "GITHUB_APP_PRIVATE_KEY_PATH": str(tmp_path / "nope.pem"),
+                "GITHUB_APP_INSTALLATION_ID": "2",
+            }.get(name)
+
+        fake_jwt = MagicMock()
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch.dict("sys.modules", {"jwt": fake_jwt}):
+            assert auth._try_github_app() is None
+        fake_jwt.encode.assert_not_called()
+
+    def test_returns_token_on_success(self, tmp_path):
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\n", encoding="utf-8")
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {
+                "GITHUB_APP_ID": "123",
+                "GITHUB_APP_PRIVATE_KEY_PATH": str(key_file),
+                "GITHUB_APP_INSTALLATION_ID": "456",
+            }.get(name)
+
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "signed.jwt"
+        resp = MagicMock(status_code=201, json=lambda: {"token": "app-token"})
+
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch.dict("sys.modules", {"jwt": fake_jwt}), \
+             patch("tools.skills_hub.httpx.post", return_value=resp) as post:
+            assert auth._try_github_app() == "app-token"
+
+        assert "api.github.com/app/installations/456/access_tokens" in post.call_args.args[0]
+        headers = post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer signed.jwt"
+
+    def test_returns_none_on_non_201(self, tmp_path):
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("x", encoding="utf-8")
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {
+                "GITHUB_APP_ID": "1",
+                "GITHUB_APP_PRIVATE_KEY_PATH": str(key_file),
+                "GITHUB_APP_INSTALLATION_ID": "2",
+            }.get(name)
+
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "signed.jwt"
+        resp = MagicMock(status_code=400, json=lambda: {})
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch.dict("sys.modules", {"jwt": fake_jwt}), \
+             patch("tools.skills_hub.httpx.post", return_value=resp):
+            assert auth._try_github_app() is None
+
+    def test_returns_none_on_httpx_error(self, tmp_path):
+        key_file = tmp_path / "key.pem"
+        key_file.write_text("x", encoding="utf-8")
+        auth = GitHubAuth()
+
+        def _get_secret(name):
+            return {
+                "GITHUB_APP_ID": "1",
+                "GITHUB_APP_PRIVATE_KEY_PATH": str(key_file),
+                "GITHUB_APP_INSTALLATION_ID": "2",
+            }.get(name)
+
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "signed.jwt"
+        with patch("agent.secret_scope.get_secret", side_effect=_get_secret), \
+             patch.dict("sys.modules", {"jwt": fake_jwt}), \
+             patch("tools.skills_hub.httpx.post", side_effect=httpx.HTTPError("boom")):
+            assert auth._try_github_app() is None
+
+
+class TestGitHubAuthPublicApi:
+    def test_get_headers_without_token(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", return_value=None), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch("tools.skills_hub.httpx.post") as post:
+            post.return_value = MagicMock(status_code=500)
+            headers = auth.get_headers()
+        assert headers == {"Accept": "application/vnd.github.v3+json"}
+        assert "Authorization" not in headers
+
+    def test_get_headers_with_token(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", side_effect=lambda name: "tok" if name == "GITHUB_TOKEN" else None):
+            headers = auth.get_headers()
+        assert headers == {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": "token tok",
+        }
+
+    def test_is_authenticated_true(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", side_effect=lambda name: "tok" if name == "GITHUB_TOKEN" else None):
+            assert auth.is_authenticated() is True
+
+    def test_is_authenticated_false(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", return_value=None), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch("tools.skills_hub.httpx.post") as post:
+            post.return_value = MagicMock(status_code=500)
+            assert auth.is_authenticated() is False
+
+    def test_auth_method_reports_pat(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", side_effect=lambda name: "tok" if name == "GITHUB_TOKEN" else None):
+            assert auth.auth_method() == "pat"
+
+    def test_auth_method_reports_anonymous(self):
+        auth = GitHubAuth()
+        with patch("agent.secret_scope.get_secret", return_value=None), \
+             patch("tools.skills_hub.subprocess.run", side_effect=FileNotFoundError), \
+             patch("tools.skills_hub.httpx.post") as post:
+            post.return_value = MagicMock(status_code=500)
+            assert auth.auth_method() == "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# GitHubSource — download helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadDirectoryViaTreeMissedBranches:
+    def test_returns_empty_dict_when_path_absent(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=("main", [{"type": "blob", "path": "other/file.txt"}]))
+        src._fetch_file_content = MagicMock()
+
+        assert src._download_directory_via_tree("owner/repo", "skills/missing") == {}
+        src._fetch_file_content.assert_not_called()
+
+    def test_returns_none_when_tree_unavailable(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=None)
+        src._fetch_file_content = MagicMock()
+
+        assert src._download_directory_via_tree("owner/repo", "skills/skill") is None
+
+    def test_skips_blob_when_fetch_fails(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=(
+            "main",
+            [
+                {"type": "blob", "path": "skills/skill/SKILL.md"},
+                {"type": "blob", "path": "skills/skill/broken.md"},
+            ],
+        ))
+        src._fetch_file_content = MagicMock(side_effect=lambda repo, path: None if path.endswith("broken.md") else "content")
+
+        result = src._download_directory_via_tree("owner/repo", "skills/skill")
+
+        assert result == {"SKILL.md": "content"}
+        assert src._fetch_file_content.call_args_list == [
+            call("owner/repo", "skills/skill/SKILL.md"),
+            call("owner/repo", "skills/skill/broken.md"),
+        ]
+
+    def test_returns_none_when_only_non_blob_entries(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=("main", [{"type": "tree", "path": "skills/skill/scripts"}]))
+        src._fetch_file_content = MagicMock()
+
+        assert src._download_directory_via_tree("owner/repo", "skills/skill") is None
+
+    def test_skips_non_matching_paths_in_tree(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=(
+            "main",
+            [
+                {"type": "blob", "path": "skills/skill/SKILL.md"},
+                {"type": "blob", "path": "other/skip.md"},
+            ],
+        ))
+        src._fetch_file_content = MagicMock(return_value="content")
+
+        result = src._download_directory_via_tree("owner/repo", "skills/skill")
+
+        assert result == {"SKILL.md": "content"}
+        # the non-matching blob's path is skipped (continue) and never fetched
+        src._fetch_file_content.assert_called_once_with("owner/repo", "skills/skill/SKILL.md")
+
+    def test_download_directory_falls_back_on_none(self):
+        src = _source()
+        src._download_directory_via_tree = MagicMock(return_value=None)
+        src._download_directory_recursive = MagicMock(return_value={"SKILL.md": "# ok"})
+
+        assert src._download_directory("owner/repo", "skills/skill") == {"SKILL.md": "# ok"}
+        src._download_directory_recursive.assert_called_once_with("owner/repo", "skills/skill")
+
+    def test_download_directory_returns_empty_without_fallback(self):
+        src = _source()
+        src._download_directory_via_tree = MagicMock(return_value={})
+        src._download_directory_recursive = MagicMock(return_value={"SKILL.md": "# ok"})
+
+        assert src._download_directory("owner/repo", "skills/skill") == {}
+        src._download_directory_recursive.assert_not_called()
+
+
+class TestDownloadDirectoryRecursiveMissedBranches:
+    def test_returns_empty_when_github_get_none(self):
+        src = _source()
+        src._github_get = MagicMock(return_value=None)
+        assert src._download_directory_recursive("owner/repo", "skill") == {}
+
+    def test_returns_empty_on_non_200(self):
+        src = _source()
+        src._github_get = MagicMock(return_value=MagicMock(status_code=404))
+        assert src._download_directory_recursive("owner/repo", "skill") == {}
+
+    def test_returns_empty_when_entries_not_list(self):
+        src = _source()
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"not": "a list"}
+        src._github_get = MagicMock(return_value=resp)
+        assert src._download_directory_recursive("owner/repo", "skill") == {}
+
+    def test_recurses_into_subdirectories(self):
+        src = _source()
+        root_resp = MagicMock(status_code=200)
+        root_resp.json.return_value = [
+            {"name": "SKILL.md", "type": "file", "path": "skill/SKILL.md"},
+            {"name": "broken.md", "type": "file", "path": "skill/broken.md"},
+            {"name": "scripts", "type": "dir", "path": "skill/scripts"},
+            {"name": "empty", "type": "dir", "path": "skill/empty"},
+        ]
+        sub_resp = MagicMock(status_code=200)
+        sub_resp.json.return_value = [
+            {"name": "run.py", "type": "file", "path": "skill/scripts/run.py"},
+        ]
+        empty_resp = MagicMock(status_code=200)
+        empty_resp.json.return_value = []
+
+        src._github_get = MagicMock(side_effect=[root_resp, sub_resp, empty_resp])
+        src._fetch_file_content = MagicMock(
+            side_effect=lambda repo, path: None if "broken" in path else "content"
+        )
+
+        result = src._download_directory_recursive("owner/repo", "skill")
+
+        assert result == {"SKILL.md": "content", "scripts/run.py": "content"}
+        # broken.md skipped via the fetch-returns-None branch; the empty
+        # subdirectory is fetched (3 calls) but contributes no files.
+        assert src._github_get.call_count == 3
+
+
+class TestFindSkillInRepoTreeMissedBranches:
+    def test_finds_top_level_skill_dir(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=(
+            "main",
+            [{"type": "blob", "path": "my-skill/SKILL.md"}, {"type": "blob", "path": "README.md"}],
+        ))
+        assert src._find_skill_in_repo_tree("owner/repo", "my-skill") == "owner/repo/my-skill"
+
+    def test_returns_none_when_no_match(self):
+        src = _source()
+        src._get_repo_tree = MagicMock(return_value=(
+            "main",
+            [{"type": "blob", "path": "other-skill/SKILL.md"}, {"type": "blob", "path": "README.md"}],
+        ))
+        assert src._find_skill_in_repo_tree("owner/repo", "missing") is None
+
+
+# ---------------------------------------------------------------------------
+# GitHubSource — file fetch helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFileContentMissedBranches:
+    def test_decodes_utf8(self):
+        src = _source()
+        src._fetch_file_bytes = MagicMock(return_value=b"hello world")
+        assert src._fetch_file_content("owner/repo", "SKILL.md") == "hello world"
+
+    def test_returns_none_when_bytes_none(self):
+        src = _source()
+        src._fetch_file_bytes = MagicMock(return_value=None)
+        assert src._fetch_file_content("owner/repo", "SKILL.md") is None
+
+    def test_returns_none_on_unicode_decode_error(self):
+        src = _source()
+        src._fetch_file_bytes = MagicMock(return_value=b"\xff\xfe\x00")
+        assert src._fetch_file_content("owner/repo", "SKILL.md") is None
+
+
+class TestFetchFileBytesMissedBranches:
+    def test_returns_content_on_200_with_raw_accept(self):
+        src = _source()
+        resp = MagicMock(status_code=200, content=b"raw-bytes")
+        src._github_get = MagicMock(return_value=resp)
+
+        assert src._fetch_file_bytes("owner/repo", "skill/SKILL.md") == b"raw-bytes"
+        assert src._github_get.call_args.kwargs["headers"]["Accept"] == "application/vnd.github.v3.raw"
+
+    def test_passes_ref_param(self):
+        src = _source()
+        resp = MagicMock(status_code=200, content=b"raw-bytes")
+        src._github_get = MagicMock(return_value=resp)
+
+        src._fetch_file_bytes("owner/repo", "skill/SKILL.md", ref="abc123")
+        assert src._github_get.call_args.kwargs["params"] == {"ref": "abc123"}
+
+    def test_returns_none_on_non_200(self):
+        src = _source()
+        src._github_get = MagicMock(return_value=MagicMock(status_code=404))
+        assert src._fetch_file_bytes("owner/repo", "skill/SKILL.md") is None
+
+
+# ---------------------------------------------------------------------------
+# _github_get — retry / backoff branches
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubGetRetryBranches:
+    def test_returns_200_response(self):
+        src = _source()
+        resp = MagicMock(status_code=200)
+        src.auth.get_headers.return_value = {"Accept": "application/vnd.github.v3+json"}
+        with patch("tools.skills_hub.httpx.get", return_value=resp) as get:
+            assert src._github_get("https://api.github.com/repos/x") is resp
+        assert get.call_args.kwargs["follow_redirects"] is True
+
+    def test_returns_none_when_all_attempts_raise(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        with patch("tools.skills_hub.httpx.get", side_effect=httpx.ConnectError("boom")), \
+             patch("tools.skills_hub.time.sleep"):
+            assert src._github_get("https://api.github.com/repos/x", max_retries=3) is None
+
+    def test_retries_on_5xx(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        resp5xx = MagicMock(status_code=500)
+        resp200 = MagicMock(status_code=200)
+        with patch("tools.skills_hub.httpx.get", side_effect=[resp5xx, resp200]) as get, \
+             patch("tools.skills_hub.time.sleep") as _sleep:
+            assert src._github_get("https://api.github.com/repos/x", max_retries=3) is resp200
+        assert get.call_count == 2
+        _sleep.assert_called_once_with(1.0)
+
+    def test_retries_on_429_with_retry_after(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        resp429 = MagicMock(status_code=429)
+        resp429.headers = {"X-RateLimit-Remaining": "0", "Retry-After": "2"}
+        resp200 = MagicMock(status_code=200)
+        with patch("tools.skills_hub.httpx.get", side_effect=[resp429, resp200]) as get, \
+             patch("tools.skills_hub.time.sleep") as _sleep:
+            assert src._github_get("https://api.github.com/repos/x", max_retries=3) is resp200
+        assert get.call_count == 2
+        _sleep.assert_called_once_with(2.0)
+
+    def test_retries_on_429_using_reset_header(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        reset = str(int(time.time()) + 60)
+        resp429 = MagicMock(status_code=429)
+        resp429.headers = {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}
+        resp200 = MagicMock(status_code=200)
+        with patch("tools.skills_hub.httpx.get", side_effect=[resp429, resp200]) as get, \
+             patch("tools.skills_hub.time.sleep") as _sleep:
+            assert src._github_get("https://api.github.com/repos/x", max_retries=3) is resp200
+        assert get.call_count == 2
+        # waits the Reset-derived delta (~60s, capped by the <=60 check)
+        _sleep.assert_called_once()
+        assert 0 < _sleep.call_args.args[0] <= 60
+
+    def test_returns_last_resp_when_no_attempts(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        with patch("tools.skills_hub.httpx.get") as get:
+            assert src._github_get("https://api.github.com/repos/x", max_retries=0) is None
+        get.assert_not_called()
+
+    def test_rate_limit_exhausted_without_retries_flags(self):
+        src = _source()
+        src.auth.get_headers.return_value = {}
+        src._check_rate_limit_response = MagicMock()
+        resp403 = MagicMock(status_code=403)
+        resp403.headers = {"X-RateLimit-Remaining": "0"}
+        with patch("tools.skills_hub.httpx.get", return_value=resp403):
+            assert src._github_get("https://api.github.com/repos/x", max_retries=3) is resp403
+        src._check_rate_limit_response.assert_called_once_with(resp403)
+
+
+# ---------------------------------------------------------------------------
+# SSRF-guarded redirect chain
+# ---------------------------------------------------------------------------
+
+
+class TestGuardedHttpGet:
+    def test_returns_response_on_success(self):
+        resp = MagicMock(status_code=200)
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=resp) as get:
+            assert _guarded_http_get("https://example.com/SKILL.md") is resp
+        get.assert_called_once_with("https://example.com/SKILL.md", timeout=20)
+
+    def test_returns_none_when_url_unsafe(self):
+        with patch("tools.skills_hub.is_safe_url", return_value=False), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get") as get:
+            assert _guarded_http_get("http://127.0.0.1/SKILL.md") is None
+        get.assert_not_called()
+
+    def test_returns_none_when_access_blocked(self):
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value={"host": "x", "rule": "blocked"}), \
+             patch("tools.skills_hub._ssrf_safe_http_get") as get:
+            assert _guarded_http_get("https://example.com/SKILL.md") is None
+        get.assert_not_called()
+
+    def test_returns_none_on_transport_error(self):
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get", side_effect=httpx.ConnectError("down")):
+            assert _guarded_http_get("https://example.com/SKILL.md") is None
+
+    def test_follows_redirect_to_next_url(self):
+        redirect = MagicMock(status_code=302)
+        redirect.headers = {"location": "/next/SKILL.md"}
+        ok = MagicMock(status_code=200)
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get", side_effect=[redirect, ok]) as get:
+            assert _guarded_http_get("https://example.com/SKILL.md") is ok
+        assert get.call_count == 2
+        assert get.call_args_list[1].args[0] == "https://example.com/next/SKILL.md"
+
+    def test_returns_none_when_redirect_has_no_location(self):
+        redirect = MagicMock(status_code=301)
+        redirect.headers = {}
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=redirect):
+            assert _guarded_http_get("https://example.com/SKILL.md") is None
+
+    def test_returns_none_when_redirect_loop_exceeds_limit(self):
+        redirect = MagicMock(status_code=302)
+        redirect.headers = {"location": "/same"}
+        with patch("tools.skills_hub.is_safe_url", return_value=True), \
+             patch("tools.skills_hub.check_website_access", return_value=None), \
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=redirect) as get:
+            assert _guarded_http_get("https://example.com/SKILL.md") is None
+        assert get.call_count == 6  # _MAX_SKILL_FETCH_REDIRECTS(5) + 1
+
+
+class TestSsrfSafeHttpGet:
+    def test_returns_client_get_response(self):
+        resp = MagicMock(status_code=200)
+        client = MagicMock()
+        client.get.return_value = resp
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+
+        with patch("tools.url_safety.create_ssrf_safe_client", return_value=cm) as create:
+            assert _ssrf_safe_http_get("https://example.com/SKILL.md") is resp
+        create.assert_called_once_with(timeout=20, follow_redirects=False)
+        client.get.assert_called_once_with("https://example.com/SKILL.md")
+
+
+# ---------------------------------------------------------------------------
+# Groupings / cache / metadata helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGetSkillshGroupings:
+    def test_returns_cached_map(self):
+        src = _source()
+        src._skillsh_groupings["repo"] = {"s": "T"}
+        src._fetch_file_content = MagicMock()
+        assert src._get_skillsh_groupings("repo") == {"s": "T"}
+        src._fetch_file_content.assert_not_called()
+
+    def test_returns_cached_none(self):
+        src = _source()
+        src._skillsh_groupings["repo"] = None
+        src._fetch_file_content = MagicMock()
+        assert src._get_skillsh_groupings("repo") is None
+        src._fetch_file_content.assert_not_called()
+
+    def test_fetches_and_parses_when_uncached(self):
+        src = _source()
+        content = json.dumps({"groupings": [{"title": "Inference", "skills": ["dynamo"]}]})
+        src._fetch_file_content = MagicMock(return_value=content)
+        result = src._get_skillsh_groupings("repo")
+        assert result == {"dynamo": "Inference"}
+        assert src._skillsh_groupings["repo"] == {"dynamo": "Inference"}
+        src._fetch_file_content.assert_called_once_with("repo", "skills.sh.json")
+
+    def test_caches_none_when_content_missing(self):
+        src = _source()
+        src._fetch_file_content = MagicMock(return_value=None)
+        assert src._get_skillsh_groupings("repo") is None
+        assert src._skillsh_groupings["repo"] is None
+
+
+class TestParseSkillshGroupingsMissedBranches:
+    def test_returns_none_on_invalid_json(self):
+        assert GitHubSource._parse_skillsh_groupings("{not json") is None
+
+    def test_returns_none_on_non_string(self):
+        assert GitHubSource._parse_skillsh_groupings(123) is None
+
+    def test_returns_none_when_not_dict(self):
+        assert GitHubSource._parse_skillsh_groupings("[1, 2]") is None
+
+    def test_returns_none_when_groupings_not_list(self):
+        assert GitHubSource._parse_skillsh_groupings(json.dumps({"groupings": "nope"})) is None
+
+    def test_skips_non_dict_group(self):
+        content = json.dumps({"groupings": [["not", "a", "dict"]]})
+        assert GitHubSource._parse_skillsh_groupings(content) == {}
+
+    def test_skips_group_with_bad_fields(self):
+        content = json.dumps({"groupings": [{"title": 5, "skills": ["a"]}, {"title": "ok", "skills": "notlist"}]})
+        assert GitHubSource._parse_skillsh_groupings(content) == {}
+
+    def test_skips_non_string_members(self):
+        content = json.dumps({"groupings": [{"title": "T", "skills": ["good", 7, ""]}]})
+        assert GitHubSource._parse_skillsh_groupings(content) == {"good": "T"}
+
+    def test_first_grouping_wins_on_duplicate(self):
+        content = json.dumps({
+            "groupings": [
+                {"title": "First", "skills": ["dup"]},
+                {"title": "Second", "skills": ["dup"]},
+            ]
+        })
+        assert GitHubSource._parse_skillsh_groupings(content) == {"dup": "First"}
+
+
+class TestReadCache:
+    def test_returns_none_when_file_missing(self, tmp_path):
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            assert src._read_cache("nope") is None
+
+    def test_returns_data_when_fresh(self, tmp_path):
+        (tmp_path / "key.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            assert src._read_cache("key") == [1, 2, 3]
+
+    def test_returns_none_when_expired(self, tmp_path):
+        cache_file = tmp_path / "key.json"
+        cache_file.write_text(json.dumps([1]), encoding="utf-8")
+        past = time.time() - 10_000
+        import os
+        os.utime(cache_file, (past, past))
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            assert src._read_cache("key") is None
+
+    def test_returns_none_on_invalid_json(self, tmp_path):
+        (tmp_path / "key.json").write_text("not json", encoding="utf-8")
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            assert src._read_cache("key") is None
+
+    def test_returns_none_on_oserror_reading_directory(self, tmp_path):
+        (tmp_path / "key.json").mkdir()  # directory where a file is expected
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            assert src._read_cache("key") is None
+
+
+class TestWriteCache:
+    def test_writes_json_to_cache_file(self, tmp_path):
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            src._write_cache("key", [1, 2])
+        assert (tmp_path / "key.json").read_text(encoding="utf-8") == json.dumps([1, 2])
+
+    def test_swallows_oserror(self, tmp_path):
+        (tmp_path / "key.json").mkdir()  # write_text on a directory raises OSError
+        src = _source()
+        with patch("tools.skills_hub._index_cache_dir", return_value=tmp_path):
+            src._write_cache("key", [1])  # must not raise
+
+
+class TestMetaToDict:
+    def test_serializes_all_fields(self):
+        meta = SkillMeta(
+            name="n",
+            description="d",
+            source="github",
+            identifier="owner/repo/skill",
+            trust_level="community",
+            repo="owner/repo",
+            path="skill",
+            tags=["a", "b"],
+            extra={"category": "X"},
+        )
+        assert GitHubSource._meta_to_dict(meta) == {
+            "name": "n",
+            "description": "d",
+            "source": "github",
+            "identifier": "owner/repo/skill",
+            "trust_level": "community",
+            "repo": "owner/repo",
+            "path": "skill",
+            "tags": ["a", "b"],
+            "extra": {"category": "X"},
+        }


### PR DESCRIPTION
## Summary

Raises `tools/skills_hub.py` statement coverage from **63% to 84%** (target: ≥70%) by adding 305 targeted tests across 5 new test files. No production code modified.

Closes #36586.

## Coverage

| Metric | Before | After |
|---|---|---|
| Statement coverage | 63% (1008 missed) | **84%** (435 missed) |
| Tests | 132 passed | **437 passed** |
| Target | ≥70% | ✅ exceeded by 14 points |

## New test files

| File | Tests | Focus |
|---|---|---|
| `test_skills_hub_coverage_t1.py` | 45 | SkillsShSource detail-page parsing + identifier helpers |
| `test_skills_hub_coverage_t2.py` | 37 | SkillsShSource sitemap catalog walk + token matching |
| `test_skills_hub_coverage_t3.py` | 68 | ClawHubSource + LobeHubSource payload/fetch branches |
| `test_skills_hub_coverage_t4.py` | 76 | WellKnown/Url/OptionalSkillSource edge branches |
| `test_skills_hub_coverage_t5.py` | 79 | GitHubSource download/cache/auth helpers |

## Verification

```bash
# Coverage measurement
env -u PYTHONPATH -u VIRTUAL_ENV venv/bin/python -m coverage run \
  --include=tools/skills_hub.py -m pytest \
  tests/tools/test_skills_hub.py tests/tools/test_skills_hub_clawhub.py \
  tests/tools/test_skills_hub_browse_sh.py \
  tests/tools/test_skills_hub_coverage_t{1,2,3,4,5}.py -q
# → 437 passed, 84% coverage

# Regression (existing tests unaffected)
env -u PYTHONPATH -u VIRTUAL_ENV venv/bin/python -m pytest \
  tests/tools/test_skills_hub.py tests/tools/test_skills_hub_clawhub.py \
  tests/tools/test_skills_hub_browse_sh.py -q
# → 132 passed (unchanged)
```

## Design notes

- All tests are deterministic and fully offline (httpx, subprocess, filesystem all mocked at module level)
- Each test file targets a disjoint set of source functions to avoid merge conflicts with parallel work
- `unittest.TestCase` style in t2/t3 matches the subagents' output; converting 177 assertions to plain pytest was judged higher-risk than the style inconsistency

## Cross-vendor review

- **Gemini 3.7 Flash (High)**: ACCEPTABLE — "No blocking issues. The test suite is fully isolated, deterministic, touches no production code."
- **GPT-OSS 120B (Medium)**: ACCEPTABLE — "The PR delivers the advertised coverage increase without compromising test reliability or security."
