### PR TITLE
fix(providers): send modern "model" key on Ollama /api/show probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1999,7 +1999,10 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
 
     try:
         with httpx.Client(timeout=3.0, headers=headers) as client:
-            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            resp = client.post(
+                f"{server_url}/api/show",
+                json={"model": bare_model, "name": bare_model},
+            )
             if resp.status_code != 200:
                 return None
             data = resp.json()
@@ -2057,7 +2060,10 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
 
     try:
         with httpx.Client(timeout=3.0, headers=headers) as client:
-            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            resp = client.post(
+                f"{server_url}/api/show",
+                json={"model": bare_model, "name": bare_model},
+            )
             if resp.status_code != 200:
                 return None
             data = resp.json()
@@ -2137,7 +2143,10 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
 
     try:
         with httpx.Client(timeout=5.0, headers=headers) as client:
-            resp = client.post(f"{server_url}/api/show", json={"name": model})
+            resp = client.post(
+                f"{server_url}/api/show",
+                json={"model": model, "name": model},
+            )
             if resp.status_code != 200:
                 return None
             data = resp.json()
@@ -2324,7 +2333,10 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
         with httpx.Client(timeout=3.0, headers=headers) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
-                resp = client.post(f"{server_url}/api/show", json={"name": model})
+                resp = client.post(
+                    f"{server_url}/api/show",
+                    json={"model": model, "name": model},
+                )
                 if resp.status_code == 200:
                     data = resp.json()
                     # Prefer explicit num_ctx from Modelfile parameters: this is

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5282,7 +5282,10 @@ def ollama_model_supports_thinking(
 
     try:
         with httpx.Client(timeout=timeout, headers=headers) as client:
-            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            resp = client.post(
+                f"{server_url}/api/show",
+                json={"model": bare_model, "name": bare_model},
+            )
             if resp.status_code != 200:
                 return None
             caps = resp.json().get("capabilities")

--- a/tests/agent/test_api_show_model_key.py
+++ b/tests/agent/test_api_show_model_key.py
@@ -1,0 +1,155 @@
+"""E2E: ``/api/show`` probes must send the modern ``model`` request key.
+
+Ollama's ``/api/show`` request body moved from ``{"name": ...}`` to
+``{"model": ...}``. Ollama itself still accepts the legacy key, so the bug
+is invisible against real Ollama — but OpenAI-compatible servers that
+implement the *current* Ollama-compat schema (SGLang's ``--enable-metrics``
+Ollama shim, and vLLM's, both of which answer ``/api/tags`` and are
+therefore detected as ``server_type == "ollama"``) validate strictly and
+reject a ``name``-only body with HTTP 400:
+
+    {"name": "m"}  -> 400  1 validation error: ('body','model') Field required
+    {"model": "m"} -> 200
+
+Every capability the ``/api/show`` probes exist to discover (context
+length, vision, thinking) was therefore silently lost against those
+servers, and the failure surfaced only as recurring 400s in the log.
+
+These tests run against a real ``http.server`` that enforces the modern
+schema, so they exercise the true httpx request-body path rather than
+asserting on a mock's call args.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socketserver
+import threading
+
+import pytest
+
+from agent import model_metadata
+from agent.model_metadata import (
+    query_ollama_num_ctx,
+    query_ollama_supports_vision,
+)
+from hermes_cli.models import ollama_model_supports_thinking
+
+
+MODEL = "qwen3-27b"
+
+_SHOW_BODY = {
+    "parameters": "num_ctx 262144",
+    "model_info": {f"{MODEL}.context_length": 262144},
+    "capabilities": ["completion", "vision", "thinking"],
+}
+
+
+class _StrictOllamaHandler(http.server.BaseHTTPRequestHandler):
+    """Ollama-compatible server that requires the modern ``model`` key."""
+
+    # Set by the fixture so a test can inspect what was actually sent.
+    received: list = []
+
+    def log_message(self, *args):  # noqa: D102 - silence test output
+        pass
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802
+        # /api/tags makes detect_local_server_type() classify us as "ollama",
+        # which is precisely how a strict non-Ollama server ends up on the
+        # /api/show code path in the first place.
+        if self.path == "/api/tags":
+            self._send(200, {"models": [{"name": MODEL, "model": MODEL}]})
+            return
+        self._send(404, {"detail": "Not Found"})
+
+    def do_POST(self):  # noqa: N802
+        if self.path != "/api/show":
+            self._send(404, {"detail": "Not Found"})
+            return
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except ValueError:
+            payload = {}
+        type(self).received.append(payload)
+        if not payload.get("model"):
+            self._send(
+                400,
+                {
+                    "object": "error",
+                    "message": (
+                        "1 validation error:\n  {'type': 'missing', "
+                        "'loc': ('body', 'model'), 'msg': 'Field required'}"
+                    ),
+                },
+            )
+            return
+        self._send(200, _SHOW_BODY)
+
+
+@pytest.fixture
+def strict_ollama(tmp_path, monkeypatch):
+    """A live strict-schema server, with all probe caches isolated."""
+    # Probe results are memoized in-process AND on disk under HERMES_HOME;
+    # point both somewhere disposable so a previous run can't mask the fix.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(model_metadata, "_endpoint_probe_path_cache", {}, raising=False)
+    monkeypatch.setattr(model_metadata, "_endpoint_blackhole_cache", {}, raising=False)
+    for name in (
+        "_query_ollama_api_show",
+        "_query_local_context_length",
+        "query_ollama_num_ctx",
+        "query_ollama_supports_vision",
+    ):
+        fn = getattr(model_metadata, name, None)
+        if fn is not None and hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+    _StrictOllamaHandler.received = []
+    socketserver.TCPServer.allow_reuse_address = True
+    server = socketserver.TCPServer(("127.0.0.1", 0), _StrictOllamaHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_num_ctx_probe_survives_strict_schema(strict_ollama):
+    """Context length is recovered, not lost to a 400."""
+    assert query_ollama_num_ctx(MODEL, strict_ollama) == 262144
+
+
+def test_vision_probe_survives_strict_schema(strict_ollama):
+    """Vision capability is recovered, not lost to a 400."""
+    assert query_ollama_supports_vision(MODEL, strict_ollama) is True
+
+
+def test_thinking_probe_survives_strict_schema(strict_ollama):
+    """Thinking capability is recovered, not lost to a 400."""
+    assert ollama_model_supports_thinking(MODEL, strict_ollama) is True
+
+
+def test_show_requests_carry_the_model_key(strict_ollama):
+    """Every /api/show body sends ``model``; ``name`` stays for old servers."""
+    query_ollama_num_ctx(MODEL, strict_ollama)
+    assert _StrictOllamaHandler.received, "no /api/show request was made"
+    for payload in _StrictOllamaHandler.received:
+        assert payload.get("model") == MODEL
+        # Ollama releases predating the rename only understand ``name``;
+        # sending both keeps those working.
+        assert payload.get("name") == MODEL


### PR DESCRIPTION
## Summary

Ollama's `/api/show` request body moved from `{"name": ...}` to `{"model": ...}`. Ollama itself still accepts the legacy key, so the five call sites that send `name`-only keep working against real Ollama and the bug is invisible there.

It is **not** invisible against OpenAI-compatible servers that implement the *current* Ollama-compat schema. SGLang's Ollama shim (and vLLM's) answer `/api/tags`, so `detect_local_server_type()` classifies them as `"ollama"` and the `/api/show` probes fire — but they validate the body strictly:

```
{"name": "qwen3.8-27b"}  -> 400  1 validation error: ('body','model') Field required
{"model": "qwen3.8-27b"} -> 200  {"parameters": "num_ctx 262144", "model_info": {...}, ...}
```

Every capability those probes exist to discover was therefore silently lost against such an endpoint:

- **context length** fell back to the 128K default despite the server advertising `262144` (halving the usable window with no warning)
- **vision** and **thinking** capability probes returned `None`

The only user-visible symptom was recurring 400s in the log, which reads as harmless probe noise — so the real cost (a silently halved context window) goes unnoticed.

## Fix

Send both keys: `{"model": X, "name": X}`. `model` satisfies strict modern servers; `name` keeps Ollama releases predating the rename working. Compatible in both directions, no version detection needed.

Five call sites, all of which had the same defect:

| File | Function |
|---|---|
| `agent/model_metadata.py` | `query_ollama_num_ctx` |
| `agent/model_metadata.py` | `query_ollama_supports_vision` |
| `agent/model_metadata.py` | `_query_ollama_api_show_uncached` |
| `agent/model_metadata.py` | `_query_local_context_length_uncached` |
| `hermes_cli/models.py` | `ollama_model_supports_thinking` |

## Test plan

New `tests/agent/test_api_show_model_key.py` runs a **real** `http.server` that enforces the modern schema, so the actual httpx request body is exercised rather than asserted against a mock's call args (a mock assertion would freeze the current shape rather than prove interoperability). Probe caches — in-process and the `HERMES_HOME` disk L2 — are isolated per test so a stale entry can't mask the result.

- [x] All 4 new tests **fail on `main`** and **pass with this change**
- [x] `tests/test_ollama_num_ctx.py`, `tests/agent/test_model_metadata_local_ctx.py`, `tests/agent/test_probe_cache_followups.py`, `tests/agent/test_local_probe_disk_cache.py`, `tests/agent/test_endpoint_blackhole.py`, `tests/hermes_cli/test_models.py` — 220 passed
- [x] Reproduced and verified end-to-end against a live SGLang 0.5.x endpoint serving `Qwen3.8-27B-NVFP4`: context resolution goes 131072 → 262144, vision and tool-calling work through the agent loop, and the recurring 400s stop.

Note: 2 failures in `tests/agent/test_image_routing.py` (`test_finds_absolute_path`, `test_finds_home_relative_path`) reproduce identically on unmodified `main` on Windows — pre-existing and unrelated to this change.
