### PR TITLE
Fix Kanban handling of mixed SQLite field types

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -57,36 +57,45 @@ def _fmt_task_line(t: kb.Task) -> str:
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
-    def _coerce_val(val: Any) -> Any:
+    def _coerce_json_safe(val: Any) -> Any:
+        if val is None:
+            return None
         if isinstance(val, bytes):
             return val.decode("utf-8", errors="replace")
-        return val
+        if isinstance(val, (int, float, bool, str)):
+            return val
+        if isinstance(val, (list, tuple, set)):
+            return [_coerce_json_safe(item) for item in val]
+        if isinstance(val, dict):
+            return {str(k): _coerce_json_safe(v) for k, v in val.items()}
+        return str(val)
 
-    return {
-        "id": _coerce_val(t.id),
-        "title": _coerce_val(t.title),
-        "body": _coerce_val(t.body),
-        "assignee": _coerce_val(t.assignee),
-        "status": _coerce_val(t.status),
+    raw_dict = {
+        "id": t.id,
+        "title": t.title,
+        "body": t.body,
+        "assignee": t.assignee,
+        "status": t.status,
         "priority": t.priority,
-        "tenant": _coerce_val(t.tenant),
-        "workspace_kind": _coerce_val(t.workspace_kind),
-        "workspace_path": _coerce_val(t.workspace_path),
-        "branch_name": _coerce_val(t.branch_name),
-        "project_id": _coerce_val(t.project_id),
-        "created_by": _coerce_val(t.created_by),
+        "tenant": t.tenant,
+        "workspace_kind": t.workspace_kind,
+        "workspace_path": t.workspace_path,
+        "branch_name": t.branch_name,
+        "project_id": t.project_id,
+        "created_by": t.created_by,
         "created_at": t.created_at,
         "started_at": t.started_at,
         "completed_at": t.completed_at,
-        "result": _coerce_val(t.result),
+        "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
-        "model_override": _coerce_val(t.model_override),
-        "provider_override": _coerce_val(t.provider_override),
-        "session_id": _coerce_val(t.session_id),
-        "workflow_template_id": _coerce_val(t.workflow_template_id),
-        "current_step_key": _coerce_val(t.current_step_key),
+        "model_override": t.model_override,
+        "provider_override": t.provider_override,
+        "session_id": t.session_id,
+        "workflow_template_id": t.workflow_template_id,
+        "current_step_key": t.current_step_key,
     }
+    return {k: _coerce_json_safe(v) for k, v in raw_dict.items()}
 
 
 def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -57,30 +57,35 @@ def _fmt_task_line(t: kb.Task) -> str:
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
+    def _coerce_val(val: Any) -> Any:
+        if isinstance(val, bytes):
+            return val.decode("utf-8", errors="replace")
+        return val
+
     return {
-        "id": t.id,
-        "title": t.title,
-        "body": t.body,
-        "assignee": t.assignee,
-        "status": t.status,
+        "id": _coerce_val(t.id),
+        "title": _coerce_val(t.title),
+        "body": _coerce_val(t.body),
+        "assignee": _coerce_val(t.assignee),
+        "status": _coerce_val(t.status),
         "priority": t.priority,
-        "tenant": t.tenant,
-        "workspace_kind": t.workspace_kind,
-        "workspace_path": t.workspace_path,
-        "branch_name": t.branch_name,
-        "project_id": t.project_id,
-        "created_by": t.created_by,
+        "tenant": _coerce_val(t.tenant),
+        "workspace_kind": _coerce_val(t.workspace_kind),
+        "workspace_path": _coerce_val(t.workspace_path),
+        "branch_name": _coerce_val(t.branch_name),
+        "project_id": _coerce_val(t.project_id),
+        "created_by": _coerce_val(t.created_by),
         "created_at": t.created_at,
         "started_at": t.started_at,
         "completed_at": t.completed_at,
-        "result": t.result,
+        "result": _coerce_val(t.result),
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
-        "model_override": t.model_override,
-        "provider_override": t.provider_override,
-        "session_id": t.session_id,
-        "workflow_template_id": t.workflow_template_id,
-        "current_step_key": t.current_step_key,
+        "model_override": _coerce_val(t.model_override),
+        "provider_override": _coerce_val(t.provider_override),
+        "session_id": _coerce_val(t.session_id),
+        "workflow_template_id": _coerce_val(t.workflow_template_id),
+        "current_step_key": _coerce_val(t.current_step_key),
     }
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1336,7 +1336,7 @@ def _board_task_counts(slug: str) -> dict[str, int]:
             return {}
         with kb.connect_closing(board=slug) as conn:
             rows = conn.execute(
-                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+                "SELECT CAST(status AS TEXT) AS status, COUNT(*) AS n FROM tasks GROUP BY CAST(status AS TEXT)"
             ).fetchall()
         return {r["status"]: int(r["n"]) for r in rows}
     except Exception:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11999,7 +11999,7 @@ def read_worker_log(
 # ---------------------------------------------------------------------------
 
 def list_profiles_on_disk() -> list[str]:
-    """Return the set of assignee/profile names discovered on disk.
+    """Return the set of live (non-tombstoned) assignee/profile names discovered on disk.
 
     Includes:
     - named profiles under ``<default-root>/profiles/<name>/config.yaml``
@@ -12010,7 +12010,7 @@ def list_profiles_on_disk() -> list[str]:
     path).
     """
     try:
-        from hermes_constants import get_default_hermes_root
+        from hermes_constants import get_default_hermes_root, named_profile_is_deleted
         default_root = get_default_hermes_root()
         profiles_dir = default_root / "profiles"
     except Exception:
@@ -12024,6 +12024,8 @@ def list_profiles_on_disk() -> list[str]:
         try:
             for entry in sorted(profiles_dir.iterdir()):
                 if not entry.is_dir():
+                    continue
+                if named_profile_is_deleted(entry):
                     continue
                 if (entry / "config.yaml").is_file():
                     names.add(entry.name)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1147,11 +1147,7 @@ class Task:
         keys = set(row.keys())
 
         def _str_val(v: Any) -> Optional[str]:
-            if v is None:
-                return None
-            if isinstance(v, bytes):
-                return v.decode("utf-8", errors="replace")
-            return str(v)
+            return _text_value(v)
 
         def _int_val(v: Any, default: Optional[int] = None) -> Optional[int]:
             if v is None:
@@ -3676,6 +3672,15 @@ def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
     return Task.from_row(row) if row else None
 
 
+def _text_value(value: Any) -> Optional[str]:
+    """Return a stable text representation for weakly typed SQLite cells."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
 # Canonical sort-order mappings for ``hermes kanban list --sort``.
 # Each value is a raw SQL fragment appended after ``ORDER BY``.
 VALID_SORT_ORDERS: dict[str, str] = {
@@ -3706,27 +3711,27 @@ def list_tasks(
     query = "SELECT * FROM tasks WHERE 1=1"
     params: list[Any] = []
     if assignee is not None:
-        query += " AND assignee = ?"
+        query += " AND CAST(assignee AS TEXT) = ?"
         params.append(_canonical_assignee(assignee))
     if status is not None:
         if status not in VALID_STATUSES:
             raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
-        query += " AND status = ?"
+        query += " AND CAST(status AS TEXT) = ?"
         params.append(status)
     if tenant is not None:
-        query += " AND tenant = ?"
+        query += " AND CAST(tenant AS TEXT) = ?"
         params.append(tenant)
     if session_id is not None:
-        query += " AND session_id = ?"
+        query += " AND CAST(session_id AS TEXT) = ?"
         params.append(session_id)
     if workflow_template_id is not None:
-        query += " AND workflow_template_id = ?"
+        query += " AND CAST(workflow_template_id AS TEXT) = ?"
         params.append(workflow_template_id)
     if current_step_key is not None:
-        query += " AND current_step_key = ?"
+        query += " AND CAST(current_step_key AS TEXT) = ?"
         params.append(current_step_key)
     if not include_archived and status != "archived":
-        query += " AND status != 'archived'"
+        query += " AND CAST(status AS TEXT) != 'archived'"
     if order_by is not None:
         order_by = order_by.strip().lower()
         if order_by not in VALID_SORT_ORDERS:
@@ -9774,7 +9779,7 @@ def count_running_tasks(conn: sqlite3.Connection) -> int:
     try:
         return int(
             conn.execute(
-                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                "SELECT COUNT(*) FROM tasks WHERE CAST(status AS TEXT) = 'running'"
             ).fetchone()[0]
         )
     except Exception:
@@ -11302,21 +11307,23 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     """
     by_status: dict[str, int] = {}
     for row in conn.execute(
-        "SELECT status, COUNT(*) AS n FROM tasks "
-        "WHERE status != 'archived' GROUP BY status"
+        "SELECT CAST(status AS TEXT) AS status, COUNT(*) AS n FROM tasks "
+        "WHERE CAST(status AS TEXT) != 'archived' GROUP BY CAST(status AS TEXT)"
     ):
-        by_status[row["status"]] = int(row["n"])
+        by_status[_text_value(row["status"]) or ""] = int(row["n"])
 
     by_assignee: dict[str, dict[str, int]] = {}
     for row in conn.execute(
-        "SELECT assignee, status, COUNT(*) AS n FROM tasks "
-        "WHERE status != 'archived' AND assignee IS NOT NULL "
-        "GROUP BY assignee, status"
+        "SELECT CAST(assignee AS TEXT) AS assignee, CAST(status AS TEXT) AS status, COUNT(*) AS n FROM tasks "
+        "WHERE CAST(status AS TEXT) != 'archived' AND assignee IS NOT NULL "
+        "GROUP BY CAST(assignee AS TEXT), CAST(status AS TEXT)"
     ):
-        by_assignee.setdefault(row["assignee"], {})[row["status"]] = int(row["n"])
+        a_key = _text_value(row["assignee"]) or ""
+        s_key = _text_value(row["status"]) or ""
+        by_assignee.setdefault(a_key, {})[s_key] = int(row["n"])
 
     oldest_row = conn.execute(
-        "SELECT MIN(created_at) AS ts FROM tasks WHERE status = 'ready'"
+        "SELECT MIN(created_at) AS ts FROM tasks WHERE CAST(status AS TEXT) = 'ready'"
     ).fetchone()
     now = int(time.time())
     oldest_ready_age = (

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1153,6 +1153,27 @@ class Task:
                 return v.decode("utf-8", errors="replace")
             return str(v)
 
+        def _int_val(v: Any, default: Optional[int] = None) -> Optional[int]:
+            if v is None:
+                return default
+            if isinstance(v, bytes):
+                try:
+                    return int(v.decode("utf-8", errors="replace").strip())
+                except Exception:
+                    return default
+            try:
+                return int(v)
+            except Exception:
+                return default
+
+        def _bool_val(v: Any, default: bool = False) -> bool:
+            if v is None:
+                return default
+            if isinstance(v, bytes):
+                s = v.decode("utf-8", errors="replace").strip().lower()
+                return s in ("1", "true", "yes", "t")
+            return bool(v)
+
         # Parse skills JSON blob if present
         skills_value: Optional[list] = None
         if "skills" in keys and row["skills"]:
@@ -1171,42 +1192,42 @@ class Task:
             body=_str_val(row["body"]),
             assignee=_str_val(row["assignee"]),
             status=_str_val(row["status"]) or "",
-            priority=row["priority"],
+            priority=_int_val(row["priority"], 0) or 0,
             created_by=_str_val(row["created_by"]),
-            created_at=row["created_at"],
-            started_at=row["started_at"],
-            completed_at=row["completed_at"],
+            created_at=_int_val(row["created_at"], 0) or 0,
+            started_at=_int_val(row["started_at"]),
+            completed_at=_int_val(row["completed_at"]),
             workspace_kind=(_str_val(row["workspace_kind"]) or "scratch") if "workspace_kind" in keys else "scratch",
             workspace_path=_str_val(row["workspace_path"]) if "workspace_path" in keys else None,
             branch_name=_str_val(row["branch_name"]) if "branch_name" in keys else None,
             project_id=_str_val(row["project_id"]) if "project_id" in keys else None,
             claim_lock=_str_val(row["claim_lock"]),
-            claim_expires=row["claim_expires"],
+            claim_expires=_int_val(row["claim_expires"]),
             tenant=_str_val(row["tenant"]) if "tenant" in keys else None,
             result=_str_val(row["result"]) if "result" in keys else None,
             idempotency_key=_str_val(row["idempotency_key"]) if "idempotency_key" in keys else None,
             consecutive_failures=(
-                row["consecutive_failures"] if "consecutive_failures" in keys
+                _int_val(row["consecutive_failures"], 0) or 0 if "consecutive_failures" in keys
                 # Pre-migration fallback: ``_migrate_add_optional_columns`` always
                 # adds ``consecutive_failures`` now, so this branch is only reachable
                 # on a DB that was never opened since pre-#20410 code ran. Keep for
                 # belt-and-suspenders safety; in practice it is dead code post-migration.
-                else (row["spawn_failures"] if "spawn_failures" in keys else 0)
+                else (_int_val(row["spawn_failures"], 0) or 0 if "spawn_failures" in keys else 0)
             ),
-            worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
+            worker_pid=_int_val(row["worker_pid"]) if "worker_pid" in keys else None,
             last_failure_error=(
                 _str_val(row["last_failure_error"]) if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
                 else (_str_val(row["last_spawn_error"]) if "last_spawn_error" in keys else None)
             ),
             max_runtime_seconds=(
-                row["max_runtime_seconds"] if "max_runtime_seconds" in keys else None
+                _int_val(row["max_runtime_seconds"]) if "max_runtime_seconds" in keys else None
             ),
             last_heartbeat_at=(
-                row["last_heartbeat_at"] if "last_heartbeat_at" in keys else None
+                _int_val(row["last_heartbeat_at"]) if "last_heartbeat_at" in keys else None
             ),
             current_run_id=(
-                row["current_run_id"] if "current_run_id" in keys else None
+                _int_val(row["current_run_id"]) if "current_run_id" in keys else None
             ),
             workflow_template_id=(
                 _str_val(row["workflow_template_id"]) if "workflow_template_id" in keys else None
@@ -1227,13 +1248,13 @@ class Task:
                 else None
             ),
             max_retries=(
-                row["max_retries"] if "max_retries" in keys else None
+                _int_val(row["max_retries"]) if "max_retries" in keys else None
             ),
             goal_mode=(
-                bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
+                _bool_val(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
             ),
             goal_max_turns=(
-                row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+                _int_val(row["goal_max_turns"]) if "goal_max_turns" in keys and row["goal_max_turns"] else None
             ),
             session_id=(
                 _str_val(row["session_id"]) if "session_id" in keys else None
@@ -1242,7 +1263,7 @@ class Task:
                 _str_val(row["block_kind"]) if "block_kind" in keys and row["block_kind"] else None
             ),
             block_recurrences=(
-                int(row["block_recurrences"])
+                _int_val(row["block_recurrences"], 0) or 0
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1145,35 +1145,46 @@ class Task:
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
+
+        def _str_val(v: Any) -> Optional[str]:
+            if v is None:
+                return None
+            if isinstance(v, bytes):
+                return v.decode("utf-8", errors="replace")
+            return str(v)
+
         # Parse skills JSON blob if present
         skills_value: Optional[list] = None
         if "skills" in keys and row["skills"]:
             try:
-                parsed = json.loads(row["skills"])
+                raw_skills = row["skills"]
+                if isinstance(raw_skills, bytes):
+                    raw_skills = raw_skills.decode("utf-8", errors="replace")
+                parsed = json.loads(raw_skills)
                 if isinstance(parsed, list):
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
         return cls(
-            id=row["id"],
-            title=row["title"],
-            body=row["body"],
-            assignee=row["assignee"],
-            status=row["status"],
+            id=_str_val(row["id"]) or "",
+            title=_str_val(row["title"]) or "",
+            body=_str_val(row["body"]),
+            assignee=_str_val(row["assignee"]),
+            status=_str_val(row["status"]) or "",
             priority=row["priority"],
-            created_by=row["created_by"],
+            created_by=_str_val(row["created_by"]),
             created_at=row["created_at"],
             started_at=row["started_at"],
             completed_at=row["completed_at"],
-            workspace_kind=row["workspace_kind"],
-            workspace_path=row["workspace_path"],
-            branch_name=row["branch_name"] if "branch_name" in keys else None,
-            project_id=row["project_id"] if "project_id" in keys else None,
-            claim_lock=row["claim_lock"],
+            workspace_kind=(_str_val(row["workspace_kind"]) or "scratch") if "workspace_kind" in keys else "scratch",
+            workspace_path=_str_val(row["workspace_path"]) if "workspace_path" in keys else None,
+            branch_name=_str_val(row["branch_name"]) if "branch_name" in keys else None,
+            project_id=_str_val(row["project_id"]) if "project_id" in keys else None,
+            claim_lock=_str_val(row["claim_lock"]),
             claim_expires=row["claim_expires"],
-            tenant=row["tenant"] if "tenant" in keys else None,
-            result=row["result"] if "result" in keys else None,
-            idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
+            tenant=_str_val(row["tenant"]) if "tenant" in keys else None,
+            result=_str_val(row["result"]) if "result" in keys else None,
+            idempotency_key=_str_val(row["idempotency_key"]) if "idempotency_key" in keys else None,
             consecutive_failures=(
                 row["consecutive_failures"] if "consecutive_failures" in keys
                 # Pre-migration fallback: ``_migrate_add_optional_columns`` always
@@ -1184,9 +1195,9 @@ class Task:
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
             last_failure_error=(
-                row["last_failure_error"] if "last_failure_error" in keys
+                _str_val(row["last_failure_error"]) if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
-                else (row["last_spawn_error"] if "last_spawn_error" in keys else None)
+                else (_str_val(row["last_spawn_error"]) if "last_spawn_error" in keys else None)
             ),
             max_runtime_seconds=(
                 row["max_runtime_seconds"] if "max_runtime_seconds" in keys else None
@@ -1198,20 +1209,20 @@ class Task:
                 row["current_run_id"] if "current_run_id" in keys else None
             ),
             workflow_template_id=(
-                row["workflow_template_id"] if "workflow_template_id" in keys else None
+                _str_val(row["workflow_template_id"]) if "workflow_template_id" in keys else None
             ),
             current_step_key=(
-                row["current_step_key"] if "current_step_key" in keys else None
+                _str_val(row["current_step_key"]) if "current_step_key" in keys else None
             ),
             skills=skills_value,
-            model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            model_override=_str_val(row["model_override"]) if "model_override" in keys and row["model_override"] else None,
             provider_override=(
-                row["provider_override"]
+                _str_val(row["provider_override"])
                 if "provider_override" in keys and row["provider_override"]
                 else None
             ),
             reasoning_effort=(
-                row["reasoning_effort"]
+                _str_val(row["reasoning_effort"])
                 if "reasoning_effort" in keys and row["reasoning_effort"]
                 else None
             ),
@@ -1225,10 +1236,10 @@ class Task:
                 row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
             ),
             session_id=(
-                row["session_id"] if "session_id" in keys else None
+                _str_val(row["session_id"]) if "session_id" in keys else None
             ),
             block_kind=(
-                row["block_kind"] if "block_kind" in keys and row["block_kind"] else None
+                _str_val(row["block_kind"]) if "block_kind" in keys and row["block_kind"] else None
             ),
             block_recurrences=(
                 int(row["block_recurrences"])

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1150,42 +1150,54 @@ def _rule_role_assignee_mismatch(task, events, runs, now, cfg) -> list[Diagnosti
 
     role_norm = role_prefix.strip().lower()
 
-    installed_profiles: set[str] = set()
-    cfg_has_explicit_profiles = False
+    # Recognized roles: common prefix vocabulary + on-disk profile directories + configured profiles
+    recognized_roles: set[str] = set(COMMON_ROLE_PREFIXES)
+    try:
+        from hermes_cli.profiles import list_profile_names
+        for p in list_profile_names():
+            s = str(p).strip().lower()
+            if s:
+                recognized_roles.add(s)
+    except Exception:
+        pass
+    try:
+        from hermes_cli.kanban_db import list_profiles_on_disk
+        for p in list_profiles_on_disk():
+            s = str(p).strip().lower()
+            if s:
+                recognized_roles.add(s)
+    except Exception:
+        pass
+
+    configured_profiles: set[str] = set()
     if isinstance(cfg, dict) and "profiles" in cfg:
-        cfg_has_explicit_profiles = True
         profiles_cfg = cfg.get("profiles")
         if isinstance(profiles_cfg, (list, set, tuple, dict)):
             for p in profiles_cfg:
                 try:
                     s = str(p).strip().lower()
                     if s:
-                        installed_profiles.add(s)
+                        configured_profiles.add(s)
+                        recognized_roles.add(s)
                 except Exception:
                     continue
 
-    recognized_roles: set[str] = set(COMMON_ROLE_PREFIXES)
-    if not cfg_has_explicit_profiles:
-        installed_profiles = _discover_installed_profiles()
-        try:
-            from hermes_cli.profiles import list_profile_names
-            for p in list_profile_names():
-                s = str(p).strip().lower()
-                if s:
-                    recognized_roles.add(s)
-        except Exception:
-            pass
-    else:
-        recognized_roles |= installed_profiles
-
-    known_roles = recognized_roles | installed_profiles
-    if role_norm not in known_roles:
+    if role_norm not in recognized_roles:
         return []
 
     if role_norm == assignee.lower():
         return []
 
-    is_spawnable = role_norm in installed_profiles
+    # Actionable target: must be a live (non-tombstoned) profile verified via profile_exists
+    installed_profiles = _discover_installed_profiles()
+    try:
+        from hermes_cli.profiles import profile_exists
+        for p in configured_profiles:
+            if profile_exists(p):
+                installed_profiles.add(p)
+        is_spawnable = (role_norm in installed_profiles) and profile_exists(role_norm)
+    except Exception:
+        is_spawnable = role_norm in installed_profiles
     task_id = str(_task_field(task, "id") or "")
     actions: list[DiagnosticAction] = []
     if is_spawnable:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1102,6 +1102,28 @@ _ROLE_PREFIX_PATTERN = re.compile(
 )
 
 
+def _discover_installed_profiles() -> set[str]:
+    """Discover installed profile names from disk."""
+    profiles: set[str] = set()
+    try:
+        from hermes_cli.kanban_db import list_profiles_on_disk
+        for p in list_profiles_on_disk():
+            s = str(p).strip().lower()
+            if s:
+                profiles.add(s)
+    except Exception:
+        pass
+    try:
+        from hermes_cli.profiles import list_profile_names
+        for p in list_profile_names():
+            s = str(p).strip().lower()
+            if s:
+                profiles.add(s)
+    except Exception:
+        pass
+    return profiles
+
+
 def _rule_role_assignee_mismatch(task, events, runs, now, cfg) -> list[Diagnostic]:
     """Detect when a recognized role prefix in the title disagrees with the task's assignee.
 
@@ -1126,52 +1148,70 @@ def _rule_role_assignee_mismatch(task, events, runs, now, cfg) -> list[Diagnosti
         return []
 
     role_norm = role_prefix.strip().lower()
-    known_roles = set(COMMON_ROLE_PREFIXES)
-    if isinstance(cfg, dict):
+
+    installed_profiles: set[str] = set()
+    cfg_has_explicit_profiles = False
+    if isinstance(cfg, dict) and "profiles" in cfg:
+        cfg_has_explicit_profiles = True
         profiles_cfg = cfg.get("profiles")
         if isinstance(profiles_cfg, (list, set, tuple, dict)):
             for p in profiles_cfg:
                 try:
                     s = str(p).strip().lower()
                     if s:
-                        known_roles.add(s)
+                        installed_profiles.add(s)
                 except Exception:
                     continue
 
+    if not cfg_has_explicit_profiles:
+        installed_profiles = _discover_installed_profiles()
+
+    known_roles = set(COMMON_ROLE_PREFIXES) | installed_profiles
     if role_norm not in known_roles:
         return []
 
     if role_norm == assignee.lower():
         return []
 
+    is_spawnable = role_norm in installed_profiles
     task_id = str(_task_field(task, "id") or "")
-    actions: list[DiagnosticAction] = [
-        DiagnosticAction(
-            kind="reassign",
-            label=f"Reassign to @{role_norm}",
-            payload={"suggested_assignee": role_norm, "current_assignee": assignee},
-            suggested=True,
-        )
-    ]
-    if task_id:
+    actions: list[DiagnosticAction] = []
+    if is_spawnable:
         actions.append(
             DiagnosticAction(
-                kind="cli_hint",
-                label=f"Reassign via CLI: hermes kanban assign {task_id} {role_norm}",
-                payload={"command": f"hermes kanban assign {task_id} {role_norm}"},
+                kind="reassign",
+                label=f"Reassign to @{role_norm}",
+                payload={"suggested_assignee": role_norm, "current_assignee": assignee},
+                suggested=True,
             )
         )
+        if task_id:
+            actions.append(
+                DiagnosticAction(
+                    kind="cli_hint",
+                    label=f"Reassign via CLI: hermes kanban assign {task_id} {role_norm}",
+                    payload={"command": f"hermes kanban assign {task_id} {role_norm}"},
+                )
+            )
+
+    detail = (
+        f"Task title begins with role prefix '{role_prefix}', but is currently "
+        f"assigned to '{assignee}'. If this task belongs to the {role_prefix} role, "
+        f"reassign it to @{role_norm}; otherwise update the title to avoid confusion."
+        if is_spawnable
+        else (
+            f"Task title begins with role prefix '{role_prefix}', but is currently "
+            f"assigned to '{assignee}'. Profile '{role_norm}' is not currently installed; "
+            f"update the title or install the profile to avoid confusion."
+        )
+    )
 
     return [
         Diagnostic(
             kind="role_assignee_mismatch",
             severity="warning",
             title=f"Title role prefix '{role_prefix}' mismatches assignee '{assignee}'",
-            detail=(
-                f"Task title begins with role prefix '{role_prefix}', but is currently "
-                f"assigned to '{assignee}'. If this task belongs to the {role_prefix} role, "
-                f"reassign it to @{role_norm}; otherwise update the title to avoid confusion."
-            ),
+            detail=detail,
             actions=actions,
             first_seen_at=now,
             last_seen_at=now,
@@ -1270,7 +1310,7 @@ def config_from_runtime_config(raw_config: Optional[dict]) -> dict:
     if isinstance(kanban_cfg, dict):
         cfg.update(config_from_kanban_config(kanban_cfg))
         cfg["kanban"] = kanban_cfg
-    for key in ("auxiliary", "model"):
+    for key in ("auxiliary", "model", "profiles"):
         value = raw_config.get(key)
         if value is not None:
             cfg[key] = value

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1103,21 +1103,22 @@ _ROLE_PREFIX_PATTERN = re.compile(
 
 
 def _discover_installed_profiles() -> set[str]:
-    """Discover installed profile names from disk."""
+    """Discover live (non-tombstoned) installed profile names from disk."""
     profiles: set[str] = set()
     try:
-        from hermes_cli.kanban_db import list_profiles_on_disk
-        for p in list_profiles_on_disk():
+        from hermes_cli.profiles import list_profile_names, profile_exists
+        for p in list_profile_names():
             s = str(p).strip().lower()
-            if s:
+            if s and profile_exists(s):
                 profiles.add(s)
     except Exception:
         pass
     try:
-        from hermes_cli.profiles import list_profile_names
-        for p in list_profile_names():
+        from hermes_cli.kanban_db import list_profiles_on_disk
+        from hermes_cli.profiles import profile_exists
+        for p in list_profiles_on_disk():
             s = str(p).strip().lower()
-            if s:
+            if s and profile_exists(s):
                 profiles.add(s)
     except Exception:
         pass
@@ -1163,10 +1164,21 @@ def _rule_role_assignee_mismatch(task, events, runs, now, cfg) -> list[Diagnosti
                 except Exception:
                     continue
 
+    recognized_roles: set[str] = set(COMMON_ROLE_PREFIXES)
     if not cfg_has_explicit_profiles:
         installed_profiles = _discover_installed_profiles()
+        try:
+            from hermes_cli.profiles import list_profile_names
+            for p in list_profile_names():
+                s = str(p).strip().lower()
+                if s:
+                    recognized_roles.add(s)
+        except Exception:
+            pass
+    else:
+        recognized_roles |= installed_profiles
 
-    known_roles = set(COMMON_ROLE_PREFIXES) | installed_profiles
+    known_roles = recognized_roles | installed_profiles
     if role_norm not in known_roles:
         return []
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, Optional
 import json
+import re
 import time
+
 
 
 # Severity rungs, ordered least → most urgent. The UI colors them
@@ -1078,6 +1080,111 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+COMMON_ROLE_PREFIXES = frozenset({
+    "coder",
+    "reviewer",
+    "devops",
+    "architect",
+    "planner",
+    "researcher",
+    "scribe",
+    "specifier",
+    "synthesizer",
+    "debugger",
+    "qa",
+    "worker",
+    "orchestrator",
+})
+
+_ROLE_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:\[(?P<bracket_role>[A-Za-z0-9_-]+)\]\s*[:\uFF1A]?|(?P<colon_role>[A-Za-z0-9_-]+)\s*[:\uFF1A])",
+    re.UNICODE,
+)
+
+
+def _rule_role_assignee_mismatch(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """Detect when a recognized role prefix in the title disagrees with the task's assignee.
+
+    For example, a title starting with 'Coder:' assigned to 'reviewer'.
+    Emits an advisory warning so operators can reassign the task or update
+    the title, without blocking task creation or execution.
+    """
+    if _task_field(task, "status") in ("done", "archived"):
+        return []
+
+    title = str(_task_field(task, "title") or "").strip()
+    assignee = str(_task_field(task, "assignee") or "").strip()
+    if not title or not assignee:
+        return []
+
+    m = _ROLE_PREFIX_PATTERN.match(title)
+    if not m:
+        return []
+
+    role_prefix = m.group("bracket_role") or m.group("colon_role")
+    if not role_prefix:
+        return []
+
+    role_norm = role_prefix.strip().lower()
+    known_roles = set(COMMON_ROLE_PREFIXES)
+    if isinstance(cfg, dict):
+        profiles_cfg = cfg.get("profiles")
+        if isinstance(profiles_cfg, (list, set, tuple, dict)):
+            for p in profiles_cfg:
+                try:
+                    s = str(p).strip().lower()
+                    if s:
+                        known_roles.add(s)
+                except Exception:
+                    continue
+
+    if role_norm not in known_roles:
+        return []
+
+    if role_norm == assignee.lower():
+        return []
+
+    task_id = str(_task_field(task, "id") or "")
+    actions: list[DiagnosticAction] = [
+        DiagnosticAction(
+            kind="reassign",
+            label=f"Reassign to @{role_norm}",
+            payload={"suggested_assignee": role_norm, "current_assignee": assignee},
+            suggested=True,
+        )
+    ]
+    if task_id:
+        actions.append(
+            DiagnosticAction(
+                kind="cli_hint",
+                label=f"Reassign via CLI: hermes kanban assign {task_id} {role_norm}",
+                payload={"command": f"hermes kanban assign {task_id} {role_norm}"},
+            )
+        )
+
+    return [
+        Diagnostic(
+            kind="role_assignee_mismatch",
+            severity="warning",
+            title=f"Title role prefix '{role_prefix}' mismatches assignee '{assignee}'",
+            detail=(
+                f"Task title begins with role prefix '{role_prefix}', but is currently "
+                f"assigned to '{assignee}'. If this task belongs to the {role_prefix} role, "
+                f"reassign it to @{role_norm}; otherwise update the title to avoid confusion."
+            ),
+            actions=actions,
+            first_seen_at=now,
+            last_seen_at=now,
+            count=1,
+            data={
+                "role_prefix": role_prefix,
+                "expected_assignee": role_norm,
+                "actual_assignee": assignee,
+            },
+        )
+    ]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
@@ -1090,6 +1197,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_role_assignee_mismatch,
 ]
 
 
@@ -1105,6 +1213,7 @@ DIAGNOSTIC_KINDS = (
     "stuck_in_blocked",
     "block_unblock_cycling",
     "stranded_in_ready",
+    "role_assignee_mismatch",
 )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19455,7 +19455,12 @@
       "name": "@hermes/root-tests",
       "devDependencies": {
         "@types/plist": "3.0.5",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
+        "jsdom": "29.1.1",
         "plist": "3.1.1",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
         "typescript": "6.0.3",
         "vitest": "4.1.10"
       }

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1695,9 +1695,19 @@
               onChange: function (e) { setReassignProfile(e.target.value); },
             },
               h("option", { value: "" }, "(unassigned)"),
-              (assignees || []).map(function (a) {
-                return h("option", { key: a, value: a }, a);
-              }),
+              (function () {
+                const list = (assignees || []).slice();
+                if (reassignProfile && list.indexOf(reassignProfile) === -1) {
+                  list.push(reassignProfile);
+                }
+                if (defaultReassignProfile && list.indexOf(defaultReassignProfile) === -1) {
+                  list.push(defaultReassignProfile);
+                }
+                list.sort();
+                return list.map(function (a) {
+                  return h("option", { key: a, value: a }, a);
+                });
+              })(),
             ),
           )
         : null,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1531,10 +1531,14 @@
   function DiagnosticCard(props) {
     const { t } = useI18n();
     const { diag, task, boardSlug, assignees, onRefresh } = props;
+    const reassignAction = (diag.actions || []).find(function (a) {
+      return a.kind === "reassign";
+    });
+    const defaultReassignProfile = (reassignAction && reassignAction.payload && reassignAction.payload.suggested_assignee) || task.assignee || "";
     const [busy, setBusy] = useState(false);
     const [msg, setMsg] = useState(null);
     const [copiedKey, setCopiedKey] = useState(null);
-    const [reassignProfile, setReassignProfile] = useState(task.assignee || "");
+    const [reassignProfile, setReassignProfile] = useState(defaultReassignProfile);
 
     const execAction = function (action) {
       if (busy) return;
@@ -1610,14 +1614,15 @@
         return;
       }
       if (action.kind === "reassign") {
-        if (!reassignProfile) {
+        const targetProfile = reassignProfile || (action.payload && action.payload.suggested_assignee);
+        if (!targetProfile) {
           setMsg({ ok: false, text: tx(t, "pickProfileFirst", "Pick a profile first.") });
           return;
         }
         setBusy(true); setMsg(null);
         const url = withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/reassign`, boardSlug);
         const body = {
-          profile: reassignProfile || null,
+          profile: targetProfile || null,
           reclaim_first: !!(action.payload && action.payload.reclaim_first),
           reason: `recovery action for ${diag.kind}`,
         };
@@ -1629,7 +1634,7 @@
           setMsg({
             ok: true,
             text: tx(t, "reassignedMessage", "Reassigned {id} to {profile}.",
-              { id: task.id, profile: reassignProfile }),
+              { id: task.id, profile: targetProfile }),
           });
           if (onRefresh) onRefresh();
         }).catch(function (err) {
@@ -1638,11 +1643,6 @@
         return;
       }
     };
-
-    // Pull out the reassign action so we can render its picker inline.
-    const reassignAction = (diag.actions || []).find(function (a) {
-      return a.kind === "reassign";
-    });
 
     const sevClass = "hermes-kanban-diag--" + (diag.severity || "warning");
     return h("div", { className: cn("hermes-kanban-diag", sevClass) },

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -4784,4 +4784,13 @@
   if (window.__HERMES_PLUGINS__ && typeof window.__HERMES_PLUGINS__.register === "function") {
     window.__HERMES_PLUGINS__.register("kanban", KanbanPage);
   }
+  KanbanPage.DiagnosticCard = DiagnosticCard;
+  KanbanPage.DiagnosticsSection = DiagnosticsSection;
+  if (typeof window !== "undefined") {
+    window.HermesKanban = {
+      KanbanPage: KanbanPage,
+      DiagnosticCard: DiagnosticCard,
+      DiagnosticsSection: DiagnosticsSection,
+    };
+  }
 })();

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1540,6 +1540,10 @@
     const [copiedKey, setCopiedKey] = useState(null);
     const [reassignProfile, setReassignProfile] = useState(defaultReassignProfile);
 
+    useEffect(function () {
+      setReassignProfile(defaultReassignProfile);
+    }, [defaultReassignProfile]);
+
     const execAction = function (action) {
       if (busy) return;
       if (action.kind === "cli_hint") {
@@ -4786,11 +4790,4 @@
   }
   KanbanPage.DiagnosticCard = DiagnosticCard;
   KanbanPage.DiagnosticsSection = DiagnosticsSection;
-  if (typeof window !== "undefined") {
-    window.HermesKanban = {
-      KanbanPage: KanbanPage,
-      DiagnosticCard: DiagnosticCard,
-      DiagnosticsSection: DiagnosticsSection,
-    };
-  }
 })();

--- a/tests-js/kanban-dashboard-diagnostic.test.ts
+++ b/tests-js/kanban-dashboard-diagnostic.test.ts
@@ -378,4 +378,61 @@ describe('DiagnosticCard visible picker parity and rerender synchronization', ()
     const body = JSON.parse(postCalls[0].opts.body)
     assert.equal(body.profile, 'devops', `POST payload profile must be 'devops'`)
   })
+
+  it('disables reassign action button when unassigned or no profile is selected', async () => {
+    const harness = setupDiagnosticCardHarness()
+    const { container, root, DiagnosticCard } = harness
+
+    const diag: DiagnosticItem = {
+      kind: 'role_assignee_mismatch',
+      severity: 'warning',
+      title: 'Title role prefix mismatches assignee',
+      detail: 'Mismatch detail',
+      actions: [
+        {
+          kind: 'reassign',
+          label: 'Reassign',
+          payload: {},
+        },
+      ],
+    }
+
+    const task: TaskItem = { id: 't_unassigned_1', title: 'Task without assignee' }
+
+    await React.act(async () => {
+      root.render(
+        React.createElement(DiagnosticCard, {
+          key: 'diag-card-stable-key',
+          diag,
+          task,
+          boardSlug: 'default',
+          assignees: ['coder', 'reviewer'],
+          onRefresh: () => {},
+        }),
+      )
+    })
+
+    const selectEl = container.querySelector('select') as HTMLSelectElement
+    assert.equal(selectEl.value, '', "Initial select value must be empty '' when unassigned")
+
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const reassignBtn = buttons.find((b) => b.textContent?.includes('Reassign'))
+    assert.ok(reassignBtn, 'Reassign button must exist')
+    assert.equal(reassignBtn.disabled, true, 'Reassign button must be disabled when unassigned')
+
+    // Selecting an option enables the button
+    await React.act(async () => {
+      selectEl.value = 'coder'
+      selectEl.dispatchEvent(new harness.win.Event('change', { bubbles: true }))
+    })
+    assert.equal(reassignBtn.disabled, false, 'Reassign button must be enabled when a profile is selected')
+
+    // Changing back to unassigned disables the button again
+    await React.act(async () => {
+      selectEl.value = ''
+      selectEl.dispatchEvent(new harness.win.Event('change', { bubbles: true }))
+    })
+    assert.equal(reassignBtn.disabled, true, 'Reassign button must be disabled when select is changed back to unassigned')
+    assert.equal(selectEl.value, '', "Select value must return to '' when changed back to unassigned")
+  })
 })

--- a/tests-js/kanban-dashboard-diagnostic.test.ts
+++ b/tests-js/kanban-dashboard-diagnostic.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for Kanban Dashboard DiagnosticCard component.
+ *
+ * Verifies:
+ * 1. Visible picker parity: When suggested_assignee (e.g. 'coder') is not in the board assignees list
+ *    (e.g. ['reviewer']), the rendered select dropdown still includes 'coder' in its options,
+ *    selectEl.value is 'coder', and clicking Reassign dispatches POST with { profile: 'coder' }.
+ * 2. Stable-key rerender synchronization: When DiagnosticCard updates with a new suggested_assignee prop
+ *    under a stable key, selectEl.value synchronizes with the new target and dispatches the updated profile.
+ * 3. Manual picker selection: When user changes select to another option, value and POST payload update.
+ * 4. Disabled state when unassigned: When value is empty, Reassign button is disabled.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// @ts-ignore jsdom declaration
+import { JSDOM } from 'jsdom'
+import React from 'react'
+import ReactDOMClient from 'react-dom/client'
+import { describe, it } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+const BUNDLE_PATH = path.join(REPO_ROOT, 'plugins', 'kanban', 'dashboard', 'dist', 'index.js')
+
+interface DiagnosticAction {
+  kind: string
+  label?: string
+  payload?: {
+    suggested_assignee?: string
+    current_assignee?: string
+    reclaim_first?: boolean
+    command?: string
+    url?: string
+  }
+  suggested?: boolean
+}
+
+interface DiagnosticItem {
+  kind: string
+  severity?: string
+  title: string
+  detail?: string
+  actions?: DiagnosticAction[]
+  data?: Record<string, unknown>
+}
+
+interface TaskItem {
+  id: string
+  title: string
+  assignee?: string
+  status?: string
+}
+
+interface PostCall {
+  url: string
+  opts: {
+    method: string
+    headers: Record<string, string>
+    body: string
+  }
+}
+
+function setupDiagnosticCardHarness() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
+    url: 'http://localhost',
+  })
+
+  // Set up React Act and DOM globals
+  const win = dom.window
+
+  const g = globalThis as any
+  g.window = win
+  g.document = win.document
+
+  try {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: win.navigator,
+      configurable: true,
+      writable: true,
+    })
+  } catch (_) {
+    g.navigator = win.navigator
+  }
+
+  g.HTMLElement = win.HTMLElement
+  g.Node = win.Node
+  g.IS_REACT_ACT_ENVIRONMENT = true
+
+
+  let registeredPage: any = null
+  const postCalls: PostCall[] = []
+
+  const SDK = {
+    React,
+    components: {
+
+      Button: (props: any) => React.createElement('button', props),
+
+      Input: (props: any) => React.createElement('input', props),
+
+      Label: (props: any) => React.createElement('label', props),
+
+      Select: (props: any) => React.createElement('select', props),
+
+      SelectOption: (props: any) => React.createElement('option', props),
+
+      Card: (props: any) => React.createElement('div', props),
+
+      CardContent: (props: any) => React.createElement('div', props),
+
+      Badge: (props: any) => React.createElement('span', props),
+    },
+    hooks: {
+      useState: React.useState,
+      useEffect: React.useEffect,
+      useCallback: React.useCallback,
+      useMemo: React.useMemo,
+      useRef: React.useRef,
+    },
+
+    utils: {
+
+      cn: (...args: any[]) => args.filter(Boolean).join(' '),
+      timeAgo: () => 'just now',
+    },
+    useI18n: () => ({ t: {}, locale: 'en' }),
+
+    fetchJSON: async (url: string, opts: any) => {
+      postCalls.push({ url, opts })
+
+      return { ok: true, task: {} }
+    },
+  }
+
+  win.__HERMES_PLUGIN_SDK__ = SDK
+  win.__HERMES_PLUGINS__ = {
+
+    register: (_name: string, component: any) => {
+      registeredPage = component
+    },
+  }
+
+  const bundleCode = fs.readFileSync(BUNDLE_PATH, 'utf8')
+  // Evaluate bundle in window context
+  const evalFn = new Function('window', 'document', 'navigator', 'globalThis', bundleCode)
+  evalFn(win, win.document, win.navigator, g)
+
+  const DiagnosticCard = registeredPage?.DiagnosticCard
+  assert.ok(DiagnosticCard, 'DiagnosticCard component must be exported on registeredPage')
+
+  const container = win.document.getElementById('root') as HTMLElement
+  assert.ok(container, 'Root container must exist')
+  const root = ReactDOMClient.createRoot(container)
+
+  return {
+    win,
+    container,
+    root,
+    DiagnosticCard,
+    postCalls,
+  }
+}
+
+describe('DiagnosticCard visible picker parity and rerender synchronization', () => {
+  it('guarantees suggested assignee is visible in picker options when missing from assignees prop', async () => {
+    const harness = setupDiagnosticCardHarness()
+    const { container, root, DiagnosticCard, postCalls } = harness
+
+    const diag: DiagnosticItem = {
+      kind: 'role_assignee_mismatch',
+      severity: 'warning',
+      title: 'Title role prefix mismatches assignee',
+      detail: 'Task title specifies Coder: but assignee is reviewer',
+      actions: [
+        {
+          kind: 'reassign',
+          label: 'Reassign to @coder',
+          payload: { suggested_assignee: 'coder', current_assignee: 'reviewer' },
+          suggested: true,
+        },
+      ],
+    }
+
+    const task: TaskItem = { id: 't_test_1', title: 'Coder: fix bug', assignee: 'reviewer' }
+
+    // assignees only contains 'reviewer' (producer has no non-archived tasks assigned to 'coder')
+    await React.act(async () => {
+      root.render(
+        React.createElement(DiagnosticCard, {
+          key: 'diag-card-stable-key',
+          diag,
+          task,
+          boardSlug: 'default',
+          assignees: ['reviewer'],
+          onRefresh: () => {},
+        }),
+      )
+    })
+
+    const selectEl = container.querySelector('select') as HTMLSelectElement
+    assert.ok(selectEl, 'Select element must be rendered')
+
+    // All options in select
+    const optionValues = Array.from(selectEl.options).map((o: HTMLOptionElement) => o.value)
+    assert.ok(
+      optionValues.includes('coder'),
+      `Picker options must include suggested assignee 'coder', got: ${JSON.stringify(optionValues)}`,
+    )
+    assert.equal(
+      selectEl.value,
+      'coder',
+      `Controlled select value must be 'coder', got: '${selectEl.value}'`,
+    )
+
+    // Click Reassign button
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const reassignBtn = buttons.find((b) => b.textContent?.includes('Reassign'))
+    assert.ok(reassignBtn, 'Reassign button must exist')
+
+    await React.act(async () => {
+      reassignBtn.click()
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    assert.equal(postCalls.length, 1, 'Clicking reassign must make exactly 1 POST call')
+    const body = JSON.parse(postCalls[0].opts.body)
+    assert.equal(body.profile, 'coder', `POST payload profile must be 'coder', got: '${body.profile}'`)
+  })
+
+  it('synchronizes picker value and options across stable-key rerenders', async () => {
+    const harness = setupDiagnosticCardHarness()
+    const { container, root, DiagnosticCard, postCalls } = harness
+
+    const diagStep1: DiagnosticItem = {
+      kind: 'role_assignee_mismatch',
+      severity: 'warning',
+      title: 'Title role prefix mismatches assignee',
+      detail: 'Mismatch detail',
+      actions: [
+        {
+          kind: 'reassign',
+          label: 'Reassign to @coder',
+          payload: { suggested_assignee: 'coder', current_assignee: 'reviewer' },
+          suggested: true,
+        },
+      ],
+    }
+
+    const taskStep1: TaskItem = { id: 't_rerender_1', title: 'Coder: fix bug', assignee: 'reviewer' }
+
+    const diagStep2: DiagnosticItem = {
+      kind: 'role_assignee_mismatch',
+      severity: 'warning',
+      title: 'Title role prefix mismatches assignee',
+      detail: 'Mismatch detail',
+      actions: [
+        {
+          kind: 'reassign',
+          label: 'Reassign to @reviewer',
+          payload: { suggested_assignee: 'reviewer', current_assignee: 'coder' },
+          suggested: true,
+        },
+      ],
+    }
+
+    const taskStep2: TaskItem = { id: 't_rerender_1', title: 'Reviewer: review PR', assignee: 'coder' }
+
+    // Step 1 render
+    await React.act(async () => {
+      root.render(
+        React.createElement(DiagnosticCard, {
+          key: 'diag-card-stable-key',
+          diag: diagStep1,
+          task: taskStep1,
+          boardSlug: 'default',
+          assignees: ['coder', 'reviewer', 'devops'],
+          onRefresh: () => {},
+        }),
+      )
+    })
+
+    const selectEl1 = container.querySelector('select') as HTMLSelectElement
+    assert.equal(selectEl1.value, 'coder', `Initial step must select 'coder', got: '${selectEl1.value}'`)
+
+    // Step 2 rerender under the same stable key
+    await React.act(async () => {
+      root.render(
+        React.createElement(DiagnosticCard, {
+          key: 'diag-card-stable-key',
+          diag: diagStep2,
+          task: taskStep2,
+          boardSlug: 'default',
+          assignees: ['coder', 'reviewer', 'devops'],
+          onRefresh: () => {},
+        }),
+      )
+    })
+
+    const selectEl2 = container.querySelector('select') as HTMLSelectElement
+    assert.equal(
+      selectEl2.value,
+      'reviewer',
+      `Rerendered step under stable key must update select value to 'reviewer', got: '${selectEl2.value}'`,
+    )
+
+    // Click Reassign
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const reassignBtn = buttons.find((b) => b.textContent?.includes('Reassign'))
+    assert.ok(reassignBtn, 'Reassign button must exist')
+
+    await React.act(async () => {
+      reassignBtn.click()
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    assert.equal(postCalls.length, 1, 'Clicking reassign must make exactly 1 POST call')
+    const body = JSON.parse(postCalls[0].opts.body)
+    assert.equal(body.profile, 'reviewer', `POST payload profile must be 'reviewer', got: '${body.profile}'`)
+  })
+
+  it('allows manual picker override and posts manually selected profile', async () => {
+    const harness = setupDiagnosticCardHarness()
+    const { container, root, DiagnosticCard, postCalls } = harness
+
+    const diag: DiagnosticItem = {
+      kind: 'role_assignee_mismatch',
+      severity: 'warning',
+      title: 'Title role prefix mismatches assignee',
+      detail: 'Mismatch detail',
+      actions: [
+        {
+          kind: 'reassign',
+          label: 'Reassign to @coder',
+          payload: { suggested_assignee: 'coder', current_assignee: 'reviewer' },
+          suggested: true,
+        },
+      ],
+    }
+
+    const task: TaskItem = { id: 't_manual_1', title: 'Coder: fix bug', assignee: 'reviewer' }
+
+    await React.act(async () => {
+      root.render(
+        React.createElement(DiagnosticCard, {
+          key: 'diag-card-stable-key',
+          diag,
+          task,
+          boardSlug: 'default',
+          assignees: ['coder', 'reviewer', 'devops'],
+          onRefresh: () => {},
+        }),
+      )
+    })
+
+    const selectEl = container.querySelector('select') as HTMLSelectElement
+    assert.equal(selectEl.value, 'coder')
+
+    // Simulate user selecting 'devops'
+    await React.act(async () => {
+      selectEl.value = 'devops'
+      selectEl.dispatchEvent(new harness.win.Event('change', { bubbles: true }))
+    })
+
+    assert.equal(selectEl.value, 'devops', `After manual change, value must be 'devops'`)
+
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const reassignBtn = buttons.find((b) => b.textContent?.includes('Reassign'))
+    assert.ok(reassignBtn, 'Reassign button must exist')
+
+    await React.act(async () => {
+      reassignBtn.click()
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    assert.equal(postCalls.length, 1)
+    const body = JSON.parse(postCalls[0].opts.body)
+    assert.equal(body.profile, 'devops', `POST payload profile must be 'devops'`)
+  })
+})

--- a/tests-js/package.json
+++ b/tests-js/package.json
@@ -12,7 +12,12 @@
   },
   "devDependencies": {
     "@types/plist": "3.0.5",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "jsdom": "29.1.1",
     "plist": "3.1.1",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "typescript": "6.0.3",
     "vitest": "4.1.10"
   }

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -103,6 +103,82 @@ def test_kanban_list_json_handles_numeric_blob_fields_in_db(kanban_home):
     assert t["max_retries"] == 3
 
 
+def test_kanban_list_json_handles_status_blob_in_db(kanban_home):
+    """Regression: tasks with BLOB status (e.g. status=b'archived') must be matched
+    by exact `hermes kanban list --status archived --json` and `list --archived --json`."""
+    with kb.connect() as conn:
+        conn.execute(
+            "INSERT INTO tasks ("
+            "  id, title, body, assignee, status, priority, workspace_kind, "
+            "  created_at, created_by"
+            ") VALUES (?, ?, ?, ?, ?, 0, 'scratch', 1000, 'user')",
+            ("t_statusblob", "status blob task", "body", "coder", b"archived"),
+        )
+        conn.execute(
+            "INSERT INTO tasks ("
+            "  id, title, body, assignee, status, priority, workspace_kind, "
+            "  created_at, created_by"
+            ") VALUES (?, ?, ?, ?, ?, 0, 'scratch', 1001, 'user')",
+            ("t_statusblob-control", "active control", "body", "coder", "ready"),
+        )
+        conn.commit()
+
+    # Exact filter command: --status archived
+    raw = kc.run_slash("list --status archived --json")
+    payload = json.loads(raw)
+    matched = [row for row in payload if row.get("id") == "t_statusblob"]
+    assert len(matched) == 1
+    assert matched[0]["id"] == "t_statusblob"
+    assert matched[0]["title"] == "status blob task"
+    assert matched[0]["assignee"] == "coder"
+    assert matched[0]["status"] == "archived"
+
+    # Also verify default list (which excludes archived) excludes the BLOB archived task
+    raw_default = kc.run_slash("list --json")
+    payload_default = json.loads(raw_default)
+    assert payload_default
+    assert any(row.get("id") == "t_statusblob-control" for row in payload_default)
+    assert not any(row.get("id") == "t_statusblob" for row in payload_default)
+
+    # And --archived flag includes it
+    raw_archived = kc.run_slash("list --archived --json")
+    payload_archived = json.loads(raw_archived)
+    assert any(row.get("id") == "t_statusblob" for row in payload_archived)
+
+
+def test_kanban_stats_handles_bytes_assignee_and_status(kanban_home):
+    """Regression: tasks with BLOB assignee/status must not crash `hermes kanban stats`
+    or `hermes kanban stats --json` when sorting."""
+    with kb.connect() as conn:
+        conn.execute(
+            "INSERT INTO tasks ("
+            "  id, title, body, assignee, status, priority, workspace_kind, "
+            "  created_at, created_by"
+            ") VALUES (?, ?, ?, ?, ?, 0, 'scratch', 1000, 'user')",
+            ("t_blob_stat1", "stat task 1", "body", b"coder", b"ready"),
+        )
+        conn.execute(
+            "INSERT INTO tasks ("
+            "  id, title, body, assignee, status, priority, workspace_kind, "
+            "  created_at, created_by"
+            ") VALUES (?, ?, ?, ?, ?, 0, 'scratch', 1000, 'user')",
+            ("t_blob_stat2", "stat task 2", "body", "reviewer", "ready"),
+        )
+        conn.commit()
+
+    text_output = kc.run_slash("stats")
+    assert "coder" in text_output
+    assert "reviewer" in text_output
+    assert "ready=1" in text_output
+
+    json_raw = kc.run_slash("stats --json")
+    data = json.loads(json_raw)
+    assert "coder" in data["by_assignee"]
+    assert "reviewer" in data["by_assignee"]
+    assert data["by_assignee"]["coder"]["ready"] == 1
+    assert data["by_assignee"]["reviewer"]["ready"] == 1
+
+
 
 
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -77,6 +77,33 @@ def test_kanban_list_json_handles_bytes_fields_in_db(kanban_home):
     )
 
 
+def test_kanban_list_json_handles_numeric_blob_fields_in_db(kanban_home):
+    """Regression: tasks with BLOBs in numeric/timestamp columns (e.g. priority=b'7',
+    created_at=b'1000', started_at=b'1010', completed_at=b'1020', max_retries=b'3')
+    must not crash `hermes kanban list --status archived --json` with TypeError."""
+    with kb.connect() as conn:
+        conn.execute(
+            "INSERT INTO tasks ("
+            "  id, title, body, assignee, status, priority, workspace_kind, "
+            "  created_at, started_at, completed_at, max_retries, created_by"
+            ") VALUES (?, ?, ?, ?, 'archived', ?, 'scratch', ?, ?, ?, ?, 'user')",
+            ("t_numblob1", "num blob task", "body", "coder", b"7", b"1000", b"1010", b"1020", b"3"),
+        )
+        conn.commit()
+
+    raw = kc.run_slash("list --status archived --json")
+    payload = json.loads(raw)
+    matched = [row for row in payload if row.get("id") == "t_numblob1"]
+    assert len(matched) == 1
+    t = matched[0]
+    assert t["priority"] == 7
+    assert t["created_at"] == 1000
+    assert t["started_at"] == 1010
+    assert t["completed_at"] == 1020
+    assert t["max_retries"] == 3
+
+
+
 
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,27 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_list_json_handles_bytes_fields_in_db(kanban_home):
+    """Regression: tasks with BLOB/bytes fields (e.g. body stored as bytes)
+    must not crash `hermes kanban list --status archived --json` with TypeError."""
+    with kb.connect() as conn:
+        conn.execute(
+            "INSERT INTO tasks (id, title, body, assignee, status, priority, workspace_kind, created_at, created_by) "
+            "VALUES (?, ?, ?, ?, 'archived', 0, 'scratch', 1000, 'user')",
+            ("t_bytes1", "bytes task", b"## archived task body as bytes", "coder"),
+        )
+        conn.commit()
+
+    raw = kc.run_slash("list --status archived --json")
+    payload = json.loads(raw)
+    assert any(
+        row.get("id") == "t_bytes1"
+        and row.get("body") == "## archived task body as bytes"
+        for row in payload
+    )
+
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -231,7 +231,17 @@ def test_severity_at_or_above_uses_threshold_semantics():
 # ---------------------------------------------------------------------------
 
 
-def test_role_assignee_mismatch_fires_on_common_prefixes():
+def test_role_assignee_mismatch_fires_on_common_prefixes(tmp_path, monkeypatch):
+    hermes_root = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: hermes_root)
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: hermes_root / "profiles")
+
+    for p in ("coder", "reviewer", "devops"):
+        pdir = hermes_root / "profiles" / p
+        pdir.mkdir(parents=True, exist_ok=True)
+        (pdir / "config.yaml").write_text(f"model: {p}-test\n")
+
     cases = [
         ("Coder: fix memory leak", "reviewer", "Coder", "coder"),
         ("Reviewer: review PR #123", "coder", "Reviewer", "reviewer"),
@@ -382,6 +392,91 @@ def test_role_assignee_mismatch_suppresses_suggested_reassign_for_tombstoned_pro
     conn = kb.connect()
     try:
         t_id = kb.create_task(conn, title="Ghost task", assignee="ghost")
+        dispatch_result = kb.dispatch_once(conn)
+        assert t_id in dispatch_result.skipped_nonspawnable, (
+            f"Expected {t_id} in skipped_nonspawnable, got {dispatch_result.skipped_nonspawnable}"
+        )
+    finally:
+        conn.close()
+
+
+def test_list_profiles_on_disk_filters_tombstones(tmp_path, monkeypatch):
+    """list_profiles_on_disk() discovers live profiles with config.yaml and excludes tombstoned dirs."""
+    from hermes_constants import mark_named_profile_deleted
+    from hermes_cli.kanban_db import list_profiles_on_disk
+
+    hermes_root = tmp_path / ".hermes"
+    profiles_dir = hermes_root / "profiles"
+    profiles_dir.mkdir(parents=True)
+
+    live_dir = profiles_dir / "live_worker"
+    live_dir.mkdir()
+    (live_dir / "config.yaml").write_text("model: test\n")
+
+    tomb_dir = profiles_dir / "tomb_worker"
+    tomb_dir.mkdir()
+    (tomb_dir / "config.yaml").write_text("model: test\n")
+    mark_named_profile_deleted(tomb_dir)
+
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: hermes_root)
+
+    discovered = list_profiles_on_disk()
+    assert "live_worker" in discovered
+    assert "tomb_worker" not in discovered
+    assert "default" in discovered
+
+
+def test_role_assignee_mismatch_explicit_config_tombstone_filtered_via_load_config(tmp_path, monkeypatch):
+    """When config.yaml defines explicit `profiles: [ghost]` but ghost has a tombstone,
+    kd.config_from_runtime_config(load_config()) processes the config and ensures ghost
+    is not marked spawnable and produces no suggested reassign or CLI actions."""
+    from hermes_constants import mark_named_profile_deleted
+    from hermes_cli.profiles import profile_exists
+    from hermes_cli.config import load_config
+    import yaml
+
+    now = int(time.time())
+    hermes_root = tmp_path / ".hermes"
+    ghost_dir = hermes_root / "profiles" / "ghost"
+    ghost_dir.mkdir(parents=True)
+    (ghost_dir / "config.yaml").write_text("model: ghost-model\n")
+    mark_named_profile_deleted(ghost_dir)
+
+    cfg_file = hermes_root / "config.yaml"
+    cfg_file.write_text(yaml.dump({"profiles": ["ghost", "reviewer"]}))
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: hermes_root)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_root)
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: hermes_root / "profiles")
+
+    assert not profile_exists("ghost"), "Tombstoned ghost profile must not exist"
+
+    runtime_cfg = load_config()
+    diag_cfg = kd.config_from_runtime_config(runtime_cfg)
+    assert "profiles" in diag_cfg
+
+    task = _task(title="Ghost: run ghost job", assignee="reviewer", status="ready")
+    diags = kd.compute_task_diagnostics(task, [], [], now=now, config=diag_cfg)
+    mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+    assert len(mismatches) == 1
+    d = mismatches[0]
+    assert d.severity == "warning"
+    assert d.data["role_prefix"] == "Ghost"
+    assert d.data["expected_assignee"] == "ghost"
+    # Actionable reassign and CLI actions must NOT be produced for tombstoned profile
+    suggested_actions = [a for a in d.actions if a.suggested]
+    assert len(suggested_actions) == 0, f"Expected 0 suggested actions, got: {suggested_actions}"
+    reassign_actions = [a for a in d.actions if a.kind == "reassign"]
+    assert len(reassign_actions) == 0, f"Expected 0 reassign actions, got: {reassign_actions}"
+    cli_actions = [a for a in d.actions if a.kind == "cli_hint"]
+    assert len(cli_actions) == 0, f"Expected 0 cli_hint actions, got: {cli_actions}"
+
+    # Dispatcher contract check
+    import hermes_cli.kanban_db as kb
+    conn = kb.connect()
+    try:
+        t_id = kb.create_task(conn, title="Ghost: run ghost job", assignee="ghost")
         dispatch_result = kb.dispatch_once(conn)
         assert t_id in dispatch_result.skipped_nonspawnable, (
             f"Expected {t_id} in skipped_nonspawnable, got {dispatch_result.skipped_nonspawnable}"

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -241,9 +241,10 @@ def test_role_assignee_mismatch_fires_on_common_prefixes():
         ("[Coder]: handle bytes body", "devops", "Coder", "coder"),
     ]
     now = int(time.time())
+    cfg = {"profiles": ["coder", "reviewer", "devops"]}
     for title, assignee, expected_prefix, expected_role in cases:
         task = _task(title=title, assignee=assignee, status="ready")
-        diags = kd.compute_task_diagnostics(task, [], [], now=now)
+        diags = kd.compute_task_diagnostics(task, [], [], now=now, config=cfg)
         mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
         assert len(mismatches) == 1, f"Failed for title={title!r}, assignee={assignee!r}"
         d = mismatches[0]
@@ -296,3 +297,47 @@ def test_role_assignee_mismatch_exempt_for_terminal_status():
         mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
         assert len(mismatches) == 0, f"Terminal task ({status}) should not fire role_assignee_mismatch"
 
+
+def test_role_assignee_mismatch_suppresses_suggested_reassign_for_uninstalled_role(monkeypatch):
+    """When a title has a role prefix for an uninstalled/non-spawnable role (e.g. architect),
+    the diagnostic fires as advisory warning but does NOT suggest reassigning to a non-spawnable target."""
+    now = int(time.time())
+    # Set known installed profiles to only ['coder', 'reviewer', 'devops']
+    cfg = {"profiles": ["coder", "reviewer", "devops"]}
+    task = _task(title="Architect: design system", assignee="reviewer", status="ready")
+    diags = kd.compute_task_diagnostics(task, [], [], now=now, config=cfg)
+    mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+    assert len(mismatches) == 1
+    d = mismatches[0]
+    assert d.severity == "warning"
+    assert d.data["role_prefix"] == "Architect"
+    assert d.data["expected_assignee"] == "architect"
+    # Reassign action must not be suggested when architect is not installed
+    suggested_actions = [a for a in d.actions if a.suggested]
+    assert len(suggested_actions) == 0, f"Uninstalled profile must not have suggested action: {suggested_actions}"
+
+
+def test_role_assignee_mismatch_recognizes_installed_custom_profiles(tmp_path, monkeypatch):
+    """Custom installed profiles (e.g. fable) discovered dynamically on disk
+    are recognized as role prefixes and generate suggested reassignments."""
+    now = int(time.time())
+    # Create fake custom profile on disk
+    hermes_root = tmp_path / ".hermes"
+    fable_dir = hermes_root / "profiles" / "fable"
+    fable_dir.mkdir(parents=True)
+    (fable_dir / "config.yaml").write_text("model: custom-model\n")
+
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: hermes_root)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_root)
+
+    task = _task(title="Fable: generate world lore", assignee="reviewer", status="ready")
+    # Call compute_task_diagnostics with default config (no explicit profiles passed)
+    diags = kd.compute_task_diagnostics(task, [], [], now=now)
+    mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+    assert len(mismatches) == 1
+    d = mismatches[0]
+    assert d.data["role_prefix"] == "Fable"
+    assert d.data["expected_assignee"] == "fable"
+    reassign_actions = [a for a in d.actions if a.kind == "reassign" and a.suggested]
+    assert len(reassign_actions) == 1
+    assert reassign_actions[0].payload["suggested_assignee"] == "fable"

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -341,3 +341,50 @@ def test_role_assignee_mismatch_recognizes_installed_custom_profiles(tmp_path, m
     reassign_actions = [a for a in d.actions if a.kind == "reassign" and a.suggested]
     assert len(reassign_actions) == 1
     assert reassign_actions[0].payload["suggested_assignee"] == "fable"
+
+
+def test_role_assignee_mismatch_suppresses_suggested_reassign_for_tombstoned_profile(tmp_path, monkeypatch):
+    """When a profile directory exists on disk but has a tombstone (.deleted marker),
+    profile_exists('ghost') is False. The role mismatch warning is still emitted,
+    but reassign action is not suggested."""
+    from hermes_constants import mark_named_profile_deleted
+    from hermes_cli.profiles import profile_exists
+
+    now = int(time.time())
+    hermes_root = tmp_path / ".hermes"
+    ghost_dir = hermes_root / "profiles" / "ghost"
+    ghost_dir.mkdir(parents=True)
+    (ghost_dir / "config.yaml").write_text("model: ghost-model\n")
+    mark_named_profile_deleted(ghost_dir)
+
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: hermes_root)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_root)
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: hermes_root / "profiles")
+
+    assert not profile_exists("ghost"), "Tombstoned profile must not exist in live profile registry"
+
+    task = _task(title="Ghost: cleanup phantom memory", assignee="reviewer", status="ready")
+    diags = kd.compute_task_diagnostics(task, [], [], now=now)
+    mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+    assert len(mismatches) == 1
+    d = mismatches[0]
+    assert d.severity == "warning"
+    assert d.data["role_prefix"] == "Ghost"
+    assert d.data["expected_assignee"] == "ghost"
+    # Actionable reassign must NOT be suggested for tombstoned profile
+    suggested_actions = [a for a in d.actions if a.suggested]
+    assert len(suggested_actions) == 0, f"Tombstoned profile must not have suggested action: {suggested_actions}"
+    reassign_actions = [a for a in d.actions if a.kind == "reassign"]
+    assert len(reassign_actions) == 0, f"Tombstoned profile must not have reassign actions: {reassign_actions}"
+
+    # Also assert dispatcher contract: ready tasks assigned to tombstoned ghost are skipped_nonspawnable
+    import hermes_cli.kanban_db as kb
+    conn = kb.connect()
+    try:
+        t_id = kb.create_task(conn, title="Ghost task", assignee="ghost")
+        dispatch_result = kb.dispatch_once(conn)
+        assert t_id in dispatch_result.skipped_nonspawnable, (
+            f"Expected {t_id} in skipped_nonspawnable, got {dispatch_result.skipped_nonspawnable}"
+        )
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -224,3 +224,75 @@ def test_severity_at_or_above_uses_threshold_semantics():
     assert kd.severity_at_or_above("error", "critical") is False
     assert kd.severity_at_or_above("mystery", "warning") is False
     assert kd.severity_at_or_above("warning", None) is True
+
+
+# ---------------------------------------------------------------------------
+# role_assignee_mismatch rule
+# ---------------------------------------------------------------------------
+
+
+def test_role_assignee_mismatch_fires_on_common_prefixes():
+    cases = [
+        ("Coder: fix memory leak", "reviewer", "Coder", "coder"),
+        ("Reviewer: review PR #123", "coder", "Reviewer", "reviewer"),
+        ("DevOps: deploy production cluster", "architect", "DevOps", "devops"),
+        ("[DevOps] deploy gateway", "reviewer", "DevOps", "devops"),
+        ("Coder\uFF1Afix json crash", "reviewer", "Coder", "coder"),
+        ("[Coder]: handle bytes body", "devops", "Coder", "coder"),
+    ]
+    now = int(time.time())
+    for title, assignee, expected_prefix, expected_role in cases:
+        task = _task(title=title, assignee=assignee, status="ready")
+        diags = kd.compute_task_diagnostics(task, [], [], now=now)
+        mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+        assert len(mismatches) == 1, f"Failed for title={title!r}, assignee={assignee!r}"
+        d = mismatches[0]
+        assert d.severity == "warning"
+        assert d.data["role_prefix"] == expected_prefix
+        assert d.data["expected_assignee"] == expected_role
+        assert d.data["actual_assignee"] == assignee
+        assert any(a.kind == "reassign" for a in d.actions)
+        assert any(a.kind == "cli_hint" for a in d.actions)
+
+
+def test_role_assignee_mismatch_does_not_fire_when_matching():
+    cases = [
+        ("Coder: fix memory leak", "coder"),
+        ("Reviewer: review PR #123", "reviewer"),
+        ("DevOps: deploy production cluster", "devops"),
+        ("[DevOps] deploy gateway", "devops"),
+        ("Coder\uFF1Afix json crash", "coder"),
+    ]
+    now = int(time.time())
+    for title, assignee in cases:
+        task = _task(title=title, assignee=assignee, status="ready")
+        diags = kd.compute_task_diagnostics(task, [], [], now=now)
+        mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+        assert len(mismatches) == 0, f"Unexpected mismatch diagnostic for {title!r} with {assignee!r}"
+
+
+def test_role_assignee_mismatch_does_not_fire_on_unrelated_prefix_or_no_prefix():
+    cases = [
+        ("Fix bug in parser", "reviewer"),
+        ("Feature: add support for streaming", "coder"),
+        ("Bug: crash on empty list", "reviewer"),
+        ("http://example.com/issue/12", "coder"),
+        ("123: numeric title", "coder"),
+        ("Quick investigation", "devops"),
+    ]
+    now = int(time.time())
+    for title, assignee in cases:
+        task = _task(title=title, assignee=assignee, status="ready")
+        diags = kd.compute_task_diagnostics(task, [], [], now=now)
+        mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+        assert len(mismatches) == 0, f"Unexpected mismatch diagnostic for non-role title {title!r}"
+
+
+def test_role_assignee_mismatch_exempt_for_terminal_status():
+    now = int(time.time())
+    for status in ("done", "archived"):
+        task = _task(title="Coder: fix bug", assignee="reviewer", status=status)
+        diags = kd.compute_task_diagnostics(task, [], [], now=now)
+        mismatches = [d for d in diags if d.kind == "role_assignee_mismatch"]
+        assert len(mismatches) == 0, f"Terminal task ({status}) should not fire role_assignee_mismatch"
+

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1172,172 +1172,9 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     assert "t_ffff00001234" in row["diagnostics"][0]["data"]["phantom_ids"]
 
 
-def _render_dashboard_diagnostic_card(
-    diag: dict | None = None,
-    task: dict | None = None,
-    board_slug: str = "default",
-    assignees: list[str] | None = None,
-    steps: list[dict] | None = None,
-) -> dict:
-    """Execute DiagnosticCard from plugins/kanban/dashboard/dist/index.js in Node.js
-    using real React and JSDOM to capture rendered DOM state plus executed network POST actions."""
-    import json
-    import os
-    import subprocess
-    from pathlib import Path
-    from hermes_constants import find_hermes_node_executable
-
-    repo_root = Path(__file__).resolve().parents[2]
-    bundle_path = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-
-    runner_script = """
-const fs = require("fs");
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom;
-const dom = new JSDOM("<!DOCTYPE html><html><body><div id=\\"root\\"></div></body></html>", { url: "http://localhost" });
-globalThis.window = dom.window;
-globalThis.document = dom.window.document;
-globalThis.navigator = dom.window.navigator;
-globalThis.HTMLElement = dom.window.HTMLElement;
-globalThis.Node = dom.window.Node;
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-
-const React = require("react");
-const ReactDOMClient = require("react-dom/client");
-
-let registeredPage = null;
-const postCalls = [];
-
-const SDK = {
-  React,
-  components: {
-    Button: (props) => React.createElement("button", props),
-    Input: (props) => React.createElement("input", props),
-    Label: (props) => React.createElement("label", props),
-    Select: (props) => React.createElement("select", props),
-    SelectOption: (props) => React.createElement("option", props),
-    Card: (props) => React.createElement("div", props),
-    CardContent: (props) => React.createElement("div", props),
-    Badge: (props) => React.createElement("span", props),
-  },
-  hooks: {
-    useState: React.useState,
-    useEffect: React.useEffect,
-    useCallback: React.useCallback,
-    useMemo: React.useMemo,
-    useRef: React.useRef,
-  },
-  utils: {
-    cn: (...args) => args.filter(Boolean).join(" "),
-    timeAgo: () => "just now",
-  },
-  useI18n: () => ({ t: {}, locale: "en" }),
-  fetchJSON: async (url, opts) => {
-    postCalls.push({ url, opts });
-    return { ok: true, task: {} };
-  }
-};
-
-globalThis.window.__HERMES_PLUGIN_SDK__ = SDK;
-globalThis.window.__HERMES_PLUGINS__ = {
-  register: (name, component) => {
-    registeredPage = component;
-  }
-};
-
-const bundleCode = fs.readFileSync(process.argv[1], "utf8");
-eval(bundleCode);
-
-const DiagnosticCard = registeredPage && registeredPage.DiagnosticCard;
-if (!DiagnosticCard) {
-  throw new Error("DiagnosticCard component not exposed on registeredPage");
-}
-
-const rawInput = fs.readFileSync(0, "utf8");
-const inputData = JSON.parse(rawInput);
-const steps = Array.isArray(inputData.steps) ? inputData.steps : [inputData];
-
-const container = document.getElementById("root");
-const root = ReactDOMClient.createRoot(container);
-
-(async () => {
-  const stepResults = [];
-  for (let s = 0; s < steps.length; s++) {
-    const step = steps[s];
-    const props = {
-      diag: step.diag,
-      task: step.task,
-      boardSlug: step.boardSlug || inputData.boardSlug || "default",
-      assignees: step.assignees || inputData.assignees || ["coder", "reviewer", "devops"],
-      onRefresh: () => {},
-    };
-
-    await React.act(async () => {
-      root.render(React.createElement(DiagnosticCard, { key: "diag-card-stable-key", ...props }));
-    });
-
-    const selectEl = container.querySelector("select");
-    const selectedValue = selectEl ? selectEl.value : null;
-
-    if (step.clickReassign !== false) {
-      const btns = container.querySelectorAll("button");
-      for (const btn of btns) {
-        if (btn.textContent.includes("Reassign")) {
-          await React.act(async () => {
-            btn.click();
-            await new Promise(r => setTimeout(r, 10));
-          });
-        }
-      }
-    }
-
-    stepResults.push({
-      stepIndex: s,
-      selectedValue,
-    });
-  }
-
-  console.log(JSON.stringify({
-    selectedValue: stepResults[stepResults.length - 1].selectedValue,
-    stepResults,
-    postCalls,
-  }));
-})();
-"""
-
-    if steps is not None:
-        payload = {"steps": steps, "boardSlug": board_slug, "assignees": assignees}
-    else:
-        payload = {
-            "diag": diag,
-            "task": task,
-            "boardSlug": board_slug,
-            "assignees": assignees or ["coder", "reviewer"],
-        }
-    node_bin = find_hermes_node_executable("node") or "node"
-    env = dict(os.environ)
-    env["NODE_PATH"] = str(repo_root / "node_modules")
-    proc = subprocess.run(
-        [node_bin, "-e", runner_script, str(bundle_path)],
-        input=json.dumps(payload),
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"Node execution failed (rc={proc.returncode}):\n"
-            f"cmd: {[node_bin, '-e', '...', str(bundle_path)]}\n"
-            f"stdout: {proc.stdout}\n"
-            f"stderr: {proc.stderr}"
-        )
-    return json.loads(proc.stdout)
-
-
 def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clears_it(client, kanban_home):
-    """Consumer contract: task with role prefix gets suggested_assignee in diagnostic action,
-    dashboard DiagnosticCard renders suggested assignee in the picker and POSTs it,
-    updating durable state and clearing the diagnostic."""
+    """Task with role prefix gets suggested_assignee in diagnostic action;
+    reassigning to suggested assignee updates durable state and clears the diagnostic."""
     # Ensure coder profile exists on disk so it is recognized as spawnable
     coder_dir = kanban_home / "profiles" / "coder"
     coder_dir.mkdir(parents=True, exist_ok=True)
@@ -1361,21 +1198,16 @@ def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clear
     suggested = reassign_actions[0]["payload"]["suggested_assignee"]
     assert suggested == "coder"
 
-    # Execute actual dashboard UI consumer component (DiagnosticCard) on the payload
-    task_data = {"id": t, "title": "Coder: fix bug", "assignee": "reviewer"}
-    consumer_result = _render_dashboard_diagnostic_card(diag, task_data, board_slug="default")
-    assert consumer_result["selectedValue"] == "coder", (
-        f"DiagnosticCard picker default expected 'coder', got {consumer_result['selectedValue']}"
-    )
-    assert len(consumer_result["postCalls"]) == 1
-    post_call = consumer_result["postCalls"][0]
-    captured_body = json.loads(post_call["opts"]["body"])
-    assert captured_body["profile"] == "coder"
+    # Verify assignees endpoint contains suggested coder profile
+    assignees_r = client.get("/api/plugins/kanban/assignees")
+    assert assignees_r.status_code == 200
+    names = [a["name"] for a in assignees_r.json().get("assignees", [])]
+    assert "coder" in names
 
-    # Send the captured UI consumer POST payload to the API
+    # Send the reassign action POST payload to the API
     post_r = client.post(
-        post_call["url"],
-        json=captured_body,
+        f"/api/plugins/kanban/tasks/{t}/reassign",
+        json={"profile": suggested, "reason": f"recovery action for {diag['kind']}"},
     )
     assert post_r.status_code == 200, post_r.text
     assert post_r.json()["assignee"] == "coder"
@@ -1385,57 +1217,6 @@ def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clear
     assert r2.status_code == 200
     mismatch_rows2 = [row for row in r2.json()["diagnostics"] if row["task_id"] == t]
     assert len(mismatch_rows2) == 0
-
-
-def test_diagnostic_card_rerender_synchronizes_suggested_assignee_and_posts_updated_target():
-    """Rerender regression: when DiagnosticCard remains mounted under a stable key
-    and suggested_assignee prop changes from coder to reviewer, reassignProfile must
-    synchronize with the updated suggestion and clicking reassign must POST reviewer."""
-    diag_step1 = {
-        "kind": "role_assignee_mismatch",
-        "severity": "warning",
-        "title": "Title role prefix mismatches",
-        "detail": "Mismatch detail",
-        "actions": [{
-            "kind": "reassign",
-            "label": "Reassign to @coder",
-            "payload": {"suggested_assignee": "coder", "current_assignee": "reviewer"},
-            "suggested": True,
-        }],
-    }
-    task_step1 = {"id": "t_1", "title": "Coder: fix bug", "assignee": "reviewer"}
-
-    diag_step2 = {
-        "kind": "role_assignee_mismatch",
-        "severity": "warning",
-        "title": "Title role prefix mismatches",
-        "detail": "Mismatch detail",
-        "actions": [{
-            "kind": "reassign",
-            "label": "Reassign to @reviewer",
-            "payload": {"suggested_assignee": "reviewer", "current_assignee": "coder"},
-            "suggested": True,
-        }],
-    }
-    task_step2 = {"id": "t_1", "title": "Reviewer: review PR", "assignee": "coder"}
-
-    steps = [
-        {"diag": diag_step1, "task": task_step1, "clickReassign": False},
-        {"diag": diag_step2, "task": task_step2, "clickReassign": True},
-    ]
-
-    res = _render_dashboard_diagnostic_card(steps=steps, board_slug="default", assignees=["coder", "reviewer", "devops"])
-    assert res["stepResults"][0]["selectedValue"] == "coder", (
-        f"Initial mount expected selectedValue 'coder', got {res['stepResults'][0]['selectedValue']}"
-    )
-    assert res["stepResults"][1]["selectedValue"] == "reviewer", (
-        f"After rerender expected selectedValue 'reviewer', got {res['stepResults'][1]['selectedValue']}"
-    )
-    assert len(res["postCalls"]) == 1
-    post_body = json.loads(res["postCalls"][0]["opts"]["body"])
-    assert post_body["profile"] == "reviewer", (
-        f"POST request expected profile 'reviewer', got {post_body['profile']}"
-    )
 
 
 def test_diagnostics_endpoint_with_explicit_config_tombstone_suppresses_suggested_reassign(client, kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1172,6 +1172,48 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     assert "t_ffff00001234" in row["diagnostics"][0]["data"]["phantom_ids"]
 
 
+def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clears_it(client, kanban_home):
+    """Consumer contract: task with role prefix gets suggested_assignee in diagnostic action,
+    posting that suggested assignee updates durable state and clears the diagnostic."""
+    # Ensure coder profile exists on disk so it is recognized as spawnable
+    coder_dir = kanban_home / "profiles" / "coder"
+    coder_dir.mkdir(parents=True, exist_ok=True)
+    (coder_dir / "config.yaml").write_text("model: test\n")
+
+    conn = kb.connect()
+    try:
+        t = kb.create_task(conn, title="Coder: fix bug", assignee="reviewer")
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/diagnostics")
+    assert r.status_code == 200
+    data = r.json()
+    mismatch_rows = [row for row in data["diagnostics"] if row["task_id"] == t]
+    assert len(mismatch_rows) == 1
+    diag = mismatch_rows[0]["diagnostics"][0]
+    assert diag["kind"] == "role_assignee_mismatch"
+    reassign_actions = [a for a in diag["actions"] if a["kind"] == "reassign"]
+    assert len(reassign_actions) == 1
+    suggested = reassign_actions[0]["payload"]["suggested_assignee"]
+    assert suggested == "coder"
+
+    # Simulate UI execution: POST /reassign using suggested_assignee target
+    post_r = client.post(
+        f"/api/plugins/kanban/tasks/{t}/reassign",
+        json={"profile": suggested, "reclaim_first": False},
+    )
+    assert post_r.status_code == 200, post_r.text
+    assert post_r.json()["assignee"] == "coder"
+
+    # Re-check diagnostics — warning should now be cleared
+    r2 = client.get("/api/plugins/kanban/diagnostics")
+    assert r2.status_code == 200
+    mismatch_rows2 = [row for row in r2.json()["diagnostics"] if row["task_id"] == t]
+    assert len(mismatch_rows2) == 0
+
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks/:id/specify — triage specifier endpoint
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1172,9 +1172,166 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     assert "t_ffff00001234" in row["diagnostics"][0]["data"]["phantom_ids"]
 
 
+def _render_dashboard_diagnostic_card(
+    diag: dict,
+    task: dict,
+    board_slug: str = "default",
+    assignees: list[str] | None = None,
+) -> dict:
+    """Execute DiagnosticCard from plugins/kanban/dashboard/dist/index.js in Node.js
+    and capture rendered DOM state plus executed network POST actions."""
+    import json
+    import subprocess
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle_path = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+
+    runner_script = """
+const fs = require("fs");
+
+let registeredPage = null;
+const postCalls = [];
+
+const React = {
+  Component: class Component {},
+  createElement: (type, props, ...children) => {
+    return { type, props: props || {}, children: children.flat(Infinity) };
+  }
+};
+
+let hookState = [];
+let hookIdx = 0;
+function useState(initial) {
+  const idx = hookIdx++;
+  if (hookState[idx] === undefined) {
+    hookState[idx] = typeof initial === "function" ? initial() : initial;
+  }
+  const setter = (val) => {
+    hookState[idx] = typeof val === "function" ? val(hookState[idx]) : val;
+  };
+  return [hookState[idx], setter];
+}
+
+const SDK = {
+  React,
+  components: {
+    Button: (props) => React.createElement("button", props),
+    Input: (props) => React.createElement("input", props),
+    Label: (props) => React.createElement("label", props),
+    Select: (props) => React.createElement("select", props),
+    SelectOption: (props) => React.createElement("option", props),
+    Card: (props) => React.createElement("div", props),
+    CardContent: (props) => React.createElement("div", props),
+    Badge: (props) => React.createElement("span", props),
+  },
+  hooks: {
+    useState,
+    useEffect: (fn) => fn(),
+    useCallback: (fn) => fn,
+    useMemo: (fn) => fn(),
+    useRef: (initial) => ({ current: initial }),
+  },
+  utils: {
+    cn: (...args) => args.filter(Boolean).join(" "),
+    timeAgo: () => "just now",
+  },
+  useI18n: () => ({ t: {}, locale: "en" }),
+  fetchJSON: async (url, opts) => {
+    postCalls.push({ url, opts });
+    return { ok: true, task: {} };
+  }
+};
+
+globalThis.window = {
+  __HERMES_PLUGIN_SDK__: SDK,
+  __HERMES_PLUGINS__: {
+    register: (name, component) => {
+      registeredPage = component;
+    }
+  },
+  prompt: (msg, val) => val,
+  navigator: {
+    clipboard: {
+      writeText: async (text) => {},
+    },
+  },
+};
+globalThis.document = {
+  querySelector: () => null,
+};
+
+const bundleCode = fs.readFileSync(process.argv[1], "utf8");
+eval(bundleCode);
+
+const DiagnosticCard = (globalThis.window.HermesKanban && globalThis.window.HermesKanban.DiagnosticCard) ||
+  (registeredPage && registeredPage.DiagnosticCard);
+
+if (!DiagnosticCard) {
+  throw new Error("DiagnosticCard component not exposed on HermesKanban or registeredPage");
+}
+
+const rawInput = fs.readFileSync(0, "utf8");
+const inputData = JSON.parse(rawInput);
+const vdom = DiagnosticCard(inputData);
+
+function findInTree(node, predicate) {
+  const res = [];
+  if (!node) return res;
+  if (predicate(node)) res.push(node);
+  if (node.children) {
+    for (const c of node.children) {
+      res.push(...findInTree(c, predicate));
+    }
+  }
+  return res;
+}
+
+const selectNodes = findInTree(vdom, n => n.type === "select");
+const selectedValue = selectNodes.length > 0 ? selectNodes[0].props.value : null;
+
+const btnNodes = findInTree(vdom, n => n.type && (n.type.name === "DiagnosticActionButton" || n.type === "button"));
+for (const btn of btnNodes) {
+  if (btn.props && typeof btn.props.onExec === "function" && btn.props.action && btn.props.action.kind === "reassign") {
+    btn.props.onExec(btn.props.action);
+  }
+}
+
+console.log(JSON.stringify({
+  selectedValue,
+  postCalls,
+}));
+"""
+
+    payload = {
+        "diag": diag,
+        "task": task,
+        "boardSlug": board_slug,
+        "assignees": assignees or ["coder", "reviewer"],
+    }
+    from hermes_constants import find_hermes_node_executable
+    import shutil
+    node_bin = find_hermes_node_executable("node") or shutil.which("node") or "node"
+    proc = subprocess.run(
+        [node_bin, "-e", runner_script, str(bundle_path)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Node execution failed (rc={proc.returncode}):\n"
+            f"cmd: {[node_bin, '-e', '...', str(bundle_path)]}\n"
+            f"stdout: {proc.stdout}\n"
+            f"stderr: {proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
 def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clears_it(client, kanban_home):
     """Consumer contract: task with role prefix gets suggested_assignee in diagnostic action,
-    posting that suggested assignee updates durable state and clears the diagnostic."""
+    dashboard DiagnosticCard renders suggested assignee in the picker and POSTs it,
+    updating durable state and clearing the diagnostic."""
     # Ensure coder profile exists on disk so it is recognized as spawnable
     coder_dir = kanban_home / "profiles" / "coder"
     coder_dir.mkdir(parents=True, exist_ok=True)
@@ -1198,15 +1355,26 @@ def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clear
     suggested = reassign_actions[0]["payload"]["suggested_assignee"]
     assert suggested == "coder"
 
-    # Simulate UI execution: POST /reassign using suggested_assignee target
+    # Execute actual dashboard UI consumer component (DiagnosticCard) on the payload
+    task_data = {"id": t, "title": "Coder: fix bug", "assignee": "reviewer"}
+    consumer_result = _render_dashboard_diagnostic_card(diag, task_data, board_slug="default")
+    assert consumer_result["selectedValue"] == "coder", (
+        f"DiagnosticCard picker default expected 'coder', got {consumer_result['selectedValue']}"
+    )
+    assert len(consumer_result["postCalls"]) == 1
+    post_call = consumer_result["postCalls"][0]
+    captured_body = json.loads(post_call["opts"]["body"])
+    assert captured_body["profile"] == "coder"
+
+    # Send the captured UI consumer POST payload to the API
     post_r = client.post(
-        f"/api/plugins/kanban/tasks/{t}/reassign",
-        json={"profile": suggested, "reclaim_first": False},
+        post_call["url"],
+        json=captured_body,
     )
     assert post_r.status_code == 200, post_r.text
     assert post_r.json()["assignee"] == "coder"
 
-    # Re-check diagnostics — warning should now be cleared
+    # Re-check diagnostics -- warning should now be cleared
     r2 = client.get("/api/plugins/kanban/diagnostics")
     assert r2.status_code == 200
     mismatch_rows2 = [row for row in r2.json()["diagnostics"] if row["task_id"] == t]

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1173,45 +1173,40 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
 
 
 def _render_dashboard_diagnostic_card(
-    diag: dict,
-    task: dict,
+    diag: dict | None = None,
+    task: dict | None = None,
     board_slug: str = "default",
     assignees: list[str] | None = None,
+    steps: list[dict] | None = None,
 ) -> dict:
     """Execute DiagnosticCard from plugins/kanban/dashboard/dist/index.js in Node.js
-    and capture rendered DOM state plus executed network POST actions."""
+    using real React and JSDOM to capture rendered DOM state plus executed network POST actions."""
     import json
+    import os
     import subprocess
     from pathlib import Path
+    from hermes_constants import find_hermes_node_executable
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle_path = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
 
     runner_script = """
 const fs = require("fs");
+const jsdom = require("jsdom");
+const { JSDOM } = jsdom;
+const dom = new JSDOM("<!DOCTYPE html><html><body><div id=\\"root\\"></div></body></html>", { url: "http://localhost" });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.navigator = dom.window.navigator;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const React = require("react");
+const ReactDOMClient = require("react-dom/client");
 
 let registeredPage = null;
 const postCalls = [];
-
-const React = {
-  Component: class Component {},
-  createElement: (type, props, ...children) => {
-    return { type, props: props || {}, children: children.flat(Infinity) };
-  }
-};
-
-let hookState = [];
-let hookIdx = 0;
-function useState(initial) {
-  const idx = hookIdx++;
-  if (hookState[idx] === undefined) {
-    hookState[idx] = typeof initial === "function" ? initial() : initial;
-  }
-  const setter = (val) => {
-    hookState[idx] = typeof val === "function" ? val(hookState[idx]) : val;
-  };
-  return [hookState[idx], setter];
-}
 
 const SDK = {
   React,
@@ -1226,11 +1221,11 @@ const SDK = {
     Badge: (props) => React.createElement("span", props),
   },
   hooks: {
-    useState,
-    useEffect: (fn) => fn(),
-    useCallback: (fn) => fn,
-    useMemo: (fn) => fn(),
-    useRef: (initial) => ({ current: initial }),
+    useState: React.useState,
+    useEffect: React.useEffect,
+    useCallback: React.useCallback,
+    useMemo: React.useMemo,
+    useRef: React.useRef,
   },
   utils: {
     cn: (...args) => args.filter(Boolean).join(" "),
@@ -1243,80 +1238,91 @@ const SDK = {
   }
 };
 
-globalThis.window = {
-  __HERMES_PLUGIN_SDK__: SDK,
-  __HERMES_PLUGINS__: {
-    register: (name, component) => {
-      registeredPage = component;
-    }
-  },
-  prompt: (msg, val) => val,
-  navigator: {
-    clipboard: {
-      writeText: async (text) => {},
-    },
-  },
-};
-globalThis.document = {
-  querySelector: () => null,
+globalThis.window.__HERMES_PLUGIN_SDK__ = SDK;
+globalThis.window.__HERMES_PLUGINS__ = {
+  register: (name, component) => {
+    registeredPage = component;
+  }
 };
 
 const bundleCode = fs.readFileSync(process.argv[1], "utf8");
 eval(bundleCode);
 
-const DiagnosticCard = (globalThis.window.HermesKanban && globalThis.window.HermesKanban.DiagnosticCard) ||
-  (registeredPage && registeredPage.DiagnosticCard);
-
+const DiagnosticCard = registeredPage && registeredPage.DiagnosticCard;
 if (!DiagnosticCard) {
-  throw new Error("DiagnosticCard component not exposed on HermesKanban or registeredPage");
+  throw new Error("DiagnosticCard component not exposed on registeredPage");
 }
 
 const rawInput = fs.readFileSync(0, "utf8");
 const inputData = JSON.parse(rawInput);
-const vdom = DiagnosticCard(inputData);
+const steps = Array.isArray(inputData.steps) ? inputData.steps : [inputData];
 
-function findInTree(node, predicate) {
-  const res = [];
-  if (!node) return res;
-  if (predicate(node)) res.push(node);
-  if (node.children) {
-    for (const c of node.children) {
-      res.push(...findInTree(c, predicate));
+const container = document.getElementById("root");
+const root = ReactDOMClient.createRoot(container);
+
+(async () => {
+  const stepResults = [];
+  for (let s = 0; s < steps.length; s++) {
+    const step = steps[s];
+    const props = {
+      diag: step.diag,
+      task: step.task,
+      boardSlug: step.boardSlug || inputData.boardSlug || "default",
+      assignees: step.assignees || inputData.assignees || ["coder", "reviewer", "devops"],
+      onRefresh: () => {},
+    };
+
+    await React.act(async () => {
+      root.render(React.createElement(DiagnosticCard, { key: "diag-card-stable-key", ...props }));
+    });
+
+    const selectEl = container.querySelector("select");
+    const selectedValue = selectEl ? selectEl.value : null;
+
+    if (step.clickReassign !== false) {
+      const btns = container.querySelectorAll("button");
+      for (const btn of btns) {
+        if (btn.textContent.includes("Reassign")) {
+          await React.act(async () => {
+            btn.click();
+            await new Promise(r => setTimeout(r, 10));
+          });
+        }
+      }
     }
+
+    stepResults.push({
+      stepIndex: s,
+      selectedValue,
+    });
   }
-  return res;
-}
 
-const selectNodes = findInTree(vdom, n => n.type === "select");
-const selectedValue = selectNodes.length > 0 ? selectNodes[0].props.value : null;
-
-const btnNodes = findInTree(vdom, n => n.type && (n.type.name === "DiagnosticActionButton" || n.type === "button"));
-for (const btn of btnNodes) {
-  if (btn.props && typeof btn.props.onExec === "function" && btn.props.action && btn.props.action.kind === "reassign") {
-    btn.props.onExec(btn.props.action);
-  }
-}
-
-console.log(JSON.stringify({
-  selectedValue,
-  postCalls,
-}));
+  console.log(JSON.stringify({
+    selectedValue: stepResults[stepResults.length - 1].selectedValue,
+    stepResults,
+    postCalls,
+  }));
+})();
 """
 
-    payload = {
-        "diag": diag,
-        "task": task,
-        "boardSlug": board_slug,
-        "assignees": assignees or ["coder", "reviewer"],
-    }
-    from hermes_constants import find_hermes_node_executable
-    import shutil
-    node_bin = find_hermes_node_executable("node") or shutil.which("node") or "node"
+    if steps is not None:
+        payload = {"steps": steps, "boardSlug": board_slug, "assignees": assignees}
+    else:
+        payload = {
+            "diag": diag,
+            "task": task,
+            "boardSlug": board_slug,
+            "assignees": assignees or ["coder", "reviewer"],
+        }
+    node_bin = find_hermes_node_executable("node") or "node"
+    env = dict(os.environ)
+    env["NODE_PATH"] = str(repo_root / "node_modules")
     proc = subprocess.run(
         [node_bin, "-e", runner_script, str(bundle_path)],
         input=json.dumps(payload),
         capture_output=True,
         text=True,
+        env=env,
     )
     if proc.returncode != 0:
         raise RuntimeError(
@@ -1379,6 +1385,92 @@ def test_diagnostics_endpoint_surfaces_role_assignee_mismatch_and_reassign_clear
     assert r2.status_code == 200
     mismatch_rows2 = [row for row in r2.json()["diagnostics"] if row["task_id"] == t]
     assert len(mismatch_rows2) == 0
+
+
+def test_diagnostic_card_rerender_synchronizes_suggested_assignee_and_posts_updated_target():
+    """Rerender regression: when DiagnosticCard remains mounted under a stable key
+    and suggested_assignee prop changes from coder to reviewer, reassignProfile must
+    synchronize with the updated suggestion and clicking reassign must POST reviewer."""
+    diag_step1 = {
+        "kind": "role_assignee_mismatch",
+        "severity": "warning",
+        "title": "Title role prefix mismatches",
+        "detail": "Mismatch detail",
+        "actions": [{
+            "kind": "reassign",
+            "label": "Reassign to @coder",
+            "payload": {"suggested_assignee": "coder", "current_assignee": "reviewer"},
+            "suggested": True,
+        }],
+    }
+    task_step1 = {"id": "t_1", "title": "Coder: fix bug", "assignee": "reviewer"}
+
+    diag_step2 = {
+        "kind": "role_assignee_mismatch",
+        "severity": "warning",
+        "title": "Title role prefix mismatches",
+        "detail": "Mismatch detail",
+        "actions": [{
+            "kind": "reassign",
+            "label": "Reassign to @reviewer",
+            "payload": {"suggested_assignee": "reviewer", "current_assignee": "coder"},
+            "suggested": True,
+        }],
+    }
+    task_step2 = {"id": "t_1", "title": "Reviewer: review PR", "assignee": "coder"}
+
+    steps = [
+        {"diag": diag_step1, "task": task_step1, "clickReassign": False},
+        {"diag": diag_step2, "task": task_step2, "clickReassign": True},
+    ]
+
+    res = _render_dashboard_diagnostic_card(steps=steps, board_slug="default", assignees=["coder", "reviewer", "devops"])
+    assert res["stepResults"][0]["selectedValue"] == "coder", (
+        f"Initial mount expected selectedValue 'coder', got {res['stepResults'][0]['selectedValue']}"
+    )
+    assert res["stepResults"][1]["selectedValue"] == "reviewer", (
+        f"After rerender expected selectedValue 'reviewer', got {res['stepResults'][1]['selectedValue']}"
+    )
+    assert len(res["postCalls"]) == 1
+    post_body = json.loads(res["postCalls"][0]["opts"]["body"])
+    assert post_body["profile"] == "reviewer", (
+        f"POST request expected profile 'reviewer', got {post_body['profile']}"
+    )
+
+
+def test_diagnostics_endpoint_with_explicit_config_tombstone_suppresses_suggested_reassign(client, kanban_home):
+    """When runtime config contains explicit `profiles: [ghost]` but ghost is tombstoned on disk,
+    the diagnostics endpoint emits advisory role mismatch without suggested reassign actions."""
+    from hermes_constants import mark_named_profile_deleted
+    import yaml
+
+    # Write config with explicit profiles
+    cfg_data = {"profiles": ["ghost", "reviewer"]}
+    (kanban_home / "config.yaml").write_text(yaml.dump(cfg_data))
+
+    # Create tombstoned ghost profile directory
+    ghost_dir = kanban_home / "profiles" / "ghost"
+    ghost_dir.mkdir(parents=True, exist_ok=True)
+    (ghost_dir / "config.yaml").write_text("model: ghost-test\n")
+    mark_named_profile_deleted(ghost_dir)
+
+    conn = kb.connect()
+    try:
+        t = kb.create_task(conn, title="Ghost: cleanup memory", assignee="reviewer")
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/diagnostics")
+    assert r.status_code == 200
+    data = r.json()
+    mismatch_rows = [row for row in data["diagnostics"] if row["task_id"] == t]
+    assert len(mismatch_rows) == 1
+    diag = mismatch_rows[0]["diagnostics"][0]
+    assert diag["kind"] == "role_assignee_mismatch"
+    suggested_actions = [a for a in diag.get("actions", []) if a.get("suggested")]
+    assert len(suggested_actions) == 0, f"Expected 0 suggested actions for dead ghost, got {suggested_actions}"
+    reassign_actions = [a for a in diag.get("actions", []) if a.get("kind") == "reassign"]
+    assert len(reassign_actions) == 0, f"Expected 0 reassign actions for dead ghost, got {reassign_actions}"
 
 
 


### PR DESCRIPTION
## Current behavior

Kanban databases can contain rows written by older versions or test tools. Because SQLite uses dynamic typing, a column declared as `TEXT` may still contain `BLOB` or `INTEGER` values.

## Problem

The CLI and dashboard assumed these fields were always strings. Legacy values could therefore make `list`, `stats`, and diagnostics omit matching tasks or fail while decoding and sorting them. The role-prefix diagnostic could also suggest invalid reassignment targets.

## Changes

- Normalize strings, BLOBs, and numeric values when converting database rows.
- Make task filters work with legacy mixed-type values without changing the normal text write path.
- Tighten role-prefix diagnostics and keep dashboard reassignment controls in sync with the current suggestion.
- Add Python and frontend regression tests for archived BLOB statuses, statistics grouping, diagnostic refreshes, and disabled reassignment controls.

## Verification

- Python: 62 tests passed
- TypeScript: `tsc --noEmit -p tests-js/tsconfig.json`
- Vitest: 4 tests passed
- ESLint passed
- Regression proof: both the archived-status and BLOB-statistics tests fail against the old implementation and pass on this branch
- `list`, `stats`, and `diagnostics` all exit successfully against an existing mixed-type Kanban database

## Result

This PR contains source and test changes only. It does not update a local runtime or restart the gateway.