### PR TITLE
fix(holographic): rebuild both banks on category move

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -303,7 +303,7 @@ class MemoryStore:
         """
         with self._lock:
             row = self._conn.execute(
-                "SELECT fact_id, trust_score FROM facts WHERE fact_id = ?", (fact_id,)
+                "SELECT fact_id, trust_score, category FROM facts WHERE fact_id = ?", (fact_id,)
             ).fetchone()
             if row is None:
                 return False
@@ -345,11 +345,12 @@ class MemoryStore:
             # Recompute HRR vector if content changed
             if content is not None:
                 self._compute_hrr_vector(fact_id, content)
-            # Rebuild bank for relevant category
-            cat = category or self._conn.execute(
-                "SELECT category FROM facts WHERE fact_id = ?", (fact_id,)
-            ).fetchone()["category"]
-            self._rebuild_bank(cat)
+            # Rebuild banks on both sides of a category move.
+            old_category = row["category"]
+            new_category = category if category is not None else old_category
+            self._rebuild_bank(new_category)
+            if old_category != new_category:
+                self._rebuild_bank(old_category)
 
             return True
 

--- a/tests/plugins/memory/test_holographic_category_bank.py
+++ b/tests/plugins/memory/test_holographic_category_bank.py
@@ -1,0 +1,26 @@
+"""Regression tests for Holographic category-bank maintenance."""
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_category_move_rebuilds_source_and_destination_banks(tmp_path) -> None:
+    with MemoryStore(db_path=tmp_path / "category_move.db", hrr_dim=64) as store:
+        moved_id = store.add_fact("Move this banked fact", category="source")
+        store.add_fact("Keep this source fact", category="source")
+        store.add_fact("Keep this destination fact", category="destination")
+
+        assert store.update_fact(moved_id, category="destination")
+
+        counts = {
+            row["bank_name"]: row["fact_count"]
+            for row in store._conn.execute(
+                "SELECT bank_name, fact_count FROM memory_banks"
+            ).fetchall()
+        }
+
+    assert counts["cat:source"] == 1
+    assert counts["cat:destination"] == 2


### PR DESCRIPTION
## What does this PR do?

Keeps Holographic memory-bank aggregates consistent when an existing fact moves between categories.

`update_fact()` previously rebuilt only the fact's category after the SQL update. When `category` changed, the destination bank was refreshed but the source bank retained a stale superposition vector and `fact_count`.

This change reads the original category with the fact row, rebuilds the destination bank, and also rebuilds the source bank when the category actually changed.

## Related Issue

No existing issue or PR matching this category-move bug was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Preserve the original fact category during `update_fact()`.
- Rebuild both affected category banks after a move.
- Add a direct regression asserting source and destination `fact_count` values after moving a fact.

This PR intentionally does not include provenance, quarantine, autonomous curation, or broader retrieval changes.

## How to Test

```bash
scripts/run_tests.sh \
  tests/plugins/memory/test_holographic_category_bank.py \
  tests/plugins/memory/test_holographic_store.py -q
```

Result: **14 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicate work.
- [x] This PR contains only the category-bank consistency fix and regression.
- [x] Focused repository-wrapper tests pass.
- [x] I've added a regression test.
- [x] Tested on Fedora Linux.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the public API is unchanged.
- [x] Config-example changes are N/A.
- [x] Architecture-guide changes are N/A.
- [x] Cross-platform impact considered: this is SQLite/Python logic with no platform-specific behavior.
- [x] Tool schema changes are N/A.
