### PR TITLE
feat(models): add provider-scoped model exclusions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1575,6 +1575,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # transient empty model resolution (#35314) instead of building an
         # agent with model="" that 400s every call until manual retry.
         self._last_resolved_model: Dict[str, str] = {}
+        self._last_resolved_provider: Dict[str, str] = {}
         self._session_db_lock: Optional[asyncio.Lock] = None  # Single-flight for lazy init
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
@@ -3074,16 +3075,28 @@ class APIServerAdapter(BasePlatformAdapter):
         # stateless request, growing unbounded for the life of the process.
         _resolved_key = gateway_session_key or ""
         if not model:
-            _recovered = (self._last_resolved_model.get(_resolved_key)
-                          or self._last_resolved_model.get("*"))
+            _recovery_key = (
+                _resolved_key
+                if self._last_resolved_model.get(_resolved_key)
+                else "*"
+            )
+            _recovered = self._last_resolved_model.get(_recovery_key)
+            _recovered_provider = self._last_resolved_provider.get(
+                _recovery_key, ""
+            )
+            _policy_provider = _recovered_provider or str(
+                runtime_kwargs.get("provider") or ""
+            )
             if _recovered:
-                from hermes_cli.model_catalog import is_automatic_model_excluded
+                from hermes_cli.model_catalog import resolve_automatic_model_recovery
 
-                if is_automatic_model_excluded(
-                    runtime_kwargs.get("provider", ""), _recovered
-                ):
-                    _recovered = ""
+                _recovered = resolve_automatic_model_recovery(
+                    _policy_provider,
+                    _recovered,
+                )
             if _recovered and _recovered != self._model_name:
+                if _policy_provider and not runtime_kwargs.get("provider"):
+                    runtime_kwargs["provider"] = _policy_provider
                 logger.warning(
                     "Empty model resolved for session=%s — recovering "
                     "last-known-good model %s (config read likely returned "
@@ -3091,11 +3104,19 @@ class APIServerAdapter(BasePlatformAdapter):
                     _resolved_key, _recovered,
                 )
                 model = _recovered
-        elif model:
-            if model != self._model_name:
                 if _resolved_key:
                     self._last_resolved_model[_resolved_key] = model
+                    self._last_resolved_provider[_resolved_key] = _policy_provider
                 self._last_resolved_model["*"] = model
+                self._last_resolved_provider["*"] = _policy_provider
+        elif model:
+            if model != self._model_name:
+                _provider = str(runtime_kwargs.get("provider") or "")
+                if _resolved_key:
+                    self._last_resolved_model[_resolved_key] = model
+                    self._last_resolved_provider[_resolved_key] = _provider
+                self._last_resolved_model["*"] = model
+                self._last_resolved_provider["*"] = _provider
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3076,6 +3076,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if not model:
             _recovered = (self._last_resolved_model.get(_resolved_key)
                           or self._last_resolved_model.get("*"))
+            if _recovered:
+                from hermes_cli.model_catalog import is_automatic_model_excluded
+
+                if is_automatic_model_excluded(
+                    runtime_kwargs.get("provider", ""), _recovered
+                ):
+                    _recovered = ""
             if _recovered and _recovered != self._model_name:
                 logger.warning(
                     "Empty model resolved for session=%s — recovering "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2888,6 +2888,7 @@ _CONVERSATION_SCOPED_STATE: tuple = (
     "_session_service_tier_overrides",
     "_pending_model_notes",
     "_last_resolved_model",
+    "_last_resolved_provider",
     "_queued_events",
     # Stall-watchdog "already notified" latch (#72016). Cleared on /new so a
     # fresh conversation can warn again if it later stalls with pending inbound.
@@ -7052,6 +7053,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "_session_service_tier_overrides"
     )
     _last_resolved_model = legacy_dict_property("_last_resolved_model")
+    _last_resolved_provider = legacy_dict_property("_last_resolved_provider")
     _queued_events = legacy_dict_property("_queued_events")
     _pending_turn_sidecar_notes = legacy_dict_property("_pending_turn_sidecar_notes")
     _pending_messages = legacy_dict_property("_pending_messages")
@@ -8471,20 +8473,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else None
             )
             _lr_star = self._peek_session_state("*")
