### PR TITLE
fix(dashboard): translate config schema field descriptions via agent.i18n

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7254,13 +7254,45 @@ async def get_defaults():
     return DEFAULT_CONFIG
 
 
+def _schema_translation_key(field: str) -> str:
+    """Catalog key for a schema field's description (dots would nest in YAML)."""
+    return f"config_schema.{field.replace('.', '-')}.description"
+
+
+def _apply_schema_translations(
+    fields: Dict[str, Dict[str, Any]], lang: Optional[str]
+) -> Dict[str, Dict[str, Any]]:
+    """Translate schema field descriptions via the shared i18n catalogs.
+
+    The dashboard's language lives in the browser (localStorage), so the
+    server cannot resolve it from config; the endpoint receives it as ``lang``
+    and this pass swaps each field's description for its catalog entry.
+    Fields without a catalog entry keep their hardcoded English text, so the
+    page degrades gracefully until catalogs grow.
+    """
+    if not lang:
+        return fields
+    from agent.i18n import t as translate
+
+    translated: Dict[str, Dict[str, Any]] = {}
+    for field, entry in fields.items():
+        key = _schema_translation_key(field)
+        rendered = translate(key, lang=lang)
+        if rendered != key:
+            translated[field] = {**entry, "description": rendered}
+        else:
+            translated[field] = entry
+    return translated
+
+
 @app.get("/api/config/schema")
-async def get_schema(profile: Optional[str] = None):
+async def get_schema(profile: Optional[str] = None, lang: Optional[str] = None):
     # Discovery-driven provider options (voice command providers + memory
     # provider plugins) are merged per-request so providers added after server
     # start still show up, scoped to the requested profile's config.
     with _config_profile_scope(profile):
         fields = _schema_with_dynamic_provider_options()
+    fields = _apply_schema_translations(fields, lang)
     return {"fields": fields, "category_order": _CATEGORY_ORDER}
 
 

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Sessie-databasis is nie beskikbaar"
     session_not_found:           "Sessie nie in databasis gevind nie."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -458,3 +458,57 @@ gateway:
     session_db_unavailable_prefix: "قاعدة بيانات الجلسات غير متاحة"
     session_not_found:           "لم يُعثر على الجلسة في قاعدة البيانات."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Session-Datenbank nicht verfügbar"
     session_not_found:           "Session nicht in der Datenbank gefunden."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -469,3 +469,57 @@ gateway:
     session_db_unavailable_prefix: "Session database not available"
     session_not_found:           "Session not found in database."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -453,3 +453,57 @@ gateway:
     session_db_unavailable_prefix: "Base de datos de sesiones no disponible"
     session_not_found:           "Sesión no encontrada en la base de datos."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de données de sessions indisponible"
     session_not_found:           "Session introuvable dans la base de données."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -460,3 +460,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Níl bunachar sonraí na seisiún ar fáil"
     session_not_found:           "Seisiún gan a aimsiú sa bhunachar sonraí."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "A munkamenet-adatbázis nem érhető el"
     session_not_found:           "A munkamenet nem található az adatbázisban."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Database delle sessioni non disponibile"
     session_not_found:           "Sessione non trovata nel database."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "セッションデータベースが利用できません"
     session_not_found:           "データベースにセッションが見つかりません。"
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "세션 데이터베이스를 사용할 수 없습니다"
     session_not_found:           "데이터베이스에서 세션을 찾을 수 없습니다."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de dados de sessões indisponível"
     session_not_found:           "Sessão não encontrada na base de dados."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База данных сеансов недоступна"
     session_not_found:           "Сеанс не найден в базе данных."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "Часовой пояс IANA (напр. Europe/Moscow). Пусто — системный часовой пояс."
