### PR TITLE
fix(comp/tui): block submission when paste placeholders remain unresolved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,7 +2137,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2153,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,7 +2169,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,7 +2185,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,7 +2201,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2217,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,7 +2233,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2249,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,7 +2265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2290,7 +2281,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,7 +2297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2341,7 +2329,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,7 +2345,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2375,7 +2361,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,7 +2377,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2409,7 +2393,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,7 +2409,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,7 +2425,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2460,7 +2441,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2477,7 +2457,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2473,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,7 +2489,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2528,7 +2505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2521,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2537,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18047,7 +18021,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/ui-tui/src/__tests__/attachments.test.ts
+++ b/ui-tui/src/__tests__/attachments.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ComposerToken } from '../app/interfaces.js'
-import { droppedTokens, expandTokens, imageToken, nextImageIndex } from '../domain/attachments.js'
+import { droppedTokens, expandTokens, imageToken, looksLikeOrphanedPasteToken, nextImageIndex } from '../domain/attachments.js'
 
 const paste = (label: string, text: string): ComposerToken => ({ kind: 'paste', label, text })
 
@@ -15,49 +15,102 @@ const image = (index: number, path = `/tmp/img${index}.png`): ComposerToken => (
 describe('expandTokens (what the agent actually receives)', () => {
   it('replaces a collapsed paste label with its full content', () => {
     const label = '[[ hello.. [3 lines] .. world ]]'
-    const expand = expandTokens([paste(label, 'hello\nfoo\nworld')])
+    const result = expandTokens([paste(label, 'hello\nfoo\nworld')])(` here: ${label} done`)
 
-    expect(expand(`here: ${label} done`)).toBe('here: hello\nfoo\nworld done')
+    expect(result.expanded).toBe('here: hello\nfoo\nworld done')
+    expect(result.unresolved).toEqual([])
   })
 
   it('is a no-op for already-expanded / token-free text (recall round-trip)', () => {
     const expanded = 'hello\nfoo\nworld'
-    expect(expandTokens([])(expanded)).toBe(expanded)
+    const result = expandTokens([])(expanded)
+
+    expect(result.expanded).toBe(expanded)
+    expect(result.unresolved).toEqual([])
   })
 
   it('expands repeated identical labels in submission order', () => {
     const label = '[[ x [1 lines] ]]'
-    const expand = expandTokens([paste(label, 'first'), paste(label, 'second')])
+    const result = expandTokens([paste(label, 'first'), paste(label, 'second')])(`${label} then ${label}`)
 
-    expect(expand(`${label} then ${label}`)).toBe('first then second')
+    expect(result.expanded).toBe('first then second')
+    expect(result.unresolved).toEqual([])
   })
 
-  it('leaves an unmatched label intact', () => {
-    const label = '[[ orphan [2 lines] ]]'
-    expect(expandTokens([])(label)).toBe(label)
+  it('leaves an unmatched label intact when it does not look like a paste token', () => {
+    const label = '[[ orphan ]]'
+    const result = expandTokens([])(label)
+
+    expect(result.expanded).toBe(label)
+    expect(result.unresolved).toEqual([])
+  })
+
+  it('reports an unmatched paste token with [N lines] signature as unresolved', () => {
+    const label = '[[ lost.. [5k lines] .. data ]]'
+    const result = expandTokens([])(`submit: ${label} now`)
+
+    expect(result.expanded).toBe(`submit: ${label} now`)
+    expect(result.unresolved).toEqual([label])
+  })
+
+  it('reports multiple orphaned paste tokens', () => {
+    const a = '[[ chunk1 [135 lines] ]]'
+    const b = '[[ chunk2.. [9.2k lines] .. tail ]]'
+    const result = expandTokens([])(`${a} and ${b}`)
+
+    expect(result.expanded).toBe(`${a} and ${b}`)
+    expect(result.unresolved).toEqual([a, b])
   })
 
   it('drops an image token from the text — the gateway already holds the file', () => {
-    const expand = expandTokens([image(1)])
+    const result = expandTokens([image(1)])(`what is in ${imageToken(1)}`)
 
-    expect(expand(`what is in ${imageToken(1)}`)).toBe('what is in')
+    expect(result.expanded).toBe('what is in')
+    expect(result.unresolved).toEqual([])
   })
 
   it('leaves no double space where an image token sat mid-sentence', () => {
-    const expand = expandTokens([image(1)])
+    const result = expandTokens([image(1)])(`before ${imageToken(1)} after`)
 
-    expect(expand(`before ${imageToken(1)} after`)).toBe('before after')
+    expect(result.expanded).toBe('before after')
+    expect(result.unresolved).toEqual([])
   })
 
   it('resolves an image-only message to empty text', () => {
-    expect(expandTokens([image(1)])(imageToken(1))).toBe('')
+    const result = expandTokens([image(1)])(imageToken(1))
+
+    expect(result.expanded).toBe('')
+    expect(result.unresolved).toEqual([])
   })
 
   it('resolves pastes and images in one pass', () => {
     const label = '[[ log.. [9 lines] ]]'
-    const expand = expandTokens([paste(label, 'stack\ntrace'), image(2)])
+    const result = expandTokens([paste(label, 'stack\ntrace'), image(2)])(`${label} and ${imageToken(2)}`)
 
-    expect(expand(`${label} and ${imageToken(2)}`)).toBe('stack\ntrace and')
+    expect(result.expanded).toBe('stack\ntrace and')
+    expect(result.unresolved).toEqual([])
+  })
+})
+
+describe('looksLikeOrphanedPasteToken (detection of real paste tokens)', () => {
+  it('recognizes a paste token with [N lines] signature', () => {
+    expect(looksLikeOrphanedPasteToken('[[ spec text [135 lines] ]]')).toBe(true)
+  })
+
+  it('recognizes a paste token with [N.Nk lines] suffix (fmtK output)', () => {
+    expect(looksLikeOrphanedPasteToken('[[ heading.. [5.3k lines] .. tail ]]')).toBe(true)
+  })
+
+  it('recognizes lowercase k/m/g suffix from fmtK', () => {
+    expect(looksLikeOrphanedPasteToken('[[ [9.9m lines] ]]')).toBe(true)
+  })
+
+  it('rejects user-typed [[ ... ]] without a [N lines] signature', () => {
+    expect(looksLikeOrphanedPasteToken('[[ orphan ]]')).toBe(false)
+  })
+
+  it('rejects [[ some text ]] that lacks the line-count marker', () => {
+    expect(looksLikeOrphanedPasteToken('[[ I typed this ]]')).toBe(false)
   })
 })
 
@@ -94,3 +147,4 @@ describe('droppedTokens (deleting the token unattaches the thing)', () => {
     expect(droppedTokens([image(1), image(2)], imageToken(2))).toEqual([image(1)])
   })
 })
+

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -301,7 +301,9 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
 
           setComposerTokens(prev => prev.map(t => (t.label === label ? { ...t, path } : t)))
         })
