### PR TITLE
fix(mcp_oauth+mcp_oauth_manager): preserve refresh_token when server omits one (RFC 6749 §6)

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -678,10 +678,240 @@ class TestInvalidateTokensOnClientChange:
         _maybe_preregister_client(storage, cfg, meta)
         assert (d / "chg-server.json").exists()
 
+    def test_preregister_same_client_does_not_rewrite_client_json(self, tmp_path, monkeypatch):
+        """Pre-registered client.json must NOT be rewritten when identity is unchanged.
+
+        The on-disk file may carry hand-curated redirect_uris (e.g. a
+        registered 127.0.0.1:53682 port), or a macOS uchg immutable flag.
+        Every-connect rewriting would clobber the redirect and/or fail with
+        Operation not permitted.  Only a real client_id/secret change should
+        trigger a write.
+        """
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import (
+            _build_client_metadata, _maybe_preregister_client,
+        )
+        storage, d = self._seed(tmp_path, monkeypatch)
+        cfg = {"client_id": "client-a", "_resolved_port": 1455}
+        meta = _build_client_metadata(dict(cfg))
+
+        # Run once: writes client.json from scratch.
+        _maybe_preregister_client(storage, cfg, meta)
+        client_path = d / "chg-server.client.json"
+        pre_mtime = client_path.stat().st_mtime_ns
+
+        # Run again with identical config: must NOT rewrite.
+        _maybe_preregister_client(storage, cfg, meta)
+        post_mtime = client_path.stat().st_mtime_ns
+        assert post_mtime == pre_mtime, \
+            "client.json mtime changed on no-op call (unnecessary rewrite)"
+
+    def test_preregister_different_client_rewrites(self, tmp_path, monkeypatch):
+        """Changing the client_id MUST rewrite client.json (so the new redirect_uri takes effect)."""
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import (
+            _build_client_metadata, _maybe_preregister_client,
+        )
+        storage, d = self._seed(tmp_path, monkeypatch)
+        cfg = {"client_id": "client-a", "_resolved_port": 1455}
+        meta = _build_client_metadata(dict(cfg))
+        _maybe_preregister_client(storage, cfg, meta)
+        client_path = d / "chg-server.client.json"
+        pre_mtime = client_path.stat().st_mtime_ns
+
+        cfg2 = {"client_id": "client-b", "_resolved_port": 1455}
+        meta2 = _build_client_metadata(dict(cfg2))
+        _maybe_preregister_client(storage, cfg2, meta2)
+        post_mtime = client_path.stat().st_mtime_ns
+        assert post_mtime > pre_mtime, \
+            "client.json mtime should advance after client_id change"
+        info = json.loads(client_path.read_text())
+        assert info["client_id"] == "client-b"
+
+    def test_preregister_changed_secret_rewrites(self, tmp_path, monkeypatch):
+        """Changing client_secret MUST rewrite client.json."""
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import (
+            _build_client_metadata, _maybe_preregister_client,
+        )
+        storage, d = self._seed(tmp_path, monkeypatch,
+                                client_id="client-a", client_secret="old-secret")
+        cfg = {"client_id": "client-a", "client_secret": "new-secret", "_resolved_port": 1455}
+        meta = _build_client_metadata(dict(cfg))
+        _maybe_preregister_client(storage, cfg, meta)
+        client_path = d / "chg-server.client.json"
+        info = json.loads(client_path.read_text())
+        assert info["client_secret"] == "new-secret"
+
 
 # ---------------------------------------------------------------------------
-# Non-interactive / startup-safety tests
+# Refresh-token carry-forward (RFC 6749 section 6)
 # ---------------------------------------------------------------------------
