### PR TITLE
fix(test): isolate env-leak + add coverage for tui_gateway/server.py helpers (closes #36614)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,8 @@ native/fts5_cjk/*.so
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
 .skills_prompt_snapshot.json
+
+# Coverage
+.coverage
+coverage.xml
+htmlcov/

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2462,6 +2462,7 @@ def test_load_enabled_toolsets_folds_project_into_focus_posture(monkeypatch):
 
 
 def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "mcp-off")
     monkeypatch.setitem(
         sys.modules,
@@ -2498,6 +2499,7 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
 
 
 def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, capsys):
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "nope")
     monkeypatch.setitem(
         sys.modules,

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -43,7 +43,7 @@ def no_desktop_env(monkeypatch):
 
 class TestDesktopUiToolset:
     def test_holds_exactly_the_gui_affordances(self):
-        assert set(resolve_toolset("desktop_ui")) == GUI_TOOLS
+        assert set(resolve_toolset("desktop_ui", include_registry=False)) == GUI_TOOLS
 
     def test_stays_off_the_core_tool_list(self):
         """Core ships on every API call — a GUI-only tool must not be there."""

--- a/tests/tui_gateway/test_server_file_helpers.py
+++ b/tests/tui_gateway/test_server_file_helpers.py
@@ -1,0 +1,266 @@
+"""Coverage for file/completion helper functions in ``tui_gateway/server.py``.
+
+Exercises the module-level helpers used by the project-tree builder and the
+C-command completer -- repo/junk classification, cached dir existence, repo
+file listing, slash-completion ranking, absolute-path prefix sensing, and
+headless CLI-exec guards.
+"""
+
+import os
+import subprocess
+
+from hermes_constants import get_hermes_home
+from tui_gateway import server
+
+
+# ── _is_repo_junk ────────────────────────────────────────────────────
+
+
+def test_is_repo_junk_marks_non_workspace_and_hermes_home(tmp_path):
+    home = os.path.expanduser("~")
+    hermes_home = str(get_hermes_home())
+
+    assert server._is_repo_junk("") is True
+    assert server._is_repo_junk(home) is True
+    assert server._is_repo_junk(os.sep) is True
+    # HERMES_HOME itself and any descendant are config, not a workspace.
+    assert server._is_repo_junk(hermes_home) is True
+    assert server._is_repo_junk(os.path.join(hermes_home, "x")) is True
+
+    # A plain temp dir (and any run-of-the-mill directory) is a valid root.
+    assert server._is_repo_junk(str(tmp_path)) is False
+    assert server._is_repo_junk(".git") is False
+    assert server._is_repo_junk("node_modules") is False
+
+
+# ── _is_session_cwd_junk ─────────────────────────────────────────────
+
+
+def test_is_session_cwd_junk_marks_non_workspace_and_hermes_home(tmp_path):
+    home = os.path.expanduser("~")
+    hermes_home = str(get_hermes_home())
+
+    assert server._is_session_cwd_junk("") is True
+    assert server._is_session_cwd_junk(home) is True
+    assert server._is_session_cwd_junk(hermes_home) is True
+
+    # Unlike a repo root, an explicit DESCENDANT of HERMES_HOME can be a
+    # legitimate prose/data workspace and must stay in flat Recents.
+    assert server._is_session_cwd_junk(str(tmp_path)) is False
+    assert server._is_session_cwd_junk(os.path.join(hermes_home, "x")) is False
+
+
+# ── _dir_exists_cached ───────────────────────────────────────────────
+
+
+def test_dir_exists_cached(tmp_path):
+    server._DIR_EXISTS_CACHE.clear()
+    try:
+        assert server._dir_exists_cached(str(tmp_path)) is True
+        assert server._dir_exists_cached(str(tmp_path / "missing")) is False
+
+        f = tmp_path / "afile"
+        f.write_text("x")
+        assert server._dir_exists_cached(str(f)) is False
+    finally:
+        server._DIR_EXISTS_CACHE.clear()
+
+
+def test_dir_exists_cached_memoizes_per_build(tmp_path):
+    server._DIR_EXISTS_CACHE.clear()
+    try:
+        d = tmp_path / "created_later"
+        assert server._dir_exists_cached(str(d)) is False
+        # Created after the first read; the memo is per-build, so the value
+        # stays cached until the next build clears it.
+        d.mkdir()
+        assert server._dir_exists_cached(str(d)) is False
+        server._DIR_EXISTS_CACHE.clear()
+        assert server._dir_exists_cached(str(d)) is True
+    finally:
+        server._DIR_EXISTS_CACHE.clear()
+
+
+# ── _list_repo_files ─────────────────────────────────────────────────
+
+
+def _in_junky_tree(root):
+    (root / "src").mkdir()
+    (root / "node_modules").mkdir()
+    (root / "__pycache__").mkdir()
+    (root / ".git").mkdir()
+    (root / "main.py").write_text("x")
+    (root / "src" / "app.py").write_text("x")
+    (root / "node_modules" / "y.js").write_text("x")
+    (root / "__pycache__" / "z.pyc").write_text("x")
+    (root / ".git" / "config").write_text("x")
+    (root / ".hidden").write_text("x")
+
+
+def test_list_repo_files_walk_filters_junk_dirs(tmp_path):
+    server._fuzzy_cache.clear()
+    try:
+        _in_junky_tree(tmp_path)
+        files = server._list_repo_files(str(tmp_path))
+        # node_modules / __pycache__ / dot-dirs are pruned from the walk while
+        # files at the tree root and under real source dirs survive.
+        assert sorted(files) == [".hidden", "main.py", "src/app.py"]
+    finally:
+        server._fuzzy_cache.clear()
+
+
+def test_list_repo_files_git_backed(tmp_path):
+    server._fuzzy_cache.clear()
+    try:
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        server._fuzzy_cache.clear()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "main.py").write_text("x")
+        (tmp_path / "src" / "app.py").write_text("x")
+        files = server._list_repo_files(str(tmp_path))
+        assert sorted(files) == ["main.py", "src/app.py"]
+    finally:
+        server._fuzzy_cache.clear()
+
+
+def test_list_repo_files_missing_root_returns_empty(tmp_path):
+    server._fuzzy_cache.clear()
+    try:
+        missing = str(tmp_path / "does_not_exist")
+        assert server._list_repo_files(missing) == []
+    finally:
+        server._fuzzy_cache.clear()
+
+
+# ── _abs_completion_prefix_exists ────────────────────────────────────
+
+
+def test_abs_completion_prefix_exists(tmp_path):
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "foo.txt").write_text("x")
+    (tmp_path / "subdir" / "file_x.txt").write_text("x")
+    t = str(tmp_path)
+
+    # Partial final segment matches an entry.
+    assert server._abs_completion_prefix_exists(os.path.join(t, "f")) is True
+    assert server._abs_completion_prefix_exists(os.path.join(t, "foo.txt")) is True
+    assert server._abs_completion_prefix_exists(os.path.join(t, "subdir", "file_x")) is True
+
+    # No matching entry, or a parent that doesn't exist.
+    assert server._abs_completion_prefix_exists(os.path.join(t, "nope")) is False
+    assert server._abs_completion_prefix_exists(os.path.join(t, "missing_dir", "f")) is False
+    assert server._abs_completion_prefix_exists("/definitely/not/here") is False
+
+    # A trailing slash means "the dir itself".
+    assert server._abs_completion_prefix_exists(os.path.join(t, "subdir") + "/") is True
+
+
+# ── _details_completion_item ─────────────────────────────────────────
+
+
+def test_details_completion_item():
+    assert server._details_completion_item("foo") == {
+        "text": "foo",
+        "display": "foo",
+        "meta": "",
+    }
+    assert server._details_completion_item("foo", "meta") == {
+        "text": "foo",
+        "display": "foo",
+        "meta": "meta",
+    }
+
+
+# ── _rank_slash_completions ──────────────────────────────────────────
+
+
+def _slash_items():
+    return [
+        {"text": "/cmd1", "kind": "command"},
+        {"text": "/cmd2", "kind": "command"},
+        {"text": "/a", "kind": "skill"},
+        {"text": "/b", "kind": "skill"},
+        {"text": "/c", "kind": "skill"},
+        {"text": "/d", "kind": "skill"},
+    ]
+
+
+def _slash_usage(name):
+    return {"a": 5, "b": 0, "c": 3, "d": 0}.get(name, 0)
+
+
+def _slash_origin(name):
+    return "bundled" if name in ("a", "b") else "hub"
+
+
+def test_rank_slash_completions_orders_skills_by_usage():
+    ranked = server._rank_slash_completions(
+        _slash_items(), _slash_usage, _slash_origin, browsing=False
+    )
+    assert [i["text"] for i in ranked] == ["/cmd1", "/cmd2", "/a", "/c", "/b", "/d"]
+
+
+def test_rank_slash_completions_browsing_drops_bundled_unused():
+    ranked = server._rank_slash_completions(
+        _slash_items(), _slash_usage, _slash_origin, browsing=True
+    )
+    # `/b` is bundled with zero recorded usage -> noise in a browse; `/d` is
+    # hub/local with zero usage but not bundled, so it survives.
+    assert [i["text"] for i in ranked] == ["/cmd1", "/cmd2", "/a", "/c", "/d"]
+
+
+def test_rank_slash_completions_caps_each_kind():
+    items = [
+        {"text": f"/cmd{i}", "kind": "command"} for i in range(40)
+    ] + [{"text": f"/skill{i}", "kind": "skill"} for i in range(40)]
+    ranked = server._rank_slash_completions(
+        items, lambda n: 0, lambda n: "hub", browsing=False
+    )
+    assert len(ranked) == 60  # 30 commands + 30 skills (per-kind cap)
+    assert [i["text"] for i in ranked[:3]] == ["/cmd0", "/cmd1", "/cmd2"]
+
+
+def test_rank_slash_completions_score_of_leads_tie():
+    items = [
+        {"text": "/x", "kind": "skill"},
+        {"text": "/y", "kind": "skill"},
+    ]
+    # Lower score = better match (exact basename beats a description hit), so
+    # the scorer's ordering must lead usage/name ties. `/y` scores as the better
+    # match and must come first even though names tie.
+    ranked = server._rank_slash_completions(
+        items,
+        lambda n: 0,
+        lambda n: "hub",
+        browsing=False,
+        score_of=lambda item: 0.0 if item["text"] == "/y" else 1.0,
+    )
+    assert [i["text"] for i in ranked] == ["/y", "/x"]
+
+
+# ── _cli_exec_blocked ────────────────────────────────────────────────
+
+
+def test_cli_exec_blocked_bare_hermes():
+    hint = server._cli_exec_blocked([])
+    assert hint is not None
+    assert "interactive" in hint
+
+
+def test_cli_exec_blocked_interactive_commands():
+    assert server._cli_exec_blocked(["setup"]) is not None
+    assert server._cli_exec_blocked(["gateway"]) is not None
+    assert server._cli_exec_blocked(["sessions", "browse"]) is not None
+    assert server._cli_exec_blocked(["config", "edit"]) is not None
+    assert server._cli_exec_blocked(["config", "edit", "config.yaml"]) is not None
+
+
+def test_cli_exec_blocked_case_insensitive_first_token():
+    assert server._cli_exec_blocked(["Setup"]) is not None
+    assert server._cli_exec_blocked(["GATEWAY"]) is not None
+
+
+def test_cli_exec_blocked_allows_headless():
+    assert server._cli_exec_blocked(["chat", "-q", "hi"]) is None
+    assert server._cli_exec_blocked(["sessions", "list"]) is None
+    assert server._cli_exec_blocked(["config", "get"]) is None

