### PR TITLE
test(compressor): bring trajectory_compressor.py to 98% coverage (#36610)

### DIFF
--- a/tests/test_trajectory_compressor_compress.py
+++ b/tests/test_trajectory_compressor_compress.py
@@ -1,0 +1,545 @@
+"""Tests for TrajectoryCompressor compression paths (compress_trajectory / async).
+
+Covers the compress_trajectory (sync, lines ~743-889) and
+compress_trajectory_async (async, lines ~891-1015) methods, plus the private
+helpers they rely on (_find_protected_indices, _snap_boundary,
+_extract_turn_content_for_summary).
+
+All scenarios are parametrized over ``branch='sync'/'async'`` and driven through
+``asyncio.run`` for the async branch so the SAME matrix exercises both paths.
+The compressor is built with the established ``__new__`` idiom (see
+tests/test_trajectory_compressor.py) and a stubbed deterministic token counter
+(word count) so no real tokenizer is downloaded and no network is touched.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from trajectory_compressor import CompressionConfig, TrajectoryCompressor
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _words(n: int) -> str:
+    """Return a value with exactly ``n`` words, so count_tokens == n."""
+    return " ".join(f"x{i}" for i in range(n))
+
+
+def _build_compressor(config: CompressionConfig) -> TrajectoryCompressor:
+    """Build a TrajectoryCompressor via __new__ with deterministic stubs.
+
+    - ``count_tokens`` is replaced by a word-count stub (instance attribute
+      shadows the class method) so token numbers are fully deterministic.
+    - ``_generate_summary`` / ``_generate_summary_async`` return a fixed summary
+      via stubbed clients; no network and no real tokenizer.
+    """
+    comp = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    comp.config = config
+    comp.logger = MagicMock()
+    comp._use_call_llm = False
+
+    # Sync client stub.
+    comp.client = MagicMock()
+    comp.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: test summary"))]
+    )
+
+    # Async client stub (AsyncMock so await create(...) resolves).
+    async_conn = MagicMock()
+    async_conn.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: test summary"))]
+        )
+    )
+    comp._get_async_client = MagicMock(return_value=async_conn)
+
+    # Deterministic token counter: 1 token per whitespace-delimited word,
+    # 0 for empty strings (matches TrajectoryCompressor.count_tokens contract).
+    comp.count_tokens = lambda text: len(text.split()) if text else 0
+    return comp
+
+
+def _compress(comp: TrajectoryCompressor, trajectory, branch: str):
+    """Run one compression branch. ``branch`` is 'sync' or 'async'."""
+    if branch == "async":
+        return asyncio.run(comp.compress_trajectory_async(trajectory))
+    return comp.compress_trajectory(trajectory)
+
+
+def _happy_path_trajectory():
+    """A 12-turn trajectory whose middle turns (indices 4..9) are compressible.
+
+    Protected head = first system/human/gpt/tool (indices 0-3); protected tail
+    = last 2 (indices 10-11). Region is [4, 10). With a word-count token stub
+    this totals 54 tokens; target 20 forces compression.
+    """
+    return (
+        [
+            {"from": "system", "value": "SYSTEM"},
+            {"from": "human", "value": "hi"},
+            {"from": "gpt", "value": "gpt0"},
+            {"from": "tool", "value": "tool0"},
+        ]
+        + [{"from": "gpt", "value": _words(8)} for _ in range(6)]
+        + [
+            {"from": "tool", "value": "toolX"},
+            {"from": "gpt", "value": "gpt11"},
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# compress_trajectory / compress_trajectory_async — scenario matrix
+# ---------------------------------------------------------------------------
+
+class TestCompressSkipsUnderTarget:
+    """total_tokens <= target_max_tokens -> unchanged, no API call."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_returns_same_trajectory_and_skip_metrics(self, branch):
+        comp = _build_compressor(CompressionConfig(target_max_tokens=1000, protect_last_n_turns=2))
+        traj = [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "hi"},
+        ]
+
+        result, metrics = _compress(comp, traj, branch)
+
+        assert result is traj
+        assert metrics.skipped_under_target is True
+        assert metrics.was_compressed is False
+        assert metrics.compression_ratio == 1.0
+        assert metrics.original_tokens == comp.count_trajectory_tokens(traj)
+        comp.client.chat.completions.create.assert_not_called()
+        comp._get_async_client.assert_not_called()
+
+
+class TestCompressEmptyRegion:
+    """compress_start >= compress_end -> unchanged, still_over_limit True."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_all_turns_protected_leaves_empty_region(self, branch):
+        # target 2 keeps the trajectory over limit, protect_last_n_turns >= len
+        # protects every turn so the head/tail brackets leave no compressible
+        # region (compress_start == compress_end).
+        comp = _build_compressor(
+            CompressionConfig(target_max_tokens=2, summary_target_tokens=5, protect_last_n_turns=10)
+        )
+        traj = [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "hi"},
+            {"from": "gpt", "value": "gpt0"},
+            {"from": "tool", "value": "tool0"},
+        ]
+
+        result, metrics = _compress(comp, traj, branch)
+
+        assert result is traj
+        assert metrics.was_compressed is False
+        assert metrics.still_over_limit is True
+        assert metrics.compression_ratio == 1.0
+        comp.client.chat.completions.create.assert_not_called()
+        comp._get_async_client.assert_not_called()
+
+
+class TestCompressHappyPath:
+    """A real mid-trajectory compression: summary inserted, notice appended."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_compresses_middle_region(self, branch):
+        comp = _build_compressor(
+            CompressionConfig(
+                target_max_tokens=20,
+                summary_target_tokens=5,
+                protect_last_n_turns=2,
+                add_summary_notice=True,
+                summary_notice_text="[notice]",
+            )
+        )
+        traj = _happy_path_trajectory()
+
+        result, metrics = _compress(comp, traj, branch)
+
+        # 12 original turns -> 4 head + 1 summary + 3 tail = 8.
+        assert len(result) == 8
+        assert metrics.original_turns == 12
+        assert metrics.original_tokens == 54
+
+        # Head system turn got the notice appended.
+        assert result[0]["from"] == "system"
+        assert result[0]["value"] == "SYSTEM[notice]"
+
+        # Summary inserted as a single human turn with the context prefix.
+        summary_turns = [t for t in result if t["value"].startswith("[CONTEXT SUMMARY]:")]
+        assert len(summary_turns) == 1
+        assert summary_turns[0]["from"] == "human"
+        assert result[4]["value"].startswith("[CONTEXT SUMMARY]:")
+
+        # Tail turns preserved verbatim.
+        assert result[5]["value"] == _words(8)
+        assert result[6]["value"] == "toolX"
+        assert result[7]["value"] == "gpt11"
+
+        # Metrics invariants.
+        assert metrics.was_compressed is True
+        assert metrics.turns_removed == metrics.original_turns - metrics.compressed_turns == 4
+        assert metrics.tokens_saved > 0
+        assert metrics.compression_ratio < 1.0
+        assert metrics.turns_compressed_start_idx == 4
+        assert metrics.turns_compressed_end_idx == 9
+        assert metrics.turns_in_compressed_region == 5
+        assert metrics.still_over_limit is False
+
+    def test_add_summary_notice_false_leaves_system_untouched(self):
+        comp = _build_compressor(
+            CompressionConfig(
+                target_max_tokens=20,
+                summary_target_tokens=5,
+                protect_last_n_turns=2,
+                add_summary_notice=False,
+                summary_notice_text="[notice]",
+            )
+        )
+        traj = _happy_path_trajectory()
+
+        result, metrics = _compress(comp, traj, "sync")
+
+        assert result[0]["from"] == "system"
+        assert result[0]["value"] == "SYSTEM"
+        assert metrics.was_compressed is True
+
+
+class TestCompressWholeRegionFallback:
+    """Region tokens below target but region non-empty -> whole region compressed."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_region_sum_below_target_compresses_entire_region(self, branch):
+        # Region [4, 10) sums to 18 tokens, below target_tokens_to_compress
+        # (higher than 18), so the whole region is consumed. The tail boundary
+        # lands on a clean (gpt) turn so compress_until stays at compress_end.
+        comp = _build_compressor(
+            CompressionConfig(target_max_tokens=10, summary_target_tokens=5, protect_last_n_turns=2)
+        )
+        traj = (
+            [
+                {"from": "system", "value": "sys"},
+                {"from": "human", "value": "hi"},
+                {"from": "gpt", "value": "gpt0"},
+                {"from": "tool", "value": "tool0"},
+            ]
+            + [{"from": "gpt", "value": _words(3)} for _ in range(6)]
+            + [
+                {"from": "gpt", "value": "gpt10"},
+                {"from": "gpt", "value": "gpt11"},
+            ]
+        )
+
+        result, metrics = _compress(comp, traj, branch)
+
+        assert metrics.was_compressed is True
+        assert metrics.turns_compressed_start_idx == 4
+        assert metrics.turns_compressed_end_idx == 10
+        assert metrics.turns_in_compressed_region == 6
+        # Only the 4 head turns remain before the summary.
+        assert result[4]["from"] == "human"
+
+
+class TestCompressSnapCollapse:
+    """Tail boundary snaps back onto the region start -> unchanged, still over."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_collapse_returns_unchanged(self, branch):
+        # Region [4, 7) is entirely tool turns. compress_until ends at the tail
+        # boundary (index 7), which is itself a tool turn, so _snap_boundary
+        # slides backward and collapses onto compress_start (4).
+        comp = _build_compressor(
+            CompressionConfig(target_max_tokens=10, summary_target_tokens=5, protect_last_n_turns=1)
+        )
+        traj = (
+            [
+                {"from": "system", "value": "sys"},
+                {"from": "human", "value": "hi"},
+                {"from": "gpt", "value": "gpt0"},
+                {"from": "tool", "value": "tool0"},
+            ]
+            + [{"from": "tool", "value": _words(5)} for _ in range(4)]
+        )
+
+        result, metrics = _compress(comp, traj, branch)
+
+        assert result is traj
+        assert metrics.was_compressed is False
+        assert metrics.still_over_limit is True
+        comp.client.chat.completions.create.assert_not_called()
+        comp._get_async_client.assert_not_called()
+
+
+class TestCompressTinyRegionGuard:
+    """Region sum <= summary_target_tokens -> compression would grow, skip."""
+
+    @pytest.mark.parametrize("branch", ["sync", "async"])
+    def test_tiny_region_returns_unchanged(self, branch):
+        # Region [4, 7) sums to 3 tokens <= summary_target_tokens (5); the
+        # summary that would replace it costs 5 tokens, so the function returns
+        # the trajectory untouched and still over limit.
+        comp = _build_compressor(
+            CompressionConfig(target_max_tokens=3, summary_target_tokens=5, protect_last_n_turns=1)
+        )
+        traj = [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "hi"},
+            {"from": "gpt", "value": "gpt0"},
+            {"from": "tool", "value": "tool0"},
+            {"from": "gpt", "value": "g"},
+            {"from": "tool", "value": "t1"},
+            {"from": "tool", "value": "t2"},
+            {"from": "gpt", "value": "gt"},
+        ]
+
+        result, metrics = _compress(comp, traj, branch)
+
+        assert result is traj
+        assert metrics.was_compressed is False
+        assert metrics.still_over_limit is True
+        comp.client.chat.completions.create.assert_not_called()
+        comp._get_async_client.assert_not_called()
+
+
+class TestCompressHappyPathMetrics:
+    """Exact metrics relationship on the happy path."""
+
+    def test_compression_ratio_relationship(self):
+        comp = _build_compressor(
+            CompressionConfig(
+                target_max_tokens=20,
+                summary_target_tokens=5,
+                protect_last_n_turns=2,
+                add_summary_notice=True,
+                summary_notice_text="[notice]",
+            )
+        )
+        traj = _happy_path_trajectory()
+
+        result, metrics = _compress(comp, traj, "sync")
+
+        assert metrics.was_compressed is True
+        assert metrics.compression_ratio == pytest.approx(
+            metrics.compressed_tokens / metrics.original_tokens
+        )
+        assert metrics.compressed_tokens == comp.count_trajectory_tokens(result)
+        assert metrics.compressed_tokens < metrics.original_tokens
+        assert metrics.still_over_limit is False
+        assert metrics.tokens_saved == metrics.original_tokens - metrics.compressed_tokens
+
+
+# ---------------------------------------------------------------------------
+# _extract_turn_content_for_summary (564-588)
+# ---------------------------------------------------------------------------
+
+class TestExtractTurnContent:
+    def setup_method(self):
+        self.comp = _build_compressor(CompressionConfig())
+
+    def test_truncates_long_values_around_mid_marker(self):
+        big = "A" * 3001
+        content = self.comp._extract_turn_content_for_summary(
+            [{"from": "gpt", "value": big}], 0, 1
+        )
+
+        assert content.startswith("[Turn 0 - GPT]:\n")
+        assert "A" * 1500 in content
+        assert "A" * 500 in content
+        assert ("A" * 1500 + "\n...[truncated]...\n" + "A" * 500) in content
+        assert content.endswith("A" * 500)
+
+    def test_joins_turns_with_index_role_headers(self):
+        content = self.comp._extract_turn_content_for_summary(
+            [
+                {"from": "system", "value": "hello"},
+                {"from": "human", "value": "world"},
+            ],
+            0,
+            2,
+        )
+
+        assert content == "[Turn 0 - SYSTEM]:\nhello\n\n[Turn 1 - HUMAN]:\nworld"
+
+    def test_non_truncating_values_kept_verbatim(self):
+        content = self.comp._extract_turn_content_for_summary(
+            [{"from": "gpt", "value": "short"}], 0, 1
+        )
+        assert content == "[Turn 0 - GPT]:\nshort"
+
+
+# ---------------------------------------------------------------------------
+# _find_protected_indices (477-523)
+# ---------------------------------------------------------------------------
+
+class TestFindProtectedIndices:
+    def setup_method(self):
+        self.comp = _build_compressor(CompressionConfig())
+
+    def test_tracks_first_occurrence_of_each_role(self):
+        # protect_last_n_turns must be below n (default is 4) so middle turns
+        # are not swallowed by the tail protection.
+        comp = _build_compressor(CompressionConfig(protect_last_n_turns=2))
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "c"},
+            {"from": "tool", "value": "d"},
+            {"from": "gpt", "value": "e"},
+            {"from": "gpt", "value": "f"},
+            {"from": "human", "value": "g"},
+            {"from": "tool", "value": "h"},
+        ]
+
+        protected, compress_start, compress_end = comp._find_protected_indices(traj)
+
+        # First occurrences + last 2 (indices 6, 7).
+        assert {0, 1, 2, 3, 6, 7} <= protected
+        assert 4 not in protected
+        assert 5 not in protected
+        assert compress_start == 4
+        assert compress_end == 6
+
+    def test_protect_first_flags_off_disables_head_protection(self):
+        comp = _build_compressor(
+            CompressionConfig(
+                protect_first_system=False,
+                protect_first_human=False,
+                protect_first_gpt=False,
+                protect_first_tool=False,
+                protect_last_n_turns=2,
+            )
+        )
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "c"},
+            {"from": "tool", "value": "d"},
+            {"from": "gpt", "value": "e"},
+            {"from": "human", "value": "f"},
+        ]
+
+        protected, compress_start, compress_end = comp._find_protected_indices(traj)
+
+        assert protected == {4, 5}
+        assert compress_start == 0
+        assert compress_end == 4
+
+    def test_empty_trajectory_returns_empty_set(self):
+        protected, compress_start, compress_end = self.comp._find_protected_indices([])
+
+        assert protected == set()
+        assert compress_start == 0
+        assert compress_end == 0
+
+    def test_protect_last_n_zero_disables_tail_protection(self):
+        comp = _build_compressor(CompressionConfig(protect_last_n_turns=0))
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "c"},
+            {"from": "tool", "value": "d"},
+            {"from": "gpt", "value": "e"},
+        ]
+
+        protected, _, _ = comp._find_protected_indices(traj)
+
+        assert protected == {0, 1, 2, 3}
+        assert 4 not in protected
+
+    def test_protect_last_n_ge_length_protects_every_turn(self):
+        comp = _build_compressor(CompressionConfig(protect_last_n_turns=10))
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "c"},
+            {"from": "tool", "value": "d"},
+        ]
+
+        protected, _, _ = comp._find_protected_indices(traj)
+
+        assert protected == {0, 1, 2, 3}
+
+
+# ---------------------------------------------------------------------------
+# _snap_boundary (539-562)
+# ---------------------------------------------------------------------------
+
+class TestSnapBoundary:
+    def test_forward_snap_onto_clean_tool_following_turn(self):
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "tool", "value": "c"},
+            {"from": "tool", "value": "d"},
+            {"from": "gpt", "value": "e"},
+        ]
+        assert TrajectoryCompressor._snap_boundary(traj, 2, 1, 4) == 4
+
+    def test_backward_snap_when_tail_starts_with_tool(self):
+        traj = [
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "e"},
+            {"from": "tool", "value": "c"},
+        ]
+        assert TrajectoryCompressor._snap_boundary(traj, 2, 1, 2) == 1
+
+    def test_clean_boundary_returns_same_index(self):
+        traj = [
+            {"from": "system", "value": "a"},
+            {"from": "human", "value": "b"},
+            {"from": "gpt", "value": "e"},
+        ]
+        assert TrajectoryCompressor._snap_boundary(traj, 1, 1, 3) == 1
+
+    def test_clamps_forward_to_max_idx(self):
+        traj = [
+            {"from": "gpt", "value": "a"},
+            {"from": "tool", "value": "b"},
+            {"from": "gpt", "value": "c"},
+        ]
+        assert TrajectoryCompressor._snap_boundary(traj, 1, 0, 2) == 2
+
+    def test_clamps_backward_to_min_idx(self):
+        traj = [
+            {"from": "tool", "value": "a"},
+            {"from": "tool", "value": "b"},
+            {"from": "tool", "value": "c"},
+        ]
+        assert TrajectoryCompressor._snap_boundary(traj, 2, 1, 2) == 1
+
+
+# ---------------------------------------------------------------------------
+# Async parity (compress_trajectory_async) — explicit named tests
+# ---------------------------------------------------------------------------
+
+class TestCompressAsyncParity:
+    """Direct async assertions, including the async client wiring."""
+
+    @pytest.mark.asyncio
+    async def test_async_happy_path_uses_get_async_client(self):
+        comp = _build_compressor(
+            CompressionConfig(
+                target_max_tokens=20,
+                summary_target_tokens=5,
+                protect_last_n_turns=2,
+                add_summary_notice=True,
+                summary_notice_text="[notice]",
+            )
+        )
+        traj = _happy_path_trajectory()
+
+        result, metrics = await comp.compress_trajectory_async(traj)
+
+        comp._get_async_client.assert_called_once()
+        assert metrics.was_compressed is True
+        assert metrics.compression_ratio < 1.0
+        assert result[4]["value"].startswith("[CONTEXT SUMMARY]:")