+            _recovery_state = (
+                _lr_state
+                if _lr_state and _lr_state.conversation.last_resolved_model
+                else _lr_star
+            )
             _recovered = (
-                (_lr_state.conversation.last_resolved_model if _lr_state else "")
-                or (_lr_star.conversation.last_resolved_model if _lr_star else "")
+                _recovery_state.conversation.last_resolved_model
+                if _recovery_state
+                else ""
+            )
+            _recovered_provider = (
+                _recovery_state.conversation.last_resolved_provider
+                if _recovery_state
+                else ""
+            )
+            _policy_provider = _recovered_provider or str(
+                runtime_kwargs.get("provider") or ""
             )
             if _recovered:
-                from hermes_cli.model_catalog import is_automatic_model_excluded
+                from hermes_cli.model_catalog import resolve_automatic_model_recovery
 
-                if is_automatic_model_excluded(
-                    runtime_kwargs.get("provider", ""),
+                _recovered = resolve_automatic_model_recovery(
+                    _policy_provider,
                     _recovered,
                     user_config,
-                ):
-                    _recovered = ""
+                )
             if _recovered:
+                if _policy_provider and not runtime_kwargs.get("provider"):
+                    runtime_kwargs["provider"] = _policy_provider
                 logger.warning(
                     "Empty model resolved for session=%s — recovering "
                     "last-known-good model %s (config read likely returned "
@@ -8492,13 +8509,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolved_session_key or "", _recovered,
                 )
                 model = _recovered
+                if resolved_session_key:
+                    _state = self._session_state(resolved_session_key).conversation
+                    _state.last_resolved_model = model
+                    _state.last_resolved_provider = _policy_provider
+                _star = self._session_state("*").conversation
+                _star.last_resolved_model = model
+                _star.last_resolved_provider = _policy_provider
         elif model:
             # Cache the good resolution for future recovery turns.
             if resolved_session_key:
-                self._session_state(
-                    resolved_session_key
-                ).conversation.last_resolved_model = model
-            self._session_state("*").conversation.last_resolved_model = model
+                _state = self._session_state(resolved_session_key).conversation
+                _state.last_resolved_model = model
+                _state.last_resolved_provider = str(
+                    runtime_kwargs.get("provider") or ""
+                )
+            _star = self._session_state("*").conversation
+            _star.last_resolved_model = model
+            _star.last_resolved_provider = str(
+                runtime_kwargs.get("provider") or ""
+            )
 
         return model, runtime_kwargs
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8476,6 +8476,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 or (_lr_star.conversation.last_resolved_model if _lr_star else "")
             )
             if _recovered:
