### PR TITLE
fix(delegate): defer timed-out child cleanup

### DIFF
--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -462,6 +462,7 @@ class TestDelegationCleanup:
         child_started = threading.Event()
         release_child = threading.Event()
         child_finished = threading.Event()
+        child_closed = threading.Event()
         parent = MagicMock()
         parent._active_children = []
         parent._active_children_lock = threading.Lock()
@@ -469,10 +470,18 @@ class TestDelegationCleanup:
         child.session_id = "timed-out-child"
         child._delegate_saved_tool_names = ["tool1"]
         child.get_activity_summary.return_value = {"api_call_count": 1}
+
+        def close_child():
+            # Resource teardown is unsafe until run_conversation has fully
+            # returned: it closes the child's owned SessionDB and HTTP clients.
+            assert child_finished.is_set()
+            child_closed.set()
+
+        child.close.side_effect = close_child
         parent._active_children.append(child)
         relay_host = MagicMock()
         monkeypatch.setattr(relay_runtime, "get_runtime", lambda **_kwargs: relay_host)
-        monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 0.1)
+        monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 1.0)
 
         def run_conversation(**kwargs):
             lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
@@ -519,9 +528,12 @@ class TestDelegationCleanup:
                 session_id=child.session_id,
             )
             relay_host.unregister_subagent.assert_not_called()
+            child.close.assert_not_called()
 
             release_child.set()
             assert child_finished.wait(timeout=5)
+            assert child_closed.wait(timeout=5)
+            child.close.assert_called_once_with()
             assert not relay_runtime.SESSION_COORDINATOR.has_active_turn(
                 profile_key=str(profile_home),
                 session_id=child.session_id,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3488,13 +3488,24 @@ def _run_single_child(
                 logger.debug("Could not remove child from active_children: %s", e)
 
         # Close tool resources (terminal sandboxes, browser daemons,
-        # background processes, httpx clients) so subagent subprocesses
-        # don't outlive the delegation.
+        # background processes, httpx clients) so subagent subprocesses do not
+        # outlive the delegation. A timeout stops waiting on the Future but does
+        # not stop its worker, so defer teardown until that worker has exited.
+        def _close_child_resources(_done_future=None) -> None:
+            try:
+                if child is not None and hasattr(child, "close"):
+                    child.close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
+
         try:
-            if hasattr(child, "close"):
-                child.close()
+            child_future = locals().get("_child_future")
+            if child_future is not None and not child_future.done():
+                child_future.add_done_callback(_close_child_resources)
+            else:
+                _close_child_resources()
         except Exception:
-            logger.debug("Failed to close child agent after delegation")
+            logger.debug("Failed to schedule child-agent cleanup after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop


### PR DESCRIPTION
## What does this PR do?

Defers cleanup of a timed-out delegated child until its worker future has actually finished.

`Future.result(timeout=...)` stops waiting but does not stop the worker thread. The existing `finally` block immediately called `child.close()`, which can close the child's SQLite and HTTP resources while `run_conversation()` is still unwinding in that worker.

If the future is still running, this change attaches cleanup with `Future.add_done_callback()`. Completed and pre-future failure paths still clean up immediately.

## Related Issue

No existing issue or PR matching this race was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update `tools/delegate_tool.py` to defer `child.close()` only while the child future remains active.
- Strengthen `tests/tools/test_zombie_process_cleanup.py` to prove cleanup does not run before the timed-out turn exits and does run exactly once afterward.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_zombie_process_cleanup.py -q
```

Result: **16 passed**.

The regression fails with the previous immediate-cleanup behavior because `child.close()` is observed before `run_conversation()` releases its active turn.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed issues/PRs for existing work.
- [x] This PR contains only the timeout-cleanup fix and its regression.
- [x] Focused repository-wrapper tests pass.
- [x] I've added a regression test.
- [x] Tested on Fedora Linux.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior is internal and covered by comments/tests.
- [x] Config-example changes are N/A.
- [x] Architecture-guide changes are N/A.
- [x] Cross-platform impact considered: this uses standard `concurrent.futures` callback behavior.
- [x] Tool schema changes are N/A.
