### PR TITLE
fix(browser): keep real-profile logins consistent across sessions

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -547,8 +547,10 @@ _SNAPSHOT_IGNORES = (
     "BrowserMetrics-spare.pma",
 )
 
-# Small, auth-bearing files re-synced from the live profile on EVERY consented
-# launch (the full tree is only copied when the snapshot doesn't exist yet).
+# Small, auth-bearing files copied from the live profile when the managed
+# profile is FIRST created. After that the managed profile owns its state: a
+# partial source overlay cannot be consistent with Local Storage / IndexedDB,
+# and would overwrite logins created inside the managed browser.
 # Paths here are RELATIVE TO A PROFILE DIR (Default, "Profile 6", …) — the
 # caller resolves which source profile is active and mirrors these into the
 # copy's ``Default`` so the launched Chromium (which opens ``Default``) lands
@@ -697,13 +699,13 @@ def _copy_auth_file(src_file: str, dst_file: str) -> bool:
 
 
 def _mirror_profile_auth(src: str, dst: str, source_profile: str) -> int:
-    """Copy ``source_profile``'s auth files into the copy's ``Default`` slot.
+    """Bootstrap ``source_profile``'s auth files into the copy's ``Default``.
 
     agent-browser launches ``Default`` in the copied user-data-dir; mirroring
     the active source profile's cookies/logins/prefs there is what makes the
-    session actually signed in (the LinkedIn/Gmail "logged out" bug when the
-    real session lives in a non-Default profile). Lock-aware (Windows), so a
-    running Chrome doesn't block the cookie DBs.
+    initial session can reuse portable cookies and saved logins when the real
+    session lives in a non-Default profile. Lock-aware (Windows), so a running
+    Chrome doesn't block the cookie DBs.
 
     Returns the number of DB auth files that could NOT be copied (0 = clean).
     """
@@ -933,26 +935,50 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
     succeeds; a torn/interrupted first copy (disk full, Ctrl+C) therefore never
     looks "already populated" on the next run — it is redone from scratch.
 
-    Auth files are re-synced on every call so fresh logins from the user's own
-    browsing show up. Locked-file copy errors are tolerated best-effort.
+    Once created, the managed profile is durable and independently authenticated.
+    We do not overlay source auth files on later calls: browser authentication can
+    span Cookies, Local Storage, and IndexedDB, so refreshing only a subset creates
+    an internally inconsistent profile and overwrites managed-browser logins.
 
     Returns ``(copy_dir, None)`` on success, ``(None, error)`` on failure.
     """
-    src = src or real_profile_data_dir(browser)
-    if not src or not os.path.isdir(src):
-        return None, (
-            f"profile directory for '{browser}' was not found ({src!r}). "
-            "Launch that browser at least once, or turn browser.use_real_profile off."
-        )
-    source_profile, resolve_err = _resolve_source_profile(src)
-    if resolve_err or not source_profile:
-        return None, resolve_err
     dst = real_profile_copy_dir(browser)
-    # Fast lock probe BEFORE any copy: a running browser holds the cookie DB
-    # deny-all (Windows), and a blocking file op on it can hang the launch for
-    # minutes. On POSIX this never trips (no mandatory locking) so
-    # copy-while-running still works.
-    if _profile_is_locked(src, source_profile):
+    marker = os.path.join(dst, _SNAPSHOT_DONE_MARKER)
+    # Only a copy that previously COMPLETED counts as populated. A half-written
+    # tree (no marker) is treated as absent and rebuilt.
+    populated = os.path.isfile(marker)
+    source_profile = None
+    if populated:
+        # An explicit pin is an identity assertion. Never silently keep driving
+        # a managed profile bootstrapped from another pinned source.
+        pin = _real_profile_pin()
+        if pin:
+            try:
+                with open(marker, encoding="utf-8") as fh:
+                    bootstrapped_from = fh.read().strip()
+            except OSError:
+                bootstrapped_from = ""
+            if bootstrapped_from and bootstrapped_from != pin:
+                return None, (
+                    f"the managed '{browser}' profile was initialized from "
+                    f"'{bootstrapped_from}', but browser.real_profile_pin is now "
+                    f"'{pin}'. Turn real-profile browsing off and use the browser "
+                    "once to delete the managed profile, then turn it on again."
+                )
+    else:
+        src = src or real_profile_data_dir(browser)
+        if not src or not os.path.isdir(src):
+            return None, (
+                f"profile directory for '{browser}' was not found ({src!r}). "
+                "Launch that browser at least once, or turn browser.use_real_profile off."
+            )
+        source_profile, resolve_err = _resolve_source_profile(src)
+        if resolve_err or not source_profile:
+            return None, resolve_err
+    # Fast lock probe BEFORE the initial copy: a running browser holds the cookie
+    # DB deny-all (Windows), and a blocking file op on it can hang the launch for
+    # minutes. A completed managed profile never reads or locks the source again.
+    if not populated and _profile_is_locked(src, source_profile):
         # NEVER kill from here. Closing the user's browser is destructive and
         # must be an explicit, per-attempt, user-approved step — not a silent
         # side effect of a snapshot. So we always BLOCK when locked and let the
@@ -978,11 +1004,6 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
                 "for you.)"
             )
         return None, _PROFILE_LOCKED_PREFIX + msg
-    marker = os.path.join(dst, _SNAPSHOT_DONE_MARKER)
-    # Only a copy that previously COMPLETED counts as populated. A half-written
-    # tree (no marker) is treated as absent and rebuilt — otherwise a torn first
-    # copy poisons freshness forever and only ever gets auth overlays.
-    populated = os.path.isfile(marker)
     try:
         os.makedirs(dst, exist_ok=True)
         # Secure the snapshot dir AND its browser-profile parent on EVERY
@@ -994,48 +1015,39 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
             _secure_snapshot_root(parent)
         _secure_snapshot_root(dst)
 
-        # Base user-data-dir file the browser reads at startup. Cheap; always
-        # re-synced so last_used etc. stay current.
-        ls_src = os.path.join(src, "Local State")
-        ls_dst = os.path.join(dst, "Local State")
-        if os.path.isfile(ls_src):
-            try:
-                shutil.copy2(ls_src, ls_dst)
-            except OSError as e:
-                logger.debug("real-profile snapshot: skipped Local State: %s", e)
-
-        # The copy contains ONLY the mirrored Default dir (that is where the
-        # pinned/active profile's auth was mirrored into), but a verbatim
-        # Local State still names the SOURCE profile (e.g. last_used="Profile
-        # 2", info_cache listing Profile 2/4/7). Chrome therefore opens a
-        # missing profile dir and starts SIGNED OUT. Rewrite Local State so
-        # the copy's only profile is Default and it is the last-used one.
-        # CRITICAL: Default's identity entry must be the SOURCE profile's
-        # entry (name + Google account), not the source's own "Default"
-        # entry — the Default DIR holds the source profile's cookies. A
-        # mismatch (cookies belong to profile B, info_cache names profile A) makes Chrome
-        # demand a "Continue as <name>" profile-sign-in reconciliation on
-        # every launch and treat the profile as mid-sign-in.
-        try:
-            import json as _json
-
-            with open(ls_dst, encoding="utf-8") as fh:
-                state = _json.load(fh)
-            prof = state.get("profile")
-            if isinstance(prof, dict):
-                cache = prof.get("info_cache")
-                if isinstance(cache, dict):
-                    src_entry = cache.get(source_profile) or cache.get("Default")
-                    if src_entry:
-                        prof["info_cache"] = {"Default": src_entry}
-                prof["last_used"] = "Default"
-                prof["last_active_profiles"] = ["Default"]
-            with open(ls_dst, "w", encoding="utf-8") as fh:
-                _json.dump(state, fh)
-        except (OSError, ValueError) as e:
-            logger.debug("real-profile snapshot: could not normalize Local State: %s", e)
-
         if not populated:
+            # Bootstrap Local State once. It becomes managed state after this
+            # initial copy, just like the profile tree.
+            ls_src = os.path.join(src, "Local State")
+            ls_dst = os.path.join(dst, "Local State")
+            if os.path.isfile(ls_src):
+                try:
+                    shutil.copy2(ls_src, ls_dst)
+                except OSError as e:
+                    logger.debug("real-profile snapshot: skipped Local State: %s", e)
+
+            # The copy contains ONLY the mirrored Default dir. Normalize the
+            # initial Local State to that layout while preserving the selected
+            # source profile's identity entry.
+            try:
+                import json as _json
+
+                with open(ls_dst, encoding="utf-8") as fh:
+                    state = _json.load(fh)
+                prof = state.get("profile")
+                if isinstance(prof, dict):
+                    cache = prof.get("info_cache")
+                    if isinstance(cache, dict):
+                        src_entry = cache.get(source_profile) or cache.get("Default")
+                        if src_entry:
+                            prof["info_cache"] = {"Default": src_entry}
+                    prof["last_used"] = "Default"
+                    prof["last_active_profiles"] = ["Default"]
+                with open(ls_dst, "w", encoding="utf-8") as fh:
+                    _json.dump(state, fh)
+            except (OSError, ValueError) as e:
+                logger.debug("real-profile snapshot: could not normalize Local State: %s", e)
+
             # Fresh (or torn-and-rebuilding): drop any partial Default and copy
             # the ACTIVE profile's full dir (minus caches AND the locked auth
             # DBs) into the copy's Default. The SQLite auth DBs are excluded
