### PR TITLE
fix(gateway): restore automatic codex threshold on live config sync

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -99,6 +99,41 @@ def test_live_codex_native_threshold_applies_on_next_turn(monkeypatch):
     assert session["agent"].codex_responses_compact_threshold == 120_000
 
 
+def test_removing_codex_native_threshold_restores_automatic(monkeypatch):
+    # UNSET semantics (#94724): removing the key must restore the
+    # agent_init default (None = automatic, derived from the local
+    # compression trigger), not stamp a flat 200_000 over it.
+    session, _ = _session_with_compressor()
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"compression": {}},
+    )
+
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].codex_responses_compact_threshold is None
+
+
+def test_invalid_codex_native_threshold_restores_automatic(monkeypatch):
+    # An invalid value must also restore the automatic threshold, matching
+    # agent_init's None-aware fallback for the same key.
+    session, _ = _session_with_compressor()
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "compression": {"codex_responses_compact_threshold": "not-a-number"}
+        },
+    )
+
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].codex_responses_compact_threshold is None
+
+
 def test_unchanged_compression_config_is_noop(monkeypatch):
     session, compressor = _session_with_compressor(threshold_tokens_cap=100_000)
     cfg = {
@@ -280,4 +315,6 @@ def test_removing_codex_native_threshold_restores_default(monkeypatch):
     session, _ = _neutral_session()
     session["agent"].codex_responses_compact_threshold = 120_000
     _sync_with_cfg(monkeypatch, session, {"compression": {}})
-    assert session["agent"].codex_responses_compact_threshold == 200_000
+    # UNSET restores the agent_init default: None = automatic threshold
+    # derived from the local compression trigger (a2af8405d1), not 200_000.
+    assert session["agent"].codex_responses_compact_threshold is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6661,22 +6661,28 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     agent.codex_responses_native_compaction = is_truthy_value(
         compression.get("codex_responses_native", False)
     )
-    native_threshold_raw = compression.get(
-        "codex_responses_compact_threshold", 200_000
-    )
-    try:
-        if isinstance(native_threshold_raw, bool):
-            raise ValueError
-        native_threshold = int(native_threshold_raw)
-        if native_threshold <= 0:
-            raise ValueError
-    except (TypeError, ValueError):
-        logger.warning(
-            "Invalid compression.codex_responses_compact_threshold=%r; "
-            "using 200000.",
-            native_threshold_raw,
-        )
-        native_threshold = 200_000
+    # Mirror agent_init's None-aware semantics (#98426-era a2af8405d1):
+    # an absent or invalid value means "automatic" — the threshold derived
+    # from the local compression trigger in native_compaction — NOT a flat
+    # 200_000 fallback. Stamping a flat 200_000 here would silently override
+    # the automatic threshold (and any model-derived value) on every live
+    # config sync, i.e. every config save on a running desktop session.
+    native_threshold_raw = compression.get("codex_responses_compact_threshold")
+    native_threshold = None
+    if native_threshold_raw is not None:
+        try:
+            if isinstance(native_threshold_raw, (bool, float)):
+                raise ValueError
+            native_threshold = int(native_threshold_raw)
+            if native_threshold <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid compression.codex_responses_compact_threshold=%r; "
+                "using the automatic threshold derived from local compression.",
+                native_threshold_raw,
+            )
+            native_threshold = None
     agent.codex_responses_compact_threshold = native_threshold
 
     # Absence restores the agent_init/config default (0 = disabled).


### PR DESCRIPTION
## Problem

`agent_init` derives `codex_responses_compact_threshold = None` (automatic — resolved from the local compression trigger in `native_compaction` via `resolve_compact_threshold`) when the key is absent or invalid (a2af8405d1). The TUI-gateway live config-sync path (`_apply_live_compression_config`) still uses the pre-None semantics: `compression.get(key, 200_000)` with a flat 200_000 fallback.

Result: **every config save on a running desktop session stamps a flat 200_000 over the init-time automatic threshold**, causing native compaction to fire far earlier than configured intent — silently, because the overwrite happens through the hot-apply path, not through construction.

## Fix

Mirror `agent_init`'s None-aware behavior in `_apply_live_compression_config`:

- absent key → `None` (automatic), honoring the UNSET semantics documented for this path (#94724 review finding on #95980)
- invalid value (non-int, bool, float, ≤0) → warn + `None`, not flat 200_000

Update the existing UNSET test (which pinned the old flat-200_000 expectation) and add coverage for both the absent-key and invalid-value restore paths.

## Verification

`tests/tui_gateway/test_compression_config_hot_reload.py`: **20/20 pass** (18 pre-existing + 2 new); the one updated test is the UNSET-semantics test whose old expectation contradicted agent_init's a2af8405d1 behavior — the contract drift this PR closes.