### PR TITLE
fix(approval): exempt temp-file cleanup spelled via gettempdir() on macOS

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -93,14 +93,21 @@ class TestDetectDangerousRm:
             assert "delete" in desc.lower()
 
 
-    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
-            for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
-                    False,
-                    None,
-                    None,
-                )
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self, tmp_path):
+        # Mock gettempdir() to a real (non-symlink) directory so the test is
+        # portable across platforms: on macOS "/tmp" is a symlink to
+        # /private/tmp and realpath() also canonicalizes the /var/folders
+        # automount prefix, so a hardcoded "/tmp" mock would exercise the
+        # alias-rejection guard instead of the exemption this test targets.
+        temp_dir = tmp_path / "tempdir"
+        temp_dir.mkdir()
+        for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
+            with mock_patch(
+                "tempfile.gettempdir", return_value=str(temp_dir)
+            ):
+                assert detect_dangerous_command(
+                    f"rm -f {temp_dir / (prefix + 'example.py')}"
+                ) == (False, None, None)
 
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1119,11 +1119,28 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     operand = argv[2]
     temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
-    return (
-        operand == os.path.join(temp_dir, basename)
-        and os.path.dirname(os.path.realpath(operand)) == temp_dir
-        and re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
-    )
+    # The operand's directory must resolve to the canonical temp dir, and its
+    # spelling must be either that canonical form or the exact value
+    # gettempdir() reports (when that value is itself a real directory —
+    # on macOS realpath() canonicalizes the automount prefix, e.g.
+    # "/var/folders/..." -> "/private/var/folders/...", so cleanup commands
+    # spelled through gettempdir()'s own value must still match). A different
+    # alias of the temp dir (any other symlink pointing at it) is rejected.
+    spelled_dir = os.path.dirname(operand)
+    if os.path.realpath(spelled_dir) != temp_dir:
+        return False
+    if spelled_dir not in (temp_dir, tempfile.gettempdir()):
+        return False
+    if (
+        spelled_dir != temp_dir
+        and os.path.islink(spelled_dir)
+    ):
+        return False
+
+    target = os.path.realpath(operand)
+    if os.path.dirname(target) != temp_dir:
+        return False
+    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
 def _is_shell_token_spliced_gateway_lifecycle(command: str) -> bool:


### PR DESCRIPTION
## Problem

On macOS, every legitimate single-file temp cleanup (`rm -f <tmpdir>/hermes-verify-*.py`) emitted by the agent's own verification flow is flagged as a **dangerous root-path delete** and demands approval.

Root cause: `_is_verification_artifact_cleanup` requires the operand to equal `join(realpath(gettempdir()), basename)`. On macOS `realpath()` canonicalizes the automount prefix — `gettempdir()` reports `/var/folders/…/T` but the canonical form is `/private/var/folders/…/T` (and `/tmp` → `/private/tmp`) — so a command spelled through the value `gettempdir()` itself returns can never match. Linux is unaffected (realpath is a no-op there), which is why CI never caught it.

## Fix

Accept the operand's spelled directory when it is either:
1. the canonical `realpath(gettempdir())`, or
2. the **exact value `gettempdir()` reports**,

provided both spellings resolve to the same canonical directory. A different symlink alias of the temp dir — the case the existing symlink guard exists for — still fails: its spelling matches neither accepted form, and a spelled-through-symlink directory that merely resolves to the canonical dir is dropped by the `islink` check.

## Test portability fix

The exemption test mocked `gettempdir()` to the literal `"/tmp"`, which on macOS is itself a symlink — so the test was exercising the alias-rejection guard rather than the exemption, and failed on macOS for the same root cause. Re-anchored on a real `tmp_path` directory so it tests what its name says on every platform (still passes on Linux CI).

## Verification

- `tests/tools/test_approval.py`: **118/118 pass** on macOS (previously 117/118 — the failing test is the one this PR fixes, plus the portability re-anchor)
- Real-world macOS semantics: `rm -f $(gettempdir)/hermes-verify-x.py` → exempt `(False, None, None)`; `rm -f /tmp/hermes-verify-x.py` (a different alias) → still flagged
- No behavior change on Linux (realpath is a no-op; the canonical branch is unchanged)