--- a/tests/tui_gateway/test_server_helpers.py
+++ b/tests/tui_gateway/test_server_helpers.py
@@ -1,0 +1,351 @@
+"""Tests for pure helper functions in ``tui_gateway.server``.
+
+These helpers are module-level and side-effect free (no ``HERMES_HOME``, no
+global state, no timers), so they are exercised directly by importing the
+module and calling them. Only ``_redact_tui_verbose_text`` needs a
+monkeypatch — it imports the redactor locally on each call.
+"""
+
+import json
+
+import tui_gateway.server as server
+
+
+# ── _fuzzy_basename_rank ────────────────────────────────────────────
+
+
+def test_fuzzy_rank_empty_query_returns_substring_tier_with_length():
+    assert server._fuzzy_basename_rank("app.tsx", "") == (3, 7)
+
+
+def test_fuzzy_rank_exact_basename_is_tier_zero():
+    assert server._fuzzy_basename_rank("appChrome.tsx", "appchrome.tsx") == (0, 13)
+
+
+def test_fuzzy_rank_prefix_is_tier_one():
+    assert server._fuzzy_basename_rank("appChrome.tsx", "app") == (1, 13)
+
+
+def test_fuzzy_rank_camel_case_word_boundary_is_tier_two():
+    assert server._fuzzy_basename_rank("appChrome.tsx", "chrome") == (2, 13)
+
+
+def test_fuzzy_rank_word_boundary_after_separator_is_tier_two():
+    # Lowercase query hits a part split on a dot/dash/underscore boundary.
+    assert server._fuzzy_basename_rank("foo-bar_baz.qux", "bar") == (2, 15)
+
+
+def test_fuzzy_rank_substring_is_tier_three():
+    assert server._fuzzy_basename_rank("appChrome.tsx", "ome") == (3, 13)
+
+
+def test_fuzzy_rank_subsequence_is_tier_four():
+    # 's s t' appear in order but not contiguously in "someStr".
+    assert server._fuzzy_basename_rank("someStr", "sst") == (4, 7)
+
+
+def test_fuzzy_rank_no_match_returns_none():
+    assert server._fuzzy_basename_rank("app.tsx", "zzz") is None
+
+
+def test_fuzzy_rank_query_longer_than_name_returns_none():
+    assert server._fuzzy_basename_rank("abc", "abcdef") is None
+
+
+def test_fuzzy_rank_secondary_key_is_name_length_for_ties():
+    # Same tier, shorter name must sort first (tier 0, secondary len).
+    assert server._fuzzy_basename_rank("b", "b") == (0, 1)
+    assert server._fuzzy_basename_rank("bb", "bb") == (0, 2)
+
+
+# ── _coerce_message_text ────────────────────────────────────────────
+
+
+def test_coerce_message_text_none_is_empty_string():
+    assert server._coerce_message_text(None) == ""
+
+
+def test_coerce_message_text_str_passthrough():
+    assert server._coerce_message_text("hi") == "hi"
+
+
+def test_coerce_message_text_numbers_become_str():
+    assert server._coerce_message_text(42) == "42"
+    assert server._coerce_message_text(True) == "True"
+    assert server._coerce_message_text(1.5) == "1.5"
+
+
+def test_coerce_message_text_list_of_strs_concatenates():
+    assert server._coerce_message_text(["a", "b"]) == "ab"
+
+
+def test_coerce_message_text_list_mixed_str_and_text_dict():
+    assert server._coerce_message_text(["a", {"text": "b"}]) == "ab"
+
+
+def test_coerce_message_text_appends_image_url_from_list():
+    content = [
+        {"type": "text", "text": "hi"},
+        {"type": "image_url", "image_url": {"url": "http://x"}},
+    ]
+    assert server._coerce_message_text(content) == "hi\nhttp://x"
+
+
+def test_coerce_message_text_image_without_url_uses_placeholder():
+    assert server._coerce_message_text([{"type": "image_url", "image_url": {}}]) == "\n[image]"
+
+
+def test_coerce_message_text_audio_block_uses_placeholder():
+    assert server._coerce_message_text([{"type": "input_audio", "input_audio": {}}]) == "\n[audio]"
+
+
+def test_coerce_message_text_unknown_block_kind_is_bracketed():
+    assert server._coerce_message_text([{"type": "weird"}]) == "\n[weird]"
+
+
+def test_coerce_message_text_dict_text_key():
+    assert server._coerce_message_text({"text": "hello"}) == "hello"
+
+
+def test_coerce_message_text_dict_image_url_returns_url():
+    assert (
+        server._coerce_message_text({"type": "image_url", "image_url": {"url": "http://y"}})
+        == "http://y"
+    )
+
+
+def test_coerce_message_text_dict_audio_is_placeholder():
+    assert server._coerce_message_text({"type": "input_audio", "input_audio": {}}) == "[audio]"
+
+
+def test_coerce_message_text_dict_unknown_kind_is_bracketed():
+    assert server._coerce_message_text({"type": "weird"}) == "[weird]"
+
+
+def test_coerce_message_text_dict_fallback_is_structured_placeholder():
+    assert server._coerce_message_text({"foo": 1}) == "[structured content]"
+
+
+# ── _cap_tui_verbose_text ───────────────────────────────────────────
+
+
+def test_cap_short_text_is_unchanged():
+    assert server._cap_tui_verbose_text("hello") == "hello"
+
+
+def test_cap_long_single_line_truncates_with_marker():
+    long_text = "x" * 1100
+    out = server._cap_tui_verbose_text(long_text)
+    assert out.startswith("[showing verbose tail; omitted 100 chars]\n")
+    # Tail (after the label) must fit the render budget.
+    assert len(out) - len("[showing verbose tail; omitted 100 chars]\n") <= (
+        server._TUI_VERBOSE_TEXT_MAX_CHARS
+    )
+    assert out.endswith("x" * server._TUI_VERBOSE_TEXT_MAX_CHARS)
+
+
+def test_cap_many_lines_truncates_line_count():
+    text = "\n".join(f"line{i}" for i in range(30))
+    out = server._cap_tui_verbose_text(text)
+    assert "[showing verbose tail; omitted" in out
+    # Label line + at most MAX_LINES shown lines.
+    assert out.count("\n") <= server._TUI_VERBOSE_TEXT_MAX_LINES + 1
+
+
+# ── _redact_tui_verbose_text ────────────────────────────────────────
+
+
+def test_redact_plain_text_passes_through(monkeypatch):
+    # The real redactor leaves non-secret text unchanged; force=True is set.
+    assert server._redact_tui_verbose_text("hello world plain") == "hello world plain"
+
+
+def test_redact_forces_redaction_and_passes_through(monkeypatch):
+    calls = []
+
+    def _fake(text, *, force=False, **kwargs):
+        calls.append((text, force))
+        return "redacted"
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", _fake)
+    out = server._redact_tui_verbose_text("some secret text")
+    assert out == "redacted"
+    assert calls == [("some secret text", True)]
+
+
+def test_redact_error_returns_empty_string(monkeypatch):
+    def _boom(text, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", _boom)
+    assert server._redact_tui_verbose_text("secret") == ""
+
+
+# ── _fmt_tool_duration ──────────────────────────────────────────────
+
+
+def test_tool_duration_none_is_empty():
+    assert server._fmt_tool_duration(None) == ""
+
+
+def test_tool_duration_zero_is_one_decimal():
+    assert server._fmt_tool_duration(0) == "0.0s"
+
+
+def test_tool_duration_sub_ten_is_one_decimal():
+    assert server._fmt_tool_duration(2.5) == "2.5s"
+
+
+def test_tool_duration_under_a_minute_is_rounded_seconds():
+    assert server._fmt_tool_duration(30.0) == "30s"
+
+
+def test_tool_duration_exactly_a_minute_is_whole_minutes():
+    assert server._fmt_tool_duration(60) == "1m"
+
+
+def test_tool_duration_minutes_and_seconds():
+    assert server._fmt_tool_duration(90) == "1m 30s"
+    assert server._fmt_tool_duration(125) == "2m 5s"
+
+
+def test_tool_duration_whole_minutes_omits_seconds():
+    assert server._fmt_tool_duration(120) == "2m"
+    assert server._fmt_tool_duration(300) == "5m"
+
+
+# ── _tool_summary ───────────────────────────────────────────────────
+
+
+def test_tool_summary_web_search_counts_results():
+    result = json.dumps({"data": {"web": [{}, {}, {}]}})
+    assert server._tool_summary("web_search", result, 1.2) == "Did 3 searches in 1.2s"
+
+
+def test_tool_summary_web_search_singular():
+    result = json.dumps({"data": {"web": [{}]}})
+    assert server._tool_summary("web_search", result, None) == "Did 1 search"
+
+
+def test_tool_summary_web_extract_counts_results():
+    result = json.dumps({"results": [{}, {}]})
+    assert server._tool_summary("web_extract", result, 2.0) == "Extracted 2 pages in 2.0s"
+
+
+def test_tool_summary_web_extract_nested_results():
+    result = json.dumps({"data": {"results": [{}]}})
+    assert server._tool_summary("web_extract", result, 2.0) == "Extracted 1 page in 2.0s"
+
+
+def test_tool_summary_unknown_or_non_json_returns_none():
+    assert server._tool_summary("foo", "not json", 5.0) is None
+    assert server._tool_summary("web_search", json.dumps({"data": {}}), None) is None
+
+
+def test_tool_summary_fallback_warning_wins_over_count():
+    result = json.dumps({"fallback_warning": "Rate limited"})
+    assert server._tool_summary("web_search", result, 2.0) == "Rate limited in 2.0s"
+
+
+# ── _is_text_only_busy_payload ──────────────────────────────────────
+
+
+def test_busy_payload_scalars():
+    assert server._is_text_only_busy_payload("hi") is True
+    assert server._is_text_only_busy_payload(42) is True
+
+
+def test_busy_payload_none_is_false():
+    assert server._is_text_only_busy_payload(None) is False
+
+
+def test_busy_payload_empty_list_is_false():
+    assert server._is_text_only_busy_payload([]) is False
+
+
+def test_busy_payload_list_of_text_parts_is_true():
+    assert server._is_text_only_busy_payload(["a", "b"]) is True
+    assert server._is_text_only_busy_payload([{"type": "text", "text": "hi"}]) is True
+    assert server._is_text_only_busy_payload([{"text": "hi"}]) is True
+
+
+def test_busy_payload_list_with_media_is_false():
+    assert (
+        server._is_text_only_busy_payload([{"type": "image_url", "image_url": {}}])
+        is False
+    )
+    assert (
+        server._is_text_only_busy_payload(
+            [{"type": "text", "text": "hi"}, {"type": "image_url", "image_url": {}}]
+        )
+        is False
+    )
+
+
+def test_busy_payload_non_dict_part_is_false():
+    assert server._is_text_only_busy_payload([123]) is False
+
+
+def test_busy_payload_dict_variants():
+    assert server._is_text_only_busy_payload({"type": "text", "text": "hi"}) is True
+    assert server._is_text_only_busy_payload({"text": "hi"}) is True
+    assert server._is_text_only_busy_payload({"type": "image_url", "image_url": {}}) is False
+    assert server._is_text_only_busy_payload({"type": "weird"}) is False
+
+
+def test_busy_payload_other_object_is_false():
+    assert server._is_text_only_busy_payload(object()) is False
+
+
+# ── _coerce_seed_history ────────────────────────────────────────────
+
+
+def test_seed_history_non_list_returns_empty():
+    assert server._coerce_seed_history(None) == []
+    assert server._coerce_seed_history("x") == []
+    assert server._coerce_seed_history({}) == []
+
+
+def test_seed_history_empty_list_returns_empty():
+    assert server._coerce_seed_history([]) == []
+
+
+def test_seed_history_keeps_valid_role_content():
+    assert server._coerce_seed_history([{"role": "user", "content": "hi"}]) == [
+        {"role": "user", "content": "hi"}
+    ]
+
+
+def test_seed_history_falls_back_to_text_key():
+    assert server._coerce_seed_history([{"role": "assistant", "text": "yes"}]) == [
+        {"role": "assistant", "content": "yes"}
+    ]
+    assert server._coerce_seed_history([{"role": "system", "text": "sys"}]) == [
+        {"role": "system", "content": "sys"}
+    ]
+
+
+def test_seed_history_drops_invalid_types_and_roles():
+    assert server._coerce_seed_history([{"role": "tool", "content": "x"}]) == []
+    assert server._coerce_seed_history([1, {"role": "user", "content": "hi"}]) == [
+        {"role": "user", "content": "hi"}
+    ]
+
+
+def test_seed_history_drops_blank_or_missing_content():
+    assert server._coerce_seed_history([{"role": "user", "content": "   "}]) == []
+    assert server._coerce_seed_history([{"role": "user"}]) == []
+
+
+def test_seed_history_filters_and_orders_valid_members():
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "tool", "content": "drop"},
+        {"role": "assistant", "content": "b"},
+        {"role": "system", "content": "c"},
+    ]
+    assert server._coerce_seed_history(history) == [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "system", "content": "c"},
+    ]


