### PR TITLE
Agent commits now carry the git identity you configure (Amp-inspired, #72556/#78374 class)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -372,6 +372,21 @@ DEFAULT_CONFIG = {
         "reasoning_echo": False,
     },
 
+    # Git identity for agent-made commits. When set, Hermes injects
+    # GIT_AUTHOR_NAME/EMAIL and GIT_COMMITTER_NAME/EMAIL into every terminal
+    # subprocess (local + sandbox backends) and the Desktop review-pane
+    # commit path, so commits the agent makes are attributed to the identity
+    # YOU chose — separate from whatever ~/.gitconfig holds, and without the
+    # model ever running `git config user.email` itself.
+    # Inspired by Amp's orb git-identity model ("No Mailmap Required").
+    # Empty (default) = no injection; git's normal config resolution applies.
+    "git": {
+        "identity": {
+            "name": "",   # e.g. "Jane Doe"
+            "email": "",  # e.g. "jane@users.noreply.github.com"
+        },
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -41,6 +41,16 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
     — it would just hang the request until the timeout. Failing fast surfaces
     the real auth error in the toast instead."""
     try:
+        env = noninteractive_git_env()
+        try:
+            from tools.environments.local import apply_git_identity_env
+
+            # Desktop review-pane commits honor config.yaml `git.identity`
+            # exactly like agent terminal commits do (one identity policy,
+            # every commit surface).
+            apply_git_identity_env(env)
+        except Exception:
+            pass
         proc = subprocess.run(
             ["git", *args],
             cwd=cwd,
@@ -48,7 +58,7 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
             text=True, encoding='utf-8', errors='replace',
             timeout=timeout,
             stdin=subprocess.DEVNULL,
-            env=noninteractive_git_env(),
+            env=env,
         )
     except (OSError, subprocess.SubprocessError):
         return 1, "", "git invocation failed"

--- a/tests/tools/test_git_identity_env.py
+++ b/tests/tools/test_git_identity_env.py
@@ -1,0 +1,119 @@
+"""Tests for config-driven git identity injection (config.yaml ``git.identity``).
+
+Inspired by Amp's orb git-identity model ("No Mailmap Required", Aug 2026):
+the harness — not the model — decides the authorship on agent-made commits.
+See issues #72556 (agent silently runs ``git config user.email``) and
+#78374 (shared placeholder identity misattributed on GitHub).
+"""
+
+from unittest.mock import patch
+
+from tools.environments.local import (
+    _make_run_env,
+    _read_git_identity_config,
+    _sanitize_subprocess_env,
+    apply_git_identity_env,
+)
+
+_ALL_KEYS = (
+    "GIT_AUTHOR_NAME",
+    "GIT_AUTHOR_EMAIL",
+    "GIT_COMMITTER_NAME",
+    "GIT_COMMITTER_EMAIL",
+)
+
+
+def _with_identity(name="Jane Doe", email="jane@users.noreply.github.com"):
+    return patch(
+        "tools.environments.local._read_git_identity_config",
+        return_value=(name, email),
+    )
+
+
+class TestApplyGitIdentityEnv:
+    def test_noop_when_unconfigured(self):
+        env = {"PATH": "/usr/bin"}
+        with _with_identity("", ""):
+            apply_git_identity_env(env)
+        assert env == {"PATH": "/usr/bin"}
+
+    def test_sets_all_four_keys(self):
+        env = {}
+        with _with_identity():
+            apply_git_identity_env(env)
+        assert env["GIT_AUTHOR_NAME"] == "Jane Doe"
+        assert env["GIT_COMMITTER_NAME"] == "Jane Doe"
+        assert env["GIT_AUTHOR_EMAIL"] == "jane@users.noreply.github.com"
+        assert env["GIT_COMMITTER_EMAIL"] == "jane@users.noreply.github.com"
+
+    def test_existing_env_values_win(self):
+        env = {"GIT_AUTHOR_NAME": "Explicit Export", "GIT_AUTHOR_EMAIL": "x@y.z"}
+        with _with_identity():
+            apply_git_identity_env(env)
+        # user-exported values are never clobbered
+        assert env["GIT_AUTHOR_NAME"] == "Explicit Export"
+        assert env["GIT_AUTHOR_EMAIL"] == "x@y.z"
+        # unset siblings still filled from config
+        assert env["GIT_COMMITTER_NAME"] == "Jane Doe"
+        assert env["GIT_COMMITTER_EMAIL"] == "jane@users.noreply.github.com"
+
+    def test_email_only_configuration(self):
+        env = {}
+        with _with_identity(name="", email="jane@example.com"):
+            apply_git_identity_env(env)
+        assert "GIT_AUTHOR_NAME" not in env
+        assert env["GIT_AUTHOR_EMAIL"] == "jane@example.com"
+        assert env["GIT_COMMITTER_EMAIL"] == "jane@example.com"
+
+    def test_name_only_configuration(self):
+        env = {}
+        with _with_identity(name="Jane Doe", email=""):
+            apply_git_identity_env(env)
+        assert env["GIT_AUTHOR_NAME"] == "Jane Doe"
+        assert "GIT_AUTHOR_EMAIL" not in env
+
+
+class TestReadGitIdentityConfig:
+    def test_reads_from_config(self):
+        cfg = {"git": {"identity": {"name": "Jane", "email": "j@e.com"}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert _read_git_identity_config() == ("Jane", "j@e.com")
+
+    def test_missing_section_returns_empty(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _read_git_identity_config() == ("", "")
+
+    def test_malformed_identity_returns_empty(self):
+        cfg = {"git": {"identity": "Jane <j@e.com>"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert _read_git_identity_config() == ("", "")
+
+    def test_newlines_clamped_to_first_line(self):
+        # embedded newlines would corrupt the commit object header
+        cfg = {"git": {"identity": {"name": "Jane\nEvil: header", "email": "j@e.com\nX: y"}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert _read_git_identity_config() == ("Jane", "j@e.com")
+
+    def test_config_failure_returns_empty(self):
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert _read_git_identity_config() == ("", "")
+
+
+class TestSpawnPathIntegration:
+    def test_make_run_env_injects_identity(self):
+        with _with_identity():
+            env = _make_run_env({"PATH": "/usr/bin"})
+        for key in _ALL_KEYS:
+            assert env.get(key), f"{key} missing from _make_run_env output"
+
+    def test_sanitize_subprocess_env_injects_identity(self):
+        with _with_identity():
+            env = _sanitize_subprocess_env({"PATH": "/usr/bin"})
+        for key in _ALL_KEYS:
+            assert env.get(key), f"{key} missing from _sanitize_subprocess_env output"
+
+    def test_unconfigured_leaves_spawn_env_untouched(self):
+        with _with_identity("", ""):
+            env = _make_run_env({"PATH": "/usr/bin"})
+        for key in _ALL_KEYS:
+            assert key not in env

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -27,6 +27,7 @@ from tools.environments.base import (
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _is_hermes_internal_secret,
+    apply_git_identity_env,
 )
 
 logger = logging.getLogger(__name__)
@@ -1566,6 +1567,10 @@ class DockerEnvironment(BaseEnvironment):
         passthrough_env, unset_names = self._resolve_passthrough_env()
         exec_env: dict[str, str] = dict(self._env)
         exec_env.update(passthrough_env)
+        # Configured git identity rides into the container's login snapshot so
+        # commits made inside the sandbox carry the same authorship as local
+        # ones (config.yaml `git.identity`).
+        apply_git_identity_env(exec_env)
         for name in unset_names:
             exec_env.pop(name, None)
         self._init_unset_passthrough_names = tuple(sorted(unset_names))

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -583,6 +583,71 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+#: Env keys git consults for commit authorship, in the order git documents
+#: them. Set from ``git.identity`` config so agent-made commits carry the
+#: identity the user chose — instead of whatever ``~/.gitconfig`` the host
+#: happens to have, or (worse) an identity the model invents with
+#: ``git config user.email`` mid-session (#72556, #78374).
+_GIT_IDENTITY_NAME_KEYS = ("GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME")
+_GIT_IDENTITY_EMAIL_KEYS = ("GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL")
+
+
+def _read_git_identity_config() -> tuple[str, str]:
+    """Return ``(name, email)`` from config.yaml ``git.identity``.
+
+    Best-effort — any config failure returns empty strings so terminal
+    execution never breaks because the config file is unreadable.
+    Values are clamped to a single line: git env vars with embedded
+    newlines would corrupt the commit object header.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        git_cfg = cfg.get("git") or {}
+        ident = git_cfg.get("identity") or {}
+        if not isinstance(ident, dict):
+            return "", ""
+        name = str(ident.get("name") or "").splitlines()[0].strip() if ident.get("name") else ""
+        email = str(ident.get("email") or "").splitlines()[0].strip() if ident.get("email") else ""
+        return name, email
+    except Exception:
+        return "", ""
+
+
+def apply_git_identity_env(env: dict) -> None:
+    """Inject configured git identity into a subprocess env, in place.
+
+    Ported from Amp's orb git-identity model ("No Mailmap Required",
+    Aug 2026): the harness sets ``GIT_AUTHOR_*`` / ``GIT_COMMITTER_*`` from
+    the user's chosen identity so every commit the agent makes is
+    attributed the way the user wants, without the agent ever running
+    ``git config``.
+
+    Rules:
+
+    * No-op unless ``git.identity.name`` and/or ``git.identity.email`` is
+      set in config.yaml — fresh installs behave exactly as before.
+    * Never overrides a key already present in *env*: an explicit
+      ``GIT_AUTHOR_NAME`` exported by the user (or bound by a caller) wins.
+    * Name and email are applied independently, so setting only
+      ``git.identity.email`` still merges with the repo-config name.
+
+    Note git's own precedence: these env vars beat repo-local and global
+    ``user.name`` / ``user.email``. That is the point — the configured
+    identity is authoritative for agent-spawned processes.
+    """
+    name, email = _read_git_identity_config()
+    if name:
+        for key in _GIT_IDENTITY_NAME_KEYS:
+            if not env.get(key):
+                env[key] = name
+    if email:
+        for key in _GIT_IDENTITY_EMAIL_KEYS:
+            if not env.get(key):
+                env[key] = email
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -653,6 +718,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         sanitized[path_key] = _prepend_hermes_bin_dir(sanitized.get(path_key, ""))
 
     _apply_windows_msys_bash_env_defaults(sanitized)
+
+    apply_git_identity_env(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
 
@@ -1467,6 +1534,8 @@ def _make_run_env(env: dict) -> dict:
     _strip_hermes_owned_pythonpath_and_runtime_markers(run_env)
 
     _apply_windows_msys_bash_env_defaults(run_env)
+
+    apply_git_identity_env(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -858,6 +858,28 @@ You can also list gitignored files to copy into worktrees via `.worktreeinclude`
 node_modules/
 ```
 
+## Git Commit Identity
+
+Choose the name and email on commits the agent makes — separate from your `~/.gitconfig`:
+
+```yaml
+git:
+  identity:
+    name: "Jane Doe"
+    email: "jane@users.noreply.github.com"
+```
+
+When set, Hermes injects `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` into every terminal subprocess (local and sandbox backends alike) and the Desktop review-pane commit path. Every commit the agent makes — in any repo, on any backend — carries the identity you chose, and the model never needs to run `git config user.email` itself.
+
+Details:
+
+- **Off by default.** With no `git.identity` configured, nothing is injected and git's normal config resolution applies unchanged.
+- **Your explicit exports win.** If `GIT_AUTHOR_NAME` (or any of the four vars) is already set in the environment, Hermes leaves it alone.
+- **Name and email are independent** — set only `email` to keep the repo-configured name.
+- Git's env vars take precedence over repo-local and global `user.name`/`user.email`; that's the point — the configured identity is authoritative for agent-spawned processes.
+
+Tip: use your GitHub noreply address (`<id>+<login>@users.noreply.github.com`) so commits link to your account without exposing your real email.
+
 ## Context Compression
 
 Hermes automatically compresses long conversations to stay within your model's context window. The compression summarizer is a separate LLM call — you can point it at any provider or endpoint.


### PR DESCRIPTION
## Summary

Commits the agent makes now carry the git identity **you** configure — not whatever `~/.gitconfig` the host has, and never an identity the model invents by running `git config user.email` mid-session.

Port of Amp's "No Mailmap Required" (Aug 28 2026, https://ampcode.com/news/no-mailmap-required): when Amp starts an orb it sets `GIT_AUTHOR_*` / `GIT_COMMITTER_*` from the user's chosen, verified identity, so agent commits attribute correctly without any repo mutation. Our adaptation is config-driven and covers all commit surfaces.

Directly addresses the bug class behind #72556 (agent silently sets `git config user.email` before committing — unexpected inherited attribution) and #78374 (`hermes@nousresearch.com` placeholder resolves to an unrelated real GitHub account): with a configured identity there is never a reason for the model to touch `git config`, and the env-var route mutates nothing on disk.

## Their mechanism vs ours

| | Amp | This PR |
|---|---|---|
| Identity source | Web UI + Puck, verified email, workspace policy | `config.yaml` → `git.identity.name` / `.email` |
| Injection point | Orb start env | Every terminal subprocess env (`_make_run_env` + `_sanitize_subprocess_env` → foreground/background/PTY), Docker login snapshot, Desktop review-pane `web_git._git` |
| Precedence | Orb identity authoritative | Config wins over repo/global gitconfig (git env-var semantics), but explicit user `GIT_AUTHOR_*` exports always win over config |
| Default | Account email | Off — empty config injects nothing, zero behavior change |

## Changes

- `tools/environments/local.py`: `_read_git_identity_config()` + `apply_git_identity_env()`; wired into `_make_run_env` and `_sanitize_subprocess_env` (covers local exec, background/PTY via process_registry, and cron)
- `tools/environments/docker.py`: identity rides into the container init env so sandboxed commits match local ones
- `hermes_cli/web_git.py`: Desktop review-pane commits honor the same identity (best-effort import, degrades gracefully)
- `hermes_cli/config_defaults.py`: new `git.identity` section (empty defaults — no version bump needed, deep-merge supplies defaults)
- `website/docs/user-guide/configuration.md`: "Git Commit Identity" section
- `tests/tools/test_git_identity_env.py`: 13 tests — no-op default, all-four-keys injection, explicit-export precedence, name/email independence, newline clamping (commit-header injection guard), config-failure resilience, spawn-path integration

## Validation

| Check | Result |
|---|---|
| New tests | 13/13 pass |
| Sibling env suites (`test_local_env_blocklist`, `test_build_subprocess_env`, `test_local_env_session_leak`) | 105 passed, 4 skipped |
| ruff | clean |
| Live E2E (isolated HERMES_HOME, real config.yaml, real `git commit` via `_make_run_env` env) | author+committer = configured identity; unconfigured → no injection; explicit export wins |

**Live repro:** on origin/main, a temp repo commit through the terminal env inherits host `~/.gitconfig` (or the model must run `git config`); with this branch + `git.identity` set, `git log -1 --pretty='%an <%ae> / %cn <%ce>'` shows `Config Identity <config-identity@example.com>` on both fields with zero repo/global config mutation.

Deliberately NOT touched: `tools/checkpoint_manager.py` (internal shadow store uses its own fixed "Hermes Checkpoint" identity — not user-facing history).

## Infographic

![Git Commit Identity — config-driven authorship on every agent commit](https://v3b.fal.media/files/b/0aa87edd/gH72qVw7bmUU_k5idWnuT_rrpInaLr.png)
