### PR TITLE
fix(session): stop session effort from reseeding the composer draft

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
@@ -4,10 +4,12 @@ import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $currentCwd,
+  $currentReasoningEffort,
   $selectedStoredSessionId,
   $workspaceCwdOwner,
   releaseWorkspaceCwdOwner,
-  setCurrentCwd
+  setCurrentCwd,
+  setCurrentReasoningEffort
 } from '@/store/session'
 
 import { handleSessionInfoEvent } from './session-info'
@@ -20,11 +22,13 @@ function sessionInfoEvent({
   activeSessionId,
   cwd,
   explicitSid = '',
+  reasoningEffort,
   storedSessionId = ''
 }: {
   activeSessionId: null | string
   cwd: string
   explicitSid?: string
+  reasoningEffort?: string
   storedSessionId?: string
 }): GatewayEventContext {
   const sessionId = explicitSid || activeSessionId
@@ -48,7 +52,7 @@ function sessionInfoEvent({
     fromActiveSource: () => true,
     isActiveEvent: !!sessionId && sessionId === activeSessionId,
     occurredAt: Date.now() / 1000,
-    payload: { cwd, stored_session_id: storedSessionId },
+    payload: { cwd, stored_session_id: storedSessionId, ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}) },
     scheduleConfigRefresh: vi.fn(),
     sessionId
   } as unknown as GatewayEventContext
@@ -65,6 +69,7 @@ describe('handleSessionInfoEvent workspace ownership', () => {
     $selectedStoredSessionId.set(null)
     $workspaceCwdOwner.set(null)
     setCurrentCwd('')
+    setCurrentReasoningEffort('')
   })
 
   // #55831 / the "workspace pane visible with no agent selected" report: with
@@ -145,5 +150,19 @@ describe('handleSessionInfoEvent workspace ownership', () => {
     handleSessionInfoEvent(ctx)
 
     expect(next).toBe(original)
+  })
+
+  it('does not copy a session.info reasoning_effort into the global composer draft', () => {
+    setCurrentReasoningEffort('')
+
+    handleSessionInfoEvent(
+      sessionInfoEvent({ activeSessionId: null, cwd: '/repo', reasoningEffort: 'high' })
+    )
+
+    // A session's pinned effort is per-session only; it must never seed the
+    // persisted composer draft that a fresh chat reads — that would override the
+    // profile's `agent.reasoning_effort` default with whatever the last-resumed
+    // session happened to pin.
+    expect($currentReasoningEffort.get()).toBe('')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -17,7 +17,6 @@ import {
   setCurrentCwdTransient,
   setCurrentFastMode,
   setCurrentPersonality,
-  setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
   setSessions,
@@ -238,10 +237,11 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
         setCurrentPersonality(normalizePersonalityValue(payload.personality))
       }
 
-      if (typeof payload?.reasoning_effort === 'string') {
-        setCurrentReasoningEffort(payload.reasoning_effort)
-      }
-
+      // `reasoning_effort` is a per-session override, not a global default: it
+      // must reach the session's own slice (via sessionInfoStatePatch →
+      // updateSessionState below), never the persisted composer draft. Writing
+      // it to $currentReasoningEffort here would reseed every new chat with the
+      // last-resumed session's pin, clobbering agent.reasoning_effort.
       if (typeof payload?.service_tier === 'string') {
         setCurrentServiceTier(payload.service_tier)
       }

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -228,7 +228,10 @@ describe('useSessionStateCache — per-session turn timer', () => {
 
     expect($currentModel.get()).toBe('anthropic/claude-opus-4.8')
     expect($currentProvider.get()).toBe('anthropic')
-    expect($currentReasoningEffort.get()).toBe('high')
+    // Reasoning effort stays per-session: mirroring it into the global composer
+    // draft would seed every new chat with the last-resumed session's pin,
+    // overriding the profile default.
+    expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('priority')
     expect($currentFastMode.get()).toBe(true)
   })
@@ -236,7 +239,6 @@ describe('useSessionStateCache — per-session turn timer', () => {
   it('clears stale model metadata when the newly focused session has no cached value', () => {
     setCurrentModel('previous-model')
     setCurrentProvider('previous-provider')
-    setCurrentReasoningEffort('high')
     setCurrentServiceTier('priority')
     setCurrentFastMode(true)
 
@@ -261,7 +263,6 @@ describe('useSessionStateCache — per-session turn timer', () => {
 
     expect($currentModel.get()).toBe('')
     expect($currentProvider.get()).toBe('')
-    expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
   })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -15,7 +15,6 @@ import {
   setCurrentModel,
   setCurrentPersonality,
   setCurrentProvider,
-  setCurrentReasoningEffort,
   setCurrentServiceTier,
   setTurnStartedAt,
   setYoloActive
@@ -43,7 +42,10 @@ interface SessionStateCacheOptions {
 function syncRuntimeMetadataToView(state: ClientSessionState) {
   setCurrentModel(state.model ?? '')
   setCurrentProvider(state.provider ?? '')
-  setCurrentReasoningEffort(state.reasoningEffort ?? '')
+  // reasoningEffort is intentionally not mirrored: it's a per-session override,
+  // and copying it into $currentReasoningEffort would persist it as the draft
+  // that seeds new chats (overriding the profile default). The session pill
+  // reads it straight from the session slice instead.
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)
   setYoloActive(state.yolo ?? false)


### PR DESCRIPTION
## Problem

`agent.reasoning_effort` is configured as `medium`, but after resuming a DeepSeek
session the composer — and every new chat — silently uses `high`. DeepSeek pins
reasoning effort per-session on the backend, and the desktop copies that pin into the
persisted composer draft instead of treating it as session-scoped.

Two paths leak the pin into `$currentReasoningEffort` (persisted to
`hermes.desktop.composer.reasoning-effort` and read by `session.create`):

1. `session-info.ts` writes `payload.reasoning_effort` straight into the composer
   atom on every `session.info`.
2. `syncRuntimeMetadataToView` mirrors `state.reasoningEffort` into the same atom
   whenever the focused session's state is flushed.

So resuming any high-pinned session re-poisons the draft, and the config default is
ignored for new chats until the user manually re-picks it.

## Change

Reasoning effort is a per-session override, not a global default — the backend
documents this in `methods_session.py` ("picking a model/effort for a new chat can't
mutate the profile default"). The desktop now respects that:

- `session-info.ts` no longer calls `setCurrentReasoningEffort`; the effort still
  reaches the session's own slice via `sessionInfoStatePatch` → `updateSessionState`.
- `syncRuntimeMetadataToView` no longer mirrors `reasoningEffort` into the composer
  draft. The session pill already reads the per-session slice directly
  (`primaryField(state => state.reasoningEffort, …)`), so it keeps showing the
  session's effort.

## Testing

- `session-info.test.ts` → "does not copy a session.info reasoning_effort into the
  global composer draft": a `session.info` carrying `reasoning_effort: "high"`
  leaves `$currentReasoningEffort` untouched (fails before the change).
- `use-session-state-cache.test.tsx` → focused-session sync no longer mirrors
  `reasoningEffort` into the composer atom; the "clears stale model metadata" case
  drops effort from the mirrored set.
- `npx vitest run --project ui src/app/session/hooks/` — 45 files, 723 tests pass.
- `npx tsc -p . --noEmit` — clean.

## Related Issue

Fixes #105461

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `npx vitest run --project ui src/app/session/hooks/` and `npx tsc -p . --noEmit` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [ ] I've updated `cli-config.yaml.example` — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [ ] I've updated tool descriptions/schemas — or N/A