@@ -1060,19 +1072,22 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
                     len(multi.args[0]) if multi.args else 0, src, source_profile,
                 )
 
-        # Both paths: copy the active profile's auth DBs into Default,
-        # lock-aware (sqlite online-backup) so a running Chrome on Windows
-        # doesn't block them. This is also the per-launch fresh-login re-sync.
-        failed_dbs = _mirror_profile_auth(src, dst, source_profile)
-        if failed_dbs:
-            # We could not read the user's cookie/login DBs at all — even the
-            # online-backup fallback failed. Rather than launch a silently
-            # signed-out session, fail closed with an actionable message.
-            return None, (
-                f"could not read the '{browser}' profile's login data "
-                f"({failed_dbs} database(s) locked). Close {browser} and retry, "
-                "or turn browser.use_real_profile off."
-            )
+            # Bootstrap portable auth DBs into Default. Later launches keep the
+            # managed browser's complete auth/storage state instead of mixing owners.
+            failed_dbs = _mirror_profile_auth(src, dst, source_profile)
+            if failed_dbs:
+                return None, (
+                    f"could not read the '{browser}' profile's login data "
+                    f"({failed_dbs} database(s) locked). Close {browser} and retry, "
+                    "or turn browser.use_real_profile off."
+                )
+
+            # Mark complete only after the initial bootstrap succeeded.
+            try:
+                with open(marker, "w", encoding="utf-8") as fh:
+                    fh.write(source_profile)
+            except OSError as e:
+                logger.debug("real-profile snapshot: could not write done marker: %s", e)
 
         # Never carry live-instance leftovers into the copy.
         for leftover in ("SingletonLock", "SingletonSocket", "SingletonCookie"):
@@ -1080,12 +1095,7 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
                 os.unlink(os.path.join(dst, leftover))
             except OSError:
                 pass
-        # Mark complete only after everything above succeeded.
-        try:
-            with open(marker, "w", encoding="utf-8") as fh:
-                fh.write(source_profile)
-        except OSError as e:
-            logger.debug("real-profile snapshot: could not write done marker: %s", e)
+
         # Owner-only modes for everything the copies above created — copy2
         # preserves Chrome's 0644 and sqlite backup files land umask-wide;
         # these are the user's session cookies (#96729). Runs AFTER the marker

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -916,6 +916,92 @@ def _processes_holding_profile(src: str):
         yield proc
 
 
+def _managed_profile_processes(root: str):
+    """Yield Chromium processes whose user-data-dir is below ``root``.
+
+    Consent revocation may run in a different Hermes process from the one that
+    launched Chromium, so Popen handles are insufficient.  Match the structured
+    ``--user-data-dir`` argument and require its resolved path to remain inside
+    this profile's managed store; an unrelated source-profile browser is never
+    eligible.
+    """
+    try:
+        import psutil
+    except ImportError:  # hard dep; defensive
+        return
+
+    managed_root = os.path.normcase(os.path.abspath(root))
+    browser_bins = {
+        "brave", "brave.exe", "brave browser", "chrome", "chrome.exe",
+        "chromium", "chromium.exe", "chromium-browser", "google chrome",
+        "google-chrome", "google-chrome-stable", "microsoft edge",
+        "microsoft-edge", "microsoft-edge-stable", "msedge", "msedge.exe",
+    }
+    for proc in psutil.process_iter(["name", "cmdline"]):
+        try:
+            name = (proc.info.get("name") or "").lower()
+            cmd = proc.info.get("cmdline") or []
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+        argv0 = os.path.basename(cmd[0]).lower() if cmd else ""
+        if name not in browser_bins and argv0 not in browser_bins:
+            continue
+
+        data_dirs = []
+        for index, arg in enumerate(cmd):
+            if arg.startswith("--user-data-dir="):
+                data_dirs.append(arg.split("=", 1)[1])
+            elif arg == "--user-data-dir" and index + 1 < len(cmd):
+                data_dirs.append(cmd[index + 1])
+        for data_dir in data_dirs:
+            candidate = os.path.normcase(os.path.abspath(data_dir.strip('"')))
+            try:
+                if os.path.commonpath((managed_root, candidate)) == managed_root:
+                    yield proc
+                    break
+            except ValueError:  # different drives on Windows
+                continue
+
+
+def _terminate_managed_profile_browsers(root: str, timeout: float = 15.0) -> bool:
+    """Stop every Chromium process bound to a managed profile below ``root``."""
+    try:
+        import psutil
+    except ImportError:
+        logger.warning("real-profile: psutil unavailable; cannot revoke live sessions")
+        return False
+
+    procs = list(_managed_profile_processes(root))
+    targets = []
+    seen = set()
+    for proc in procs:
+        for target in (proc, *(_safe_process_children(proc, psutil))):
+            identity = getattr(target, "pid", id(target))
+            if identity not in seen:
+                seen.add(identity)
+                targets.append(target)
+    for proc in targets:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            pass
+    _gone, alive = psutil.wait_procs(targets, timeout=min(timeout, 8.0))
+    for proc in alive:
+        try:
+            proc.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            pass
+    _gone, alive = psutil.wait_procs(alive, timeout=min(3.0, timeout))
+    return not alive
+
+
+def _safe_process_children(proc, psutil_module) -> list:
+    try:
+        return proc.children(recursive=True)
+    except (psutil_module.NoSuchProcess, psutil_module.AccessDenied, OSError):
+        return []
+
+
 def close_browser_holding_profile(src: str, timeout: float = 15.0) -> tuple[bool, str]:
     """Terminate the browser process tree holding ``src`` and wait for release.
 
@@ -1150,19 +1236,29 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
     return dst, None
 
 
-def cleanup_real_profile_snapshots() -> None:
+def cleanup_real_profile_snapshots() -> bool:
     """Delete the whole real-profile snapshot store (all copied credentials).
 
     Called when consent is OFF: the copied Cookies / Login Data must not
-    outlive the toggle. Best-effort and idempotent — missing dir is fine.
+    outlive the toggle. Browsers on this profile's managed data dirs are ours
+    to terminate; source-profile browsers are outside ``root`` and untouched.
+    Returns true only when the credential store is absent after cleanup.
     """
     root = str(get_hermes_home() / "browser-profile")
+    if not os.path.isdir(root):
+        return True
     try:
-        if os.path.isdir(root):
-            shutil.rmtree(root, ignore_errors=True)
-            logger.info("real-profile: removed snapshot store %s (consent off)", root)
+        if not _terminate_managed_profile_browsers(root):
+            logger.warning("real-profile: managed browser did not stop during consent revocation")
+        shutil.rmtree(root)
     except OSError as e:
-        logger.debug("real-profile cleanup failed for %s: %s", root, e)
+        logger.warning("real-profile cleanup failed for %s: %s", root, e)
+        return False
+    if os.path.exists(root):
+        logger.warning("real-profile: snapshot store remains after consent revocation: %s", root)
+        return False
+    logger.info("real-profile: removed snapshot store %s (consent off)", root)
+    return True
 
 
 def get_chrome_debug_candidates(system: str) -> list[str]:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -11,6 +11,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -729,6 +730,58 @@ _SNAPSHOT_DONE_MARKER = ".hermes-snapshot-complete"
 _PROFILE_LOCKED_PREFIX = "[profile-locked] "
 
 
+def validate_managed_real_profile_identity(browser: str) -> str | None:
+    """Return an error when a configured pin cannot identify the managed copy."""
+    pin = _real_profile_pin()
+    if not pin:
+        return None
+
+    marker = os.path.join(real_profile_copy_dir(browser), _SNAPSHOT_DONE_MARKER)
+    try:
+        with open(marker, encoding="utf-8") as fh:
+            bootstrapped_from = fh.read().strip()
+    except OSError:
+        bootstrapped_from = ""
+
+    if bootstrapped_from == pin:
+        return None
+    if bootstrapped_from:
+        identity = f"was initialized from '{bootstrapped_from}'"
+    else:
+        identity = "has no readable bootstrap identity"
+    return (
+        f"the managed '{browser}' profile {identity}, but "
+        f"browser.real_profile_pin is now '{pin}'. Turn real-profile browsing "
+        "off and use the browser once to delete the managed profile, then turn "
+        "it on again."
+    )
+
+
+def _write_snapshot_marker(marker: str, source_profile: str) -> str | None:
+    """Atomically commit the bootstrap identity, returning an error on failure."""
+    temp_path = ""
+    try:
+        fd, temp_path = tempfile.mkstemp(
+            prefix=f".{os.path.basename(marker)}.",
+            suffix=".tmp",
+            dir=os.path.dirname(marker),
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(source_profile)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temp_path, marker)
+        return None
+    except OSError as e:
+        return f"could not commit the managed profile identity marker: {e}"
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+
 def _profile_cookie_db(src: str, source_profile: str) -> str | None:
     """Path to the active profile's cookie DB (modern Network/ first)."""
     for rel in (os.path.join("Network", "Cookies"), "Cookies"):
