### PR TITLE
fix(simplex): send() returns failure when WebSocket absent instead of silent success

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -831,6 +831,9 @@ class SimplexAdapter(BasePlatformAdapter):
             content = re.sub(r"MEDIA:\S+", "", content).strip()
 
         if content:
+            if not self._ws:
+                logger.warning("SimpleX: send() called but WebSocket not connected — message dropped")
+                return SendResult(success=False, error="SimpleX WebSocket not connected")
             corr_id = self._make_corr_id()
             # Structured form: addresses by ID, and json.dumps escapes
             # newlines + special chars correctly.  The bare @id text

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿send() returned success=True when _ws was absent because _send_ws() silently drops. Add guard: check _ws before sending, return failure if absent. Fixes #98949.
