### PR TITLE
test(terminal): improve terminal_tool.py coverage from 31% to 81%

### DIFF
--- a/tests/tools/test_terminal_env_lifecycle.py
+++ b/tests/tools/test_terminal_env_lifecycle.py
@@ -1,0 +1,1336 @@
+"""Tests for terminal environment config, creation, lifecycle, and cleanup.
+
+Covers ``tools/terminal_tool.py``:
+- ``_get_env_config``                (config resolution from TERMINAL_* env vars)
+- ``_ssh_config_from_config``        (SSH connection dict extraction)
+- ``_container_config_from_config``  (container resource dict extraction)
+- ``_create_environment``            (backend selection + unknown-type ValueError)
+- ``ensure_task_env``                (lazy create / cache / failure)
+- ``is_persistent_env``              (persistence predicate)
+- ``cleanup_all_environments``       (global teardown)
+- ``cleanup_vm``                     (per-task teardown + force_remove dispatch)
+- ``_cleanup_inactive_envs``         (idle reaper)
+- ``_atexit_cleanup``                (process-exit teardown)
+- ``_evict_environment_for_task``    (drop a degraded env)
+- ``register_task_env_overrides`` / ``clear_task_env_overrides``
+- ``register_container_alias`` / ``_resolve_container_alias``
+
+The module reads ALL of its settings from ``os.environ`` and keeps a set of
+process-global registries (``_active_environments``, ``_last_activity``,
+``_creation_locks``, ``_task_env_overrides``, ``_container_aliases``,
+``_session_cwd``).  The ``_hermetic_env_state`` autouse fixture resets those
+registries around every test so the shared interpreter never leaks state
+between cases, and the config-bridge is stubbed so a developer's
+``config.yaml`` cannot perturb TERMINAL_* results.
+"""
+
+import os
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_DEFAULT_IMAGE = "nikolaik/python-nodejs:python3.11-nodejs20"
+
+
+def _stub_config_bridge(monkeypatch):
+    """Prevent the one-shot config.yaml -> env bridge from mutating os.environ."""
+    monkeypatch.setattr(terminal_tool, "_ensure_terminal_env_bridged", lambda: None)
+
+
+class _CleanupRecorder:
+    """Double for an environment that records how it was torn down."""
+
+    def __init__(self, accept_force_remove=False):
+        self.cleaned = False
+        self.stopped = False
+        self.terminated = False
+        self.force_remove = None
+        self._accept_force_remove = accept_force_remove
+
+    def cleanup(self, **kwargs):
+        self.cleaned = True
+        if self._accept_force_remove:
+            self.force_remove = kwargs.get("force_remove")
+
+    def stop(self):
+        self.stopped = True
+
+    def terminate(self):
+        self.terminated = True
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env_state(monkeypatch):
+    """Reset the module's process-global registries around each test.
+
+    Each test file gets a fresh interpreter, but tests *within* this file
+    share one.  These dicts are mutated by the lifecycle functions under test,
+    so any residue would silently change later assertions (e.g. a leftover
+    ``_task_env_overrides`` entry flipping ``_resolve_container_task_id``).
+    """
+    registries = [
+        "_active_environments",
+        "_last_activity",
+        "_creation_locks",
+        "_task_env_overrides",
+        "_container_aliases",
+        "_session_cwd",
+    ]
+    # Snapshot the original objects so monkeypatch.setattr in a test restores
+    # them afterwards, and clear their contents both sides of each test.
+    originals = {name: getattr(terminal_tool, name) for name in registries}
+    monkeypatch.setattr(terminal_tool, "_container_alias_lock", threading.Lock())
+    for name in registries:
+        originals[name].clear()
+    # Neutralise any host TERMINAL_* env so config resolution is deterministic.
+    for key in list(os.environ):
+        if key.startswith("TERMINAL_"):
+            monkeypatch.delenv(key, raising=False)
+    yield
+    for name in registries:
+        getattr(terminal_tool, name).clear()
+    # Restore any genuine objects a test swapped in via setattr anyway.
+    monkeypatch.setattr(terminal_tool, "_container_alias_lock", threading.Lock())
+
+
+def _fake_process_registry(monkeypatch):
+    """Install a no-op process_registry so `_cleanup_inactive_envs` uses it."""
+    fake = types.ModuleType("tools.process_registry")
+
+    class _Registry:
+        @staticmethod
+        def has_active_processes(task_id):
+            return False
+
+    fake.process_registry = _Registry()
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake)
+
+
+# ---------------------------------------------------------------------------
+# _get_env_config
+# ---------------------------------------------------------------------------
+class TestGetEnvConfig:
+    def test_defaults_local(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        for key in list(os.environ):
+            if key.startswith("TERMINAL_"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(terminal_tool, "_safe_getcwd", lambda: "/host/workdir")
+
+        cfg = terminal_tool._get_env_config()
+
+        assert cfg["env_type"] == "local"
+        assert cfg["docker_image"] == _DEFAULT_IMAGE
+        assert cfg["singularity_image"] == f"docker://{_DEFAULT_IMAGE}"
+        assert cfg["modal_image"] == _DEFAULT_IMAGE
+        assert cfg["daytona_image"] == _DEFAULT_IMAGE
+        assert cfg["vercel_runtime"] == ""
+        assert cfg["cwd"] == "/host/workdir"
+        assert cfg["host_cwd"] is None
+        assert cfg["timeout"] == 180
+        assert cfg["lifetime_seconds"] == 300
+        assert cfg["container_cpu"] == 1.0
+        assert cfg["container_memory"] == 5120
+        assert cfg["container_disk"] == 51200
+        assert cfg["container_persistent"] is True
+        assert cfg["local_persistent"] is False
+        assert cfg["ssh_persistent"] is True
+        assert cfg["ssh_host"] == ""
+        assert cfg["ssh_user"] == ""
+        assert cfg["ssh_port"] == 22
+        assert cfg["ssh_key"] == ""
+        assert cfg["docker_volumes"] == []
+        assert cfg["docker_env"] == {}
+        assert cfg["docker_extra_args"] == []
+        assert cfg["docker_forward_env"] == []
+        assert cfg["docker_shm_size"] == "1g"
+        assert cfg["docker_network"] is True
+        assert cfg["docker_run_as_host_user"] is False
+        assert cfg["docker_mount_cwd_to_workspace"] is False
+        assert cfg["docker_persist_across_processes"] is True
+        assert cfg["docker_orphan_reaper"] is True
+
+    def test_env_type_from_env(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        cfg = terminal_tool._get_env_config()
+        assert cfg["env_type"] == "docker"
+        # Container backends default to /root when no TERMINAL_CWD set.
+        assert cfg["cwd"] == "/root"
+
+    def test_docker_image_override(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "myrepo/edge:latest")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["docker_image"] == "myrepo/edge:latest"
+
+    def test_cwd_env_override(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_CWD", "/custom/workspace")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["cwd"] == "/custom/workspace"
+
+    def test_container_backend_rejects_host_cwd(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "/home/vagrant/proj")
+        cfg = terminal_tool._get_env_config()
+        # A host path cannot be a container workdir -> fall back to /root.
+        assert cfg["cwd"] == "/root"
+
+    def test_ssh_env_fields(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "sandbox.example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ubuntu")
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "2222")
+        monkeypatch.setenv("TERMINAL_SSH_KEY", "/home/user/.ssh/id_ed25519")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["ssh_host"] == "sandbox.example.com"
+        assert cfg["ssh_user"] == "ubuntu"
+        assert cfg["ssh_port"] == 2222
+        assert cfg["ssh_key"] == "/home/user/.ssh/id_ed25519"
+        # SSH default cwd is the remote home.
+        assert cfg["cwd"] == "~"
+
+    def test_docker_volumes_json_parsed(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv(
+            "TERMINAL_DOCKER_VOLUMES",
+            '[{"host_path": "/data", "container_path": "/workspace", "read_only": false}]',
+        )
+        cfg = terminal_tool._get_env_config()
+        assert cfg["docker_volumes"] == [
+            {"host_path": "/data", "container_path": "/workspace", "read_only": False}
+        ]
+
+    def test_docker_env_json_parsed(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_ENV", '{"A": "1", "B": "2"}')
+        cfg = terminal_tool._get_env_config()
+        assert cfg["docker_env"] == {"A": "1", "B": "2"}
+
+    def test_timeout_env(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "90")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["timeout"] == 90
+
+    def test_invalid_timeout_raises(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "5m")
+        with pytest.raises(ValueError):
+            terminal_tool._get_env_config()
+
+    def test_invalid_docker_volumes_raises(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "not-json")
+        with pytest.raises(ValueError):
+            terminal_tool._get_env_config()
+
+    def test_container_persistent_bool(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["container_persistent"] is False
+
+    def test_ssh_persistent_env_override(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_PERSISTENT", "false")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["ssh_persistent"] is False
+
+    def test_local_persistent_env(self, monkeypatch):
+        _stub_config_bridge(monkeypatch)
+        monkeypatch.setenv("TERMINAL_LOCAL_PERSISTENT", "true")
+        cfg = terminal_tool._get_env_config()
+        assert cfg["local_persistent"] is True
+
+
+# ---------------------------------------------------------------------------
+# _ssh_config_from_config
+# ---------------------------------------------------------------------------
+class TestSshConfigFromConfig:
+    def test_extracts_fields(self):
+        result = terminal_tool._ssh_config_from_config(
+            {
+                "ssh_host": "h",
+                "ssh_user": "u",
+                "ssh_port": 2222,
+                "ssh_key": "/k",
+                "ssh_persistent": True,
+            }
+        )
+        assert result == {
+            "host": "h",
+            "user": "u",
+            "port": 2222,
+            "key": "/k",
+            "persistent": True,
+        }
+
+    def test_defaults(self):
+        result = terminal_tool._ssh_config_from_config({})
+        assert result == {
+            "host": "",
+            "user": "",
+            "port": 22,
+            "key": "",
+            "persistent": False,
+        }
+
+
+# ---------------------------------------------------------------------------
+# _container_config_from_config
+# ---------------------------------------------------------------------------
+class TestContainerConfigFromConfig:
+    def test_extracts_fields(self):
+        config = {
+            "container_cpu": 2,
+            "container_memory": 4096,
+            "container_disk": 100,
+            "container_persistent": False,
+            "modal_mode": "direct",
+            "vercel_runtime": "node18",
+            "docker_volumes": [{"host_path": "/data"}],
+            "docker_mount_cwd_to_workspace": True,
+            "docker_forward_env": [{"name": "A"}],
+            "docker_env": {"A": "1"},
+            "docker_run_as_host_user": True,
+            "docker_extra_args": ["--network", "host"],
+            "docker_shm_size": "2g",
+            "docker_network": False,
+            "docker_persist_across_processes": False,
+            "docker_shared_container_key": "shared:key",
+            "docker_orphan_reaper": False,
+        }
+        result = terminal_tool._container_config_from_config(config)
+        assert result["container_cpu"] == 2
+        assert result["container_memory"] == 4096
+        assert result["container_disk"] == 100
+        assert result["container_persistent"] is False
+        assert result["modal_mode"] == "direct"
+        assert result["vercel_runtime"] == "node18"
+        assert result["docker_volumes"] == [{"host_path": "/data"}]
+        assert result["docker_mount_cwd_to_workspace"] is True
+        assert result["docker_forward_env"] == [{"name": "A"}]
+        assert result["docker_env"] == {"A": "1"}
+        assert result["docker_run_as_host_user"] is True
+        assert result["docker_extra_args"] == ["--network", "host"]
+        assert result["docker_shm_size"] == "2g"
+        assert result["docker_network"] is False
+        assert result["docker_persist_across_processes"] is False
+        assert result["docker_shared_container_key"] == "shared:key"
+        assert result["docker_orphan_reaper"] is False
+
+    def test_defaults(self):
+        result = terminal_tool._container_config_from_config({})
+        assert result["container_cpu"] == 1
+        assert result["container_memory"] == 5120
+        assert result["container_disk"] == 51200
+        assert result["container_persistent"] is True
+        assert result["modal_mode"] == "auto"
+        assert result["vercel_runtime"] == ""
+        assert result["docker_volumes"] == []
+        assert result["docker_mount_cwd_to_workspace"] is False
+        assert result["docker_forward_env"] == []
+        assert result["docker_env"] == {}
+        assert result["docker_run_as_host_user"] is False
+        assert result["docker_extra_args"] == []
+        assert result["docker_shm_size"] == "1g"
+        assert result["docker_network"] is True
+        assert result["docker_persist_across_processes"] is True
+        assert result["docker_shared_container_key"] == ""
+        assert result["docker_orphan_reaper"] is True
+
+
+# ---------------------------------------------------------------------------
+# _create_environment
+# ---------------------------------------------------------------------------
+class TestCreateEnvironment:
+    def test_create_local(self, monkeypatch):
+        calls = {}
+
+        class _FakeLocal:
+            def __init__(self, cwd, timeout):
+                calls["cwd"] = cwd
+                calls["timeout"] = timeout
+
+        monkeypatch.setattr(terminal_tool, "_LocalEnvironment", _FakeLocal)
+        env = terminal_tool._create_environment(
+            "local", image="", cwd="/workspace", timeout=42
+        )
+        assert isinstance(env, _FakeLocal)
+        assert calls == {"cwd": "/workspace", "timeout": 42}
+
+    def test_create_docker(self, monkeypatch):
+        calls = {}
+
+        class _FakeDocker:
+            def __init__(self, **kwargs):
+                calls.update(kwargs)
+
+        monkeypatch.setattr(terminal_tool, "_DockerEnvironment", _FakeDocker)
+        monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda cc: None)
+        monkeypatch.setattr(terminal_tool, "_docker_session_isolation_enabled", lambda: False)
+        container_config = {
+            "container_cpu": 2,
+            "container_memory": 4096,
+            "container_disk": 100,
+            "container_persistent": False,
+            "docker_volumes": [{"host_path": "/data"}],
+            "docker_mount_cwd_to_workspace": True,
+            "docker_forward_env": [{"name": "A"}],
+            "docker_env": {"A": "1"},
+            "docker_run_as_host_user": True,
+            "docker_network": False,
+            "docker_extra_args": ["--network", "host"],
+            "docker_persist_across_processes": False,
+            "docker_shared_container_key": "shared:key",
+            "docker_shm_size": "2g",
+        }
+        env = terminal_tool._create_environment(
+            "docker",
+            image="img:tag",
+            cwd="/workspace",
+            timeout=30,
+            container_config=container_config,
+            task_id="task1",
+            host_cwd="/host",
+        )
+        assert isinstance(env, _FakeDocker)
+        assert calls["image"] == "img:tag"
+        assert calls["cwd"] == "/workspace"
+        assert calls["timeout"] == 30
+        assert calls["cpu"] == 2
+        assert calls["memory"] == 4096
+        assert calls["disk"] == 100
+        assert calls["persistent_filesystem"] is False
+        assert calls["task_id"] == "task1"
+        assert calls["host_cwd"] == "/host"
+        assert calls["auto_mount_cwd"] is True
+        assert calls["forward_env"] == [{"name": "A"}]
+        assert calls["env"] == {"A": "1"}
+        assert calls["run_as_host_user"] is True
+        assert calls["network"] is False
+        assert calls["extra_args"] == ["--network", "host"]
+        assert calls["persist_across_processes"] is False
+        assert calls["shared_container_key"] == "shared:key"
+        assert calls["shm_size"] == "2g"
+
+    def test_create_docker_defaults(self, monkeypatch):
+        calls = {}
+
+        class _FakeDocker:
+            def __init__(self, **kwargs):
+                calls.update(kwargs)
+
+        monkeypatch.setattr(terminal_tool, "_DockerEnvironment", _FakeDocker)
+        monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda cc: None)
+        monkeypatch.setattr(terminal_tool, "_docker_session_isolation_enabled", lambda: False)
+        terminal_tool._create_environment(
+            "docker", image="img", cwd="/workspace", timeout=30, task_id="default"
+        )
+        assert calls["cpu"] == 1
+        assert calls["memory"] == 5120
+        assert calls["disk"] == 51200
+        assert calls["persistent_filesystem"] is True
+        assert calls["network"] is True
+        assert calls["run_as_host_user"] is False
+        assert calls["persist_across_processes"] is True
+        assert calls["shm_size"] == "1g"
+        assert calls["auto_mount_cwd"] is False
+
+    def test_create_ssh(self, monkeypatch):
+        calls = {}
+
+        class _FakeSSH:
+            def __init__(self, **kwargs):
+                calls.update(kwargs)
+
+        monkeypatch.setattr(terminal_tool, "_SSHEnvironment", _FakeSSH)
+        ssh_config = {
+            "host": "h",
+            "user": "u",
+            "port": 2222,
+            "key": "/k",
+            "persistent": True,
+        }
+        env = terminal_tool._create_environment(
+            "ssh", image="", cwd="/home/u", timeout=30, ssh_config=ssh_config
+        )
+        assert isinstance(env, _FakeSSH)
+        assert calls["host"] == "h"
+        assert calls["user"] == "u"
+        assert calls["port"] == 2222
+        assert calls["key_path"] == "/k"
+        assert calls["cwd"] == "/home/u"
+        assert calls["timeout"] == 30
+
+    def test_create_ssh_missing_config_raises(self, monkeypatch):
+        with pytest.raises(ValueError):
+            terminal_tool._create_environment(
+                "ssh", image="", cwd="/home/u", timeout=30, ssh_config={}
+            )
+
+    def test_create_ssh_missing_host_raises(self, monkeypatch):
+        with pytest.raises(ValueError):
+            terminal_tool._create_environment(
+                "ssh",
+                image="",
+                cwd="/home/u",
+                timeout=30,
+                ssh_config={"user": "u"},
+            )
+
+    def test_create_singularity(self, monkeypatch):
+        calls = {}
+
+        class _FakeSingularity:
+            def __init__(self, **kwargs):
+                calls.update(kwargs)
+
+        monkeypatch.setattr(terminal_tool, "_SingularityEnvironment", _FakeSingularity)
+        terminal_tool._create_environment(
+            "singularity",
+            image="img",
+            cwd="/w",
+            timeout=30,
+            container_config={"container_cpu": 2, "container_memory": 4096, "container_disk": 100, "container_persistent": False},
+            task_id="task1",
+        )
+        assert calls["image"] == "img"
+        assert calls["cpu"] == 2
+        assert calls["memory"] == 4096
+        assert calls["disk"] == 100
+        assert calls["persistent_filesystem"] is False
+        assert calls["task_id"] == "task1"
+
+    def test_create_modal(self, monkeypatch):
+        calls = {}
+
+        class _FakeModal:
+            def __init__(self, **kwargs):
+                calls.update(kwargs)
+
+        monkeypatch.setattr(terminal_tool, "_ModalEnvironment", _FakeModal)
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_modal_backend_state",
+            lambda mode: {"selected_backend": "direct", "mode": "direct"},
+        )
+        terminal_tool._create_environment(
+            "modal",
+            image="img",
+            cwd="/w",
+            timeout=30,
+            container_config={"container_cpu": 2, "container_memory": 4096, "container_persistent": True},
+            task_id="task1",
+        )
+        assert calls["image"] == "img"
+        assert calls["modal_sandbox_kwargs"]["cpu"] == 2
+        assert calls["modal_sandbox_kwargs"]["memory"] == 4096
+        assert calls["persistent_filesystem"] is True
+        assert calls["task_id"] == "task1"
+
+    def test_create_unknown_type_raises(self, monkeypatch):
+        monkeypatch.setattr(terminal_tool, "_get_plugin_env_provider", lambda et: None)
+        with pytest.raises(ValueError, match="Unknown environment type"):
+            terminal_tool._create_environment("bogus", image="", cwd="/w", timeout=30)
+
+
+# ---------------------------------------------------------------------------
+# ensure_task_env
+# ---------------------------------------------------------------------------
+def _docker_config():
+    return {
+        "env_type": "docker",
+        "docker_image": "img",
+        "cwd": "/workspace",
+        "timeout": 30,
+        "host_cwd": None,
+        "ssh_host": "",
+        "ssh_user": "",
+        "ssh_port": 22,
+        "ssh_key": "",
+        "ssh_persistent": True,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "modal_mode": "auto",
+        "docker_volumes": [],
+        "docker_mount_cwd_to_workspace": False,
+        "docker_forward_env": [],
+        "docker_env": {},
+    }
+
+
+class TestEnsureTaskEnv:
+    def test_local_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            terminal_tool, "_get_env_config", lambda: {"env_type": "local"}
+        )
+        assert terminal_tool.ensure_task_env("task1") is None
+
+    def test_returns_existing_active_env(self, monkeypatch):
+        existing = object()
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config())
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda tid: tid)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: existing)
+        assert terminal_tool.ensure_task_env("task1") is existing
+
+    def test_creates_and_caches_env(self, monkeypatch):
+        env_obj = _CleanupRecorder()
+        created = []
+
+        def fake_create(**kwargs):
+            created.append(kwargs)
+            return env_obj
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config())
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda tid: tid)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: None)
+        monkeypatch.setattr(terminal_tool, "_create_environment", fake_create)
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+        result = terminal_tool.ensure_task_env("task1")
+
+        assert result is env_obj
+        assert terminal_tool._active_environments["task1"] is env_obj
+        assert "task1" in terminal_tool._last_activity
+        assert created
+        assert created[0]["env_type"] == "docker"
+        assert created[0]["task_id"] == "task1"
+        assert created[0]["image"] == "img"
+        assert created[0]["host_cwd"] is None
+
+    def test_creation_failure_returns_none(self, monkeypatch):
+        def boom(**kwargs):
+            raise RuntimeError("sandbox unavailable")
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _docker_config())
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda tid: tid)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: None)
+        monkeypatch.setattr(terminal_tool, "_create_environment", boom)
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+        assert terminal_tool.ensure_task_env("task1") is None
+        assert terminal_tool._active_environments == {}
+        assert terminal_tool._last_activity == {}
+
+
+# ---------------------------------------------------------------------------
+# is_persistent_env
+# ---------------------------------------------------------------------------
+class TestIsPersistentEnv:
+    def test_no_env_false(self, monkeypatch):
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: None)
+        assert terminal_tool.is_persistent_env("t") is False
+
+    def test_session_scoped_true(self, monkeypatch):
+        env = types.SimpleNamespace(_session_scoped=True, _persistent=False)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: env)
+        assert terminal_tool.is_persistent_env("t") is True
+
+    def test_persistent_attr_true(self, monkeypatch):
+        env = types.SimpleNamespace(_session_scoped=False, _persistent=True)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: env)
+        assert terminal_tool.is_persistent_env("t") is True
+
+    def test_not_persistent_false(self, monkeypatch):
+        env = types.SimpleNamespace(_session_scoped=False, _persistent=False)
+        monkeypatch.setattr(terminal_tool, "get_active_env", lambda tid: env)
+        assert terminal_tool.is_persistent_env("t") is False
+
+
+# ---------------------------------------------------------------------------
+# cleanup_vm
+# ---------------------------------------------------------------------------
+class TestCleanupVm:
+    def test_cleanup_nonexistent_task_noop(self, monkeypatch):
+        terminal_tool.cleanup_vm("missing")  # must not raise
+        assert terminal_tool._active_environments == {}
+
+    def test_cleanup_calls_env_cleanup(self, monkeypatch):
+        env = _CleanupRecorder()
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        # stub the file_ops cache invalidator so the test is hermetic
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool.cleanup_vm("task1")
+
+        assert env.cleaned is True
+        assert "task1" not in terminal_tool._active_environments
+        assert "task1" not in terminal_tool._last_activity
+
+    def test_cleanup_force_remove_dispatch(self, monkeypatch):
+        # DockerEnvironment-style cleanup that accepts force_remove by name.
+        calls = {}
+
+        class _DockerLike:
+            def cleanup(self, force_remove=False):
+                calls["force_remove"] = force_remove
+
+        env = _DockerLike()
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool.cleanup_vm("task1", force_remove=True)
+        assert calls["force_remove"] is True
+
+    def test_cleanup_not_forced_when_env_rejects(self, monkeypatch):
+        # cleanup() that does not accept a keyword -> called with no args.
+        env = _CleanupRecorder(accept_force_remove=False)
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool.cleanup_vm("task1", force_remove=True)
+        assert env.cleaned is True
+        assert env.force_remove is None
+
+    def test_cleanup_swallows_404_error(self, monkeypatch):
+        env = _CleanupRecorder()
+
+        def boom():
+            raise ValueError("container 404 not found")
+
+        env.cleanup = boom
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool.cleanup_vm("task1")  # must not raise
+        assert "task1" not in terminal_tool._active_environments
+
+    def test_cleanup_stop_fallback(self, monkeypatch):
+        # An env with no cleanup() but a stop() method still gets torn down.
+        class _StopOnly:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        env = _StopOnly()
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool.cleanup_vm("task1")
+        assert env.stopped is True
+
+
+# ---------------------------------------------------------------------------
+# cleanup_all_environments
+# ---------------------------------------------------------------------------
+class TestCleanupAllEnvironments:
+    def test_cleans_all(self, monkeypatch, tmp_path):
+        e1 = _CleanupRecorder()
+        e2 = _CleanupRecorder()
+        terminal_tool._active_environments.update({"a": e1, "b": e2})
+        terminal_tool._last_activity.update({"a": time.time(), "b": time.time()})
+        _stub_file_tools(monkeypatch)
+        monkeypatch.setattr(terminal_tool, "_get_scratch_dir", lambda: tmp_path)
+
+        cleaned = terminal_tool.cleanup_all_environments()
+
+        assert cleaned == 2
+        assert e1.cleaned is True
+        assert e2.cleaned is True
+        assert terminal_tool._active_environments == {}
+
+    def test_no_active_envs_returns_zero(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(terminal_tool, "_get_scratch_dir", lambda: tmp_path)
+        assert terminal_tool.cleanup_all_environments() == 0
+
+    def test_continues_past_one_bad_env(self, monkeypatch, tmp_path):
+        good = _CleanupRecorder()
+
+        class _Bad:
+            def cleanup(self):
+                raise RuntimeError("boom")
+
+        terminal_tool._active_environments.update({"bad": _Bad(), "good": good})
+        terminal_tool._last_activity.update({"bad": time.time(), "good": time.time()})
+        _stub_file_tools(monkeypatch)
+        monkeypatch.setattr(terminal_tool, "_get_scratch_dir", lambda: tmp_path)
+
+        cleaned = terminal_tool.cleanup_all_environments()
+        assert cleaned == 2
+        assert good.cleaned is True
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_inactive_envs
+# ---------------------------------------------------------------------------
+class TestCleanupInactiveEnvs:
+    def test_removes_inactive_keeps_fresh(self, monkeypatch):
+        stale_env = _CleanupRecorder()
+        fresh_env = _CleanupRecorder()
+        now = time.time()
+        terminal_tool._active_environments.update(
+            {"stale": stale_env, "fresh": fresh_env}
+        )
+        terminal_tool._last_activity.update(
+            {"stale": now - 1000, "fresh": now}
+        )
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert stale_env.cleaned is True
+        assert fresh_env.cleaned is False
+        assert "stale" not in terminal_tool._active_environments
+        assert "stale" not in terminal_tool._last_activity
+        assert "fresh" in terminal_tool._active_environments
+        assert "fresh" in terminal_tool._last_activity
+
+    def test_nothing_inactive_is_kept(self, monkeypatch):
+        env = _CleanupRecorder()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+        assert env.cleaned is False
+
+    def test_active_process_keeps_sandbox_alive(self, monkeypatch):
+        env = _CleanupRecorder()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        _stub_file_tools(monkeypatch)
+        # Register "t" as having active background processes.
+        fake = types.ModuleType("tools.process_registry")
+
+        class _Registry:
+            @staticmethod
+            def has_active_processes(task_id):
+                return task_id == "t"
+
+        fake.process_registry = _Registry()
+        monkeypatch.setitem(sys.modules, "tools.process_registry", fake)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+        assert env.cleaned is False
+        assert "t" in terminal_tool._active_environments
+
+
+# ---------------------------------------------------------------------------
+# _atexit_cleanup
+# ---------------------------------------------------------------------------
+class TestAtexitCleanup:
+    def test_stops_thread_and_cleans(self, monkeypatch):
+        env = _CleanupRecorder()
+        terminal_tool._active_environments["t"] = env
+        calls = {"cleanup": 0}
+        monkeypatch.setattr(terminal_tool, "_stop_cleanup_thread", lambda: None)
+        monkeypatch.setattr(
+            terminal_tool,
+            "cleanup_all_environments",
+            lambda: calls.__setitem__("cleanup", 1) or 1,
+        )
+        terminal_tool._atexit_cleanup()
+        assert calls["cleanup"] == 1
+
+    def test_no_envs_is_noop(self, monkeypatch):
+        monkeypatch.setattr(terminal_tool, "_stop_cleanup_thread", lambda: None)
+        monkeypatch.setattr(terminal_tool, "cleanup_all_environments", lambda: 0)
+        terminal_tool._atexit_cleanup()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _evict_environment_for_task
+# ---------------------------------------------------------------------------
+class TestEvictEnvironmentForTask:
+    def test_evicts_and_cleans(self, monkeypatch):
+        env = _CleanupRecorder()
+        terminal_tool._active_environments["task1"] = env
+        terminal_tool._last_activity["task1"] = time.time()
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda tid: tid)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._evict_environment_for_task("task1")
+
+        assert env.cleaned is True
+        assert "task1" not in terminal_tool._active_environments
+        assert "task1" not in terminal_tool._last_activity
+
+    def test_evict_swallows_cleanup_error(self, monkeypatch):
+        env = _CleanupRecorder()
+        terminal_tool._active_environments["task1"] = env
+        monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda tid: tid)
+        monkeypatch.setattr(env, "cleanup", lambda: (_ for _ in ()).throw(RuntimeError("x")))
+        terminal_tool._evict_environment_for_task("task1")  # must not raise
+        assert "task1" not in terminal_tool._active_environments
+
+
+# ---------------------------------------------------------------------------
+# Task env overrides
+# ---------------------------------------------------------------------------
+class TestTaskEnvOverrides:
+    def test_register_stores_overrides(self, monkeypatch):
+        terminal_tool.register_task_env_overrides("t1", {"docker_image": "img"})
+        assert terminal_tool._task_env_overrides["t1"] == {"docker_image": "img"}
+
+    def test_register_cwd_updates_env(self, monkeypatch):
+        env = types.SimpleNamespace(cwd="/old")
+        terminal_tool._active_environments["t1"] = env
+        monkeypatch.setattr(
+            terminal_tool, "_resolve_container_task_id", lambda tid: tid
+        )
+        terminal_tool.register_task_env_overrides("t1", {"cwd": "/proj/root"})
+        assert env.cwd == "/proj/root"
+        assert terminal_tool._session_cwd["t1"] == "/proj/root"
+
+    def test_clear_drops_all_artifacts(self, monkeypatch):
+        terminal_tool._task_env_overrides["t1"] = {"x": 1}
+        terminal_tool._session_cwd["t1"] = "/proj"
+        terminal_tool._container_aliases["t1"] = "default"
+        terminal_tool.clear_task_env_overrides("t1")
+        assert terminal_tool._task_env_overrides == {}
+        assert terminal_tool._session_cwd == {}
+        assert terminal_tool._container_aliases == {}
+
+
+# ---------------------------------------------------------------------------
+# Container aliasing
+# ---------------------------------------------------------------------------
+class TestContainerAlias:
+    def test_register_alias(self, monkeypatch):
+        terminal_tool.register_container_alias("child", "parent")
+        assert terminal_tool._container_aliases["child"] == "parent"
+
+    def test_register_alias_none_parent_defaults(self, monkeypatch):
+        terminal_tool.register_container_alias("child", None)
+        assert terminal_tool._container_aliases["child"] == "default"
+
+    def test_register_alias_empty_child_noop(self, monkeypatch):
+        terminal_tool.register_container_alias("", "parent")
+        assert terminal_tool._container_aliases == {}
+
+    def test_resolve_alias_chain(self, monkeypatch):
+        terminal_tool._container_aliases.update({"child": "mid", "mid": "default"})
+        assert terminal_tool._resolve_container_alias("child") == "default"
+
+    def test_resolve_alias_no_entry_returns_self(self, monkeypatch):
+        assert terminal_tool._resolve_container_alias("standalone") == "standalone"
+
+    def test_resolve_alias_cycle_safe(self, monkeypatch):
+        terminal_tool._container_aliases.update({"a": "b", "b": "a"})
+        # Must terminate (no infinite loop); returns the last-hop key.
+        assert terminal_tool._resolve_container_alias("a") in {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# fixture-internal helpers (defined at bottom to keep fixtures coherent)
+# ---------------------------------------------------------------------------
+def _stub_file_tools(monkeypatch):
+    """Neutralise the file_ops cache invalidation in cleanup paths."""
+    fake = types.ModuleType("tools.file_tools")
+    fake.clear_file_ops_cache = lambda task_id: None
+    monkeypatch.setitem(sys.modules, "tools.file_tools", fake)
+
+
+def _capture_logger(info=None, warning=None, debug=None, error=None):
+    """A logger double that appends (args, kwargs) to the requested lists."""
+
+    class _Logger:
+        def info(self, *a, **k):
+            if info is not None:
+                info.append((a, k))
+
+        def warning(self, *a, **k):
+            if warning is not None:
+                warning.append((a, k))
+
+        def debug(self, *a, **k):
+            if debug is not None:
+                debug.append((a, k))
+
+        def error(self, *a, **k):
+            if error is not None:
+                error.append((a, k))
+
+    return _Logger()
+
+
+# ---------------------------------------------------------------------------
+# _maybe_reap_docker_orphans
+# ---------------------------------------------------------------------------
+class TestMaybeReapDockerOrphans:
+    def _reset(self, monkeypatch):
+        # The reaper is a once-per-process guard; reset it (and its lock) so
+        # each test can observe a fresh sweep independent of earlier cases.
+        monkeypatch.setattr(terminal_tool, "_docker_orphan_reaper_ran", False)
+        monkeypatch.setattr(
+            terminal_tool, "_docker_orphan_reaper_lock", threading.Lock()
+        )
+
+    def _fake_docker_module(self, monkeypatch, reap_returns=0, reap_raises=None):
+        """Install a fake tools.environments.docker with recorded reap calls."""
+        fake = types.ModuleType("tools.environments.docker")
+        fake._container_identity = lambda key: f"profile:{key}"
+        calls = {}
+
+        if reap_raises is not None:
+
+            def boom(max_age_seconds, profile_filter):
+                raise reap_raises
+
+            fake.reap_orphan_containers = boom
+        else:
+
+            def reap(max_age_seconds, profile_filter):
+                calls["max_age"] = max_age_seconds
+                calls["profile"] = profile_filter
+                return reap_returns
+
+            fake.reap_orphan_containers = reap
+
+        fake._reap_calls = calls
+        monkeypatch.setitem(sys.modules, "tools.environments.docker", fake)
+        return fake
+
+    def test_disabled_returns_early(self, monkeypatch):
+        self._reset(monkeypatch)
+        terminal_tool._maybe_reap_docker_orphans({"docker_orphan_reaper": False})
+        # Early return: the once-per-process guard must NOT have been set.
+        assert terminal_tool._docker_orphan_reaper_ran is False
+
+    def test_already_ran_skips_sweep(self, monkeypatch):
+        self._reset(monkeypatch)
+        terminal_tool._docker_orphan_reaper_ran = True
+        terminal_tool._maybe_reap_docker_orphans({})
+        assert terminal_tool._docker_orphan_reaper_ran is True
+
+    def test_sweeps_and_logs_removed(self, monkeypatch):
+        self._reset(monkeypatch)
+        info = []
+        monkeypatch.setattr(terminal_tool, "logger", _capture_logger(info=info))
+        fake = self._fake_docker_module(monkeypatch, reap_returns=2)
+        # Hermetic fixture already drops TERMINAL_* => default lifetime 300.
+        monkeypatch.delenv("TERMINAL_LIFETIME_SECONDS", raising=False)
+
+        terminal_tool._maybe_reap_docker_orphans(
+            {"docker_shared_container_key": "shared:key"}
+        )
+
+        assert fake._reap_calls["max_age"] == 600  # 2 x lifetime_seconds
+        assert fake._reap_calls["profile"] == "profile:shared:key"
+        # logger.info(msg, removed, profile) — logging defers %-interpolation.
+        assert info and info[0][0][1] == 2
+        assert info[0][0][2] == "profile:shared:key"
+
+    def test_invalid_lifetime_falls_back_to_default(self, monkeypatch):
+        self._reset(monkeypatch)
+        monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "not-an-int")
+        fake = self._fake_docker_module(monkeypatch, reap_returns=0)
+
+        terminal_tool._maybe_reap_docker_orphans({})
+
+        assert fake._reap_calls["max_age"] == 600  # default 300 * 2
+
+    def test_lifetime_floor_at_60(self, monkeypatch):
+        self._reset(monkeypatch)
+        monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "0")
+        fake = self._fake_docker_module(monkeypatch, reap_returns=0)
+
+        terminal_tool._maybe_reap_docker_orphans({})
+
+        # max(60, 0) * 2 == 120, not an instant reap that races our own setup.
+        assert fake._reap_calls["max_age"] == 120
+
+    def test_import_error_returns_gracefully(self, monkeypatch):
+        self._reset(monkeypatch)
+        # Empty module lacks reap_orphan_containers/_container_identity =>
+        # the lazy import inside the function raises and we bail out.
+        monkeypatch.setitem(
+            sys.modules, "tools.environments.docker", types.ModuleType("tools.environments.docker")
+        )
+        terminal_tool._maybe_reap_docker_orphans({})  # must not raise
+        assert terminal_tool._docker_orphan_reaper_ran is True
+
+    def test_reap_exception_swallowed(self, monkeypatch):
+        self._reset(monkeypatch)
+        debug = []
+        monkeypatch.setattr(terminal_tool, "logger", _capture_logger(debug=debug))
+        self._fake_docker_module(
+            monkeypatch, reap_raises=RuntimeError("docker daemon down")
+        )
+        terminal_tool._maybe_reap_docker_orphans({})  # must not raise
+        assert terminal_tool._docker_orphan_reaper_ran is True
+        assert debug  # debug log recorded the janitor failure
+
+
+# ---------------------------------------------------------------------------
+# Cleanup background thread: _start / _stop / _cleanup_thread_worker
+# ---------------------------------------------------------------------------
+class TestCleanupThread:
+    def _stop_thread(self):
+        terminal_tool._cleanup_running = False
+        t = terminal_tool._cleanup_thread
+        if t is not None and t.is_alive():
+            t.join(timeout=2)
+        terminal_tool._cleanup_thread = None
+
+    def test_start_creates_daemon_thread(self, monkeypatch):
+        self._stop_thread()
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"lifetime_seconds": 1})
+        monkeypatch.setattr(terminal_tool, "_cleanup_inactive_envs", lambda ls: None)
+        monkeypatch.setattr(time, "sleep", lambda s: None)
+
+        terminal_tool._start_cleanup_thread()
+
+        assert terminal_tool._cleanup_running is True
+        assert terminal_tool._cleanup_thread is not None
+        assert terminal_tool._cleanup_thread.is_alive()
+        assert terminal_tool._cleanup_thread.daemon is True
+        self._stop_thread()
+
+    def test_start_is_idempotent(self, monkeypatch):
+        self._stop_thread()
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"lifetime_seconds": 1})
+        monkeypatch.setattr(terminal_tool, "_cleanup_inactive_envs", lambda ls: None)
+        monkeypatch.setattr(time, "sleep", lambda s: None)
+
+        terminal_tool._start_cleanup_thread()
+        first = terminal_tool._cleanup_thread
+        terminal_tool._start_cleanup_thread()
+
+        assert terminal_tool._cleanup_thread is first
+        self._stop_thread()
+
+    def test_stop_stops_thread(self, monkeypatch):
+        self._stop_thread()
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"lifetime_seconds": 1})
+        monkeypatch.setattr(terminal_tool, "_cleanup_inactive_envs", lambda ls: None)
+        monkeypatch.setattr(time, "sleep", lambda s: None)
+
+        terminal_tool._start_cleanup_thread()
+        thread = terminal_tool._cleanup_thread
+        terminal_tool._stop_cleanup_thread()
+
+        assert terminal_tool._cleanup_running is False
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    def test_stop_with_no_thread_is_noop(self, monkeypatch):
+        self._stop_thread()
+        monkeypatch.setattr(terminal_tool, "_cleanup_thread", None)
+        terminal_tool._stop_cleanup_thread()
+        assert terminal_tool._cleanup_running is False
+
+    def test_worker_runs_cleanup_with_lifetime(self, monkeypatch):
+        self._stop_thread()
+        calls = []
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"lifetime_seconds": 42})
+        monkeypatch.setattr(terminal_tool, "_cleanup_inactive_envs", lambda ls: calls.append(ls))
+        real_sleep = time.sleep
+        ran_once = threading.Event()
+
+        def fake_sleep(secs):
+            if not ran_once.is_set():
+                ran_once.set()
+            real_sleep(0.005)
+
+        monkeypatch.setattr(time, "sleep", fake_sleep)
+        terminal_tool._cleanup_running = True
+        t = threading.Thread(target=terminal_tool._cleanup_thread_worker, daemon=True)
+        t.start()
+
+        assert ran_once.wait(2)
+        terminal_tool._cleanup_running = False
+        t.join(timeout=2)
+
+        assert not t.is_alive()
+        assert calls and calls[0] == 42
+
+    def test_worker_swallows_error_logs_warning(self, monkeypatch):
+        self._stop_thread()
+        warnings = []
+        monkeypatch.setattr(terminal_tool, "logger", _capture_logger(warning=warnings))
+
+        def boom():
+            raise RuntimeError("config read failed")
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", boom)
+        real_sleep = time.sleep
+        ran_once = threading.Event()
+
+        def fake_sleep(secs):
+            if not ran_once.is_set():
+                ran_once.set()
+            real_sleep(0.005)
+
+        monkeypatch.setattr(time, "sleep", fake_sleep)
+        terminal_tool._cleanup_running = True
+        t = threading.Thread(target=terminal_tool._cleanup_thread_worker, daemon=True)
+        t.start()
+
+        assert ran_once.wait(2)
+        terminal_tool._cleanup_running = False
+        t.join(timeout=2)
+
+        assert not t.is_alive()
+        assert warnings
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_inactive_envs — remaining branches
+# ---------------------------------------------------------------------------
+class TestCleanupInactiveEnvsEdges:
+    def test_process_registry_import_error_handled(self, monkeypatch):
+        # Force `from tools.process_registry import process_registry` to fail so
+        # the whole sandbox-keepalive block is skipped without crashing.
+        monkeypatch.setitem(
+            sys.modules, "tools.process_registry", types.ModuleType("tools.process_registry")
+        )
+        env = _CleanupRecorder()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert env.cleaned is True
+
+    def test_file_tools_import_error_handled(self, monkeypatch):
+        # Force the file_ops cache invalidation import to fail.
+        _fake_process_registry(monkeypatch)
+        monkeypatch.setitem(
+            sys.modules, "tools.file_tools", types.ModuleType("tools.file_tools")
+        )
+        env = _CleanupRecorder()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert env.cleaned is True
+
+    def test_cleanup_stop_fallback(self, monkeypatch):
+        class _StopOnly:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        env = _StopOnly()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert env.stopped is True
+
+    def test_cleanup_terminate_fallback(self, monkeypatch):
+        class _TerminateOnly:
+            def __init__(self):
+                self.terminated = False
+
+            def terminate(self):
+                self.terminated = True
+
+        env = _TerminateOnly()
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert env.terminated is True
+
+    def test_404_error_logged_as_already_cleaned(self, monkeypatch):
+        def boom():
+            raise ValueError("container 404 not found")
+
+        env = _CleanupRecorder()
+        env.cleanup = boom
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        info = []
+        monkeypatch.setattr(terminal_tool, "logger", _capture_logger(info=info))
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)  # must not raise
+
+        assert info and "already cleaned up" in str(info[0])
+
+    def test_other_cleanup_error_logged_warning(self, monkeypatch):
+        def boom():
+            raise RuntimeError("disk full")
+
+        env = _CleanupRecorder()
+        env.cleanup = boom
+        now = time.time()
+        terminal_tool._active_environments["t"] = env
+        terminal_tool._last_activity["t"] = now - 1000
+        warning = []
+        monkeypatch.setattr(terminal_tool, "logger", _capture_logger(warning=warning))
+        _fake_process_registry(monkeypatch)
+        _stub_file_tools(monkeypatch)
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=300)  # must not raise
+
+        assert warning
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_compound_background — branch coverage (parens / semicolon / pipe /
+# comment without trailing newline)
+# ---------------------------------------------------------------------------
+class TestRewriteCompoundBackgroundBranches:
+    def test_paren_group_untouched(self):
+        assert (
+            terminal_tool._rewrite_compound_background("(A && B &)") == "(A && B &)"
+        )
+
+    def test_semicolon_resets_chain(self):
+        cmd = "A && B ; C &"
+        assert terminal_tool._rewrite_compound_background(cmd) == cmd
+
+    def test_pipe_resets_chain(self):
+        cmd = "A && B | C &"
+        assert terminal_tool._rewrite_compound_background(cmd) == cmd
+
+    def test_comment_no_trailing_newline_untouched(self):
+        cmd = "echo hi # A && B &"
+        assert terminal_tool._rewrite_compound_background(cmd) == cmd
+
+    def test_comment_only_no_newline_untouched(self):
+        cmd = "# just a comment"
+        assert terminal_tool._rewrite_compound_background(cmd) == cmd

--- a/tests/tools/test_terminal_exit_and_cwd.py
+++ b/tests/tools/test_terminal_exit_and_cwd.py
@@ -1,0 +1,391 @@
+"""Tests for exit-code interpretation, command-cwd resolution, and session-cwd helpers.
+
+Covers ``_interpret_exit_code`` / ``_interpret_signal_exit`` (the human-readable
+note added when a non-zero exit is expected), ``_resolve_command_cwd`` (the
+``workdir`` > session-record > default resolution ladder, container-aware),
+the ``_session_cwd`` record helpers, and the small env/cwd utility predicates
+(``_parse_env_var``, ``_safe_getcwd``, ``_is_container_backend``,
+``_is_unusable_container_cwd``).
+
+Semantics asserted here are pinned against the live implementation, not a
+spec: e.g. ``_parse_env_var`` *raises* on a malformed value (it does not fall
+back to the default), and ``_safe_getcwd`` falls back to ``$HOME`` /
+``TERMINAL_CWD`` (not ``/``).
+"""
+
+import json
+import os
+
+import pytest
+
+import tools.terminal_tool as tt
+
+
+@pytest.fixture(autouse=True)
+def _clean_store(monkeypatch):
+    """Isolate each test from any shared session-cwd / override state."""
+    monkeypatch.setattr(tt, "_session_cwd", {})
+    monkeypatch.setattr(tt, "_task_env_overrides", {})
+
+
+class TestInterpretSignalExit:
+    """_interpret_signal_exit: map signal terminations (negative & 128+signum)."""
+
+    # -- negative codes: subprocess -signum semantics (definite signal death) --
+
+    @pytest.mark.parametrize("code,expect", [
+        (-3, "SIGQUIT"),
+        (-4, "SIGILL"),
+        (-6, "SIGABRT"),
+        (-7, "SIGBUS"),
+        (-8, "SIGFPE"),
+        (-9, "SIGKILL"),
+        (-11, "SIGSEGV"),
+        (-13, "SIGPIPE"),
+        (-15, "SIGTERM"),
+        (-24, "SIGXCPU"),
+        (-25, "SIGXFSZ"),
+    ])
+    def test_negative_curated_signals(self, code, expect):
+        note = tt._interpret_signal_exit(code)
+        assert note is not None
+        assert expect in note
+        assert "terminated by signal" in note
+
+    def test_negative_oom_killer_note(self):
+        # Killed by the kernel OOM killer (kill -9) must surface that hint.
+        note = tt._interpret_signal_exit(-9)
+        assert note is not None
+        assert "OOM" in note
+
+    def test_negative_unknown_signum_uses_name(self):
+        # Signum without a curated note still yields a note; a platform-known
+        # signal resolves to its name (e.g. 31 -> SIGUSR2 on macOS).
+        note = tt._interpret_signal_exit(-31)
+        assert note is not None
+        assert "31" in note
+
+    def test_negative_out_of_range_signum_generic(self):
+        # Signum 65 is not a valid Signals member on common platforms: the
+        # ValueError fallback yields a generic "signal 65" note, never raising.
+        note = tt._interpret_signal_exit(-65)
+        assert note is not None
+        assert "65" in note
+
+    def test_negative_sigint_excluded(self):
+        # SIGINT has bespoke interrupt-marker handling in the executor.
+        assert tt._interpret_signal_exit(-2) is None
+
+    # -- 128+signum band: shell convention (hedged with "usually") --
+
+    @pytest.mark.parametrize("code,expect", [
+        (131, "SIGQUIT"),
+        (132, "SIGILL"),
+        (134, "SIGABRT"),
+        (136, "SIGFPE"),
+        (137, "SIGKILL"),
+        (139, "SIGSEGV"),
+        (141, "SIGPIPE"),
+        (143, "SIGTERM"),
+        (152, "SIGXCPU"),
+        (153, "SIGXFSZ"),
+    ])
+    def test_shell_band_curated_signals(self, code, expect):
+        note = tt._interpret_signal_exit(code)
+        assert note is not None
+        assert expect in note
+        assert "usually" in note
+
+    def test_shell_band_uncurated_signum_returns_none(self):
+        # A signum outside the curated table is never guessed: an app could
+        # legitimately exit with that code, so stay silent.
+        assert tt._interpret_signal_exit(128 + 20) is None
+        assert tt._interpret_signal_exit(128 + 65) is None
+
+    def test_shell_band_sigint_excluded(self):
+        assert tt._interpret_signal_exit(130) is None
+
+    # -- normal / non-signal codes --
+
+    @pytest.mark.parametrize("code", [0, 1, 2, 42, 100, 127, 128])
+    def test_normal_codes_return_none(self, code):
+        assert tt._interpret_signal_exit(code) is None
+
+
+class TestInterpretExitCode:
+    """_interpret_exit_code: non-erroneous non-zero exit notes (and None for errors)."""
+
+    def test_exit_zero_returns_none(self):
+        assert tt._interpret_exit_code("anything", 0) is None
+
+    # -- command-specific semantics --
+
+    @pytest.mark.parametrize("base", [
+        "grep foo bar.txt", "egrep foo bar.txt", "fgrep foo bar.txt",
+        "rg foo", "ag foo", "ack foo", "/usr/bin/grep foo", "/usr/local/bin/rg foo",
+    ])
+    def test_grep_family_exit_one_is_no_matches(self, base):
+        assert tt._interpret_exit_code(base, 1) == "No matches found (not an error)"
+
+    def test_grep_exit_two_is_error(self):
+        # grep exit 2 is a real error (e.g. file not found) — no note.
+        assert tt._interpret_exit_code("grep foo bar.txt", 2) is None
+
+    @pytest.mark.parametrize("base", ["diff a b", "colordiff a b"])
+    def test_diff_exit_one_is_files_differ(self, base):
+        assert tt._interpret_exit_code(base, 1) == "Files differ (expected, not an error)"
+
+    def test_diff_exit_two_is_error(self):
+        assert tt._interpret_exit_code("diff a b", 2) is None
+
+    def test_find_exit_one(self):
+        assert tt._interpret_exit_code("find . -name x", 1) == (
+            "Some directories were inaccessible (partial results may still be valid)"
+        )
+
+    @pytest.mark.parametrize("base", ["test -f foo", "[ -f foo ]"])
+    def test_test_bracket_exit_one(self, base):
+        assert tt._interpret_exit_code(base, 1) == (
+            "Condition evaluated to false (expected, not an error)"
+        )
+
+    @pytest.mark.parametrize("code,expect", [
+        (6, "Could not resolve host"),
+        (7, "Failed to connect to host"),
+        (22, "HTTP response code indicated error (e.g. 404, 500)"),
+        (28, "Operation timed out"),
+    ])
+    def test_curl_codes(self, code, expect):
+        assert tt._interpret_exit_code("curl -s http://example.com", code) == expect
+
+    def test_curl_unlisted_code_is_none(self):
+        assert tt._interpret_exit_code("curl -s http://example.com", 5) is None
+
+    def test_git_exit_one(self):
+        assert tt._interpret_exit_code("git diff", 1) == (
+            "Non-zero exit (often normal — e.g. 'git diff' returns 1 when files differ)"
+        )
+
+    # -- pipeline / chain: exit code comes from the LAST segment --
+
+    def test_pipeline_last_segment_drives_semantics(self):
+        assert tt._interpret_exit_code("find . -name x | grep foo", 1) == (
+            "No matches found (not an error)"
+        )
+
+    def test_chain_and_then_last_segment(self):
+        assert tt._interpret_exit_code("echo hi && grep foo", 1) == (
+            "No matches found (not an error)"
+        )
+
+    def test_semicolon_last_segment_rules(self):
+        # Last segment is `ls` — no semantics -> None even though grep ran first.
+        assert tt._interpret_exit_code("grep foo a.txt; ls", 1) is None
+
+    def test_env_assignment_prefix_still_resolves_to_command(self):
+        assert tt._interpret_exit_code("VAR=val grep foo", 1) == (
+            "No matches found (not an error)"
+        )
+
+    def test_only_env_assignment_has_no_command(self):
+        assert tt._interpret_exit_code("FOO=bar", 1) is None
+
+    # -- signal notes win over command semantics --
+
+    def test_signal_note_wins_over_grep_semantics(self):
+        note = tt._interpret_exit_code("grep foo huge.log", 137)
+        assert note is not None
+        assert "SIGKILL" in note
+
+    # -- unknown command + non-zero -> None --
+
+    @pytest.mark.parametrize("cmd", ["unknowncmd", "ls --weird", "./build.sh"])
+    def test_unknown_command_nonzero_returns_none(self, cmd):
+        assert tt._interpret_exit_code(cmd, 3) is None
+
+
+def env_type_from(container):
+    return "docker" if container else "local"
+
+
+class TestResolveCommandCwd:
+    """_resolve_command_cwd: workdir > session record > default (container-aware)."""
+
+    def _resolve(self, monkeypatch, *, workdir, default_cwd, recorded="<none>",
+                 container=False, unusable=False):
+        """Call _resolve_command_cwd with the three seam functions mocked."""
+        def fake_get(key):
+            return None if recorded == "<none>" else recorded
+
+        monkeypatch.setattr(tt, "get_session_cwd", fake_get)
+        monkeypatch.setattr(tt, "_is_container_backend", lambda env: container)
+        monkeypatch.setattr(tt, "_is_unusable_container_cwd", lambda cwd: unusable)
+        return tt._resolve_command_cwd(
+            workdir=workdir, default_cwd=default_cwd,
+            session_key="sess-a", env_type=env_type_from(container),
+        )
+
+    def test_workdir_overrides_everything(self, monkeypatch):
+        assert self._resolve(monkeypatch, workdir="/explicit", default_cwd="/def",
+                             recorded="/recorded") == "/explicit"
+
+    def test_record_beats_default(self, monkeypatch):
+        assert self._resolve(monkeypatch, workdir=None, default_cwd="/def",
+                             recorded="/recorded") == "/recorded"
+
+    def test_no_record_uses_default(self, monkeypatch):
+        assert self._resolve(monkeypatch, workdir=None, default_cwd="/def") == "/def"
+
+    def test_container_unusable_record_falls_back_to_default(self, monkeypatch):
+        # Host path recorded on a container backend must not be used (exit 126).
+        assert self._resolve(monkeypatch, workdir=None, default_cwd="/def",
+                             recorded="/home/user", container=True, unusable=True) == "/def"
+
+    def test_container_usable_record_is_kept(self, monkeypatch):
+        # A sandbox-native recorded cwd is fine even on a container backend.
+        assert self._resolve(monkeypatch, workdir=None, default_cwd="/def",
+                             recorded="/workspace", container=True, unusable=False) == "/workspace"
+
+    def test_non_container_unusable_record_is_kept(self, monkeypatch):
+        # On a non-container backend the container-unusability guard is moot.
+        assert self._resolve(monkeypatch, workdir=None, default_cwd="/def",
+                             recorded="/home/user", container=False, unusable=True) == "/home/user"
+
+
+class TestSessionCwdStore:
+    """record_session_cwd / get_session_cwd / clear_session_cwd round-trip."""
+
+    def test_record_get_clear_cycle(self):
+        tt.record_session_cwd("sess-a", "/start")
+        assert tt.get_session_cwd("sess-a") == "/start"
+        tt.record_session_cwd("sess-a", "/moved")
+        assert tt.get_session_cwd("sess-a") == "/moved"
+        tt.clear_session_cwd("sess-a")
+        assert tt.get_session_cwd("sess-a") is None
+
+    def test_none_key_collapses_to_default(self):
+        tt.record_session_cwd(None, "/defaulted")
+        assert tt.get_session_cwd(None) == "/defaulted"
+        assert tt.get_session_cwd("default") == "/defaulted"
+
+    def test_sessions_are_isolated(self):
+        tt.record_session_cwd("sess-a", "/a")
+        tt.record_session_cwd("sess-b", "/b")
+        assert tt.get_session_cwd("sess-a") == "/a"
+        assert tt.get_session_cwd("sess-b") == "/b"
+        assert tt.get_session_cwd("sess-c") is None
+
+    @pytest.mark.parametrize("bad", ["", "   ", None, 0, 123])
+    def test_non_string_or_empty_cwd_is_ignored(self, bad):
+        tt.record_session_cwd("sess-a", "/keep")
+        tt.record_session_cwd("sess-a", bad)
+        assert tt.get_session_cwd("sess-a") == "/keep"
+
+    def test_clear_only_drops_named_session(self):
+        tt.record_session_cwd("sess-a", "/a")
+        tt.record_session_cwd("sess-b", "/b")
+        tt.clear_session_cwd("sess-a")
+        assert tt.get_session_cwd("sess-a") is None
+        assert tt.get_session_cwd("sess-b") == "/b"
+
+
+class TestParseEnvVar:
+    """_parse_env_var: converts cleanly, raises on malformed values."""
+
+    def test_valid_int(self):
+        assert tt._parse_env_var("TT_TEST", "180") == 180
+
+    def test_valid_converter(self, monkeypatch):
+        monkeypatch.setenv("TT_TEST", '["a", "b"]')
+        assert tt._parse_env_var("TT_TEST", "[]", converter=json.loads,
+                                 type_label="valid JSON") == ["a", "b"]
+
+    def test_not_set_uses_default(self, monkeypatch):
+        monkeypatch.delenv("TT_TEST", raising=False)
+        assert tt._parse_env_var("TT_TEST", "180") == 180
+
+    def test_invalid_raises_with_name_and_label(self, monkeypatch):
+        monkeypatch.setenv("TT_TEST", "5m")
+        with pytest.raises(ValueError, match="TT_TEST"):
+            tt._parse_env_var("TT_TEST", "180")
+
+    def test_empty_string_int_raises(self, monkeypatch):
+        # An empty-but-set value is NOT treated as absent: int("") raises.
+        monkeypatch.setenv("TT_TEST", "")
+        with pytest.raises(ValueError):
+            tt._parse_env_var("TT_TEST", "180")
+
+    def test_empty_string_str_converter_is_empty(self, monkeypatch):
+        monkeypatch.setenv("TT_TEST", "")
+        assert tt._parse_env_var("TT_TEST", "180", converter=str, type_label="string") == ""
+
+    def test_invalid_json_raises(self, monkeypatch):
+        monkeypatch.setenv("TT_TEST", "not json")
+        with pytest.raises(ValueError, match="valid JSON"):
+            tt._parse_env_var("TT_TEST", "[]", converter=json.loads, type_label="valid JSON")
+
+
+class TestSafeGetcwd:
+    """_safe_getcwd: tolerate deleted / TCC-blocked CWD, propagate unrelated OSError."""
+
+    def test_normal_getcwd_passthrough(self):
+        assert tt._safe_getcwd() == os.getcwd()
+
+    def test_file_not_found_uses_home(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(os, "getcwd", lambda: (_ for _ in ()).throw(
+            FileNotFoundError(2, "No such file or directory")))
+        assert tt._safe_getcwd() == os.path.expanduser("~")
+
+    def test_permission_error_uses_home(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(os, "getcwd", lambda: (_ for _ in ()).throw(
+            PermissionError(1, "Operation not permitted")))
+        assert tt._safe_getcwd() == os.path.expanduser("~")
+
+    def test_terminal_cwd_beats_home(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", "/custom/from/env")
+        monkeypatch.setattr(os, "getcwd", lambda: (_ for _ in ()).throw(
+            PermissionError(1, "Operation not permitted")))
+        assert tt._safe_getcwd() == "/custom/from/env"
+
+    def test_unrelated_oserror_propagates(self, monkeypatch):
+        # NotADirectoryError is an OSError but NOT caught deliberately — good
+        # callers must see the real problem rather than a silent fallback.
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(os, "getcwd", lambda: (_ for _ in ()).throw(
+            NotADirectoryError(20, "not a directory")))
+        with pytest.raises(OSError):
+            tt._safe_getcwd()
+
+
+class TestIsContainerBackend:
+    """_is_container_backend: built-in sandbox backends, local/ssh excluded."""
+
+    @pytest.mark.parametrize("env_type", ["docker", "singularity", "modal",
+                                          "daytona", "vercel_sandbox"])
+    def test_container_backends_true(self, env_type):
+        assert tt._is_container_backend(env_type) is True
+
+    @pytest.mark.parametrize("env_type", ["local", "ssh", "managed_modal", "", None])
+    def test_non_container_backends_false(self, env_type):
+        assert tt._is_container_backend(env_type) is False
+
+
+class TestIsUnusableContainerCwd:
+    """_is_unusable_container_cwd: host/relative paths can't be a sandbox workdir."""
+
+    @pytest.mark.parametrize("cwd", ["/workspace", "/workspace/proj", "/root",
+                                     "/root/sub", "/data", "/tmp/scratch"])
+    def test_sandbox_paths_are_usable(self, cwd):
+        assert tt._is_unusable_container_cwd(cwd) is False
+
+    @pytest.mark.parametrize("cwd", [
+        "/home/user", "/Users/alice/work", "C:\\Users\\me", "C:/Users/me", ".",
+        "src/", "../up", "relative/path",
+    ])
+    def test_host_or_relative_paths_are_unusable(self, cwd):
+        assert tt._is_unusable_container_cwd(cwd) is True
+
+    def test_empty_cwd_is_not_unusable(self):
+        assert tt._is_unusable_container_cwd("") is False

--- a/tests/tools/test_terminal_main_path.py
+++ b/tests/tools/test_terminal_main_path.py
@@ -1,0 +1,947 @@
+"""Tests for the terminal_tool main path and support functions.
+
+Focus areas:
+  * check_terminal_requirements()  -- backend requirement gates
+  * terminal_tool()                -- the tool entry point (validation, sudo,
+                                      foreground execution, background spawn,
+                                      signal interpretation)
+  * _handle_terminal()             -- tool handler wrapper (notify mapping,
+                                      argument recovery)
+  * _check_vercel_sandbox_requirements() -- Vercel auth/runtime gates
+"""
+
+import json
+from types import SimpleNamespace, ModuleType
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_config(**overrides):
+    """A complete local-backend config dict, mirroring _get_env_config output."""
+    config = {
+        "env_type": "local",
+        "modal_mode": "auto",
+        "docker_image": "img",
+        "docker_forward_env": [],
+        "singularity_image": "simg",
+        "modal_image": "mimg",
+        "daytona_image": "dimg",
+        "vercel_runtime": "",
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "docker_mount_cwd_to_workspace": False,
+        "timeout": 30,
+        "lifetime_seconds": 300,
+        "ssh_host": "",
+        "ssh_user": "",
+        "ssh_port": 22,
+        "ssh_key": "",
+        "ssh_persistent": False,
+        "local_persistent": False,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "docker_volumes": [],
+        "docker_env": {},
+        "docker_run_as_host_user": False,
+        "docker_network": True,
+        "docker_extra_args": [],
+        "docker_shm_size": "1g",
+        "docker_persist_across_processes": True,
+        "docker_shared_container_key": "",
+        "docker_orphan_reaper": True,
+    }
+    config.update(overrides)
+    return config
+
+
+class MockEnv:
+    """Stand-in for a base-environment object returned by _create_environment."""
+
+    def __init__(self, execute_result=None, cwd=None):
+        self.execute_result = execute_result or {"output": "hello", "returncode": 0, "error": ""}
+        self.cwd = cwd
+        self.persistent = False
+        self.env = {}  # background local path reads env.env
+        self.executed = []
+
+    def execute(self, command, **kwargs):
+        self.executed.append((command, kwargs))
+        return dict(self.execute_result)
+
+    def cleanup(self):
+        pass
+
+
+def _patch_guard_headroom(monkeypatch, config=None):
+    """Mock everything needed to get *past* config resolution and into execution.
+
+    Leaves env creation and guards to the caller where relevant.
+    """
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config or _base_config())
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "_is_supervised_gateway_process", lambda: False)
+    # Fresh module state so no previously-created env leaks into this test.
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+
+
+def _patch_foreground_success(monkeypatch, env, config=None):
+    """Full mock set for a foreground command that reaches env.execute()."""
+    _patch_guard_headroom(monkeypatch, config)
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+
+
+def _patch_vercel_secrets(monkeypatch, mapping):
+    monkeypatch.setattr(
+        "agent.secret_scope.get_secret", lambda name: mapping.get(name)
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_terminal_requirements
+# ---------------------------------------------------------------------------
+
+
+def test_requirements_local_backend(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _base_config(env_type="local"))
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_docker_found_and_version_works(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _base_config(env_type="docker"))
+    monkeypatch.setattr("tools.environments.docker.find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(terminal_tool.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0))
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_docker_missing(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _base_config(env_type="docker"))
+    monkeypatch.setattr("tools.environments.docker.find_docker", lambda: None)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_singularity_found_and_version_works(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _base_config(env_type="singularity"))
+    monkeypatch.setattr(terminal_tool.shutil, "which", lambda name: "/usr/bin/apptainer")
+    monkeypatch.setattr(terminal_tool.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0))
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_ssh_ok(monkeypatch):
+    config = _base_config(env_type="ssh", ssh_host="h", ssh_user="u")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_ssh_missing_user(monkeypatch):
+    config = _base_config(env_type="ssh", ssh_host="h", ssh_user="")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_managed_backend(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="managed")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_get_modal_backend_state", lambda mode: {"selected_backend": "managed"})
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_modal_direct_no_credentials(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="direct")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(
+        terminal_tool, "_get_modal_backend_state",
+        lambda mode: {"selected_backend": "direct", "mode": "direct"},
+    )
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: None)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_vercel_delegates_to_checker(monkeypatch):
+    config = _base_config(env_type="vercel_sandbox")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_check_vercel_sandbox_requirements", lambda cfg: True)
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def _patch_daytona_import(monkeypatch):
+    """Make ``from daytona import Daytona`` succeed even without the SDK."""
+    fake = ModuleType("daytona")
+    fake.Daytona = object()
+    monkeypatch.setitem(__import__("sys").modules, "daytona", fake)
+
+
+def test_requirements_daytona_with_api_key(monkeypatch):
+    _patch_daytona_import(monkeypatch)
+    config = _base_config(env_type="daytona")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr("agent.secret_scope.get_secret", lambda name: "key" if name == "DAYTONA_API_KEY" else None)
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_daytona_without_api_key(monkeypatch):
+    _patch_daytona_import(monkeypatch)
+    config = _base_config(env_type="daytona")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr("agent.secret_scope.get_secret", lambda name: None)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_unknown_env_with_plugin_provider(monkeypatch):
+    config = _base_config(env_type="custom-env")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    provider = SimpleNamespace(check_requirements=lambda cfg: True)
+    monkeypatch.setattr(terminal_tool, "_get_plugin_env_provider", lambda env_type: provider)
+    assert terminal_tool.check_terminal_requirements() is True
+
+
+def test_requirements_unknown_env_without_plugin(monkeypatch):
+    config = _base_config(env_type="custom-env")
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_get_plugin_env_provider", lambda env_type: None)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_exception_returns_false(monkeypatch):
+    def _boom():
+        raise RuntimeError("config exploded")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", _boom)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# _check_vercel_sandbox_requirements
+# ---------------------------------------------------------------------------
+
+_VERCEL_OK_SPEC = object()
+
+
+def _vercel_config(**overrides):
+    config = {"vercel_runtime": "", "container_disk": 51200}
+    config.update(overrides)
+    return config
+
+
+def test_vercel_unsupported_runtime(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config(vercel_runtime="node20")) is False
+
+
+def test_vercel_invalid_disk(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config(container_disk=8192)) is False
+
+
+def test_vercel_sdk_not_installed(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: None)
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config()) is False
+
+
+def test_vercel_oidc_token_auth(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    _patch_vercel_secrets(monkeypatch, {"VERCEL_OIDC_TOKEN": "tok"})
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config()) is True
+
+
+def test_vercel_full_token_auth(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    _patch_vercel_secrets(
+        monkeypatch,
+        {"VERCEL_TOKEN": "t", "VERCEL_PROJECT_ID": "p", "VERCEL_TEAM_ID": "m"},
+    )
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config()) is True
+
+
+def test_vercel_partial_token_auth(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    _patch_vercel_secrets(monkeypatch, {"VERCEL_TOKEN": "t", "VERCEL_PROJECT_ID": "p"})
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config()) is False
+
+
+def test_vercel_no_auth_at_all(monkeypatch):
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: _VERCEL_OK_SPEC)
+    _patch_vercel_secrets(monkeypatch, {})
+    assert terminal_tool._check_vercel_sandbox_requirements(_vercel_config()) is False
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- entry-point validation & guidance
+# ---------------------------------------------------------------------------
+
+
+def test_non_string_command_returns_error_json():
+    result = json.loads(terminal_tool.terminal_tool(1234))
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "expected string, got int" in result["error"]
+
+
+def test_invalid_timeout_rejected(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    result = json.loads(terminal_tool.terminal_tool("echo hi", timeout=0))
+    assert "timeout must be a positive number of seconds" in result["error"]
+
+
+def test_foreground_timeout_over_cap_rejected(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    over_cap = terminal_tool.FOREGROUND_MAX_TIMEOUT + 1
+    result = json.loads(terminal_tool.terminal_tool("echo hi", timeout=over_cap))
+    assert "exceeds the maximum" in result["error"]
+    assert str(over_cap) in result["error"]
+
+
+def test_foreground_long_lived_command_flagged(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    result = json.loads(terminal_tool.terminal_tool("nohup sleep 100"))
+    assert result["exit_code"] == -1
+    assert "nohup/disown/setsid" in result["error"]
+
+
+def test_workdir_validation_failure(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    result = json.loads(terminal_tool.terminal_tool("echo hi", workdir="/tmp; rm -rf /"))
+    assert result["status"] == "blocked"
+    assert "workdir contains disallowed character" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- foreground execution
+# ---------------------------------------------------------------------------
+
+
+def test_foreground_success_returns_result_json(monkeypatch):
+    env = MockEnv(execute_result={"output": "hello world", "returncode": 0, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+
+    result = json.loads(terminal_tool.terminal_tool("echo hello world"))
+    assert result["output"] == "hello world"
+    assert result["exit_code"] == 0
+    assert result["error"] is None
+    # The command must be forwarded to the environment, with bounded capture on.
+    assert env.executed[0][0] == "echo hello world"
+    assert env.executed[0][1].get("bounded_capture") is True
+
+
+def test_signal_killed_command_includes_signal_note(monkeypatch):
+    env = MockEnv(execute_result={"output": "killed", "returncode": -9, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+
+    result = json.loads(terminal_tool.terminal_tool("run-something"))
+    assert result["exit_code"] == -9
+    assert "signal 9" in result["exit_code_meaning"]
+
+
+def test_sudo_command_forwards_to_env(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "secret")
+    try:
+        env = MockEnv(execute_result={"output": "done", "returncode": 0, "error": ""})
+        _patch_foreground_success(monkeypatch, env)
+
+        result = json.loads(terminal_tool.terminal_tool("sudo apt install -y ripgrep"))
+        assert result["exit_code"] == 0
+        assert env.executed[0][0] == "sudo apt install -y ripgrep"
+    finally:
+        monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+
+
+def test_transform_sudo_command_rewrites_and_returns_stdin(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo apt install -y ripgrep")
+    assert transformed == "sudo -S -p '' apt install -y ripgrep"
+    assert sudo_stdin == "testpass\n"
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- background spawn & notify/watch conflict
+# ---------------------------------------------------------------------------
+
+
+class FakeProcSession:
+    id = "proc-123"
+    pid = 9999
+    watcher_platform = ""
+    watcher_interval = 5
+    notify_on_complete = False
+    watch_patterns = None
+    parent_session_id = ""
+
+
+class FakeProcessRegistry:
+    def __init__(self):
+        self.pending_watchers = []
+
+    def spawn_local(self, **kwargs):
+        return FakeProcSession()
+
+    def spawn_via_env(self, **kwargs):
+        return FakeProcSession()
+
+
+def test_background_notify_watch_conflict(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+
+    import gateway.session_context as sc
+    monkeypatch.setattr(sc, "async_delivery_supported", lambda: True)
+    monkeypatch.setattr(sc, "get_session_env", lambda key, default="": default)
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "run-server",
+            background=True,
+            notify_on_complete=True,
+            watch_patterns=["ready"],
+        )
+    )
+    assert result["exit_code"] == 0
+    # notify_on_complete wins over watch_patterns; watch_patterns is dropped.
+    assert result["notify_on_complete"] is True
+    assert "watch_patterns_ignored" in result
+    assert "duplicate notifications" in result["watch_patterns_ignored"]
+    assert "watch_patterns" not in result
+
+
+# ---------------------------------------------------------------------------
+# _handle_sudo_failure
+# ---------------------------------------------------------------------------
+
+
+def test_handle_sudo_failure_gateway_context_tip(monkeypatch):
+    monkeypatch.setattr(
+        terminal_tool, "env_var_enabled",
+        lambda name, default="": name == "HERMES_GATEWAY_SESSION",
+    )
+    monkeypatch.setattr(terminal_tool, "_in_delegated_child_context", lambda: False)
+    out = terminal_tool._handle_sudo_failure("sudo: a password is required", "local")
+    assert "To enable sudo over messaging" in out
+
+
+def test_handle_sudo_failure_delegated_child_tip(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "env_var_enabled", lambda name, default="": False)
+    monkeypatch.setattr(terminal_tool, "_in_delegated_child_context", lambda: True)
+    out = terminal_tool._handle_sudo_failure("sudo: a password is required", "local")
+    assert "Subagents cannot prompt for a sudo password" in out
+
+
+def test_handle_sudo_failure_headless_passthrough(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "env_var_enabled", lambda name, default="": False)
+    monkeypatch.setattr(terminal_tool, "_in_delegated_child_context", lambda: False)
+    out = terminal_tool._handle_sudo_failure("sudo: a password is required", "local")
+    assert out == "sudo: a password is required"
+
+
+def test_handle_sudo_failure_ignores_other_output(monkeypatch):
+    monkeypatch.setattr(
+        terminal_tool, "env_var_enabled",
+        lambda name, default="": name == "HERMES_GATEWAY_SESSION",
+    )
+    monkeypatch.setattr(terminal_tool, "_in_delegated_child_context", lambda: False)
+    out = terminal_tool._handle_sudo_failure("all good here", "local")
+    assert out == "all good here"
+
+
+# ---------------------------------------------------------------------------
+# _handle_terminal
+# ---------------------------------------------------------------------------
+
+
+def test_handle_terminal_delegates_to_terminal_tool(monkeypatch):
+    captured = {}
+
+    def _fake_terminal_tool(**kwargs):
+        captured.update(kwargs)
+        return '{"ok": true}'
+
+    monkeypatch.setattr(terminal_tool, "terminal_tool", _fake_terminal_tool)
+    res = terminal_tool._handle_terminal(
+        {"command": "ls", "background": True, "workdir": "/tmp", "timeout": 5}
+    )
+    assert res == '{"ok": true}'
+    assert captured["command"] == "ls"
+    assert captured["background"] is True
+    assert captured["workdir"] == "/tmp"
+    assert captured["timeout"] == 5
+
+
+def test_handle_terminal_rejects_code_misrouting():
+    res = terminal_tool._handle_terminal({"code": "print(1)"})
+    assert "terminal received a 'code' parameter" in res
+
+
+def test_handle_terminal_rejects_notify_on_foreground():
+    res = terminal_tool._handle_terminal({"command": "ls", "notify": True})
+    assert "notify only applies to background commands" in res
+
+
+def test_handle_terminal_rejects_pty_on_foreground():
+    res = terminal_tool._handle_terminal({"command": "ls", "pty": True})
+    assert "pty requires background=true" in res
+
+
+def test_handle_terminal_notify_bool_maps_to_notify_on_complete(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(terminal_tool, "terminal_tool", lambda **kw: captured.update(kw) or "{}")
+    terminal_tool._handle_terminal({"command": "job", "background": True, "notify": True})
+    assert captured["notify_on_complete"] is True
+    assert captured["watch_patterns"] is None
+
+
+def test_handle_terminal_notify_list_maps_to_watch_patterns(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(terminal_tool, "terminal_tool", lambda **kw: captured.update(kw) or "{}")
+    terminal_tool._handle_terminal({"command": "server", "background": True, "notify": ["ready"]})
+    assert captured["watch_patterns"] == ["ready"]
+    assert captured["notify_on_complete"] is False
+
+
+def test_handle_terminal_rejects_bad_notify_type():
+    res = terminal_tool._handle_terminal({"command": "ls", "background": True, "notify": "boom"})
+    assert "notify must be true/false" in res
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- gateway lifecycle guard (supervised gateway process)
+# ---------------------------------------------------------------------------
+
+
+class _RaiseEnv(MockEnv):
+    """A MockEnv whose execute() raises a given exception each call."""
+
+    def __init__(self, exc):
+        super().__init__()
+        self.exc = exc
+
+    def execute(self, command, **kwargs):
+        self.executed.append((command, kwargs))
+        raise self.exc
+
+
+def _patch_gateway_env(monkeypatch, env=None):
+    """Reach the gateway lifecycle guard: supervised gateway probe -> True."""
+    _patch_guard_headroom(monkeypatch)
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env or MockEnv())
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "_is_supervised_gateway_process", lambda: True)
+
+
+def test_gateway_launchctl_submit_blocked(monkeypatch):
+    _patch_gateway_env(monkeypatch)
+    import cron.lifecycle_guard as clg
+    monkeypatch.setattr(clg, "contains_launchctl_submit_command", lambda command: True)
+    monkeypatch.setattr(
+        clg, "contains_gateway_lifecycle_command_or_referenced_script", lambda *a, **k: False
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["exit_code"] == 1
+    assert result["status"] == "error"
+    assert "launchctl submit/bootstrap registers a persistent" in result["error"]
+
+
+def test_gateway_lifecycle_command_blocked(monkeypatch):
+    _patch_gateway_env(monkeypatch)
+    import cron.lifecycle_guard as clg
+    monkeypatch.setattr(clg, "contains_launchctl_submit_command", lambda command: False)
+    monkeypatch.setattr(
+        clg, "contains_gateway_lifecycle_command_or_referenced_script", lambda *a, **k: True
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["exit_code"] == 1
+    assert result["status"] == "error"
+    assert "cannot restart, stop, or uninstall the gateway" in result["error"]
+
+
+def test_gateway_supervised_normal_command_passes(monkeypatch):
+    env = MockEnv(execute_result={"output": "ok", "returncode": 0, "error": ""})
+    _patch_gateway_env(monkeypatch, env)
+    import cron.lifecycle_guard as clg
+    monkeypatch.setattr(clg, "contains_launchctl_submit_command", lambda command: False)
+    monkeypatch.setattr(
+        clg, "contains_gateway_lifecycle_command_or_referenced_script", lambda *a, **k: False
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["exit_code"] == 0
+    assert result["output"] == "ok"
+    assert env.executed, "env.execute should have been called for a normal command"
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- guard blocking / pending / approval notes
+# ---------------------------------------------------------------------------
+
+
+def test_guard_blocked_returns_error(monkeypatch):
+    env = MockEnv()
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {"approved": False, "message": "Explicitly denied", "description": "flagged as dangerous"},
+    )
+    result = json.loads(terminal_tool.terminal_tool("rm -rf /tmp/foo"))
+    assert result["status"] == "blocked"
+    assert result["exit_code"] == -1
+    assert "Explicitly denied" in result["error"]
+
+
+def test_guard_blocked_fallback_message(monkeypatch):
+    env = MockEnv()
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {"approved": False, "description": "flagged as dangerous"},
+    )
+    result = json.loads(terminal_tool.terminal_tool("rm -rf /tmp/foo"))
+    assert result["status"] == "blocked"
+    assert "Command denied" in result["error"]
+
+
+def test_guard_pending_approval_returns_pending(monkeypatch):
+    env = MockEnv()
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {
+            "approved": False, "status": "pending_approval", "command": "cmd",
+            "description": "desc", "pattern_key": "pk", "smart_denied": True,
+            "allow_permanent": True,
+        },
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["status"] == "pending_approval"
+    assert result["approval_pending"] is True
+    assert result["command"] == "cmd"
+    assert result["pattern_key"] == "pk"
+
+
+def test_force_skips_guard_check(monkeypatch):
+    monkeypatch.setattr("tools.interrupt.clear_current_thread_interrupt", lambda: None)
+    env = MockEnv(execute_result={"output": "ran", "returncode": 0, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: pytest.fail("guard must be skipped when force=True"),
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi", force=True))
+    assert result["exit_code"] == 0
+    assert env.executed
+
+
+def test_user_approved_command_gets_foreground_note(monkeypatch):
+    monkeypatch.setattr("tools.interrupt.clear_current_thread_interrupt", lambda: None)
+    env = MockEnv(execute_result={"output": "out", "returncode": 0, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {"approved": True, "user_approved": True, "description": "flagged as dangerous"},
+    )
+    result = json.loads(terminal_tool.terminal_tool("run-cmd"))
+    assert result["exit_code"] == 0
+    assert "approved by the user" in result["approval"]
+
+
+def test_smart_approved_command_gets_foreground_note(monkeypatch):
+    env = MockEnv(execute_result={"output": "out", "returncode": 0, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {"approved": True, "smart_approved": True, "description": "flagged"},
+    )
+    result = json.loads(terminal_tool.terminal_tool("run-cmd"))
+    assert result["exit_code"] == 0
+    assert "auto-approved by smart approval" in result["approval"]
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- pty / background execution path variants
+# ---------------------------------------------------------------------------
+
+
+def test_pty_disabled_for_pipe_stdin_background(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    monkeypatch.setattr(terminal_tool, "_command_requires_pipe_stdin", lambda command: True)
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    result = json.loads(terminal_tool.terminal_tool("gh auth login --with-token", background=True, pty=True))
+    assert "PTY disabled" in result["pty_note"]
+
+
+def test_background_spawn_via_env_nonlocal(monkeypatch):
+    config = _base_config(env_type="ssh", ssh_host="h", ssh_user="u")
+    _patch_guard_headroom(monkeypatch, config)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    result = json.loads(terminal_tool.terminal_tool("ls", background=True))
+    assert result["exit_code"] == 0
+    assert result["session_id"] == "proc-123"
+
+
+def test_background_user_approved_adds_note(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards",
+        lambda *a, **k: {"approved": True, "user_approved": True, "description": "flagged as dangerous"},
+    )
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    result = json.loads(terminal_tool.terminal_tool("run-server", background=True))
+    assert result["exit_code"] == 0
+    assert "approved by the user" in result["approval"]
+
+
+def test_background_silent_process_hint(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    result = json.loads(terminal_tool.terminal_tool("sleep 999", background=True))
+    assert "runs SILENTLY" in result["hint"]
+
+
+def test_background_ci_poller_hint(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    result = json.loads(
+        terminal_tool.terminal_tool("gh pr view 1 --json statusCheckRollup --jq .x", background=True)
+    )
+    assert "homebrewed CI poller" in result["hint"]
+
+
+def test_background_notify_unsupported_async(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    import gateway.session_context as sc
+    monkeypatch.setattr(sc, "async_delivery_supported", lambda: False)
+    result = json.loads(terminal_tool.terminal_tool("run", background=True, notify_on_complete=True))
+    assert result["notify_on_complete"] is False
+    assert "notify_unsupported" in result
+
+
+def test_background_watcher_platform_registers_watcher(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    reg = FakeProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", reg)
+    import gateway.session_context as sc
+    monkeypatch.setattr(sc, "async_delivery_supported", lambda: True)
+
+    def _gse(key, default=""):
+        return {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_CHAT_ID": "c123",
+            "HERMES_SESSION_ID": "sess-1",
+        }.get(key, default)
+
+    monkeypatch.setattr(sc, "get_session_env", _gse)
+    result = json.loads(terminal_tool.terminal_tool("run", background=True, notify_on_complete=True))
+    assert result["notify_on_complete"] is True
+    assert len(reg.pending_watchers) == 1
+    assert reg.pending_watchers[0]["platform"] == "telegram"
+    assert reg.pending_watchers[0]["chat_id"] == "c123"
+
+
+def test_background_watch_patterns_set(monkeypatch):
+    _patch_guard_headroom(monkeypatch)
+    env = MockEnv()
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kw: env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", FakeProcessRegistry())
+    import gateway.session_context as sc
+    monkeypatch.setattr(sc, "async_delivery_supported", lambda: True)
+    monkeypatch.setattr(sc, "get_session_env", lambda key, default="": default)
+    result = json.loads(terminal_tool.terminal_tool("run-srv", background=True, watch_patterns=["ready"]))
+    assert result["watch_patterns"] == ["ready"]
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool -- foreground result processing
+# ---------------------------------------------------------------------------
+
+
+def test_foreground_timeout_exception_returns_124(monkeypatch):
+    env = _RaiseEnv(TimeoutError("command timeout"))
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda *a: None)
+    result = json.loads(terminal_tool.terminal_tool("sleep 100"))
+    assert result["exit_code"] == 124
+    assert "timed out after" in result["error"]
+
+
+def test_foreground_transient_error_retries_then_fails(monkeypatch):
+    env = _RaiseEnv(ValueError("boom"))
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda *a: None)
+    result = json.loads(terminal_tool.terminal_tool("flakey-cmd"))
+    assert result["exit_code"] == -1
+    assert "Command execution failed" in result["error"]
+    assert len(env.executed) == 4  # initial attempt + 3 retries
+
+
+def test_cwd_observed_records_session_cwd(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    env = MockEnv(
+        execute_result={"output": "moved", "returncode": 0, "error": "", "cwd_observed": True},
+        cwd="/tmp/newdir",
+    )
+    _patch_foreground_success(monkeypatch, env)
+    result = json.loads(terminal_tool.terminal_tool("cd /tmp/newdir"))
+    assert result["exit_code"] == 0
+    assert result["cwd"] == "/tmp/newdir"
+    assert terminal_tool.get_session_cwd("") == "/tmp/newdir"
+
+
+def test_spill_path_reports_truncation_metadata(monkeypatch, tmp_path):
+    spill = tmp_path / "spill.log"
+    spill.write_text("full-spill-content")
+    env = MockEnv(
+        execute_result={
+            "output": "out", "returncode": 0, "error": "",
+            "output_total_chars": 100, "full_output_path": str(spill),
+        }
+    )
+    _patch_foreground_success(monkeypatch, env)
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["full_output_path"] == str(spill)
+    assert result["output_total_chars"] == 100
+    assert "truncation_note" in result
+
+
+def test_verification_evidence_recorded(monkeypatch):
+    env = MockEnv(execute_result={"output": "o", "returncode": 0, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+    monkeypatch.setattr(
+        "agent.verification_evidence.record_terminal_result",
+        lambda **kw: {"status": "verified", "kind": "k", "scope": "s", "canonical_command": "c"},
+    )
+    result = json.loads(terminal_tool.terminal_tool("echo hi"))
+    assert result["verification_evidence"]["status"] == "verified"
+
+
+def test_sudo_auth_failure_invalidates_cache_and_reprompts(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_password_cache", {})
+    # A STABLE callback object so the sudo-password cache scope
+    # (``callback:{id(cb)}``) is identical across set and get calls.
+    _pw_cb = lambda: "pw"  # noqa: E731
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: _pw_cb)
+    terminal_tool._set_cached_sudo_password("secret")
+    monkeypatch.setattr(terminal_tool, "_in_delegated_child_context", lambda: False)
+    monkeypatch.setattr(terminal_tool, "env_var_enabled", lambda name, default="": False)
+    env = MockEnv(execute_result={"output": "sudo: authentication failed\nbad", "returncode": 1, "error": ""})
+    _patch_foreground_success(monkeypatch, env)
+    result = json.loads(terminal_tool.terminal_tool("sudo apt install -y x"))
+    assert result["exit_code"] == 1
+    assert result["sudo_auth_failed"] is True
+    assert result["sudo_cache_cleared"] is True
+    assert "Sudo authentication failed" in result["output"]
+
+
+# ---------------------------------------------------------------------------
+# check_terminal_requirements -- singularity missing & modal branches
+# ---------------------------------------------------------------------------
+
+
+def test_requirements_singularity_missing(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _base_config(env_type="singularity"))
+    monkeypatch.setattr(terminal_tool.shutil, "which", lambda name: None)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def _patch_modal_state(monkeypatch, config, state, managed_enabled=False):
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_get_modal_backend_state", lambda mode: state)
+    monkeypatch.setattr(terminal_tool, "managed_nous_tools_enabled", lambda: managed_enabled)
+    monkeypatch.setattr(
+        terminal_tool, "nous_tool_gateway_unavailable_message", lambda *a, **k: "gateway unavailable"
+    )
+
+
+def test_requirements_modal_managed_blocked(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="managed")
+    state = {"selected_backend": None, "managed_mode_blocked": True, "mode": "managed"}
+    _patch_modal_state(monkeypatch, config, state)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_managed_unavailable(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="managed")
+    state = {"selected_backend": None, "managed_mode_blocked": False, "mode": "managed"}
+    _patch_modal_state(monkeypatch, config, state)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_direct_nocreds_managed_enabled(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="direct")
+    state = {"selected_backend": None, "managed_mode_blocked": False, "mode": "direct"}
+    _patch_modal_state(monkeypatch, config, state, managed_enabled=True)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_direct_nocreds_managed_disabled(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="direct")
+    state = {"selected_backend": None, "managed_mode_blocked": False, "mode": "direct"}
+    _patch_modal_state(monkeypatch, config, state, managed_enabled=False)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_auto_nocreds_managed_enabled(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="auto")
+    state = {"selected_backend": None, "managed_mode_blocked": False, "mode": "auto"}
+    _patch_modal_state(monkeypatch, config, state, managed_enabled=True)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_auto_nocreds_managed_disabled(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="auto")
+    state = {"selected_backend": None, "managed_mode_blocked": False, "mode": "auto"}
+    _patch_modal_state(monkeypatch, config, state, managed_enabled=False)
+    assert terminal_tool.check_terminal_requirements() is False
+
+
+def test_requirements_modal_direct_with_sdk_present(monkeypatch):
+    config = _base_config(env_type="modal", modal_mode="direct")
+    state = {"selected_backend": "direct", "managed_mode_blocked": False, "mode": "direct"}
+    _patch_modal_state(monkeypatch, config, state)
+    monkeypatch.setattr(terminal_tool.importlib.util, "find_spec", lambda name: object())
+    assert terminal_tool.check_terminal_requirements() is True

--- a/tests/tools/test_terminal_pure_helpers.py
+++ b/tests/tools/test_terminal_pure_helpers.py
@@ -1,0 +1,383 @@
+"""Coverage for pure helper functions in tools/terminal_tool.py.
+
+These are all side-effect-free (no subprocess/network/Docker), so they are
+exercised directly against the live module. Assertions are written as behavior
+contracts (invariants/relationships) rather than change-detector snapshots
+wherever the exact prose is incidental (e.g. guidance strings), and as exact
+values where the return is an enum-like decision.
+"""
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+# ---------------------------------------------------------------------------
+# _safe_command_preview
+# ---------------------------------------------------------------------------
+
+def test_safe_command_preview_none():
+    assert terminal_tool._safe_command_preview(None) == "<None>"
+
+
+def test_safe_command_preview_str_under_limit():
+    assert terminal_tool._safe_command_preview("hello") == "hello"
+
+
+def test_safe_command_preview_str_truncated():
+    long_str = "x" * 300
+    result = terminal_tool._safe_command_preview(long_str, limit=200)
+    assert result == "x" * 200
+    assert len(result) == 200
+
+
+def test_safe_command_preview_str_respects_custom_limit():
+    assert terminal_tool._safe_command_preview("abcde", limit=3) == "abc"
+
+
+def test_safe_command_preview_non_str_uses_repr():
+    # repr(12345) == "12345"; limit 3 truncates
+    assert terminal_tool._safe_command_preview(12345, limit=3) == "123"
+    assert terminal_tool._safe_command_preview([1, 2, 3]) == "[1, 2, 3]"
+
+
+def test_safe_command_preview_repr_raises_falls_back_to_type():
+    class _BadRepr:
+        def __repr__(self):
+            raise ValueError("boom")
+
+    assert terminal_tool._safe_command_preview(_BadRepr()) == "<_BadRepr>"
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_env_assignment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        ("FOO=bar", True),
+        ("A1_B2=x", True),
+        ("_FOO=1", True),
+        ("FOO=", True),
+        ("=val", False),
+        ("no-eq", False),
+        ("FOO", False),
+        ("1FOO=x", False),   # name can't start with a digit
+        ("A B=x", False),    # whitespace not allowed in name
+    ],
+)
+def test_looks_like_env_assignment(token, expected):
+    assert terminal_tool._looks_like_env_assignment(token) is expected
+
+
+# ---------------------------------------------------------------------------
+# _read_shell_token
+# ---------------------------------------------------------------------------
+
+def test_read_shell_token_single_quoted():
+    token, i = terminal_tool._read_shell_token("'single' word", 0)
+    assert token == "'single'"
+    assert i == 8
+
+
+def test_read_shell_token_double_quoted_keeps_inner_whitespace():
+    token, i = terminal_tool._read_shell_token('"a b" rest', 0)
+    assert token == '"a b"'
+    assert i == 5
+
+
+def test_read_shell_token_double_quoted_with_escaped_quote():
+    token, i = terminal_tool._read_shell_token('"a\\"b" rest', 0)
+    assert token == '"a\\"b"'
+    assert i == 6
+
+
+def test_read_shell_token_backslash_escape():
+    # After a backslash the next char is consumed literally (escaped space kept)
+    token, i = terminal_tool._read_shell_token(r"\a\ b c", 0)
+    assert token == r"\a\ b"
+    assert i == 5
+
+
+@pytest.mark.parametrize("sep", [";", "&", "|", "("])
+def test_read_shell_token_stops_at_operator_separators(sep):
+    token, i = terminal_tool._read_shell_token(f"x{sep}y", 0)
+    assert token == "x"
+    assert i == 1
+
+
+def test_read_shell_token_stops_at_whitespace():
+    assert terminal_tool._read_shell_token("foo bar", 0) == ("foo", 3)
+
+
+# ---------------------------------------------------------------------------
+# _strip_quotes
+# ---------------------------------------------------------------------------
+
+def test_strip_quotes_single():
+    assert terminal_tool._strip_quotes("cmd 'nohup' arg") == "cmd '' arg"
+
+
+def test_strip_quotes_double():
+    assert terminal_tool._strip_quotes("cmd 'setsid' arg") == "cmd '' arg"
+
+
+def test_strip_quotes_backtick():
+    assert terminal_tool._strip_quotes("cmd `foo` arg") == "cmd `` arg"
+
+
+def test_strip_quotes_preserves_unquoted_text():
+    assert terminal_tool._strip_quotes("echo 'a' 'b' \"c\" x") == "echo '' '' \"\" x"
+
+
+def test_strip_quotes_handles_escaped_double_quote():
+    assert terminal_tool._strip_quotes('echo "a\\"b" c') == 'echo "" c'
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_help_or_version_command
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cmd --help",
+        "cmd -h",
+        "cmd --version",
+        "cmd -V",       # case-insensitive (lowered before matching)
+        "cmd -v",
+        "git --help sub",
+    ],
+)
+def test_looks_like_help_or_version_true(command):
+    assert terminal_tool._looks_like_help_or_version_command(command) is True
+
+
+def test_looks_like_help_or_version_plain_command():
+    assert terminal_tool._looks_like_help_or_version_command("cmd run") is False
+
+
+def test_looks_like_help_or_version_embedded_flag_is_not_version():
+    # '--version' anywhere counts, but a bare '-h'/'--help' only counts as a
+    # trailing/space-delimited informational flag.
+    assert terminal_tool._looks_like_help_or_version_command("cmd --version run") is True
+
+
+# ---------------------------------------------------------------------------
+# _command_requires_pipe_stdin
+# ---------------------------------------------------------------------------
+
+def test_command_requires_pipe_stdin_gh_with_token():
+    assert terminal_tool._command_requires_pipe_stdin("gh auth login --with-token") is True
+
+
+def test_command_requires_pipe_stdin_case_insensitive():
+    assert terminal_tool._command_requires_pipe_stdin("GH AUTH LOGIN --WITH-TOKEN") is True
+
+
+def test_command_requires_pipe_stdin_missing_token():
+    assert terminal_tool._command_requires_pipe_stdin("gh auth login") is False
+
+
+def test_command_requires_pipe_stdin_non_gh_with_token():
+    assert terminal_tool._command_requires_pipe_stdin("gh auth logout --with-token") is False
+
+
+def test_command_requires_pipe_stdin_pipe_operator_is_not_signal():
+    # A literal pipe is NOT the trigger for this helper — only `gh auth login
+    # --with-token` is.
+    assert terminal_tool._command_requires_pipe_stdin("echo hi | cat") is False
+
+
+# ---------------------------------------------------------------------------
+# _foreground_background_guidance
+# ---------------------------------------------------------------------------
+
+def _assert_guidance_mentions_background(result):
+    assert result is not None
+    assert "background" in result
+
+
+def test_guidance_none_for_help_version():
+    assert terminal_tool._foreground_background_guidance("cmd --help") is None
+    assert terminal_tool._foreground_background_guidance("cmd -h") is None
+    assert terminal_tool._foreground_background_guidance("cmd --version") is None
+
+
+@pytest.mark.parametrize("command", ["nohup python s.py", "disown", "setsid cmd", "a && setsid b", "nohup python server.py &"])
+def test_guidance_shell_level_background_wrappers(command):
+    _assert_guidance_mentions_background(
+        terminal_tool._foreground_background_guidance(command)
+    )
+
+
+@pytest.mark.parametrize("command", ["python server.py &", "python server.py & # bg", "cmd & other"])
+def test_guidance_inline_or_trailing_amp(command):
+    _assert_guidance_mentions_background(
+        terminal_tool._foreground_background_guidance(command)
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -m http.server 8000",
+        "npm run dev",
+        "docker compose up",
+        "uvicorn app:app",
+        "nodemon",
+    ],
+)
+def test_guidance_long_lived_server_patterns(command):
+    _assert_guidance_mentions_background(
+        terminal_tool._foreground_background_guidance(command)
+    )
+
+
+def test_guidance_normal_command():
+    assert terminal_tool._foreground_background_guidance("ls -la") is None
+
+
+def test_guidance_ignores_keywords_inside_strings():
+    # 'setsid' inside a quoted string must not trigger the wrapper guidance.
+    assert terminal_tool._foreground_background_guidance("git commit -m 'setsid foo'") is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_notification_flag_conflict
+# ---------------------------------------------------------------------------
+
+def test_notification_flag_conflict_drops_watch_patterns():
+    watch_patterns, note = terminal_tool._resolve_notification_flag_conflict(
+        notify_on_complete=True, watch_patterns=["foo"], background=True
+    )
+    assert watch_patterns is None
+    assert note != ""
+    assert "duplicate" in note
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(notify_on_complete=True, watch_patterns=["x"], background=False),
+        dict(notify_on_complete=False, watch_patterns=[], background=True),
+        dict(notify_on_complete=False, watch_patterns=["x"], background=False),
+        dict(notify_on_complete=True, watch_patterns=[], background=True),
+    ],
+)
+def test_notification_flag_no_conflict_preserves_watch_patterns(kwargs):
+    watch_patterns, note = terminal_tool._resolve_notification_flag_conflict(**kwargs)
+    assert watch_patterns == kwargs["watch_patterns"]
+    assert note == ""
+
+
+# ---------------------------------------------------------------------------
+# _is_safe_workdir_char
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ch", list("abcXYZ0129_ /"))
+def test_is_safe_workdir_char_allowed(ch):
+    assert terminal_tool._is_safe_workdir_char(ch) is True
+
+
+@pytest.mark.parametrize(
+    "ch",
+    [
+        "\x00",     # NUL
+        "\n",       # control
+        "\t",       # control
+        "\x1f",     # control
+        "\x7f",     # DEL
+        "$",
+        ";",
+        "|",
+        "",
+    ],
+)
+def test_is_safe_workdir_char_rejected(ch):
+    assert terminal_tool._is_safe_workdir_char(ch) is False
+
+
+def test_is_safe_workdir_char_unicode_letter():
+    assert terminal_tool._is_safe_workdir_char("用") is True
+
+
+# ---------------------------------------------------------------------------
+# _validate_workdir
+# ---------------------------------------------------------------------------
+
+def test_validate_workdir_empty_safe():
+    assert terminal_tool._validate_workdir("") is None
+
+
+@pytest.mark.parametrize("workdir", ["/safe/path", "/tmp/  x", "/用户/文档", "relative/path"])
+def test_validate_workdir_safe(workdir):
+    assert terminal_tool._validate_workdir(workdir) is None
+
+
+@pytest.mark.parametrize("bad_char", ["$", ";", "|", "\n"])
+def test_validate_workdir_rejects_metachar(bad_char):
+    result = terminal_tool._validate_workdir(f"/tmp/x{bad_char}y")
+    assert isinstance(result, str)
+    assert "Blocked: workdir contains disallowed character" in result
+
+
+# ---------------------------------------------------------------------------
+# _docker_volume_uses_host_path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "/host:/container",
+        "~/data:/data",
+        "./rel:/abs",
+        "../up:/abs",
+        "C:\\win",
+    ],
+)
+def test_docker_volume_uses_host_path_true(spec):
+    assert terminal_tool._docker_volume_uses_host_path(spec) is True
+
+
+@pytest.mark.parametrize("spec", ["named_volume", "", "   ", 123, None, ["/h:/c"]])
+def test_docker_volume_uses_host_path_false(spec):
+    assert terminal_tool._docker_volume_uses_host_path(spec) is False
+
+
+# ---------------------------------------------------------------------------
+# _docker_has_host_access
+# ---------------------------------------------------------------------------
+
+def test_docker_has_host_access_requires_docker_env():
+    assert terminal_tool._docker_has_host_access({"env_type": "local"}) is False
+
+
+def test_docker_has_host_access_via_mount_cwd():
+    config = {
+        "env_type": "docker",
+        "host_cwd": "/home/me",
+        "docker_mount_cwd_to_workspace": True,
+    }
+    assert terminal_tool._docker_has_host_access(config) is True
+
+
+def test_docker_has_host_access_via_volume():
+    config = {"env_type": "docker", "docker_volumes": ["/host:/container"]}
+    assert terminal_tool._docker_has_host_access(config) is True
+
+
+def test_docker_has_host_access_via_mount_cwd_requires_both():
+    # host_cwd set but docker_mount_cwd_to_workspace falsy -> no host access
+    config = {"env_type": "docker", "host_cwd": "/home/me", "docker_mount_cwd_to_workspace": False}
+    assert terminal_tool._docker_has_host_access(config) is False
+
+
+def test_docker_has_host_access_no_sources():
+    assert terminal_tool._docker_has_host_access({"env_type": "docker"}) is False
+
+
+def test_docker_has_host_access_named_volume_not_host():
+    config = {"env_type": "docker", "docker_volumes": ["named_volume"]}
+    assert terminal_tool._docker_has_host_access(config) is False

--- a/tests/tools/test_terminal_sudo_cache.py
+++ b/tests/tools/test_terminal_sudo_cache.py
@@ -1,0 +1,352 @@
+"""Tests for the sudo password cache and interactive prompt helpers.
+
+Covers ``tools/terminal_tool.py`` functions:
+
+* ``_get_sudo_password_cache_scope`` / get/set/reset of the scoped cache
+* ``_sudo_wrong_password_failure`` / ``_invalidate_cached_sudo_on_auth_failure``
+* ``_prompt_for_sudo_password`` (callback delegation + non-interactive fallback)
+* ``_sudo_nopasswd_works``
+"""
+
+import threading
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+def setup_function():
+    terminal_tool._reset_cached_sudo_passwords()
+
+
+def teardown_function():
+    terminal_tool._reset_cached_sudo_passwords()
+
+
+# ---------------------------------------------------------------------------
+# _get_sudo_password_cache_scope
+# ---------------------------------------------------------------------------
+
+def test_sudo_scope_prefers_session_key(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-abc")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    assert terminal_tool._get_sudo_password_cache_scope() == "session:sess-abc"
+
+
+def test_sudo_scope_session_key_takes_priority_over_callback(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-abc")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: object())
+    assert terminal_tool._get_sudo_password_cache_scope() == "session:sess-abc"
+
+
+def test_sudo_scope_plain_callback_uses_callback_id(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+
+    def plain_cb():
+        pass
+
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: plain_cb)
+    assert terminal_tool._get_sudo_password_cache_scope() == f"callback:{id(plain_cb)}"
+
+
+def test_sudo_scope_bound_method_callback_uses_owner_and_func(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+
+    class _Owner:
+        def prompt(self):
+            pass
+
+    owner = _Owner()
+    bound = owner.prompt
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: bound)
+    assert (
+        terminal_tool._get_sudo_password_cache_scope()
+        == f"callback-owner:{id(owner)}:{id(bound.__func__)}"
+    )
+
+
+def test_sudo_scope_falls_back_to_thread_id(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    assert terminal_tool._get_sudo_password_cache_scope() == f"thread:{threading.get_ident()}"
+
+
+# ---------------------------------------------------------------------------
+# _get_cached_sudo_password / _set_cached_sudo_password / _reset
+# ---------------------------------------------------------------------------
+
+def test_get_cached_sudo_password_empty_by_default(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_set_then_get_cached_sudo_password(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    terminal_tool._set_cached_sudo_password("s3cret")
+    assert terminal_tool._get_cached_sudo_password() == "s3cret"
+
+
+def test_set_cached_sudo_password_empty_removes_entry(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    terminal_tool._set_cached_sudo_password("s3cret")
+    assert terminal_tool._get_cached_sudo_password() == "s3cret"
+    terminal_tool._set_cached_sudo_password("")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_set_cached_sudo_password_without_setting_empty_is_absent(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+    terminal_tool._set_cached_sudo_password("")
+    # Empty string never creates a cache entry.
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_cached_sudo_password_scoped_by_session(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-1")
+    terminal_tool._set_cached_sudo_password("pw1")
+    assert terminal_tool._get_cached_sudo_password() == "pw1"
+    # A different session key reads a different (empty) slot.
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-2")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_reset_cached_sudo_passwords_clears_all(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-1")
+    terminal_tool._set_cached_sudo_password("pw1")
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-2")
+    terminal_tool._set_cached_sudo_password("pw2")
+    terminal_tool._reset_cached_sudo_passwords()
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-1")
+    assert terminal_tool._get_cached_sudo_password() == ""
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "sess-2")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+# ---------------------------------------------------------------------------
+# _sudo_wrong_password_failure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "sudo: authentication failed",
+        "something before\nsudo: incorrect password attempt\nafter",
+        "sudo: maximum 3 incorrect authentication attempts",
+        "sudo: 3 incorrect password attempts",
+        "SUDO: AUTHENTICATION FAILED",  # case-insensitive
+    ],
+)
+def test_sudo_wrong_password_failure_true_on_markers(output):
+    assert terminal_tool._sudo_wrong_password_failure(output) is True
+
+
+@pytest.mark.parametrize(
+    "output",
+    ["", None, "sudo succeeded", "permission denied", "command not found"],
+)
+def test_sudo_wrong_password_failure_false_otherwise(output):
+    assert terminal_tool._sudo_wrong_password_failure(output) is False
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_cached_sudo_on_auth_failure
+# ---------------------------------------------------------------------------
+
+def _thread_scope(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: "")
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+
+
+def test_invalidate_auth_failure_returns_false_when_sudo_password_in_env(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "operator-set")
+    _thread_scope(monkeypatch)
+    terminal_tool._set_cached_sudo_password("cached")
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure(
+            "sudo true", "sudo: authentication failed"
+        )
+        is False
+    )
+    # The env-configured password path is left alone: cache preserved.
+    assert terminal_tool._get_cached_sudo_password() == "cached"
+
+
+def test_invalidate_auth_failure_returns_false_without_sudo_failure(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    _thread_scope(monkeypatch)
+    terminal_tool._set_cached_sudo_password("cached")
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure("sudo true", "done")
+        is False
+    )
+    assert terminal_tool._get_cached_sudo_password() == "cached"
+
+
+def test_invalidate_auth_failure_returns_false_without_real_sudo(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    _thread_scope(monkeypatch)
+    terminal_tool._set_cached_sudo_password("cached")
+    # "sudo" is an argument (grep pattern), not a real sudo invocation.
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure(
+            "grep -r sudo .", "sudo: authentication failed"
+        )
+        is False
+    )
+    assert terminal_tool._get_cached_sudo_password() == "cached"
+
+
+def test_invalidate_auth_failure_returns_false_when_no_cached_password(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    _thread_scope(monkeypatch)
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure(
+            "sudo true", "sudo: authentication failed"
+        )
+        is False
+    )
+
+
+def test_invalidate_auth_failure_clears_cache_when_all_conditions_met(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    _thread_scope(monkeypatch)
+    terminal_tool._set_cached_sudo_password("bad-pw")
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure(
+            "sudo apt install -y curl", "sudo: authentication failed"
+        )
+        is True
+    )
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_invalidate_auth_failure_short_circuits_on_command_none(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    _thread_scope(monkeypatch)
+    terminal_tool._set_cached_sudo_password("bad-pw")
+    # None command coerces to "" -> zero real sudo invocations -> False.
+    assert (
+        terminal_tool._invalidate_cached_sudo_on_auth_failure(None, "sudo: authentication failed")
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _prompt_for_sudo_password
+# ---------------------------------------------------------------------------
+
+def test_prompt_delegates_to_registered_callback(monkeypatch):
+    calls = []
+
+    def mock_cb():
+        calls.append(True)
+        return "typed-pw"
+
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: mock_cb)
+    assert terminal_tool._prompt_for_sudo_password(timeout_seconds=1) == "typed-pw"
+    assert calls == [True]
+
+
+def test_prompt_returns_empty_when_callback_returns_none(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: lambda: None)
+    assert terminal_tool._prompt_for_sudo_password(timeout_seconds=1) == ""
+
+
+def test_prompt_returns_empty_when_callback_returns_empty_string(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: lambda: "")
+    assert terminal_tool._prompt_for_sudo_password(timeout_seconds=1) == ""
+
+
+def test_prompt_returns_empty_when_callback_raises(monkeypatch):
+    def exploding_cb():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: exploding_cb)
+    assert terminal_tool._prompt_for_sudo_password(timeout_seconds=1) == ""
+
+
+def test_prompt_non_interactive_no_tty_returns_empty(monkeypatch):
+    """Without a callback, a headless/uninteractive context never prompts.
+
+    The /dev/tty read path is exercised with ``os.open`` forced to fail, as it
+    does when no controlling terminal (or raw non-interactive child) is
+    attached; the function must degrade to an empty string instead of hanging.
+    """
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: None)
+
+    def _no_tty(*_args, **_kwargs):
+        raise OSError("no controlling terminal")
+
+    monkeypatch.setattr(terminal_tool.os, "open", _no_tty)
+    monkeypatch.setattr(terminal_tool.os.environ, "__contains__", lambda k: False)
+
+    assert terminal_tool._prompt_for_sudo_password(timeout_seconds=1) == ""
+
+
+# ---------------------------------------------------------------------------
+# _sudo_nopasswd_works
+# ---------------------------------------------------------------------------
+
+def test_sudo_nopasswd_returns_false_when_terminal_env_not_local(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(terminal_tool, "subprocess", _never_called_subprocess())
+    assert terminal_tool._sudo_nopasswd_works() is False
+
+
+def test_sudo_nopasswd_returns_true_on_subprocess_success(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(terminal_tool, "subprocess", _stub_subprocess(rc=0))
+    assert terminal_tool._sudo_nopasswd_works() is True
+
+
+def test_sudo_nopasswd_returns_false_on_subprocess_failure(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(terminal_tool, "subprocess", _stub_subprocess(rc=1))
+    assert terminal_tool._sudo_nopasswd_works() is False
+
+
+def test_sudo_nopasswd_returns_false_when_subprocess_raises(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(terminal_tool, "subprocess", _raising_subprocess())
+    assert terminal_tool._sudo_nopasswd_works() is False
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _stub_subprocess(rc):
+    class _Stub:
+        DEVNULL = object()
+
+        @staticmethod
+        def run(*_args, **_kwargs):
+            return type("Probe", (), {"returncode": rc})()
+
+    return _Stub()
+
+
+def _raising_subprocess():
+    class _Stub:
+        DEVNULL = object()
+
+        @staticmethod
+        def run(*_args, **_kwargs):
+            raise OSError("no sudo")
+
+    return _Stub()
+
+
+def _never_called_subprocess():
+    class _Stub:
+        DEVNULL = object()
+
+        @staticmethod
+        def run(*_args, **_kwargs):
+            raise AssertionError("subprocess.run should not be called for non-local TERMINAL_ENV")
+
+    return _Stub()


### PR DESCRIPTION
## Summary

Improve `tools/terminal_tool.py` statement coverage from **31% to 81%** (target: ≥70%), adding 660 new tests across 5 new test files.

## Coverage

```
tools/terminal_tool.py    1645    307    81%
660 passed in 17.54s
```

## What's tested

| File | Tests | Covers |
|------|-------|--------|
| `test_terminal_pure_helpers.py` | 112 | `_safe_command_preview`, `_looks_like_env_assignment`, `_read_shell_token`, `_strip_quotes`, `_looks_like_help_or_version_command`, `_command_requires_pipe_stdin`, `_foreground_background_guidance`, `_resolve_notification_flag_conflict`, `_is_safe_workdir_char`, `_validate_workdir`, `_docker_volume_uses_host_path`, `_docker_has_host_access` |
| `test_terminal_sudo_cache.py` | 36 | `_get_sudo_password_cache_scope`, `_get_cached_sudo_password`, `_set_cached_sudo_password`, `_reset_cached_sudo_passwords`, `_sudo_wrong_password_failure`, `_invalidate_cached_sudo_on_auth_failure`, `_prompt_for_sudo_password`, `_sudo_nopasswd_works` |
| `test_terminal_exit_and_cwd.py` | 117 | `_interpret_exit_code` (grep/diff/find/curl/git semantics), `_interpret_signal_exit`, `_resolve_command_cwd`, `record_session_cwd`/`get_session_cwd`/`clear_session_cwd`, `_parse_env_var`, `_safe_getcwd`, `_is_container_backend`, `_is_unusable_container_cwd` |
| `test_terminal_env_lifecycle.py` | 250 | `_get_env_config`, `_ssh_config_from_config`, `_container_config_from_config`, `_create_environment`, `ensure_task_env`, `is_persistent_env`, `cleanup_all_environments`, `cleanup_vm`, `_cleanup_inactive_envs`, `_atexit_cleanup`, `_evict_environment_for_task`, `register_task_env_overrides`, `register_container_alias`, `_rewrite_compound_background`, `_maybe_reap_docker_orphans`, cleanup thread lifecycle |
| `test_terminal_main_path.py` | 145 | `check_terminal_requirements` (all backends), `terminal_tool` main path (guards, gateway lifecycle, execution, result processing, sudo handling), `_handle_terminal`, `_check_vercel_sandbox_requirements` |

## Notes

- All tests run against the real module (no fabricated imports) using `env -u PYTHONPATH -u VIRTUAL_ENV /Users/dmetcalfe/.hermes/hermes-agent/venv/bin/python -m pytest`
- Tests use `monkeypatch` for env vars and subprocess mocking; no network or Docker required
- Existing test files are untouched — all changes are additive new files

Closes #36590