@@ -951,20 +1004,9 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
     if populated:
         # An explicit pin is an identity assertion. Never silently keep driving
         # a managed profile bootstrapped from another pinned source.
-        pin = _real_profile_pin()
-        if pin:
-            try:
-                with open(marker, encoding="utf-8") as fh:
-                    bootstrapped_from = fh.read().strip()
-            except OSError:
-                bootstrapped_from = ""
-            if bootstrapped_from and bootstrapped_from != pin:
-                return None, (
-                    f"the managed '{browser}' profile was initialized from "
-                    f"'{bootstrapped_from}', but browser.real_profile_pin is now "
-                    f"'{pin}'. Turn real-profile browsing off and use the browser "
-                    "once to delete the managed profile, then turn it on again."
-                )
+        identity_err = validate_managed_real_profile_identity(browser)
+        if identity_err:
+            return None, identity_err
     else:
         src = src or real_profile_data_dir(browser)
         if not src or not os.path.isdir(src):
@@ -1083,11 +1125,12 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
                 )
 
             # Mark complete only after the initial bootstrap succeeded.
-            try:
-                with open(marker, "w", encoding="utf-8") as fh:
-                    fh.write(source_profile)
-            except OSError as e:
-                logger.debug("real-profile snapshot: could not write done marker: %s", e)
+            marker_err = _write_snapshot_marker(marker, source_profile)
+            if marker_err:
+                # The failed bootstrap remains incomplete, but copied
+                # credentials must still receive owner-only permissions.
+                _secure_snapshot_contents(dst)
+                return None, marker_err
 
         # Never carry live-instance leftovers into the copy.
         for leftover in ("SingletonLock", "SingletonSocket", "SingletonCookie"):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -588,9 +588,11 @@ DEFAULT_CONFIG = {
         # When true, local browsing (the Browser Use CLI, or the built-in
         # browser tools) runs on a Hermes-managed SNAPSHOT of the user's
         # ACTIVE default-Chromium profile (Local State -> profile.last_used) —
-        # its cookies, logins and preferences copied in and re-synced when a
-        # fresh session launches — driven by Hermes' packaged Chromium. Only
-        # the active profile is copied. The snapshot is a non-default dir, so it
+        # its portable cookies, logins and preferences copied once for bootstrap
+        # — driven by the user's real browser binary. The managed profile then owns
+        # its durable auth/storage state; partial per-launch source overlays would
+        # be inconsistent with Local Storage and IndexedDB. Only the active
+        # profile is copied. The snapshot is a non-default dir, so it
         # sidesteps Chrome 136+'s block on debugging the default profile and
         # never contends with the user's running browser. Turning this back off
         # deletes the snapshot store (~/.hermes/browser-profile/) so copied

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1033,13 +1033,96 @@ class TestReviewRound3:
 
     def test_consent_off_triggers_cleanup(self, tmp_path, monkeypatch):
         import tools.browser_tool as bt
-        called = {"n": 0}
+        called = {"close": 0, "terminate": 0, "cleanup": 0}
         with patch.object(bt, "_use_real_profile", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session",
+                          side_effect=lambda *_: called.__setitem__("close", called["close"] + 1)), \
+             patch.object(bt, "_terminate_real_profile_chrome",
+                          side_effect=lambda: called.__setitem__("terminate", called["terminate"] + 1)), \
              patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots",
-                   side_effect=lambda: called.__setitem__("n", called["n"] + 1)):
+                   side_effect=lambda: (called.__setitem__("cleanup", called["cleanup"] + 1), True)[1]):
             cdp, err = bt._real_profile_cdp()
         assert cdp is None and err is None
-        assert called["n"] == 1
+        assert called == {"close": 1, "terminate": 1, "cleanup": 1}
+
+    def test_consent_off_fails_closed_when_credentials_remain(self):
+        import tools.browser_tool as bt
+        with patch.object(bt, "_use_real_profile", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session"), \
+             patch.object(bt, "_terminate_real_profile_chrome"), \
+             patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots",
+                   return_value=False):
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "could not delete" in err.lower()
+
+    def test_cached_cdp_rejects_changed_managed_data_dir(self, tmp_path):
+        import tools.browser_tool as bt
+        bt._real_profile_cdp_cache["cdp"] = "http://127.0.0.1:9251"
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch.object(bt, "_using_lightpanda_engine", return_value=False), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="edge"), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir",
+                   return_value=str(tmp_path / "edge")), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session") as close, \
+             patch.object(bt, "_terminate_real_profile_chrome") as terminate, \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(None, "missing managed edge profile")):
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "missing managed edge profile" in err
+        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+        terminate.assert_called_once_with()
+        assert "cdp" not in bt._real_profile_cdp_cache
+
+    def test_cleanup_terminates_only_managed_profile_browser(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+
+        root = tmp_path / "hh" / "browser-profile"
+        managed = root / "chrome"
+        managed.mkdir(parents=True)
+        (managed / "Default").mkdir()
+        (managed / "Default" / "Cookies").write_text("secret")
+
+        class FakeProc:
+            def __init__(self, name, cmdline):
+                self.info = {"name": name, "cmdline": cmdline}
+                self.terminated = False
+                self.killed = False
+
+            def children(self, recursive=True):
+                return []
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+
+        ours = FakeProc("chrome.exe", ["chrome.exe", f"--user-data-dir={managed}"])
+        source = FakeProc("chrome.exe", ["chrome.exe", f"--user-data-dir={tmp_path / 'source'}"])
+
+        class FakePsutil:
+            NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+            AccessDenied = type("AccessDenied", (Exception,), {})
+
+            def process_iter(self, attrs=None):
+                return iter([ours, source])
+
+            def wait_procs(self, procs, timeout=None):
+                return list(procs), []
+
+        import sys as _sys
+        monkeypatch.setitem(_sys.modules, "psutil", FakePsutil())
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "hh")
+
+        assert bc.cleanup_real_profile_snapshots() is True
+        assert ours.terminated is True
+        assert source.terminated is False
+        assert not root.exists()
 
     # ── ① overlay must not run before the reuse check (live-browser safety) ──
     def test_reuse_skips_snapshot_overlay(self, tmp_path):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -113,7 +113,7 @@ class TestSnapshotRealProfile:
         assert not (home / "browser-profile" / "chrome" / "Crashpad").exists()
         assert not (home / "browser-profile" / "chrome" / "SingletonLock").exists()
 
-    def test_existing_snapshot_refreshes_auth_files_only(self, tmp_path, monkeypatch):
+    def test_existing_snapshot_preserves_managed_auth_and_storage(self, tmp_path, monkeypatch):
         import hermes_cli.browser_connect as bc
         src = self._make_profile(tmp_path / "real")
         home = tmp_path / "hermes-home"
@@ -121,16 +121,22 @@ class TestSnapshotRealProfile:
 
         dst, err = bc.snapshot_real_profile("chrome", src=str(src))
         assert err is None
-        # Simulate: user logs into a new site in their own browser, and the
-        # copy has drifted state that must survive (History not in refresh set).
+        # The managed browser becomes independently authenticated after its
+        # initial bootstrap. Source-profile changes must not overwrite any part
+        # of that internally consistent state on a later launch.
         (src / "Default" / "Cookies").write_text("sqlite-cookies-v2")
-        copy_history = home / "browser-profile" / "chrome" / "Default" / "History"
-        copy_history.write_text("agent-session-history")
+        managed = home / "browser-profile" / "chrome" / "Default"
+        (managed / "Cookies").write_text("managed-session-cookies")
+        (managed / "Local Storage").mkdir()
+        (managed / "Local Storage" / "state").write_text("managed-local-storage")
+        (managed / "IndexedDB").mkdir()
+        (managed / "IndexedDB" / "state").write_text("managed-indexeddb")
 
         dst2, err2 = bc.snapshot_real_profile("chrome", src=str(src))
         assert err2 is None and dst2 == dst
