### PR TITLE
fix(whatsapp): gate allowed groups and serialize reconnects

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -18,6 +18,21 @@ export function parseAllowedUsers(rawValue) {
   );
 }
 
+export function parseAllowedGroups(rawValue) {
+  return new Set(
+    String(rawValue || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+}
+
+export function groupAllowlistFromEnv(env = {}) {
+  return parseAllowedGroups(
+    env.WHATSAPP_GROUP_ALLOWED_USERS || env.WHATSAPP_GROUP_ALLOW_FROM || ''
+  );
+}
+
 function readMappingFile(sessionDir, identifier, suffix = '') {
   const filePath = path.join(sessionDir, `lid-mapping-${identifier}${suffix}.json`);
   if (!existsSync(filePath)) {

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,10 +6,28 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  groupAllowlistFromEnv,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
+  parseAllowedGroups,
   parseAllowedUsers,
 } from './allowlist.js';
+
+test('parseAllowedGroups preserves canonical group JIDs', () => {
+  const groups = parseAllowedGroups('120363001@g.us, 120363002@g.us');
+  assert.deepEqual([...groups], ['120363001@g.us', '120363002@g.us']);
+});
+
+test('groupAllowlistFromEnv honors the gateway variable and compatibility alias', () => {
+  assert.deepEqual(
+    [...groupAllowlistFromEnv({ WHATSAPP_GROUP_ALLOWED_USERS: '120363001@g.us' })],
+    ['120363001@g.us'],
+  );
+  assert.deepEqual(
+    [...groupAllowlistFromEnv({ WHATSAPP_GROUP_ALLOW_FROM: '120363002@g.us' })],
+    ['120363002@g.us'],
+  );
+});
 
 test('normalizeWhatsAppIdentifier strips jid syntax and plus prefix', () => {
   assert.equal(normalizeWhatsAppIdentifier('+19175395595@s.whatsapp.net'), '19175395595');

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { groupAllowlistFromEnv, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -113,6 +113,9 @@ const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+// The Python gateway translates config.yaml group_allow_from to
+// WHATSAPP_GROUP_ALLOWED_USERS. GROUP_ALLOW_FROM remains a compatibility alias.
+const GROUP_ALLOWLIST = groupAllowlistFromEnv(process.env);
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -402,7 +405,7 @@ async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
   const version = await getWAVersion();
 
-  sock = makeWASocket({
+  const currentSock = makeWASocket({
     ...(version ? { version } : {}),
     auth: state,
     logger,
@@ -418,10 +421,13 @@ async function startSocket() {
       return { conversation: '' };
     },
   });
+  sock = currentSock;
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 
   sock.ev.on('connection.update', (update) => {
+    // Ignore late events from a socket superseded by a reconnect attempt.
+    if (sock !== currentSock) return;
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
@@ -646,7 +652,7 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (!(isGroup && GROUP_ALLOWLIST.has(chatId)) && WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -89,6 +89,27 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   assert.equal(timers.length, 2);
 }
 
+// Repeated close events must coalesce into one reconnect. Without this guard,
+// overlapping Baileys sockets evict one another in a 408/428 reconnect loop.
+{
+  const timers = [];
+  let attempts = 0;
+  const schedule = createReconnectScheduler(
+    async () => { attempts += 1; },
+    { setTimeoutFn: (fn, ms) => timers.push({ fn, ms }) },
+  );
+
+  assert.equal(schedule(3000), true);
+  assert.equal(schedule(3000), false);
+  assert.equal(schedule(3000), false);
+  assert.equal(timers.length, 1);
+
+  timers[0].fn();
+  await tick();
+  await tick();
+  assert.equal(attempts, 1);
+}
+
 // -- createVersionResolver ------------------------------------------------
 
 // A successful fetch returns and caches the version.

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -581,15 +581,27 @@ export function createReconnectScheduler(startFn, {
   log = console.log,
   setTimeoutFn = setTimeout,
 } = {}) {
+  let timerPending = false;
+  let startPending = false;
+
   function scheduleReconnect(delayMs) {
+    if (timerPending || startPending) return false;
+    timerPending = true;
     setTimeoutFn(() => {
+      timerPending = false;
+      startPending = true;
       Promise.resolve()
         .then(startFn)
+        .then(() => {
+          startPending = false;
+        })
         .catch((err) => {
+          startPending = false;
           log(`⚠️  Reconnect failed (${err?.message || err}). Retrying in ${Math.round(retryDelayMs / 1000)}s...`);
           scheduleReconnect(retryDelayMs);
         });
     }, delayMs);
+    return true;
   }
   return scheduleReconnect;
 }


### PR DESCRIPTION
## Summary
- honor canonical `WHATSAPP_GROUP_ALLOWED_USERS` in the Node bridge, retaining `WHATSAPP_GROUP_ALLOW_FROM` as a compatibility alias
- let configured group JIDs reach Python group/reply gating without opening the DM sender allowlist
- coalesce duplicate Baileys reconnect attempts and ignore late close events from superseded sockets

## Root cause
The gateway exports YAML `group_allow_from` as `WHATSAPP_GROUP_ALLOWED_USERS`, while the local bridge patch read only `WHATSAPP_GROUP_ALLOW_FROM`. Separately, repeated close events could schedule overlapping sockets, producing a 408/428 reconnect loop.

## Tests
- `node --test *.test.mjs` — 24 passed
- targeted Python WhatsApp group/stale-bridge tests — 14 passed
- `git diff --cached --check`
- independent review against staged tree `fa8eedde7a568b032677ef6c1578f0ae153af57c` — pass, no blockers