### PR TITLE
fix(desktop): route active SSH through managed updates

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DesktopUpdateStatus } from '@/global'
+import type { DesktopConnectionKind, DesktopUpdateStatus } from '@/global'
 
 const storage = new Map<string, string>()
 
@@ -102,11 +102,11 @@ const {
 
 const { setConnection } = await import('./session')
 
-const registryOf = (ids: string[]) => ({
+const registryOf = (ids: string[], kinds: Partial<Record<string, DesktopConnectionKind>> = {}) => ({
   version: 2,
   primary: ids[0] ?? 'local',
   secureTokenStorage: true,
-  connections: ids.map(id => ({ id, kind: id === 'local' ? 'local' : 'remote', label: id }))
+  connections: ids.map(id => ({ id, kind: kinds[id] ?? (id === 'local' ? 'local' : 'remote'), label: id }))
 })
 
 const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus => ({
@@ -119,9 +119,10 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
 
 const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
 
-const setRemote = (on: boolean) =>
+const setRemote = (on: boolean, connectionId?: string) =>
   setConnection({
     baseUrl: 'http://box:9119',
+    connectionId,
     isFullscreen: false,
     mode: on ? 'remote' : 'local',
     nativeOverlayWidth: 0,
@@ -498,7 +499,7 @@ describe('applyEverythingUpdate', () => {
   })
 
   it('fans out to other registered connections, excluding local and the active backend', async () => {
-    setRemote(true)
+    setRemote(true, 'vps')
     $mockConnectionsRegistry.set(registryOf(['local', 'vps', 'homelab']))
     $backendUpdateStatus.set(status({ behind: 1 }))
 
@@ -507,6 +508,22 @@ describe('applyEverythingUpdate', () => {
     expect(updateAllMock).toHaveBeenCalledTimes(1)
     const options = updateAllMock.mock.calls[0]?.[0] as { excludeIds: string[] }
     expect(options.excludeIds).toContain('local')
+    expect(options.excludeIds).toContain('vps')
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes the active registered SSH backend through the managed update fan-out', async () => {
+    setRemote(true, 'homelab')
+    $mockConnectionsRegistry.set(registryOf(['local', 'homelab'], { homelab: 'ssh' }))
+    $backendUpdateStatus.set(status({ behind: 1 }))
+
+    await applyEverythingUpdate()
+
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect(updateAllMock).toHaveBeenCalledTimes(1)
+    const options = updateAllMock.mock.calls[0]?.[0] as { excludeIds: string[] }
+    expect(options.excludeIds).toContain('local')
+    expect(options.excludeIds).not.toContain('homelab')
   })
 
   it('local mode with a multi-connection registry: fans out and updates the client, no active-backend leg', async () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -856,25 +856,34 @@ async function runEverythingUpdate(): Promise<void> {
   $updateEverything.set({ running: true })
 
   try {
-    // 1. Active backend first (remote mode), with the detailed overlay flow.
-    //    Its own finish path re-checks and nudges, but the everything-flow
-    //    continues regardless of the outcome: one unreachable backend must
-    //    not strand the other machines or the client.
-    if (isRemoteMode()) {
+    const remoteMode = isRemoteMode()
+    const bridge = window.hermesDesktop?.connections
+    const registry = $connectionsRegistry.get() ?? (await refreshConnectionsRegistry().catch(() => null))
+    const activeConnectionId = $connection.get()?.connectionId
+    const activeConnection = registry?.connections.find(connection => connection.id === activeConnectionId)
+    const activeUsesManagedSshUpdate = remoteMode && activeConnection?.kind === 'ssh'
+
+    // 1. Active URL backend first (remote mode), with the detailed overlay
+    //    flow. A registered SSH backend must stay in the fan-out below: the
+    //    Electron handler routes it through the transactional managed SSH
+    //    drain/update/restore lifecycle instead of the forwarded HTTP API.
+    //    The everything-flow continues regardless of an active URL backend's
+    //    outcome so one unreachable backend cannot strand the other machines
+    //    or the client.
+    if (remoteMode && !activeUsesManagedSshUpdate) {
       $updateOverlayTarget.set('backend')
 
       await applyBackendUpdate().catch(() => null)
     }
 
-    // 2. Fan out to every OTHER eligible registered connection. The active
-    //    backend was just updated (excluded), and the local runtime updates
-    //    with the client in step 3 (excluded). No registry/bridge → skip.
-    const bridge = window.hermesDesktop?.connections
-    const registry = $connectionsRegistry.get() ?? (await refreshConnectionsRegistry().catch(() => null))
+    // 2. Fan out to eligible registered connections. An active URL backend was
+    //    just updated and is excluded; an active managed SSH backend remains
+    //    included so Electron can own its lifecycle. The local runtime updates
+    //    with the client in step 3 and is always excluded. No registry/bridge
+    //    means there is nothing to fan out.
     const excludeIds = ['local']
-    const activeConnectionId = $connection.get()?.connectionId
 
-    if (isRemoteMode() && activeConnectionId && !excludeIds.includes(activeConnectionId)) {
+    if (remoteMode && !activeUsesManagedSshUpdate && activeConnectionId && !excludeIds.includes(activeConnectionId)) {
       excludeIds.push(activeConnectionId)
     }
 


### PR DESCRIPTION
## Summary

- resolve the active registered connection before orchestrating an Everything update
- keep an active SSH connection in the connection fan-out so Electron routes it through the managed drain/update/restore lifecycle
- preserve the existing detailed backend updater and exclusion behavior for URL-based remotes
- add focused regression coverage for both routing paths

## Root cause

The renderer always updated the active remote through the forwarded HTTP backend first, then excluded it from `connections.updateAll`. That is correct for URL remotes, but an active registered SSH connection must reach the Electron `update-all` handler to use the transactional managed SSH updater. Excluding it bypassed that lifecycle.

## Verification

- `npm test --workspace apps/desktop -- --project ui src/store/updates.test.ts` (59 passed)
- `npm test --workspace apps/desktop -- --project electron electron/update-remote.test.ts` (6 passed)
- `npm run typecheck --workspace apps/desktop`
- `npx eslint src/store/updates.ts src/store/updates.test.ts`
- `npx prettier --check src/store/updates.ts src/store/updates.test.ts`
- `git diff --check`

Fixes #98791