### PR TITLE
fix(gateway): preserve progress across transient previews

### DIFF
--- a/gateway/progress_events.py
+++ b/gateway/progress_events.py
@@ -1,0 +1,90 @@
+"""Typed progress-timeline events shared by stream and progress delivery."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class DurableContentSource(str, Enum):
+    """Delivery paths that create a new persistent chat timeline entry."""
+
+    STREAM_FINALIZED = "stream_finalized"
+    STREAM_PERSISTED = "stream_persisted"
+    COMMENTARY = "commentary"
+    OVERFLOW = "overflow"
+    FALLBACK = "fallback"
+    FRESH_FINAL = "fresh_final"
+
+
+@dataclass(frozen=True, slots=True)
+class DurableContentBoundary:
+    """A confirmed persistent content entry that seals prior progress."""
+
+    boundary_id: str
+    source: DurableContentSource
+    message_id: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionalContentBoundary:
+    """A preview delivery whose durable/retracted outcome is not known yet."""
+
+    boundary_id: str
+    message_id: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class RetractedContentBoundary:
+    """Resolution indicating that a provisional preview left no chat entry."""
+
+    boundary_id: str
+
+
+ContentBoundaryEvent = (
+    DurableContentBoundary | ProvisionalContentBoundary | RetractedContentBoundary
+)
+
+
+class ContentBoundaryBuffer:
+    """Hold progress behind unresolved previews, preserving producer order."""
+
+    def __init__(self):
+        from collections import deque
+        self.pending = deque()
+        self.resolved = {}
+        self.seen = set()
+
+    def feed(self, event):
+        if isinstance(event, (ProvisionalContentBoundary, DurableContentBoundary, RetractedContentBoundary)):
+            key = (event.boundary_id, type(event))
+            if key in self.seen:
+                return []
+            self.seen.add(key)
+            if isinstance(event, ProvisionalContentBoundary):
+                self.pending.append(event)
+            elif event.boundary_id not in self.resolved:
+                self.resolved[event.boundary_id] = event
+                if (event.boundary_id, ProvisionalContentBoundary) not in self.seen:
+                    self.pending.append(event)
+        else:
+            self.pending.append(event)
+        ready = []
+        while self.pending:
+            raw = self.pending[0]
+            if isinstance(raw, ProvisionalContentBoundary):
+                if raw.boundary_id not in self.resolved:
+                    break
+                raw = self.resolved[raw.boundary_id]
+            self.pending.popleft()
+            if not isinstance(raw, RetractedContentBoundary):
+                ready.append(raw)
+        return ready
+
+    def finish(self):
+        # Missing acknowledgements may still have left content on screen. Never
+        # replay deferred tools above it; release them below a conservative seal.
+        for raw in self.pending:
+            if isinstance(raw, ProvisionalContentBoundary):
+                self.resolved.setdefault(raw.boundary_id, DurableContentBoundary(
+                    raw.boundary_id, DurableContentSource.STREAM_PERSISTED, raw.message_id))
+        return self.feed(RetractedContentBoundary("cleanup"))

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3541,7 +3541,7 @@ class GatewayTurnMixin:
     ) -> None:
         """``finally`` half of a turn: cancel background tasks, flush stream, release the session slot."""
         stream_consumer_holder, session_key = turn_ctx.stream_consumer_holder, turn_ctx.session_key
-        for task in (progress_task, log_task, interrupt_monitor, _notify_task):
+        for task in (log_task, interrupt_monitor, _notify_task):
             if task:
                 task.cancel()
 
@@ -3553,6 +3553,16 @@ class GatewayTurnMixin:
                     await stream_task
             else:
                 await self._await_stream_task(stream_task)
+
+        # Stream cleanup must publish preview resolutions before progress drains.
+        if progress_task:
+            progress_task.cancel()
+            try:
+                await asyncio.wait_for(progress_task, timeout=5.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            except Exception:
+                logger.debug("Progress drain failed during cleanup", exc_info=True)
 
         # Abort + bounded wait for streaming TTS: covers paths where normal finalisation was skipped.
         _stts_finally = turn_ctx.streaming_tts_consumer_holder[0]

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -7,6 +7,9 @@ keeps intercepting them at call time.
 
 from __future__ import annotations
 
+from collections import deque
+from gateway.progress_events import ContentBoundaryBuffer, DurableContentBoundary
+
 import asyncio
 import dataclasses
 import json
@@ -471,6 +474,8 @@ class TurnRunner:
         _progress_len_fn: Any
         _PROGRESS_TEXT_LIMIT: int
         _edit_accepts_metadata: bool
+        boundaries: Any = dataclasses.field(default_factory=ContentBoundaryBuffer)
+        ready: Any = dataclasses.field(default_factory=deque)
 
     def _progress_edit_state(self, adapter) -> "TurnRunner._ProgressEditState":
         ctx = self._ctx
@@ -559,9 +564,17 @@ class TurnRunner:
         st.progress_lines = groups[-1]
         return True
 
-    @staticmethod
-    def _is_reset_marker(raw) -> bool:
-        return isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__"
+    def _next_progress_event(self, st):
+        while not st.ready:
+            st.ready.extend(st.boundaries.feed(self._ctx.progress_queue.get_nowait()))
+        return st.ready.popleft()
+
+    async def _seal_progress_boundary(self, st):
+        await self._roll_progress_overflow_if_needed(st)
+        if st.progress_lines and st.progress_msg_id is None:
+            await self._progress_send_or_edit(st, self._progress_text(st.progress_lines))
+        await self._flush_progress_edit(st)
+        self._reset_progress_bubble(st)
 
     def _reset_progress_bubble(self, st) -> None:
         """Content bubble landed — close the tool-progress bubble so the next tool starts fresh
@@ -574,6 +587,7 @@ class TurnRunner:
         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
             _, base_msg, count = raw
             if not st.progress_lines:
+                st.progress_lines.append(base_msg)
                 return base_msg
             st.progress_lines[-1] = f"{base_msg} (×{count + 1})"
             return st.progress_lines[-1]
@@ -587,22 +601,27 @@ class TurnRunner:
 
     async def _drain_progress_on_cancel(self, st) -> None:
         ctx = self._ctx
