### PR TITLE
fix: suppress short prefixes at tool boundaries

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -276,6 +276,10 @@ class GatewayStreamConsumer:
         # turn-final payload for multi-message deliveries (#78541).
         self._stream_ledger = ""
         self._message_id: Optional[str] = None
+        # A short cursor-suffixed prefix may be held back by _send_or_edit.
+        # Remember it so a following tool-boundary finalize does not strip the
+        # cursor and send that same prefix as a standalone message.
+        self._short_cursor_prefix_pending = False
         # Wall-clock timestamp (time.monotonic) when ``_message_id`` was
         # first assigned from a successful first-send.  Used by the
         # fresh-final logic to detect long-lived previews whose edit
@@ -3057,7 +3061,22 @@ class GatewayStreamConsumer:
                 and self.cfg.cursor
                 and self.cfg.cursor in text
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
+            self._short_cursor_prefix_pending = True
             return True  # too short for a standalone message — accumulate more
+
+        # The segment-break path finalizes without appending the cursor. If a
+        # short cursor-era prefix was held back above, do not turn it into a
+        # standalone one-character message at the tool boundary. The next
+        # segment will still be delivered normally, while a real turn-final
+        # one-character answer keeps its existing delivery semantics.
+        if (
+            self._short_cursor_prefix_pending
+            and finalize
+            and not is_turn_final
+            and len(_visible_stripped) < _MIN_NEW_MSG_CHARS
+        ):
+            self._short_cursor_prefix_pending = False
+            return True
 
         # Native streaming transport (e.g. WeCom): every frame — first send,
         # mid-stream updates, and the final answer — flows through

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -351,6 +351,35 @@ class TestSegmentBreakOnToolBoundary:
             f"Cursor found in finalized segment: {thinking_texts[-1]!r}"
         )
 
+    @pytest.mark.asyncio
+    async def test_run_does_not_send_short_held_prefix_at_tool_boundary(self):
+        """A skipped short cursor preview must not be finalized as a message."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            side_effect=[
+                SimpleNamespace(success=True, message_id="msg_1"),
+            ]
+        )
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        )
+        consumer.on_delta("I")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(None)
+        consumer.on_delta("Done")
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs.get("content", "") for call in adapter.send.call_args_list]
+        assert "I" not in sent_texts
+        assert "Done" in sent_texts
+
 
     @pytest.mark.asyncio
     async def test_segment_break_clears_failed_edit_fallback_state(self):
@@ -1487,4 +1516,3 @@ class TestFlushPendingSync:
 
         consumer.finish()
         await task
-


### PR DESCRIPTION
## Summary
- remember when a short cursor-suffixed preview was intentionally held back
- avoid finalizing that prefix as a standalone message when a tool boundary arrives
- add an end-to-end stream-consumer regression test covering `on_delta(None)`

## Validation
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py -q` — 66 passed, 1 skipped
- `python3 scripts/check-windows-footguns.py --diff main`
- `git diff --check`
- `python -m py_compile gateway/stream_consumer.py tests/gateway/test_stream_consumer.py`

The existing #9538 guard covers the first preview send; this closes the remaining run-path gap where the boundary finalize stripped the cursor and sent the short prefix.