### PR TITLE
fix(desktop): route /btw through the prompt.btw RPC so side-question answers reach the conversation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
@@ -1,0 +1,67 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => stream.handleEvent({ payload, session_id: sessionId, type }))
+}
+
+function lastMessage(id = SID) {
+  return stream.state(id).messages.at(-1)
+}
+
+describe('btw.complete event', () => {
+  beforeEach(() => {
+    mountStream()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #99065: the side-question answer arrives on this event from prompt.btw.
+  // Before the desktop routed /btw through that RPC, the slash-worker route
+  // printed the answer from a fire-and-forget thread after the stdout
+  // capture window closed, so only the acknowledgement ever rendered.
+  it('appends the answer to the originating session as a system message', () => {
+    emit('btw.complete', { task_id: 'btw_ab12cd', question: 'which file was that error in?', text: 'src/main.ts' })
+
+    const message = lastMessage()
+
+    expect(message?.role).toBe('system')
+    expect(message?.id).toBe('btw-complete-btw_ab12cd')
+    expect(stream.text()).toBe('[btw "which file was that error in?" (btw_ab12cd)]\nsrc/main.ts')
+  })
+
+  it('keeps another session untouched when the event targets this one', () => {
+    emit('btw.complete', { task_id: 'btw_1', text: 'for the other chat' }, OTHER_SID)
+
+    expect(lastMessage()).toBeUndefined()
+    expect(stream.text(OTHER_SID)).toBe('[btw (btw_1)]\nfor the other chat')
+  })
+
+  it('omits the question and task-id header bits when the backend omits them', () => {
+    emit('btw.complete', { text: 'the answer' })
+
+    expect(stream.text()).toBe('[btw]\nthe answer')
+  })
+
+  it('drops an empty completion instead of appending a blank line', () => {
+    emit('btw.complete', { task_id: 'btw_1', question: 'q', text: '   ' })
+
+    expect(lastMessage()).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -41,6 +41,40 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     return true
   }
 
+  if (event.type === 'btw.complete') {
+    // prompt.btw RPC (the TUI's /btw path) answers a side question from a
+    // snapshot of the live conversation and reports it here; the event
+    // carries the originating session id, so the answer lands in the
+    // conversation that asked. Persistent transcript line (not a toast),
+    // mirroring the TUI's `[btw "question"]` system line — without it the
+    // answer was indistinguishable from a lost command: the slash-worker
+    // route printed it from a fire-and-forget thread after the stdout
+    // capture window closed (#99065).
+    const text = coerceGatewayText(payload?.text).trim()
+
+    if (text && sessionId) {
+      const taskId = String(payload?.task_id ?? '').trim()
+      const question = coerceGatewayText(payload?.question).trim()
+      const header = `[btw${question ? ` "${question}"` : ''}${taskId ? ` (${taskId})` : ''}]`
+
+      flushQueuedDeltas(sessionId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `btw-complete-${taskId || Date.now()}`,
+            role: 'system',
+            parts: [textPart(`${header}\n${text}`, occurredAt)],
+            timestamp: occurredAt
+          }
+        ]
+      }))
+    }
+
+    return true
+  }
+
   if (event.type === 'review.summary') {
     // Self-improvement background review saved something to memory/skills
     // and emitted a persistent summary (Python formats it as

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1002,6 +1002,102 @@ describe('usePromptActions /compress', () => {
   })
 })
 