-        with suppress(Exception):
-            while not ctx.progress_queue.empty():
-                raw = ctx.progress_queue.get_nowait()
-                if self._is_reset_marker(raw):
-                    # Content-bubble marker during drain: close the current progress bubble
-                    # and start a fresh one for tool lines that arrived after.
-                    await self._roll_progress_overflow_if_needed(st)
-                    await self._flush_progress_edit(st)
-                    self._reset_progress_bubble(st)
+        if not ctx._run_still_current() or self._agent_interrupted():
+            self._drain_progress_queue()
+            return
+        while not ctx.progress_queue.empty():
+            st.ready.extend(st.boundaries.feed(ctx.progress_queue.get_nowait()))
+        st.ready.extend(st.boundaries.finish())
+        while st.ready:
+            raw = st.ready.popleft()
+            if isinstance(raw, DurableContentBoundary):
+                await self._seal_progress_boundary(st)
+            else:
+                msg = self._progress_absorb(st, raw)
+                if not st.can_edit:
+                    await self._send_progress_text(st, msg)
+                    st.progress_lines.clear()
                 else:
-                    self._progress_absorb(st, raw)
                     await self._roll_progress_overflow_if_needed(st)
-        # Final edit with all remaining tools (only if editing works)
-        if st.can_edit and st.progress_lines and st.progress_msg_id:
-            await self._roll_progress_overflow_if_needed(st)
-        await self._flush_progress_edit(st)
+        if st.can_edit and st.progress_lines:
+            if st.progress_msg_id is None:
+                await self._progress_send_or_edit(st, self._progress_text(st.progress_lines))
+            await self._flush_progress_edit(st)
 
     async def _progress_restore_typing(self, st) -> None:
         ctx = self._ctx
@@ -658,14 +677,14 @@ class TurnRunner:
                 if not ctx._run_still_current():
                     self._drain_progress_queue()
                     return
-                raw = ctx.progress_queue.get_nowait()
+                raw = self._next_progress_event(st)
                 # Drain silently when interrupted: events queued in the window between tool parse
                 # and interrupt processing should not render as bubbles.
                 if self._agent_interrupted():
                     await asyncio.sleep(0)
                     continue
-                if self._is_reset_marker(raw):
-                    self._reset_progress_bubble(st)
+                if isinstance(raw, DurableContentBoundary):
+                    await self._seal_progress_boundary(st)
                     continue
                 msg = self._progress_absorb(st, raw)
                 if not await self._roll_progress_overflow_if_needed(st):
@@ -683,7 +702,11 @@ class TurnRunner:
                 last_edit_ts = time.monotonic()
                 await self._progress_restore_typing(st)
             except queue.Empty:
-                await asyncio.sleep(0.3)
+                try:
+                    await asyncio.sleep(0.3)
+                except asyncio.CancelledError:
+                    await self._drain_progress_on_cancel(st)
+                    return
             except asyncio.CancelledError:
                 await self._drain_progress_on_cancel(st)
                 return
