### PR TITLE
test: isolate Codex home in auth command tests

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -80,7 +80,9 @@ def _codex_pool_only_store(*, exhausted: bool = False) -> dict:
 
 
 @pytest.fixture(autouse=True)
-def _clear_provider_env(monkeypatch):
+def _clear_provider_env(monkeypatch, tmp_path):
+    # Keep tests from importing credentials from the runner's shared Codex CLI.
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
     for key in (
         "OPENROUTER_API_KEY",
         "OPENAI_API_KEY",


### PR DESCRIPTION
## Summary
- isolate `CODEX_HOME` in the auth command test autouse fixture
- prevent tests from reading credentials from a developer or CI runner's shared `~/.codex/auth.json`

## Verification
- `pytest tests/hermes_cli/test_auth_commands.py -q` (27 passed)
- `pytest tests/hermes_cli/test_auth_codex_self_heal.py -q` (2 passed)
- `git diff --check`
- `python3 -m py_compile tests/hermes_cli/test_auth_commands.py`
