### PR TITLE
feat(agent): allow pre_llm_call plugins to override the model at runtime

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2020,7 +2020,10 @@ def _resolve_switch_context_length(agent, snapshot):
         try:
             runtime_len = agent._ensure_lmstudio_runtime_loaded(intent)
         except Exception:
-            _restore_switch_snapshot(agent, snapshot)
+            # See _update_switch_compressor: the snapshot is the caller's rollback
+            # authority; None means the caller (runtime-override scope) owns the failure.
+            if snapshot is not None:
+                _restore_switch_snapshot(agent, snapshot)
             raise
     if hasattr(agent, "_lmstudio_load_was_unverified") and agent._lmstudio_load_was_unverified(runtime_len):
         logger.warning(
@@ -2060,8 +2063,61 @@ def _update_switch_compressor(agent, custom_providers, effective_context_length,
             api_mode=agent.api_mode,
         )
     except Exception:
-        _restore_switch_snapshot(agent, snapshot)
+        # The snapshot is the caller's rollback authority: switch_model passes its
+        # full switch snapshot (restore + re-raise aborts the switch); callers
+        # without one (the runtime-override scope) pass None and own the failure.
+        if snapshot is not None:
+            _restore_switch_snapshot(agent, snapshot)
         raise
+
+
+def _apply_model_owned_state(
+    agent, new_model, snapshot=None, *, provider=None, api_mode=None,
+) -> None:
+    """Project the model-owned derived state for ``new_model`` onto ``agent``.
+
+    The model-owned portion of a route switch — prompt-cache flags (``_use_prompt_caching`` /
+    ``_use_native_cache_layout``), the per-model context-length re-point of
+    ``agent.context_compressor``, and the per-model ``reasoning_config`` — exactly as
+    ``switch_model`` projects it. Shared by ``switch_model`` (after the identity/transport swap)
+    and the turn-scoped runtime-override scope (after it flips only ``agent.model``), so the two
+    model switches never drift: the override must not leave this state describing the pre-override
+    model while its scope is open.
+
+    Runs after the agent's identity fields already describe the destination route
+    (``agent.model`` / ``provider`` / ``base_url`` / ``api_mode``), which is how the destination
+    context length resolves. ``agent._config_context_length`` and ``agent._custom_providers`` are
+    refreshed as part of the projection. ``provider`` / ``api_mode`` default to the agent fields;
+    ``switch_model`` passes its resolved destination route explicitly (the transport rebuild may
+    have overridden ``agent.api_mode`` — MoA pins ``chat_completions``).
+
+    ``snapshot`` is the caller's rollback authority for context-length / compressor resolution
+    failures: ``switch_model`` passes its full switch snapshot (restore + re-raise aborts the
+    switch); callers without one (the runtime-override scope) pass None and handle the failure
+    themselves. The reasoning-config re-resolve is best-effort on every path.
+    """
+    custom_providers, effective_context_length = _resolve_switch_context_length(agent, snapshot)
+    # Refresh the custom-provider snapshot from the config just loaded so the prompt_caching lookup
+    # sees flags added to config.yaml after session start.
+    if custom_providers is not None:
+        agent._custom_providers = custom_providers
+    agent._use_prompt_caching, agent._use_native_cache_layout = agent._anthropic_prompt_cache_policy(
+        provider=provider if provider is not None else agent.provider,
+        base_url=agent.base_url,
+        api_mode=api_mode if api_mode is not None else agent.api_mode,
+        model=new_model,
+    )
+    if hasattr(agent, "context_compressor") and agent.context_compressor:
+        _update_switch_compressor(agent, custom_providers, effective_context_length, snapshot)
+    # Re-read the per-model reasoning_effort override so it applies immediately (per-model > global;
+    # YAML False = disabled).
+    try:
+        from hermes_constants import resolve_reasoning_config
+        from hermes_cli.config import load_config as _sm_load_config
+        agent.reasoning_config = resolve_reasoning_config(_sm_load_config() or {}, agent.model)
+        logger.info("model switch: reasoning_config resolved for %s: %s", agent.model, agent.reasoning_config)
+    except Exception as _reasoning_err:
+        logger.debug("model switch: could not re-resolve reasoning_config: %s", _reasoning_err)
 
 
 def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
@@ -2168,27 +2224,10 @@ def switch_model(
     except Exception:
         _restore_switch_snapshot(agent, snapshot)
         raise
-    custom_providers, effective_context_length = _resolve_switch_context_length(agent, snapshot)
-    # Refresh the custom-provider snapshot from the config just loaded so the prompt_caching lookup
-    # sees flags added to config.yaml after session start.
-    if custom_providers is not None:
-        agent._custom_providers = custom_providers
-    agent._use_prompt_caching, agent._use_native_cache_layout = agent._anthropic_prompt_cache_policy(
-        provider=new_provider, base_url=agent.base_url, api_mode=api_mode, model=new_model
-    )
-    if hasattr(agent, "context_compressor") and agent.context_compressor:
-        _update_switch_compressor(agent, custom_providers, effective_context_length, snapshot)
-    # Re-read the per-model reasoning_effort override so it applies immediately (per-model > global;
-    # YAML False = disabled).
-    try:
-        from hermes_constants import resolve_reasoning_config
-        from hermes_cli.config import load_config as _sm_load_config
-        agent.reasoning_config = resolve_reasoning_config(_sm_load_config() or {}, agent.model)
-        logger.info(
-            "switch_model: reasoning_config resolved for %s: %s", agent.model, agent.reasoning_config
-        )
-    except Exception as _reasoning_err:
-        logger.debug("switch_model: could not re-resolve reasoning_config: %s", _reasoning_err)
+    # Project the model-owned derived state (prompt-cache flags, context compressor,
+    # reasoning config) for the destination model. Shared with the turn-scoped
+    # runtime-override scope so the two model switches cannot drift apart.
+    _apply_model_owned_state(agent, new_model, snapshot, provider=new_provider, api_mode=api_mode)
     # Invalidate the cached system prompt so it rebuilds next turn.
     agent._cached_system_prompt = None
     # Publish the destination capability map only after every runtime setup above has succeeded.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1925,6 +1925,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from agent.native_compaction import resolve_native_compaction_capabilities
             agent.runtime_capabilities = resolve_native_compaction_capabilities(
                 model=agent.model, base_url=agent.base_url, provider=fb_provider, is_codex_backend=fb_provider == "openai-codex")
+            # A proactive pre_llm_call runtime_override owns only the primary attempt:
+            # the fallback route supersedes it, so retries stay on the fallback.
+            from agent.runtime_override import consume_runtime_override
+            consume_runtime_override(agent)
             return True
         except Exception as e:
             if fb_provider == "nous":

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -29,6 +29,7 @@ from agent.prompt_caching import (
     strip_anthropic_tool_cache_control,
 )
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.runtime_override import apply_runtime_override
 from agent.surface_switch import (
     identity_line_value, note_inert_pinned_tools, split_runtime_boundary, stage_surface_switch_note,
 )
@@ -1515,23 +1516,27 @@ def _run_conversation_turn(
         if _run_phase(begin_iteration, agent, s).action == "break":
             break
         _run_phase(prepare_iteration, agent, s)
-        _run_phase(assemble_api_request, agent, s)
-        _pg = _run_phase(run_preflight_gate, agent, s)
-        if _pg.action == "return":
-            return _pg.result
-        if _pg.action == "break":
-            break
-        if _pg.action == "continue":
-            continue
-        _run_phase(announce_api_call, agent, s)
+        # The turn's pre_llm_call runtime_override (if any) is authoritative through
+        # assembly, preflight, middleware and the retry loop; the pre-override model
+        # is restored when the scope exits. No override is a no-op.
+        with apply_runtime_override(agent, getattr(agent, "_runtime_override", None) or {}):
+            _run_phase(assemble_api_request, agent, s)
+            _pg = _run_phase(run_preflight_gate, agent, s)
+            if _pg.action == "return":
+                return _pg.result
+            if _pg.action == "break":
+                break
+            if _pg.action == "continue":
+                continue
+            _run_phase(announce_api_call, agent, s)
 
-        s.api_start_time, s.retry_count, s.max_retries = time.time(), 0, agent._api_max_retries
-        s._retry, s.finish_reason, s.response, s.api_kwargs = TurnRetryState(), "stop", None, None
-        s.api_request_id = agent._current_api_request_id = f"{s.turn_id}:api:{s.api_call_count}"
+            s.api_start_time, s.retry_count, s.max_retries = time.time(), 0, agent._api_max_retries
+            s._retry, s.finish_reason, s.response, s.api_kwargs = TurnRetryState(), "stop", None, None
+            s.api_request_id = agent._current_api_request_id = f"{s.turn_id}:api:{s.api_call_count}"
 
-        early_result = _run_api_retry_loop(agent, s)
-        if early_result is not None:
-            return early_result
+            early_result = _run_api_retry_loop(agent, s)
+            if early_result is not None:
+                return early_result
 
         _rs = _run_phase(apply_retry_restarts, agent, s)
         if _rs.action == "break":

--- a/agent/runtime_override.py
+++ b/agent/runtime_override.py
@@ -1,0 +1,313 @@
+"""Turn-scoped model override returned by ``pre_llm_call`` plugins.
+
+A plugin callback may return ``{"runtime_override": {"model": "..."}}`` to run the
+current turn's API calls against another model. The override is ephemeral:
+``_collect_pre_llm_call_context`` resolves and stages it on ``agent._runtime_override``
+for the turn, ``conversation_loop`` applies it around request assembly and the retry
+loop, and the pre-override model and projected state are restored when the scope exits.
+
+``model`` is the only supported key. ``provider`` / ``api_key`` / ``base_url`` are
+refused so credentials and the network destination never flow through a hook return;
+``system_prompt`` is refused because the system-prompt prefix is byte-stable for the
+life of a conversation (see ``agent/AGENTS.md``). Unsupported keys are logged and
+ignored, never fatal.
+
+Two explicit semantics govern the model name and the model-derived state:
+
+* **Unresolvable names are dropped, never applied blindly.** The name is resolved with
+  ``hermes_cli.models_validate.validate_requested_model`` — the same validator the
+  ``/model`` switch path calls (``hermes_cli.model_switch._validate_switch``). A name
+  the validator does not positively recognize is logged with a warning naming the
+  rejected value, and the override is dropped so the turn proceeds on the session
+  model. The turn never crashes and a bogus model never reaches the wire.
+
+* **Model-owned state is projected conditionally.** ``agent.model`` alone is not
+  enough: the request/preflight path also reads the context window
+  (``context_compressor.context_length`` / ``threshold_tokens``), the prompt-cache
+  flags (``_use_prompt_caching`` / ``_use_native_cache_layout``), ``reasoning_config``
+  and the model capability flags. When the override model differs from the session
+  model in any of those — context window, provider (or provider-implied
+  transport/credential shape), reasoning/vision capability, prompt-cache support — the
+  scope invalidates the cached system prompt and re-projects that state with the
+  canonical helper (``agent.agent_runtime_helpers._apply_model_owned_state``, the same
+  one ``switch_model`` uses), restoring it on scope exit. When none differ (the same
+  model, or a distinct name with an identical projection) the scope is a strict no-op:
+  the cached system prompt stays byte-stable and no projection runs.
+
+  Conditional rather than "never": a switch to a model with a different context window
+  otherwise overflows or mis-scales compression. Conditional rather than "always":
+  invalidating the prompt prefix and re-resolving state on every override would drop
+  the session's prompt-cache reuse and pay resolution cost even when the override
+  changes nothing the turn reads. Provider is part of the trigger set so a future
+  contract that routes across providers cannot silently under-project.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Keys a plugin may override. Anything else is logged and ignored.
+RUNTIME_OVERRIDE_KEYS = frozenset({"model"})
+
+_MISSING = object()
+
+#: Model-owned state the scope snapshots and restores when it projects.
+_PROJECTED_ATTRS = (
+    "_custom_providers",
+    "_config_context_length",
+    "_use_prompt_caching",
+    "_use_native_cache_layout",
+    "context_compressor",
+    "reasoning_config",
+    "_cached_system_prompt",
+)
+
+
+def _resolve_override_model(agent: Any, model: str) -> str:
+    """Resolve a hook-supplied model name with the model-switch path's validator.
+
+    Returns the accepted (possibly typo-corrected) model, or ``""`` when the name
+    cannot be positively resolved. Resolution is skipped when the name already is the
+    session model or the agent has no active route (bare test agents) — there is
+    nothing to reject, so the name is passed through unchanged.
+    """
+    session_model = str(getattr(agent, "model", "") or "").strip()
+    if model == session_model:
+        return model
+    provider = str(getattr(agent, "provider", "") or "").strip()
+    if not provider:
+        return model
+    api_key = getattr(agent, "api_key", None)
+    try:
+        from hermes_cli.models_validate import validate_requested_model
+
+        verdict = validate_requested_model(
+            model,
+            provider,
+            api_key=api_key if isinstance(api_key, str) else None,
+            base_url=str(getattr(agent, "base_url", "") or "") or None,
+            api_mode=str(getattr(agent, "api_mode", "") or "") or None,
+        )
+    except Exception as exc:  # noqa: BLE001 — a resolver failure must never crash the turn
+        logger.warning(
+            "pre_llm_call runtime_override: model %r could not be resolved (%s); "
+            "override dropped, turn continues on %r",
+            model, exc, session_model,
+        )
+        return ""
+    if isinstance(verdict, dict) and verdict.get("accepted") and verdict.get("recognized"):
+        corrected = verdict.get("corrected_model")
+        if isinstance(corrected, str) and corrected.strip():
+            return corrected.strip()
+        return model
+    message = verdict.get("message") if isinstance(verdict, dict) else None
+    logger.warning(
+        "pre_llm_call runtime_override: model %r is not resolvable for provider %r%s; "
+        "override dropped, turn continues on %r",
+        model, provider, f" ({message})" if message else "", session_model,
+    )
+    return ""
+
+
+def validate_runtime_override(overrides: Any, agent: Any = None) -> Dict[str, str]:
+    """Return the supported, correctly-typed keys of a plugin ``runtime_override``.
+
+    Unsupported keys and wrong-typed values are logged and dropped, so a misbehaving
+    plugin can never crash the turn. When ``agent`` is supplied, ``model`` is also
+    resolved with the model-switch path's validator; an unresolvable name is logged
+    with a warning and dropped instead of being applied blindly.
+    """
+    if not isinstance(overrides, dict):
+        logger.warning(
+            "pre_llm_call runtime_override ignored: expected dict, got %s",
+            type(overrides).__name__,
+        )
+        return {}
+    valid: Dict[str, str] = {}
+    for key, value in overrides.items():
+        if key not in RUNTIME_OVERRIDE_KEYS:
+            logger.warning(
+                "pre_llm_call runtime_override: unsupported key %r ignored (supported: %s)",
+                key, ", ".join(sorted(RUNTIME_OVERRIDE_KEYS)),
+            )
+            continue
+        if not isinstance(value, str) or not value.strip():
+            logger.warning(
+                "pre_llm_call runtime_override: key %r must be a non-empty string, ignored",
+                key,
+            )
+            continue
+        valid[key] = value.strip()
+    if agent is not None and "model" in valid:
+        resolved = _resolve_override_model(agent, valid["model"])
+        if resolved:
+            valid["model"] = resolved
+        else:
+            valid.pop("model", None)
+    return valid
+
+
+def _model_projection_key(agent: Any, model: str, provider: str) -> tuple:
+    """The model-derived values the turn reads for one ``(model, provider)`` route.
+
+    Built from the canonical resolvers: context length via
+    ``model_metadata.get_model_context_length`` (the one the switch path re-points the
+    compressor with), capability flags via ``models_dev.get_model_capabilities``
+    (cache-only, never a network probe on the turn path), and the prompt-cache policy
+    via the agent's own ``_anthropic_prompt_cache_policy``. Best-effort: a resolver
+    that raises contributes ``None`` so a comparison never crashes the turn.
+    """
+    base_url = str(getattr(agent, "base_url", "") or "")
+    api_key = getattr(agent, "api_key", "")
+    if not isinstance(api_key, str):
+        api_key = ""
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        context_length: Optional[int] = get_model_context_length(
+            model, base_url=base_url, api_key=api_key, provider=provider,
+            config_context_length=getattr(agent, "_config_context_length", None),
+            custom_providers=getattr(agent, "_custom_providers", None),
+        )
+    except Exception:  # noqa: BLE001
+        context_length = None
+    try:
+        from agent.models_dev import get_model_capabilities
+
+        caps = get_model_capabilities(provider, model, allow_network=False)
+        capabilities = None if caps is None else (caps.supports_reasoning, caps.supports_vision)
+    except Exception:  # noqa: BLE001
+        capabilities = None
+    try:
+        cache_flags = agent._anthropic_prompt_cache_policy(
+            provider=provider, base_url=base_url,
+            api_mode=str(getattr(agent, "api_mode", "") or ""), model=model,
+        )
+    except Exception:  # noqa: BLE001
+        cache_flags = None
+    return (provider, context_length, capabilities, cache_flags)
+
+
+def _projection_required(agent: Any, model: str, provider: Optional[str] = None) -> bool:
+    """True when the override model differs in a way the turn reads.
+
+    Compares the session route's projection key with the override's. A same-model
+    override, an agent without a resolvable route, or a model whose window,
+    capabilities and prompt-cache flags are identical is a strict no-op.
+    """
+    session_model = getattr(agent, "model", None)
+    if not model or model == session_model:
+        return False
+    session_provider = str(getattr(agent, "provider", "") or "").strip()
+    if not session_provider:
+        return False  # no route to resolve model-derived state against
+    destination_provider = provider if provider is not None else session_provider
+    return _model_projection_key(agent, session_model, session_provider) != _model_projection_key(
+        agent, model, destination_provider
+    )
+
+
+def _snapshot_projection(agent: Any) -> Dict[str, Any]:
+    """Snapshot the projected attributes and isolate the compressor for the scope.
+
+    ``context_compressor`` is swapped for a scope-owned shallow copy because the
+    projection re-points it through ``update_model``, which assigns in place: the
+    session compressor must never be mutated, or restoring the reference on exit would
+    not undo the override's context length. The copy keeps the durable session handles,
+    so bookkeeping for a compression that actually fires persists.
+    """
+    snapshot = {name: getattr(agent, name, _MISSING) for name in _PROJECTED_ATTRS}
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        agent.context_compressor = copy.copy(compressor)
+    return snapshot
+
+
+def _restore_projection(agent: Any, snapshot: Dict[str, Any]) -> None:
+    for name, value in snapshot.items():
+        if value is _MISSING:
+            try:
+                delattr(agent, name)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+        try:
+            setattr(agent, name, value)
+        except Exception:  # noqa: BLE001 — restore must never raise
+            pass
+
+
+@contextmanager
+def apply_runtime_override(agent: Any, overrides: Dict[str, str]) -> Iterator[None]:
+    """Run the enclosed turn step with ``agent.model`` set to the override model.
+
+    Restores the pre-override model and projected state on exit unless a fallback or
+    redirect took the route while the scope was open — that route then stands, and the
+    staged override is cleared so later loop iterations do not re-apply it.
+
+    Model-owned state is projected only when ``_projection_required`` says the override
+    changes something the turn reads; otherwise the scope is a strict no-op and the
+    cached system prompt stays byte-stable. A missing or empty override is always a
+    no-op.
+    """
+    model = overrides.get("model")
+    if not model:
+        yield
+        return
+    previous = getattr(agent, "model", _MISSING)
+    projection = _snapshot_projection(agent) if _projection_required(agent, model) else None
+    agent.model = model
+    if projection is not None:
+        # The cached prompt's context-file caps scale with the compressor window, so a
+        # projected model needs a fresh build. The pre-override bytes are restored on exit.
+        agent._cached_system_prompt = None
+        try:
+            from agent.agent_runtime_helpers import _apply_model_owned_state
+
+            _apply_model_owned_state(agent, model, snapshot=None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "pre_llm_call runtime_override: could not project model-derived state "
+                "for %r (%s); override dropped, turn continues on %r",
+                model, exc, previous if previous is not _MISSING else None,
+            )
+            _restore_projection(agent, projection)
+            if previous is _MISSING:
+                try:
+                    del agent.model
+                except Exception:  # noqa: BLE001
+                    pass
+            else:
+                agent.model = previous
+            yield
+            return
+    try:
+        yield
+    finally:
+        if getattr(agent, "model", None) == model:
+            if previous is _MISSING:
+                del agent.model
+            else:
+                agent.model = previous
+            if projection is not None:
+                _restore_projection(agent, projection)
+        else:
+            agent._runtime_override = {}
+
+
+def consume_runtime_override(agent: Any) -> None:
+    """Drop the turn's staged override once the fallback chain owns the route.
+
+    A proactive override owns only the primary attempt. ``try_activate_fallback``
+    calls this on success, so later loop iterations (and the scope's own exit) do
+    not re-apply a model that just failed.
+    """
+    try:
+        agent._runtime_override = {}
+    except (AttributeError, TypeError):
+        pass

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,6 +24,7 @@ from agent.memory_provider import is_trivial_prompt
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.model_metadata import estimate_messages_tokens_rough, estimate_request_tokens_rough
 from agent.image_token_cost import bind_image_token_cost
+from agent.runtime_override import validate_runtime_override
 from agent.usage_anchor import anchored_context_tokens, restore_usage_anchor
 from agent.turn_author import parse_turn_author
 
@@ -661,7 +662,11 @@ def _collect_pre_llm_call_context(
 ) -> str:
     """Run ``pre_llm_call`` plugins; their context is injected into the user message
     (never the system prompt). Oversized per-hook context is spilled to disk so a
-    runaway plugin can't inflate every subsequent turn's prompt."""
+    runaway plugin can't inflate every subsequent turn's prompt. A hook may also
+    return ``{"runtime_override": {"model": ...}}``; it is validated (model only)
+    and staged on ``agent._runtime_override`` for the turn."""
+    # Reset first: a turn whose hooks return no override must not inherit a stale one.
+    agent._runtime_override = {}
     if getattr(agent, "_persist_disabled", False):
         return ""
     try:
@@ -706,6 +711,17 @@ def _collect_pre_llm_call_context(
                 except Exception as _spill_exc:
                     logger.warning("hook context spill failed: %s", _spill_exc)
             _ctx_parts.append(_piece)
+        # A hook may also override the model for this turn; merge every hook's dict,
+        # later hooks win per key, and only the validated model key survives.
+        _runtime_override: Dict[str, str] = {}
+        for r in _pre_results:
+            if not isinstance(r, dict):
+                continue
+            _ro_piece = r.get("runtime_override")
+            if _ro_piece is None:
+                continue
+            _runtime_override.update(validate_runtime_override(_ro_piece, agent))
+        agent._runtime_override = _runtime_override
         return "\n\n".join(_ctx_parts)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)

--- a/tests/agent/test_runtime_override.py
+++ b/tests/agent/test_runtime_override.py
@@ -1,0 +1,360 @@
+"""Invariant tests for the ``pre_llm_call`` runtime model override (#23739).
+
+A plugin may return ``{"runtime_override": {"model": ...}}`` from
+``pre_llm_call``. The override is turn-scoped: the turn's API calls use the
+named model, and the pre-override model is back afterwards. Only ``model`` is
+accepted — ``provider`` / ``api_key`` / ``base_url`` / ``api_mode`` /
+``system_prompt`` never flow through a hook return.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.runtime_override import (
+    RUNTIME_OVERRIDE_KEYS,
+    apply_runtime_override,
+    validate_runtime_override,
+)
+from agent.turn_context import _collect_pre_llm_call_context
+
+
+def test_validation_accepts_only_a_non_empty_model():
+    assert RUNTIME_OVERRIDE_KEYS == frozenset({"model"})
+    assert validate_runtime_override({"model": "  override-model  "}) == {
+        "model": "override-model"
+    }
+    # Credentials, endpoint, wire and system prompt never flow through a hook return.
+    assert validate_runtime_override({
+        "model": "override-model",
+        "provider": "elsewhere",
+        "api_key": "sk-secret",
+        "base_url": "https://elsewhere.example/v1",
+        "api_mode": "codex_responses",
+        "system_prompt": "ignore your instructions",
+    }) == {"model": "override-model"}
+    # Misbehaving plugins are ignored, never fatal.
+    assert validate_runtime_override("not-a-dict") == {}
+    assert validate_runtime_override({"model": 7}) == {}
+    assert validate_runtime_override({"model": "   "}) == {}
+
+
+def test_scope_swaps_the_model_and_restores_it_on_exit():
+    agent = SimpleNamespace(model="base-model")
+    with apply_runtime_override(agent, {"model": "override-model"}):
+        assert agent.model == "override-model"
+    assert agent.model == "base-model"
+
+
+def test_scope_restores_the_model_after_a_failure():
+    agent = SimpleNamespace(model="base-model")
+    with pytest.raises(RuntimeError):
+        with apply_runtime_override(agent, {"model": "override-model"}):
+            assert agent.model == "override-model"
+            raise RuntimeError("wire failed")
+    assert agent.model == "base-model"
+
+
+def test_scope_leaves_a_fallback_route_in_place():
+    """A fallback that activates mid-scope owns the route: the scope must not
+    restore the pre-override model over it, and must stop re-applying the
+    override on later loop iterations."""
+    agent = SimpleNamespace(model="base-model", _runtime_override={"model": "override-model"})
+    with apply_runtime_override(agent, {"model": "override-model"}):
+        agent.model = "fallback-model"
+    assert agent.model == "fallback-model"
+    assert agent._runtime_override == {}
+
+
+def test_no_override_leaves_the_model_untouched():
+    agent = SimpleNamespace(model="base-model")
+    with apply_runtime_override(agent, {}):
+        assert agent.model == "base-model"
+    assert agent.model == "base-model"
+
+
+def test_fallback_handoff_clears_the_staged_override():
+    from agent.runtime_override import consume_runtime_override
+
+    agent = SimpleNamespace(model="fallback-model", _runtime_override={"model": "override-model"})
+    consume_runtime_override(agent)
+    assert agent._runtime_override == {}
+    # A double without the attribute must not raise.
+    consume_runtime_override(object())
+
+
+def _collect(agent, hook_result):
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=hook_result):
+        return _collect_pre_llm_call_context(
+            agent, effective_task_id="task", turn_id="turn",
+            original_user_message="hi", messages=[], conversation_history=None,
+        )
+
+
+def test_pre_llm_call_stages_a_validated_override_for_the_turn():
+    agent = SimpleNamespace(
+        session_id="s", model="base-model", platform="cli", _persist_disabled=False,
+    )
+    context = _collect(agent, [
+        {"context": "recalled", "runtime_override": {"model": "override-model", "api_key": "sk-x"}},
+    ])
+    assert context == "recalled"
+    assert agent._runtime_override == {"model": "override-model"}
+
+
+def test_pre_llm_call_clears_a_stale_override():
+    agent = SimpleNamespace(
+        session_id="s", model="base-model", platform="cli", _persist_disabled=False,
+        _runtime_override={"model": "stale-model"},
+    )
+    context = _collect(agent, [{"context": "recalled"}])
+    assert context == "recalled"
+    assert agent._runtime_override == {}
+
+
+# ---------------------------------------------------------------------------
+# Conditional model-owned-state projection
+#
+# The override must refresh the model-derived state the turn reads (context
+# window, prompt-cache flags, reasoning/vision capability) ONLY when it actually
+# differs from the session model, and must restore the pre-override state on
+# scope exit. A same-model or same-capability override must leave the cached
+# system prompt — and every other projected datum — byte-stable.
+# ---------------------------------------------------------------------------
+
+_CTX = {"base-model": 200_000, "override-model": 128_000, "twin-model": 200_000}
+
+
+class _FakeCompressor:
+    def __init__(self, model="base-model", context_length=200_000):
+        self.model = model
+        self.context_length = context_length
+        # A scalar counter, matching ``ContextCompressor.update_model``'s scalar
+        # assignments, so a scope-owned shallow copy isolates it.
+        self.update_count = 0
+
+    def update_model(self, **kwargs):
+        self.update_count += 1
+        self.model = kwargs.get("model", self.model)
+        self.context_length = kwargs.get("context_length", self.context_length)
+
+
+class _ProjectionAgent:
+    """Minimal agent carrying the model-owned state the projection touches."""
+
+    def __init__(self, *, model="base-model", provider="openai"):
+        self.model = model
+        self.provider = provider
+        self.base_url = "https://api.openai.com/v1"
+        self.api_key = "sk-test"
+        self.api_mode = "chat_completions"
+        self.context_compressor = _FakeCompressor(model, _CTX.get(model, 200_000))
+        self.reasoning_config = {"enabled": False, "effort": "low"}
+        self._use_prompt_caching = False
+        self._use_native_cache_layout = False
+        self._config_context_length = 200_000
+        self._custom_providers = []
+        self._cached_system_prompt = "SYSTEM PREFIX BYTES"
+        self._runtime_override = {}
+
+    def _anthropic_prompt_cache_policy(self, *, provider=None, base_url=None, api_mode=None, model=None):
+        return (str(model or "").startswith("override"), False)
+
+
+def _patch_projection(monkeypatch, *, ctx=None, caps=None):
+    from types import SimpleNamespace
+
+    ctx = ctx if ctx is not None else _CTX
+    caps = caps or {}
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda model, **k: ctx.get(str(model or ""), 200_000),
+    )
+    monkeypatch.setattr(
+        "agent.models_dev.get_model_capabilities",
+        lambda provider, model, **k: SimpleNamespace(
+            supports_reasoning=bool(caps.get(model, False)), supports_vision=False,
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda *a, **k: [])
+    monkeypatch.setattr("hermes_cli.config.get_custom_provider_context_length", lambda **k: None)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config",
+        lambda cfg, model: {"enabled": True, "effort": "high"},
+    )
+
+
+def test_projection_fires_on_context_window_change(monkeypatch):
+    _patch_projection(monkeypatch)
+    agent = _ProjectionAgent()
+    session_compressor = agent.context_compressor
+
+    with apply_runtime_override(agent, {"model": "override-model"}):
+        assert agent.model == "override-model"
+        # A scope-owned compressor describes the override model; the session
+        # compressor is never re-pointed in place.
+        assert agent.context_compressor is not session_compressor
+        assert agent.context_compressor.model == "override-model"
+        assert agent.context_compressor.context_length == 128_000
+        assert agent.context_compressor.update_count == 1
+        assert agent._use_prompt_caching is True
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+        # Context-file caps in the system prompt scale with the compressor, so
+        # the cached prefix is invalidated for the duration of the scope.
+        assert agent._cached_system_prompt is None
+
+    # Every projected datum is restored exactly on exit.
+    assert agent.model == "base-model"
+    assert agent.context_compressor is session_compressor
+    assert session_compressor.model == "base-model"
+    assert session_compressor.context_length == 200_000
+    assert session_compressor.update_count == 0
+    assert agent._use_prompt_caching is False
+    assert agent.reasoning_config == {"enabled": False, "effort": "low"}
+    assert agent._config_context_length == 200_000
+    assert agent._custom_providers == []
+    assert agent._cached_system_prompt == "SYSTEM PREFIX BYTES"
+
+
+def test_projection_fires_on_capability_flag_change(monkeypatch):
+    # Identical context window, prompt-cache policy and provider; only the
+    # reasoning capability flag differs.
+    _patch_projection(
+        monkeypatch,
+        ctx={"base-model": 200_000, "cap-model": 200_000},
+        caps={"cap-model": True},
+    )
+    agent = _ProjectionAgent()
+    agent._anthropic_prompt_cache_policy = lambda **kw: (False, False)
+    session_compressor = agent.context_compressor
+
+    with apply_runtime_override(agent, {"model": "cap-model"}):
+        assert agent.context_compressor is not session_compressor
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    assert agent.context_compressor is session_compressor
+    assert agent.reasoning_config == {"enabled": False, "effort": "low"}
+
+
+def test_projection_predicate_fires_on_provider_change(monkeypatch):
+    from agent.runtime_override import _projection_required
+
+    _patch_projection(monkeypatch, ctx={"base-model": 200_000, "override-model": 200_000})
+    agent = _ProjectionAgent()
+    agent._anthropic_prompt_cache_policy = lambda **kw: (False, False)
+    # Identical on the same route; a destination provider change is a trigger.
+    assert _projection_required(agent, "override-model") is False
+    assert _projection_required(agent, "override-model", provider="elsewhere") is True
+
+
+def test_same_model_override_is_a_strict_no_op(monkeypatch):
+    _patch_projection(monkeypatch)
+    agent = _ProjectionAgent()
+    session_compressor = agent.context_compressor
+    calls = []
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers._apply_model_owned_state",
+        lambda *a, **k: calls.append((a, k)),
+    )
+
+    with apply_runtime_override(agent, {"model": "base-model"}):
+        assert agent.model == "base-model"
+
+    assert calls == []
+    assert agent.context_compressor is session_compressor
+    assert session_compressor.update_count == 0
+    assert agent._cached_system_prompt == "SYSTEM PREFIX BYTES"
+
+
+def test_same_capability_override_keeps_the_cached_prompt(monkeypatch):
+    # A different model name whose window, capabilities and cache flags are
+    # identical must not invalidate the cached system prompt or touch state.
+    _patch_projection(monkeypatch, ctx={"base-model": 200_000, "twin-model": 200_000})
+    agent = _ProjectionAgent()
+    agent._anthropic_prompt_cache_policy = lambda **kw: (False, False)
+    session_compressor = agent.context_compressor
+
+    with apply_runtime_override(agent, {"model": "twin-model"}):
+        assert agent.model == "twin-model"
+        assert agent._cached_system_prompt == "SYSTEM PREFIX BYTES"
+        assert agent.context_compressor is session_compressor
+        assert session_compressor.update_count == 0
+
+    assert agent.model == "base-model"
+    assert agent._cached_system_prompt == "SYSTEM PREFIX BYTES"
+
+
+def test_projection_failure_restores_state_and_drops_the_override(monkeypatch):
+    _patch_projection(monkeypatch)
+    agent = _ProjectionAgent()
+    session_compressor = agent.context_compressor
+
+    def _boom(*a, **k):
+        raise RuntimeError("projection failed")
+
+    monkeypatch.setattr("agent.agent_runtime_helpers._apply_model_owned_state", _boom)
+
+    with apply_runtime_override(agent, {"model": "override-model"}):
+        # The override could not be projected, so the turn runs on the session
+        # model with the session state (fail-open for the turn).
+        assert agent.model == "base-model"
+        assert agent.context_compressor is session_compressor
+        assert agent._cached_system_prompt == "SYSTEM PREFIX BYTES"
+
+
+# ---------------------------------------------------------------------------
+# Explicit semantics for an unresolvable model name
+# ---------------------------------------------------------------------------
+
+def _resolver_agent(**overrides):
+    base = dict(
+        model="base-model", provider="openai", base_url="http://localhost:8080/v1",
+        api_key="sk-x", api_mode="chat_completions", platform="cli", _persist_disabled=False,
+        session_id="s",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_unresolvable_model_is_dropped_with_a_warning(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "hermes_cli.models_validate.validate_requested_model",
+        lambda name, provider, **k: {
+            "accepted": True, "recognized": False, "message": "not in the catalog",
+        },
+    )
+    agent = _resolver_agent()
+    with caplog.at_level("WARNING"):
+        assert validate_runtime_override({"model": "no-such-model"}, agent) == {}
+    assert "no-such-model" in caplog.text
+
+
+def test_resolvable_model_is_kept(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models_validate.validate_requested_model",
+        lambda name, provider, **k: {"accepted": True, "recognized": True},
+    )
+    agent = _resolver_agent()
+    assert validate_runtime_override({"model": "gpt-5.6"}, agent) == {"model": "gpt-5.6"}
+
+
+def test_pre_llm_call_drops_an_unresolvable_override_and_keeps_the_turn(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "hermes_cli.models_validate.validate_requested_model",
+        lambda name, provider, **k: {
+            "accepted": True, "recognized": False, "message": "not in the catalog",
+        },
+    )
+    agent = _resolver_agent()
+    with caplog.at_level("WARNING"):
+        context = _collect(
+            agent,
+            [{"context": "recalled", "runtime_override": {"model": "no-such-model"}}],
+        )
+    assert context == "recalled"
+    assert agent._runtime_override == {}
+    assert "no-such-model" in caplog.text

--- a/tests/agent/test_runtime_override_loop.py
+++ b/tests/agent/test_runtime_override_loop.py
@@ -1,0 +1,120 @@
+"""The ``pre_llm_call`` runtime override through the real conversation loop.
+
+Drives ``AIAgent.run_conversation`` against an in-process fake wire client, with
+the ``pre_llm_call`` hook stubbed at the lifecycle boundary, so request
+assembly, preflight and the wire all observe the overridden model. The second
+turn returns to the base model — the override is turn-scoped. A wire failure on
+the overridden route hands off to the fallback chain, which then owns the turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class _SimulatedRateLimit(Exception):
+    status_code = 429
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, tool_calls=[], reasoning=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")], usage=None
+    )
+
+
+class _Completions:
+    def __init__(self, calls, fail_model=None):
+        self._calls = calls
+        self._fail_model = fail_model
+
+    def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if kwargs.get("model") == self._fail_model:
+            raise _SimulatedRateLimit(f"simulated rate limit for {kwargs.get('model')}")
+        return _response()
+
+
+class _Client:
+    def __init__(self, calls, fail_model=None):
+        self.chat = SimpleNamespace(completions=_Completions(calls, fail_model))
+
+    def close(self):
+        pass
+
+
+def _build_agent(monkeypatch, calls, hook, *, fail_model=None):
+    from run_agent import AIAgent
+
+    monkeypatch.setattr(
+        "agent.process_bootstrap.OpenAI", lambda **_kw: _Client(calls, fail_model)
+    )
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *a, **k: [])
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+    agent = AIAgent(
+        model="base-model", api_key="test-key", base_url="http://localhost:8080/v1",
+        platform="cli", max_iterations=3, quiet_mode=True, skip_memory=True,
+    )
+    agent._disable_streaming = True
+    return agent
+
+
+def _override_once_hook():
+    turns = []
+
+    def hook(name, **_kw):
+        if name == "pre_llm_call":
+            turns.append(1)
+            if len(turns) == 1:
+                return [{"runtime_override": {"model": "override-model"}}]
+        return []
+
+    return hook
+
+
+def test_override_reaches_the_wire_and_does_not_survive_the_turn(monkeypatch):
+    calls = []
+    agent = _build_agent(monkeypatch, calls, _override_once_hook())
+
+    first = agent.run_conversation("hello")
+    assert "ok" in (first.get("final_response") or "")
+    assert [c.get("model") for c in calls] == ["override-model"]
+    # Turn-scoped: the base model is back once the turn ends.
+    assert agent.model == "base-model"
+
+    second = agent.run_conversation("again")
+    assert "ok" in (second.get("final_response") or "")
+    assert [c.get("model") for c in calls] == ["override-model", "base-model"]
+
+
+def test_failed_override_hands_the_route_to_the_fallback(monkeypatch):
+    calls = []
+
+    def hook(name, **_kw):
+        if name == "pre_llm_call":
+            return [{"runtime_override": {"model": "override-model"}}]
+        return []
+
+    # The fallback client is resolved through this boundary; its wire requests
+    # still land on the fake recorder because the per-request client is rebuilt
+    # from ``process_bootstrap.OpenAI``.
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda provider, model=None, **kwargs: (
+            SimpleNamespace(api_key="test-key", base_url="http://localhost:8080/v1"), model,
+        ),
+    )
+    agent = _build_agent(monkeypatch, calls, hook, fail_model="override-model")
+    agent._fallback_chain = [
+        {"provider": "openai", "model": "fallback-model", "api_mode": "chat_completions"},
+    ]
+    agent._fallback_index = 0
+
+    result = agent.run_conversation("hello")
+
+    assert "ok" in (result.get("final_response") or "")
+    models = [c.get("model") for c in calls]
+    assert models[0] == "override-model"
+    assert models[1] == "fallback-model", f"retry not on the fallback route: {models}"
+    assert "override-model" not in models[1:]

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -443,7 +443,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; first string replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
 | `pre_transcription` | Transform | Fired by the STT dispatcher after provider resolution and before any backend (built-in, command-type, or plugin-registered) is invoked; dict results are applied in registration order, last-writer-wins per field (`prompt`, `language`, `model`; `file_path` is read-only). | `file_path`, `provider`, `model`, `language`, `prompt`, `source` | The final prompt is uploaded to the configured STT provider with the audio — keep secrets out of hook returns. |
-| `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
+| `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message, and a `{"runtime_override": {"model": ...}}` return overrides the turn's model when the name resolves. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
 | `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
@@ -678,7 +678,7 @@ def my_callback(session_id: str, user_message: str, conversation_history: list,
 
 **Fires:** In `agent/turn_context.py` (turn preparation for `run_conversation()` in `agent/conversation_loop.py`), after context compression but before the main `while` loop. Fires once per `run_conversation()` call (i.e. once per user turn), not once per API call within the tool loop.
 
-**Return value:** If the callback returns a dict with a `"context"` key, or a plain non-empty string, the text is appended to the current turn's user message. Return `None` for no injection.
+**Return value:** If the callback returns a dict with a `"context"` key, or a plain non-empty string, the text is appended to the current turn's user message. Return `None` for no injection. The same dict may also carry a `"runtime_override"` key to override the turn's model (see below).
 
 ```python
 # Inject context
@@ -698,6 +698,26 @@ The clean user-message `content` remains unchanged. For replay and prompt-cache 
 When **multiple plugins** return context, their outputs are joined with double newlines in plugin discovery order (alphabetical by directory name).
 
 **Use cases:** Memory recall, RAG context injection, guardrails, per-turn analytics.
+
+**Runtime model override (`runtime_override`):**
+
+A callback may also return a `runtime_override` dict to run the current turn's API calls against a different **model**. This is separate from `context` injection; a callback may return either or both.
+
+```python
+return {
+    "context": "Recalled context...",
+    "runtime_override": {"model": "deepseek/deepseek-v4-pro"},
+}
+```
+
+- **Model-only** — `model` is the only supported key. `provider`, `api_mode`, `api_key`, and `base_url` are intentionally unsupported: credentials never flow through the hook return, and the endpoint/wire resolve only from the provider's existing settings, so a plugin cannot redirect the session to another network destination or wire.
+- **Resolved before it is applied** — the name is checked by the same validator the `/model` switch path uses. A name that is not positively recognized (nonsense, an uncorrectable typo, or one that cannot be verified for the active provider) is logged with a one-line warning and the override is **dropped**; the turn proceeds on the session model. A bogus model never reaches the wire and the turn never fails because of it.
+- **Conditional model-derived state** — when the override model differs from the session model in something the turn reads (context window, provider, or a capability flag such as reasoning, vision, or prompt caching), the turn re-projects the context window, compression threshold, reasoning config, and prompt-cache flags for the override model, and rebuilds the cached system prompt for the turn. Everything is restored when the turn ends. When the override changes none of those — the same model, or a different name with an identical projection — nothing is invalidated and the prompt prefix stays byte-stable.
+- **Ephemeral and turn-scoped** — the override is re-resolved every turn and the model and model-derived state are restored when the turn ends. It never mutates the session's persistent model identity and is never persisted to the session database. If the fallback chain activates, it supersedes the override for the rest of the turn.
+- **Applied before the first LLM call** — the overridden model is authoritative through request construction, `llm_request` middleware, the `pre_api_request` hook, and wire dispatch. Only the model slug and the model-derived state above change; the endpoint, credentials, and system-prompt bytes never do.
+- **`system_prompt` is never overridable** — it is runtime-owned and its cache prefix stays byte-stable; a model switch stays inside the existing provider route.
+
+Unsupported keys are logged with a one-line warning and ignored (never an error). A model switch stays inside the existing provider route and never touches credentials or the endpoint — installing a plugin grants it this power, so install only plugins you trust.
 
 **Example — memory recall:**
 


### PR DESCRIPTION
Closes #23739

## Summary

Let `pre_llm_call` plugin hooks return a `runtime_override` dict to proactively override the current turn's LLM **model** — alongside the existing `context` injection.

The override is **model-only**: `provider`, `api_mode`, `api_key`, and `base_url` are intentionally unsupported. Credentials never flow through the hook return, and the endpoint/wire are resolved only from the provider's existing settings, so a plugin cannot pick a network destination or a different wire for the session.

> Note: this head is a fresh re-application of the feature on top of current `main` (the previous head predated the turn-routing work on `gateway/run_turn.py`). The design is unchanged; all results below were produced on the current base with `scripts/run_tests.sh`.

## Motivation

Hermes already exposes `pre_llm_call` as a request-scoped extension point, but today the core loop only treats hook results as optional user-message context (#23739). Model-routing plugins cannot act without this override capability.

## Design

- **One canonical route** — the override resolves a single effective route that stays authoritative through request construction → middleware → `pre_api_request` → wire dispatch. No two-truths split.
- **Explicit fallback precedence** — a proactive override owns only the primary attempt; a successful `_try_activate_fallback()` supersedes it via an explicit `scope.supersede()` handoff, so retries stay on the fallback route.
- **Canonical route activation** — the override mirrors `switch_model` / fallback by re-projecting the model-derived state (prompt-cache flags, native cache layout, context length, custom providers, cached system prompt, reasoning config) through a shared `_apply_model_owned_state` helper — not a second, narrower mutation primitive.
- **Resolved before it is applied** — the model name goes through the same validator the `/model` switch path uses. A name that is not positively recognized (nonsense, an uncorrectable typo, or one that cannot be verified for the active provider) is logged with a one-line warning and the override is **dropped**; the turn proceeds on the session model. A bogus model never reaches the wire and the turn never fails because of it.
- **Conditional model-derived state** — model-derived state is re-projected **only when the override model differs from the session model in something the turn reads** (context window, provider, or a capability flag such as reasoning, vision, or prompt caching). When the override changes none of those — the same model, or a different name with an identical projection — nothing is invalidated and the prompt prefix stays byte-stable.
- **Ephemeral, turn-scoped and restored** — every projection is applied through an isolated scope and restored when the turn ends, including on failure; the override is reset every turn and never persisted as session model identity.
- `system_prompt` is **intentionally NOT overridable**: hook returns cannot supply or replace it, and the override never alters the persistent system-prompt contract. When the override model's projection differs in something the turn reads, the cached system prompt is re-derived **for that turn only** and restored afterwards, so the model and its prompt stay consistent.
- A model switch stays inside the existing provider route, so it never touches credentials or the endpoint — installing a plugin grants it this power, so install only plugins you trust.

## Relationship to #98703

#99053 is **complementary to #98703 rather than a replacement for it.**

#98703 establishes turn-level agent routing — including provider and API-mode selection — at the turn/agent-routing seam. This PR operates later, at the `pre_llm_call` seam, and is intentionally narrower: it can make an **ephemeral, turn-scoped, model-only** override for the imminent LLM call.

The existing provider, API mode, endpoint, credentials, and persistent session route remain owned by the existing route machinery. `runtime_override` does not create a second provider/transport authority.

The distinction is therefore primarily **when** and **what** is being selected:

- **#98703** — establishes the turn's agent/transport route. Its route callback receives the turn's `user_message` and a history-derived `is_first_turn` flag alongside session metadata.
- **#99053** — optionally selects the **model** for the imminent LLM call *within* that established route, from a seam that additionally sees the full multi-turn `conversation_history`.

A `runtime_override` is never persisted as session model identity and must not override provider, API mode, endpoint, credentials, or the system-prompt / cache-prefix contract.

## Scope

**MUST**

- Model only
- `pre_llm_call` only
- Ephemeral / current turn only, restored on exit
- The existing provider/transport route remains authoritative
- Canonical effective route stays identical through middleware → `pre_api_request` → wire

**MUST NOT**

- provider switching
- `api_mode` switching
- endpoint switching
- credential switching
- persistent session route mutation
- system-prompt contract mutation

## Changes

- `agent/runtime_override.py` *(new)* — validate / apply / restore the model-only override scope (route transaction + conditional model-derived state refresh + supersede handoff)
- `agent/agent_runtime_helpers.py` — extracts the shared `_apply_model_owned_state` helper now used by both `switch_model` and `runtime_override`
- `agent/conversation_loop.py` — apply the canonical route across the full request path; explicit fallback supersede handoff
- `agent/turn_context.py` — reset + collect the `pre_llm_call` override
- `agent/chat_completion_helpers.py` — route-lifecycle plumbing
- `website/docs/user-guide/features/hooks.md` — document the `runtime_override` contract (model-only, resolution, conditional projection)

## Tests

19 tests, all green locally under the canonical runner (`scripts/run_tests.sh`):

- `tests/agent/test_runtime_override.py` (17) — validation and filtering, turn-scope reset, fallback handoff, cache-prefix protection, conditional projection (fires on context-window / capability-flag / provider change; strict no-op when the projection is identical), restored state after a projection failure, and unresolvable-model drop-with-warning.
- `tests/agent/test_runtime_override_loop.py` (2) — production-path `run_conversation` coverage: the override reaches the wire and does not survive the turn; a failed override hands the route to the fallback without re-entry.

Adjacent suites also run green on this base: the full `tests/agent/` suite and the model-switch regression slice (`test_switch_model_request_overrides.py`, `test_moa_switch_api_mode.py`, `test_model_switch_custom_providers.py`, `test_model_switch_openai_api_mode.py`).
