### PR TITLE
fix(desktop): deliver /btw answers via prompt.btw instead of the slash worker

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
@@ -1,0 +1,45 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'btw-session'
+
+let stream: MessageStreamHarness
+
+const event = (type: string, payload: Record<string, unknown> = {}, session_id = SID) =>
+  act(() => stream.handleEvent({ payload: { ...payload, timestamp: 900 }, session_id, type }))
+
+describe('btw.complete event', () => {
+  beforeEach(async () => {
+    stream = renderMessageStream(SID)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the side-question answer as a persistent system message', () => {
+    event('btw.complete', { question: 'which file failed?', task_id: 'btw_abc123', text: 'tests/test_x.py' })
+
+    const system = stream.state(SID).messages.filter(m => m.role === 'system')
+    const row = system.at(-1)
+
+    expect(row).toBeDefined()
+    expect(row?.parts.at(-1)).toMatchObject({ text: '💬 btw "which file failed?"\ntests/test_x.py' })
+  })
+
+  it('falls back to a bare header when the question is missing', () => {
+    event('btw.complete', { task_id: 'btw_abc123', text: 'the answer' })
+
+    const row = stream.state(SID).messages.filter(m => m.role === 'system').at(-1)
+
+    expect(row?.parts.at(-1)).toMatchObject({ text: '💬 btw\nthe answer' })
+  })
+
+  it('drops an empty answer instead of seeding a blank row', () => {
+    event('btw.complete', { task_id: 'btw_abc123', text: '' })
+
+    expect(stream.state(SID).messages.filter(m => m.role === 'system')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -78,6 +78,37 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     return true
   }
 
+  if (event.type === 'btw.complete') {
+    // Answer to a /btw side question (prompt.btw RPC): the backend finished
+    // the one-shot auxiliary call against the conversation snapshot. The CLI
+    // prints it as a panel and the Ink TUI as a system line; without this
+    // handler the desktop showed only the acknowledgement and the answer
+    // vanished (#99065). Persistent system message, not a toast — the whole
+    // point of the question is to read the answer.
+    const text = coerceGatewayText(payload?.text).trim()
+
+    if (text && sessionId) {
+      const question = coerceGatewayText((payload as { question?: string } | undefined)?.question).trim()
+      const header = question ? `💬 btw "${question}"` : '💬 btw'
+
+      flushQueuedDeltas(sessionId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `btw-complete-${Date.now()}`,
+            role: 'system',
+            parts: [textPart([header, text].join('\n'), occurredAt)],
+            timestamp: occurredAt
+          }
+        ]
+      }))
+    }
+
+    return true
+  }
+
   if (event.type === 'notification.show') {
     // Driver-agnostic agent notice (credits usage/grant/depleted/restored
     // from `agent/credits_tracker.py`). The Ink TUI renders these in its

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -616,6 +616,103 @@ describe('usePromptActions /wake', () => {
   })
 })
 