+
+class TestRefreshTokenCarryForward:
+    """Hermes' _handle_token_response and _handle_refresh_response overrides
+    must preserve an existing refresh_token when the server omits one in its
+    response (RFC 6749 section 6: the client "MUST use the existing refresh token").
+
+    The MCP SDK's base class already implements this for _handle_refresh_response,
+    but Hermes delegates to a custom override that dropped the base behavior.
+    """
+
+    @pytest.mark.asyncio
+    async def test_carry_forward_on_refresh_when_server_omits(self, tmp_path, monkeypatch):
+        """When a refresh response has no refresh_token, the previous one MUST be carried
+        forward so the credential does not degrade to access-only."""
+        import httpx
+
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("test-server", "https://example.com/mcp")
+        assert provider is not None
+
+        from mcp.shared.auth import OAuthToken
+        initial = OAuthToken(
+            access_token="acc1",
+            refresh_token="rt-keep-me",
+            token_type="Bearer",
+        )
+        provider.context.current_tokens = initial
+        provider.context.update_token_expiry(initial)
+
+        # Simulate a refresh grant response that OMITS refresh_token (Google's behavior).
+        response = httpx.Response(200, json={
+            "access_token": "acc2",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })
+        result = await provider._handle_refresh_response(response)
+
+        assert result is True, "refresh should succeed"
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "acc2"
+        assert provider.context.current_tokens.refresh_token == "rt-keep-me", \
+            "refresh_token must be carried forward when server omits it"
+
+        # On-disk token must also carry the refresh_token.
+        token_path = tmp_path / "mcp-tokens" / "test-server.json"
+        assert token_path.exists()
+        data = json.loads(token_path.read_text())
+        assert data["refresh_token"] == "rt-keep-me"
+
+    @pytest.mark.asyncio
+    async def test_carry_forward_on_token_exchange(self, tmp_path, monkeypatch):
+        """The carry-forward also applies to _handle_token_response for defense in
+        depth — the initial exchange typically includes it, but a 201 Created with
+        malformed scopes shouldn't silently drop it either."""
+        import httpx
+
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("test-server", "https://example.com/mcp")
+        assert provider is not None
+
+        from mcp.shared.auth import OAuthToken
+        initial = OAuthToken(
+            access_token="acc1",
+            refresh_token="original-rt",
+            token_type="Bearer",
+        )
+        provider.context.current_tokens = initial
+
+        # 201 Created with refresh_token omitted.
+        response = httpx.Response(201, json={
+            "access_token": "acc-new",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })
+        await provider._handle_token_response(response)
+
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token == "original-rt"
+
+    @pytest.mark.asyncio
+    async def test_no_carry_forward_without_prior_token(self, tmp_path, monkeypatch):
+        """When there is no prior token (first-time auth exchange), a missing
+        refresh_token is left as None — we cannot carry forward what never existed."""
+        import httpx
+
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("test-server", "https://example.com/mcp")
+        assert provider is not None
+        provider.context.current_tokens = None  # no prior state
+
+        response = httpx.Response(200, json={
+            "access_token": "acc-fresh",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })
+        result = await provider._handle_refresh_response(response)
+
+        assert result is True
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None, \
+            "no prior token -> refresh_token stays None (next refresh will fail)"
+
+    @pytest.mark.asyncio
+    async def test_server_provided_refresh_token_is_not_overwritten(self, tmp_path, monkeypatch):
+        """When the server DOES include a refresh_token, we MUST NOT overwrite it
+        with the previous one — the server may be rotating tokens (RFC 6749 section 10.4)."""
+        import httpx
+
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("test-server", "https://example.com/mcp")
+        assert provider is not None
+
+        from mcp.shared.auth import OAuthToken
+        provider.context.current_tokens = OAuthToken(
+            access_token="old-acc",
+            refresh_token="old-rt",
+            token_type="Bearer",
+        )
+
+        # Server sends a new refresh_token (rotation).
+        response = httpx.Response(200, json={
+            "access_token": "new-acc",
+            "refresh_token": "new-rt",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })
+        result = await provider._handle_refresh_response(response)
+
+        assert result is True
+        assert provider.context.current_tokens.refresh_token == "new-rt", \
+            "server-issued refresh_token must NOT be replaced by carry-forward"
+
+    @pytest.mark.asyncio
+    async def test_carry_forward_logs_info(self, tmp_path, monkeypatch, caplog):
+        """The carry-forward path should log at INFO level."""
+        import httpx
+        import logging
+
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _set_interactive_stdin(monkeypatch)
+        provider = build_oauth_auth("carry-log-test", "https://example.com/mcp")
+        assert provider is not None
+
+        from mcp.shared.auth import OAuthToken
+        provider.context.current_tokens = OAuthToken(
+            access_token="a1", refresh_token="rt-log", token_type="Bearer",
+        )
+
+        with caplog.at_level(logging.INFO, logger="tools.mcp_oauth"):
+            await provider._handle_refresh_response(
+                httpx.Response(200, json={"access_token": "a2", "token_type": "Bearer"})
+            )
+
+        assert any(
+            "carried forward existing" in msg for msg in caplog.messages
+        ), "carry-forward should log an info message"
 
 class TestIsInteractive:
     """_is_interactive() detects headless/daemon/container environments."""

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1826,6 +1826,27 @@ def _maybe_preregister_client(
     _invalidate_tokens_on_client_change(
         storage, client_id, cfg.get("client_secret")
     )
+
+    # Same pre-registered client already persisted: leave the on-disk file alone.
+    # Hand-curated redirect_uris (e.g. Google's registered 127.0.0.1:53682 port)
+    # would otherwise be clobbered on every connect with a freshly-resolved
+    # random-port redirect, and uchg-locked files would fail the handshake with
+    # "Operation not permitted". Only rewrite when the client actually changed.
+    try:
+        with open(storage._client_info_path()) as fh:
+            existing = json.load(fh)
+        if (
+            existing.get("client_id") == client_id
+            and (existing.get("client_secret") or None) == (cfg.get("client_secret") or None)
+        ):
+            logger.debug(
+                "Same pre-registered client already persisted for '%s'; keeping on-disk client info",
+                storage._server_name,
+            )
+            return
+    except (OSError, ValueError):
+        pass
+
     port = cfg["_resolved_port"]
     redirect_uri = _resolve_redirect_uri(cfg, port)
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1217,6 +1217,25 @@ def _get_hermes_oauth_provider_class() -> type | None:
             request = await super()._refresh_token()
             return self._stamp_token_user_agent(request)
 
+        def _preserve_refresh_token(self, token_response):
+            """RFC 6749 §6: a refresh-grant response may omit refresh_token,
+            meaning "keep the existing one". Google does this every time.
+            Without this, each hourly self-refresh degrades the stored token
+            to access-only and it dies an hour later."""
+            prev = getattr(self.context, "current_tokens", None)
+            prev_rt = getattr(prev, "refresh_token", None)
+            if getattr(token_response, "refresh_token", None) is None and prev_rt:
+                try:
+                    token_response.refresh_token = prev_rt
+                except Exception:
+                    data = token_response.model_dump(mode="json", exclude_none=True)
+                    data["refresh_token"] = prev_rt
+                    token_response = OAuthToken.model_validate(data)
+                logger.info(
+                    "Server omitted refresh_token on refresh; carried forward existing"
+                )
+            return token_response
+
         async def _handle_token_response(self, response):
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:
@@ -1228,6 +1247,7 @@ def _get_hermes_oauth_provider_class() -> type | None:
                     token_response = await handle_token_response_scopes(response)
                 except (HTTPError, OAuthTokenError):
                     raise OAuthTokenError("Invalid token response") from None
+                token_response = self._preserve_refresh_token(token_response)
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
@@ -1250,6 +1270,7 @@ def _get_hermes_oauth_provider_class() -> type | None:
             try:
                 content = await response.aread()
                 token_response = OAuthToken.model_validate_json(content)
+                token_response = self._preserve_refresh_token(token_response)
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -198,6 +198,27 @@ def _make_hermes_provider_class() -> Optional[type]:
             request = await super()._refresh_token()
             return self._stamp_token_user_agent(request)
 
+        def _preserve_refresh_token(self, token_response):
+            """RFC 6749 §6: a refresh-grant response may omit refresh_token,
+            meaning "keep the existing one". Google does this every time.
+            Without this, each hourly self-refresh degrades the stored token
+            to access-only and it dies an hour later."""
+            from mcp.shared.auth import OAuthToken
+
+            prev = getattr(self.context, "current_tokens", None)
+            prev_rt = getattr(prev, "refresh_token", None)
+            if getattr(token_response, "refresh_token", None) is None and prev_rt:
+                try:
+                    token_response.refresh_token = prev_rt
+                except Exception:
+                    data = token_response.model_dump(mode="json", exclude_none=True)
+                    data["refresh_token"] = prev_rt
+                    token_response = OAuthToken.model_validate(data)
+                logger.info(
+                    "Server omitted refresh_token on refresh; carried forward existing"
+                )
+            return token_response
+
         async def _handle_token_response(self, response):
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:
@@ -209,6 +230,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                     token_response = await handle_token_response_scopes(response)
                 except (HTTPError, OAuthTokenError):
                     raise OAuthTokenError("Invalid token response") from None
+                token_response = self._preserve_refresh_token(token_response)
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)
@@ -232,6 +254,7 @@ def _make_hermes_provider_class() -> Optional[type]:
             try:
                 content = await response.aread()
                 token_response = OAuthToken.model_validate_json(content)
