### PR TITLE
fix(bot-mode): Bot Mode DMs no longer fail under Git Bash on native Windows (salvage #97758)

### DIFF
--- a/contributors/emails/yozamono@gmail.com
+++ b/contributors/emails/yozamono@gmail.com
@@ -1,0 +1,1 @@
+sambai-dev

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -390,6 +390,36 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
+    tmp_path, monkeypatch
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+    responses = [
+        subprocess.CompletedProcess([], 1, stdout="", stderr="HTTP 429 rate limit"),
+        subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    ]
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    returncode = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "researcher"], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 0
+    assert len(calls) == 2
+    assert [kwargs["stdin"] for _argv, kwargs in calls] == [
+        subprocess.DEVNULL,
+        subprocess.DEVNULL,
+    ]
+    assert not dm_file.exists()
+
+
 @pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
 def test_delivery_main_rejects_invalid_cli(args):
     assert bot_mode_dm._delivery_main(args) == 2

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -572,6 +572,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
             )
@@ -587,6 +588,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                     proc = subprocess.run(
                         [*argv, "--query-file", dm_file],
                         check=False,
+                        stdin=subprocess.DEVNULL,
                         capture_output=True,
                         text=True,
                     )


### PR DESCRIPTION
## Summary
Bot Mode DM delivery no longer dies with `WinError 6` on native Windows under Git Bash — query-file transport children stop inheriting the shell's invalid stdin pseudo-handle (salvage of #97758 by @sambai-dev).

Root cause: the query-file transport never reads stdin, but `subprocess.run` implicitly inherited Git Bash's unusable pseudo-handle, failing the spawn before the child started. The policy-gated retry path had the same shape.

## Changes
- `tools/bot_mode_dm.py`: `stdin=subprocess.DEVNULL` on both query-file `subprocess.run` sites (initial attempt + retry). Peer/`stdin_file=True` delivery keeps its real message stream, untouched.
- `tests/tools/test_bot_mode_dm.py`: regression test asserting DEVNULL on both attempts through the retry path, rc 0, and DM-file unlink.
- `contributors/emails/`: attribution mapping for @sambai-dev.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_bot_mode_dm.py` (full file, worktree venv) | 40 passed, 1 skipped |
| Sabotage run (main's `bot_mode_dm.py` + new test) | test FAILS — regression test bites |
| Windows A/B proof (windows-latest, single-use wine2e lane) | run 33356511890 — leg A repro on main fires, leg B clean with fix, regression test passes natively |

**Live repro:** native `windows-latest` runner, Git Bash with `exec 0<&-`, real `_run_delivery` spawning a real python child — before: OSError WinError 6 on main; after: rc 0 with fix. Run: https://github.com/NousResearch/hermes-agent/actions/runs/33356511890

Refs #48986. Salvaged from #97758 with @sambai-dev's authorship preserved via cherry-pick; independent Win11 verification by @monerostar on the original PR.

## Infographic

![Bot Mode DMs fixed on Windows](https://v3b.fal.media/files/b/0aa88002/8RBopsUlhyZCJNxgKwL8r_TemPkbQO.png)
