### PR TITLE
fix(cli): swallow UnicodeDecodeError from setproctitle on macOS with CJK/emoji argv

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -254,6 +254,12 @@ def _set_process_title() -> None:
         return
     except ImportError:
         pass
+    except Exception:
+        # setproctitle 1.3.7 on Darwin with PS_USE_CLOBBER_ARGV raises
+        # UnicodeDecodeError when argv ends with a multibyte character
+        # (CJK, emoji).  The title is purely cosmetic — swallow any
+        # exception and fall through to the ctypes strategies (#98620).
+        pass
 
     # Strategy 2/3: platform-specific ctypes fallback
     import ctypes

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿setproctitle 1.3.7 raises UnicodeDecodeError when argv ends with a multibyte char on Darwin. Only ImportError was caught. Fall through on any exception since title is cosmetic. Fixes #98620.
