### PR TITLE
feat(holographic): detect attribute-value conflicts in contradict()

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -435,9 +436,30 @@ class FactRetriever:
                 v2 = hrr.bytes_to_phases(f2["hrr_vector"], dim=self.hrr_dim)
                 content_sim = hrr.similarity(v1, v2)
 
+                # Attribute-value conflict detection: two facts about the same
+                # subject may be semantically similar yet state conflicting
+                # values for the same structured attribute (e.g. "expires
+                # 2026-11-14" vs "expires 2026-11-24"). The vector-based
+                # score above treats those as near-duplicates because the
+                # surrounding prose is almost identical, so we additionally
+                # compare extracted attributes and flag any shared attribute
+                # whose value differs.
+                attrs1 = self._extract_attribute_values(f1["content"])
+                attrs2 = self._extract_attribute_values(f2["content"])
+                attr_conflicts = sorted(
+                    attr for attr in attrs1
+                    if attr in attrs2 and attrs1[attr] != attrs2[attr]
+                )
+
                 # High entity overlap + low content similarity = potential contradiction
                 # contradiction_score: higher = more contradictory
                 contradiction_score = entity_overlap * (1.0 - (content_sim + 1.0) / 2.0)
+
+                # An explicit attribute-value mismatch is a strong, direct
+                # contradiction signal: promote it above the threshold so it
+                # is surfaced even when prose similarity is high.
+                if attr_conflicts:
+                    contradiction_score = max(contradiction_score, 0.6)
 
                 if contradiction_score >= threshold:
                     # Strip hrr_vector from output (not JSON serializable)
@@ -450,6 +472,7 @@ class FactRetriever:
                         "content_similarity": round(content_sim, 3),
                         "contradiction_score": round(contradiction_score, 3),
                         "shared_entities": sorted(ents1 & ents2),
+                        "attribute_conflicts": attr_conflicts,
                     })
 
         contradictions.sort(key=lambda x: x["contradiction_score"], reverse=True)
@@ -640,6 +663,42 @@ class FactRetriever:
         intersection = len(set_a & set_b)
         union = len(set_a | set_b)
         return intersection / union if union > 0 else 0.0
