### PR TITLE
fix(mem0): skip platform key lookup in OSS mode

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -86,7 +86,6 @@ def _load_config() -> dict:
 
     config = {
         "mode": os.environ.get("MEM0_MODE", "platform"),
-        "api_key": get_secret("MEM0_API_KEY", ""),
         "host": os.environ.get("MEM0_HOST", ""),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "oss": {},
@@ -106,6 +105,16 @@ def _load_config() -> dict:
                            if v is not None and v != ""})
         except Exception:
             pass
+
+    # MEM0_API_KEY authenticates the Platform and self-hosted HTTP backends;
+    # pure OSS mode constructs its backend from the local ``oss`` config and
+    # has no platform credential to resolve. Decide only after mem0.json has
+    # overridden the env fallback so a scope-less multiplex caller can load an
+    # OSS config without weakening fail-closed reads for credentialed modes.
+    if config.get("mode", "platform") == "oss":
+        config.setdefault("api_key", "")
+    elif not config.get("api_key"):
+        config["api_key"] = get_secret("MEM0_API_KEY", "")
 
     return config
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -5,6 +5,7 @@ import threading
 import time
 import pytest
 
+from agent import secret_scope
 import plugins.memory.mem0 as mem0_plugin
 from plugins.memory.mem0 import Mem0MemoryProvider
 
@@ -263,6 +264,59 @@ class TestMem0V3Config:
 
 class TestMem0ModeSwitch:
 
+    def test_oss_mode_initializes_without_unscoped_platform_key(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        (tmp_path / "mem0.json").write_text(
+            json.dumps(
+                {
+                    "mode": "oss",
+                    "oss": {"vector_store": {"provider": "qdrant"}},
+                }
+            )
+        )
+
+        token = secret_scope.set_secret_scope(None)
+        secret_scope.set_multiplex_active(True)
+        try:
+            provider = Mem0MemoryProvider()
+            provider._create_backend = lambda: None  # type: ignore[method-assign]
+            provider.initialize("test")
+            available = provider.is_available()
+        finally:
+            secret_scope.set_multiplex_active(False)
+            secret_scope.reset_secret_scope(token)
+
+        assert provider._mode == "oss"
+        assert provider._api_key == ""
+        assert available is True
+
+    def test_platform_config_still_fails_closed_without_profile_scope(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+        token = secret_scope.set_secret_scope(None)
+        secret_scope.set_multiplex_active(True)
+        try:
+            with pytest.raises(secret_scope.UnscopedSecretError):
+                Mem0MemoryProvider().is_available()
+        finally:
+            secret_scope.set_multiplex_active(False)
+            secret_scope.reset_secret_scope(token)
+
+    def test_file_api_key_still_overrides_environment(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "env-key")
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"api_key": "file-key"})
+        )
+
+        assert mem0_plugin._load_config()["api_key"] == "file-key"
+
     def test_default_mode_is_platform(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("MEM0_API_KEY", "test-key")
@@ -407,5 +461,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-


### PR DESCRIPTION
## Summary

- load non-secret Mem0 settings and canonical `mem0.json` overrides before deciding whether a platform credential is required
- skip `MEM0_API_KEY` resolution only for pure OSS mode, where the local backend does not consume that credential
- preserve fail-closed secret-scope behavior for Platform and self-hosted HTTP modes, plus existing file-over-environment precedence

Fixes #99121

## Verification

- red/green regression: OSS initialization without an active multiplex secret scope failed with `UnscopedSecretError` before the fix and passes after it
- `HERMES_PYTHON=/private/tmp/hermes-88839-venv/bin/python scripts/run_tests.sh tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_backend_integration.py tests/plugins/memory/test_mem0_providers.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_v3.py -q` — 69 passed, 1 skipped
- `/private/tmp/hermes-88839-venv/bin/python -m ruff check plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v3.py`

Claude Opus 4.8 independently reviewed the scoped diff and reported no blocking findings.