### PR TITLE
fix(providers): honor enabled:false in shared resolver

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -347,6 +347,11 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     entry = user_config.get(name) if isinstance(user_config, dict) and user_config else None
     if not isinstance(entry, dict):
         return None
+    # Direct callers such as explicit /model selection and web normalization do
+    # not necessarily pass through a later picker/runtime enablement gate.
+    from hermes_cli.config import is_provider_enabled
+    if not is_provider_enabled(entry):
+        return None
     return _user_pdef(name, entry.get("name", "") or name,
                       entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or "",
                       entry.get("key_env") or entry.get("api_key_env") or "",

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -239,6 +239,22 @@ def test_resolve_provider_full_finds_named_custom_provider():
     assert resolved.source == "user-config"
 
 
+def test_resolve_provider_full_rejects_disabled_user_provider():
+    """Explicit provider resolution must honor ``providers.*.enabled``."""
+    resolved = resolve_provider_full(
+        "my-local",
+        user_providers={
+            "my-local": {
+                "name": "My Local",
+                "base_url": "http://127.0.0.1:1234/v1",
+                "enabled": False,
+            }
+        },
+    )
+
+    assert resolved is None
+
+
 @pytest.mark.parametrize(
     "requested",
     [


### PR DESCRIPTION
## Summary

- make `resolve_user_provider()` reject a `providers.<name>` entry when its existing `enabled` gate is false
- keep direct resolver callers such as explicit `/model --provider` and web route normalization aligned with the picker, runtime, and doctor
- add a regression test through `resolve_provider_full()`

## Why

The picker/runtime/doctor paths already honor `providers.<name>.enabled: false`, but the shared user-provider resolver returned a `ProviderDef` without checking that flag. Direct callers could therefore select and persist an endpoint the operator had explicitly disabled.

## Validation

- `78 passed` across the model-switch custom-provider, Kimi identity, and Upstage resolver suites
- `112 passed, 4 skipped` in `tests/hermes_cli/test_config.py`
- Ruff passed for both changed files
- `git diff --check` passed

Closes #99089