### PR TITLE
fix(desktop): add Full Size/Fit toggle to image lightbox for tall/high-res images

### DIFF
--- a/apps/desktop/src/components/chat/zoomable-image.tsx
+++ b/apps/desktop/src/components/chat/zoomable-image.tsx
@@ -76,17 +76,22 @@ export function ImageLightbox({
   saving: boolean
   src: string
 }) {
+  const [showOriginal, setShowOriginal] = useState(false)
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
-        bodyClassName="block overflow-visible p-0"
-        className="w-auto max-h-[calc(100vh-12rem)] max-w-[calc(100vw-12rem)] border-0 bg-transparent shadow-none"
+        bodyClassName={showOriginal ? "block overflow-auto p-0 max-h-[calc(100vh-12rem)]" : "block overflow-visible p-0"}
+        className={showOriginal ? "w-auto border-0 bg-transparent shadow-none" : "w-auto max-h-[calc(100vh-12rem)] max-w-[calc(100vw-12rem)] border-0 bg-transparent shadow-none"}
         showCloseButton={false}
       >
         <div className="group/lightbox relative inline-block">
           <img
             alt={alt ?? ''}
-            className="block max-h-[calc(100vh-12rem)] max-w-[calc(100vw-12rem)] cursor-zoom-out select-auto rounded-lg object-contain shadow-2xl"
+            className={showOriginal
+              ? "block max-w-[calc(100vw-12rem)] cursor-zoom-out select-auto rounded-lg shadow-2xl"
+              : "block max-h-[calc(100vh-12rem)] max-w-[calc(100vw-12rem)] cursor-zoom-out select-auto rounded-lg object-contain shadow-2xl"
+            }
             onClick={() => onOpenChange(false)}
             src={src}
           />
@@ -96,6 +101,13 @@ export function ImageLightbox({
             onClick={onClick}
             saving={saving}
           />
+          <button
+            className="absolute bottom-3 right-3 rounded-md bg-black/70 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover/lightbox:opacity-100"
+            onClick={(e) => { e.stopPropagation(); setShowOriginal(prev => !prev) }}
+            type="button"
+          >
+            {showOriginal ? "Fit" : "Full Size"}
+          </button>
         </div>
       </DialogContent>
     </Dialog>

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Add Full Size/Fit toggle to the image lightbox for viewing tall images at natural dimensions. Fixes #99066.