+  memory-provider:
+    description: "Плагин провайдера памяти"
+  model:
+    description: "Модель по умолчанию (напр. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Переопределение размера контекстного окна (0 = автоопределение по метаданным модели)"
+  terminal-backend:
+    description: "Бэкенд исполнения терминальных команд"
+  terminal-vercel_runtime:
+    description: "Рантайм Vercel Sandbox"
+  terminal-modal_mode:
+    description: "Режим песочницы Modal"
+  proxy-credential_source:
+    description: "Откуда iron-proxy загружает реальные секреты апстрима при старте"
+  proxy-enforce_on_docker:
+    description: "Запрещать Docker-песочницы, когда egress включён, но не настроен/не запущен"
+  tts-provider:
+    description: "Провайдер синтеза речи"
+  stt-provider:
+    description: "Провайдер распознавания речи"
+  stt-local-model:
+    description: "Размер локальной модели faster-whisper"
+  stt-groq-model:
+    description: "Модель Groq Whisper"
+  stt-openai-model:
+    description: "Модель транскрибации OpenAI"
+  stt-elevenlabs-model_id:
+    description: "Модель ElevenLabs Scribe"
+  display-skin:
+    description: "Визуальная тема CLI"
+  dashboard-theme:
+    description: "Тема веб-дашборда"
+  display-resume_display:
+    description: "Как возобновлённые сессии показывают историю"
+  display-busy_input_mode:
+    description: "Поведение ввода, пока агент выполняет задачу"
+  approvals-mode:
+    description: "Режим подтверждения опасных команд"
+  context-engine:
+    description: "Движок управления контекстом"
+  human_delay-mode:
+    description: "Режим имитации задержки печати"
+  logging-level:
+    description: "Уровень логирования для agent.log"
+  agent-service_tier:
+    description: "Сервисный уровень API (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Усилия на рассуждение для субагентов-делегатов"
+  browser-headed:
+    description: "Запускать локальный браузер в оконном режиме (видимое окно). Окно также остаётся открытым между ходами; неактивные сессии всё равно закрываются после browser.inactivity_timeout."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Oturum veritabanı kullanılamıyor"
     session_not_found:           "Oturum veritabanında bulunamadı."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База даних сеансів недоступна"
     session_not_found:           "Сеанс не знайдено в базі даних."
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "工作階段資料庫無法使用"
     session_not_found:           "資料庫中找不到此工作階段。"
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA timezone (e.g. America/New_York). Blank uses the system timezone."
+  memory-provider:
+    description: "Memory provider plugin"
+  model:
+    description: "Default model (e.g. anthropic/claude-sonnet-4.6)"
+  model_context_length:
+    description: "Context window override (0 = auto-detect from model metadata)"
+  terminal-backend:
+    description: "Terminal execution backend"
+  terminal-vercel_runtime:
+    description: "Vercel Sandbox runtime"
+  terminal-modal_mode:
+    description: "Modal sandbox mode"
+  proxy-credential_source:
+    description: "Where iron-proxy loads real upstream secrets at start time"
+  proxy-enforce_on_docker:
+    description: "Refuse Docker sandboxes when egress is enabled but not configured/running"
+  tts-provider:
+    description: "Text-to-speech provider"
+  stt-provider:
+    description: "Speech-to-text provider"
+  stt-local-model:
+    description: "Local faster-whisper model size"
+  stt-groq-model:
+    description: "Groq Whisper model"
+  stt-openai-model:
+    description: "OpenAI transcription model"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe model"
+  display-skin:
+    description: "CLI visual theme"
+  dashboard-theme:
+    description: "Web dashboard visual theme"
+  display-resume_display:
+    description: "How resumed sessions display history"
+  display-busy_input_mode:
+    description: "Input behavior while agent is running"
+  approvals-mode:
+    description: "Dangerous command approval mode"
+  context-engine:
+    description: "Context management engine"
+  human_delay-mode:
+    description: "Simulated typing delay mode"
+  logging-level:
+    description: "Log level for agent.log"
+  agent-service_tier:
+    description: "API service tier (OpenAI/Anthropic)"
+  delegation-reasoning_effort:
+    description: "Reasoning effort for delegated subagents"
+  browser-headed:
+    description: "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout."

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -456,3 +456,57 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "会话数据库不可用"
     session_not_found:           "数据库中未找到该会话。"
     warn_passthrough:            "⚠️ {error}"
