### PR TITLE
fix(desktop): stop the auto-speak toggle from writing voice.auto_tts

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -323,7 +323,8 @@ function ConversationIndicator({
 
 // Pure-TTS toggle: type normally, but have every assistant reply read aloud —
 // no dictation, no full conversation loop. Filled/accent when on, mirroring the
-// muted-mic pressed state above. Driven by (and persisted to) `voice.auto_tts`.
+// muted-mic pressed state above. Driven by a desktop-local preference,
+// deliberately decoupled from `voice.auto_tts` (#99076).
 function AutoSpeakButton({ active, disabled, onToggle }: { active: boolean; disabled: boolean; onToggle: () => void }) {
   const { t } = useI18n()
   const c = t.composer

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -1,11 +1,52 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/hermes', () => ({
-  getHermesConfigRecord: vi.fn(async () => ({})),
-  saveHermesConfig: vi.fn(async () => undefined)
-}))
+import {
+  $autoSpeakReplies,
+  $voiceStopPhrase,
+  applyAutoSpeakFromConfig,
+  applyVoiceStopPhraseFromConfig,
+  setAutoSpeakReplies
+} from './voice-prefs'
 
-import { $voiceStopPhrase, applyVoiceStopPhraseFromConfig } from './voice-prefs'
+describe('desktop-local auto-speak preference', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $autoSpeakReplies.set(false)
+  })
+
+  it('migrates from the legacy shared voice.auto_tts value on first run', () => {
+    applyAutoSpeakFromConfig({ voice: { auto_tts: true } })
+
+    expect($autoSpeakReplies.get()).toBe(true)
+    expect(window.localStorage.getItem('hermes.desktop.autoSpeakReplies')).toBeNull()
+  })
+
+  it('keeps the stored local preference over a later config refresh', () => {
+    window.localStorage.setItem('hermes.desktop.autoSpeakReplies', 'false')
+
+    applyAutoSpeakFromConfig({ voice: { auto_tts: true } })
+
+    expect($autoSpeakReplies.get()).toBe(false)
+  })
+
+  it('toggling persists locally without touching the shared config', async () => {
+    await setAutoSpeakReplies(true)
+
+    expect($autoSpeakReplies.get()).toBe(true)
+    expect(window.localStorage.getItem('hermes.desktop.autoSpeakReplies')).toBe('true')
+  })
+
+  it('a failed local write reverts the atom', async () => {
+    const failing = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    })
+
+    await expect(setAutoSpeakReplies(true)).rejects.toThrow()
+    expect($autoSpeakReplies.get()).toBe(false)
+
+    failing.mockRestore()
+  })
+})
 
 describe('applyVoiceStopPhraseFromConfig', () => {
   it('defaults to "stop" when the key is absent (backend default applies)', () => {

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   $autoSpeakReplies,
@@ -37,14 +37,34 @@ describe('desktop-local auto-speak preference', () => {
   })
 
   it('a failed local write reverts the atom', async () => {
-    const failing = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new DOMException('quota exceeded', 'QuotaExceededError')
-    })
+    // Swap the whole `localStorage` property rather than mocking
+    // `Storage.prototype`: under Node 26 the setup file installs a
+    // plain-object storage fallback whose methods are own properties (no
+    // Storage prototype), while jsdom's Storage wrapper silently drops
+    // own-property overrides. Replacing the property works under both.
+    const real = window.localStorage
 
-    await expect(setAutoSpeakReplies(true)).rejects.toThrow()
-    expect($autoSpeakReplies.get()).toBe(false)
+    const failing: Storage = {
+      get length() {
+        return real.length
+      },
+      key: index => real.key(index),
+      getItem: key => real.getItem(key),
+      setItem: () => {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      },
+      removeItem: key => real.removeItem(key),
+      clear: () => real.clear()
+    }
 
-    failing.mockRestore()
+    Object.defineProperty(window, 'localStorage', { value: failing, configurable: true })
+
+    try {
+      await expect(setAutoSpeakReplies(true)).rejects.toThrow()
+      expect($autoSpeakReplies.get()).toBe(false)
+    } finally {
+      Object.defineProperty(window, 'localStorage', { value: real, configurable: true })
+    }
   })
 })
 

--- a/apps/desktop/src/store/voice-prefs.ts
+++ b/apps/desktop/src/store/voice-prefs.ts
@@ -1,14 +1,37 @@
 import { atom } from 'nanostores'
 
-import { getHermesConfigRecord, saveHermesConfig } from '@/hermes'
+// "Read replies aloud" — a desktop-local preference. It deliberately does NOT
+// read or write `voice.auto_tts`: that key also drives the messaging gateway's
+// auto-TTS, so sharing it made the gateway voice bubble and desktop auto-speak
+// fire together (double-read, #99076). The first run with no stored preference
+// migrates from the old shared value once, so existing setups keep their state.
+const AUTO_SPEAK_KEY = 'hermes.desktop.autoSpeakReplies'
 
