### PR TITLE
ci: lint workflows with actionlint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,12 @@ jobs:
     with:
       event_name: ${{ needs.detect.outputs.event_name }}
 
+  workflow-lint:
+    name: GitHub Actions workflow lint
+    needs: detect
+    if: needs.detect.outputs.ci_review == 'true'
+    uses: ./.github/workflows/lint-workflows.yml
+
   js-tests:
     name: JS & TS checks
     needs: detect
@@ -220,6 +226,7 @@ jobs:
       - tests
       - tests-os
       - lint
+      - workflow-lint
       - js-tests
       - installer-tests
       - rust-tests

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions workflow lint
+
+# Reusable sub-workflow: ci.yaml owns the pull_request/push triggers and the
+# all-checks-pass branch-protection gate.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.10
+          ACTIONLINT_SHA256: f4c76b71db5755a713e6055cbb0857ed07e103e028bda117817660ebadb4386f
+        run: |
+          curl --fail --location --retry 3 \
+            --output actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+          chmod 0755 actionlint
+
+      - name: Lint workflows
+        run: ./actionlint -color=false -shellcheck=""


### PR DESCRIPTION
Add a reusable actionlint check for GitHub Actions workflows. It is wired through the existing ci.yaml workflow_call architecture, gated by the existing ci_review classifier for .github/workflows changes, and included in all-checks-pass. actionlint v1.7.10 is pinned with an archive SHA-256 check. Ruby YAML parsing, git diff --check, and the classifier check pass locally; actionlint itself was not run because GitHub release-assets returned LibreSSL SSL_ERROR_SYSCALL locally.