### PR TITLE
fix(gateway): gate sub-floor preamble finalizes on tool boundaries

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -3052,11 +3052,20 @@ class GatewayStreamConsumer:
         # This was reported on Telegram, Matrix, and other clients where the
         # ▉ block character renders as a visible white box ("tofu").
         # Existing messages (edits) are unaffected — only first sends gated.
+        # A segment-break finalize carries the same risk and must be gated
+        # too: its text never contains the cursor (the cursor is only
+        # appended to mid-stream frames), so the cursor-membership test
+        # alone let a 1-2 token preamble land as its own durable message at
+        # every tool boundary, firing on_new_message and resetting the
+        # tool-progress anchor — fragmenting accumulated progress into one
+        # bubble per tool (#99026).  Turn finals are exempt: a complete
+        # answer below the threshold must still be delivered.
         _MIN_NEW_MSG_CHARS = 4
+        _preamble_finalize = finalize and not is_turn_final
         if (self._message_id is None
-                and self.cfg.cursor
-                and self.cfg.cursor in text
-                and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
+                and len(_visible_stripped) < _MIN_NEW_MSG_CHARS
+                and (_preamble_finalize
+                     or (self.cfg.cursor and self.cfg.cursor in text))):
             return True  # too short for a standalone message — accumulate more
 
         # Native streaming transport (e.g. WeCom): every frame — first send,

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1111,15 +1111,17 @@ class TestOnNewMessageCallback:
             on_new_message=lambda: events.append("reset"),
         )
 
-        consumer.on_delta("A")
+        consumer.on_delta("First preamble")
         consumer.on_delta(None)
-        consumer.on_delta("B")
+        consumer.on_delta("Second preamble")
         consumer.on_delta(None)
-        consumer.on_delta("C")
+        consumer.on_delta("Final answer")
         consumer.finish()
         await consumer.run()
 
-        # Three content bubbles ⇒ three reset notifications
+        # Three content bubbles ⇒ three reset notifications. (Segment text
+        # must clear the sub-floor standalone-message guard — a 1-2 token
+        # preamble is intentionally held back now, see #99026.)
         assert events == ["reset", "reset", "reset"]
 
 

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -337,6 +337,103 @@ def _make_fresh_final_adapter():
     return adapter
 
 