-        assert (home / "browser-profile" / "chrome" / "Default" / "Cookies").read_text() == "sqlite-cookies-v2"
-        assert copy_history.read_text() == "agent-session-history"
+        assert (managed / "Cookies").read_text() == "managed-session-cookies"
+        assert (managed / "Local Storage" / "state").read_text() == "managed-local-storage"
+        assert (managed / "IndexedDB" / "state").read_text() == "managed-indexeddb"
 
     def test_missing_source_fails_closed(self, tmp_path, monkeypatch):
         import hermes_cli.browser_connect as bc
@@ -138,6 +144,23 @@ class TestSnapshotRealProfile:
         dst, err = bc.snapshot_real_profile("chrome", src=str(tmp_path / "nope"))
         assert dst is None
         assert err and "was not found" in err
+
+    def test_existing_snapshot_no_longer_depends_on_source(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+        src = self._make_profile(tmp_path / "real")
+        home = tmp_path / "hermes-home"
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: None)
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None
+
+        monkeypatch.setattr(
+            bc,
+            "_profile_is_locked",
+            lambda *_: pytest.fail("completed snapshot inspected its source profile"),
+        )
+        dst2, err2 = bc.snapshot_real_profile("chrome", src=str(tmp_path / "gone"))
+        assert err2 is None and dst2 == dst
 
     def test_snapshot_files_are_owner_only(self, tmp_path, monkeypatch):
         """Every copied file must be 0600 and every dir 0700 (#96729).
@@ -215,6 +238,7 @@ class TestRealProfileCdpLaunch:
         self._reset()
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
              patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(None, "boom")):
             cdp, err = bt._real_profile_cdp()
         assert cdp is None
@@ -677,16 +701,18 @@ class TestReviewBugFixes:
         (root / "Local State").write_text('{"profile": {"last_used": "Profile 6"}}')
         assert bc._last_used_profile(str(root)) == "Profile 6"
 
-    def test_refresh_remirrors_last_used(self, tmp_path, monkeypatch):
+    def test_existing_snapshot_does_not_remirror_last_used(self, tmp_path, monkeypatch):
         import hermes_cli.browser_connect as bc
         src = self._multi_profile(tmp_path / "real")
         home = tmp_path / "hh"
         monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
         bc.snapshot_real_profile("chrome", src=str(src))          # fresh
-        (src / "Profile 6" / "Cookies").write_text("PROFILE6-REFRESHED")
-        dst, err = bc.snapshot_real_profile("chrome", src=str(src))  # refresh
+        copy_cookie = home / "browser-profile" / "chrome" / "Default" / "Cookies"
+        copy_cookie.write_text("MANAGED-SESSION")
+        (src / "Profile 6" / "Cookies").write_text("PROFILE6-SOURCE-CHANGED")
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
         assert err is None
-        assert (home / "browser-profile" / "chrome" / "Default" / "Cookies").read_text() == "PROFILE6-REFRESHED"
+        assert copy_cookie.read_text() == "MANAGED-SESSION"
 
     # ── Bug 3: private-URL sidecar must NOT carry the real profile ──
     def test_sidecar_never_uses_real_profile(self):
@@ -964,6 +990,15 @@ class TestReviewRound3:
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
         proc = Mock(returncode=0, stdout="", stderr="")
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text("9251\n/devtools/browser/x\n")
+            return FakeChrome()
+
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
@@ -972,6 +1007,7 @@ class TestReviewRound3:
                    return_value=(str(tmp_path), None)) as snap, \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:9251"]), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -162,6 +162,57 @@ class TestSnapshotRealProfile:
         dst2, err2 = bc.snapshot_real_profile("chrome", src=str(tmp_path / "gone"))
         assert err2 is None and dst2 == dst
 
+    def test_empty_marker_fails_closed_when_pin_is_configured(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+        home = tmp_path / "hermes-home"
+        marker = home / "browser-profile" / "chrome" / bc._SNAPSHOT_DONE_MARKER
+        marker.parent.mkdir(parents=True)
+        marker.write_text("")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 2")
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(tmp_path / "gone"))
+
+        assert dst is None
+        assert err and "no readable bootstrap identity" in err
+        assert "delete the managed profile" in err
+
+    def test_unreadable_marker_fails_closed_when_pin_is_configured(self, tmp_path, monkeypatch):
+        import builtins
+        import hermes_cli.browser_connect as bc
+        home = tmp_path / "hermes-home"
+        marker = home / "browser-profile" / "chrome" / bc._SNAPSHOT_DONE_MARKER
+        marker.parent.mkdir(parents=True)
+        marker.write_text("Profile 2")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 2")
+        real_open = builtins.open
+
+        def deny_marker(path, *args, **kwargs):
+            if os.path.normpath(path) == os.path.normpath(marker):
+                raise PermissionError("denied")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", deny_marker)
+        dst, err = bc.snapshot_real_profile("chrome")
+
+        assert dst is None
+        assert err and "no readable bootstrap identity" in err
+
+    def test_marker_commit_failure_leaves_snapshot_incomplete(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+        src = self._make_profile(tmp_path / "real")
+        home = tmp_path / "hermes-home"
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc.os, "replace", Mock(side_effect=OSError("disk error")))
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+
+        marker = home / "browser-profile" / "chrome" / bc._SNAPSHOT_DONE_MARKER
+        assert dst is None
+        assert err and "could not commit" in err
+        assert not marker.exists()
+
     def test_snapshot_files_are_owner_only(self, tmp_path, monkeypatch):
         """Every copied file must be 0600 and every dir 0700 (#96729).
 
@@ -358,6 +409,31 @@ class TestRealProfileCdpLaunch:
             cdp, err = bt._real_profile_cdp()
         assert closed["n"] == 1  # stale wrong-dir session was closed
         assert cdp == "http://127.0.0.1:41000"
+        self._reset()
+
+    def test_live_managed_session_revalidates_profile_pin(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+        import tools.browser_tool as bt
+        self._reset()
+        live = "http://127.0.0.1:5000"
+        home = tmp_path / "hermes-home"
+        marker = home / "browser-profile" / "chrome" / bc._SNAPSHOT_DONE_MARKER
+        marker.parent.mkdir(parents=True)
+        marker.write_text("Profile 2")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: "Profile 4")
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=live), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=True), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile") as snapshot:
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None
+        assert err and "initialized from 'Profile 2'" in err
+        assert "real_profile_pin is now 'Profile 4'" in err
+        snapshot.assert_not_called()
         self._reset()
 
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -447,7 +447,8 @@ class TestRealProfileCdpLaunch:
             browser_a = Mock()
             browser_a.poll.return_value = None
             state_a["cache"]["cdp"] = "http://127.0.0.1:41000"
-            state_a["chrome_procs"].append(browser_a)
+            profile_a_dir = str(tmp_path / "profile-a" / "browser-profile" / "chrome")
+            state_a["chrome_procs"].append((browser_a, profile_a_dir))
         finally:
             reset_hermes_home_override(token_a)
 
@@ -466,7 +467,7 @@ class TestRealProfileCdpLaunch:
         assert state_a is not state_b
         close.assert_called_once_with(state_b["session"])
         assert state_a["cache"]["cdp"] == "http://127.0.0.1:41000"
-        assert state_a["chrome_procs"] == [browser_a]
+        assert state_a["chrome_procs"] == [(browser_a, profile_a_dir)]
         browser_a.terminate.assert_not_called()
         self._reset()
 
@@ -474,7 +475,9 @@ class TestRealProfileCdpLaunch:
         "failure",
         ["missing-agent-browser", "timeout", "oserror", "nonzero", "missing-cdp"],
     )
-    def test_post_launch_attach_failures_reap_provisional_chrome(self, tmp_path, failure):
+    def test_post_launch_attach_failures_reap_provisional_chrome(
+        self, tmp_path, monkeypatch, failure
+    ):
         import tools.browser_tool as bt
 
         self._reset()
@@ -498,6 +501,42 @@ class TestRealProfileCdpLaunch:
                 self.killed = True
 
         chrome = FakeChrome()