--- a/tests/test_trajectory_compressor_init_summary.py
+++ b/tests/test_trajectory_compressor_init_summary.py
@@ -1,0 +1,561 @@
+"""Tests for trajectory_compressor.py -- init/provider-detection layer and summary retry/fallback.
+
+Covers the regions of ``trajectory_compressor.py`` that exercise:
+
+1. ``_effective_temperature_for_model`` import-success / import-failure branches.
+2. ``_init_tokenizer`` success and runtime-error paths.
+3. ``_init_summarizer`` provider-vs-custom-endpoint routing and the missing-key error.
+4. ``_detect_provider`` base-url -> provider-name mapping.
+5. ``count_tokens`` fallback on tokenizer failure and the empty-text short-circuit.
+6. ``_generate_summary`` sync: call_llm path, temperature-omission, retry, exhaustion.
+7. ``_generate_summary_async`` async: the same four shapes.
+
+All tests are hermetic: no network, no real tokenizer, no API keys. The
+``transformers`` package isn't installed in this venv, so ``_init_tokenizer``
+tests inject a fake ``transformers`` module via ``sys.modules`` rather than
+patching a module that does not exist.
+"""
+
+import sys
+from types import SimpleNamespace, ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from trajectory_compressor import (
+    CompressionConfig,
+    TrajectoryMetrics,
+    TrajectoryCompressor,
+    _effective_temperature_for_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared construction helper
+# ---------------------------------------------------------------------------
+
+
+class FALLBACK_SUMMARY:
+    """The exact fallback string returned when all summary retries are exhausted."""
+
+    TEXT = (
+        "[CONTEXT SUMMARY]: [Summary generation failed - previous turns "
+        "contained tool calls and responses that have been compressed to save "
+        "context space.]"
+    )
+
+
+def _new_compressor(config=None):
+    """Build a compressor via ``__new__`` (skip __init__ network/tokenizer IO)."""
+    comp = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    comp.config = config if config is not None else CompressionConfig()
+    comp.logger = MagicMock()
+    return comp
+
+
+def _summary_response(text):
+    """A fake OpenAI chat-completions response carrying ``text`` as content."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+def _fake_transformers_module(return_value=None, side_effect=None):
+    """A stub ``transformers`` module whose AutoTokenizer is a MagicMock.
+
+    ``transformers`` is not installed in the CI venv, so the real module
+    cannot be patched. Injecting a fake module lets ``_init_tokenizer``'s
+    ``from transformers import AutoTokenizer`` resolve to an injectable mock.
+    """
+    fake_tf = ModuleType("transformers")
+    auto_tokenizer = MagicMock()
+    if return_value is not None:
+        auto_tokenizer.from_pretrained.return_value = return_value
+    if side_effect is not None:
+        auto_tokenizer.from_pretrained.side_effect = side_effect
+    fake_tf.AutoTokenizer = auto_tokenizer
+    return fake_tf, auto_tokenizer
+
+
+# ---------------------------------------------------------------------------
+# _effective_temperature_for_model
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveTemperatureForModel:
+    """``_effective_temperature_for_model`` applies model temperature contracts.
+
+    The helper delegates to ``agent.auxiliary_client._fixed_temperature_for_model``;
+    the three import-success outcomes are sensibly distinct, and the
+    import-failure fallback must return the requested temperature untouched.
+    """
+
+    def test_omit_temperature_sentinel_returns_none(self):
+        """Kimi models return the OMIT_TEMPERATURE sentinel -> effective None.
+
+        The caller must drop the ``temperature`` kwarg entirely because the
+        provider manages temperature server-side.
+        """
+        from agent.auxiliary_client import OMIT_TEMPERATURE, _fixed_temperature_for_model
+
+        # The sentinel's identity is a singleton object, not None.
+        assert OMIT_TEMPERATURE is not None
+        assert _fixed_temperature_for_model("kimi-for-coding") is OMIT_TEMPERATURE
+        assert _effective_temperature_for_model("kimi-for-coding", 0.3) is None
+
+    def test_fixed_temperature_override(self):
+        """Trinity Large Thinking carries a server-side fixed temperature of 0.5.
+
+        ``_fixed_temperature_for_model`` returns a concrete float, which the
+        effective helper forwards verbatim regardless of the requested value.
+        """
+        from agent.auxiliary_client import _fixed_temperature_for_model
+
+        assert _fixed_temperature_for_model("arcee/trinity-large-thinking") == 0.5
+        assert _effective_temperature_for_model("arcee/trinity-large-thinking", 0.3) == 0.5
+
+    def test_no_override_passes_requested_through(self):
+        """Models with no fixed contract return None -> requested temperature.
+
+        A plain model (gemini default) has no override, so the requested
+        temperature must survive untouched.
+        """
+        from agent.auxiliary_client import _fixed_temperature_for_model
+
+        assert _fixed_temperature_for_model("google/gemini-3-flash-preview") is None
+        assert _effective_temperature_for_model("google/gemini-3-flash-preview", 0.3) == 0.3
+
+    def test_import_failure_falls_back_to_requested(self):
+        """If ``agent.auxiliary_client`` cannot be imported, return requested.
+
+        The lazy import lives in a try/except; any exception (simulated here by
+        stubbing the module to None) must degrade to passing the requested
+        temperature through — safe for callers never expecting to omit it.
+        """
+        with patch.dict(sys.modules, {"agent.auxiliary_client": None}):
+            assert _effective_temperature_for_model("kimi-for-coding", 0.42) == 0.42
+
+
+# ---------------------------------------------------------------------------
+# _init_tokenizer
+# ---------------------------------------------------------------------------
+
+
+class TestInitTokenizer:
+    """``_init_tokenizer`` loads a HuggingFace tokenizer or raises a RuntimeError."""
+
+    def test_success_sets_tokenizer_and_prints(self, monkeypatch, capsys):
+        """On success the tokenizer attribute is set and a status line prints.
+
+        The fake ``transformers`` module supplies an AutoTokenizer whose
+        ``from_pretrained`` returns the mock we assert on.
+        """
+        comp = _new_compressor()
+        tokenizer_mock = MagicMock()
+        fake_tf, _ = _fake_transformers_module(return_value=tokenizer_mock)
+        monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+
+        comp._init_tokenizer()
+
+        assert comp.tokenizer is tokenizer_mock
+        assert "Loaded tokenizer" in capsys.readouterr().out
+
+    def test_failure_raises_runtime_error_with_tokenizer_name(self, monkeypatch):
+        """A tokenizer load failure becomes a RuntimeError naming the tokenizer.
+
+        The error message must carry ``config.tokenizer_name`` so users can
+        diagnose which model/tokenizer failed to load.
+        """
+        comp = _new_compressor()
+        comp.config.tokenizer_name = "my/pretrained-tok"
+        fake_tf, _ = _fake_transformers_module(side_effect=Exception("boom"))
+        monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+
+        with pytest.raises(RuntimeError, match="my/pretrained-tok"):
+            comp._init_tokenizer()
+
+
+# ---------------------------------------------------------------------------
+# _init_summarizer
+# ---------------------------------------------------------------------------
+
+
+class TestInitSummarizer:
+    """``_init_summarizer`` routes to call_llm vs raw client construction."""
+
+    def test_provider_path_uses_call_llm(self, capsys):
+        """A known provider base_url enables call_llm routing.
+
+        When ``_detect_provider`` returns a provider (openrouter), the
+        compressor delegates to ``resolve_provider_client`` and keeps
+        ``client``/``async_client`` as None — they are not used directly.
+        """
+        comp = _new_compressor()
+        comp.config.base_url = "https://openrouter.ai/api/v1"
+        rpc = MagicMock(return_value=(MagicMock(), None))
+
+        with patch("agent.auxiliary_client.resolve_provider_client", rpc):
+            comp._init_summarizer()
+
+        assert comp._use_call_llm is True
+        assert comp._llm_provider == "openrouter"
+        assert comp.client is None
+        assert comp.async_client is None
+        rpc.assert_called_once_with(
+            "openrouter", model=comp.config.summarization_model
+        )
+        assert "Initialized summarizer client" in capsys.readouterr().out
+
+    def test_custom_endpoint_builds_raw_openai_client(self, monkeypatch, capsys):
+        """An unknown base_url falls back to a raw OpenAI client.
+
+        The custom-endpoint branch reads the key from ``api_key_env`` and
+        constructs an OpenAI client, storing the key for lazy async creation.
+        """
+        comp = _new_compressor()
+        comp.config.base_url = "http://localhost:8000/v1"
+        comp.config.api_key_env = "TEST_TC_API_KEY"
+        monkeypatch.setenv("TEST_TC_API_KEY", "secret-key")
+        openai_mock = MagicMock()
+
+        with patch("openai.OpenAI", openai_mock):
+            comp._init_summarizer()
+
+        assert comp._use_call_llm is False
+        assert comp.client is openai_mock.return_value
+        assert comp.async_client is None
+        assert comp._async_client_api_key == "secret-key"
+        openai_mock.assert_called_once_with(
+            api_key="secret-key", base_url="http://localhost:8000/v1"
+        )
+        assert "Initialized summarizer client" in capsys.readouterr().out
+
+    def test_missing_api_key_raises_runtime_error(self, monkeypatch):
+        """A custom endpoint with no key in the env raises a descriptive error.
+
+        Only the custom-endpoint branch demands a key; it must name the env var
+        so the operator knows exactly what to export.
+        """
+        comp = _new_compressor()
+        comp.config.base_url = "http://localhost:8000/v1"
+        comp.config.api_key_env = "TEST_TC_API_KEY"
+        monkeypatch.delenv("TEST_TC_API_KEY", raising=False)
+
+        with patch("openai.OpenAI", MagicMock()):
+            with pytest.raises(RuntimeError, match="TEST_TC_API_KEY"):
+                comp._init_summarizer()
+
+
+# ---------------------------------------------------------------------------
+# _detect_provider
+# ---------------------------------------------------------------------------
+
+
+class TestDetectProvider:
+    """``_detect_provider`` maps a configured base_url to a provider name."""
+
+    @pytest.mark.parametrize(
+        "base_url,expected",
+        [
+            ("https://openrouter.ai/api/v1", "openrouter"),
+            ("https://nousresearch.com/api/v1", "nous"),
+            ("https://chatgpt.com/backend-api/codex", "codex"),
+            ("https://z.ai/api/v1", "zai"),
+            ("https://api.moonshot.ai/v1", "kimi-coding"),
+            ("https://api.moonshot.cn/v1", "kimi-coding"),
+            ("https://api.kimi.com/v1", "kimi-coding"),
+            ("https://api.arcee.ai/v1", "arcee"),
+            ("https://api.minimaxi.com/v1", "minimax-cn"),
+            ("https://api.minimax.io/v1", "minimax"),
+            ("http://localhost:9/v1", ""),
+        ],
+        ids=[
+            "openrouter",
+            "nous",
+            "codex",
+            "zai",
+            "moonshot-ai-kimi",
+            "moonshot-cn-kimi",
+            "kimi-com",
+            "arcee",
+            "minimax-cn",
+            "minimax",
+            "unknown-localhost",
+        ],
+    )
+    def test_detects_provider_from_base_url(self, base_url, expected):
+        """A base_url must resolve to exactly one provider (or '' if unknown).
+
+        Uses the real ``base_url_host_matches``/``base_url_hostname`` helpers
+        from ``utils`` (imported by the production module), so a URL fixture
+        that fails a host match is a genuine deployment-detect regression.
+        """
+        comp = _new_compressor()
+        comp.config.base_url = base_url
+        assert comp._detect_provider() == expected
+
+
+# ---------------------------------------------------------------------------
+# count_tokens fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCountTokensFallback:
+    """``count_tokens`` character-approximation fallback and empty short-circuit."""
+
+    def test_empty_text_returns_zero(self):
+        """Empty input short-circuits to 0 without touching the tokenizer."""
+        comp = _new_compressor()
+        comp.tokenizer = MagicMock()
+        comp.tokenizer.encode = MagicMock(side_effect=AssertionError("must not call"))
+        assert comp.count_tokens("") == 0
+
+    def test_tokenizer_error_falls_back_to_character_estimate(self):
+        """A tokenizer failure degrades to ``len(text) // 4``.
+
+        The fallback keeps compression working even when the tokenizer is
+        unavailable, at the cost of a coarse approximation.
+        """
+        comp = _new_compressor()
+        comp.tokenizer = MagicMock()
+        comp.tokenizer.encode = MagicMock(side_effect=Exception("tokenizer down"))
+        assert comp.count_tokens("12345678") == 2
+
+
+# ---------------------------------------------------------------------------
+# _generate_summary (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummarySync:
+    """``_generate_summary`` call_llm / raw-client routing, retry and fallback."""
+
+    def test_call_llm_path_forwards_kwargs(self):
+        """The call_llm path forwards provider/model/messages/temperature/max_tokens.
+
+        The centralized router (``call_llm``) is the single seam for known
+        providers, so the compressor must hand it the exact request it would
+        have sent directly and count a single summarization API call.
+        """
+        comp = _new_compressor()
+        comp._use_call_llm = True
+        comp._llm_provider = "openrouter"
+        call_llm_mock = MagicMock(
+            return_value=_summary_response("[CONTEXT SUMMARY]: ok")
+        )
+
+        with patch("agent.auxiliary_client.call_llm", call_llm_mock):
+            metrics = TrajectoryMetrics()
+            result = comp._generate_summary("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: ok"
+        kwargs = call_llm_mock.call_args.kwargs
+        assert kwargs["provider"] == "openrouter"
+        assert kwargs["model"] == comp.config.summarization_model
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0]["role"] == "user"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == comp.config.summary_target_tokens * 2
+        assert metrics.summarization_api_calls == 1
+
+    def test_raw_client_kimi_omits_temperature(self):
+        """Kimi models drop temperature from raw client create kwargs.
+
+        ``_effective_temperature_for_model`` returns None for Kimi, and the
+        raw-client branch must leave ``temperature`` out of the request.
+        """
+        comp = _new_compressor()
+        comp.config.summarization_model = "kimi-for-coding"
+        comp._use_call_llm = False
+        client = MagicMock()
+        client.chat.completions.create.return_value = _summary_response(
+            "[CONTEXT SUMMARY]: kimi"
+        )
+        comp.client = client
+
+        metrics = TrajectoryMetrics()
+        result = comp._generate_summary("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: kimi"
+        assert "temperature" not in client.chat.completions.create.call_args.kwargs
+
+    def test_raw_client_non_kimi_includes_temperature(self):
+        """Non-Kimi models pass the configured temperature into create kwargs.
+
+        This is the complementary branch to the Kimi omission test: a default
+        model keeps a concrete temperature value in the request.
+        """
+        comp = _new_compressor()
+        comp._use_call_llm = False
+        client = MagicMock()
+        client.chat.completions.create.return_value = _summary_response(
+            "[CONTEXT SUMMARY]: ok"
+        )
+        comp.client = client
+
+        metrics = TrajectoryMetrics()
+        comp._generate_summary("tool output", metrics)
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == comp.config.summary_target_tokens * 2
+
+    def test_retry_recovers_after_one_failure(self):
+        """A single transient failure is retried and the summary returned.
+
+        After a failed attempt the compressor sleeps a backoff (mocked to 0),
+        retries, and on success must count two API calls, one error, and log a
+        warning — while still returning the correct summary.
+        """
+        comp = _new_compressor()
+        comp.config.max_retries = 2
+        comp.config.retry_delay = 0
+        comp._use_call_llm = False
+        client = MagicMock()
+        client.chat.completions.create.side_effect = [
+            Exception("transient"),
+            _summary_response("[CONTEXT SUMMARY]: ok"),
+        ]
+        comp.client = client
+
+        with patch("trajectory_compressor.jittered_backoff", return_value=0):
+            metrics = TrajectoryMetrics()
+            result = comp._generate_summary("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: ok"
+        assert metrics.summarization_api_calls == 2
+        assert metrics.summarization_errors == 1
+        comp.logger.warning.assert_called()
+
+    def test_exhaustion_returns_fallback_summary(self):
+        """Every attempt failing returns the fixed fallback summary.
+
+        With max_retries=2 and both calls failing, the compressor must count
+        two errors and return the canned fallback rather than raising.
+        """
+        comp = _new_compressor()
+        comp.config.max_retries = 2
+        comp.config.retry_delay = 0
+        comp._use_call_llm = False
+        client = MagicMock()
+        client.chat.completions.create.side_effect = Exception("permanent")
+        comp.client = client
+
+        with patch("trajectory_compressor.jittered_backoff", return_value=0):
+            metrics = TrajectoryMetrics()
+            result = comp._generate_summary("tool output", metrics)
+
+        assert result == FALLBACK_SUMMARY.TEXT
+        assert metrics.summarization_api_calls == 2
+        assert metrics.summarization_errors == 2
+
+
+# ---------------------------------------------------------------------------
+# _generate_summary_async
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummaryAsync:
+    """``_generate_summary_async`` mirrors the sync shapes in an event loop."""
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_path(self):
+        """The async call_llm path forwards kwargs and counts one API call."""
+        comp = _new_compressor()
+        comp._use_call_llm = True
+        comp._llm_provider = "openrouter"
+        async_call_llm_mock = AsyncMock(
+            return_value=_summary_response("[CONTEXT SUMMARY]: ok")
+        )
+
+        with patch("agent.auxiliary_client.async_call_llm", async_call_llm_mock):
+            metrics = TrajectoryMetrics()
+            result = await comp._generate_summary_async("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: ok"
+        assert async_call_llm_mock.call_args.kwargs["provider"] == "openrouter"
+        assert len(async_call_llm_mock.call_args.kwargs["messages"]) == 1
+        assert async_call_llm_mock.call_args.kwargs["temperature"] == 0.3
+        assert metrics.summarization_api_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_async_raw_client_kimi_omits_temperature(self):
+        """Async raw client path omits temperature for Kimi models."""
+        comp = _new_compressor()
+        comp.config.summarization_model = "kimi-for-coding"
+        comp._use_call_llm = False
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(
+            return_value=_summary_response("[CONTEXT SUMMARY]: kimi")
+        )
+        comp._get_async_client = MagicMock(return_value=async_client)
+
+        metrics = TrajectoryMetrics()
+        result = await comp._generate_summary_async("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: kimi"
+        assert (
+            "temperature"
+            not in async_client.chat.completions.create.call_args.kwargs
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_raw_client_non_kimi_includes_temperature(self):
+        """Async raw client path passes temperature for non-Kimi models."""
+        comp = _new_compressor()
+        comp._use_call_llm = False
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(
+            return_value=_summary_response("[CONTEXT SUMMARY]: ok")
+        )
+        comp._get_async_client = MagicMock(return_value=async_client)
+
+        metrics = TrajectoryMetrics()
+        await comp._generate_summary_async("tool output", metrics)
+
+        kwargs = async_client.chat.completions.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_async_retry_recovers_after_one_failure(self):
+        """Async path retries a transient failure and returns the summary."""
+        comp = _new_compressor()
+        comp.config.max_retries = 2
+        comp.config.retry_delay = 0
+        comp._use_call_llm = False
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                Exception("transient"),
+                _summary_response("[CONTEXT SUMMARY]: ok"),
+            ]
+        )
+        comp._get_async_client = MagicMock(return_value=async_client)
+
+        with patch("trajectory_compressor.jittered_backoff", return_value=0):
+            metrics = TrajectoryMetrics()
+            result = await comp._generate_summary_async("tool output", metrics)
+
+        assert result == "[CONTEXT SUMMARY]: ok"
+        assert metrics.summarization_api_calls == 2
+        assert metrics.summarization_errors == 1
+        comp.logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_async_exhaustion_returns_fallback_summary(self):
+        """Async exhaustion returns the canned fallback and counts two errors."""
+        comp = _new_compressor()
+        comp.config.max_retries = 2
+        comp.config.retry_delay = 0
+        comp._use_call_llm = False
+        async_client = MagicMock()
+        async_client.chat.completions.create = AsyncMock(side_effect=Exception("permanent"))
+        comp._get_async_client = MagicMock(return_value=async_client)
+
+        with patch("trajectory_compressor.jittered_backoff", return_value=0):
+            metrics = TrajectoryMetrics()
+            result = await comp._generate_summary_async("tool output", metrics)
+
+        assert result == FALLBACK_SUMMARY.TEXT
+        assert metrics.summarization_api_calls == 2
+        assert metrics.summarization_errors == 2

--- a/tests/test_trajectory_compressor_pipeline.py
+++ b/tests/test_trajectory_compressor_pipeline.py
@@ -1,0 +1,727 @@
+"""Tests for the trajectory_compressor.py *pipeline*: process_entry(_async),
+_process_directory_async, _print_summary, and main().
+
+These cover the end-to-end CLI/pipeline regions (lines ~1017-1594) that the
+unit tests in test_trajectory_compressor.py (config / metrics / compression
+math) deliberately skip.  Everything is hermetic: the HF tokenizer and the LLM
+summarizer are stubbed so no network or model download happens.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from trajectory_compressor import (
+    AggregateMetrics,
+    CompressionConfig,
+    TrajectoryCompressor,
+    TrajectoryMetrics,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_compressor(config=None):
+    """Build a TrajectoryCompressor via __new__ with a stubbed tokenizer.
+
+    Unlike ``_make_compressor`` in the unit-test module (which goes through
+    ``__init__`` while patching the init hooks), we bypass ``__init__`` so the
+    pipeline helpers can be monkeypatched on the instance without touching the
+    real tokenizer/LLM plumbing.
+    """
+    if config is None:
+        config = CompressionConfig()
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = logging.getLogger("test_trajectory_compressor_pipeline")
+    compressor.tokenizer = MagicMock()
+    # 1 token per 4 chars (matches the existing test-module convention).
+    compressor.tokenizer.encode = lambda text: [0] * max(1, len(text) // 4)
+    compressor.aggregate_metrics = AggregateMetrics()
+    return compressor
+
+
+def _pipeline_config(**overrides):
+    """A CompressionConfig tuned to force compression through the pipeline."""
+    config = CompressionConfig(
+        target_max_tokens=30,
+        summary_target_tokens=10,
+        per_trajectory_timeout=60,
+        max_retries=1,
+        protect_last_n_turns=2,
+    )
+    config.metrics_enabled = True
+    config.metrics_per_trajectory = True
+    config.metrics_output_file = "compression_metrics.json"
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _trajectory(middle_value):
+    """An 8-turn trajectory whose protected region is [4, 6)."""
+    return [
+        {"from": "system", "value": "You are an agent."},
+        {"from": "human", "value": "Please do the task."},
+        {"from": "gpt", "value": "I will use a tool to search."},
+        {"from": "tool", "value": "Search result returned."},
+        {"from": "gpt", "value": middle_value},
+        {"from": "tool", "value": "tool result here."},
+        {"from": "gpt", "value": "final answer."},
+        {"from": "human", "value": "thanks"},
+    ]
+
+
+def _big_middle_entry(marker):
+    """A compressible entry; ``marker`` is embedded in the compressible middle."""
+    assert len(marker) >= 1
+    middle = (marker + " ") + ("blah " * 200)
+    return {"id": marker, "conversations": _trajectory(middle)}
+
+
+async def _fake_generate_summary_async(self, content, metrics):
+    """Stands in for the LLM: counts a call and returns a summary."""
+    metrics.summarization_api_calls += 1
+    return "[CONTEXT SUMMARY]: fake summary"
+
+
+@pytest.fixture
+def stub_summarizer(monkeypatch):
+    """Point the async summary generator at the deterministic fake."""
+
+    async def _fake(self, content, metrics):
+        metrics.summarization_api_calls += 1
+        return "[CONTEXT SUMMARY]: fake summary"
+
+    monkeypatch.setattr(TrajectoryCompressor, "_generate_summary_async", _fake)
+
+
+def _write_jsonl(path, lines):
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# process_entry / process_entry_async  (lines ~1017-1063)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessEntry:
+    """process_entry: entry plumbing without the compression math."""
+
+    def test_no_conversations_returns_entry_unchanged(self):
+        """An entry lacking 'conversations' is returned as-is with default metrics."""
+        compressor = _make_compressor()
+        entry = {"id": "metadata-only"}
+
+        result, metrics = compressor.process_entry(entry)
+
+        assert result == entry
+        assert metrics.original_tokens == 0
+        assert metrics.was_compressed is False
+
+    def test_conversations_replaced_by_compressor_output(self):
+        """The compressor's output replaces entry['conversations']."""
+        compressor = _make_compressor()
+        original = {"id": "x", "conversations": _trajectory("old middle")}
+        compressed = _trajectory("new middle")
+        metrics = TrajectoryMetrics()
+        metrics.was_compressed = True
+        compressor.compress_trajectory = MagicMock(return_value=(compressed, metrics))
+
+        result, _ = compressor.process_entry(original)
+
+        assert result["conversations"] == compressed
+        compressor.compress_trajectory.assert_called_once_with(original["conversations"])
+
+    def test_compression_metrics_added_when_compressed_and_enabled(self):
+        """compression_metrics appears only on a compressed, enabled entry."""
+        compressor = _make_compressor(_pipeline_config(metrics_per_trajectory=True))
+        original = {"id": "x", "conversations": _trajectory("old")}
+        metrics = TrajectoryMetrics()
+        metrics.original_tokens = 100
+        metrics.was_compressed = True
+        compressor.compress_trajectory = MagicMock(
+            return_value=(_trajectory("new"), metrics)
+        )
+
+        result, _ = compressor.process_entry(original)
+
+        assert "compression_metrics" in result
+        assert result["compression_metrics"] == metrics.to_dict()
+
+    def test_no_compression_metrics_when_metric_disabled(self):
+        """metrics_per_trajectory=False suppresses the per-entry metrics key."""
+        compressor = _make_compressor(_pipeline_config(metrics_per_trajectory=False))
+        original = {"id": "x", "conversations": _trajectory("old")}
+        metrics = TrajectoryMetrics()
+        metrics.was_compressed = True
+        compressor.compress_trajectory = MagicMock(
+            return_value=(_trajectory("new"), metrics)
+        )
+
+        result, _ = compressor.process_entry(original)
+
+        assert "compression_metrics" not in result
+
+    def test_no_compression_metrics_when_skipped(self):
+        """A skipped (uncompressed) entry never gains a compression_metrics key."""
+        compressor = _make_compressor(_pipeline_config(metrics_per_trajectory=True))
+        original = {"id": "x", "conversations": _trajectory("old")}
+        metrics = TrajectoryMetrics()  # was_compressed is False
+        compressor.compress_trajectory = MagicMock(
+            return_value=(_trajectory("same"), metrics)
+        )
+
+        result, _ = compressor.process_entry(original)
+
+        assert "compression_metrics" not in result
+
+
+class TestProcessEntryAsync:
+    """process_entry_async: the same invariants through the async path."""
+
+    def test_no_conversations_returns_entry_unchanged(self):
+        compressor = _make_compressor()
+        entry = {"id": "metadata-only"}
+
+        result, metrics = asyncio.run(compressor.process_entry_async(entry))
+
+        assert result == entry
+        assert metrics.was_compressed is False
+
+    def test_conversations_replaced_by_async_compressor_output(self):
+        compressor = _make_compressor()
+        original = {"id": "x", "conversations": _trajectory("old")}
+        compressed = _trajectory("new")
+        metrics = TrajectoryMetrics()
+        metrics.was_compressed = True
+        compressor.compress_trajectory_async = AsyncMock(
+            return_value=(compressed, metrics)
+        )
+
+        result, _ = asyncio.run(compressor.process_entry_async(original))
+
+        assert result["conversations"] == compressed
+        compressor.compress_trajectory_async.assert_awaited_once_with(
+            original["conversations"]
+        )
+
+    def test_compression_metrics_added_when_compressed_and_enabled(self):
+        compressor = _make_compressor(_pipeline_config(metrics_per_trajectory=True))
+        original = {"id": "x", "conversations": _trajectory("old")}
+        metrics = TrajectoryMetrics()
+        metrics.original_tokens = 100
+        metrics.was_compressed = True
+        compressor.compress_trajectory_async = AsyncMock(
+            return_value=(_trajectory("new"), metrics)
+        )
+
+        result, _ = asyncio.run(compressor.process_entry_async(original))
+
+        assert "compression_metrics" in result
+        assert result["compression_metrics"] == metrics.to_dict()
+
+    def test_no_compression_metrics_when_skipped(self):
+        compressor = _make_compressor(_pipeline_config(metrics_per_trajectory=True))
+        original = {"id": "x", "conversations": _trajectory("old")}
+        metrics = TrajectoryMetrics()
+        compressor.compress_trajectory_async = AsyncMock(
+            return_value=(_trajectory("same"), metrics)
+        )
+
+        result, _ = asyncio.run(compressor.process_entry_async(original))
+
+        assert "compression_metrics" not in result
+
+
+# ---------------------------------------------------------------------------
+# _process_directory_async  (lines ~1076-1269)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessDirectoryAsync:
+    """End-to-end directory pipeline with the LLM + tokenizer stubbed."""
+
+    def test_happy_path_compresses_and_writes_metrics(
+        self, tmp_path, stub_summarizer
+    ):
+        """Valid entries compress, invalid JSON is skipped, metrics are written."""
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+
+        file1 = input_dir / "file1.jsonl"
+        _write_jsonl(
+            file1,
+            [
+                json.dumps(_big_middle_entry("first")),
+                "{ this is not valid json",  # skipped
+            ],
+        )
+        file2 = input_dir / "file2.jsonl"
+        _write_jsonl(
+            file2,
+            [
+                json.dumps({"id": "no-conversations"}),  # untouched entry
+                json.dumps(_big_middle_entry("second")),
+            ],
+        )
+
+        compressor = _make_compressor(_pipeline_config())
+        compressor.process_directory(input_dir, output_dir)
+
+        # Output files exist with the same names, in the same order.
+        out1 = output_dir / "file1.jsonl"
+        out2 = output_dir / "file2.jsonl"
+        assert out1.exists()
+        assert out2.exists()
+
+        # file1: the invalid line was dropped, so exactly one entry remains.
+        out1_entries = [json.loads(l) for l in out1.read_text().splitlines()]
+        assert len(out1_entries) == 1
+        assert out1_entries[0]["id"] == "first"
+        assert "compression_metrics" in out1_entries[0]
+
+        # file2: the no-conversations entry passes through untouched; the
+        # compressible one is compressed.
+        out2_entries = [json.loads(l) for l in out2.read_text().splitlines()]
+        assert len(out2_entries) == 2
+        assert out2_entries[0] == {"id": "no-conversations"}
+        assert out2_entries[1]["id"] == "second"
+        assert "compression_metrics" in out2_entries[1]
+
+        # Aggregate metrics count every valid trajectory; two were compressed.
+        assert compressor.aggregate_metrics.total_trajectories == 3
+        assert compressor.aggregate_metrics.trajectories_compressed == 2
+
+        # Metrics file is written with the expected top-level keys.
+        metrics_path = output_dir / "compression_metrics.json"
+        assert metrics_path.exists()
+        metrics = json.loads(metrics_path.read_text())
+        assert set(metrics) == {
+            "summary",
+            "tokens",
+            "turns",
+            "averages",
+            "summarization",
+            "processing",
+        }
+        assert metrics["summary"]["total_trajectories"] == 3
+        assert metrics["summary"]["trajectories_compressed"] == 2
+
+    def test_error_path_keeps_original_and_counts_failed(
+        self, tmp_path, monkeypatch
+    ):
+        """An entry whose summarization raises is preserved verbatim + counted."""
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+
+        file1 = input_dir / "file1.jsonl"
+        _write_jsonl(
+            file1,
+            [
+                json.dumps(_big_middle_entry("FAILMARK")),  # raises
+                json.dumps(_big_middle_entry("ok")),  # compresses
+            ],
+        )
+
+        async def _raise_on_failmark(self, content, metrics):
+            if "FAILMARK" in content:
+                raise RuntimeError("summarization exploded")
+            metrics.summarization_api_calls += 1
+            return "[CONTEXT SUMMARY]: fake summary"
+
+        monkeypatch.setattr(
+            TrajectoryCompressor, "_generate_summary_async", _raise_on_failmark
+        )
+
+        compressor = _make_compressor(_pipeline_config())
+        compressor.process_directory(input_dir, output_dir)
+
+        out_entries = [
+            json.loads(l)
+            for l in (output_dir / "file1.jsonl").read_text().splitlines()
+        ]
+        assert len(out_entries) == 2
+
+        # The failing entry is preserved in its original (uncompressed) form.
+        failed = next(e for e in out_entries if e["id"] == "FAILMARK")
+        assert failed["conversations"] == _trajectory(
+            ("FAILMARK ") + ("blah " * 200)
+        )
+        # The surviving entry was compressed.
+        ok = next(e for e in out_entries if e["id"] == "ok")
+        assert "compression_metrics" in ok
+
+        assert compressor.aggregate_metrics.trajectories_failed == 1
+        assert compressor.aggregate_metrics.trajectories_compressed == 1
+
+    def test_empty_input_dir_returns_early_no_output(self, tmp_path):
+        """A directory without any .jsonl produces no output dir."""
+        input_dir = tmp_path / "empty_in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+
+        compressor = _make_compressor(_pipeline_config())
+        compressor.process_directory(input_dir, output_dir)
+
+        assert not output_dir.exists()
+        # No trajectories were recorded.
+        assert compressor.aggregate_metrics.total_trajectories == 0
+
+
+# ---------------------------------------------------------------------------
+# _print_summary  (lines ~1271-1377)
+# ---------------------------------------------------------------------------
+
+
+class TestPrintSummary:
+    """_print_summary: report content, not exact formatting."""
+
+    def test_compressed_branch_prints_report(self, capsys):
+        """A report with compressor work shows the headline + Space Savings."""
+        compressor = _make_compressor()
+        aggregate = AggregateMetrics()
+        aggregate.processing_start_time = "2026-01-01T00:00:00"
+        aggregate.processing_end_time = "2026-01-01T00:05:00"
+        aggregate.processing_duration_seconds = 5.0
+        m = TrajectoryMetrics()
+        m.original_tokens = 1000
+        m.compressed_tokens = 500
+        m.tokens_saved = 500
+        m.compression_ratio = 0.5
+        m.original_turns = 10
+        m.compressed_turns = 6
+        m.turns_removed = 4
+        m.was_compressed = True
+        aggregate.add_trajectory_metrics(m)
+        compressor.aggregate_metrics = aggregate
+
+        compressor._print_summary()
+        out = capsys.readouterr().out
+
+        assert "TRAJECTORY COMPRESSION REPORT" in out
+        assert "Total Processed" in out
+        assert "Space Savings" in out
+        # Short duration renders in seconds; throughput line is present.
+        assert "seconds" in out
+
+    def test_no_compressed_branch_prints_message(self, capsys):
+        """With nothing compressed, the report says so instead of crashing."""
+        compressor = _make_compressor()
+        aggregate = AggregateMetrics()
+        aggregate.processing_start_time = "2026-01-01T00:00:00"
+        aggregate.processing_end_time = "2026-01-01T00:01:00"
+        aggregate.processing_duration_seconds = 1.0
+        compressor.aggregate_metrics = aggregate
+
+        compressor._print_summary()
+        out = capsys.readouterr().out
+
+        assert "TRAJECTORY COMPRESSION REPORT" in out
+        assert "No trajectories were compressed" in out
+        # tokens_before == 0, so the Space Savings line must be omitted.
+        assert "Space Savings" not in out
+
+    def test_long_duration_branch_renders_minutes(self, capsys):
+        """A duration over 60s is reported in minutes."""
+        compressor = _make_compressor()
+        aggregate = AggregateMetrics()
+        aggregate.processing_start_time = "2026-01-01T00:00:00"
+        aggregate.processing_end_time = "2026-01-01T01:01:00"
+        aggregate.processing_duration_seconds = 61.0
+        compressor.aggregate_metrics = aggregate
+
+        compressor._print_summary()
+        out = capsys.readouterr().out
+
+        assert "1.0 minutes" in out
+        assert "minutes" in out
+
+
+# ---------------------------------------------------------------------------
+# main()  (lines ~1380-1594)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """main(): the Fire-wrapped CLI entry point.
+
+    TrajectoryCompressor.__init__ normally loads a real HF tokenizer
+    (_init_tokenizer) and builds an LLM client (_init_summarizer).  Both are
+    stubbed so constructing the compressor inside main() is cheap and
+    network-free.  The async summarizer is also stubbed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_compressor_init(self, monkeypatch):
+        def _init_tokenizer(self):
+            self.tokenizer = MagicMock()
+            self.tokenizer.encode = lambda text: [0] * max(1, len(text) // 4)
+
+        def _init_summarizer(self):
+            self._use_call_llm = False
+            self.client = MagicMock()
+            self.async_client = None
+            self._async_client_api_key = "fake"
+
+        async def _generate_summary_async(self, content, metrics):
+            metrics.summarization_api_calls += 1
+            return "[CONTEXT SUMMARY]: fake summary"
+
+        monkeypatch.setattr(TrajectoryCompressor, "_init_tokenizer", _init_tokenizer)
+        monkeypatch.setattr(
+            TrajectoryCompressor, "_init_summarizer", _init_summarizer
+        )
+        monkeypatch.setattr(
+            TrajectoryCompressor, "_generate_summary_async", _generate_summary_async
+        )
+
+    @staticmethod
+    def _missing_config(tmp_path):
+        return str(tmp_path / "does-not-exist.yaml")
+
+    def test_input_not_found_returns_early(self, tmp_path, capsys):
+        """A nonexistent input prints an error and returns without crashing."""
+        ret = main(
+            input=str(tmp_path / "nope.jsonl"),
+            config=self._missing_config(tmp_path),
+        )
+        assert ret is None
+        assert "Input not found" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("bad_pct", [0, 150])
+    def test_invalid_sample_percent_returns_early(self, tmp_path, capsys, bad_pct):
+        """sample_percent outside (1,100) returns with an error message."""
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(input_file, [json.dumps({"id": "a"})])
+
+        ret = main(
+            input=str(input_file),
+            sample_percent=bad_pct,
+            config=self._missing_config(tmp_path),
+        )
+        assert ret is None
+        out = capsys.readouterr().out
+        assert "sample_percent must be between 1 and 100" in out
+
+    def test_file_input_dry_run_creates_no_output(self, tmp_path, capsys):
+        """dry_run on a file prints a preview and writes nothing."""
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(input_file, [json.dumps({"id": "a"})])
+        output_file = tmp_path / "out.jsonl"
+
+        ret = main(
+            input=str(input_file),
+            output=str(output_file),
+            config=self._missing_config(tmp_path),
+            dry_run=True,
+        )
+        assert ret is None
+        assert "DRY RUN MODE" in capsys.readouterr().out
+        assert not output_file.exists()
+
+    def test_directory_input_dry_run_creates_no_output(self, tmp_path, capsys):
+        """dry_run on a directory prints a preview and writes nothing."""
+        input_dir = tmp_path / "in_dir"
+        input_dir.mkdir()
+        _write_jsonl(input_dir / "a.jsonl", [json.dumps({"id": "a"})])
+        output_dir = tmp_path / "out_dir"
+
+        ret = main(
+            input=str(input_dir),
+            output=str(output_dir),
+            config=self._missing_config(tmp_path),
+            dry_run=True,
+        )
+        assert ret is None
+        assert "DRY RUN MODE" in capsys.readouterr().out
+        assert not output_dir.exists()
+
+    def test_file_input_happy_path(self, tmp_path, capsys):
+        """A file input is compressed and the metrics file is copied beside it."""
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(
+            input_file,
+            [
+                json.dumps({"id": "a", "conversations": _trajectory("aa " * 200)}),
+                json.dumps({"id": "b"}),  # no conversations: passes through
+            ],
+        )
+        output_file = tmp_path / "out.jsonl"
+
+        main(
+            input=str(input_file),
+            output=str(output_file),
+            config=self._missing_config(tmp_path),
+        )
+
+        out_entries = [
+            json.loads(l) for l in output_file.read_text().splitlines()
+        ]
+        # The two input entries are both present in the output.
+        assert len(out_entries) == 2
+        assert {e["id"] for e in out_entries} == {"a", "b"}
+        # The file-input path copies the metrics file as <stem>_metrics.json.
+        assert (tmp_path / "out_metrics.json").exists()
+        assert "Compression complete" in capsys.readouterr().out
+
+    def test_directory_input_happy_path(self, tmp_path):
+        """A directory input writes every same-named JSONL into the output dir."""
+        input_dir = tmp_path / "in_dir"
+        input_dir.mkdir()
+        _write_jsonl(input_dir / "a.jsonl", [json.dumps({"id": "a"})])
+        _write_jsonl(input_dir / "b.jsonl", [json.dumps({"id": "b"})])
+        output_dir = tmp_path / "out_dir"
+
+        main(
+            input=str(input_dir),
+            output=str(output_dir),
+            config=self._missing_config(tmp_path),
+        )
+
+        assert (output_dir / "a.jsonl").exists()
+        assert (output_dir / "b.jsonl").exists()
+        assert (
+            json.loads((output_dir / "a.jsonl").read_text().splitlines()[0])["id"]
+            == "a"
+        )
+
+    def test_directory_input_sample_percent(self, tmp_path):
+        """sample_percent in directory mode samples entries from each file."""
+        input_dir = tmp_path / "in_dir"
+        input_dir.mkdir()
+        lots = "x " * 200
+        # 4 entries per file; a 50% sample keeps 2 per file (seed=42).
+        for name in ("a.jsonl", "b.jsonl"):
+            _write_jsonl(
+                input_dir / name,
+                [json.dumps({"id": f"{name}-{i}", "conversations": _trajectory(lots)})
+                 for i in range(4)]
+                + ["{ not json"],  # invalid line sampled-out during load
+            )
+        output_dir = tmp_path / "out_dir"
+
+        main(
+            input=str(input_dir),
+            output=str(output_dir),
+            config=self._missing_config(tmp_path),
+            sample_percent=50,
+        )
+
+        for name in ("a.jsonl", "b.jsonl"):
+            entries = [
+                json.loads(l)
+                for l in (output_dir / name).read_text().splitlines()
+            ]
+            assert len(entries) == 2
+
+    def test_file_input_default_output_and_cli_overrides(
+        self, tmp_path, capsys
+    ):
+        """Config-found branch, CLI overrides, and output=None default path."""
+        config_path = tmp_path / "cfg.yaml"
+        config_path.write_text("compression:\n  target_max_tokens: 40\n", encoding="utf-8")
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(input_file, [json.dumps({"id": "a", "conversations": _trajectory("aa " * 200)})])
+
+        # output=None -> default <stem>_compressed.jsonl beside the input.
+        main(
+            input=str(input_file),
+            config=str(config_path),
+            target_max_tokens=40,
+            tokenizer="fake-tokenizer",
+        )
+
+        default_out = tmp_path / "in_compressed.jsonl"
+        assert default_out.exists()
+        out = capsys.readouterr().out
+        assert "Loading config from" in out
+        # The entry was compressed (target ~40 < trajectory tokens), so the
+        # output differs from the input and the metrics file was copied.
+        assert (tmp_path / "in_compressed_metrics.json").exists()
+
+    def test_file_input_skips_invalid_json(self, tmp_path, capsys):
+        """A malformed JSON line is skipped and reported."""
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(
+            input_file,
+            [json.dumps({"id": "a"}), "{ not json"],
+        )
+        output_file = tmp_path / "out.jsonl"
+
+        main(
+            input=str(input_file),
+            output=str(output_file),
+            config=self._missing_config(tmp_path),
+        )
+
+        out_entries = [json.loads(l) for l in output_file.read_text().splitlines()]
+        assert len(out_entries) == 1
+        assert out_entries[0]["id"] == "a"
+        assert "Skipping invalid JSON" in capsys.readouterr().out
+
+    def test_file_input_sample_percent(self, tmp_path, capsys):
+        """sample_percent in file mode samples from the loaded entries."""
+        input_file = tmp_path / "in.jsonl"
+        _write_jsonl(
+            input_file,
+            [json.dumps({"id": f"e{i}", "conversations": _trajectory("x " * 200)}) for i in range(4)],
+        )
+        output_file = tmp_path / "out.jsonl"
+
+        main(
+            input=str(input_file),
+            output=str(output_file),
+            config=self._missing_config(tmp_path),
+            sample_percent=50,
+        )
+
+        out_entries = [json.loads(l) for l in output_file.read_text().splitlines()]
+        # 4 entries x 50% -> 2 sampled entries.
+        assert len(out_entries) == 2
+        assert "Sampled" in capsys.readouterr().out
+
+    def test_directory_input_default_output(self, tmp_path):
+        """output=None for a directory defaults to <name>_compressed."""
+        input_dir = tmp_path / "data"
+        input_dir.mkdir()
+        _write_jsonl(input_dir / "a.jsonl", [json.dumps({"id": "a"})])
+
+        main(
+            input=str(input_dir),
+            config=self._missing_config(tmp_path),
+        )
+
+        default_out = tmp_path / "data_compressed"
+        assert (default_out / "a.jsonl").exists()
+
+    def test_directory_sample_percent_dry_run_no_output(self, tmp_path, capsys):
+        """dry_run in sampled-directory mode returns without writing."""
+        input_dir = tmp_path / "in_dir"
+        input_dir.mkdir()
+        _write_jsonl(
+            input_dir / "a.jsonl",
+            [json.dumps({"id": f"a-{i}", "conversations": _trajectory("x " * 200)}) for i in range(4)],
+        )
+        output_dir = tmp_path / "out_dir"
+
+        ret = main(
+            input=str(input_dir),
+            output=str(output_dir),
+            config=self._missing_config(tmp_path),
+            sample_percent=50,
+            dry_run=True,
+        )
+        assert ret is None
+        assert "DRY RUN MODE" in capsys.readouterr().out
+        assert not output_dir.exists()


### PR DESCRIPTION
## Summary

Brings `trajectory_compressor.py` from **42% to 98%** statement coverage (780 stmts, 14 missed) by adding three new test files with 88 tests total. The 70% threshold requested in #36610 is exceeded by 28 percentage points.

The 14 remaining uncovered lines are all unreachable through the public API:
- **819–820, 946–947**: dead code — the `if accumulated_tokens < target and compress_until < compress_end` guard is unsatisfiable after the accumulation loop (the loop always sets `compress_until == compress_end` before exiting)
- **1175–1188**: `asyncio.TimeoutError` branch in `_process_directory_async` (requires a hung stub)
- **387**: one `_init_summarizer` error branch
- **1598**: `if __name__ == "__main__": fire.Fire(main)` (unreachable in-process)

## What's tested

| File | Covers | Tests |
|------|--------|-------|
| `tests/test_trajectory_compressor_init_summary.py` | `_effective_temperature_for_model`, `_init_tokenizer`, `_init_summarizer` (provider + custom endpoint + missing key), `_detect_provider` (all 9 host mappings), `count_tokens` fallback, `_generate_summary` + `_generate_summary_async` (call_llm path, raw client, retry, exhaustion fallback) | 32 |
| `tests/test_trajectory_compressor_compress.py` | `compress_trajectory` + `compress_trajectory_async` (under-target skip, empty region, happy path, whole-region fallback, snap-collapse, tiny-region guard), `_find_protected_indices`, `_snap_boundary`, `_extract_turn_content_for_summary` | 28 |
| `tests/test_trajectory_compressor_pipeline.py` | `process_entry` + `process_entry_async`, `_process_directory_async` (happy/error/empty paths), `_print_summary` (compressed + no-compressed + duration>60 branches), `main()` CLI (file/dir input, dry-run, sampling, invalid input, missing config, metrics file copy) | 28 |

## Verification

```
117 passed in 156.12s
trajectory_compressor.py     780     14    98%
```

All tests hermetic — no network, no HF tokenizer downloads, no API keys. Uses the established `__new__` idiom to bypass heavy `__init__`.

## Notes

- **Relation to #45470**: This PR is independent of @Bartok9's helper-coverage PR #45470 (which targets `_is_boundary_clean`, `_coerce_summary_content`, `_ensure_summary_prefix`, `_effective_temperature_for_model`). Those helpers are already covered on current `main` except `_effective_temperature_for_model` lines 71–72/78, which this PR also covers. No conflict — disjoint test files.
- **Dead code at 819–820 / 946–947**: Both reviewers (Gemini 3.7 Flash, GPT-OSS 120B) independently confirmed these branches are unreachable. A production-code cleanup to remove them would be a separate PR.

Closes #36610