+                from hermes_cli.model_catalog import is_automatic_model_excluded
+
+                if is_automatic_model_excluded(
+                    runtime_kwargs.get("provider", ""),
+                    _recovered,
+                    user_config,
+                ):
+                    _recovered = ""
+            if _recovered:
                 logger.warning(
                     "Empty model resolved for session=%s — recovering "
                     "last-known-good model %s (config read likely returned "

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -101,6 +101,8 @@ class ConversationState:
     service_tier_override: Any = _UNSET_TIER
     # Last successfully-resolved non-empty model (#35314 recovery).
     last_resolved_model: str = ""
+    # Provider paired with last_resolved_model for provider-scoped policy.
+    last_resolved_provider: str = ""
     # /queue overflow FIFO (adapter slot holds the head).
     queued_events: List[Any] = field(default_factory=list)
     # Per-turn must-deliver sidecar notes (one-shot).
@@ -122,6 +124,7 @@ class ConversationState:
         self.reasoning_override = None
         self.service_tier_override = _UNSET_TIER
         self.last_resolved_model = ""
+        self.last_resolved_provider = ""
         self.queued_events = []
         self.sidecar_notes = []
         self.ephemeral_pin = None
@@ -386,6 +389,9 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_last_resolved_model": _FieldSpec(
         "conversation", "last_resolved_model", str, _present_nonzero
+    ),
+    "_last_resolved_provider": _FieldSpec(
+        "conversation", "last_resolved_provider", str, _present_nonzero
     ),
     "_queued_events": _FieldSpec("conversation", "queued_events", list, _present_nonzero),
     "_pending_turn_sidecar_notes": _FieldSpec(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7748,6 +7748,20 @@ def _prompt_model_selection(
         compute_sale_discount,
     )
 
+    if confirm_provider:
+        from hermes_cli.model_catalog import (
+            filter_model_catalog_exclusions,
+            get_model_catalog_exclusions,
+        )
+
+        excluded_models = get_model_catalog_exclusions()
+        model_ids = filter_model_catalog_exclusions(
+            confirm_provider, model_ids, excluded_models
+        )
+        unavailable_models = filter_model_catalog_exclusions(
+            confirm_provider, unavailable_models or [], excluded_models
+        )
+
     _unavailable = unavailable_models or []
     # Sale chrome (★ / -N% / was) is Nous Portal-only — never for OpenRouter
     # or other providers even if pricing.original is somehow present.
@@ -7755,6 +7769,14 @@ def _prompt_model_selection(
 
     def _confirmed_selection(mid: str) -> Optional[str]:
         if not mid:
+            return None
+        if confirm_provider and not filter_model_catalog_exclusions(
+            confirm_provider, [mid], excluded_models
+        ):
+            print(
+                f"Model {mid!r} is excluded by "
+                f"model_catalog.excluded_models.{confirm_provider}."
+            )
             return None
         # Unified guard registry (hermes_cli.model_selection_guards): the cost
         # guard only runs when a provider is known (pricing lookups need one);

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3043,6 +3043,9 @@ DEFAULT_CONFIG = {
         #     openrouter:
         #       url: https://example.com/my-curation.json
         "providers": {},
+        # Provider-scoped model IDs hidden from merged pickers and skipped by
+        # automatic defaults/fallbacks. Raw upstream caches stay untouched.
+        "excluded_models": {},
     },
 
     # Per-model metadata overrides — manually declare context_window,

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -87,11 +87,21 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """
 
     config = config or {}
+    from hermes_cli.model_catalog import (
+        filter_model_catalog_exclusions,
+        get_model_catalog_exclusions,
+    )
+
+    excluded_models = get_model_catalog_exclusions(config)
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 
     for key in ("fallback_providers", "fallback_model"):
         for entry in _iter_fallback_entries(config.get(key)):
+            if not filter_model_catalog_exclusions(
+                entry["provider"], [entry["model"]], excluded_models
+            ):
+                continue
             identity = _entry_identity(entry)
             if identity in seen:
                 continue

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -53,6 +53,7 @@ class ConfigContext:
     user_providers: dict
     custom_providers: list
     excluded_providers: list = None
+    excluded_models: dict = None
 
     def with_overrides(
         self,
@@ -103,7 +104,11 @@ def load_picker_context() -> ConfigContext:
         current_model = str(model_cfg) if model_cfg else ""
         current_provider = ""
         current_base_url = ""
-    excluded = cfg.get("model_catalog", {}).get("excluded_providers") or []
+    catalog_cfg = cfg.get("model_catalog")
+    if not isinstance(catalog_cfg, dict):
+        catalog_cfg = {}
+    excluded = catalog_cfg.get("excluded_providers") or []
+    excluded_models = catalog_cfg.get("excluded_models") or {}
     return ConfigContext(
         current_provider=current_provider,
         current_model=current_model,
@@ -111,6 +116,9 @@ def load_picker_context() -> ConfigContext:
         user_providers=stringify_provider_map(cfg.get("providers")),
         custom_providers=get_compatible_custom_providers(cfg),
         excluded_providers=excluded if isinstance(excluded, list) else [],
+        excluded_models=(
+            excluded_models if isinstance(excluded_models, dict) else {}
+        ),
     )
 
 
@@ -268,6 +276,9 @@ def build_models_payload(
 
     if include_unconfigured:
         rows = list(rows) + [r for r in _append_unconfigured_rows(rows, ctx) if str(r.get("slug", "")).lower() != "moa"]
+    from hermes_cli.model_catalog import filter_model_catalog_rows
+
+    rows = filter_model_catalog_rows(rows, ctx.excluded_models or {})
     if picker_hints:
         _apply_picker_hints(rows)
     if canonical_order:

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -112,6 +112,104 @@ def _load_catalog_config() -> dict[str, Any]:
     }
 
 
+def get_model_catalog_exclusions(
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the provider-scoped local model exclusion policy."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config() or {}
+        except Exception:
+            return {}
+    raw = config.get("model_catalog") if isinstance(config, dict) else None
+    if not isinstance(raw, dict):
+        return {}
+    excluded = raw.get("excluded_models")
+    return dict(excluded) if isinstance(excluded, dict) else {}
+
+
+def filter_model_catalog_exclusions(
+    provider: str,
+    model_ids: list[str],
+    excluded_models: Any,
+) -> list[str]:
+    """Return a copy without exact, case-insensitive provider/model matches."""
+    if not isinstance(excluded_models, dict):
+        return list(model_ids or [])
+    provider_key = str(provider or "").strip().lower()
+    blocked: set[str] = set()
+    for configured_provider, configured_models in excluded_models.items():
+        if str(configured_provider or "").strip().lower() != provider_key:
+            continue
+        if not isinstance(configured_models, list):
+            continue
+        blocked.update(
+            model_id.strip().lower()
+            for model_id in configured_models
+            if isinstance(model_id, str) and model_id.strip()
+        )
+    return [
+        model_id
+        for model_id in (model_ids or [])
+        if str(model_id).strip().lower() not in blocked
+    ]
+
+
+def is_automatic_model_excluded(
+    provider: str,
+    model_id: str,
+    config: dict[str, Any] | None = None,
+) -> bool:
+    """Apply local policy to an automatic model, even after config loss."""
+    policy_config = (
+        config
+        if isinstance(config, dict)
+        and isinstance(config.get("model_catalog"), dict)
+        else None
+    )
+    policy = get_model_catalog_exclusions(policy_config)
+    provider_id = str(provider or "").strip()
+    if provider_id:
+        return not filter_model_catalog_exclusions(
+            provider_id, [model_id], policy
+        )
+    return any(
+        not filter_model_catalog_exclusions(
+            str(candidate), [model_id], policy
+        )
+        for candidate in policy
+    )
+
+
+def filter_model_catalog_rows(
+    rows: list[dict[str, Any]],
+    excluded_models: Any,
+) -> list[dict[str, Any]]:
+    """Filter merged picker rows without mutating cache-backed row data."""
+    filtered_rows: list[dict[str, Any]] = []
+    for row in rows or []:
+        models = list(row.get("models") or [])
+        visible = filter_model_catalog_exclusions(
+            str(row.get("slug") or ""), models, excluded_models
+        )
+        if len(visible) == len(models):
+            filtered_rows.append(row)
+            continue
+        filtered = dict(row)
+        filtered["models"] = visible
+        total = row.get("total_models")
+        removed = len(models) - len(visible)
+        filtered["total_models"] = (
+            max(len(visible), total - removed)
+            if isinstance(total, int)
+            else len(visible)
+        )
+        filtered_rows.append(filtered)
+    return filtered_rows
+
+
 def _cache_path() -> Path:
     """Return the disk cache path. Import lazily so tests can monkeypatch home."""
     from hermes_constants import get_hermes_home

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -171,16 +171,47 @@ def is_automatic_model_excluded(
     )
     policy = get_model_catalog_exclusions(policy_config)
     provider_id = str(provider or "").strip()
-    if provider_id:
-        return not filter_model_catalog_exclusions(
-            provider_id, [model_id], policy
+    if not provider_id:
+        return False
+    return not filter_model_catalog_exclusions(provider_id, [model_id], policy)
+
+
+def resolve_automatic_model_recovery(
+    provider: str,
+    model_id: str,
+    config: dict[str, Any] | None = None,
+) -> str:
+    """Keep an allowed recovery model or select the next allowed local route."""
+    provider_id = str(provider or "").strip()
+    model = str(model_id or "").strip()
+    if not model or not is_automatic_model_excluded(provider_id, model, config):
+        return model
+
+    candidates: list[str] = []
+    try:
+        from hermes_cli.models import get_default_model_for_provider
+
+        candidates.append(get_default_model_for_provider(provider_id))
+    except Exception:
+        pass
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        candidates.extend(
+            str(entry.get("model") or "")
+            for entry in get_fallback_chain(config)
+            if str(entry.get("provider") or "").strip().lower()
+            == provider_id.lower()
         )
-    return any(
-        not filter_model_catalog_exclusions(
-            str(candidate), [model_id], policy
-        )
-        for candidate in policy
-    )
+    except Exception:
+        pass
+
+    for candidate in candidates:
+        if candidate and not is_automatic_model_excluded(
+            provider_id, candidate, config
+        ):
+            return candidate
+    return ""
 
 
 def filter_model_catalog_rows(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3996,6 +3996,10 @@ def list_picker_providers(
     The typed ``/model <name>`` path is unaffected -- only the interactive
     picker payload is narrowed.
     """
+    from hermes_cli.model_catalog import (
+        filter_model_catalog_rows,
+        get_model_catalog_exclusions,
+    )
     from hermes_cli.models import fetch_openrouter_models
 
     providers = list_authenticated_providers(
@@ -4011,6 +4015,7 @@ def list_picker_providers(
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
+    excluded_models = get_model_catalog_exclusions()
     filtered: List[dict] = []
     for p in providers:
         slug = str(p.get("slug", "")).lower()
@@ -4024,6 +4029,7 @@ def list_picker_providers(
             p["models"] = live_ids[:max_models] if max_models is not None else live_ids
             p["total_models"] = len(live_ids)
 
+        p = filter_model_catalog_rows([p], excluded_models)[0]
         has_models = bool(p.get("models"))
         is_custom_endpoint = bool(p.get("is_user_defined")) and bool(p.get("api_url"))
         if not has_models and not is_custom_endpoint:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1616,6 +1616,14 @@ def pick_silent_default_model(model_ids: list[str], provider: str = "openrouter"
     model on the user's behalf without an interactive picker (GUI onboarding
     recommended-default, empty-model runtime fallback).
     """
+    from hermes_cli.model_catalog import (
+        filter_model_catalog_exclusions,
+        get_model_catalog_exclusions,
+    )
+
+    model_ids = filter_model_catalog_exclusions(
+        provider, model_ids, get_model_catalog_exclusions()
+    )
     preferred = get_preferred_silent_default_model(provider)
     if preferred in model_ids:
         return preferred
@@ -1657,13 +1665,27 @@ def get_default_model_for_provider(provider: str) -> str:
     catalog-labeled default instead; a missing model must never auto-escalate
     to the flagship.
     """
-    models = _PROVIDER_MODELS.get(provider, [])
+    from hermes_cli.model_catalog import (
+        filter_model_catalog_exclusions,
+        get_model_catalog_exclusions,
+    )
+
+    excluded_models = get_model_catalog_exclusions()
+    models = filter_model_catalog_exclusions(
+        provider, _PROVIDER_MODELS.get(provider, []), excluded_models
+    )
     if provider in _SILENT_DEFAULT_PROVIDERS:
         preferred = get_preferred_silent_default_model(provider)
         # Trust the preferred default even when the provider has no static
         # catalog (OpenRouter's picker list is fetched live; its curated
         # snapshot carries the default).
-        if preferred and (preferred in models or not models):
+        if (
+            preferred
+            and filter_model_catalog_exclusions(
+                provider, [preferred], excluded_models
+            )
+            and (preferred in models or not models)
+        ):
             return preferred
     return models[0] if models else ""
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2974,7 +2974,7 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
-    def test_create_agent_does_not_recover_locally_excluded_model(
+    def test_create_agent_replaces_locally_excluded_cached_pair(
         self, monkeypatch,
     ):
         captured = []
@@ -2997,20 +2997,23 @@ class TestCreateAgentModelRecovery:
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
         adapter._last_resolved_model["ch"] = "glm-4.5-air"
+        adapter._last_resolved_provider["ch"] = "zai"
 
         monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
         monkeypatch.setattr(
             "gateway.run._resolve_runtime_agent_kwargs",
-            lambda: {"provider": "zai", "base_url": None, "api_mode": None},
+            lambda: {"provider": None, "base_url": None, "api_mode": None},
         )
         monkeypatch.setattr(
             "hermes_cli.models.get_default_model_for_provider",
-            lambda _provider: "",
+            lambda provider: "glm-5.3-flash" if provider == "zai" else "",
         )
 
         adapter._create_agent(session_id="s1", gateway_session_key="ch")
 
-        assert captured[0]["model"] == ""
+        assert captured[0]["model"] == "glm-5.3-flash"
+        assert captured[0]["provider"] == "zai"
+        assert adapter._last_resolved_provider["ch"] == "zai"
 
     # ── Recovery-net alias guards (PR for #79101) ──────────────────────
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2974,6 +2974,44 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
+    def test_create_agent_does_not_recover_locally_excluded_model(
+        self, monkeypatch,
+    ):
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        _patch_create_agent_runtime(monkeypatch, {}, FakeAgent)
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model_catalog": {
+                    "excluded_models": {"zai": ["glm-4.5-air"]}
+                }
+            },
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        adapter._last_resolved_model["ch"] = "glm-4.5-air"
+
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "zai", "base_url": None, "api_mode": None},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.get_default_model_for_provider",
+            lambda _provider: "",
+        )
+
+        adapter._create_agent(session_id="s1", gateway_session_key="ch")
+
+        assert captured[0]["model"] == ""
+
     # ── Recovery-net alias guards (PR for #79101) ──────────────────────
 
     def test_create_agent_does_not_cache_virtual_alias(self, monkeypatch):

--- a/tests/gateway/test_empty_model_recovery.py
+++ b/tests/gateway/test_empty_model_recovery.py
@@ -58,6 +58,29 @@ def test_empty_model_recovers_session_last_good(monkeypatch):
     assert model == "deepseek/deepseek-v4-flash", "recovery turn must reuse last-known-good, not build model=''"
 
 
+def test_empty_model_does_not_recover_locally_excluded_model(monkeypatch):
+    runner = _make_runner()
+    sk = "agent:main:discord:dm:retired"
+    config = {
+        "model_catalog": {"excluded_models": {"zai": ["glm-4.5-air"]}}
+    }
+
+    _patch_resolution(
+        monkeypatch,
+        model_from_config="glm-4.5-air",
+        provider="zai",
+    )
+    runner._resolve_session_agent_runtime(session_key=sk, user_config=config)
+
+    _patch_resolution(monkeypatch, model_from_config="", provider="")
+    model, _ = runner._resolve_session_agent_runtime(
+        session_key=sk,
+        user_config=config,
+    )
+
+    assert model == ""
+
+
 def test_bare_runner_without_cache_attr_does_not_crash(monkeypatch):
     """object.__new__ runners (test helpers / pitfall #17) lack _last_resolved_model.
 
@@ -88,5 +111,4 @@ def test_has_pending_fallback_empty_chain():
     agent._fallback_chain = []
     agent._fallback_index = 0
     assert agent._has_pending_fallback() is False
-
 

--- a/tests/gateway/test_empty_model_recovery.py
+++ b/tests/gateway/test_empty_model_recovery.py
@@ -58,7 +58,7 @@ def test_empty_model_recovers_session_last_good(monkeypatch):
     assert model == "deepseek/deepseek-v4-flash", "recovery turn must reuse last-known-good, not build model=''"
 
 
-def test_empty_model_does_not_recover_locally_excluded_model(monkeypatch):
+def test_empty_model_replaces_locally_excluded_cached_pair(monkeypatch):
     runner = _make_runner()
     sk = "agent:main:discord:dm:retired"
     config = {
@@ -72,13 +72,43 @@ def test_empty_model_does_not_recover_locally_excluded_model(monkeypatch):
     )
     runner._resolve_session_agent_runtime(session_key=sk, user_config=config)
 
+    monkeypatch.setattr(
+        "hermes_cli.models.get_default_model_for_provider",
+        lambda provider: "glm-5.3-flash" if provider == "zai" else "",
+    )
+    _patch_resolution(monkeypatch, model_from_config="", provider="")
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key=sk,
+        user_config=config,
+    )
+
+    assert model == "glm-5.3-flash"
+    assert runtime["provider"] == "zai"
+    assert runner._last_resolved_provider[sk] == "zai"
+
+
+def test_providerless_recovery_preserves_cached_provider_scope(monkeypatch):
+    runner = _make_runner()
+    sk = "agent:main:discord:dm:provider-scope"
+    config = {
+        "model_catalog": {"excluded_models": {"zai": ["shared-name"]}}
+    }
+
+    _patch_resolution(
+        monkeypatch,
+        model_from_config="shared-name",
+        provider="openrouter",
+    )
+    runner._resolve_session_agent_runtime(session_key=sk, user_config=config)
+
     _patch_resolution(monkeypatch, model_from_config="", provider="")
     model, _ = runner._resolve_session_agent_runtime(
         session_key=sk,
         user_config=config,
     )
 
-    assert model == ""
+    assert model == "shared-name"
+    assert runner._last_resolved_provider[sk] == "openrouter"
 
 
 def test_bare_runner_without_cache_attr_does_not_crash(monkeypatch):
@@ -111,4 +141,3 @@ def test_has_pending_fallback_empty_chain():
     agent._fallback_chain = []
     agent._fallback_index = 0
     assert agent._has_pending_fallback() is False
-

--- a/tests/hermes_cli/test_model_catalog_exclusions.py
+++ b/tests/hermes_cli/test_model_catalog_exclusions.py
@@ -9,7 +9,10 @@ POLICY = {"zai": [RETIRED]}
 
 
 def test_filter_is_exact_provider_scoped_and_fail_open():
-    from hermes_cli.model_catalog import filter_model_catalog_exclusions
+    from hermes_cli.model_catalog import (
+        filter_model_catalog_exclusions,
+        is_automatic_model_excluded,
+    )
 
     assert filter_model_catalog_exclusions(
         "ZAI", [RETIRED.upper(), CURRENT], POLICY
@@ -20,6 +23,38 @@ def test_filter_is_exact_provider_scoped_and_fail_open():
     assert filter_model_catalog_exclusions(
         "zai", [RETIRED, CURRENT], {"zai": RETIRED}
     ) == [RETIRED, CURRENT]
+    assert not is_automatic_model_excluded(
+        "",
+        RETIRED,
+        {"model_catalog": {"excluded_models": POLICY}},
+    )
+
+
+def test_messaging_picker_applies_shared_exclusion_policy(monkeypatch):
+    from hermes_cli.model_switch import list_picker_providers
+
+    source_rows = [
+        {
+            "slug": "zai",
+            "name": "Z.AI",
+            "models": [RETIRED, CURRENT],
+            "total_models": 2,
+        }
+    ]
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **_kwargs: source_rows,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_catalog": {"excluded_models": POLICY}},
+    )
+
+    rows = list_picker_providers()
+
+    assert rows[0]["models"] == [CURRENT]
+    assert rows[0]["total_models"] == 1
+    assert source_rows[0]["models"] == [RETIRED, CURRENT]
 
 
 def test_merged_inventory_hides_retired_model_without_mutating_source():
@@ -57,6 +92,20 @@ def test_merged_inventory_hides_retired_model_without_mutating_source():
     assert source_rows[0]["models"] == [RETIRED, CURRENT]
 
 
+def test_picker_context_loads_profile_scoped_exclusions(monkeypatch):
+    from hermes_cli.inventory import load_picker_context
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {"provider": "zai", "default": CURRENT},
+            "model_catalog": {"excluded_models": POLICY},
+        },
+    )
+
+    assert load_picker_context().excluded_models == POLICY
+
+
 def test_automatic_default_and_fallback_skip_retired_model(monkeypatch):
     from hermes_cli import models as models_module
     from hermes_cli.fallback_config import get_fallback_chain
@@ -77,6 +126,17 @@ def test_automatic_default_and_fallback_skip_retired_model(monkeypatch):
         == CURRENT
     )
     assert get_fallback_chain(config) == [{"provider": "zai", "model": CURRENT}]
+
+    legacy = {
+        "model_catalog": {"excluded_models": POLICY},
+        "fallback_model": [
+            {"provider": "zai", "model": RETIRED},
+            {"provider": "zai", "model": CURRENT},
+        ],
+    }
+    assert get_fallback_chain(legacy) == [
+        {"provider": "zai", "model": CURRENT}
+    ]
 
 
 def test_classic_setup_picker_hides_retired_but_keeps_manual_entry():

--- a/tests/hermes_cli/test_model_catalog_exclusions.py
+++ b/tests/hermes_cli/test_model_catalog_exclusions.py
@@ -1,0 +1,121 @@
+"""Focused policy tests for provider-scoped model catalog exclusions."""
+
+from unittest.mock import patch
+
+
+RETIRED = "glm-4.5-air"
+CURRENT = "glm-5.3-flash"
+POLICY = {"zai": [RETIRED]}
+
+
+def test_filter_is_exact_provider_scoped_and_fail_open():
+    from hermes_cli.model_catalog import filter_model_catalog_exclusions
+
+    assert filter_model_catalog_exclusions(
+        "ZAI", [RETIRED.upper(), CURRENT], POLICY
+    ) == [CURRENT]
+    assert filter_model_catalog_exclusions(
+        "openrouter", [RETIRED, CURRENT], POLICY
+    ) == [RETIRED, CURRENT]
+    assert filter_model_catalog_exclusions(
+        "zai", [RETIRED, CURRENT], {"zai": RETIRED}
+    ) == [RETIRED, CURRENT]
+
+
+def test_merged_inventory_hides_retired_model_without_mutating_source():
+    from hermes_cli.inventory import ConfigContext, build_models_payload
+
+    source_rows = [
+        {
+            "slug": "zai",
+            "name": "Z.AI",
+            "models": [RETIRED, CURRENT],
+            "total_models": 2,
+        }
+    ]
+    context = ConfigContext(
+        current_provider="zai",
+        current_model=CURRENT,
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        excluded_models=POLICY,
+    )
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_authenticated_providers",
+            return_value=source_rows,
+        ),
+        patch("hermes_cli.inventory._moa_provider_row", return_value=None),
+        patch("hermes_cli.providers.is_routing_aggregator", return_value=False),
+    ):
+        payload = build_models_payload(context)
+
+    assert payload["providers"][0]["models"] == [CURRENT]
+    assert payload["providers"][0]["total_models"] == 1
+    assert source_rows[0]["models"] == [RETIRED, CURRENT]
+
+
+def test_automatic_default_and_fallback_skip_retired_model(monkeypatch):
+    from hermes_cli import models as models_module
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    config = {
+        "model_catalog": {"excluded_models": POLICY},
+        "fallback_providers": [
+            {"provider": "zai", "model": RETIRED},
+            {"provider": "zai", "model": CURRENT},
+        ],
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setitem(models_module._PROVIDER_MODELS, "zai", [RETIRED, CURRENT])
+
+    assert models_module.get_default_model_for_provider("zai") == CURRENT
+    assert (
+        models_module.pick_silent_default_model([RETIRED, CURRENT], provider="zai")
+        == CURRENT
+    )
+    assert get_fallback_chain(config) == [{"provider": "zai", "model": CURRENT}]
+
+
+def test_classic_setup_picker_hides_retired_but_keeps_manual_entry():
+    from hermes_cli.auth import _prompt_model_selection
+
+    captured = {}
+
+    def capture(_title, choices, **_kwargs):
+        captured["choices"] = choices
+        return -1
+
+    config = {"model_catalog": {"excluded_models": POLICY}}
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.curses_ui.curses_radiolist", side_effect=capture),
+    ):
+        assert (
+            _prompt_model_selection(
+                [RETIRED, CURRENT],
+                current_model=RETIRED,
+                confirm_provider="zai",
+            )
+            is None
+        )
+
+    rendered = repr(captured["choices"])
+    assert RETIRED not in rendered
+    assert CURRENT in rendered
+    assert "Enter custom model name" in captured["choices"]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.curses_ui.curses_radiolist", return_value=1),
+        patch("hermes_cli.cli_output.line_input", return_value=RETIRED),
+    ):
+        assert (
+            _prompt_model_selection(
+                [RETIRED, CURRENT],
+                confirm_provider="zai",
+            )
+            is None
+        )


### PR DESCRIPTION
## Summary

- add model_catalog.excluded_models as a provider-scoped local policy
- apply exclusions after curated, configured, and live picker rows merge, including the classic setup picker
- skip excluded IDs in silent defaults, configured fallback chains, and last-known-good recovery while preserving explicit runtime model overrides
- leave raw models.dev and provider caches untouched

This prevents a locally retired model from reappearing after a live provider catalog refresh without turning the provider catalog into a second allowlist subsystem.

## Tests

- scripts/run_tests.sh on 7 focused and adjacent files: 171 passed, 0 failed
- ruff check on every touched Python file
- git diff --check