-// "Read replies aloud" — mirrors the canonical `voice.auto_tts` config key (also
-// in Settings → Voice, honored by the messaging gateway) so the composer toggle
-// and the Settings switch are one source of truth, not two that can disagree.
-export const $autoSpeakReplies = atom<boolean>(false)
+function readStoredAutoSpeak(): boolean | null {
+  try {
+    const raw = window.localStorage.getItem(AUTO_SPEAK_KEY)
 
-/** Seed the atom from a loaded config payload (mount / refresh). */
+    return raw === null ? null : raw === 'true'
+  } catch {
+    // Storage unavailable (locked-down renderer, quota edge) — fall back to
+    // treating the preference as unset rather than crashing module load.
+    return null
+  }
+}
+
+export const $autoSpeakReplies = atom<boolean>(readStoredAutoSpeak() ?? false)
+
+/**
+ * Seed the atom from a loaded config payload (mount / refresh). Only migrates
+ * from the legacy shared `voice.auto_tts` value while this desktop has never
+ * stored its own preference — after that, gateway-side changes to
+ * `voice.auto_tts` must not flip the local toggle.
+ */
 export function applyAutoSpeakFromConfig(config: { voice?: { auto_tts?: unknown } | null } | null | undefined) {
+  if (readStoredAutoSpeak() !== null) {
+    return
+  }
+
   $autoSpeakReplies.set(Boolean(config?.voice?.auto_tts))
 }
 
@@ -49,9 +72,9 @@ export function applyThinkingSoundFromConfig(
 }
 
 /**
- * Flip the preference and persist it. Optimistic — the atom updates instantly and
- * reverts if the config write fails. Read-modify-writes the whole record (the
- * same path the Settings page uses; there's no partial-update endpoint).
+ * Flip the preference and persist it locally. Optimistic — the atom updates
+ * instantly and reverts if the write fails. Never touches the shared config:
+ * `voice.auto_tts` stays owned by Settings → Voice and the gateway.
  */
 export async function setAutoSpeakReplies(enabled: boolean): Promise<void> {
   const previous = $autoSpeakReplies.get()
@@ -63,10 +86,7 @@ export async function setAutoSpeakReplies(enabled: boolean): Promise<void> {
   $autoSpeakReplies.set(enabled)
 
   try {
-    const record = await getHermesConfigRecord()
-    const voice = record.voice && typeof record.voice === 'object' ? (record.voice as Record<string, unknown>) : {}
-
-    await saveHermesConfig({ ...record, voice: { ...voice, auto_tts: enabled } })
+    window.localStorage.setItem(AUTO_SPEAK_KEY, String(enabled))
   } catch (error) {
     $autoSpeakReplies.set(previous)
     throw error


### PR DESCRIPTION
## What does this PR do?

The desktop composer's "Read replies aloud" toggle persisted its state to the shared `voice.auto_tts` config key. That key also drives the messaging gateway's auto-TTS, so toggling desktop auto-speak re-enabled the gateway voice bubble, and both TTS paths read every reply aloud (double-read). Users also could not keep desktop auto-speak on while turning the gateway's auto-TTS off — the desktop toggle wrote the shared key right back.

This decouples the two: the desktop auto-speak preference now lives in desktop-local storage (`hermes.desktop.autoSpeakReplies`, following the existing `hermes.desktop.*` key convention), and `voice.auto_tts` stays owned by Settings → Voice and the gateway. On first run with no stored local preference, the value migrates once from the legacy shared `voice.auto_tts`, so existing setups keep their toggle state instead of silently resetting.

This is the second double-read path called out in #99076, separate from the stream-id rewrite fix in 63565fa26.

## Related Issue

Fixes #99076

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/voice-prefs.ts` — `setAutoSpeakReplies()` now writes desktop-local storage instead of read-modify-writing the whole shared config record; the atom seeds from local storage at module load; `applyAutoSpeakFromConfig()` only migrates from the legacy `voice.auto_tts` value while no local preference has ever been stored, so later config refreshes no longer flip the local toggle.
- `apps/desktop/src/app/chat/composer/controls.tsx` — comment updated to reflect the decoupled preference source.
- `apps/desktop/src/store/voice-prefs.test.ts` — regression tests: one-time migration, config refresh not overriding a stored local preference, local-only persistence, and optimistic revert on a failed write.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run src/store/voice-prefs.test.ts --project ui`
2. Observed result: 9 passed (4 new auto-speak preference tests + 5 existing stop-phrase tests).
3. Also ran `vitest run src/app/chat/composer --project ui` (386 passed) and `vitest run src/app/session/hooks src/lib/spoken-reply.test.ts src/lib/voice-playback --project ui` (735 passed) to cover the toggle's consumers.
4. Manual check on a gateway setup: set `voice.auto_tts: false` in config.yaml, then flip the desktop "Read replies aloud" toggle on — the config file must stay `false` and only the desktop should speak (previously the toggle flipped the key back to `true` and the gateway voice bubble read the reply a second time).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (TypeScript-only change; ran the desktop vitest suites listed under How to Test instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior-internal storage swap, code comments updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added; the fix stops writing one)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (localStorage is available in the Electron renderer on all platforms; storage failures fall back to the legacy config value)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A