### PR TITLE
docs: fix test command paths

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -8,8 +8,8 @@ or a running terminal backend. They verify the core sandbox mechanics:
 UDS socket lifecycle, hermes_tools generation, timeout enforcement,
 output capping, tool call counting, and error propagation.
 
-Run with:  python -m pytest tests/test_code_execution.py -v
-   or:     python tests/test_code_execution.py
+Run with:  python -m pytest tests/tools/test_code_execution.py -v
+   or:     python tests/tools/test_code_execution.py
 """
 
 import pytest

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -1,6 +1,6 @@
 """Tests for the interrupt system.
 
-Run with: python -m pytest tests/test_interrupt.py -v
+Run with: python -m pytest tests/tools/test_interrupt.py -v
 """
 
 import queue


### PR DESCRIPTION
## Summary
- update the `test_interrupt.py` command example to its current `tests/tools/` path
- update both `test_code_execution.py` command examples to the current `tests/tools/` path

## Verification
- `pytest tests/tools/test_interrupt.py -q` (7 passed)
- `python3 -m py_compile tests/tools/test_interrupt.py tests/tools/test_code_execution.py`
- `git diff --check`
