### PR TITLE
fix(dashboard): keep post-login redirect and logout under the proxy path prefix

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -588,7 +588,14 @@ async def auth_callback(
     # that lets attacker-controlled bytes into the cookie would otherwise
     # produce an open redirect.
     landing = _validate_post_login_target(next_from_cookie) or "/"
-    resp = RedirectResponse(url=landing, status_code=302)
+    # ``landing`` is a back-end-relative path (the proxy already stripped
+    # the mount prefix before the request reached us), so it must be
+    # re-prefixed here — every other dashboard-internal redirect in this
+    # file already goes through ``_prefix(request)``; the post-login
+    # landing is not an exemption (#99123).
+    resp = RedirectResponse(
+        url=f"{_prefix(request)}{landing}", status_code=302
+    )
     set_session_cookies(
         resp,
         access_token=session.access_token,

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -31,6 +31,7 @@ those rules surfaces before a Mission Control deploy.
 from __future__ import annotations
 
 import logging
+from urllib.parse import quote
 
 import pytest
 
@@ -250,6 +251,102 @@ class TestOAuthRedirectUriRespectsPrefix:
         parsed = urlparse(redirect_uri)
         assert parsed.netloc == "fly-app.fly.dev"
         assert parsed.path == "/auth/callback"
+
+
+# ---------------------------------------------------------------------------
+# /auth/callback: the post-login landing redirect carries the prefix
+# ---------------------------------------------------------------------------
+
+
+class TestPostLoginLandingCarriesPrefix:
+    """The final 302 of the OAuth flow must stay under the mount prefix.
+
+    ``landing`` comes from the ``next=`` value stored in the PKCE cookie,
+    which the gate encoded as a *back-end-relative* path (the proxy
+    already stripped the prefix before forwarding). Redirecting there
+    verbatim sends the browser to ``/chat`` instead of ``/hermes/chat``
+    — a 404 behind the proxy, reading to the user as "login failed"
+    even though the session was minted fine (#99123).
+    """
+
+    PREFIX_HEADERS = {"x-forwarded-prefix": "/hermes"}
+
+    @staticmethod
+    def _drive_callback(client, headers, next_path=""):
+        """Walk /login → provider button → IDP → /auth/callback like a
+        real browser (mirrors TestAuthCallbackNext in
+        test_dashboard_auth_401_reauth.py) and return the callback's
+        final 302 response.
+
+        TestClient semantics (same as
+        test_cookies_read_back_round_trip_through_prefix below): the
+        client sees the literal back-end paths, so a PKCE cookie set
+        with ``Path=/hermes`` is not replayed by its jar onto the
+        unprefixed ``/auth/callback`` request — a real browser hitting
+        ``/hermes/auth/callback`` WOULD send it. We therefore round-trip
+        the PKCE cookie by hand via an explicit ``Cookie`` header."""
+        login_path = "/login"
+        if next_path:
+            login_path = f"/login?next={quote(next_path, safe='')}"
+        r_login = client.get(
+            login_path, headers=headers, follow_redirects=False
+        )
+        assert r_login.status_code == 200
+        body = r_login.text
+        i = body.find('class="provider-btn"')
+        assert i != -1, "no provider button in /login HTML"
+        h = body.find('href="', i) + len('href="')
+        j = body.find('"', h)
+        href = body[h:j]
+        r_to_idp = client.get(
+            href, headers=headers, follow_redirects=False
+        )
+        assert r_to_idp.status_code == 302
+        state = r_to_idp.headers["location"].split("state=")[1]
+        pkce_set = next(
+            c for c in r_to_idp.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        )
+        pkce_kv = pkce_set.split(";", 1)[0]
+        callback_headers = dict(headers or {})
+        callback_headers["cookie"] = pkce_kv
+        return client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers=callback_headers,
+            follow_redirects=False,
+        )
+
+    def test_landing_with_next_carries_prefix(self, gated_app_proxied):
+        r = self._drive_callback(
+            gated_app_proxied, self.PREFIX_HEADERS, next_path="/sessions"
+        )
+        assert r.status_code == 302
+        assert r.headers["location"] == "/hermes/sessions", (
+            f"post-login landing escaped the prefix: "
+            f"{r.headers['location']!r}"
+        )
+
+    def test_default_landing_root_carries_prefix(self, gated_app_proxied):
+        """No ``next=`` → landing is ``/``; behind a proxy that must be
+        ``/hermes/`` (bare ``/`` hits the proxy root, not the mount)."""
+        r = self._drive_callback(gated_app_proxied, self.PREFIX_HEADERS)
+        assert r.status_code == 302
+        assert r.headers["location"] == "/hermes/", (
+            f"post-login default landing escaped the prefix: "
+            f"{r.headers['location']!r}"
+        )
+
+    def test_landing_stays_unprefixed_on_direct_deploy(
+        self, gated_app_direct
+    ):
+        r = self._drive_callback(
+            gated_app_direct, headers=None, next_path="/sessions"
+        )
+        assert r.status_code == 302
+        assert r.headers["location"] == "/sessions", (
+            f"direct deploy gained a spurious prefix: "
+            f"{r.headers['location']!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -369,8 +369,10 @@ export const api = {
     }).then((r) => {
       // /auth/logout returns 302 → /login. Follow that with a full-page
       // navigation rather than letting fetch() opaquely consume the
-      // redirect — the SPA needs to leave the protected area.
-      window.location.assign("/login");
+      // redirect — the SPA needs to leave the protected area. Route the
+      // navigation through BASE like every other dashboard URL, so a
+      // path-prefix reverse proxy deploy lands on /<prefix>/login (#99123).
+      window.location.assign(`${BASE}/login`);
       return r;
     }),
   getSessions: (


### PR DESCRIPTION
## What does this PR do?

When the dashboard is mounted behind a path-prefix reverse proxy (nginx `location /hermes/` + `X-Forwarded-Prefix: /hermes`), two closing navigations of the auth flow drop the mount prefix and land on the proxy 404 page:

1. **Post-login landing** — `hermes_cli/dashboard_auth/routes.py`: the `/auth/callback` 302 redirects to the validated `next=` landing verbatim. That value is a back-end-relative path (the proxy already stripped the prefix before forwarding), so the browser is sent to `/chat` instead of `/hermes/chat`. This was the only dashboard-internal redirect in the file built without `_prefix(request)` — the very next statement already passes `prefix=_prefix(request)` to `set_session_cookies` on the same response, and every other internal redirect (`:199`, `:389`, `:903`) includes it.
2. **Dashboard logout** — `web/src/lib/api.ts`: `logout()` fetches `` `${BASE}/auth/logout` `` but then navigates to the hardcoded `"/login"`, escaping the prefix the same way.

In both cases the operation itself succeeds (session minted / revoked, cookies set correctly) — only the final navigation is wrong, which reads to the user as "login failed" / "logout failed". The fix re-uses the prefix/BASE helpers already present at each site, so direct (unproxied) deploys are byte-identical: `_prefix` returns `""` and `BASE` is `""`.

No open-redirect surface is added: `_validate_post_login_target` only returns same-origin paths starting with `/` (rejecting `//`, `/login`, `/auth/*`, `/api/*`), and prefixing such a value cannot produce an absolute URL.

## Related Issue

Fixes #99123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py` — `/auth/callback` success path: `RedirectResponse(url=f"{_prefix(request)}{landing}")` instead of the raw back-end-relative landing (with a comment explaining why the prefix must be re-applied).
- `web/src/lib/api.ts` — `logout()`: `window.location.assign(\`${BASE}/login\`)` instead of `"/login"`, matching the `fetch` directly above it.
- `tests/hermes_cli/test_dashboard_auth_prefix.py` — new `TestPostLoginLandingCarriesPrefix` class: drives the full OAuth round trip (`/login` → provider button → IDP bounce → `/auth/callback`) behind `X-Forwarded-Prefix: /hermes` and pins the final 302 `Location`:
  - `next=/sessions` landing → `/hermes/sessions`
  - default `/` landing → `/hermes/`
  - direct deploy (no prefix header) stays unprefixed (`/sessions`)

## How to Test

1. `python -m pytest tests/hermes_cli/test_dashboard_auth_prefix.py -q` — Observed result: **16 passed** (13 pre-existing + 3 new).
2. Confirm the new tests pin the bug: reverting only the `routes.py` change makes `test_landing_with_next_carries_prefix` and `test_default_landing_root_carries_prefix` fail (`Location` is `/sessions` / `/` without the prefix); with the fix they pass.
3. Full dashboard-auth suites: `python -m pytest tests/hermes_cli/test_dashboard_auth_prefix.py tests/hermes_cli/test_dashboard_auth_cookies.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_dashboard_auth_gate.py -q` — Observed result: **100 passed**.
4. Frontend: `cd web && npx tsc -p . --noEmit` (clean) and `npx vitest run src/lib/` — Observed result: **222 passed**.
5. Manual behind a prefix proxy (as in the issue): nginx `location /hermes/ { proxy_pass http://127.0.0.1:9119/; proxy_set_header X-Forwarded-Prefix /hermes; }` — after OIDC sign-in the browser should land on `https://host/hermes/...` (was `https://host/chat`), and logout should navigate to `https://host/hermes/login` (was `https://host/login`). The web bundle must be rebuilt for the `api.ts` half to take effect.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass *(dashboard-auth suites listed above: 100 passed; frontend: 222 passed)*
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I have updated tool descriptions/schemas if I changed tool behavior — or N/A