+
+config_schema:
+  timezone:
+    description: "IANA 时区（如 Asia/Shanghai）。留空使用系统时区。"
+  memory-provider:
+    description: "记忆提供者插件"
+  model:
+    description: "默认模型（如 anthropic/claude-sonnet-4.6）"
+  model_context_length:
+    description: "上下文窗口覆盖（0 = 依据模型元数据自动检测）"
+  terminal-backend:
+    description: "终端执行后端"
+  terminal-vercel_runtime:
+    description: "Vercel 沙箱运行时"
+  terminal-modal_mode:
+    description: "Modal 沙箱模式"
+  proxy-credential_source:
+    description: "iron-proxy 启动时加载真实上游凭据的位置"
+  proxy-enforce_on_docker:
+    description: "启用出站代理但未配置/未运行时拒绝 Docker 沙箱"
+  tts-provider:
+    description: "语音合成提供者"
+  stt-provider:
+    description: "语音识别提供者"
+  stt-local-model:
+    description: "本地 faster-whisper 模型规格"
+  stt-groq-model:
+    description: "Groq Whisper 模型"
+  stt-openai-model:
+    description: "OpenAI 转录模型"
+  stt-elevenlabs-model_id:
+    description: "ElevenLabs Scribe 模型"
+  display-skin:
+    description: "CLI 视觉主题"
+  dashboard-theme:
+    description: "网页控制台主题"
+  display-resume_display:
+    description: "恢复会话时如何显示历史记录"
+  display-busy_input_mode:
+    description: "代理运行时的输入行为"
+  approvals-mode:
+    description: "危险命令审批模式"
+  context-engine:
+    description: "上下文管理引擎"
+  human_delay-mode:
+    description: "模拟输入延迟模式"
+  logging-level:
+    description: "agent.log 的日志级别"
+  agent-service_tier:
+    description: "API 服务层级（OpenAI/Anthropic）"
+  delegation-reasoning_effort:
+    description: "委托子代理的推理力度"
+  browser-headed:
+    description: "以有界面模式运行本地浏览器（可见窗口）。窗口在多轮之间保持打开；空闲会话仍会在 browser.inactivity_timeout 之后被回收。"

