### PR TITLE
feat(toolsets): add read-only review bundle

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -69,6 +69,13 @@ class TestResolveToolset:
         assert "web_search" in tools
         assert "web_extract" in tools
 
+    def test_review_toolset_exposes_inspection_without_mutation(self):
+        tools = set(resolve_toolset("review"))
+        assert {"read_file", "search_files", "web_search", "web_extract"}.issubset(tools)
+        assert not tools.intersection(
+            {"write_file", "patch", "terminal", "process", "execute_code", "delegate_task", "cronjob"}
+        )
+
     def test_cycle_detection(self):
         # Create a cycle: A includes B, B includes A
         TOOLSETS["_cycle_a"] = {"description": "test", "tools": ["t1"], "includes": ["_cycle_b"]}

--- a/toolsets.py
+++ b/toolsets.py
@@ -367,6 +367,22 @@ TOOLSETS = {
         "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
     },
     
+    "review": {
+        "description": (
+            "Read-only inspection for independent reviews: local evidence, source, "
+            "and public web research without file mutation, shell access, code "
+            "execution, cron, delegation, or service writes"
+        ),
+        "tools": [
+            "read_file", "search_files",
+            "web_search", "web_extract",
+            "vision_analyze",
+            "skills_list", "skill_view",
+            "session_search", "clarify",
+        ],
+        "includes": [],
+    },
+
     "safe": {
         "description": "Safe toolkit without terminal access",
         "tools": [],


### PR DESCRIPTION
## Summary

Adds a built-in `review` toolset for independent, read-only evidence inspection.

It exposes only: `read_file`, `search_files`, web research/extraction, image analysis, read-only skill/session lookup, and clarification.

It deliberately excludes all mutation and execution paths: `write_file`, `patch`, `terminal`, `process`, `execute_code`, `delegate_task`, and `cronjob`.

## Why

A least-privilege Reviewer needs to inspect exact runtime evidence and source files without receiving code-editing or shell access. Existing `file` includes writes, while `coding` includes files plus shell/execution. This bundle reuses existing tools; it adds no new core tool or handler.

## Validation

- RED: regression test failed before the bundle existed.
- GREEN: targeted test passed.
- `tests/test_toolsets.py`: 26 passed.
- `ruff check toolsets.py tests/test_toolsets.py`: passed.
- Runtime schema snapshot verified the review toolset contains inspection tools and no write/execute/cron/delegate tools.

## Scope

This PR only adds the toolset. It does not modify any user profile, schedule, credential, gateway, or production job.