### PR TITLE
fix(cron): make parse_schedule idempotent over its own display strings

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -962,6 +962,48 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     original = schedule
     schedule_lower = schedule.lower()
 
+    # Round-trip compatibility: parse_schedule emits "once at YYYY-MM-DD HH:MM"
+    # and "once in <duration>" as human-readable display strings, but those
+    # formats were never accepted as input.  Any caller that round-trips a job's
+    # .display field back as a new schedule (e.g. a UI that pre-fills the edit
+    # form with the current display) would get ValueError: Invalid schedule.
+    # Accept both display forms as first-class inputs so parse_schedule is
+    # idempotent over its own output (#89560).
+    if schedule_lower.startswith("once at "):
+        # "once at 2026-08-19 08:00" → treat as ISO timestamp
+        dt_str = schedule[len("once at "):].strip()
+        # Normalise space between date and time to T so dateutil/fromisoformat parses it
+        dt_str = dt_str.replace(" ", "T", 1)
+        try:
+            import dateutil.parser as _dup
+            _dt = _dup.parse(dt_str)
+        except Exception:
+            raise ValueError(
+                f"Invalid schedule '{original}': unrecognised 'once at' timestamp '{dt_str}'"
+            )
+        return {
+            "kind": "once",
+            "run_at": _dt.isoformat(),
+            "display": f"once at {_dt.strftime('%Y-%m-%d %H:%M')}",
+        }
+
+    if schedule_lower.startswith("once in "):
+        # "once in 2h 30m" → parse the duration and schedule relative to now
+        dur_str = schedule[len("once in "):].strip()
+        try:
+            _minutes = _parse_duration_to_minutes(dur_str)
+        except Exception:
+            raise ValueError(
+                f"Invalid schedule '{original}': unrecognised 'once in' duration '{dur_str}'"
+            )
+        import datetime as _dt_mod
+        _run_at = _dt_mod.datetime.utcnow() + _dt_mod.timedelta(minutes=_minutes)
+        return {
+            "kind": "once",
+            "run_at": _run_at.isoformat(),
+            "display": f"once in {dur_str}",
+        }
+
     # "every X" pattern → recurring interval, OR a documented natural-language
     # day/time phrase ("every monday 9am", "every day at 9am") → cron.
     if schedule_lower.startswith("every "):

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿parse_schedule emits 'once at ...' and 'once in ...' display strings but couldn't re-parse them. Adding round-trip parsing makes parse_schedule idempotent over its own output, fixing HTTP 500 when UIs pre-fill the edit form with the current schedule. Fixes #89560.
