### PR TITLE
fix(auxiliary): project task reasoning through provider profiles

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5897,12 +5897,18 @@ def _project_provider_profile(
 
 def _merge_aux_extra_body(
     extra_body: Optional[dict], projection: _ProfileProjection, reasoning_config: Optional[dict], provider_norm: str,
+    reasoning_from_extra_body: bool = False,
 ) -> Dict[str, Any]:
     """Caller extra_body + profile body/reasoning + generic reasoning fallback + Nous tags."""
     merged_extra = dict(extra_body or {})
     merged_extra.update(projection.body)
     merged_extra.update(projection.reasoning_extra)
-    if reasoning_config and isinstance(reasoning_config, dict) and not projection.handles_reasoning:
+    if (
+        reasoning_config
+        and isinstance(reasoning_config, dict)
+        and not projection.handles_reasoning
+        and not reasoning_from_extra_body
+    ):
         if reasoning_config.get("enabled") is False:
             merged_extra["reasoning"] = {"enabled": False}
         else:
@@ -5952,9 +5958,20 @@ def _build_call_kwargs(
     # Provider profiles are the source of truth for reasoning wire shapes (top-level, nested body,
     # or extra_body.reasoning); providers without a reasoning-aware profile keep the generic
     # ``extra_body.reasoning`` fallback.
+    # Task-level auxiliary reasoning is folded into extra_body.reasoning by
+    # _get_task_extra_body(). Promote that canonical config back into the
+    # provider-profile input so native projections (for example DeepSeek's
+    # extra_body.thinking toggle) see it too. Direct per-call reasoning_config
+    # remains higher priority.
+    reasoning_from_extra_body = False
+    if reasoning_config is None and isinstance(extra_body, dict):
+        task_reasoning = extra_body.get("reasoning")
+        if isinstance(task_reasoning, dict):
+            reasoning_config = dict(task_reasoning)
+            reasoning_from_extra_body = True
     projection = _project_provider_profile(provider, provider_norm, model, effective_base, reasoning_config)
     kwargs.update(projection.top_level)
-    if merged_extra := _merge_aux_extra_body(extra_body, projection, reasoning_config, provider_norm):
+    if merged_extra := _merge_aux_extra_body(extra_body, projection, reasoning_config, provider_norm, reasoning_from_extra_body):
         kwargs["extra_body"] = merged_extra
     # Anthropic Messages adapters take reasoning via a private kwarg that plain OpenAI SDK clients
     # would reject; Portal Claude is dual-wire, so include it only when the catalog id selects

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2481,6 +2481,35 @@ class TestAuxiliaryTaskExtraBody:
         assert kwargs["extra_body"]["reasoning"] == {"effort": "none"}
         assert kwargs["extra_body"]["metadata"] == {"source": "test"}
 
+    def test_sync_deepseek_task_reasoning_none_disables_thinking(self):
+        """Task-level reasoning_effort must reach provider-profile projection."""
+        client = MagicMock()
+        client.base_url = "https://api.deepseek.com/v1"
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+        config = {
+            "auxiliary": {
+                "compression": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-flash",
+                    "reasoning_effort": "none",
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch("hermes_cli.config.load_config_readonly", return_value=config), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(client, "deepseek-v4-flash")):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+
     @pytest.mark.asyncio
     async def test_async_call_explicit_extra_body_overrides_task_config(self):
         client = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes a propagation gap in auxiliary LLM calls: `auxiliary.<task>.reasoning_effort` is correctly parsed by `_get_task_extra_body()` into `extra_body.reasoning`, but `_build_call_kwargs()` passed a separate `reasoning_config=None` to provider profiles. Reasoning-aware profiles therefore never saw the task-level setting.

For native DeepSeek V4 this made:

```yaml
auxiliary:
  compression:
    provider: deepseek
    model: deepseek-v4-flash
    reasoning_effort: none
```

still emit `thinking: {type: enabled}` and generate reasoning tokens.

The fix promotes task-derived `extra_body.reasoning` into the provider-profile input when no explicit per-call `reasoning_config` exists. It records that the value came from `extra_body` so providers without a reasoning-aware profile retain the original payload unchanged. Explicit per-call `reasoning_config` remains higher priority.

This is a follow-up to #32813: the per-task config knob exists on current `main`, but its provider-profile projection is incomplete on the auxiliary path.

## Related Issue

Follow-up to #32813. Related DeepSeek wire context: #17212.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Project task-derived reasoning config through provider profiles.
  - Preserve explicit per-call priority.
  - Preserve the original `extra_body.reasoning` shape for providers without reasoning-aware profile projection.
- `tests/agent/test_auxiliary_client.py`
  - Add a regression test proving DeepSeek receives `thinking: {type: disabled}` for task-level `reasoning_effort: none`.
  - Existing generic-provider test continues to pin exact `extra_body.reasoning` preservation.

## How to Test

1. Regression sabotage on current `origin/main`: restore pre-fix `agent/auxiliary_client.py` while keeping the new test. The new test fails with `thinking: {type: enabled}` instead of `disabled`.
2. Apply the fix and run:

```bash
uv run --extra dev pytest tests/agent/test_auxiliary_client.py -q
uv run ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
git diff --check
```

Observed:

```text
186 passed in 7.39s
All checks passed!
```

3. Live native DeepSeek probe using the configured `compression` auxiliary slot returned `OK` with no non-whitespace `reasoning_content` and no reported reasoning tokens. The pre-fix control returned reasoning content/tokens.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused affected-file suite run; full repository suite not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux, Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A — existing documented config behavior is corrected
- [x] `cli-config.yaml.example` update is N/A — no config key added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure Python provider-argument projection, no platform-specific code
- [x] Tool descriptions/schemas update is N/A — no tool schema change

## Screenshots / Logs

Pre-fix regression:

```text
assert {'type': 'enabled'} == {'type': 'disabled'}
```

Post-fix live probe:

```text
model=deepseek-v4-flash
response=OK
reasoning_nonspace=False
reasoning_tokens=None
```
