### PR TITLE
fix(desktop): keep SSH Windows probe stable against CLIXML progress-stream pollution

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -170,6 +170,53 @@ test('Windows probe validates Hermes and Python topology before selection', asyn
   assert.ok(pythonCheck < output)
 })
 
+const CLEAN_PROBE_RESULT = JSON.stringify({
+  os: 'Windows',
+  arch: 'AMD64',
+  hermesHome: 'C:\\h',
+  hermesPath: 'C:\\h\\hermes.exe',
+  python: 'C:\\h\\python.exe'
+})
+
+const CLIXML_PROGRESS =
+  '#< CLIXML <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/maml/2004/10"><Obj S="progress" RefId="0">正在标准配置首次使用模块</Obj></Objs>'
+
+test('Windows probe script silences the PowerShell progress stream', async () => {
+  let script = ''
+  await probeWindowsRemote(
+    sshWith(async command => {
+      script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+
+      return CLEAN_PROBE_RESULT
+    })
+  )
+
+  assert.ok(script.indexOf('$ProgressPreference="SilentlyContinue"') >= 0)
+  assert.ok(script.indexOf('$ProgressPreference') < script.indexOf('$ErrorActionPreference'))
+})
+
+test('Windows probe tolerates CLIXML progress-stream pollution around the probe JSON', async () => {
+  const pollutedOutputs = [
+    `${CLIXML_PROGRESS}\r\n${CLEAN_PROBE_RESULT}`,
+    `${CLIXML_PROGRESS}${CLEAN_PROBE_RESULT}`,
+    `\uFEFF${CLEAN_PROBE_RESULT}\r\n${CLIXML_PROGRESS}`
+  ]
+
+  for (const output of pollutedOutputs) {
+    const parsed = await probeWindowsRemote(sshWith(async () => output))
+
+    assert.equal(parsed.os, 'Windows')
+    assert.equal(parsed.arch, 'AMD64')
+    assert.equal(parsed.hermesPath, 'C:\\h\\hermes.exe')
+    assert.equal(parsed.python, 'C:\\h\\python.exe')
+  }
+})
+
+test('Windows probe still rejects output that is not platform JSON', async () => {
+  await assert.rejects(probeWindowsRemote(sshWith(async () => 'hermes is not installed on this host')))
+  await assert.rejects(probeWindowsRemote(sshWith(async () => JSON.stringify({ os: 'Windows' })+'\n'+JSON.stringify({unrelated:true}) )))
+})
+
 test('platform detection preserves POSIX and falls back to Windows PowerShell', async () => {
   assert.deepEqual(await detectRemotePlatform(sshWith(async () => 'Linux\nx86_64\n')), { os: 'Linux', arch: 'x86_64' })
   const calls: string[] = []

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -23,6 +23,10 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
   const explicit = psLiteral(explicitHermesPath)
 
   const script = [
+    // Module auto-load / cold-start progress records get serialized by Windows
+    // OpenSSH as "#< CLIXML <Objs S=\"progress\">..." into the same stdout the
+    // probe parses; silence the progress stream before anything can emit it.
+    '$ProgressPreference="SilentlyContinue"',
     '$ErrorActionPreference="Stop"',
     'function Assert-NoReparse([string]$candidate,[bool]$allowMissing=$false){',
     'if([string]::IsNullOrWhiteSpace($candidate)){return}',
@@ -65,7 +69,25 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
   ].join(';')
 
-  return JSON.parse((await ssh.exec(powerShellCommand(script))).trim())
+  // Windows OpenSSH may serialize PowerShell's progress stream as
+  // "#< CLIXML <Objs ...>...</Objs>" blocks into the same stdout channel the
+  // probe reads, ahead of, after, or on the same line as the probe JSON
+  // (module auto-load racing the exec read). Drop every block, then apply
+  // the sibling helpers' convention: the JSON is the last meaningful line.
+  const lines = String(await ssh.exec(powerShellCommand(script)))
+    .replace(/^\uFEFF/, '')
+    .replace(/#< CLIXML[\s\S]*?<\/Objs>/g, '')
+    .trim()
+    .split(/\r?\n/)
+    .filter(line => line.trim() && !line.trimStart().startsWith('#< CLIXML'))
+
+  const parsed = JSON.parse(lines[lines.length - 1] || 'null')
+
+  if (!parsed?.os || !parsed?.arch) {
+    throw new Error(`Windows probe did not return the expected platform JSON: ${String(lines[lines.length - 1] ?? '').slice(0, 200)}`)
+  }
+
+  return parsed
 }
 
 function windowsUpdateMarkerProbeCommand(hermesHome) {


### PR DESCRIPTION
## Summary

`probeWindowsRemote()` in `apps/desktop/electron/windows-remote-lifecycle.ts` ran the probe with a strict `JSON.parse` over the *entire* stdout of the PowerShell EncodedCommand. On Windows OpenSSH, PowerShell can serialize its progress stream (module auto-load / cold-start records, `<Obj S=\"progress\">`) as a `#< CLIXML <Objs ...>...</Objs>` block into that same stdout channel. When it lands ahead of, after, or on the same line as the probe JSON, `JSON.parse` throws, `detectRemotePlatform()` surfaces the misleading `unsupported-platform` error, and Desktop SSH intermittently fails to add the connection (retries pass — a race between progress emission and the exec read). This is the separate trigger reported in #99022, distinct from the #91479 missing-`python.exe` case.

Fix, in two layers (both from the issue's proposed directions):

1. **Suppress at the source**: the generated probe script now starts with `$ProgressPreference=\"SilentlyContinue\"` before `$ErrorActionPreference=\"Stop\"`, so progress records are not emitted/serialized at all in the common case.
2. **Tolerate the residue**: the captured output is cleaned with the sibling helpers' conventions (`assertWindowsRemoteInstallUpdateClear`, `helper`, `atomicWindowsSpawn` already parse "last meaningful line" and strip a BOM): strip a leading BOM, drop every `#< CLIXML ... </Objs>` block, skip bare leftover `#< CLIXML` lines, then `JSON.parse` the last remaining line. A shape check (`os`/`arch` present) keeps genuinely-broken output a hard, descriptive failure instead of a silent wrong verdict.

The strict-topology script itself is unchanged — only stream hygiene around it.

## Testing

```
cd apps/desktop
npx vitest run electron/windows-remote-lifecycle.test.ts --project electron
  Test Files  1 passed (1)
       Tests  17 passed (17)   # 14 before + 3 new

npx tsc --build tsconfig.electron.json   # clean exit 0
./node_modules/.bin/eslint apps/desktop/electron/windows-remote-lifecycle.ts apps/desktop/electron/windows-remote-lifecycle.test.ts   # clean
```

New tests: the generated script silences the progress stream (`$ProgressPreference` first); CLIXML pollution ahead of / glued to / after the probe JSON (incl. the CJK auto-load message from the report) still yields the parsed platform record; non-JSON or wrong-shape output still rejects.

Full electron project on this tree: `1961 passed, 1 failed` — the single failure is `managed-ssh-update.test.ts › POSIX managed launcher...` (`'127' !== '0'`), which reproduces **on a clean `main` checkout with my changes stashed** and is unrelated to this diff.

RED check: reverting only the source file makes the two new behavior tests fail (progress-stream assertion + CLIXML tolerance), confirming they exercise the fix.

Fixes #99022