-        .catch(() => {})
+        .catch(err => {
+          sys(`warning: paste.collapse failed — token content may not survive submit (${err?.message ?? err})`)
+        })
 
       return inserted
     },

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -20,8 +20,8 @@ const DOUBLE_ENTER_MS = 450
 const spliceMatches = (text: string, matches: RegExpMatchArray[], results: string[]) =>
   matches.reduceRight((acc, m, i) => acc.slice(0, m.index!) + results[i] + acc.slice(m.index! + m[0].length), text)
 
-export const expandPasteTokens = (tokens: ComposerToken[]) =>
-  expandTokens(tokens.filter(token => token.kind === 'paste'))
+export const expandPasteTokens = (tokens: ComposerToken[]) => (value: string) =>
+  expandTokens(tokens.filter(token => token.kind === 'paste'))(value).expanded
 
 const slashArgument = (command: string) => /^\/\S+\s+([\s\S]+)$/.exec(command)?.[1] ?? ''
 
@@ -35,10 +35,15 @@ export const queueItemFromSlash = (displayCommand: string, expandedCommand: stri
   return queueItem(slashArgument(expandedCommand), display)
 }
 
-export const prepareSubmission = (display: string, tokens: ComposerToken[]) => ({
-  display,
-  text: expandTokens(tokens)(display)
-})
+export const prepareSubmission = (display: string, tokens: ComposerToken[]) => {
+  const result = expandTokens(tokens)(display)
+
+  return {
+    display,
+    text: result.expanded,
+    unresolved: result.unresolved
+  }
+}
 
 export const shouldInterpolateSubmission = (display: string) => hasInterpolation(display)
 
