### PR TITLE
fix(checkpoint): write project metadata atomically via temp+replace to prevent corrupt JSON on crash

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -601,7 +601,12 @@ def _register_project(store: Path, working_dir: str) -> None:
             pass
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        # Write atomically via temp+replace so a SIGKILL between open and
+        # close cannot leave a truncated JSON that triggers orphan detection
+        # and silently deletes rollback history (#98832).  Mirrors _save_ledger.
+        _tmp = meta_path.with_suffix(".json.tmp")
+        _tmp.write_text(json.dumps(meta), encoding="utf-8")
+        _tmp.replace(meta_path)
     except OSError as exc:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 
@@ -630,7 +635,11 @@ def _touch_project(store: Path, working_dir: str) -> None:
     if evidence:
         meta.update(evidence)
     try:
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        # Write atomically via temp+replace so a crash cannot truncate the
+        # metadata and trigger orphan detection (#98832).
+        _tmp = meta_path.with_suffix(".json.tmp")
+        _tmp.write_text(json.dumps(meta), encoding="utf-8")
+        _tmp.replace(meta_path)
     except OSError as exc:
         logger.debug("Could not update project metadata %s: %s", meta_path, exc)
 


### PR DESCRIPTION
﻿_register_project/_touch_project used write_text() (non-atomic). Crash between open and close leaves truncated JSON, triggering orphan detection which silently deletes rollback history. Use temp+replace to match _save_ledger. Fixes #98832.
