### PR TITLE
feat(monitoring): add content-free JSON health status

### DIFF
--- a/docs/observability/monitoring.md
+++ b/docs/observability/monitoring.md
@@ -60,6 +60,20 @@ Check the posture any time:
 hermes monitoring status
 ```
 
+For machine-readable local health, add `--json`:
+
+```bash
+hermes monitoring status --json
+```
+
+The versioned payload reuses the gateway and cron gauge vocabulary above.
+Section status is `available` when collection succeeded, `unavailable` when
+liveness could not be determined, and `error` when snapshot construction
+failed. Export flags report effective state. The command never reads gateway
+logs or includes events, raw install ids, profile identity, OTLP endpoint
+values, prompts, messages, tool arguments/results, or raw errors. Metric
+attributes pass through a fixed content-free allowlist.
+
 The OpenTelemetry SDK is an optional extra (`pip install 'hermes-agent[otlp]'`),
 lazy-installed on first use. When the SDK is missing or the endpoint is down,
 the gateway runs unaffected: metric collection and ordinary event export stay
@@ -281,6 +295,7 @@ values with no error:
 
 ```bash
 hermes monitoring status                 # posture
+hermes monitoring status --json          # content-free local health
 python scripts/observability/gateway_health_export_probe.py \
   --endpoint http://127.0.0.1:4318/v1/traces \
   --log /tmp/cap.jsonl --wait 8          # drive the real exporter

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12935,6 +12935,12 @@ def cmd_monitoring(args):
     mon: dict = mon_raw if isinstance(mon_raw, dict) else {}
 
     if action == "status":
+        if getattr(args, "json", False):
+            from hermes_cli.subcommands.monitoring import build_monitoring_status_payload
+
+            print(json.dumps(build_monitoring_status_payload(config), indent=2, sort_keys=True))
+            return
+
         from agent.monitoring import otlp_exporter
 
         gh_raw = mon.get("gateway_health_export")