### PR DESCRIPTION
## What

Closes #36614.

The issue's headline claim (12.99% coverage on `tui_gateway/server.py`) is stale — the module has tripled in size since June 1 and current `origin/main` already measures **72%** (8305 statements, 2293 missed) with the existing tui_gateway test suites. The 70% acceptance criterion is already met.

This PR does three things:

### 1. Fixes 3 pre-existing test failures on clean `origin/main`

All three fail for **any contributor running tests from inside a Hermes Desktop session** (the terminal leaks `HERMES_DESKTOP=1`):

- **`test_load_enabled_toolsets_rejects_disabled_mcp_env`** + **`test_load_enabled_toolsets_falls_back_when_tui_env_invalid`**: added `monkeypatch.delenv("HERMES_DESKTOP", raising=False)`. The Desktop gateway sets `HERMES_DESKTOP=1`, which makes `_resolve_session_platform()` return `"desktop"` and fold `desktop_ui` into the toolset list via `_gui_surface_toolsets()`.

- **`test_holds_exactly_the_gui_affordances`**: changed to `resolve_toolset("desktop_ui", include_registry=False)`. The `apply_layout` tool registers itself into `desktop_ui` at import time via the tool registry (line 67 of `tools/apply_layout_tool.py`), so the default `include_registry=True` picked it up as a runtime mutation of the static contract.

