### PR TITLE
fix(gateway): stop delegation wakes from blocking unrelated API sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25920,6 +25920,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 exc_info=True,
                             )
                     return False
+            if (
+                durable_claim_id
+                and not str(evt.get("origin_session_id") or "").strip()
+                and await asyncio.to_thread(self._build_process_event_source, evt) is None
+            ):
+                # A delegation without either its dispatch-captured API session
+                # or a structured gateway route can never acquire a delivery
+                # target.  Release would make restart recovery replay the same
+                # permanently unroutable row forever, so give the held durable
+                # claim the same honest terminal disposition as a gone parent.
+                logger.warning(
+                    "Async delegation %s has no verified wake target; "
+                    "terminally dropping delivery (result remains in the "
+                    "delegation records).",
+                    durable_delegation_id,
+                )
+                try:
+                    from tools.async_delegation import drop_completion_delivery
+
+                    drop_completion_delivery(
+                        durable_delegation_id, durable_claim_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not drop unroutable durable completion claim",
+                        exc_info=True,
+                    )
+                return None
         elif evt.get("type") == "completion":
             # Background-process completions carry only session_key (chat/
             # thread routing), so after /new the notification from the OLD

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25629,7 +25629,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # server's own /v1/chat/completions entry point instead of
             # dropping the event.
             raw_sid = str(evt.get("origin_session_id") or "").strip()
-            if not raw_sid:
+            if not raw_sid and evt.get("type") != "async_delegation":
+                # Async delegations capture their owning API session explicitly
+                # at dispatch.  Their session_key may be a legacy/stale gateway
+                # route and is not sufficient ownership evidence for a self-post.
+                # Generic process events predate that field and retain the raw-key
+                # compatibility fallback.
                 _sk = str(evt.get("session_key") or "").strip()
                 if _sk and _parse_session_key(_sk) is None:
                     raw_sid = _sk

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -580,6 +580,45 @@ async def test_inject_watch_notification_origin_session_id_wins(monkeypatch, tmp
     assert posts == ["raw-origin-sid"]
 
 
+@pytest.mark.asyncio
+async def test_async_delegation_does_not_infer_wake_target_from_raw_session_key(
+    monkeypatch, tmp_path,
+):
+    """Delegation wakes require their dispatch-captured API session id.
+
+    A raw ``session_key`` is not sufficient ownership evidence: restored or
+    legacy events can carry an unrelated gateway key. Treating that key as the
+    self-post target can wake and contend with another session indefinitely.
+    """
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    api_adapter = SimpleNamespace(
+        supports_async_delivery=False,
+        handle_message=AsyncMock(),
+        _host="127.0.0.1", _port=8642, _api_key="k", _model_name="m",
+    )
+    runner.adapters[Platform.API_SERVER] = api_adapter
+
+    posts = []
+
+    async def fake_self_post(adapter, *, text, session_id):
+        posts.append(session_id)
+
+    import gateway.wake as wake_mod
+    monkeypatch.setattr(wake_mod, "_self_post_chat_completion", fake_self_post)
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_unowned",
+        "session_key": "raw-but-unverified-session",
+        "origin_session_id": "",
+    }
+    result = await runner._inject_watch_notification("[SYSTEM: done]", evt)
+
+    assert result is None
+    assert posts == []
+    api_adapter.handle_message.assert_not_awaited()
+
+
 def test_gateway_drain_retains_and_formats_overflow_events():
     """watch_overflow_* events must survive the gateway drain and render
     their summary — previously they were discarded at the drain (only

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -132,6 +132,35 @@ def test_unroutable_async_event_is_not_requeued_forever(
     assert isolated.empty()
 
 
+def test_unroutable_durable_async_event_is_terminally_dropped(
+    isolated_registry,
+):
+    """Restart recovery must not replay a delegation with no verified target."""
+    event = _async_event("deleg_unroutable_durable")
+    event["session_key"] = "raw-but-unverified-session"
+    event["origin_session_id"] = ""
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    result = asyncio.run(
+        runner._deliver_completion_notification("completion", dict(event))
+    )
+
+    from tools import async_delegation
+
+    row = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert result is None
+    assert row is not None
+    assert row["delivery_state"] == "dropped"
+    adapter.handle_message.assert_not_awaited()
+
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 0
+    assert restored.empty()
+
+
 def test_concurrent_claims_share_the_same_narrow_delivery_seam():
     """Concurrent consumers in one runner cannot both enter the adapter."""
     entered = asyncio.Event()


### PR DESCRIPTION
## What does this PR do?

API-server async-delegation completions without a verified origin could treat any unstructured gateway session key as their self-post target. That allowed restored or legacy completion events to wake and contend with an unrelated session. This change requires delegation wakes to use the API session ID captured at dispatch while preserving the legacy raw-key fallback for generic background-process notifications.

### Symptom

An unresolvable async-delegation completion could repeatedly self-post into the raw session named by `session_key`, even though the event did not carry dispatch-time ownership metadata.

### Impact

The wrong API session could receive synthetic completion turns and contend for its turn lease, delaying unrelated user messages. The affected blast radius is limited to stateless API-server delivery events that lack `origin_session_id`.

### Bug Cause

**Trigger:** `gateway/run.py:25631` / `_inject_watch_notification()` when an `async_delegation` event has no resolvable source and no `origin_session_id`.

**Causal chain:**
1. A restored or legacy delegation completion lacks its dispatch-captured raw API session ID.
2. The fallback treats any unstructured `session_key` as the wake target and self-posts a synthetic turn there.
3. The synthetic turn can enter an unrelated busy session and compete for its turn lease.

**Why it is wrong:** A gateway routing key is not proof that an async delegation was spawned by the corresponding API session. Delegation dispatch already has a dedicated ownership field for this purpose.

**Working sibling / contrast:** Current async-delegation dispatch records capture and persist `origin_session_id`; generic process notifications do not have that ownership field and still need the existing raw-key compatibility fallback.

**Durable-state boundary:** Releasing a claimed completion without any verifiable target made restart recovery replay the same permanently unroutable row. The delivery path now gives that row a terminal dropped disposition while retaining the result in delegation records.

### Fix

Only non-delegation process events may infer a raw API wake target from `session_key`. Async delegations without `origin_session_id` now fail closed without a self-post; explicitly owned delegation wakes continue unchanged.

## Related Issue

Fixes #99055

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - require dispatch-captured ownership for API-server delegation self-posts and terminally drop durable rows that have no verifiable wake target.
- `tests/gateway/test_background_process_notifications.py` - add a red-to-green regression covering an unowned raw delegation event.
- `tests/gateway/test_completion_delivery.py` - verify a durable unroutable completion is dropped instead of replayed after restart.

## How to Test

1. Run the focused API-server wake regression and confirm the unowned delegation is not self-posted.
2. Run the related gateway delivery, session-binding, and delegation dispatch suites.

```bash
scripts/run_tests.sh tests/gateway/test_background_process_notifications.py tests/gateway/test_completion_delivery.py tests/gateway/test_async_delegation_session_binding.py tests/tools/test_delegate_apiserver_background.py -q
```

Result: 58 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on all relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact; the change is platform-independent routing logic
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

N/A - the automated regression exercises the routing branch directly.
