### PR TITLE
fix(holographic): track trusted retrievals

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -295,6 +295,7 @@ class HolographicMemoryProvider(MemoryProvider):
                 results = retriever.probe(
                     args["entity"],
                     category=args.get("category"),
+                    min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
                 )
                 return json.dumps({"results": results, "count": len(results)})
@@ -303,6 +304,7 @@ class HolographicMemoryProvider(MemoryProvider):
                 results = retriever.related(
                     args["entity"],
                     category=args.get("category"),
+                    min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
                 )
                 return json.dumps({"results": results, "count": len(results)})
@@ -314,6 +316,7 @@ class HolographicMemoryProvider(MemoryProvider):
                 results = retriever.reason(
                     entities,
                     category=args.get("category"),
+                    min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
                 )
                 return json.dumps({"results": results, "count": len(results)})
@@ -321,6 +324,7 @@ class HolographicMemoryProvider(MemoryProvider):
             elif action == "contradict":
                 results = retriever.contradict(
                     category=args.get("category"),
+                    min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
                 )
                 return json.dumps({"results": results, "count": len(results)})

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -119,6 +119,7 @@ class FactRetriever:
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
+        self._record_retrievals(results)
         return results
 
     def probe(
@@ -126,6 +127,7 @@ class FactRetriever:
         entity: str,
         category: str | None = None,
         limit: int = 10,
+        min_trust: float = 0.3,
     ) -> list[dict]:
         """Compositional entity query using HRR algebra.
 
@@ -137,7 +139,9 @@ class FactRetriever:
         """
         if not hrr._HAS_NUMPY:
             # Fallback to keyword search on entity name
-            return self.search(entity, category=category, limit=limit)
+            return self.search(
+                entity, category=category, min_trust=min_trust, limit=limit
+            )
 
         conn = self.store._conn
 
@@ -157,13 +161,18 @@ class FactRetriever:
                 bank_vec = hrr.bytes_to_phases(bank_row["vector"], dim=self.hrr_dim)
                 extracted = hrr.unbind(bank_vec, probe_key)
                 # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
-                    extracted, category=category, limit=limit
+                results = self._score_facts_by_vector(
+                    extracted,
+                    category=category,
+                    min_trust=min_trust,
+                    limit=limit,
                 )
+                self._record_retrievals(results)
+                return results
 
         # Score against individual fact vectors directly
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
+        where = "WHERE hrr_vector IS NOT NULL AND trust_score >= ?"
+        params: list = [min_trust]
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -181,7 +190,9 @@ class FactRetriever:
 
         if not rows:
             # Final fallback: keyword search
-            return self.search(entity, category=category, limit=limit)
+            return self.search(
+                entity, category=category, min_trust=min_trust, limit=limit
+            )
 
         # role_content is loop-invariant — encode it once (deterministic
         # SHA-256-based atom) instead of once per fact row.
@@ -199,13 +210,16 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._record_retrievals(results)
+        return results
 
     def related(
         self,
         entity: str,
         category: str | None = None,
         limit: int = 10,
+        min_trust: float = 0.3,
     ) -> list[dict]:
         """Discover facts that share structural connections with an entity.
 
@@ -216,16 +230,18 @@ class FactRetriever:
         Falls back to FTS5 search if numpy unavailable.
         """
         if not hrr._HAS_NUMPY:
-            return self.search(entity, category=category, limit=limit)
+            return self.search(
+                entity, category=category, min_trust=min_trust, limit=limit
+            )
 
         conn = self.store._conn
 
         # Encode entity as a bare atom (not role-bound — we want ANY structural match)
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
 
-        # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
+        # Get all trusted facts with vectors
+        where = "WHERE hrr_vector IS NOT NULL AND trust_score >= ?"
+        params: list = [min_trust]
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -242,7 +258,9 @@ class FactRetriever:
         ).fetchall()
 
         if not rows:
-            return self.search(entity, category=category, limit=limit)
+            return self.search(
+                entity, category=category, min_trust=min_trust, limit=limit
+            )
 
         # Score each fact by how much the entity's atom appears in its vector
         # This catches both role-bound entity matches AND content word matches
