### PR TITLE
fix(memory): new_text alias fallback triggers on empty-string content

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1113,7 +1113,10 @@ def memory_tool(
         return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
 
     # Accept new_text as an alias for content (single-op path). See docstring.
-    if content is None and new_text is not None:
+    # Use `not content` rather than `content is None` so that runtimes that
+    # serialise an omitted optional string as "" still trigger the fallback;
+    # `content is None` alone skips it when the provider sends content="" (#90468).
+    if not content and new_text is not None:
         content = new_text
 
     # Some strict providers fill optional schema fields with JSON null rather


### PR DESCRIPTION
When content is serialized as empty string instead of None, the new_text alias was skipped. Change guard from 'content is None' to 'not content'. Fixes #90468