+class TestSubFloorPreambleToolBoundaries:
+    """Regression for #99026: a 1-2 token preamble finalized at a tool
+    boundary must NOT land as its own durable message.
+
+    The sub-floor standalone-message guard keyed on ``cursor in text``,
+    but a segment-break finalize's text never carries the cursor (the
+    cursor is only appended to mid-stream frames), so every short
+    preamble became a real sendMessage, fired on_new_message, and reset
+    the gateway's tool-progress anchor — fragmenting accumulated progress
+    into one bubble per tool on draft-streaming platforms (Telegram).
+    """
+
+    @pytest.mark.asyncio
+    async def test_short_preamble_rounds_keep_progress_anchor(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        resets: list[str] = []
+        consumer._on_new_message = lambda: resets.append("reset")
+
+        task = asyncio.create_task(consumer.run())
+        for _ in range(3):
+            consumer.on_delta("Ok")
+            await asyncio.sleep(0.05)
+            consumer.on_delta(None)  # tool boundary
+            await asyncio.sleep(0.05)
+        consumer.finish("Done.")
+        await task
+
+        # No sub-floor preamble landed as a standalone durable message, so
+        # the tool-progress anchor was never reset between tool rounds.
+        assert resets == []
+        sends = [c.kwargs.get("content") for c in adapter.send.await_args_list]
+        assert sends == [], sends
+        # The sub-floor preamble was held back at every stage: the mid-stream
+        # frame guard suppressed the "Ok ▉" draft frame (legacy behavior),
+        # and the segment-break finalize no longer turns it into a real
+        # message either.
+        assert all(len((c["content"] or "").replace("▉", "").strip()) >= 4
+                   for c in adapter.draft_calls) or not adapter.draft_calls
+        # The consumer never claimed final delivery (drafts don't set
+        # already_sent), so the gateway's final-send path owns "Done.".
+        assert consumer.final_response_sent is False
+
+    @pytest.mark.asyncio
+    async def test_full_preamble_rounds_still_reset_once_each(self):
+        """Counterpart: a preamble long enough to stand alone SHOULD land as
+        a durable message and reset the progress anchor below it (the
+        #17280 chronological-order contract)."""
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        resets: list[str] = []
+        consumer._on_new_message = lambda: resets.append("reset")
+
+        task = asyncio.create_task(consumer.run())
+        for i in range(3):
+            consumer.on_delta(f"Round {i} preamble text")
+            await asyncio.sleep(0.05)
+            consumer.on_delta(None)  # tool boundary
+            await asyncio.sleep(0.05)
+        consumer.finish("Done.")
+        await task
+
+        assert len(resets) == 3, resets
+        sends = [c.kwargs.get("content") for c in adapter.send.await_args_list]
+        assert sends == [
+            "Round 0 preamble text",
+            "Round 1 preamble text",
+            "Round 2 preamble text",
+        ], sends
+
+    @pytest.mark.asyncio
+    async def test_turn_final_short_answer_is_never_swallowed(self):
+        """The sub-floor guard must not eat a turn-final answer, or the
+        gateway's final-send suppression would drop it entirely."""
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Ok")
+        consumer.finish()
+        await consumer.run()
+
+        sends = [c.kwargs.get("content") for c in adapter.send.await_args_list]
+        assert any("Ok" in (s or "") for s in sends), sends
+
+
 class TestAdapterPrefersFreshFinal:
     """An adapter whose send path is richer than its edit path (e.g. Telegram
     rich messages) finalizes a streamed reply by sending a fresh final message


### PR DESCRIPTION
## What does this PR do?

Stops 1-2 token preambles from landing as their own durable message at every tool boundary, which reset the tool-progress anchor and fragmented accumulated tool progress into one persistent message per tool (the #99026 symptom on Telegram draft streaming with `tool_progress_grouping: accumulate`).

Root cause: the sub-floor standalone-message guard in `GatewayStreamConsumer._send_or_edit` keyed on `cursor in text`, but a segment-break finalize's text never contains the streaming cursor (the cursor is only appended to mid-stream frames), so the guard never fired on the finalize path. Each short preamble therefore went out as a real first-send, fired `on_new_message`, and `send_progress_messages` cleared `progress_msg_id`/`progress_lines` — so the next tool event opened a fresh progress bubble, once per tool.

The fix extends the guard to segment-break finalizes (`finalize and not is_turn_final`) instead of requiring cursor membership. Turn finals stay exempt, so a complete short answer is never swallowed.

Note on the issue's RCA: the resets are not caused by an ephemeral draft boundary itself — draft frames (`_send_draft_frame`) never call `_notify_new_message`. The trigger is a real (durable) send of a sub-floor preamble that should have been held back, per the guard's own documented intent for rapid tool-calling.

## Related Issue

Fixes #99026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py` — extend the `_MIN_NEW_MSG_CHARS` guard to segment-break finalizes (`finalize and not is_turn_final`), with a comment documenting why cursor-membership alone cannot gate the finalize path (#99026).
- `tests/gateway/test_stream_consumer.py` — `test_callback_fires_once_per_segment` now uses segment text above the sub-floor threshold; its intent (per-segment durable content ⇒ per-segment reset) is unchanged, but single-character segments are now intentionally held back.
- `tests/gateway/test_stream_consumer_draft.py` — new `TestSubFloorPreambleToolBoundaries`: short-preamble rounds produce no durable sends and no progress resets; full-preamble rounds keep one send + one reset per segment (\#17280 contract); a turn-final short answer is always delivered.

## How to Test

1. Run the draft/stream consumer suites:
   ```
   pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_stream_final_contract.py tests/gateway/test_stream_consumer_wecom_native.py tests/gateway/test_stream_abandon_on_turn_death.py tests/gateway/test_interim_send_lanes.py tests/gateway/test_slack_native_streaming.py tests/gateway/test_telegram_send_draft_format.py tests/gateway/test_telegram_rich_messages.py -q
   ```
   Observed result: 187 passed.
2. Before the fix, the new `test_short_preamble_rounds_keep_progress_anchor` fails with 3 resets and 3 real sends (one per tool boundary); after the fix it passes with 0 resets and 0 durable sends — the preamble animates through drafts only and the progress anchor survives.
3. `test_turn_final_short_answer_is_never_swallowed` verifies a turn-final answer below the threshold is still delivered, so the guard cannot drop a real answer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in the guard's comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — transport-agnostic guard, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill change.