### PR TITLE
test(desktop): pin floating pet inward-facing geometry

### DIFF
--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -26,6 +26,7 @@ import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
+import { petFacingTransform } from './pet-facing'
 import { PET_STARTUP_RETRY_MS, petInfoPollIntervalMs } from './pet-info-poll'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
@@ -50,12 +51,6 @@ function clampPoint(x: number, y: number, w: number, h: number): Point {
     x: Math.min(Math.max(0, x), Math.max(0, (window.innerWidth || 800) - w)),
     y: Math.min(Math.max(0, y), Math.max(0, (window.innerHeight || 600) - h))
   }
-}
-
-// The sprite art faces left by default, so mirror it when the pet's center sits
-// on the left half of the window — it always faces inward, toward the content.
-function facing(leftX: number, petW: number): string {
-  return leftX + petW / 2 < (window.innerWidth || 800) / 2 ? 'scaleX(-1)' : 'none'
 }
 
 function loadPosition(): Point {
@@ -379,7 +374,7 @@ export function FloatingPet() {
       el.style.top = `${next.y}px`
 
       if (spriteWrapRef.current) {
-        spriteWrapRef.current.style.transform = facing(next.x, petW)
+        spriteWrapRef.current.style.transform = petFacingTransform(next.x, petW, window.innerWidth || 800)
       }
     },
     [clamp, petW]
@@ -499,7 +494,12 @@ export function FloatingPet() {
         style={{
           lineHeight: 0,
           position: 'relative',
-          transform: roamDir !== 0 ? (walk.mirror ? 'scaleX(-1)' : 'none') : facing(position.x, petW),
+          transform:
+            roamDir !== 0
+              ? walk.mirror
+                ? 'scaleX(-1)'
+                : 'none'
+              : petFacingTransform(position.x, petW, window.innerWidth || 800),
           zIndex: 1
         }}
       >

--- a/apps/desktop/src/components/pet/pet-facing.test.ts
+++ b/apps/desktop/src/components/pet/pet-facing.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { petFacingTransform } from './pet-facing'
+
+describe('petFacingTransform', () => {
+  it('mirrors a pet on the left so it faces right toward the center', () => {
+    expect(petFacingTransform(100, 100, 800)).toBe('scaleX(-1)')
+  })
+
+  it('keeps a pet on the right facing left toward the center', () => {
+    expect(petFacingTransform(600, 100, 800)).toBe('none')
+  })
+
+  it('uses the right-half orientation at the exact midpoint', () => {
+    expect(petFacingTransform(350, 100, 800)).toBe('none')
+  })
+})

--- a/apps/desktop/src/components/pet/pet-facing.ts
+++ b/apps/desktop/src/components/pet/pet-facing.ts
@@ -1,0 +1,7 @@
+/**
+ * Return the transform that points a left-facing sprite toward the viewport
+ * center. A pet on the left looks right; a pet on the right looks left.
+ */
+export function petFacingTransform(leftX: number, petW: number, viewportWidth: number): string {
+  return leftX + petW / 2 < viewportWidth / 2 ? 'scaleX(-1)' : 'none'
+}


### PR DESCRIPTION
## Summary

- extract the existing center-facing transform calculation into a pure helper
- cover left-half, right-half, and exact-midpoint behavior with unit tests
- preserve the roaming-direction override and all current runtime behavior

The fallback sprite rows face left by convention, so the current transform is already inward-facing. This PR makes that geometry executable and reviewable without applying the inversion proposed in #99086.

## Verification

- npx vitest run --project ui src/components/pet/pet-facing.test.ts (3 passed)
- inverted the ternary locally: all 3 new assertions failed, then restored it
- npx vitest run --project ui src/components/pet (7 files, 34 tests passed)
- npm run typecheck
- targeted ESLint and Prettier checks

Refs #99086