@@ -269,13 +287,16 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._record_retrievals(results)
+        return results
 
     def reason(
         self,
         entities: list[str],
         category: str | None = None,
         limit: int = 10,
+        min_trust: float = 0.3,
     ) -> list[dict]:
         """Multi-entity compositional query — vector-space JOIN.
 
@@ -291,7 +312,9 @@ class FactRetriever:
         if not hrr._HAS_NUMPY or not entities:
             # Fallback: search with all entities as keywords
             query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+            return self.search(
+                query, category=category, min_trust=min_trust, limit=limit
+            )
 
         conn = self.store._conn
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
@@ -304,9 +327,9 @@ class FactRetriever:
             probe_key = hrr.bind(entity_vec, role_entity)
             entity_residuals.append(probe_key)
 
-        # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
+        # Get all trusted facts with vectors
+        where = "WHERE hrr_vector IS NOT NULL AND trust_score >= ?"
+        params: list = [min_trust]
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -324,7 +347,9 @@ class FactRetriever:
 
         if not rows:
             query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+            return self.search(
+                query, category=category, min_trust=min_trust, limit=limit
+            )
 
         # Score each fact by how much EACH entity is structurally present.
         # A fact scores high only if ALL entities have structural presence
@@ -347,13 +372,16 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self._record_retrievals(results)
+        return results
 
     def contradict(
         self,
         category: str | None = None,
         threshold: float = 0.3,
         limit: int = 10,
+        min_trust: float = 0.3,
     ) -> list[dict]:
         """Find potentially contradictory facts via entity overlap + content divergence.
 
@@ -369,9 +397,9 @@ class FactRetriever:
 
         conn = self.store._conn
 
-        # Get all facts with vectors and their linked entities
-        where = "WHERE f.hrr_vector IS NOT NULL"
-        params: list = []
+        # Get all trusted facts with vectors and their linked entities
+        where = "WHERE f.hrr_vector IS NOT NULL AND f.trust_score >= ?"
+        params: list = [min_trust]
         if category:
             where += " AND f.category = ?"
             params.append(category)
@@ -460,12 +488,13 @@ class FactRetriever:
         target_vec: "np.ndarray",
         category: str | None = None,
         limit: int = 10,
+        min_trust: float = 0.3,
     ) -> list[dict]:
-        """Score facts by similarity to a target vector."""
+        """Score trusted facts by similarity to a target vector."""
         conn = self.store._conn
 
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
+        where = "WHERE hrr_vector IS NOT NULL AND trust_score >= ?"
+        params: list = [min_trust]
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -491,6 +520,41 @@ class FactRetriever:
 
         scored.sort(key=lambda x: x["score"], reverse=True)
         return scored[:limit]
