### PR TITLE
fix(desktop): paused Group Chat bots stay visible after reload (#97740, salvage #97808)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -72,6 +72,7 @@ import {
 import type { GroupChatRoom } from './group-chat'
 import { GroupClarifyCard, GroupImageControls, GroupMentionInput } from './group-chat-parts'
 import type { GroupRoomPrompt } from './group-chat-parts'
+import { GroupHoldStatus } from './group-hold-status'
 import {
   botGroups,
   groupChatMemberBots,
@@ -1233,6 +1234,11 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
         </div>
       ) : null}
       {header}
+      <GroupHoldStatus
+        holds={room.holds}
+        memberLabel={member => displayName(member, botRosterMeta(member, allMeta))}
+        members={members}
+      />
       {activityPanel}
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
         <div className="grid gap-1.5 px-2.5 pb-2">

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+import type { GroupMember } from './types'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+  const base = await pluginSdkMock(host)
+
+  return {
+    ...base,
+    Button: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
+    Codicon: ({ name }: { name: string }) => <span aria-hidden data-icon={name} />,
+    ConfirmDialog: () => null,
+    CopyButton: () => null,
+    Dialog: () => null,
+    DialogContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogDescription: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogFooter: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogHeader: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogTitle: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+    relativeTime: () => 'now',
+    RowButton: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    Tip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useI18n: () => ({ t: { common: { cancel: 'Cancel', save: 'Save' } } }),
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./group-chat-parts', () => ({
+  GroupClarifyCard: () => null,
+  GroupImageControls: () => null,
+  GroupMentionInput: (props: { 'aria-label'?: string }) => <textarea aria-label={props['aria-label']} />
+}))
+
+const MEMBERS: GroupMember[] = [
+  { name: 'research', title: 'Research' },
+  { name: 'builder', title: 'Builder' }
+]
+
+beforeEach(() => {
+  vi.resetModules()
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('durable group holds', () => {
+  it('shows an accessible all-members status without relying on the activity feed', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 2 }, research: { at: 1 } }}
+        memberLabel={member => member.title || member.name}
+        members={MEMBERS}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('All 2 bots are paused')
+    expect(status.textContent).toContain('Mention a paused bot or send @all resume to release them.')
+    expect(status.querySelector('[data-icon="debug-pause"]')).not.toBeNull()
+  })
+
+  it('keeps unmatched holds visible instead of reporting all current members held', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 1 }, 'mac-mini::research': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[{ name: 'builder', title: 'Builder' }]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('Paused:')
+    expect(status.textContent).toContain('Builder')
+    expect(status.textContent).toContain('research')
+    expect(status.textContent).not.toContain('All 1 bots are paused')
+  })
+
+  it('names a partial hold and disappears after the production resume directive clears it', async () => {
+    const [{ GroupHoldStatus }, { applyGroupHoldDirective }] = await Promise.all([
+      import('./group-hold-status'),
+      import('./group-rounds')
+    ])
+
+    const held = { builder: { at: 2 } }
+
+    const view = render(
+      <GroupHoldStatus holds={held} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Builder')
+
+    const released = applyGroupHoldDirective(held, { everyone: true, mentioned: [] }, '@all resume', {})
+    view.rerender(
+      <GroupHoldStatus holds={released} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('keeps a persisted source-scoped hold visible while its roster row is unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: builder')
+  })
+
+  it('source-qualifies same-named holds whose roster rows are unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 1 }, 'laptop::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('builder (mac-mini)')
+    expect(status.textContent).toContain('builder (laptop)')
+  })
+
+  it('projects hydrated holds into the real group workspace', async () => {
+    const [{ GroupChatWorkspace }, chat] = await Promise.all([import('./group-chat-view'), import('./group-chat')])
+
+    chat.$groupChats.set({
+      Core: {
+        holds: { research: { at: 1 } },
+        log: [],
+        members: MEMBERS,
+        watermarks: {}
+      }
+    })
+
+    render(<GroupChatWorkspace group="Core" members={MEMBERS} />)
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Research')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
@@ -1,0 +1,60 @@
+import { Codicon } from '@hermes/plugin-sdk'
+
+import { groupMemberKey } from './group-membership'
+import { useBots } from './i18n'
+import type { GroupHold, GroupMember } from './types'
+
+interface GroupHoldStatusProps {
+  holds?: Record<string, GroupHold>
+  memberLabel: (member: GroupMember) => string
+  members: GroupMember[]
+}
+
+/** Durable room-level explanation for sticky Stop holds. Activity is scoped to
+ * one run and disappears across epochs/reloads; this status reads the room's
+ * persisted hold map instead. */
+export function GroupHoldStatus(props: GroupHoldStatusProps) {
+  const b = useBots()
+  const held = new Set(Object.keys(props.holds || {}))
+  const memberKeys = new Set(props.members.map(groupMemberKey))
+  const heldMembers = props.members.filter(member => held.has(groupMemberKey(member)))
+
+  const unavailableHeldLabels = [...held]
+    .filter(key => !memberKeys.has(key))
+    .map(key => {
+      const [source, name] = key.split('::')
+
+      return source && name ? `${name} (${source})` : key
+    })
+
+  const heldLabels = [...heldMembers.map(props.memberLabel), ...unavailableHeldLabels]
+
+  const allHeld =
+    props.members.length > 0 &&
+    unavailableHeldLabels.length === 0 &&
+    props.members.every(member => held.has(groupMemberKey(member)))
+
+  const label = allHeld
+    ? b.group.allHeldStatus(props.members.length)
+    : heldLabels.length
+      ? b.group.heldMembersStatus(heldLabels.join(', '))
+      : null
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <div
+      className="flex items-start gap-1.5 border-b border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-2.5 py-1.5 text-[0.7rem]"
+      data-slot="group-hold-status"
+      role="status"
+    >
+      <Codicon aria-hidden className="mt-0.5 shrink-0 text-(--ui-text-secondary)" name="debug-pause" />
+      <div className="min-w-0">
+        <div className="font-medium text-(--ui-text-primary)">{label}</div>
+        <div className="text-(--ui-text-tertiary)">{b.group.holdReleaseHint}</div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -156,6 +156,9 @@ type BotsMessages = {
     hideActivity: string
     stop: string
     stopHint: string
+    allHeldStatus: (count: number) => string
+    heldMembersStatus: (members: string) => string
+    holdReleaseHint: string
     needsYourInput: string
     pictureGenerationFailed: string
     nameTaken: (name: string) => string
@@ -354,6 +357,9 @@ const en: BotsMessages = {
     hideActivity: 'Hide room activity',
     stop: 'Stop',
     stopHint: 'Stop this run — interrupts the member on turn and holds the rest',
+    allHeldStatus: count => `All ${count} bots are paused`,
+    heldMembersStatus: members => `Paused: ${members}`,
+    holdReleaseHint: 'Mention a paused bot or send @all resume to release them.',
     needsYourInput: 'A bot in this group chat needs your input',
     pictureGenerationFailed: 'Group picture generation failed',
     nameTaken: name => `A group named “${name}” already exists.`,
@@ -545,6 +551,9 @@ const ja: BotsMessages = {
     hideActivity: '部屋のアクティビティを隠す',
     stop: '停止',
     stopHint: 'この実行を停止 — ターン中のメンバーを中断し、残りを保留します',
+    allHeldStatus: count => `すべてのボット（${count}体）が一時停止中`,
+    heldMembersStatus: members => `一時停止中: ${members}`,
+    holdReleaseHint: '一時停止中のボットにメンションするか、@all resume を送信して再開します。',
     needsYourInput: 'このグループチャットのボットが入力を待っています',
     pictureGenerationFailed: 'グループ画像の生成に失敗しました',
     nameTaken: name => `「${name}」という名前のグループはすでに存在します。`,
@@ -735,6 +744,9 @@ const zh: BotsMessages = {
     hideActivity: '隐藏房间活动',
     stop: '停止',
     stopHint: '停止本次运行 — 中断当前回合的成员，并暂停其余成员',
+    allHeldStatus: count => `全部 ${count} 个机器人已暂停`,
+    heldMembersStatus: members => `已暂停：${members}`,
+    holdReleaseHint: '提及已暂停的机器人，或发送 @all resume 以恢复它们。',
     needsYourInput: '此群聊中有机器人需要你输入',
     pictureGenerationFailed: '群组图片生成失败',
     nameTaken: name => `已存在名为“${name}”的群聊。`,
@@ -925,6 +937,9 @@ const zhHant: BotsMessages = {
     hideActivity: '隱藏房間活動',
     stop: '停止',
     stopHint: '停止本次執行 — 中斷目前回合的成員，並暫停其餘成員',
+    allHeldStatus: count => `全部 ${count} 個機器人已暫停`,
+    heldMembersStatus: members => `已暫停：${members}`,
+    holdReleaseHint: '提及已暫停的機器人，或傳送 @all resume 以恢復它們。',
     needsYourInput: '此群組聊天中有機器人需要您的輸入',
     pictureGenerationFailed: '群組圖片產生失敗',
     nameTaken: name => `已存在名為「${name}」的群組聊天。`,

--- a/contributors/emails/yozamono@gmail.com
+++ b/contributors/emails/yozamono@gmail.com
@@ -1,0 +1,1 @@
+sambai-dev


### PR DESCRIPTION
## Summary
Desktop Group Chat rooms with paused (held) bots now show a durable "Paused: …" / "All N bots are paused" status row that survives reloads — previously the only explanation lived in the run-scoped Activity feed, so a reopened room looked silently dead (salvage of #97808 by @sambai-dev; visibility half of #97740).

## Changes
- `apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx` (new): `GroupHoldStatus` projects the persisted `room.holds` map into an accessible `role="status"` row with a release hint (`@member` or `@all resume`); source-qualified fallback labels for holds whose roster row is unavailable.
- `group-chat-view.tsx`: status wired between the room header and the Activity panel.
- `i18n.ts`: en / ja / zh / zh-TW copy for the three new strings.
- `group-hold-status.test.tsx` (new): 6 cases — all-held, partial, unmatched holds, source-qualified holds, resume-directive clearing, real-workspace hydration.

No change to hold authority or mutation semantics; plugin-local, no core files.

## Validation
| Check | Result |
|---|---|
| `vitest run group-hold-status.test.tsx` | 6 passed |
| Live render (real `GroupChatWorkspace` + hydrated store) | status row present with paused member named; absent when holds clear |

**Live repro:** vitest real-workspace hydration on this branch — a room hydrated from persisted `holds` (fresh-reload shape, no Activity entries) renders the paused status; on main the same shape renders nothing.

Note: this covers the visibility half of #97740 only — the `@all`-without-"resume" release gap remains open there.

Salvaged from #97808 with @sambai-dev's authorship preserved via cherry-pick.

## Infographic

![Paused bots stay visible](https://v3b.fal.media/files/b/0aa87ff2/VETXFnNLxF3novMUZStUF_v8ZztUk3.png)