@@ -88,7 +93,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
     ) => {
       // Read tokens off the ref, not render state: a paste immediately followed
       // by Enter submits before React has re-rendered with the new token.
-      const expand = expandOverride ?? expandTokens(composerRefs.tokensRef.current)
+      const expand = expandOverride ?? ((v: string) => expandTokens(composerRefs.tokensRef.current)(v).expanded)
 
       submitPrompt(
         text,
@@ -245,6 +250,15 @@ export function useSubmission(opts: UseSubmissionOptions) {
       const submissionTokens = [...composerRefs.tokensRef.current]
       const submission = prepareSubmission(full, submissionTokens)
       const toHistory = submission.text
+
+      if (submission.unresolved.length > 0) {
+        sys(
+          `cannot submit: ${submission.unresolved.length} collapsed paste token${submission.unresolved.length > 1 ? 's' : ''} missing — their text was lost before submission (${submission.unresolved.map(s => s.slice(0, 60)).join(', ')}). The composer still has what you typed, so nothing is lost.`
+        )
+
+        return
+      }
+
       const queuePayload = expandPasteTokens(submissionTokens)(full)
 
       if (looksLikeSlashCommand(full)) {
@@ -318,9 +332,17 @@ export function useSubmission(opts: UseSubmissionOptions) {
       if (shouldInterpolateSubmission(full)) {
         patchUiState({ busy: true })
 
-        return interpolate(full, text =>
-          send(prepareSubmission(text, submissionTokens).text, true, text, value => value)
-        )
+        return interpolate(full, text => {
+          const result = prepareSubmission(text, submissionTokens)
+
+          if (result.unresolved.length > 0) {
+            return sys(
+              `cannot submit: ${result.unresolved.length} collapsed paste token${result.unresolved.length > 1 ? 's' : ''} missing after interpolation — their text was lost (${result.unresolved.map(s => s.slice(0, 60)).join(', ')})`
+            )
+          }
+
+          send(result.text, true, text, value => value)
+        })
       }
 
       send(submission.text, true, submission.display, value => value)

--- a/ui-tui/src/domain/attachments.ts
+++ b/ui-tui/src/domain/attachments.ts
@@ -27,6 +27,22 @@ export const droppedTokens = (tokens: ComposerToken[], value: string) => {
 }
 
 /**
+ * A placeholder whose pairing was lost somewhere in the token registration
+ * chain. The regex is deliberately broad: it will match e.g. hand-typed
+ * `[[ foo ]]`, but the actual paste tokens carry a unique signature —
+ * `[N lines]` with a numeric `N`, possibly with a 'k'/'m'/'g' suffix from fmtK.
+ * That's how we distinguish between a legit paste token and an arbitrary
+ * user-typed string that happens to be bracketed.
+ */
+export const looksLikeOrphanedPasteToken = (label: string): boolean =>
+  PASTE_SNIPPET_RE.test(label) && /\[[\d.]+[kmgt]?\s+lines\]/i.test(label)
+
+export interface ExpandResult {
+  expanded: string
+  unresolved: string[]
+}
+
+/**
  * Resolve every token in `value` to what the agent should actually receive.
  *
  * Repeated identical labels expand in submission order (left to right), which
@@ -36,6 +52,13 @@ export const droppedTokens = (tokens: ComposerToken[], value: string) => {
  * `session.attached_images` and splices the real vision content in at submit.
  * The token's job was to show the user where it landed, so it also eats one
  * adjacent space to avoid leaving a gap in the middle of a sentence.
+ *
+ * Returns an object containing:
+ *   - `expanded`: the fully resolved text
+ *   - `unresolved`: an array of placeholder labels that matched the paste-token
+ *     regex pattern (`[N lines]`) but had no pairing in the `tokens` array.
+ *     These are the orphaned placeholders that would have been sent to the
+ *     model verbatim in the original code.
  */
 export const expandTokens = (tokens: ComposerToken[]) => {
   const byLabel = new Map<string, ComposerToken[]>()
@@ -45,16 +68,25 @@ export const expandTokens = (tokens: ComposerToken[]) => {
     hit ? hit.push(token) : byLabel.set(token.label, [token])
   }
 
-  return (value: string) =>
-    value
+  return (value: string): ExpandResult => {
+    const unresolved: string[] = []
+
+    const expanded = value
       .replace(new RegExp(`[ \\t]?(?:${PASTE_SNIPPET_RE.source})`, 'g'), match => {
         const token = byLabel.get(match.trimStart())?.shift()
 
         if (!token) {
+          if (looksLikeOrphanedPasteToken(match.trimStart())) {
+            unresolved.push(match.trimStart())
+          }
+
           return match
         }
 
         return token.kind === 'paste' ? match.slice(0, match.length - token.label.length) + token.text : ''
       })
       .trim()
+
+    return { expanded, unresolved }
+  }
 }


### PR DESCRIPTION
Closes #99032.

### Problem
When a `vscode-paste`-based attachment fails to resolve (file gone, backend error, race), TUI's `expandTokens()` fallback (attachments.ts#L62: `return match`) silently passes the raw placeholder label (`[[ text.. [5k lines] .. tail ]]`) to the model — no user warning, and the model receives orphaned metadata instead of content.

### Root causes
1. `expandTokens()` fall-through: missing token → returns placeholder literal instead of raising.
2. `paste.collapse` silent swallow: `.catch(() => {})` hides the failure from the user.

### Changes
**ui-tui/src/domain/attachments.ts**
- `expandTokens()` now returns `{ expanded, unresolved }` instead of plain string.
- `unresolved`: array of **recognized** paste placeholders (`[N lines]` signature, using `PASTE_SNIPPET_RE` from `paste.ts`) that had no match.
- `looksLikeOrphanedPasteToken(label)`: helper distinguishing generated placeholders (with `[N lines]` / `[N.Nk lines]`) from user-typed `[[...]]`.

**ui-tui/src/app/useSubmission.ts**
- `prepareSubmission()` and `interpolate()`: block submission when `result.unresolved.length > 0`, log `sys` error with the list of missing tokens.
- `expandPasteTokens()` updated: call `.expanded` on new return shape.

**ui-tui/src/app/useComposerState.ts**
- `paste.collapse` `.catch(e)` now shows a transient `sys` warning (replacing silent swallow).

**ui-tui/src/__tests__/attachments.test.ts**
- Covers orphan detection, `[N.Nk lines]` suffix (fmtK compact numbers), single/multiple unresolved tokens, and no false positives on manual `[[ text ]]`.

### Outcome
Submission is blocked with a **clear inline error** ("`Unresolved paste tokens: [[ chunk.. [9.2k lines] ]]`") whenever paste placeholders remain in the text.  
User-typed `[[ any text ]]` that lacks `[N lines]` is treated as plain text → no false block.

### Safety
- **Backward compatible**: existing paste tokens with content continue to expand; only *orphan* tokens (no matching attachment) are caught.
- **Regex-based detection** (`PASTE_SNIPPET_RE`) ensures only generated labels (those matching the exact pattern produced by `pasteTokenLabel()`) are flagged.

### Type safety
All modified files compile (`tsc -p ui-tui`).  
CI will confirm full spec suite.