### PR TITLE
fix(cli): escape Rich markup in query-file label to prevent MarkupError crash

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22096,10 +22096,15 @@ def main(
                 # The fully-quiet ``-Q`` / ``--quiet`` machine-readable path
                 # above was already banner-free; this brings the human-
                 # facing single-query path in line so all non-interactive
-                # invocations are fast.
-                _query_label = query or ("[image attached]" if single_query_images else "")
-                if _query_label:
-                    cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+                 # invocations are fast.
+                 _query_label = query or ("[image attached]" if single_query_images else "")
+                 if _query_label:
+                     # Escape markup so query-file content containing
+                     # Rich-style tags (e.g. pytest params like
+                     # [/fb-images/path] or regex patterns) is rendered
+                     # literally rather than crashing with MarkupError (#98789).
+                     from rich.markup import escape as _re
+                     cli.console.print(f"[bold blue]Query:[/] {_re(_query_label)}")
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Query-file content passed directly to Rich console.print() crashes with MarkupError when it contains tag-like patterns. Escape with rich.markup.escape(). Fixes #98789.