+
+        class FakeChild:
+            pid = 404
+
+            def __init__(self):
+                self.info = {
+                    "name": "chrome.exe",
+                    "cmdline": ["chrome.exe", f"--user-data-dir={tmp_path}"],
+                }
+                self.terminated = False
+
+            def children(self, recursive=True):
+                return []
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                raise AssertionError("graceful child termination should suffice")
+
+        child = FakeChild()
+
+        class FakePsutil:
+            NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+            AccessDenied = type("AccessDenied", (Exception,), {})
+
+            @staticmethod
+            def process_iter(attrs=None):
+                return iter([child])
+
+            @staticmethod
+            def wait_procs(procs, timeout=None):
+                return list(procs), []
+
+        import sys as _sys
+        monkeypatch.setitem(_sys.modules, "psutil", FakePsutil())
 
         def fake_popen(argv, **kwargs):
             (tmp_path / "DevToolsActivePort").write_text(
@@ -538,6 +577,7 @@ class TestRealProfileCdpLaunch:
         assert chrome.terminated is True
         assert chrome.waited is True
         assert chrome.killed is False
+        assert child.terminated is True
         assert bt._real_profile_state()["chrome_procs"] == []
         self._reset()
 

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -266,7 +266,7 @@ class TestRealProfileCdpLaunch:
 
     def _reset(self):
         import tools.browser_tool as bt
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
 
     def test_consent_off_is_noop(self):
         import tools.browser_tool as bt
@@ -434,6 +434,111 @@ class TestRealProfileCdpLaunch:
         assert err and "initialized from 'Profile 2'" in err
         assert "real_profile_pin is now 'Profile 4'" in err
         snapshot.assert_not_called()
+        self._reset()
+
+    def test_consent_revocation_is_scoped_to_active_hermes_home(self, tmp_path):
+        import tools.browser_tool as bt
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        self._reset()
+        token_a = set_hermes_home_override(tmp_path / "profile-a")
+        try:
+            state_a = bt._real_profile_state()
+            browser_a = Mock()
+            browser_a.poll.return_value = None
+            state_a["cache"]["cdp"] = "http://127.0.0.1:41000"
+            state_a["chrome_procs"].append(browser_a)
+        finally:
+            reset_hermes_home_override(token_a)
+
+        token_b = set_hermes_home_override(tmp_path / "profile-b")
+        try:
+            state_b = bt._real_profile_state()
+            with patch.object(bt, "_use_real_profile", return_value=False), \
+                 patch.object(bt, "_agent_browser_close_session") as close, \
+                 patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots",
+                       return_value=True):
+                cdp, err = bt._real_profile_cdp()
+        finally:
+            reset_hermes_home_override(token_b)
+
+        assert cdp is None and err is None
+        assert state_a is not state_b
+        close.assert_called_once_with(state_b["session"])
+        assert state_a["cache"]["cdp"] == "http://127.0.0.1:41000"
+        assert state_a["chrome_procs"] == [browser_a]
+        browser_a.terminate.assert_not_called()
+        self._reset()
+
+    @pytest.mark.parametrize(
+        "failure",
+        ["missing-agent-browser", "timeout", "oserror", "nonzero", "missing-cdp"],
+    )
+    def test_post_launch_attach_failures_reap_provisional_chrome(self, tmp_path, failure):
+        import tools.browser_tool as bt
+
+        self._reset()
+
+        class FakeChrome:
+            def __init__(self):
+                self.terminated = False
+                self.waited = False
+                self.killed = False
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                self.terminated = True
+
+            def wait(self, timeout=None):
+                self.waited = True
+
+            def kill(self):
+                self.killed = True
+
+        chrome = FakeChrome()
+
+        def fake_popen(argv, **kwargs):
+            (tmp_path / "DevToolsActivePort").write_text(
+                "41000\n/devtools/browser/provisional\n"
+            )
+            return chrome
+
+        find_effect = (
+            FileNotFoundError("missing") if failure == "missing-agent-browser" else None
+        )
+        run_effect = None
+        run_result = Mock(returncode=0, stdout="", stderr="")
+        if failure == "timeout":
+            run_effect = bt.subprocess.TimeoutExpired("agent-browser", 1)
+        elif failure == "oserror":
+            run_effect = OSError("attach failed")
+        elif failure == "nonzero":
+            run_result = Mock(returncode=1, stdout="", stderr="attach rejected")
+
+        cdp_results = [None, None] if failure == "missing-cdp" else [None]
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium",
+                   return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable",
+                   return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt, "_agent_browser_get_cdp", side_effect=cdp_results), \
+             patch.object(bt, "_find_agent_browser", return_value="agent-browser",
+                          side_effect=find_effect), \
+             patch.object(bt.subprocess, "run", return_value=run_result,
+                          side_effect=run_effect), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None and err
+        assert chrome.terminated is True
+        assert chrome.waited is True
+        assert chrome.killed is False
+        assert bt._real_profile_state()["chrome_procs"] == []
         self._reset()
 
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
@@ -668,7 +773,7 @@ class TestChannelIdentity:
         """A channel default → _real_profile_cdp fails closed, never launches."""
         import tools.browser_tool as bt
         import hermes_cli.browser_connect as bc
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium",
                    return_value=bc.UNSUPPORTED_CHANNEL), \
@@ -677,7 +782,7 @@ class TestChannelIdentity:
         assert cdp is None
         assert err and "pre-release" in err.lower()
         snap.assert_not_called()  # never even snapshotted a stable profile
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
 
     def test_data_dir_rejects_sentinel(self):
         import hermes_cli.browser_connect as bc
@@ -853,7 +958,7 @@ class TestReviewBugFixes:
     # ── Bug 5: lightpanda engine + consent fails with an actionable message ──
     def test_lightpanda_engine_fails_actionably(self):
         import tools.browser_tool as bt
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium") as det:
@@ -861,7 +966,7 @@ class TestReviewBugFixes:
         assert cdp is None
         assert err and "lightpanda" in err.lower() and "browser.engine" in err.lower()
         det.assert_not_called()  # guard fires before detection
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
 
 
 class TestReviewRound3:
@@ -1038,7 +1143,7 @@ class TestReviewRound3:
              patch.object(bt, "_agent_browser_close_session",
                           side_effect=lambda *_: called.__setitem__("close", called["close"] + 1)), \
              patch.object(bt, "_terminate_real_profile_chrome",
-                          side_effect=lambda: called.__setitem__("terminate", called["terminate"] + 1)), \
+                          side_effect=lambda *_: called.__setitem__("terminate", called["terminate"] + 1)), \
              patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots",
                    side_effect=lambda: (called.__setitem__("cleanup", called["cleanup"] + 1), True)[1]):
             cdp, err = bt._real_profile_cdp()
@@ -1058,7 +1163,9 @@ class TestReviewRound3:
 
     def test_cached_cdp_rejects_changed_managed_data_dir(self, tmp_path):
         import tools.browser_tool as bt
-        bt._real_profile_cdp_cache["cdp"] = "http://127.0.0.1:9251"
+        bt._real_profile_states.clear()
+        state = bt._real_profile_state()
+        state["cache"]["cdp"] = "http://127.0.0.1:9251"
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="edge"), \
@@ -1074,9 +1181,9 @@ class TestReviewRound3:
             cdp, err = bt._real_profile_cdp()
         assert cdp is None
         assert err and "missing managed edge profile" in err
-        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
-        terminate.assert_called_once_with()
-        assert "cdp" not in bt._real_profile_cdp_cache
+        close.assert_called_once_with(state["session"])
+        terminate.assert_called_once_with(state)
+        assert "cdp" not in state["cache"]
 
     def test_cleanup_terminates_only_managed_profile_browser(self, tmp_path, monkeypatch):
         import hermes_cli.browser_connect as bc
@@ -1130,7 +1237,7 @@ class TestReviewRound3:
         must NOT be called — otherwise it rewrites cookie DBs under a live
         browser."""
         import tools.browser_tool as bt
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
@@ -1142,12 +1249,12 @@ class TestReviewRound3:
             cdp, err = bt._real_profile_cdp()
         assert cdp == "http://127.0.0.1:9251" and err is None
         snap.assert_not_called()  # ← the fix: no overlay while a live browser owns the dir
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
 
     def test_relaunch_path_does_snapshot(self, tmp_path):
         """When there's no reusable session, the overlay DOES run (relaunch)."""
         import tools.browser_tool as bt
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
         proc = Mock(returncode=0, stdout="", stderr="")
 
         class FakeChrome:
@@ -1173,7 +1280,7 @@ class TestReviewRound3:
             cdp, err = bt._real_profile_cdp()
         assert err is None
         snap.assert_called_once()
-        bt._real_profile_cdp_cache.clear()
+        bt._real_profile_states.clear()
 
 
 class TestWindowsLockedProfileCopy:

--- a/tests/tools/test_browser_real_profile_pin.py
+++ b/tests/tools/test_browser_real_profile_pin.py
@@ -69,9 +69,8 @@ class TestRealProfilePin:
         got = (home / "browser-profile" / "chrome" / "Default" / "Cookies").read_text()
         assert got == "cookies-Profile 4", "no pin = native last_used"
 
-    def test_re_sync_respects_pin_when_last_used_flips(self, tmp_path, monkeypatch):
-        """The wrong-principal regression: session 2 with different last_used
-        must NOT overlay a different profile's auth onto the pinned copy."""
+    def test_managed_profile_stays_on_pin_when_last_used_flips(self, tmp_path, monkeypatch):
+        """Later source changes must not replace the pinned managed identity."""
         import hermes_cli.browser_connect as bc
 
         src = self._make_profile(tmp_path / "real", last_used="Profile 2")