+
+    @staticmethod
+    def _extract_attribute_values(content: str) -> dict[str, str]:
+        """Extract attribute-value pairs from fact content.
+
+        Recognises common structured values that may conflict between two
+        facts about the same subject: dates (2026-11-14, 2026年11月14日),
+        money ($20, 7400元), percentages (60%), capacities (1.9GB), and
+        version numbers (v7.0.0). Returns a mapping of attribute name →
+        extracted value; unknown attributes are ignored so non-structured
+        prose does not produce spurious matches.
+        """
+        if not content:
+            return {}
+        values: dict[str, str] = {}
+        # ISO-ish dates: 2026-11-14 / 2026/11/14 / 2026年11月14日
+        m = re.search(r"(20\d{2}[-/年]\d{1,2}[-/月]\d{1,2}日?)", content)
+        if m:
+            values["date"] = m.group(1)
+        # Money: $20 / $20.5 / 7400元 / 7400 元
+        m = re.search(r"[$¥]\s*\d+(?:\.\d+)?|\d+(?:\.\d+)?\s*(?:元|美元|人民币)", content)
+        if m:
+            values["money"] = m.group(0).strip()
+        # Percent: 60% / 60 %
+        m = re.search(r"\d+(?:\.\d+)?\s*%", content)
+        if m:
+            values["percent"] = m.group(0).strip()
+        # Capacity: 1.9GB / 30G / 512MB (case-insensitive, whole number+unit)
+        m = re.search(r"\d+(?:\.\d+)?\s*(?:GB|G|TB|T|MB|M)(?![A-Za-z])", content, re.IGNORECASE)
+        if m:
+            values["capacity"] = m.group(0).strip()
+        # Version: v7.0.0 / 7.0.0 / 3.15.1
+        m = re.search(r"\bv?\d+\.\d+\.\d+\b", content)
+        if m:
+            values["version"] = m.group(0).strip()
+        return values
 
     def _temporal_decay(self, timestamp_str: str | None) -> float:
         """Exponential decay: 0.5^(age_days / half_life_days).

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -238,3 +238,84 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
     )
+
+
+# ---------------------------------------------------------------------------
+# contradict() — attribute-value conflict detection (2026-08-31)
+# Two facts about the same subject can be semantically near-identical prose
+# yet state conflicting values for the same structured attribute (e.g. an
+# expiry date). The HRR-vector similarity treats them as duplicates, so the
+# original score never surfaced them. We now extract common attributes
+# (dates, money, percents, capacities, versions) and flag value mismatches.
+# ---------------------------------------------------------------------------
+
+def _make_store(db_path, facts):
+    store = MemoryStore(str(db_path))
+    for content, category in facts:
+        store.add_fact(content=content, category=category)
+    return store
+
+
+def test_contradict_detects_attribute_value_mismatch(tmp_path):
+    """Same subject, same attribute (date), different value → surfaced."""
+    store = _make_store(
+        tmp_path / "attr_conflict.db",
+        [
+            ('"GITHUB_TOKEN" expires 2026-11-14', "tool"),
+            ('"GITHUB_TOKEN" expires 2026-11-24', "tool"),
+        ],
+    )
+    retriever = FactRetriever(store=store)
+    results = retriever.contradict()
+    assert results, "attribute mismatch should be reported as a contradiction"
+    top = results[0]
+    assert top["attribute_conflicts"] == ["date"], (
+        f"expected date conflict, got {top['attribute_conflicts']}"
+    )
+    assert top["contradiction_score"] >= 0.3
+
+
+def test_contradict_ignores_same_attribute_same_value(tmp_path):
+    """Same subject, same attribute, same value → not a conflict."""
+    store = _make_store(
+        tmp_path / "attr_same.db",
+        [
+            ('"GITHUB_TOKEN" expires 2026-11-24', "tool"),
+            ('"GITHUB_TOKEN" expires 2026-11-24; rotate early', "tool"),
+        ],
+    )
+    retriever = FactRetriever(store=store)
+    results = retriever.contradict()
+    assert not results, "identical attribute values must not be a conflict"
+
+
+def test_contradict_no_attribute_fields_preserved(tmp_path):
+    """Existing behaviour: no attributes → no attribute_conflicts field noise."""
+    store = _make_store(
+        tmp_path / "attr_none.db",
+        [
+            ('"Server" 1.9GB RAM 1 core', "tool"),
+            ('"Server" runs gateway and webui', "tool"),
+        ],
+    )
+    retriever = FactRetriever(store=store)
+    results = retriever.contradict()
+    # Both share the "Server" entity; no shared attribute differs.
+    for r in results:
+        assert r["attribute_conflicts"] == []
+
+
+def test_extract_attribute_values_unit():
+    """Attribute extraction recognises structured values and ignores prose."""
+    assert FactRetriever._extract_attribute_values(
+        '"GITHUB_TOKEN" expires 2026-11-14, rotate before then'
+    ) == {"date": "2026-11-14"}
+    assert FactRetriever._extract_attribute_values(
+        "Budget is $20/month"
+    )["money"] == "$20"
+    assert FactRetriever._extract_attribute_values(
+        "Server 1.9GB RAM, 30G disk"
+    )["capacity"] == "1.9GB"
+    assert FactRetriever._extract_attribute_values(
+        "no structured values here"
+    ) == {}


### PR DESCRIPTION
## What does this PR do?

`FactRetriever.contradict()` detects contradictions via entity overlap × content
divergence. Two facts about the same subject with near-identical prose but
conflicting structured values — e.g. an expiry date (`"GITHUB_TOKEN" expires
2026-11-14` vs `expires 2026-11-24`) — are scored as near-duplicates by the
HRR-vector similarity, so the conflict is never surfaced.

This PR adds attribute-value conflict detection: extract common structured
attributes (dates, money, percents, capacities, versions) from fact content,
and when two facts share an attribute whose value differs, promote the pair
above the threshold (score ≥ 0.6) and expose the mismatch via a new
`attribute_conflicts` field on the result.

## Related Issue

No existing issue — found while running `contradict()` against a real fact
store that held a genuine date mismatch.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor

## Changes Made

- `plugins/memory/holographic/retrieval.py` — new `_extract_attribute_values()`
  static method; `contradict()` compares shared attributes and flags value
  mismatches.
- `tests/plugins/memory/test_holographic_retrieval.py` — 4 new tests (mismatch
  detected, same-value not a conflict, backward-compatible empty field,
  extraction unit test).

## How to Test

1. `pytest tests/plugins/memory/test_holographic_retrieval.py -q` → 17 passed
2. Seed two facts with the same quoted entity and different dates, call
   `contradict()` → returns the pair with `attribute_conflicts: ["date"]`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (none found for `contradict` conflicts)
- [x] My PR contains only changes related to this fix
- [x] I've run pytest and holographic tests pass (46/46; pre-existing
      hindsight-provider failures unrelated, also fail on main)
- [x] I've added tests for my changes
- [x] Tested on Linux (AlmaLinux 8, x86_64)

### Documentation & Housekeeping

- [x] Updated docstrings — or N/A
- [ ] cli-config.yaml.example — N/A
- [ ] CONTRIBUTING.md — N/A
- [x] Cross-platform impact — N/A (pure `re`, stdlib only)
- [ ] Tool descriptions — N/A