+describe('usePromptActions /btw', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    setMessages([])
+    vi.restoreAllMocks()
+  })
+
+  it('routes through prompt.btw (not the slash worker) and acknowledges', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        return { task_id: 'btw_abc123' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw which file did that error come from?')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.btw', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'which file did that error come from?'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(
+      renderedSeedTexts(seeds).some(text => text.includes('answering from a conversation snapshot'))
+    ).toBe(true)
+  })
+
+  it('prints usage for a bare /btw without calling the gateway', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const seeds: Record<string, unknown>[] = []
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw')
+
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.btw', expect.anything())
+    expect(renderedSeedTexts(seeds).some(text => text.includes('usage: /btw'))).toBe(true)
+  })
+
+  it('falls back to the slash worker when an older gateway lacks prompt.btw', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        throw new Error('method not found: prompt.btw')
+      }
+
+      if (method === 'slash.exec') {
+        return { output: '💬 Side question: "legacy"' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw why did it fail?')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'btw why did it fail?' }))
+  })
+})
+
 describe('usePromptActions /compress', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -56,6 +56,7 @@ import {
 import type {
   BrowserManageResponse,
   ClientSessionState,
+  PromptBtwResponse,
   SessionCompressResponse,
   SessionTitleResponse,
   SlashExecResponse
@@ -661,6 +662,50 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           } finally {
             compressInFlightRef.current.delete(sessionId)
+          }
+        },
+        // /btw runs against the live session agent via prompt.btw (the TUI's
+        // path). The RPC returns immediately with a task id; the answer is
+        // emitted asynchronously as a btw.complete event that the gateway-event
+        // dispatcher renders into the transcript. Routing through slash.exec
+        // instead would run the CLI's console variant inside the slash worker,
+        // where the answer only ever reaches the worker's stdout (#99065).
+        btw: async ctx => {
+          const question = ctx.arg.trim()
+
+          if (!question) {
+            const resolved = await withSlashOutput(ctx)
+
+            resolved?.render('usage: /btw <question> — answers without interrupting the current work')
+
+            return
+          }
+
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+
+          try {
+            await requestGateway<PromptBtwResponse>('prompt.btw', {
+              session_id: sessionId,
+              text: question
+            })
+
+            renderSlashOutput(`💬 answering from a conversation snapshot: "${question}"`)
+          } catch (err) {
+            // Older gateway without the RPC — keep the once-working worker
+            // path instead of a hard "method not found".
+            if (isMissingRpcMethod(err)) {
+              await runExec(ctx)
+
+              return
+            }
+
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -53,6 +53,13 @@ export interface BrowserManageResponse {
   messages?: string[]
 }
 
+/** Response from the `prompt.btw` RPC: the backend starts answering against a
+ *  snapshot of the live conversation and the answer itself arrives later as a
+ *  `btw.complete` gateway event. */
+export interface PromptBtwResponse {
+  task_id?: string
+}
+
 /** Response from the `session.compress` RPC. `messages` is the post-compress
  *  history (same shape `session.resume` returns via `_history_to_messages`),
  *  so the desktop can replace its transcript from it rather than leaving stale

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -99,6 +99,9 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashCommandArgumentMode('/bg')).toBe('text')
     expect(isDesktopSlashCommand('/btw')).toBe(true)
     expect(desktopSlashCommandArgumentMode('/btw')).toBe('text')
+    // /btw owns a dedicated prompt.btw action — the slash worker's CLI variant
+    // prints the answer to stdout where the desktop can't see it (#99065).
+    expect(resolveDesktopCommand('/btw')?.surface).toEqual({ kind: 'action', action: 'btw' })
     expect(resolveDesktopCommand('/lcm')?.surface).toEqual({ kind: 'exec' })
     expect(desktopSlashCommandArgumentMode('/lcm')).toBe('text')
   })
@@ -234,7 +237,6 @@ describe('desktop slash command curation', () => {
   it('still routes commands without dedicated RPCs through exec()', () => {
     const execNames = [
       '/bg',
-      '/btw',
       '/debug',
       '/goal',
       '/personality',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -55,6 +55,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'btw'
   | 'compress'
   | 'handoff'
   | 'hatch'
@@ -238,6 +239,17 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Compress this conversation context',
     aliases: ['/compact'],
     surface: action('compress'),
+    argumentMode: 'text'
+  },
+  // /btw must be an action wired to the prompt.btw RPC, not exec: the slash
+  // worker runs the CLI's console variant, which prints the answer to the
+  // worker's stdout — the desktop never sees it, so the acknowledgement is
+  // the last thing the user gets (#99065). The answer arrives as a
+  // btw.complete gateway event rendered by the event dispatcher.
+  {
+    name: '/btw',
+    description: 'Ask a side question about this conversation without interrupting it',
+    surface: action('btw'),
     argumentMode: 'text'
   },
   {


### PR DESCRIPTION
## Summary

`/btw` in the Desktop app printed the "💬 Side question" acknowledgement and the answer never appeared (#99065).

**Root cause:** the backend already owns the correct async channel — `prompt.btw` RPC (`tui_gateway/methods_prompt.py`) snapshots the live conversation and emits the answer as a `btw.complete` event. The Ink TUI uses exactly that path. The Desktop never called `prompt.btw` and never handled `btw.complete`: `/btw` fell through to the generic `slash.exec` route, which runs the CLI's console variant inside the slash-worker subprocess — there the answer is printed to the worker's stdout with `ChatConsole().print(Panel(...))`, which the desktop never sees.

**Fix (desktop-side only, no backend changes):**
- `desktop-slash-commands.ts`: `/btw` becomes a dedicated `action('btw')` row (same pattern as `/compress` → `session.compress`), with `argumentMode: 'text'`.
- `use-prompt-actions/slash.ts`: the `btw` action calls `prompt.btw` against the resolved target session and renders a snapshot acknowledgement; an older gateway without the RPC falls back to the legacy slash-worker path (`isMissingRpcMethod`), same compatibility pattern as `/compress`.
- `use-message-stream/gateway-event/status.ts`: a `btw.complete` handler renders the answer as a persistent system message ("💬 btw \"question\"\nanswer"), mirroring how `review.summary` lands — not a toast, since the whole point is to read the answer.

## Testing

```
cd apps/desktop
npx vitest run --project ui src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
  Test Files  2 passed (2) — Tests 33 passed (33)
npx vitest run --project ui src/app/session/hooks/use-prompt-actions/index.test.tsx
  Test Files  1 passed (1) — Tests 129 passed (129)   (incl. 3 new /btw specs)
npx tsc --noEmit -p tsconfig.json   # clean
```

New specs: `prompt.btw` routing (no `slash.exec`/`command.dispatch`), bare `/btw` usage line, legacy-gateway fallback, and `btw.complete` rendering (header + answer, bare header fallback, empty answer dropped).

Fixes #99065