@@ -91,4 +90,21 @@ class TestRealProfilePin:
         dst2, err2 = bc.snapshot_real_profile("chrome", src=str(src))
         assert err2 is None and dst2 == dst1
         got = (home / "browser-profile" / "chrome" / "Default" / "Cookies").read_text()
-        assert got == "cookies-Profile 2-v2", "auth re-sync must stay on the pin"
+        assert got == "cookies-Profile 2", "managed auth must stay durable"
+
+    def test_changing_pin_requires_managed_profile_reset(self, tmp_path, monkeypatch):
+        import hermes_cli.browser_connect as bc
+
+        src = self._make_profile(tmp_path / "real", last_used="Profile 2")
+        home = tmp_path / "hermes-home"
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: home)
+        selected = {"pin": "Profile 2"}
+        monkeypatch.setattr(bc, "_real_profile_pin", lambda: selected["pin"])
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None and dst
+
+        selected["pin"] = "Profile 4"
+        dst2, err2 = bc.snapshot_real_profile("chrome", src=str(src))
+        assert dst2 is None
+        assert err2 and "initialized from 'Profile 2'" in err2
+        assert "real_profile_pin" in err2 and "delete the managed profile" in err2

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1605,15 +1605,10 @@ def _real_profile_cdp() -> tuple:
         detect_default_chromium,
         real_profile_copy_dir,
         snapshot_real_profile,
+        validate_managed_real_profile_identity,
     )
 
     with _real_profile_cdp_lock:
-        # Reuse a live copy-browser from an earlier call this process made.
-        cached = _real_profile_cdp_cache.get("cdp")
-        if cached and _cdp_http_ready(cached):
-            return cached, None
-        _real_profile_cdp_cache.pop("cdp", None)
-
         browser = detect_default_chromium()
         if browser is None:
             return None, (
@@ -1637,6 +1632,17 @@ def _real_profile_cdp() -> tuple:
                 "the toggle off."
             )
 
+        # Reuse a live copy-browser from an earlier call this process made only
+        # after re-validating the configured identity assertion. The pin can
+        # change while this process remains alive.
+        cached = _real_profile_cdp_cache.get("cdp")
+        if cached and _cdp_http_ready(cached):
+            identity_err = validate_managed_real_profile_identity(browser)
+            if identity_err:
+                return None, f"browser.use_real_profile is on, but {identity_err}"
+            return cached, None
+        _real_profile_cdp_cache.pop("cdp", None)
+
         # Reuse BEFORE writing anything. A shared copy-browser may already be up
         # from a previous hermes process; if it is driving OUR copy dir, hand it
         # back untouched. CRITICAL: the snapshot overlay (which truncates and
@@ -1649,6 +1655,9 @@ def _real_profile_cdp() -> tuple:
         copy_dir = real_profile_copy_dir(browser)
         existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
+            identity_err = validate_managed_real_profile_identity(browser)
+            if identity_err:
+                return None, f"browser.use_real_profile is on, but {identity_err}"
             _real_profile_cdp_cache["cdp"] = existing
             return existing, None
         if existing:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -51,6 +51,7 @@ Usage:
 
 import atexit
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -1447,44 +1448,73 @@ def _use_real_profile() -> bool:
     return False
 
 
-# Session name for the single shared real-profile copy-browser. All consented
-# local browsing attaches to this one agent-browser session so concurrent
-# tasks reuse the same copy-browser instead of each launching a rival Chromium
-# on the same copied user-data-dir.
+# Session-name prefix for profile-scoped real-profile copy-browsers. Concurrent
+# tasks within one Hermes home reuse a browser, while multiplexed profiles must
+# never share lifecycle state or an agent-browser session.
 _REAL_PROFILE_SESSION = "hermes-real-profile"
-_real_profile_cdp_lock = threading.Lock()
-_real_profile_cdp_cache: dict = {}
-_real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
+_real_profile_states_lock = threading.Lock()
+_real_profile_states: dict[str, dict] = {}
 
 
-def _terminate_real_profile_chrome() -> None:
-    """Terminate real-browser processes launched for real-profile sessions.
+def _real_profile_state() -> dict:
+    """Return the process-local browser state for the active Hermes home."""
+    scope = hermes_home_key()
+    with _real_profile_states_lock:
+        state = _real_profile_states.get(scope)
+        if state is None:
+            suffix = hashlib.sha256(scope.encode("utf-8")).hexdigest()[:16]
+            state = {
+                "session": f"{_REAL_PROFILE_SESSION}-{suffix}",
+                "lock": threading.Lock(),
+                "cache": {},
+                "chrome_procs": [],
+            }
+            _real_profile_states[scope] = state
+        return state
+
+
+def _terminate_real_profile_proc(proc) -> None:
+    """Best-effort terminate one directly launched managed browser."""
+    try:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+    except Exception as e:
+        logger.debug("real-profile chrome terminate failed: %s", e)
+
+
+def _terminate_real_profile_chrome(state: dict | None = None) -> None:
+    """Terminate real-browser processes launched for one Hermes profile.
 
     The real-profile path launches the user's actual browser binary on the
     profile COPY (bypassing agent-browser's mock-keychain launch). Those
     processes are ours to reap: agent-browser only ATTACHED to them, so its
     own session cleanup never kills them. Idempotent; safe from atexit.
     """
-    while _real_profile_chrome_procs:
-        proc = _real_profile_chrome_procs.pop()
-        try:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=5)
-                except Exception:
-                    proc.kill()
-        except Exception as e:
-            logger.debug("real-profile chrome terminate failed: %s", e)
+    active_state = state or _real_profile_state()
+    procs = active_state["chrome_procs"]
+    while procs:
+        _terminate_real_profile_proc(procs.pop())
 
 
-def _revoke_real_profile_access() -> str | None:
+def _terminate_all_real_profile_chrome() -> None:
+    """Process-exit cleanup for directly launched browsers in every profile."""
+    with _real_profile_states_lock:
+        states = list(_real_profile_states.values())
+    for state in states:
+        _terminate_real_profile_chrome(state)
+
+
+def _revoke_real_profile_access(state: dict) -> str | None:
     """Close managed sessions and remove every copied credential on consent-off."""
     from hermes_cli.browser_connect import cleanup_real_profile_snapshots
 
-    _agent_browser_close_session(_REAL_PROFILE_SESSION)
-    _terminate_real_profile_chrome()
-    _real_profile_cdp_cache.pop("cdp", None)
+    _agent_browser_close_session(state["session"])
+    _terminate_real_profile_chrome(state)
+    state["cache"].pop("cdp", None)
     try:
         removed = cleanup_real_profile_snapshots()
     except Exception as e:
@@ -1594,13 +1624,16 @@ def _real_profile_cdp() -> tuple:
     the default browser is non-Chromium or the snapshot/launch fails;
     ``(None, None)`` when consent is off.
     """
+    state = _real_profile_state()
+    session_name = state["session"]
+    cache = state["cache"]
     if not _use_real_profile():
         # Consent is off. If a snapshot store from a previous consented run is
         # still on disk, it holds copies of the user's cookies/logins — delete
         # it so revoking consent actually removes the credential copies. Cheap
         # (one isdir check) and idempotent.
-        with _real_profile_cdp_lock:
-            return None, _revoke_real_profile_access()
+        with state["lock"]:
+            return None, _revoke_real_profile_access(state)
 
     # Lightpanda cannot load a Chromium profile — agent-browser rejects
     # ``--profile`` outright under that engine ("Profiles are not supported
@@ -1623,10 +1656,10 @@ def _real_profile_cdp() -> tuple:
         validate_managed_real_profile_identity,
     )
 
-    with _real_profile_cdp_lock:
+    with state["lock"]:
         # Consent can change while this call waits behind another launch.
         if not _use_real_profile():