+describe('usePromptActions /btw', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #99065: the slash-worker route printed the side-question answer from a
+  // fire-and-forget thread after process_command already returned — past the
+  // worker's stdout capture window — so the answer never reached the desktop
+  // conversation. The dedicated prompt.btw RPC is the TUI's path; the answer
+  // arrives later as a btw.complete gateway event.
+  it('routes through prompt.btw (not slash.exec) and renders the start notice', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        return { task_id: 'btw_ab12cd' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw which file was that error in?')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.btw', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'which file was that error in?'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(renderedSeedTexts(seeds).some(text => text.includes('btw_ab12cd'))).toBe(true)
+  })
+
+  it('shows usage when no question is typed', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async () => ({} as never))
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw')
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(renderedSeedTexts(seeds).some(text => text.includes('Usage: /btw'))).toBe(true)
+  })
+
+  it('falls back to the slash worker when an older gateway lacks prompt.btw', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        throw new Error('method not found: prompt.btw')
+      }
+
+      if (method === 'slash.exec') {
+        return { output: 'Side question started by legacy gateway' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw anything')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'btw anything' }))
+    expect(renderedSeedTexts(seeds).some(text => text.includes('legacy gateway'))).toBe(true)
+  })
+})
+
 describe('usePromptActions exec fallback error reporting', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -497,6 +497,59 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         branch: async () => {
           await branchCurrentSession()
         },
+        // /btw answers a side question from a snapshot of the LIVE
+        // conversation via the gateway's prompt.btw RPC — the TUI's path
+        // (ui-tui/src/app/slash/commands/session.ts). It must NOT go through
+        // runExec: the slash worker's HermesCLI prints the answer from a
+        // fire-and-forget thread after process_command already returned,
+        // past the worker's stdout capture window, so the answer never
+        // reached the desktop conversation (#99065) — only the synchronous
+        // "Side question: …" acknowledgement rendered. The RPC replies
+        // immediately with the task id; the answer itself arrives later as a
+        // btw.complete gateway event, which the gateway-event dispatcher
+        // appends to this session.
+        btw: async ctx => {
+          const question = ctx.arg.trim()
+
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+
+          if (!question) {
+            renderSlashOutput(
+              'Usage: /btw <question> — answered from a snapshot of this conversation without interrupting it.'
+            )
+
+            return
+          }
+
+          try {
+            const result = await requestGateway<{ task_id?: string }>('prompt.btw', {
+              session_id: sessionId,
+              text: question
+            })
+
+            renderSlashOutput(
+              result.task_id
+                ? `💬 Side question (${result.task_id}) — answering from a conversation snapshot; the answer will appear here.`
+                : '💬 Side question — answering from a conversation snapshot; the answer will appear here.'
+            )
+          } catch (err) {
+            // Older gateways without the dedicated RPC still have the
+            // slash-worker route — same compatibility fallback as runRpc.
+            if (isMissingRpcMethod(err)) {
+              await runExec(ctx)
+
+              return
+            }
+
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        },
         // /compress (alias /compact) runs the gateway's dedicated
         // session.compress RPC — the TUI's path
         // (ui-tui/src/app/slash/commands/session.ts). It must NOT go through

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -94,6 +94,8 @@ export type GatewayEventPayload = {
   // clarify.request
   request_id?: string
   question?: string
+  // btw.complete / background.complete — id of the side/background task
+  task_id?: string
   choices?: string[] | null
   multi_select?: boolean
   // clarify.request batch form: questions replaces question/choices, and

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -232,9 +232,11 @@ describe('desktop slash command curation', () => {
   })
 
   it('still routes commands without dedicated RPCs through exec()', () => {
+    // /btw deliberately NOT here — it has the dedicated prompt.btw RPC since
+    // #99065 (the slash worker's side-question answer print lands after the
+    // capture window closes, so the answer never reached the desktop).
     const execNames = [
       '/bg',
-      '/btw',
       '/debug',
       '/goal',
       '/personality',
@@ -249,6 +251,13 @@ describe('desktop slash command curation', () => {
     for (const name of execNames) {
       expect(resolveDesktopCommand(name)?.surface).toEqual({ kind: 'exec' })
     }
+  })
+
+  it('routes /btw to the prompt.btw side-question action', () => {
+    expect(resolveDesktopCommand('/btw')?.surface).toEqual({ kind: 'action', action: 'btw' })
+    expect(isDesktopSlashCommand('/btw')).toBe(true)
+    expect(isDesktopSlashSuggestion('/btw')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/btw')).toBeNull()
   })
 
   it('distinguishes free prose from finite slash option lists', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -55,6 +55,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'btw'
   | 'compress'
   | 'handoff'
   | 'hatch'
@@ -238,6 +239,19 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Compress this conversation context',
     aliases: ['/compact'],
     surface: action('compress'),
+    argumentMode: 'text'
+  },
+  // /btw must be an action (prompt.btw RPC — the TUI's path), not exec: the
+  // slash worker's HermesCLI prints the side-question answer from a
+  // fire-and-forget thread after process_command already returned, past the
+  // worker's stdout capture window, so Desktop only ever saw the
+  // acknowledgement (#99065). The RPC replies immediately with a task id;
+  // the answer arrives later as a btw.complete gateway event, which the
+  // gateway-event dispatcher appends to this session.
+  {
+    name: '/btw',
+    description: 'Ask a side question about this conversation without interrupting it',
+    surface: action('btw'),
     argumentMode: 'text'
   },
   {


### PR DESCRIPTION
## What does this PR do?

**Fixes #99065** — `/btw <question>` in the Hermes Desktop app printed the "💬 Side question: …" acknowledgement but the answer never appeared.

### Root cause

Desktop routed `/btw` through `slash.exec` → the persistent slash-worker subprocess. The worker's `HermesCLI` → `_handle_btw_command` prints the answer from a **fire-and-forget thread after `process_command` already returned** — past the worker's stdout capture window (`slash_worker.py` restores `_cprint` and exits `redirect_stdout` in its `finally`) — so the answer print can never travel back over the JSON-lines pipe. The worker's `_drain_stdout` then drops the late non-JSON line. Only the synchronous acknowledgement rendered.

### Fix (mirrors the TUI's existing path)

`ui-tui/src/app/slash/commands/session.ts` already routes `/btw` through the gateway's `prompt.btw` RPC and renders the `btw.complete` event (`createGatewayEventHandler.ts`). This PR brings the same path to Desktop:

- **`desktop-slash-commands.ts`** — `/btw` becomes a desktop `action` (like `/compress`) instead of falling through to `exec`
- **`use-prompt-actions/slash.ts`** — new `btw` action handler calls `prompt.btw` (`{session_id, text}`), renders the task-id notice immediately, and falls back to the slash worker only when an older gateway lacks the RPC (`isMissingRpcMethod`, same pattern as `runRpc`)
- **`gateway-event/status.ts`** — handles `btw.complete`: appends the answer as a persistent system line (`[btw "question" (task_id)]\nanswer`) to the **originating** session the event carries
- **`chat-messages/types.ts`** — payload gains `task_id`
- Tests: event routing (originating-session targeting, header shapes, empty drops) + dispatch (RPC route, usage, legacy fallback)

## Notes

- `#97937` established the cross-surface `/btw` side-question command (and retired `/background` in favor of `/bg`). This PR closes its remaining Desktop surface gap.
- **Do not conflate with #97649** — that PR (still open) changes the `/background`/`/bg` path and its description still lists `/btw` as a `/background` alias, which was true before #97937 but is no longer. `/btw` is its own command here, wired to `prompt.btw` / `btw.complete`.
- The answer line uses the same `[btw "question"]` convention as the Ink TUI.

## Test plan

- `npx vitest run src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx` ✅ (4 tests)
- `npx vitest run src/lib/desktop-slash-commands.test.ts` ✅ (31 tests)
- `npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx` ✅ (129 tests)
- `npx eslint` on all touched files ✅ (0 errors)
- `npx tsc --noEmit` ✅

Closes #99065