--- a/hermes_cli/subcommands/monitoring.py
+++ b/hermes_cli/subcommands/monitoring.py
@@ -10,7 +10,112 @@ subcommand).
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
+
+_JSON_METRIC_ATTRIBUTE_KEYS = frozenset({
+    "service.instance.id",
+    "service.version",
+    "hermes.supervision_mode",
+    "hermes.gateway.state",
+    "hermes.platform",
+    "hermes.platform.state",
+    "hermes.error_code",
+})
+
+
+def _metric_payload(metric: Any) -> dict[str, Any]:
+    """Project an existing content-free metric into the CLI JSON contract."""
+    return {
+        "name": str(metric.name),
+        "value": metric.value,
+        "attributes": {
+            key: value
+            for key, value in metric.attributes.items()
+            if key in _JSON_METRIC_ATTRIBUTE_KEYS
+        },
+    }
+
+
+def build_monitoring_status_payload(config: dict[str, Any]) -> dict[str, Any]:
+    """Build a machine-readable local health snapshot without reading logs."""
+    from agent.monitoring import otlp_exporter
+
+    mon_raw = config.get("monitoring") if isinstance(config, dict) else None
+    mon: dict[str, Any] = mon_raw if isinstance(mon_raw, dict) else {}
+    health_raw = mon.get("gateway_health_export")
+    health_cfg: dict[str, Any] = health_raw if isinstance(health_raw, dict) else {}
+    export_raw = mon.get("export")
+    export_cfg: dict[str, Any] = export_raw if isinstance(export_raw, dict) else {}
+    otlp_raw = export_cfg.get("otlp")
+    otlp: dict[str, Any] = otlp_raw if isinstance(otlp_raw, dict) else {}
+    health_enabled = bool(health_cfg.get("enabled"))
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "content_free": True,
+        "export": {
+            "health_enabled": health_enabled,
+            "metrics_enabled": health_enabled
+            and bool(health_cfg.get("metrics_enabled", True)),
+            "diagnostic_events_enabled": health_enabled
+            and bool(
+                health_cfg.get("diagnostic_events_enabled", True),
+            ),
+            "warning_error_events_enabled": health_enabled
+            and bool(
+                health_cfg.get("warning_error_events_enabled", True),
+            ),
+            "otlp_configured": bool(otlp.get("enabled") and otlp.get("endpoint")),
+            "otlp_sdk_available": bool(otlp_exporter.is_available()),
+        },
+        "health": {
+            "gateway": {"status": "unavailable", "metrics": []},
+            "cron": {"status": "unavailable", "metrics": []},
+        },
+    }
+
+    try:
+        from agent.monitoring.gateway_health import build_gateway_health_snapshot
+        from gateway.status import (
+            get_running_pid,
+            read_runtime_status,
+            resolve_gateway_liveness,
+        )
+        from hermes_cli import __version__
+
+        runtime = read_runtime_status() or {}
+        liveness = resolve_gateway_liveness(
+            runtime=runtime,
+            use_cache=False,
+            pid_probe=lambda: get_running_pid(cleanup_stale=False),
+        )
+        if not (liveness.probe_error and not liveness.running):
+            snapshot = build_gateway_health_snapshot(
+                runtime,
+                gateway_running=bool(liveness.running),
+                profile="default",
+                install_id=str(mon.get("install_id") or "unknown"),
+                version=str(__version__),
+            )
+            payload["health"]["gateway"] = {
+                "status": "available",
+                "metrics": [_metric_payload(metric) for metric in snapshot.metrics],
+            }
+    except Exception:
+        payload["health"]["gateway"]["status"] = "error"
+
+    try:
+        from agent.monitoring.cron_health import build_cron_health_snapshot
+
+        snapshot = build_cron_health_snapshot()
+        payload["health"]["cron"] = {
+            "status": "available",
+            "metrics": [_metric_payload(metric) for metric in snapshot.metrics],
+        }
+    except Exception:
+        payload["health"]["cron"]["status"] = "error"
+
+    return payload
 
 
 def build_monitoring_parser(subparsers, *, cmd_monitoring: Callable) -> None:
@@ -28,9 +133,14 @@ def build_monitoring_parser(subparsers, *, cmd_monitoring: Callable) -> None:
     )
     sub = p.add_subparsers(dest="monitoring_action")
 
