### PR TITLE
fix(acp): persist explicitly empty message history

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2129,7 +2129,11 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
+        if (
+            isinstance(result, dict)
+            and "messages" in result
+            and isinstance(result["messages"], list)
+        ):
             state.history = result["messages"]
             # Persist updated history so sessions survive process restarts.
             self.session_manager.save_session(session_id)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,29 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_prompt_persists_explicitly_empty_messages(self, agent, mock_manager):
+        """An empty result history is a clear-history instruction, not absence."""
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+        state.history = [{"role": "user", "content": "stale"}]
+
+        def _run(*args, **kwargs):
+            return {"final_response": "cleared", "messages": []}
+
+        state.agent.run_conversation = _run
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        agent.session_manager.save_session = MagicMock()
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="clear")],
+            session_id=resp.session_id,
+        )
+
+        assert state.history == []
+        agent.session_manager.save_session.assert_called_once_with(resp.session_id)
+
 
 
 


### PR DESCRIPTION
## Summary
- treat an explicit `messages=[]` result from `run_conversation()` as a history update
- persist the cleared history instead of retaining stale ACP session messages
- add a regression test covering the clear-and-save behavior

## Verification
- `uv run --with pytest --with pytest-asyncio --extra acp python -m pytest tests/acp/test_server.py tests/acp/test_session.py -q` (50 passed)
- `python3 -m py_compile acp_adapter/server.py tests/acp/test_server.py`
- `git diff --check`