--- a/tests/hermes_cli/test_web_server_config_schema_i18n.py
+++ b/tests/hermes_cli/test_web_server_config_schema_i18n.py
@@ -1,0 +1,92 @@
+"""GET /api/config/schema?lang= translates field descriptions.
+
+The dashboard's UI language lives in browser localStorage, so the server
+cannot resolve it from config.yaml. The endpoint takes ``lang`` and swaps
+each schema field's description for its ``config_schema.*`` catalog entry;
+fields without an entry keep their English text, and an absent ``lang``
+leaves the schema byte-identical to today.
+"""
+
+import pytest
+
+
+class TestSchemaTranslation:
+    @pytest.fixture(autouse=True)
+    def _home(self, _isolate_hermes_home):
+        pass
+
+    def test_no_lang_returns_english(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        body = client.get("/api/config/schema").json()
+        desc = body["fields"]["model"]["description"]
+        assert desc == "Default model (e.g. anthropic/claude-sonnet-4.6)"
+
+    def test_ru_lang_translates_known_field(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        body = client.get("/api/config/schema?lang=ru").json()
+        desc = body["fields"]["model"]["description"]
+        assert "по умолчанию" in desc
+        assert desc != "Default model (e.g. anthropic/claude-sonnet-4.6)"
+
+    def test_field_without_catalog_entry_keeps_english(self):
+        """Auto-generated fields (no ``config_schema`` entry) stay English."""
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import (
+            app,
+            _SESSION_HEADER_NAME,
+            _SESSION_TOKEN,
+            _apply_schema_translations,
+        )
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        body = client.get("/api/config/schema?lang=ru").json()
+        # Pick any field the catalogs do not cover and verify it kept its text.
+        uncovered = [
+            f for f, e in body["fields"].items()
+            if "description" in e
+            and not f.replace(".", "-") in {
+                "timezone", "memory-provider", "model", "model_context_length",
+                "terminal-backend", "terminal-vercel_runtime", "terminal-modal_mode",
+                "proxy-credential_source", "proxy-enforce_on_docker", "tts-provider",
+                "stt-provider", "stt-local-model", "stt-groq-model", "stt-openai-model",
+                "stt-elevenlabs-model_id", "display-skin", "dashboard-theme",
+                "display-resume_display", "display-busy_input_mode", "approvals-mode",
+                "context-engine", "human_delay-mode", "logging-level",
+                "agent-service_tier", "delegation-reasoning_effort", "browser-headed",
+            }
+        ]
+        assert uncovered
+        # Structurally: translation never adds or drops fields.
+        plain = client.get("/api/config/schema").json()
+        assert set(body["fields"]) == set(plain["fields"])
+
+    def test_helper_returns_input_when_lang_missing(self):
+        from hermes_cli.web_server import _apply_schema_translations
+
+        fields = {"model": {"description": "Default model"}}
+        assert _apply_schema_translations(fields, None) is fields
+
+    def test_helper_keeps_uncovered_field_untouched(self):
+        from hermes_cli.web_server import _apply_schema_translations
+
+        fields = {"brand_new_field": {"description": "Plain English"}}
+        out = _apply_schema_translations(fields, "ru")
+        assert out["brand_new_field"]["description"] == "Plain English"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -522,7 +522,10 @@ export const api = {
   getConfig: (profile = getManagementProfile()) =>
     fetchJSON<Record<string, unknown>>(appendProfileParam("/api/config", profile)),
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
-  getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
+  getSchema: (lang?: string) =>
+    fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>(
+      `/api/config/schema${lang ? `?lang=${encodeURIComponent(lang)}` : ""}`,
+    ),
   getModelInfo: (profile = getManagementProfile()) =>
     fetchJSON<ModelInfoResponse>(appendProfileParam("/api/model/info", profile)),
   getModelOptions: (

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -122,7 +122,7 @@ export default function ConfigPage() {
   const [confirmReset, setConfirmReset] = useState(false);
   const { toast, showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const { setEnd } = usePageHeader();
 
   useLayoutEffect(() => {
@@ -167,7 +167,7 @@ export default function ConfigPage() {
       .then(setConfig)
       .catch(() => {});
     api
-      .getSchema()
+      .getSchema(locale)
       .then((resp) => {
         // memory.provider has a dedicated management UI on the Plugins page
         // (provider cards + guided setup/switch flow). Hide it from the
@@ -200,7 +200,7 @@ export default function ConfigPage() {
       .getStatus()
       .then((resp) => setConfigPath((prev) => prev ?? resp.config_path))
       .catch(() => {});
-  }, []);
+  }, [locale]);
 
   // Set active category when categories load
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `GET /api/config/schema` accepts an optional `?lang=` parameter and routes each field's `description` through `t()` from `agent.i18n` (keys: `config_schema.<field-with-dashes>.description`). Fields without a catalog entry keep their English text, and an absent `lang` leaves the payload byte-identical to before.
- The web dashboard's `api.getSchema()` now passes its localStorage locale (`hermes-locale`), and `ConfigPage` refetches the schema when the language changes mid-session.
- New `config_schema` section in all 17 locale catalogs (parity invariant enforced by `test_catalog_keys_match_english`). `ru` and `zh` carry real translations; the other 15 fall back to English values until native speakers contribute.

## Why server-side

The dashboard's language lives in browser localStorage and never reaches `display.language`, so the server can't resolve the locale from config — the endpoint takes it explicitly. This keeps one translation mechanism for the whole backend (same catalogs as `gateway/run.py` et al.), needs zero changes to the 17 typed TS locale files, and degrades gracefully field-by-field.

## Testing

- `tests/hermes_cli/test_web_server_config_schema_i18n.py` (new): no-lang payload unchanged, `ru` translates a known field, uncovered fields keep English, field set is never added to or dropped from, helper passthrough.
- `tests/agent/test_i18n.py`: 41 passed (catalog parity for all 17 locales with the new section).
- `tests/hermes_cli/test_web_server*.py` neighbors: 181 passed, 1 skipped.
- Web: `tsc -p . --noEmit` clean, `vitest run` 279/279, eslint on touched files — same 4 pre-existing warnings as `main` (verified via `git stash -u` roundtrip).

Fixes #98994