-    sub.add_parser(
+    status = sub.add_parser(
         "status",
         help="Show monitoring settings, export state, and redaction posture",
+    )
+    status.add_argument(
+        "--json",
+        action="store_true",
+        help="Print content-free local health and export status as JSON",
     )
 
     p.set_defaults(func=cmd_monitoring)

--- a/tests/monitoring/test_monitoring_cli.py
+++ b/tests/monitoring/test_monitoring_cli.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+from types import SimpleNamespace
+
+
+def test_monitoring_status_parser_accepts_json_flag():
+    from hermes_cli.subcommands.monitoring import build_monitoring_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_monitoring_parser(subparsers, cmd_monitoring=lambda args: None)
+
+    args = parser.parse_args(["monitoring", "status", "--json"])
+
+    assert args.monitoring_action == "status"
+    assert args.json is True
+
+
+def test_monitoring_status_payload_is_content_free(monkeypatch):
+    from agent.monitoring.cron_health import CronHealthSnapshot
+    from agent.monitoring.gateway_health import GatewayMetric
+    from gateway import status as gateway_status
+    from agent.monitoring import cron_health
+    from hermes_cli.subcommands.monitoring import build_monitoring_status_payload
+
+    runtime = {
+        "gateway_state": "running",
+        "active_agents": 2,
+        "platforms": {
+            "slack": {
+                "state": "fatal",
+                "error_message": "Bearer top-secret-token for alice@example.com",
+            }
+        },
+    }
+    monkeypatch.setattr(gateway_status, "read_runtime_status", lambda: runtime)
+    monkeypatch.setattr(
+        gateway_status,
+        "resolve_gateway_liveness",
+        lambda **kwargs: SimpleNamespace(running=True, probe_error=False),
+    )
+    monkeypatch.setattr(
+        cron_health,
+        "build_cron_health_snapshot",
+        lambda: CronHealthSnapshot(
+            metrics=[
+                GatewayMetric(
+                    "hermes.cron.jobs.enabled",
+                    3,
+                    {"job.name": "private payroll for alice@example.com"},
+                )
+            ],
+            events=[],
+        ),
+    )
+
+    payload = build_monitoring_status_payload({
+        "monitoring": {
+            "install_id": "private-install-id",
+            "gateway_health_export": {"enabled": True},
+            "export": {
+                "otlp": {
+                    "enabled": True,
+                    "endpoint": "https://alice:secret@example.com/v1/metrics",
+                }
+            },
+        }
+    })
+
+    assert payload["schema_version"] == 1
+    assert payload["content_free"] is True
+    assert payload["export"]["health_enabled"] is True
+    assert payload["export"]["otlp_configured"] is True
+    assert payload["health"]["gateway"]["status"] == "available"
+    assert payload["health"]["cron"]["status"] == "available"
+    assert {metric["name"] for metric in payload["health"]["gateway"]["metrics"]} >= {
+        "hermes.gateway.up",
+        "hermes.gateway.active_agents",
+        "hermes.platform.up",
+    }
+    assert payload["health"]["cron"]["metrics"] == [
+        {"name": "hermes.cron.jobs.enabled", "value": 3, "attributes": {}}
+    ]
+
+    rendered = json.dumps(payload)
+    assert "private-install-id" not in rendered
+    assert "alice@example.com" not in rendered
+    assert "top-secret-token" not in rendered
+    assert "alice:secret" not in rendered
+    assert "events" not in payload["health"]["gateway"]
+    assert "events" not in payload["health"]["cron"]
+    assert "sha256:" in rendered
+    assert {
+        key
+        for metric in payload["health"]["gateway"]["metrics"]
+        for key in metric["attributes"]
+    } <= {
+        "service.instance.id",
+        "service.version",
+        "hermes.supervision_mode",
+        "hermes.gateway.state",
+        "hermes.platform",
+        "hermes.platform.state",
+        "hermes.error_code",
+    }
+
+
+def test_monitoring_status_payload_marks_failed_sections_unavailable(monkeypatch):
+    from agent.monitoring import cron_health
+    from gateway import status as gateway_status
+    from hermes_cli.subcommands.monitoring import build_monitoring_status_payload
+
+    monkeypatch.setattr(gateway_status, "read_runtime_status", lambda: {})
+    monkeypatch.setattr(
+        gateway_status,
+        "resolve_gateway_liveness",
+        lambda **kwargs: SimpleNamespace(running=False, probe_error=False),
+    )
+
+    def fail_cron_snapshot():
+        raise RuntimeError("private path /Users/alice/jobs.json")
+
+    monkeypatch.setattr(cron_health, "build_cron_health_snapshot", fail_cron_snapshot)
+
+    payload = build_monitoring_status_payload({})
+
+    assert payload["health"]["gateway"]["status"] == "available"
+    assert payload["health"]["cron"] == {"status": "error", "metrics": []}
+    assert "alice" not in json.dumps(payload)
+
+
+def test_monitoring_status_payload_does_not_report_down_when_liveness_is_unknown(
+    monkeypatch,
+):
+    from gateway import status as gateway_status
+    from hermes_cli.subcommands.monitoring import build_monitoring_status_payload
+
+    monkeypatch.setattr(gateway_status, "read_runtime_status", lambda: {})
+    monkeypatch.setattr(
+        gateway_status,
+        "resolve_gateway_liveness",
+        lambda **kwargs: SimpleNamespace(running=False, probe_error=True),
+    )
+
+    payload = build_monitoring_status_payload({})
+
+    assert payload["health"]["gateway"] == {
+        "status": "unavailable",
+        "metrics": [],
+    }
+
+
+def test_monitoring_status_payload_marks_gateway_snapshot_errors(monkeypatch):
+    from gateway import status as gateway_status
+    from hermes_cli.subcommands.monitoring import build_monitoring_status_payload
+
+    def fail_runtime_read():
+        raise OSError("private path /Users/alice/gateway_state.json")
+
+    monkeypatch.setattr(gateway_status, "read_runtime_status", fail_runtime_read)
+
+    payload = build_monitoring_status_payload({})
+
+    assert payload["health"]["gateway"] == {"status": "error", "metrics": []}
+    assert "alice" not in json.dumps(payload)
+
+
+def test_cmd_monitoring_prints_json_payload(monkeypatch, capsys):
+    from hermes_cli import config as config_module
+    from hermes_cli import main
+    from hermes_cli.subcommands import monitoring
+
+    expected = {
+        "schema_version": 1,
+        "content_free": True,
+        "export": {},
+        "health": {},
+    }
+    monkeypatch.setattr(config_module, "load_config", lambda: {})
+    monkeypatch.setattr(
+        monitoring, "build_monitoring_status_payload", lambda config: expected
+    )
+
+    main.cmd_monitoring(SimpleNamespace(monitoring_action="status", json=True))
+
+    assert json.loads(capsys.readouterr().out) == expected


### PR DESCRIPTION
## What does this PR do?

Adds a machine-readable local health view to the existing monitoring surface:

```bash
hermes monitoring status --json
```

The versioned payload composes the existing gateway and cron health snapshots instead of parsing content-bearing logs or introducing another telemetry path. Existing human-readable output is unchanged.

Privacy is enforced at the CLI boundary: raw install IDs are hashed by the existing snapshot builder, OTLP endpoint values and events are omitted, and metric attributes pass through a fixed content-free allowlist. Gateway and cron collection report independent `available`, `unavailable`, or `error` states without exposing exception text.

## Related Issue

Implements the first local structured-status slice of #88839. Delivery timestamps, refusal counters, and dispatcher instrumentation remain out of scope for this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `--json` to `hermes monitoring status`.
- Reuse existing gateway and cron gauge builders for a versioned local payload.
- Resolve gateway liveness without cleaning stale PID files and avoid reporting a false down state when liveness is unknown.
- Keep snapshot failures independent and content-free.
- Document the local JSON contract and privacy boundary.
- Add parser, payload, privacy, failure-mode, and CLI dispatch tests.

## How to Test

1. Run `hermes monitoring status --json` with the gateway stopped and confirm valid JSON with gateway and cron sections.
2. Start a configured gateway and confirm existing gauge names appear without prompts, messages, raw errors, profile identity, raw install IDs, or OTLP endpoint values.
3. Run the scoped suite and static checks listed below.

Verification:

- `HERMES_PYTHON=/private/tmp/hermes-88839-venv/bin/python scripts/run_tests.sh tests/monitoring -q` — 25 passed, 1 skipped
- `ruff check hermes_cli/subcommands/monitoring.py hermes_cli/main.py tests/monitoring/test_monitoring_cli.py` — passed
- `python scripts/check-windows-footguns.py hermes_cli/subcommands/monitoring.py hermes_cli/main.py tests/monitoring/test_monitoring_cli.py` — passed
- Actual module CLI JSON and existing text output — exit 0 on macOS

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] Searched issue timeline plus open and closed PRs for overlap
- [x] PR contains only this feature slice
- [ ] Full `pytest tests/ -q` — scoped monitoring suite run instead
- [x] Added behavioral tests
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Updated `docs/observability/monitoring.md`
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow changed
- [x] Cross-platform impact considered and Windows footgun scan passed
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

The command emits JSON only when `--json` is supplied; the default text output remains unchanged.