### 2. Adds 75 new tests for 16 previously-untested pure helpers

Two new test files:

- `tests/tui_gateway/test_server_helpers.py` (58 tests): `_fuzzy_basename_rank`, `_coerce_message_text`, `_cap_tui_verbose_text`, `_redact_tui_verbose_text`, `_fmt_tool_duration`, `_tool_summary`, `_is_text_only_busy_payload`, `_coerce_seed_history`

- `tests/tui_gateway/test_server_file_helpers.py` (17 tests): `_list_repo_files`, `_is_repo_junk`, `_is_session_cwd_junk`, `_dir_exists_cached`, `_abs_completion_prefix_exists`, `_details_completion_item`, `_rank_slash_completions`, `_cli_exec_blocked`

### 3. Adds coverage artifacts to .gitignore

`.coverage`, `coverage.xml`, `htmlcov/` — prevents accidental check-ins of local coverage reports.

## Coverage impact

| Metric | Before (origin/main) | After |
|---|---|---|
| Statement coverage | 72% (2293 missed) | **74%** (2124 missed) |
| Lines covered | — | +169 |
| Test count | 1345 passed | **1423 passed**, 0 failed |

## Notes

**Open question:** Both reviewers (Gemini 3.7 Flash + GPT-OSS 120B) suggested converting the per-test `HERMES_DESKTOP` scrubbing to an `autouse` fixture in `conftest.py` to prevent future env-leak regressions across the entire test suite. This is a reasonable follow-up but scope-expands beyond the issue — filed as a potential follow-up.

## Verification

```bash
cd ~/.hermes/worktrees/tui-cov-36614
env -u PYTHONPATH -u VIRTUAL_ENV ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/tui_gateway tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py \
  -q -p no:cacheprovider
# 1423 passed in 54.72s

env -u PYTHONPATH -u VIRTUAL_ENV ~/.hermes/hermes-agent/venv/bin/python -m coverage run \
  --source=tui_gateway.server -m pytest \
  tests/tui_gateway tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py \
  -q -p no:cacheprovider
env -u PYTHONPATH -u VIRTUAL_ENV ~/.hermes/hermes-agent/venv/bin/python -m coverage report \
  --include='*server.py'
# tui_gateway/server.py    8305   2124    74%
```