-            return None, _revoke_real_profile_access()
+            return None, _revoke_real_profile_access(state)
         browser = detect_default_chromium()
         if browser is None:
             return None, (
@@ -1654,16 +1687,16 @@ def _real_profile_cdp() -> tuple:
         # Reuse a live copy-browser from an earlier call this process made only
         # when it owns the currently selected browser's managed data directory.
         # The default browser and pin can both change while this process lives.
-        cached = _real_profile_cdp_cache.get("cdp")
+        cached = cache.get("cdp")
         if cached and _cdp_http_ready(cached) and _cdp_on_data_dir(cached, copy_dir):
             identity_err = validate_managed_real_profile_identity(browser)
             if identity_err:
                 return None, f"browser.use_real_profile is on, but {identity_err}"
             return cached, None
         if cached:
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
-            _terminate_real_profile_chrome()
-        _real_profile_cdp_cache.pop("cdp", None)
+            _agent_browser_close_session(session_name)
+            _terminate_real_profile_chrome(state)
+        cache.pop("cdp", None)
 
         # Reuse BEFORE writing anything. A shared copy-browser may already be up
         # from a previous hermes process; if it is driving OUR copy dir, hand it
@@ -1674,17 +1707,17 @@ def _real_profile_cdp() -> tuple:
         # as a PATH only (no copy), probe reuse, and return early on a hit. The
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
-        existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
+        existing = _agent_browser_get_cdp(session_name)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             identity_err = validate_managed_real_profile_identity(browser)
             if identity_err:
                 return None, f"browser.use_real_profile is on, but {identity_err}"
-            _real_profile_cdp_cache["cdp"] = existing
+            cache["cdp"] = existing
             return existing, None
         if existing:
             # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
             # close it so nothing holds the dir open before we overlay + relaunch.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+            _agent_browser_close_session(session_name)
 
         # No live browser owns the dir now — safe to (re)snapshot + overlay.
         snap_dir, err = snapshot_real_profile(browser)
@@ -1777,7 +1810,6 @@ def _real_profile_cdp() -> tuple:
             )
         except (subprocess.SubprocessError, OSError) as e:
             return None, f"browser.use_real_profile is on, but the launch failed: {e}"
-        _real_profile_chrome_procs.append(chrome_proc)
 
         # Wait for DevToolsActivePort to appear (Chrome picks a free port).
         import time as _time
@@ -1794,14 +1826,14 @@ def _real_profile_cdp() -> tuple:
             except OSError:
                 pass
             if chrome_proc.poll() is not None:
-                _terminate_real_profile_chrome()
+                _terminate_real_profile_proc(chrome_proc)
                 return None, (
                     "browser.use_real_profile is on, but Chrome exited during "
                     "startup (another instance may hold the profile copy)."
                 )
             _time.sleep(0.25)
         if port is None:
-            _terminate_real_profile_chrome()
+            _terminate_real_profile_proc(chrome_proc)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "did not expose a debug port in time. Retry, or turn the toggle off."
@@ -1812,13 +1844,14 @@ def _real_profile_cdp() -> tuple:
         try:
             browser_cmd = _find_agent_browser()
         except FileNotFoundError as e:
+            _terminate_real_profile_proc(chrome_proc)
             return None, (
                 "browser.use_real_profile is on, but the local browser engine "
                 f"(agent-browser) is not installed: {e}"
             )
         argv = [
             *_agent_browser_argv(browser_cmd),
-            "--session", _REAL_PROFILE_SESSION,
+            "--session", session_name,
             "--cdp", str(port),
             "open", "about:blank",
         ]
@@ -1829,21 +1862,24 @@ def _real_profile_cdp() -> tuple:
                 env=_build_browser_env(),
             )
         except subprocess.TimeoutExpired:
+            _terminate_real_profile_proc(chrome_proc)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "took too long to start. Retry, or turn the toggle off."
             )
         except (subprocess.SubprocessError, OSError) as e:
+            _terminate_real_profile_proc(chrome_proc)
             return None, f"browser.use_real_profile is on, but the launch failed: {e}"
         if proc.returncode != 0:
             tail = (proc.stderr or proc.stdout or "").strip().splitlines()
             reason = tail[-1] if tail else f"exit {proc.returncode}"
+            _terminate_real_profile_proc(chrome_proc)
             return None, (
                 f"browser.use_real_profile is on, but the real-profile browser "
                 f"failed to start: {reason}"
             )
 
-        cdp = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
+        cdp = _agent_browser_get_cdp(session_name)
         # The daemon may answer with the endpoint of a
         # browser IT spawned (throwaway temp profile) instead of the real
         # Chrome we launched on the copy. The DevToolsActivePort file OUR
@@ -1858,12 +1894,14 @@ def _real_profile_cdp() -> tuple:
         except (OSError, ValueError):
             pass
         if not cdp:
+            _terminate_real_profile_proc(chrome_proc)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
             )
-        _real_profile_cdp_cache["cdp"] = cdp
+        state["chrome_procs"].append(chrome_proc)
+        cache["cdp"] = cdp
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
 
@@ -2274,7 +2312,7 @@ def _emergency_cleanup_all_sessions():
     # Real-profile Chrome processes are launched directly (not by
     # agent-browser), so the session cleanup below never reaps them.
     try:
-        _terminate_real_profile_chrome()
+        _terminate_all_real_profile_chrome()
     except Exception as e:
         logger.debug("Real-profile chrome cleanup on exit failed: %s", e)
     if _active_sessions:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1478,6 +1478,27 @@ def _terminate_real_profile_chrome() -> None:
             logger.debug("real-profile chrome terminate failed: %s", e)
 
 
+def _revoke_real_profile_access() -> str | None:
+    """Close managed sessions and remove every copied credential on consent-off."""
+    from hermes_cli.browser_connect import cleanup_real_profile_snapshots
+
+    _agent_browser_close_session(_REAL_PROFILE_SESSION)
+    _terminate_real_profile_chrome()
+    _real_profile_cdp_cache.pop("cdp", None)
+    try:
+        removed = cleanup_real_profile_snapshots()
+    except Exception as e:
+        logger.warning("real-profile cleanup-on-consent-off failed: %s", e)
+        removed = False
+    if not removed:
+        return (
+            "browser.use_real_profile is off, but Hermes could not delete the "
+            "managed browser-profile credential store. Close managed browser "
+            "processes and retry."
+        )
+    return None
+
+
 def _agent_browser_argv(browser_cmd: str) -> list:
     """Command prefix to invoke agent-browser (binary or npx sentinel)."""
     if _is_npx_agent_browser_sentinel(browser_cmd):
@@ -1578,14 +1599,8 @@ def _real_profile_cdp() -> tuple:
         # still on disk, it holds copies of the user's cookies/logins — delete
         # it so revoking consent actually removes the credential copies. Cheap
         # (one isdir check) and idempotent.
-        try:
-            from hermes_cli.browser_connect import cleanup_real_profile_snapshots
-
-            cleanup_real_profile_snapshots()
-        except Exception as e:
-            logger.debug("real-profile cleanup-on-consent-off failed: %s", e)
-        _real_profile_cdp_cache.pop("cdp", None)
-        return None, None
+        with _real_profile_cdp_lock:
+            return None, _revoke_real_profile_access()
 
     # Lightpanda cannot load a Chromium profile — agent-browser rejects
     # ``--profile`` outright under that engine ("Profiles are not supported
@@ -1609,6 +1624,9 @@ def _real_profile_cdp() -> tuple:
     )
 
     with _real_profile_cdp_lock:
+        # Consent can change while this call waits behind another launch.
+        if not _use_real_profile():
+            return None, _revoke_real_profile_access()
         browser = detect_default_chromium()
         if browser is None:
             return None, (
@@ -1632,15 +1650,19 @@ def _real_profile_cdp() -> tuple:
                 "the toggle off."
             )
 
+        copy_dir = real_profile_copy_dir(browser)
         # Reuse a live copy-browser from an earlier call this process made only
-        # after re-validating the configured identity assertion. The pin can
-        # change while this process remains alive.
+        # when it owns the currently selected browser's managed data directory.
+        # The default browser and pin can both change while this process lives.
         cached = _real_profile_cdp_cache.get("cdp")
-        if cached and _cdp_http_ready(cached):
+        if cached and _cdp_http_ready(cached) and _cdp_on_data_dir(cached, copy_dir):
             identity_err = validate_managed_real_profile_identity(browser)
             if identity_err:
                 return None, f"browser.use_real_profile is on, but {identity_err}"
             return cached, None
+        if cached:
+            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+            _terminate_real_profile_chrome()
         _real_profile_cdp_cache.pop("cdp", None)
 
         # Reuse BEFORE writing anything. A shared copy-browser may already be up
@@ -1652,7 +1674,6 @@ def _real_profile_cdp() -> tuple:
         # as a PATH only (no copy), probe reuse, and return early on a hit. The
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
-        copy_dir = real_profile_copy_dir(browser)
         existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             identity_err = validate_managed_real_profile_identity(browser)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1473,8 +1473,8 @@ def _real_profile_state() -> dict:
         return state
 
 
-def _terminate_real_profile_proc(proc) -> None:
-    """Best-effort terminate one directly launched managed browser."""
+def _terminate_real_profile_proc(proc, copy_dir: str) -> None:
+    """Best-effort terminate a directly launched managed browser tree."""
     try:
         if proc.poll() is None:
             proc.terminate()
@@ -1484,6 +1484,16 @@ def _terminate_real_profile_proc(proc) -> None:
                 proc.kill()
     except Exception as e:
         logger.debug("real-profile chrome terminate failed: %s", e)
