### PR TITLE
feat(gateway): compose wildcard channel prompts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2916,29 +2916,42 @@ def resolve_channel_prompt(
     channel_id: str,
     parent_id: str | None = None,
 ) -> str | None:
-    """Resolve a per-channel ephemeral prompt from platform config.
+    """Resolve a channel prompt, including an optional global policy.
 
-    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.
-    Prefers an exact match on *channel_id*; falls back to *parent_id*
-    (useful for forum threads / child channels inheriting a parent prompt).
+    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.  A
+    string ``"*"`` entry is a global policy prepended to every resolved prompt.
+    The channel-specific tier still prefers an exact *channel_id* match and
+    falls back to *parent_id* (useful for forum threads / child channels).
 
-    Returns the prompt string, or None if no match is found.  Blank/whitespace-
-    only prompts are treated as absent.
+    Returns the non-blank parts joined by a blank line, or None.  Blank or
+    non-string wildcard values are ignored.  An exact/parent prompt identical
+    to the wildcard after trimming is emitted once, while still counting as
+    the selected exact/parent tier.
     """
     prompts = config_extra.get("channel_prompts") or {}
     if not isinstance(prompts, dict):
         return None
 
+    parts: list[str] = []
+    wildcard = prompts.get("*")
+    if isinstance(wildcard, str):
+        wildcard = wildcard.strip()
+        if wildcard:
+            parts.append(wildcard)
+
     for key in (channel_id, parent_id):
-        if not key:
+        if not key or key == "*":
             continue
         prompt = prompts.get(key)
         if prompt is None:
             continue
         prompt = str(prompt).strip()
-        if prompt:
-            return prompt
-    return None
+        if not prompt:
+            continue
+        if prompt not in parts:
+            parts.append(prompt)
+        break
+    return "\n\n".join(parts) or None
 
 
 def resolve_channel_skills(

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -14,6 +14,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    resolve_channel_prompt,
     safe_url_for_log,
     utf16_len,
     validate_inbound_media_size,
@@ -21,6 +22,88 @@ from gateway.platforms.base import (
     _prefix_within_utf16_limit,
     cache_audio_from_bytes,
 )
+
+
+class TestResolveChannelPrompt:
+    def test_wildcard_only_applies_to_any_channel(self):
+        config = {"channel_prompts": {"*": "Global policy"}}
+
+        assert resolve_channel_prompt(config, "channel-a") == "Global policy"
+        assert resolve_channel_prompt(config, "channel-b") == "Global policy"
+
+    def test_wildcard_is_prepended_to_exact_prompt(self):
+        config = {
+            "channel_prompts": {
+                "*": "Global policy",
+                "channel-a": "Exact context",
+            }
+        }
+
+        assert resolve_channel_prompt(config, "channel-a") == (
+            "Global policy\n\nExact context"
+        )
+
+    def test_wildcard_is_prepended_to_inherited_parent_prompt(self):
+        config = {
+            "channel_prompts": {
+                "*": "Global policy",
+                "parent": "Parent context",
+            }
+        }
+
+        assert resolve_channel_prompt(config, "thread", "parent") == (
+            "Global policy\n\nParent context"
+        )
+
+    def test_exact_prompt_still_wins_over_parent(self):
+        config = {
+            "channel_prompts": {
+                "*": "Global policy",
+                "thread": "Exact context",
+                "parent": "Parent context",
+            }
+        }
+
+        assert resolve_channel_prompt(config, "thread", "parent") == (
+            "Global policy\n\nExact context"
+        )
+
+    def test_existing_resolution_is_unchanged_without_wildcard(self):
+        config = {
+            "channel_prompts": {
+                "thread": "Exact context",
+                "parent": "Parent context",
+            }
+        }
+
+        assert resolve_channel_prompt(config, "thread", "parent") == "Exact context"
+        assert resolve_channel_prompt(config, "other", "parent") == "Parent context"
+        assert resolve_channel_prompt(config, "other") is None
+
+    @pytest.mark.parametrize("wildcard", [None, "   ", [], {}, 0, False])
+    def test_blank_or_malformed_wildcard_is_ignored(self, wildcard):
+        config = {
+            "channel_prompts": {
+                "*": wildcard,
+                "channel-a": "Exact context",
+            }
+        }
+
+        assert resolve_channel_prompt(config, "channel-a") == "Exact context"
+        assert resolve_channel_prompt(config, "channel-b") is None
+
+    def test_identical_wildcard_and_selected_prompt_are_emitted_once(self):
+        config = {
+            "channel_prompts": {
+                "*": "Same policy",
+                "thread": "  Same policy  ",
+                "parent": "Different parent context",
+            }
+        }
+
+        # The exact entry still wins over the parent; it is merely de-duplicated
+        # from the already-selected wildcard text.
+        assert resolve_channel_prompt(config, "thread", "parent") == "Same policy"
 
 
 def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import resolve_channel_prompt
 from gateway.session import SessionSource
 from gateway.turn_context import TurnContext
 
@@ -145,3 +146,92 @@ class TestTurnRunner:
             "Context length exceeded. Cannot compress further."
         )
         assert result["compression_exhausted"] is True
+
+    def test_wildcard_channel_prompt_composes_with_channel_override(self):
+        class _CapturingAgent:
+            init_kwargs: dict = {}
+
+            def __init__(self, **kwargs):
+                type(self).init_kwargs = kwargs
+                self.model = kwargs["model"]
+                self.session_id = kwargs["session_id"]
+                self.tools = []
+                self.context_compressor = SimpleNamespace(
+                    last_prompt_tokens=0,
+                    context_length=200_000,
+                )
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+
+            def run_conversation(self, _message, **_kwargs):
+                return {
+                    "final_response": "ok",
+                    "messages": [],
+                    "api_calls": 1,
+                    "completed": True,
+                }
+
+        gateway_runner = MagicMock()
+        gateway_runner.config = SimpleNamespace(streaming=None)
+        gateway_runner._provider_routing = {}
+        gateway_runner._agent_cache_lock = None
+        gateway_runner._agent_cache = {}
+        gateway_runner._session_db = None
+        gateway_runner._prefill_messages = None
+        gateway_runner._pending_model_notes = {}
+        gateway_runner._pending_skills_reload_notes = {}
+        gateway_runner.session_store._entries = {}
+        gateway_runner._get_system_prompt_for_channel.return_value = "Override persona"
+        gateway_runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+        gateway_runner._resolve_session_reasoning_config.return_value = None
+        gateway_runner._resolve_session_service_tier.return_value = None
+        gateway_runner._resolve_turn_agent_config.return_value = {
+            "model": "test-model",
+            "runtime": {},
+        }
+        gateway_runner._agent_config_signature.return_value = ("test-signature",)
+        gateway_runner._extract_cache_busting_config.return_value = {}
+        gateway_runner._refresh_fallback_model.return_value = None
+        gateway_runner._consume_pending_native_image_paths.return_value = []
+        gateway_runner._consume_pending_turn_sidecar_notes.return_value = []
+        gateway_runner._is_telegram_topic_lane.return_value = False
+        gateway_runner._is_discord_auto_thread_lane.return_value = False
+        gateway_runner._is_relay_discord_channel_lane.return_value = False
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-a",
+            user_id="test-user",
+        )
+        channel_prompt = resolve_channel_prompt(
+            {
+                "channel_prompts": {
+                    "*": "Global policy",
+                    "channel-a": "Exact context",
+                }
+            },
+            source.chat_id,
+        )
+        ctx = TurnContext(
+            source=source,
+            message="continue",
+            history=[],
+            session_id="test-session",
+            session_key="test-session-key",
+            user_config={},
+            context_prompt="Platform context",
+            channel_prompt=channel_prompt,
+            AIAgent=_CapturingAgent,
+            resolve_display_setting=lambda *_args: False,
+            _run_still_current=lambda: True,
+            _hooks_ref=SimpleNamespace(loaded_hooks=False),
+        )
+
+        from gateway.run import TurnRunner
+
+        result = TurnRunner(gateway_runner, ctx).run_sync()
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.init_kwargs["ephemeral_system_prompt"] == (
+            "Platform context\n\nGlobal policy\n\nExact context\n\nOverride persona"
+        )

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -464,6 +464,8 @@ Per-channel ephemeral system prompts that are injected on every turn in the matc
 ```yaml
 discord:
   channel_prompts:
+    "*": |
+      Follow the server-wide privacy and escalation policy.
     "1234567890": |
       This channel is for research tasks. Prefer deep comparisons,
       citations, and concise synthesis.
@@ -473,8 +475,10 @@ discord:
 ```
 
 Behavior:
-- Exact thread/channel ID matches win.
-- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
+- The `"*"` prompt is prepended for every channel or thread.
+- Exact thread/channel ID matches win over parent entries.
+- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes composes the wildcard with the parent channel/forum prompt.
+- An identical wildcard and selected prompt are emitted once.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
 #### `discord.history_backfill`

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -292,6 +292,29 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 }
 ```
 
+## Shared Channel Prompt Policies
+
+Platforms that support `channel_prompts` (Discord, Telegram, Slack,
+Mattermost, and Feishu/Lark) use the same resolver. Use `"*"` for policy
+text that must apply to every channel, then add channel-specific context:
+
+```yaml
+discord:
+  channel_prompts:
+    "*": |
+      Follow the organization's privacy and escalation policy.
+    "123456789012345678": |
+      This channel handles code review. Focus on correctness and regressions.
+```
+
+The wildcard is prepended to the selected channel prompt. Exact channel or
+thread IDs win over parent channel/forum IDs; without an exact match, threads
+inherit the parent prompt. Blank or non-string wildcard values are ignored. If
+the selected prompt is identical to the wildcard after trimming, Hermes emits
+it once. `channel_prompts` remain additive when a matching
+`channel_overrides.system_prompt` is configured: the override prompt is
+appended after the wildcard and selected channel prompt.
+
 ## Per-Channel Model & System Prompt Overrides
 
 Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -315,6 +315,8 @@ Assign ephemeral system prompts to specific Mattermost channels. The prompt is i
 ```yaml
 mattermost:
   channel_prompts:
+    "*": |
+      Follow the workspace-wide privacy and escalation policy.
     "channel_id_abc123": |
       You are a research assistant. Focus on academic sources,
       citations, and concise synthesis.
@@ -323,7 +325,7 @@ mattermost:
       performance implications.
 ```
 
-Keys are Mattermost channel IDs (find them in the channel URL or via the API). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
+Keys are Mattermost channel IDs (find them in the channel URL or via the API). The `"*"` prompt is prepended to every channel; a matching channel prompt is appended as additional ephemeral context.
 
 ## Security
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -956,6 +956,8 @@ Assign ephemeral system prompts to specific Slack channels. The prompt is inject
 ```yaml
 slack:
   channel_prompts:
+    "*": |
+      Follow the workspace-wide privacy and escalation policy.
     "C01RESEARCH": |
       You are a research assistant. Focus on academic sources,
       citations, and concise synthesis.
@@ -964,7 +966,7 @@ slack:
       performance implications.
 ```
 
-Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
+Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). The `"*"` prompt is prepended to every channel; a matching channel prompt is appended as additional ephemeral context.
 
 ## Per-Channel Skill Bindings
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1251,6 +1251,8 @@ Assign ephemeral system prompts to specific Telegram groups or forum topics. The
 ```yaml
 telegram:
   channel_prompts:
+    "*": |
+      Follow the shared privacy and escalation policy.
     "-1001234567890": |
       You are a research assistant. Focus on academic sources,
       citations, and concise synthesis.
@@ -1259,11 +1261,11 @@ telegram:
       constructive.
 ```
 
-Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, topic-level prompts override the group-level prompt:
+Keys are chat IDs (groups/supergroups) or forum topic IDs. The `"*"` prompt is prepended globally. For forum groups, the exact topic prompt is selected before the group-level parent prompt:
 
 - Message in topic `42` inside group `-1001234567890` → uses topic `42`'s prompt
 - Message in topic `99` (no explicit entry) → falls back to group `-1001234567890`'s prompt
-- Message in a group with no entry → no channel prompt applied
+- Message in a group with no entry → uses only the `"*"` prompt (or no prompt if `"*"` is absent)
 
 Numeric YAML keys are automatically normalized to strings.
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `channel_prompts["*"]` policy at the shared platform resolver and composes it with the existing exact-channel or inherited-parent prompt.

This provides one platform-wide ephemeral policy while preserving channel/thread-specific context:

```yaml
discord:
  channel_prompts:
    "*": "Follow the organization's privacy and escalation policy."
    "123456789012345678": "This channel handles code review."
```

Resolution order is:

1. non-blank string wildcard;
2. exact channel/thread prompt, otherwise parent prompt;
3. existing `channel_overrides.system_prompt` composition in the turn path.

Without a wildcard, existing exact/parent behavior is unchanged. Blank or malformed wildcard values are ignored, and identical wildcard/selected text is emitted once.

## Related Work

This is complementary to #52298, which adds `channel_prompts` support to the SMS adapter. This PR deliberately does **not** duplicate that adapter change; once both land, SMS can rely on this shared wildcard behavior without adapter-local fallback logic.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Compose wildcard and exact/parent prompts in `gateway/platforms/base.py`.
- Add direct resolver coverage for wildcard-only, exact, inherited parent, precedence, malformed values, unchanged legacy behavior, and duplicate handling.
- Add a turn-path regression showing wildcard + selected channel prompt + `channel_overrides.system_prompt` composition.
- Document the shared policy on the messaging overview and supported platform pages.

## How to Test

```bash
scripts/run_tests.sh \
  tests/gateway/test_platform_base.py \
  tests/gateway/test_turn_context.py \
  tests/gateway/test_discord_channel_prompts.py \
  tests/gateway/test_feishu_channel_prompts.py -q
```

Result: **119 passed, 1 skipped**.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs and kept #52298's SMS integration separate.
- [x] This PR contains only shared resolver, integration-test, and documentation changes.
- [x] Focused repository-wrapper tests pass.
- [x] I've added tests for the new behavior.
- [x] Tested on Fedora Linux.

### Documentation & Housekeeping

- [x] Relevant messaging documentation is updated.
- [x] Config-example changes are N/A; this extends the existing `channel_prompts` mapping.
- [x] Architecture-guide changes are N/A.
- [x] Cross-platform impact considered: the implementation is in the shared platform resolver and preserves no-wildcard behavior.
- [x] Tool schema changes are N/A.
