### PR TITLE
fix(gateway): respect tool_preview_length=0 as unlimited

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4794,11 +4794,11 @@ class TurnRunner:
             _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
             # Single-line, capped preview for non-verbose modes.
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
+            _cap: int | None = _pl if _pl > 0 else None
             _lines = _cmd_full.splitlines()
             _cmd_short = _lines[0] if _lines else _cmd_full
             _multiline = len(_lines) > 1
-            if len(_cmd_short) > _cap:
+            if _cap is not None and len(_cmd_short) > _cap:
                 _cmd_short = _cmd_short[:_cap - 3] + "..."
             elif _multiline:
                 _cmd_short = _cmd_short + " ..."
@@ -4845,12 +4845,11 @@ class TurnRunner:
                 verb_drops_preview,
             )
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
             _prepared_preview = prepare_tool_preview(
                 tool_name,
                 args,
                 fallback=preview,
-                max_len=_cap,
+                max_len=_pl,
             )
             if _progress_adapter is not None:
                 preview = _progress_adapter.format_tool_preview(_prepared_preview)

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -133,6 +133,19 @@ class TestPrepareToolPreview:
         assert preview.truncated is False
         assert preview.url is None
 
+    def test_max_len_zero_means_unlimited(self):
+        """max_len=0 (the default tool_preview_length) must NOT truncate."""
+        url = "https://example.com/a/very/long/path/to/a/page"
+        for kwargs in (
+            {"urls": [url]},
+            {"query": url},
+        ):
+            preview = prepare_tool_preview(
+                "web_extract", kwargs, fallback=url, max_len=0
+            )
+            assert preview.text == url
+            assert preview.truncated is False
+
     def test_truncated_non_url_has_no_link_target(self):
         preview = prepare_tool_preview(
             "web_search",

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -742,8 +742,8 @@ def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):
     assert len(preview_text) <= 120, f"Preview too long ({len(preview_text)}): {preview_text}"
 
 
-def test_discord_truncated_tool_url_links_to_full_destination(monkeypatch, tmp_path):
-    """The real gateway path must retain the URL beyond its visible cap."""
+def test_discord_tool_url_not_truncated_at_zero(monkeypatch, tmp_path):
+    """tool_preview_length: 0 must show the full URL (documented 'no limit')."""
     import yaml
 
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
@@ -790,9 +790,7 @@ def test_discord_truncated_tool_url_links_to_full_destination(monkeypatch, tmp_p
 
     assert result["final_response"] == "done"
     assert adapter.sent
-    visible = UrlPreviewAgent.URL[:37] + "..."
-    label = visible.removeprefix("https://")
-    assert f"[{label}](<{UrlPreviewAgent.URL}>)" in adapter.sent[0]["content"]
+    assert UrlPreviewAgent.URL in adapter.sent[0]["content"]
 
 
 class CommentaryAgent:


### PR DESCRIPTION
# Summary

Fixes #51067 

Fixes a bug where `display.tool_preview_length=0` is not respected by tool-progress paths in the gateway. Updates a pre-existing test that asserted the old bugged behavior. 

This PR may be picked up as a duplicate (#51107) but the changes are kept minimal. The test for the real gateway path is updated, and no redundant or unnecessary tests are added.

## Changes

* `gateway/run.py`: Fixed cap comparison that collapses 0 (unlimited) to 40
* `tests/gateway/test_run_progress_topics.py`: Corrected a test that asserted the test URL would be truncated — it now asserts the full URL appears in the message
* `tests/agent/test_display.py`: Added a display test that asserts a test URL is not truncated `tool_preview_length` is 0

## Related Issue

* #51067 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12

## Screenshots / Logs

Verified fix with my own Hermes agent via Discord.

**Before**

<img width="994" height="83" alt="Discord_ddyGMehV5Z" src="https://github.com/user-attachments/assets/d7166d28-b7fc-4245-9923-32c080046723" />

**After**

<img width="1005" height="71" alt="image" src="https://github.com/user-attachments/assets/0438b4db-38b2-4921-8815-f1e737ce6da6" />