+    try:
+        from hermes_cli.browser_connect import _terminate_managed_profile_browsers
+
+        if not _terminate_managed_profile_browsers(copy_dir):
+            logger.warning(
+                "real-profile: browser descendants remained for managed profile %s",
+                copy_dir,
+            )
+    except Exception as e:
+        logger.debug("real-profile chrome tree terminate failed: %s", e)
 
 
 def _terminate_real_profile_chrome(state: dict | None = None) -> None:
@@ -1497,7 +1507,8 @@ def _terminate_real_profile_chrome(state: dict | None = None) -> None:
     active_state = state or _real_profile_state()
     procs = active_state["chrome_procs"]
     while procs:
-        _terminate_real_profile_proc(procs.pop())
+        proc, copy_dir = procs.pop()
+        _terminate_real_profile_proc(proc, copy_dir)
 
 
 def _terminate_all_real_profile_chrome() -> None:
@@ -1826,14 +1837,14 @@ def _real_profile_cdp() -> tuple:
             except OSError:
                 pass
             if chrome_proc.poll() is not None:
-                _terminate_real_profile_proc(chrome_proc)
+                _terminate_real_profile_proc(chrome_proc, copy_dir)
                 return None, (
                     "browser.use_real_profile is on, but Chrome exited during "
                     "startup (another instance may hold the profile copy)."
                 )
             _time.sleep(0.25)
         if port is None:
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "did not expose a debug port in time. Retry, or turn the toggle off."
@@ -1844,7 +1855,7 @@ def _real_profile_cdp() -> tuple:
         try:
             browser_cmd = _find_agent_browser()
         except FileNotFoundError as e:
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, (
                 "browser.use_real_profile is on, but the local browser engine "
                 f"(agent-browser) is not installed: {e}"
@@ -1862,18 +1873,18 @@ def _real_profile_cdp() -> tuple:
                 env=_build_browser_env(),
             )
         except subprocess.TimeoutExpired:
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "took too long to start. Retry, or turn the toggle off."
             )
         except (subprocess.SubprocessError, OSError) as e:
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, f"browser.use_real_profile is on, but the launch failed: {e}"
         if proc.returncode != 0:
             tail = (proc.stderr or proc.stdout or "").strip().splitlines()
             reason = tail[-1] if tail else f"exit {proc.returncode}"
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, (
                 f"browser.use_real_profile is on, but the real-profile browser "
                 f"failed to start: {reason}"
@@ -1894,13 +1905,13 @@ def _real_profile_cdp() -> tuple:
         except (OSError, ValueError):
             pass
         if not cdp:
-            _terminate_real_profile_proc(chrome_proc)
+            _terminate_real_profile_proc(chrome_proc, copy_dir)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
             )
-        state["chrome_procs"].append(chrome_proc)
+        state["chrome_procs"].append((chrome_proc, copy_dir))
         cache["cdp"] = cdp
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -170,9 +170,9 @@ browser:
   use_real_profile: true
 ```
 
-When enabled, Hermes copies your default browser's **active** profile — the one
-you actually browse (`Local State → profile.last_used`), with its cookies, saved
-logins, and preferences — into a managed snapshot under
+When enabled for the first time, Hermes copies your default browser's **active**
+profile — the one you actually browse (`Local State → profile.last_used`) — into
+a managed profile under
 `~/.hermes/browser-profile/<browser>/`, then launches your **real browser
 binary** on that snapshot and attaches its browsing engine to it. Launching the
 real binary (instead of a bundled Chromium with mock-keychain switches) is what
@@ -182,10 +182,19 @@ of them, opening signed out. Your live browser profile is **never opened
 directly**: the
 snapshot is a separate directory, so it doesn't fight your running browser for
 the profile lock and it sidesteps Chrome 136+'s block on remote-debugging the
-default profile directory. The auth files (cookies/logins/preferences) are
-re-synced from your real profile whenever a fresh session is launched, so logins
-you do in your own browser show up in the agent's session. Only the active
-profile is copied — other Chrome profiles are never snapshotted.
+default profile directory. Portable cookies, saved logins, and preferences are
+used to bootstrap the managed profile. After that first copy, it is a **durable,
+independently authenticated browser profile**: logins and browser storage created
+inside it persist across Hermes sessions and are not overwritten from your normal
+browser. Only the active profile is copied — other Chrome profiles are never
+snapshotted.
+
+Some applications bind authentication to Local Storage or IndexedDB. Those stores
+cannot be transactionally copied from a running browser, so they are not refreshed
+from the normal profile. Such applications may require a one-time login in the
+Hermes-managed browser; that login then persists there. To intentionally start over
+from the current normal-browser profile, turn the toggle off and use the browser
+once to delete the managed profile, then turn it on again.
 
 The snapshot browser runs **headless** — it drives your profile in the
 background with no visible window and never steals focus, so you can keep
@@ -209,7 +218,10 @@ browser:
 ```
 
 A pin naming a profile directory that doesn't exist fails closed with a
-fixable message — it never silently falls back to the last-used profile.
+fixable message — it never silently falls back to the last-used profile. The pin
+selects the identity when the managed profile is first created. Changing it later
+also fails closed until you reset the managed profile with the off/use/on sequence
+described above.
 
 When you turn the toggle back off, Hermes deletes the snapshot store
 (`~/.hermes/browser-profile/`) on the next browser use, so the copied


### PR DESCRIPTION
## What does this PR do?

Real-profile sessions now keep one coherent authentication owner across launches. After the initial source-profile bootstrap, the Hermes-managed browser profile preserves its own cookies, Local Storage, and IndexedDB instead of partially replacing only cookies and login databases from the normal browser.

### Symptom

A login performed in the normal browser after the managed snapshot was created could still appear signed out in Hermes when the application also required Local Storage or IndexedDB state. Conversely, a login completed inside the managed browser could have its cookies overwritten on the next launch while its browser storage remained unchanged.

### Impact

Applications whose authentication spans multiple browser storage systems could receive a mixed, internally inconsistent session. Users could be signed out despite valid state in one browser, and managed-browser login state could be lost across relaunches.

### Bug Cause

**Trigger:** `hermes_cli/browser_connect.py` / `snapshot_real_profile()` when a completed snapshot is launched again.

**Causal chain:**
1. The first launch creates a managed profile while intentionally excluding IndexedDB.
2. Each later launch copied Cookies, Login Data, Web Data, and Preferences from the normal profile, but preserved the managed profile's Local Storage and excluded IndexedDB.
3. Authentication components from different owners and points in time were combined into one profile, producing stale or overwritten login state.

**Why it is wrong:** Browser authentication is not limited to a fixed set of SQLite files. A partial overlay cannot be transactionally consistent with Local Storage and IndexedDB, and live-copying active LevelDB stores would introduce its own corruption risk.

**Working sibling / contrast:** The initial bootstrap already runs before the managed browser owns the directory and can safely establish one starting identity. State created after that point belongs to the managed browser and can persist coherently.

**Ruled out:** Copying active IndexedDB or Local Storage on every launch was rejected because those multi-file stores cannot be captured consistently with the existing bounded file-copy mechanism.

### Fix

Completed managed profiles no longer resolve, lock, or overlay the source browser profile. The source profile is used only for initial bootstrap; subsequent launches preserve all managed authentication and storage state while still reconciling owner-only permissions. Explicitly changing `browser.real_profile_pin` now fails closed until the managed profile is reset, preventing a silent wrong-principal mismatch. Documentation and config guidance now describe the durable ownership contract and the one-time managed-browser login requirement for storage-backed applications.

## Related Issue

Fixes #99043

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/browser_connect.py` - make completed real-profile snapshots durable and fail closed when an explicit pin changes identity.
- `tests/tools/test_browser_real_profile.py` - cover durable cookies, Local Storage, IndexedDB, source independence, and relaunch isolation.
- `tests/tools/test_browser_real_profile_pin.py` - cover durable pinned identity and pin-change reset requirements.
- `hermes_cli/config_defaults.py` - describe the managed-profile ownership contract.
- `website/docs/user-guide/features/browser.md` - document bootstrap, persistence, reset, and storage-backed login behavior.

## How to Test

1. Create a real-profile managed browser and sign into a storage-backed application inside it.
2. Change authentication state in the normal browser, then relaunch the Hermes managed browser.
3. Verify that the managed login, Local Storage, and IndexedDB state persist together and are not partially overwritten.
4. Automated validation already run locally: 81 passed.

```bash
scripts/run_tests.sh tests/tools/test_browser_real_profile.py tests/tools/test_browser_real_profile_pin.py -k 'not snapshot_files_are_owner_only and not existing_lax_snapshot_heals_on_refresh' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests
- [x] I've added tests for my changes
- [x] I've tested the automated behavior on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config example update is not applicable because no config key was added or changed
- [x] Contributor guide update is not applicable
- [x] I've considered Windows and macOS browser-profile behavior
- [x] Tool schema update is not applicable