@@ -863,8 +886,8 @@ class TurnRunner:
                     stream_consumer = GatewayStreamConsumer(
                         adapter=adapter, chat_id=ctx.source.chat_id, config=consumer_cfg,
                         metadata=ctx._status_thread_metadata,
-                        on_new_message=(
-                            (lambda: ctx.progress_queue.put(("__reset__",))) if ctx.progress_queue is not None else None
+                        on_content_boundary=(
+                            ctx.progress_queue.put if ctx.progress_queue is not None else None
                         ),
                         on_before_finalize=pause_typing_before_finalize,
                         initial_reply_to_id=ctx.event_message_id, run_still_current=ctx._run_still_current,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -31,6 +31,8 @@ from gateway.response_filters import (
     is_intentional_silence_response as _is_intentional_silence_response,
     is_partial_silence_marker as _is_partial_silence_marker)
 from gateway.stream_consumer_fences import ensure_closed_code_fences
+from gateway.stream_consumer_boundaries import StreamBoundaryMixin
+from gateway.progress_events import ContentBoundaryEvent, ProvisionalContentBoundary
 from gateway.stream_consumer_transport import StreamTransportMixin
 from gateway.stream_consumer_fallback import StreamFallbackMixin
 from gateway.stream_consumer_think import StreamThinkFilterMixin
@@ -96,7 +98,7 @@ class _Tick:
         return not self.got_done and not self.got_segment_break and self.commentary_text is None
 
 
-class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThinkFilterMixin):
+class GatewayStreamConsumer(StreamBoundaryMixin, StreamTransportMixin, StreamFallbackMixin, StreamThinkFilterMixin):
     """Async consumer that progressively edits a platform message with streamed tokens.
     Usage: ``agent.stream_delta_callback = consumer.on_delta``; ``create_task(consumer.run())``;
     after the agent finishes ``consumer.finish()`` then ``await task`` for the final edit."""
@@ -115,7 +117,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
-        on_new_message: Optional[callable] = None,
+        on_content_boundary: Optional[Callable[[ContentBoundaryEvent], None]] = None,
         on_before_finalize: Optional[Callable[[], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None):
@@ -123,9 +125,13 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
-        # Hooks (exceptions swallowed): on_new_message per fresh content bubble (next
-        # tool-progress bubble goes BELOW it); on_before_finalize once (pause typing).
-        self._on_new_message = on_new_message
+        self._on_content_boundary = on_content_boundary
+        self._pending_preview_boundary = None
+        self._producer_boundary = None
+        self._content_boundary_lock = threading.Lock()
+        self._content_boundary_sequence = 0
+        self._published_content_boundaries = set()
+        self._persistent_stream_boundary_published = False
         self._on_before_finalize = on_before_finalize
         self._initial_reply_to_id = initial_reply_to_id
         self._turn_id = str(uuid.uuid4())  # keys send_stream_frame() per concurrent consumer
@@ -360,7 +366,9 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
 
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
-        self._queue.put(_NEW_SEGMENT)
+        with self._content_boundary_lock:
+            self._queue.put(_NEW_SEGMENT)
+            self._producer_boundary = None
 
     def close_for_approval_prompt(
         self, placeholder: str | None = None, reason: str = "Approval", reopen: bool = False,
@@ -390,7 +398,10 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
     def on_commentary(self, text: str) -> None:
         """Queue a completed interim assistant commentary message."""
         if text:
-            self._queue.put((_COMMENTARY, text))
+            self.on_segment_break()
+            self._enqueue_content((_COMMENTARY, text))
+            with self._content_boundary_lock:
+                self._producer_boundary = None
 
     def flush_pending_sync(self, timeout: float = 5.0) -> bool:
         """Block the agent worker thread until everything queued so far is delivered:
@@ -414,14 +425,6 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         if self._reopen_seed_pending():
             self._queue.put(_REOPEN_SEED)
 
-    def _notify_new_message(self) -> None:
-        """Fire the on_new_message callback, swallowing any errors."""
-        try:
-            if self._on_new_message is not None:
-                self._on_new_message()
-        except Exception:
-            logger.debug("on_new_message callback error", exc_info=True)
-
     @staticmethod
     def _signal_flush(flush_event) -> None:
         """Wake a thread blocked in flush_pending_sync(), swallowing errors.  Every loop path
@@ -434,6 +437,8 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
             return
+        self._settle_preview_boundary()
+        self._persistent_stream_boundary_published = False
         # Retain the segment's visible text so has_delivered_text still matches.
         finalized = self._clean_for_display(self._last_sent_text).strip()
         if finalized:
@@ -512,7 +517,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         boundary: the current message is finalized and subsequent text goes out as a new
         message below any tool-progress messages."""
         if text:
-            self._queue.put(text)
+            self._enqueue_content(text)
         elif text is None:
             self.on_segment_break()
 
@@ -587,6 +592,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
         finally:
+            self._settle_preview_boundary()
             self._wake_flush_waiters()
 
     # ── run() collaborators ─────────────────────────────────────────────
@@ -631,6 +637,13 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
                 item = self._queue.get_nowait()
             except queue.Empty:
                 return tick
+            if isinstance(item, ProvisionalContentBoundary):
+                if self._pending_preview_boundary is not None:
+                    from gateway.progress_events import RetractedContentBoundary
+                    self._publish_content_boundary(RetractedContentBoundary(item.boundary_id))
+                else:
+                    self._pending_preview_boundary = item
+                continue
             if item is _DONE:
                 tick.got_done = True
                 return tick
@@ -881,8 +894,6 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         """Post commentary as its own message.  Cumulative transports keep the stream going —
         resetting _accumulated would break the append-only invariant / lose text."""
         cumulative = self._cumulative_transport()
-        if not cumulative:
-            self._reset_segment_state()
         await self._send_commentary(commentary_text)
         self._last_edit_time = time.monotonic()
         if not cumulative:
@@ -896,6 +907,8 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         must keep its sentinel or every tool boundary posts a new message; the
         continuation goes out once via _send_fallback_final."""
         if self._cumulative_transport():
+            # Keep its first boundary until the persistent stream is finalized.
+            # Later segments do not create additional chat entries.
             return
         # If the segment-break edit didn't land (flood control / fallback mode),
         # _accumulated holds unseen pre-boundary text — flush it before the reset.
@@ -927,6 +940,9 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         with contextlib.suppress(Exception):
             while True:
                 item = self._queue.get_nowait()
+                if isinstance(item, ProvisionalContentBoundary):
+                    from gateway.progress_events import RetractedContentBoundary
+                    self._publish_content_boundary(RetractedContentBoundary(item.boundary_id))
                 if isinstance(item, tuple) and len(item) == 2 and item[0] is _FLUSH:
                     self._signal_flush(item[1])
 

--- a/gateway/stream_consumer_boundaries.py
+++ b/gateway/stream_consumer_boundaries.py
@@ -1,0 +1,144 @@
+"""Correlated stream preview lifecycle, independent of transport details."""
+
+import logging
+import uuid
+from typing import Optional
+
+from gateway.progress_events import (
+    ContentBoundaryEvent, DurableContentBoundary, DurableContentSource,
+    ProvisionalContentBoundary, RetractedContentBoundary,
+)
+
+logger = logging.getLogger("gateway.stream_consumer")
+
+
+class StreamBoundaryMixin:
+    def _publish_content_boundary(self, event: ContentBoundaryEvent) -> None:
+        """Publish each lifecycle phase for a boundary at most once."""
+        cb = self._on_content_boundary
+        if cb is None:
+            return
+        event_key = (event.boundary_id, type(event).__name__)
+        if event_key in self._published_content_boundaries:
+            return
+        self._published_content_boundaries.add(event_key)
+        try:
+            cb(event)
+        except Exception:
+            logger.debug("content boundary callback error", exc_info=True)
+
+    def _notify_content_boundary(
+        self,
+        source: DurableContentSource,
+        *,
+        message_id: Optional[str] = None,
+    ) -> None:
+        """Publish one idempotent boundary for confirmed persistent content."""
+        normalized_message_id = str(message_id) if message_id is not None else None
+        if normalized_message_id is not None:
+            boundary_id = f"{self._turn_id}:message:{normalized_message_id}"
+        else:
+            self._content_boundary_sequence += 1
+            boundary_id = f"{self._turn_id}:boundary:{self._content_boundary_sequence}"
+        self._publish_content_boundary(
+            DurableContentBoundary(
+                boundary_id=boundary_id,
+                source=source,
+                message_id=normalized_message_id,
+            )
+        )
+
+    def _open_preview_boundary(self) -> None:
+        """Pause later progress before a preview delivery can overtake it."""
+        if self._pending_preview_boundary is not None:
+            return
+        self._content_boundary_sequence += 1
+        event = ProvisionalContentBoundary(
+            boundary_id=(
+                f"{self._turn_id}:preview:{self._content_boundary_sequence}"
+            )
+        )
+        self._pending_preview_boundary = event
+        self._publish_content_boundary(event)
+
+    def _record_pending_preview_message_id(self, message_id: str) -> None:
+        """Attach the platform id after a provisional send succeeds."""
+        pending = self._pending_preview_boundary
+        if pending is None:
+            return
+        self._pending_preview_boundary = ProvisionalContentBoundary(
+            boundary_id=pending.boundary_id,
+            message_id=str(message_id),
+        )
+
+    def _confirm_pending_preview_boundary(
+        self,
+        *,
+        source: DurableContentSource = DurableContentSource.STREAM_FINALIZED,
+        message_id: Optional[str] = None,
+    ) -> None:
+        """Resolve a provisional preview as a persistent timeline entry."""
+        pending = self._pending_preview_boundary
+        if pending is None:
+            return
+        self._pending_preview_boundary = None
+        self._publish_content_boundary(
+            DurableContentBoundary(
+                boundary_id=pending.boundary_id,
+                source=source,
+                message_id=(str(message_id) if message_id is not None else pending.message_id),
+            )
+        )
+
+    def _confirm_or_notify_content_boundary(
+        self,
+        source: DurableContentSource,
+        *,
+        message_id: Optional[str] = None,
+    ) -> None:
+        """Resolve the active preview, otherwise publish a direct boundary."""
+        if self._pending_preview_boundary is not None:
+            self._confirm_pending_preview_boundary(
+                source=source,
+                message_id=message_id,
+            )
+        else:
+            self._notify_content_boundary(source, message_id=message_id)
+
+    def _retract_pending_preview_boundary(self) -> None:
+        """Resolve a provisional preview that left no persistent chat entry."""
+        pending = self._pending_preview_boundary
+        if pending is None:
+            return
+        self._pending_preview_boundary = None
+        self._publish_content_boundary(
+            RetractedContentBoundary(boundary_id=pending.boundary_id)
+        )
+
+
+    def _ack_persistent_stream_boundary(self):
+        # Persistent native/draft frames are visible now, not only at turn end.
+        # Subsequent frames update the same entry and must not split progress.
+        if self._persistent_stream_boundary_published:
+            self._retract_pending_preview_boundary()
+        else:
+            self._confirm_or_notify_content_boundary(DurableContentSource.STREAM_PERSISTED)
+            self._persistent_stream_boundary_published = True
+
+    def _settle_preview_boundary(self):
+        # Draft text alone is not a persistent timeline entry.
+        if self._message_id is not None or self._already_sent:
+            self._confirm_pending_preview_boundary()
+        else:
+            self._retract_pending_preview_boundary()
+
+    def _enqueue_content(self, item):
+        # Producer and consumer have different boundary slots: the worker can
+        # queue several segments while the platform is still sending the first.
+        with self._content_boundary_lock:
+            if self._producer_boundary is None:
+                boundary = ProvisionalContentBoundary(boundary_id=str(uuid.uuid4()))
+                self._producer_boundary = boundary
+                self._publish_content_boundary(boundary)
+                self._queue.put(boundary)
+            self._queue.put(item)

--- a/gateway/stream_consumer_fallback.py
+++ b/gateway/stream_consumer_fallback.py
@@ -3,6 +3,8 @@ stop working, chunking, cursor cleanup, commentary and silence retraction."""
 
 from __future__ import annotations
 
+from gateway.progress_events import DurableContentSource
+
 import asyncio
 import contextlib
 import logging
@@ -34,7 +36,7 @@ class StreamFallbackMixin:
             self._track_preview_ids_from_result(result)
             self._already_sent = True
             self._last_sent_text = text
-            self._notify_new_message()
+            self._confirm_or_notify_content_boundary(DurableContentSource.OVERFLOW, message_id=result.message_id)
             return str(result.message_id)
         except Exception as e:
             logger.error("Stream send chunk error: %s", e)
@@ -123,7 +125,7 @@ class StreamFallbackMixin:
             sent_any_chunk = True
             last_successful_chunk = chunk
             last_message_id = result.message_id or last_message_id
-            self._notify_new_message()
+            self._confirm_or_notify_content_boundary(DurableContentSource.FALLBACK, message_id=result.message_id)
 
         # Best-effort delete of the frozen partial — ONLY when the FULL final was
         # re-sent.  If only the missing tail went out, the partial IS the head of
@@ -254,7 +256,7 @@ class StreamFallbackMixin:
         self._last_sent_text = final_text
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
-        self._notify_new_message()
+        self._confirm_or_notify_content_boundary(DurableContentSource.FRESH_FINAL, message_id=result.message_id)
         return "delivered"
 
     @staticmethod
@@ -339,14 +341,23 @@ class StreamFallbackMixin:
             # Do NOT set _already_sent: commentary is interim, and the flag would
             # suppress the real final after multiple tool calls.
             if result.success:
-                self._notify_new_message()
+                self._confirm_or_notify_content_boundary(DurableContentSource.COMMENTARY, message_id=result.message_id)
                 # Lets run.py confirm whether an interim send carried the final.
                 # Record the exact delivered text so run.py can confirm whether an interim "preview"
                 # actually carried the final response, vs. unrelated commentary delivered during a session
                 # split (#14238).
                 self._delivered_commentary_texts.append(text)
+            if not result.success:
+                if self._send_failure_may_have_delivered(result):
+                    self._confirm_pending_preview_boundary(source=DurableContentSource.STREAM_PERSISTED)
+                else:
+                    self._retract_pending_preview_boundary()
             return result.success
         except Exception as e:
+            if self._send_failure_may_have_delivered(e):
+                self._confirm_pending_preview_boundary(source=DurableContentSource.STREAM_PERSISTED)
+            else:
+                self._retract_pending_preview_boundary()
             logger.error("Commentary send error: %s", e)
             return False
 
@@ -378,10 +389,15 @@ class StreamFallbackMixin:
         fallback send happens either."""
         # A native-stream bubble isn't a deletable message — close an open one
         # (e.g. from an eager re-seed) with an empty finalize so it doesn't hang.
+        closed = True
         if self._native_stream_opened:
-            await self._close_empty_native_bubble("Silence-marker native stream close failed: %s")
+            closed = await self._close_empty_native_bubble("Silence-marker native stream close failed: %s")
 
-        await self._delete_previews(self._stale_preview_ids(), label="Silence-marker")
+        deleted = await self._delete_previews(self._stale_preview_ids(), label="Silence-marker")
+        if closed and deleted and self._message_id != "__no_edit__":
+            self._retract_pending_preview_boundary()
+        else:
+            self._confirm_pending_preview_boundary(source=DurableContentSource.STREAM_PERSISTED)
         self._preview_message_ids = set()
         self._message_id = None
         self._accumulated = self._stream_ledger = self._last_sent_text = ""

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -5,6 +5,8 @@ state model and the drain loop that calls into these."""
 
 from __future__ import annotations
 
+from gateway.progress_events import DurableContentSource
+
 import asyncio
 import inspect
 import logging
@@ -68,11 +70,12 @@ class StreamTransportMixin:
         self._native_stream_opened = False
         self._native_last_pushed_len = 0
 
-    async def _close_empty_native_bubble(self, fail_log: str) -> None:
+    async def _close_empty_native_bubble(self, fail_log: str) -> bool:
         """Best-effort empty finalize frame to close an open typing bubble, then mark closed."""
-        await self._try_frame(self._send_frame("", finalize=True), fail_log)
+        closed = await self._try_frame(self._send_frame("", finalize=True), fail_log)
         self._close_native_state()
         self._reopen_seeded_eagerly = False
+        return closed
 
     def _degrade_native_to_buffered_send(self) -> None:
         """Leave native mode; buffer_only so post-boundary output is ONE send() at got_done
@@ -98,11 +101,12 @@ class StreamTransportMixin:
         return stale_ids
 
     async def _delete_previews(self, stale_ids, *, skip=None, label: str,
-                               retry_on_false: bool = False, skip_sentinel: bool = True) -> None:
+                               retry_on_false: bool = False, skip_sentinel: bool = True) -> bool:
         """Best-effort delete of stale previews; never the message just sent (``skip``)."""
         delete_fn = getattr(self.adapter, "delete_message", None)
         if delete_fn is None:
-            return
+            return not stale_ids
+        deleted_all = True
         for stale_id in stale_ids:
             if not stale_id or stale_id == skip or (skip_sentinel and stale_id == "__no_edit__"):
                 continue
@@ -114,9 +118,13 @@ class StreamTransportMixin:
                     # preview bubble next to the fresh final (#71047 Problem B). One short bounded retry
                     # clears the common transient case; a second failure stays best-effort.
                     await asyncio.sleep(1.0)
-                    await delete_fn(self.chat_id, stale_id)
+                    deleted = await delete_fn(self.chat_id, stale_id)
+                if deleted is False or getattr(deleted, "success", True) is False:
+                    deleted_all = False
             except Exception as e:
+                deleted_all = False
                 logger.debug("%s preview cleanup failed (%s): %s", label, stale_id, e)
+        return deleted_all
 
     def _resolve_draft_streaming(self) -> bool:
         """cfg.transport "draft"/"auto" → the adapter's supports_draft_streaming probe
@@ -173,6 +181,8 @@ class StreamTransportMixin:
         else:
             if getattr(result, "success", False):
                 self._last_sent_text = text  # parity with the edit-based no-op skip
+                if self._stream_is_message():
+                    self._ack_persistent_stream_boundary()
                 return True
             # P5(b): an AUTHORIZATION decline is terminal for the whole run, not
             # merely "drafts are unusable". Disabling drafts alone routes the
@@ -289,6 +299,7 @@ class StreamTransportMixin:
         self._adopt_message_id(new_message_id)
         self._already_sent = True
         self._last_sent_text = text
+        self._confirm_or_notify_content_boundary(DurableContentSource.FRESH_FINAL, message_id=new_message_id)
         if is_turn_final:
             self._final_response_sent = True
             self._record_turn_final_payload(text)
@@ -383,6 +394,8 @@ class StreamTransportMixin:
             self._already_sent = True
             self._last_sent_text = text
             self._native_last_pushed_len = len(text)
+            if self._accumulated:
+                self._ack_persistent_stream_boundary()
             if finalize:
                 self._mark_final_delivered()
             return True
@@ -439,10 +452,22 @@ class StreamTransportMixin:
                 "declined this destination for this run"
             )
             return False
-        result = await self.adapter.send(
-            chat_id=self.chat_id, content=text, reply_to=self._initial_reply_to_id,
-            metadata=self._metadata_for_send(final=finalize, expect_edits=not finalize))
+        self._open_preview_boundary()
+        try:
+            result = await self.adapter.send(
+                chat_id=self.chat_id, content=text, reply_to=self._initial_reply_to_id,
+                metadata=self._metadata_for_send(final=finalize, expect_edits=not finalize))
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError) or self._send_failure_may_have_delivered(exc):
+                self._confirm_pending_preview_boundary(source=DurableContentSource.STREAM_PERSISTED)
+            else:
+                self._retract_pending_preview_boundary()
+            raise
         if not result.success:
+            if self._send_failure_may_have_delivered(result):
+                self._confirm_pending_preview_boundary(source=DurableContentSource.STREAM_PERSISTED)
+            else:
+                self._retract_pending_preview_boundary()
             self._edit_supported = False
             return False
         self._already_sent = True
@@ -454,7 +479,11 @@ class StreamTransportMixin:
             # No editable id: fallback mode + sentinel so we don't re-enter first-send.
             self._enter_fallback_mode(self._visible_prefix())
             self._message_id = "__no_edit__"
-        self._notify_new_message()
+        if result.message_id:
+            self._record_pending_preview_message_id(str(result.message_id))
+        if finalize or not result.message_id:
+            self._confirm_pending_preview_boundary(source=(DurableContentSource.STREAM_FINALIZED
+                if finalize else DurableContentSource.STREAM_PERSISTED))
         return True
 
     async def _edit_existing(self, text: str, *, finalize: bool, is_turn_final: bool) -> bool:
@@ -492,7 +521,7 @@ class StreamTransportMixin:
             self._turn_split_delivery = True
             self._adopt_message_id(str(result.message_id))
             self._last_sent_text = ""
-            self._notify_new_message()
+            self._confirm_or_notify_content_boundary(DurableContentSource.OVERFLOW, message_id=result.message_id)
         else:
             self._last_sent_text = text
         self._flood_strikes = 0
@@ -552,7 +581,7 @@ class StreamTransportMixin:
                 self._fallback_preserve_partial_messages = False
                 self._enter_fallback_mode(self._visible_prefix())
             if getattr(result, "continuation_message_ids", ()):
-                self._notify_new_message()
+                self._confirm_or_notify_content_boundary(DurableContentSource.OVERFLOW, message_id=result.message_id)
             return False
 
         # Flood control: adaptive backoff (double the interval); disable edits only

--- a/tests/gateway/test_progress_boundary_order.py
+++ b/tests/gateway/test_progress_boundary_order.py
@@ -1,0 +1,126 @@
+"""Progress ordering across asynchronous producer and delivery boundaries."""
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.progress_events import (
+    ContentBoundaryBuffer, DurableContentBoundary, DurableContentSource,
+    ProvisionalContentBoundary, RetractedContentBoundary,
+)
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def test_overlapping_preview_outcomes_preserve_progress_order():
+    buffer = ContentBoundaryBuffer()
+    first = ProvisionalContentBoundary("first")
+    second = ProvisionalContentBoundary("second")
+    durable = DurableContentBoundary("second", DurableContentSource.STREAM_FINALIZED)
+    assert buffer.feed("before") == ["before"]
+    for item in [first, "middle", second, "after", durable, durable]:
+        assert buffer.feed(item) == []
+    assert buffer.feed(RetractedContentBoundary("first")) == ["middle", durable, "after"]
+    assert buffer.feed(RetractedContentBoundary("first")) == []
+    assert buffer.finish() == []
+
+
+@pytest.mark.asyncio
+async def test_worker_queues_multiple_segments_before_platform_delivery():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(side_effect=[
+        SimpleNamespace(success=True, message_id="first"),
+        SimpleNamespace(success=True, message_id="second"),
+    ])
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+    events = []
+    consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig(),
+        on_content_boundary=events.append)
+    consumer.on_delta("first segment")
+    consumer.on_segment_break()
+    consumer.on_delta("second segment")
+    consumer.finish()
+    provisional = list(events)
+    assert all(isinstance(item, ProvisionalContentBoundary) for item in provisional)
+    assert len(provisional) == 2
+    await consumer.run()
+    durable = [item for item in events if isinstance(item, DurableContentBoundary)]
+    assert [item.boundary_id for item in durable] == [item.boundary_id for item in provisional]
+    assert [item.message_id for item in durable] == ["first", "second"]
+    assert [call.kwargs["content"] for call in adapter.send.call_args_list] == [
+        "first segment", "second segment"]
+
+
+def test_dedup_after_a_durable_seal_becomes_first_line():
+    from gateway.run_turn_runner import TurnRunner
+    state = SimpleNamespace(progress_lines=[])
+    text = TurnRunner._progress_absorb(None, state, ("__dedup__", "same tool", 1))
+    assert state.progress_lines == [text] == ["same tool"]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_commentary_is_not_declared_deleted():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=False,
+        error="read timeout", retryable=False))
+    events = []
+    consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig(),
+        on_content_boundary=events.append)
+    consumer.on_commentary("possibly delivered")
+    consumer.finish()
+    await consumer.run()
+    assert len(events) == 2
+    assert isinstance(events[0], ProvisionalContentBoundary)
+    assert isinstance(events[1], DurableContentBoundary)
+    assert events[0].boundary_id == events[1].boundary_id
+
+
+@pytest.mark.asyncio
+async def test_persistent_draft_releases_live_progress_before_turn_end():
+    from tests.gateway.test_stream_consumer_draft import _make_draft_capable_adapter
+    adapter = _make_draft_capable_adapter()
+    adapter.draft_stream_is_message = True
+    buffer = ContentBoundaryBuffer()
+    ready = []
+    consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig(
+        transport="draft", chat_type="dm", cursor=""),
+        on_content_boundary=lambda event: ready.extend(buffer.feed(event)))
+    consumer.on_delta("first segment")
+    consumer._drain_queue()
+    await consumer._start_transports()
+    assert await consumer._send_or_edit("first segment")
+    assert buffer.feed("tool started") == ["tool started"]
+    consumer.on_segment_break()
+    consumer.on_delta(" continued")
+    tick = consumer._drain_queue()
+    await consumer._end_segment(tick)
+    consumer._drain_queue()
+    assert await consumer._send_or_edit("first segment continued")
+    assert len([event for event in ready if isinstance(event, DurableContentBoundary)]) == 1
+    assert consumer._accumulated == "first segment continued"
+
+
+@pytest.mark.asyncio
+async def test_progress_cleanup_failure_cannot_leak_the_session_slot():
+    import asyncio
+    from gateway.run import GatewayRunner
+    started = asyncio.Event()
+    async def failing_drain():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("transport disconnected")
+    progress = asyncio.create_task(failing_drain())
+    tracking = asyncio.create_task(asyncio.Event().wait())
+    await started.wait()
+    runner = object.__new__(GatewayRunner)
+    runner._release_running_agent_state = MagicMock()
+    runner._draining = False
+    ctx = SimpleNamespace(stream_consumer_holder=[None], session_key="owned",
+        streaming_tts_consumer_holder=[None], run_generation=1)
+    await runner._run_agent_cleanup_turn_tasks(ctx, progress_task=progress,
+        log_task=None, interrupt_monitor=None, _notify_task=None,
+        tracking_task=tracking, stream_task=None)
+    assert tracking.cancelled()
+    runner._release_running_agent_state.assert_called_once_with("owned", run_generation=1)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -60,6 +60,59 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+class EphemeralPreviewCaptureAdapter(ProgressCaptureAdapter):
+    """Track message identity and preview deletion across one streamed turn."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.deleted = []
+        self._next_id = 0
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._next_id += 1
+        message_id = f"message-{self._next_id}"
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "message_id": message_id,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(
+        self,
+        chat_id,
+        message_id,
+        content,
+        **kwargs,
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                **kwargs,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.append({"chat_id": chat_id, "message_id": message_id})
+        return True
+
+
+class SlowPreviewCaptureAdapter(EphemeralPreviewCaptureAdapter):
+    """Delay only the provisional content send to expose ordering races."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if "temporary preview" in content:
+            await asyncio.sleep(0.5)
+        return await super().send(chat_id, content, reply_to, metadata)
+
+
 class DiscordProgressCaptureAdapter(ProgressCaptureAdapter):
     """Capture sends while exercising Discord's real preview formatter."""
 
@@ -228,6 +281,40 @@ class FakeAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+
+class EphemeralPreviewBetweenToolsAgent:
+    """Emit a retractable stream preview between two tool starts."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.tool_progress_callback is not None
+        assert self.stream_delta_callback is not None
+        self.tool_progress_callback("tool.started", "terminal", "first", {})
+        time.sleep(0.35)
+        self.stream_delta_callback("temporary preview")
+        time.sleep(0.1)
+        self.tool_progress_callback("tool.started", "terminal", "second", {})
+        time.sleep(0.35)
+        return {
+            "final_response": "[SILENT]",
+            "response_previewed": True,
+            "messages": [],
+            "api_calls": 2,
+        }
+
+
+class DurablePreviewBetweenToolsAgent(EphemeralPreviewBetweenToolsAgent):
+    """Keep the streamed preview as durable content at turn finalization."""
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        result = super().run_conversation(message, conversation_history, task_id)
+        result["final_response"] = "temporary preview"
+        return result
 
 
 class NativeTaskCardAdapter(ProgressCaptureAdapter):
@@ -1056,6 +1143,104 @@ async def _run_with_agent(
         session_key=session_key,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_preview_does_not_split_accumulated_progress(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        EphemeralPreviewBetweenToolsAgent,
+        session_id="sess-ephemeral-progress",
+        config_data={
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "streaming": True,
+                        "tool_progress": "all",
+                        "tool_progress_grouping": "accumulate",
+                        "cleanup_progress": True,
+                    }
+                }
+            },
+        },
+        chat_id="1234",
+        chat_type="private",
+        thread_id="77",
+        adapter_cls=EphemeralPreviewCaptureAdapter,
+    )
+
+    assert result["final_response"] == "[SILENT]"
+    assert isinstance(adapter, EphemeralPreviewCaptureAdapter)
+    deleted_ids = {entry["message_id"] for entry in adapter.deleted}
+    assert any(
+        sent["message_id"] in deleted_ids and "temporary preview" in sent["content"]
+        for sent in adapter.sent
+    )
+    progress_sends = [
+        sent
+        for sent in adapter.sent
+        if "Running" in sent["content"]
+    ]
+    assert len(progress_sends) == 1, (
+        adapter.sent,
+        adapter.deleted,
+        adapter.edits,
+    )
+    progress_id = progress_sends[0]["message_id"]
+    assert adapter.edits
+    assert {edit["message_id"] for edit in adapter.edits} == {progress_id}
+    assert "first" in adapter.edits[-1]["content"]
+    assert "second" in adapter.edits[-1]["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [EphemeralPreviewCaptureAdapter, SlowPreviewCaptureAdapter],
+)
+async def test_durable_preview_splits_progress_at_confirmed_boundary(
+    monkeypatch, tmp_path, adapter_cls
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DurablePreviewBetweenToolsAgent,
+        session_id="sess-durable-progress",
+        config_data={
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "streaming": True,
+                        "tool_progress": "all",
+                        "tool_progress_grouping": "accumulate",
+                        "cleanup_progress": False,
+                    }
+                }
+            },
+        },
+        chat_id="1234",
+        chat_type="private",
+        thread_id="77",
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "temporary preview"
+    assert isinstance(adapter, EphemeralPreviewCaptureAdapter)
+    progress_sends = [sent for sent in adapter.sent if "Running" in sent["content"]]
+    assert len(progress_sends) == 2, (
+        [sent["content"] for sent in adapter.sent],
+        adapter.edits,
+    )
+    assert "first" in progress_sends[0]["content"]
+    assert "second" not in progress_sends[0]["content"]
+    assert "second" in progress_sends[1]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -7,6 +7,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.progress_events import (
+    DurableContentBoundary,
+    DurableContentSource,
+    ProvisionalContentBoundary,
+    RetractedContentBoundary,
+)
 
 
 def test_stream_send_metadata_carries_original_reply_anchor():
@@ -758,7 +764,7 @@ class TestEditOverflowSplitAndDeliver:
     """When edit_message split-and-delivers an oversized payload across the
     original message + N continuations (Telegram >4096 UTF-16), the consumer
     must update _message_id to the latest continuation, reset _last_sent_text,
-    and fire on_new_message so subsequent tool-progress bubbles linearize
+    and publish a durable boundary so subsequent tool-progress bubbles linearize
     below the new visible message."""
 
     @pytest.mark.asyncio
@@ -782,9 +788,8 @@ class TestEditOverflowSplitAndDeliver:
         )
         consumer = GatewayStreamConsumer(adapter, "chat_999", config)
 
-        # Track on_new_message firings.
-        new_msg_count = [0]
-        consumer._on_new_message = lambda: new_msg_count.__setitem__(0, new_msg_count[0] + 1)
+        boundaries = []
+        consumer._on_content_boundary = boundaries.append
 
         # Seed the consumer as if a first send succeeded already.
         consumer._message_id = "msg_initial"
@@ -799,9 +804,9 @@ class TestEditOverflowSplitAndDeliver:
         assert consumer._message_id == "msg_continuation_2"
         # Skip-if-same cache reset so the next edit doesn't false-positive.
         assert consumer._last_sent_text == ""
-        # on_new_message fired so the tool-progress bubble breaks below
-        # the new continuation (per the openclaw #32535 lesson).
-        assert new_msg_count[0] == 1
+        assert len(boundaries) == 1
+        assert boundaries[0].source is DurableContentSource.OVERFLOW
+        assert boundaries[0].message_id == "msg_continuation_2"
 
 
 class TestInterimCommentaryMessages:
@@ -1076,12 +1081,13 @@ class TestCursorStrippingOnFallback:
         assert consumer._last_sent_text == "Hello world"
 
 
-# ── on_new_message callback (tool-progress linearization) ─────────────
+# ── durable content boundary callback (tool-progress linearization) ───
 
 
-class TestOnNewMessageCallback:
-    """The on_new_message callback fires whenever a fresh content bubble
-    lands on the platform. Gateway uses this to close off the current
+class TestContentBoundaryCallback:
+    """The callback fires whenever a durable content bubble lands.
+
+    Gateway uses this to close off the current
     tool-progress bubble so the next tool.started opens a new bubble
     below the content — preserving chronological order in the chat.
 
@@ -1092,6 +1098,121 @@ class TestOnNewMessageCallback:
     content messages lined up below, making the timeline look scrambled.
     """
 
+    def test_duplicate_delivery_confirmation_is_idempotent(self):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        events = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat",
+            StreamConsumerConfig(),
+            on_content_boundary=events.append,
+        )
+
+        consumer._notify_content_boundary(
+            DurableContentSource.COMMENTARY,
+            message_id="same-message",
+        )
+        consumer._notify_content_boundary(
+            DurableContentSource.COMMENTARY,
+            message_id="same-message",
+        )
+
+        assert len(events) == 1
+        assert events[0].boundary_id.endswith(":message:same-message")
+
+    @pytest.mark.asyncio
+    async def test_stream_preview_is_provisional_until_segment_seals(self):
+        """A preview opens a pause point but cannot reset progress yet."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="preview_1")
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="preview_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        events = []
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1)
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat",
+            config,
+            on_content_boundary=events.append,
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("provisional")
+        assert len(events) == 1
+        assert isinstance(events[0], ProvisionalContentBoundary)
+        await asyncio.sleep(0.05)
+
+        assert adapter.send.await_count == 1
+        assert len(events) == 1
+        boundary_id = events[0].boundary_id
+
+        consumer.on_segment_break()
+        await asyncio.sleep(0.05)
+        assert len(events) == 2
+        assert isinstance(events[1], DurableContentBoundary)
+        assert events[1].boundary_id == boundary_id
+        assert events[1].source is DurableContentSource.STREAM_FINALIZED
+        assert events[1].message_id == "preview_1"
+
+        consumer.finish()
+        await task
+
+    @pytest.mark.asyncio
+    async def test_filtered_segment_retracts_provisional_boundary(self):
+        """Hidden-only deltas cannot commit a durable content split."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.edit_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        events = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+            on_content_boundary=events.append,
+        )
+
+        consumer.on_delta("<think>hidden</think>")
+        consumer.on_segment_break()
+        consumer.finish()
+        await consumer.run()
+
+        assert isinstance(events[0], ProvisionalContentBoundary)
+        assert isinstance(events[1], RetractedContentBoundary)
+        assert events[0].boundary_id == events[1].boundary_id
+        assert not any(isinstance(event, DurableContentBoundary) for event in events)
+        adapter.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_overflow_send_resolves_matching_provisional_boundary(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="overflow_1")
+        )
+        adapter.edit_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        events = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat",
+            StreamConsumerConfig(),
+            on_content_boundary=events.append,
+        )
+
+        consumer.on_delta("preview")
+        consumer._drain_queue()  # Adopt the producer boundary before transport delivery.
+        await consumer._send_new_chunk("overflow", None)
+
+        assert isinstance(events[0], ProvisionalContentBoundary)
+        assert isinstance(events[1], DurableContentBoundary)
+        assert events[1].source is DurableContentSource.OVERFLOW
+        assert events[0].boundary_id == events[1].boundary_id
 
     @pytest.mark.asyncio
     async def test_callback_fires_once_per_segment(self):
