### PR TITLE
fix(error): classify OpenRouter free-model 413 as rate_limit so fallback chain engages

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1350,6 +1350,25 @@ def _classify_by_status(
         )
 
     if status_code == 413:
+        # OpenRouter free models return HTTP 413 "Payload Too Large" on
+        # capacity exhaustion — both when the model is genuinely at capacity
+        # and when the system prompt exceeds the free tier's capped context
+        # window.  The status code is wrong (should be 429 or 503) but the
+        # recovery is the same: retryable with fallback so the pool can
+        # rotate to a paid backup.  Classifying as payload_too_large with
+        # compress-retry is wrong: no amount of compression helps when the
+        # free tier itself is refusing, and the user cannot shrink their
+        # request past the already-cropped free-tier context ceiling (#96739).
+        if provider == "openrouter" and any(
+            p in error_msg
+            for p in ("free model", "capacity", "try again later",
+                      "exceeded", "rate limited", "overloaded")
+        ):
+            return result_fn(
+                FailoverReason.rate_limit,
+                retryable=True,
+                should_fallback=True,
+            )
         return result_fn(
             FailoverReason.payload_too_large,
             retryable=True,

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿OpenRouter returns HTTP 413 for free-model capacity exhaustion. Add a provider guard: reclassify as rate_limit with should_fallback=True when body mentions free model, capacity, or overload signals. Fixes #96739.
