### PR TITLE
feat(agent): add README context fallback

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -325,6 +325,42 @@ class SubdirectoryHintTracker:
             except Exception as exc:
                 logger.debug("Could not read %s: %s", hint_path, exc)
 
+        # A README is descriptive documentation, not an instruction file. Only
+        # use it when this directory has no authoritative context hint, and
+        # label it explicitly so it cannot silently take the same priority.
+        if not found_hints:
+            readme_path = directory / "README.md"
+            try:
+                if readme_path.is_file():
+                    content = readme_path.read_text(encoding="utf-8").strip()
+                    if content:
+                        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                        if digest not in self._loaded_digests:
+                            self._loaded_digests.add(digest)
+                            content = _scan_context_content(content, "README.md")
+                            if len(content) > _MAX_HINT_CHARS:
+                                content = (
+                                    content[:_MAX_HINT_CHARS]
+                                    + f"\n\n[...truncated README.md: {len(content):,} chars total]"
+                                )
+                            rel_path = str(readme_path)
+                            try:
+                                rel_path = str(readme_path.relative_to(self.working_dir))
+                            except (ValueError, RuntimeError):
+                                try:
+                                    rel_path = "~/" + readme_path.relative_to(Path.home()).as_posix()
+                                except (ValueError, RuntimeError):
+                                    pass
+                            found_hints.append(
+                                (
+                                    rel_path,
+                                    "[README.md contextual documentation; not project instructions]\n"
+                                    + content,
+                                )
+                            )
+            except Exception as exc:
+                logger.debug("Could not read %s: %s", readme_path, exc)
+
         if not found_hints:
             return None
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -297,3 +297,47 @@ class TestExcludedDirectories:
         assert result is not None
         assert "Personal backend override" in result
         assert "Committed backend rules" not in result
+
+    def test_readme_is_loaded_as_labeled_context_without_hints(self, tmp_path):
+        """README.md supplies bounded context when no instruction file exists."""
+        sub = tmp_path / "docs"
+        sub.mkdir()
+        (sub / "README.md").write_text("Documentation for this subtree")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call("read_file", {"path": str(sub / "guide.md")})
+
+        assert result is not None
+        assert "Documentation for this subtree" in result
+        assert "contextual documentation; not project instructions" in result
+
+    def test_authoritative_hint_suppresses_readme(self, tmp_path):
+        """An instruction hint keeps priority over descriptive README content."""
+        sub = tmp_path / "backend"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Backend instructions")
+        (sub / "README.md").write_text("Backend documentation")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call("read_file", {"path": str(sub / "app.py")})
+
+        assert result is not None
+        assert "Backend instructions" in result
+        assert "Backend documentation" not in result
+
+    def test_identical_readme_content_is_deduplicated(self, tmp_path):
+        """Identical README copies do not consume context twice."""
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        (first / "README.md").write_text("Shared documentation")
+        (second / "README.md").write_text("Shared documentation")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        first_result = tracker.check_tool_call("read_file", {"path": str(first / "a.py")})
+        second_result = tracker.check_tool_call("read_file", {"path": str(second / "b.py")})
+
+        assert first_result is not None
+        assert "Shared documentation" in first_result
+        assert second_result is None

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -66,6 +66,8 @@ This approach has two advantages over loading everything at startup:
 
 Each subdirectory is checked at most once per session. The discovery also walks up parent directories, so reading `backend/src/main.py` will discover `backend/AGENTS.md` even if `backend/src/` has no context file of its own.
 
+If a visited subdirectory has no `AGENTS.md`, `CLAUDE.md`, or `.cursorrules`, Hermes may include its `README.md` as **contextual documentation**. README content is explicitly labeled as descriptive material, does not override project instructions, and is processed through the same prompt-injection scan and size limit.
+
 :::info
 Subdirectory context files go through the same [security scan](#security-prompt-injection-protection) as startup context files. Malicious files are blocked.
 :::


### PR DESCRIPTION
Use a subdirectory README.md as bounded contextual documentation only when no AGENTS.md, CLAUDE.md, or .cursorrules exists. Preserve the existing security scan, 8000-character limit, workspace boundary, and digest deduplication; label README content as non-instruction documentation. Update context-files.md and add three behavioral tests. scripts/run_tests.sh tests/agent/test_subdirectory_hints.py -q passes 29 tests; Windows footgun scan, py_compile, and git diff --check pass. Separate from open PR #47198, which only caps combined hint output.