@@ -1108,7 +1229,7 @@ class TestOnNewMessageCallback:
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1)
         consumer = GatewayStreamConsumer(
             adapter, "chat", config,
-            on_new_message=lambda: events.append("reset"),
+            on_content_boundary=events.append,
         )
 
         consumer.on_delta("A")
@@ -1119,13 +1240,20 @@ class TestOnNewMessageCallback:
         consumer.finish()
         await consumer.run()
 
-        # Three content bubbles ⇒ three reset notifications
-        assert events == ["reset", "reset", "reset"]
+        durable = [event for event in events if isinstance(event, DurableContentBoundary)]
+        provisional = [
+            event for event in events if isinstance(event, ProvisionalContentBoundary)
+        ]
+        assert [event.message_id for event in durable] == ["msg_1", "msg_2", "msg_3"]
+        assert len(provisional) == 3
+        assert [event.boundary_id for event in provisional] == [
+            event.boundary_id for event in durable
+        ]
 
 
     @pytest.mark.asyncio
     async def test_no_callback_when_none(self):
-        """Consumer works correctly when on_new_message is None (default)."""
+        """Consumer works correctly when the boundary callback is None."""
         adapter = MagicMock()
         adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
         adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.progress_events import DurableContentBoundary, ProvisionalContentBoundary
 from gateway.stream_consumer import (
     GatewayStreamConsumer,
     StreamConsumerConfig,
@@ -106,13 +107,25 @@ class TestDraftStreamingHappyPath:
             transport="auto", chat_type="dm",
             edit_interval=0.01, buffer_threshold=5, cursor="",
         )
