### PR TITLE
fix(desktop): honor bare slash picker selection

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -92,6 +92,14 @@ describe('acceptsTriggerCompletion', () => {
 describe('implicitSlashAcceptIndex', () => {
   const rows = ['/compress', '/review', '/resume']
 
+  it('honours an arrowed pick on a bare slash query', () => {
+    expect(implicitSlashAcceptIndex('', rows, 1, true)).toBe(1)
+  })
+
+  it('does not accept the default row on a bare slash query', () => {
+    expect(implicitSlashAcceptIndex('', rows, 0, false)).toBeNull()
+  })
+
   it('completes a prefix of the highlighted row', () => {
     expect(implicitSlashAcceptIndex('com', rows, 0, false)).toBe(0)
   })

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -106,12 +106,12 @@ export function implicitSlashAcceptIndex(
 ): number | null {
   const typed = slashCompletionToken(query)
 
-  if (!typed) {
-    return null
-  }
-
   if (activeExplicit && itemTexts[activeIndex] != null) {
     return activeIndex
+  }
+
+  if (!typed) {
+    return null
   }
 
   const exact = itemTexts.findIndex(text => slashCompletionToken(text) === typed)


### PR DESCRIPTION
## What does this PR do?

Keeps Enter aligned with the slash picker highlight after the user explicitly moves it with the arrow keys, even when the query is still a bare `/`.

The picker previously returned early for an empty completion token before consulting `activeExplicit`, so Enter sent an empty command instead of accepting the highlighted row. This reorders the existing guards without changing passive bare-slash behavior.

## Related Issue

Fixes #98535

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Check a valid explicit picker selection before the empty-token guard in `composer-utils.ts`.
- Cover both the arrowed bare-slash selection and the untouched default-row case in `composer-utils.test.ts`.

## How to Test

1. Type `/` in the Desktop composer.
2. Move the picker highlight with an arrow key and press Enter; the highlighted command should be accepted.
3. Leave the default row untouched and press Enter; the picker should not implicitly accept it.

Automated checks:

- `npm run test:ui --workspace apps/desktop -- src/app/chat/composer/composer-utils.test.ts` — 25 passed
- `npm run typecheck --workspace apps/desktop` — passed
- `npx eslint apps/desktop/src/app/chat/composer/composer-utils.ts apps/desktop/src/app/chat/composer/composer-utils.test.ts` — passed
- `npx prettier --check apps/desktop/src/app/chat/composer/composer-utils.ts apps/desktop/src/app/chat/composer/composer-utils.test.ts` — passed
- `npm run test:ui --workspace apps/desktop` — 6,754 passed

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] Searched existing open PRs for this issue and symptom
- [x] PR contains only this fix
- [ ] `pytest tests/ -q` — N/A, Desktop TypeScript-only change
- [x] Added regression tests
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; pure selection logic has no platform-specific behavior
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

No visual change. The regression test failed before the guard reorder (`expected null to be 1`) and passes after it.