+                token_response = self._preserve_refresh_token(token_response)
                 self.context.current_tokens = token_response
                 self.context.update_token_expiry(token_response)
                 await self.context.storage.set_tokens(token_response)


### PR DESCRIPTION
## Summary

Fixes the recurring Google Workspace MCP token expiry cycle: every ~1h, the stored token degrades to access-only and can never self-heal, requiring a fresh browser consent. The root cause was missing refresh_token carry-forward in **two** OAuth provider classes.

## Changes

### fix(mcp_oauth): carry forward refresh_token on token/refresh responses (`mcp_oauth.py`) ✅

`_HermesOAuthClientProvider._handle_token_response` and `_handle_refresh_response` now call `_preserve_refresh_token()` to carry forward the existing `refresh_token` when the server omits it (RFC 6749 §6 — Google does this every time).

### fix(mcp_oauth_manager): carry forward refresh_token on token/refresh responses (`mcp_oauth_manager.py`) ✅ **NEW**

`HermesMCPOAuthProvider` — the class actually used by `get_manager()` for **all HTTP MCP servers** — had the **same bug** but was never patched. Both `_handle_token_response` and `_handle_refresh_response` now call `_preserve_refresh_token()`.

### How both bugs manifest

1. Initial consent returns a `refresh_token` ✓
2. ~1h later, the MCP SDK auto-refreshes the access_token via Google's token endpoint
3. Google's response includes only the new `access_token` — **no** `refresh_token`
4. Without `_preserve_refresh_token`, `set_tokens()` calls `model_dump(exclude_none=True)` → `refresh_token` (now `None`) is **silently dropped from the file**
5. ~1h later, the access token expires and there's no refresh_token to get a new one
6. Every MCP call fails, and the only recovery is a full browser re-consent

### Test plan

- [ ] Run `hermes mcp test gmail` → Connected
- [ ] Run a live Gmail tool call → returns real data
- [ ] Let the token expire naturally (wait ~1h) or force-refresh via the cron
- [ ] Verify stored token file still has `refresh_token` field
- [ ] Repeat for calendar, docs, sheets, google-drive

### Related

Closes recurring Google MCP MISSING refresh_token requiring daily browser re-consent