-        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        boundaries = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "12345",
+            cfg,
+            on_content_boundary=boundaries.append,
+        )
 
         consumer.on_delta("Hello ")
         task = asyncio.create_task(consumer.run())
         await asyncio.sleep(0.05)
         consumer.on_delta("world!")
         await asyncio.sleep(0.05)
+        assert len(boundaries) == 1
+        assert isinstance(boundaries[0], ProvisionalContentBoundary)
+        assert not any(
+            isinstance(boundary, DurableContentBoundary)
+            for boundary in boundaries
+        ), "native draft frames are not persistent entries"
         consumer.finish()
         await task
 
@@ -139,6 +152,10 @@ class TestDraftStreamingHappyPath:
         final_metadata = final_call.kwargs.get("metadata") or {}
         assert final_metadata.get("notify") is True
         assert "expect_edits" not in final_metadata
+        assert len(boundaries) == 2
+        assert isinstance(boundaries[0], ProvisionalContentBoundary)
+        assert isinstance(boundaries[1], DurableContentBoundary)
+        assert boundaries[0].boundary_id == boundaries[1].boundary_id
 
     @pytest.mark.asyncio
     async def test_stream_is_message_preserves_cumulative_text_across_tool_boundaries(self):

--- a/tests/gateway/test_stream_consumer_silence.py
+++ b/tests/gateway/test_stream_consumer_silence.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.progress_events import DurableContentBoundary, ProvisionalContentBoundary
 from gateway.response_filters import (
     is_intentional_silence_response,
     is_partial_silence_marker,
@@ -152,5 +153,29 @@ class TestStreamedSilenceSuppression:
         adapter.delete_message.assert_awaited_once_with("chat_1", "preview_1")
         assert consumer.final_content_delivered is False
         assert consumer.already_sent is False
+
+    @pytest.mark.asyncio
+    async def test_failed_preview_delete_commits_boundary(self):
+        """A preview that remains visible is a durable timeline entry."""
+        adapter = _make_adapter()
+        adapter.delete_message.return_value = False
+        events = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+            on_content_boundary=events.append,
+        )
+        consumer._message_id = "preview_1"
+        consumer._preview_message_ids = {"preview_1"}
+        consumer._already_sent = True
+
+        consumer.on_delta("NO_REPLY")
+        consumer.finish()
+        await consumer.run()
+
+        assert isinstance(events[0], ProvisionalContentBoundary)
+        assert isinstance(events[1], DurableContentBoundary)
+        assert events[0].boundary_id == events[1].boundary_id
 
 