+
+    def _record_retrievals(self, results: list[dict]) -> None:
+        """Increment usage telemetry for facts returned by a recall path."""
+        ids = sorted(
+            {
+                int(fact["fact_id"])
+                for fact in results
+                if fact.get("fact_id") is not None
+            }
+        )
+        if not ids:
+            return
+        try:
+            with self.store._lock:
+                self.store._conn.executemany(
+                    """
+                    UPDATE facts
+                    SET retrieval_count = retrieval_count + 1
+                    WHERE fact_id = ?
+                    """,
+                    [(fact_id,) for fact_id in ids],
+                )
+                self.store._conn.commit()
+            id_set = set(ids)
+            for fact in results:
+                if fact.get("fact_id") in id_set:
+                    fact["retrieval_count"] = int(
+                        fact.get("retrieval_count") or 0
+                    ) + 1
+        except Exception:
+            # Retrieval remains available if best-effort telemetry cannot write.
+            try:
+                self.store._conn.rollback()
+            except Exception:
+                pass
 
     def _fts_candidates(
         self,

--- a/tests/plugins/memory/test_holographic_retrieval_correctness.py
+++ b/tests/plugins/memory/test_holographic_retrieval_correctness.py
@@ -1,0 +1,135 @@
+"""Regression tests for Holographic retrieval telemetry and trust filtering."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_vector_retrieval_signatures_preserve_positional_limit() -> None:
+    expected = {
+        "probe": ["self", "entity", "category", "limit", "min_trust"],
+        "related": ["self", "entity", "category", "limit", "min_trust"],
+        "reason": ["self", "entities", "category", "limit", "min_trust"],
+        "contradict": [
+            "self",
+            "category",
+            "threshold",
+            "limit",
+            "min_trust",
+        ],
+    }
+
+    for method_name, parameter_names in expected.items():
+        method = getattr(FactRetriever, method_name)
+        assert list(inspect.signature(method).parameters) == parameter_names
+
+
+def test_public_retrieval_paths_record_returned_fact_usage(tmp_path) -> None:
+    store = MemoryStore(str(tmp_path / "retrieval_usage.db"))
+    try:
+        fact_id = store.add_fact(
+            '"Shared Entity" owns the durable alpha configuration.',
+            category="general",
+        )
+        retriever = FactRetriever(store=store)
+
+        result_sets = [
+            retriever.search("Shared Entity", limit=10),
+            retriever.probe("Shared Entity", category="general", limit=10),
+            retriever.related("Shared Entity", category="general", limit=10),
+            retriever.reason(["Shared Entity"], category="general", limit=10),
+        ]
+
+        for expected_count, results in enumerate(result_sets, start=1):
+            assert [result["fact_id"] for result in results] == [fact_id]
+            assert results[0]["retrieval_count"] == expected_count
+
+        stored_count = store._conn.execute(
+            "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+        ).fetchone()["retrieval_count"]
+        assert stored_count == 4
+    finally:
+        store.close()
+
+
+def test_vector_retrieval_paths_honor_min_trust(tmp_path) -> None:
+    store = MemoryStore(str(tmp_path / "retrieval_trust.db"))
+    try:
+        trusted_id = store.add_fact(
+            '"Shared Entity" owns the durable alpha configuration.',
+            category="general",
+        )
+        low_trust_id = store.add_fact(
+            '"Shared Entity" owns the stale alpha configuration.',
+            category="general",
+        )
+        assert store.update_fact(low_trust_id, trust_delta=-0.4)
+        retriever = FactRetriever(store=store)
+
+        result_sets = [
+            retriever.probe(
+                "Shared Entity", category="general", min_trust=0.3, limit=10
+            ),
+            retriever.related(
+                "Shared Entity", category="general", min_trust=0.3, limit=10
+            ),
+            retriever.reason(
+                ["Shared Entity"], category="general", min_trust=0.3, limit=10
+            ),
+        ]
+
+        for results in result_sets:
+            assert {result["fact_id"] for result in results} == {trusted_id}
+
+        assert retriever.contradict(min_trust=0.3, threshold=0.0, limit=10) == []
+    finally:
+        store.close()
+
+
+def test_provider_passes_trust_threshold_to_every_retrieval_action() -> None:
+    class RecordingRetriever:
+        def __init__(self):
+            self.calls = []
+
+        def __getattr__(self, name):
+            def record(*args, **kwargs):
+                self.calls.append((name, kwargs))
+                return []
+
+            return record
+
+    provider = HolographicMemoryProvider(
+        config={"min_trust_threshold": 0.7}
+    )
+    recorder = RecordingRetriever()
+    untyped_provider: Any = provider
+    untyped_provider._store = object()
+    untyped_provider._retriever = recorder
+
+    actions = [
+        {"action": "probe", "entity": "Shared Entity"},
+        {"action": "related", "entity": "Shared Entity"},
+        {"action": "reason", "entities": ["Shared Entity"]},
+        {"action": "contradict"},
+    ]
+    for args in actions:
+        response = json.loads(provider._handle_fact_store(args))
+        assert response == {"results": [], "count": 0}
+
+    assert [name for name, _ in recorder.calls] == [
+        "probe",
+        "related",
+        "reason",
+        "contradict",
+    ]
+    assert all(kwargs["min_trust"] == 0.7 for _, kwargs in recorder.calls)


### PR DESCRIPTION
## What does this PR do?

Makes Holographic retrieval telemetry and trust filtering consistent across the public retrieval actions.

Before this change:

- `search()` returned facts without incrementing their `retrieval_count`;
- `probe()`, `related()`, and `reason()` also bypassed usage telemetry;
- vector-backed retrieval and contradiction scans did not honor the provider's configured `min_trust_threshold`, even though keyword search did.

This change records returned facts for the fact-returning recall paths and applies the same trust floor before vector scoring. The existing positional `limit` slots are preserved; `min_trust` is appended to those method signatures so current positional callers keep their behavior.

## Related Issue

No existing issue or PR matching this retrieval-consistency bug was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Record returned fact usage after `search`, `probe`, `related`, and `reason`.
- Increment each distinct returned fact once per retrieval call.
- Filter vector candidates by `min_trust` in `probe`, `related`, `reason`, and `contradict`.
- Pass the configured provider trust threshold into every retrieval action.
- Preserve the pre-existing positional argument order for `limit`.
- Add regressions for telemetry, trust filtering, provider propagation, and signature compatibility.

This PR intentionally does not include quarantine policy, provenance/event curation, autonomous maintenance, or retrieval-algorithm redesign.

## How to Test

```bash
scripts/run_tests.sh \
  tests/plugins/memory/test_holographic_retrieval_correctness.py \
  tests/plugins/memory/test_holographic_retrieval.py \
  tests/plugins/memory/test_holographic_auto_extract.py \
  tests/plugins/memory/test_holographic_shutdown_closes_db.py \
  tests/plugins/memory/test_holographic_store.py -q
```

Result: **46 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicate work.
- [x] This PR contains only retrieval telemetry/trust consistency and regressions.
- [x] Focused repository-wrapper tests pass.
- [x] I've added regression tests.
- [x] Tested on Fedora Linux.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the existing tool schema already documents `min_trust`.
- [x] Config-example changes are N/A.
- [x] Architecture-guide changes are N/A.
- [x] Cross-platform impact considered: this is SQLite/Python logic with no platform-specific behavior.
- [x] Tool schema changes are N/A.