### PR DESCRIPTION
## What does this PR do?

Replaces the gateway's untyped progress-reset sentinel with correlated content-boundary lifecycle events:

- `ProvisionalContentBoundary` pauses later tool updates before an async preview send can be overtaken
- `DurableContentBoundary` seals the existing progress bubble and replays deferred tools below confirmed content
- `RetractedContentBoundary` resumes the existing progress bubble when a preview leaves no persistent entry

The boundary ID is stable across provisional, durable, and retracted phases. Native draft frames and empty/filtered segments never commit a durable split. Failed preview deletion is treated conservatively as durable because the content may still be visible.

## Related Issue

Fixes #99026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added typed, idempotent content-boundary events in `gateway/progress_events.py`
- Updated `gateway/stream_consumer.py` to open provisional boundaries synchronously, then correlate durable/retracted outcomes after platform delivery
- Updated `gateway/run.py` to defer progress during provisional content and replay it on the correct side of the resolved boundary
- Kept accumulated progress in one editable message when a preview is retracted
- Preserved chronology when content remains durable, including slow sends and overflow continuations
- Added Telegram DM-topic regressions plus draft, silence, cleanup, edit, and interrupt coverage

## How to Test

1. Run the focused content/progress lifecycle suite:
   ```bash
   scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_stream_consumer_silence.py tests/gateway/test_stream_consumer_tool_progress.py tests/gateway/test_run_progress_topics.py
   ```
2. Run adjacent progress cleanup and Telegram edit coverage:
   ```bash
   scripts/run_tests.sh tests/gateway/test_run_cleanup_progress.py tests/gateway/test_run_progress_interrupt.py tests/gateway/test_telegram_progress_edit_transient.py tests/gateway/test_telegram_polling_progress.py
   ```
3. Run lint on the changed files:
   ```bash
   ruff check gateway/progress_events.py gateway/run.py gateway/stream_consumer.py tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_stream_consumer_silence.py tests/gateway/test_run_progress_topics.py
   ```

Observed locally: 131 focused lifecycle tests passed, 33 adjacent progress tests passed, and Ruff passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib queue/deque and existing adapter contracts only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

The regression tests cover the exact failure modes:

- retracted preview: one accumulated progress send followed by edits
- durable preview: a new progress send below content
- delayed preview send: later tools remain deferred until the matching boundary resolves
- failed preview deletion: resolve as durable rather than replaying progress above still-visible content
