### PR TITLE
fix(cron): stop gateway restarts from falsely failing queued ticks

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -711,6 +711,14 @@ _running_lock = threading.Lock()
 _running_since: dict = {}
 _running_futures: dict = {}
 
+# Dispatches submitted to an executor but not yet started.  The gateway
+# shutdown path cancels these before it marks genuinely running jobs
+# interrupted: a queued tick has no tool subprocess to kill and must not emit
+# an interrupted-run notification.  Keep the copied Context with the record so
+# one-shot claim cleanup and execution-ledger finalization run against the same
+# profile-local store that created the attempt.
+_queued_dispatches: dict[str, dict] = {}
+
 # Sentinel installed in ``_running_futures`` at claim time, before
 # ``pool.submit`` has returned a real future.  This closes the race the
 # stale sweep previously had: a sweep landing between the claim critical
@@ -830,6 +838,73 @@ def release_running_job(job_id: str) -> None:
         _running_job_ids.discard(job_id)
         _running_since.pop(job_id, None)
         _running_futures.pop(job_id, None)
+        _queued_dispatches.pop(job_id, None)
+
+
+def cancel_queued_jobs_for_shutdown(reason: str) -> list[str]:
+    """Cancel executor-queued ticks and restore them to schedulable state.
+
+    ``Future.cancel()`` is the race authority: it succeeds only while the
+    worker has not started.  Started workers stay registered and continue down
+    the existing interruption + owner-notification path.  Cancelled recurring
+    jobs retain their due time; cancelled one-shots additionally have the
+    pre-dispatch ``run_claim`` cleared so the replacement gateway can fire them
+    immediately instead of waiting for the claim TTL.
+    """
+    cancelled: list[tuple[str, dict]] = []
+    with _running_lock:
+        for job_id, dispatch in list(_queued_dispatches.items()):
+            future = dispatch.get("future")
+            if future is _FUTURE_PENDING or future is None:
+                continue
+            if not future.cancel():
+                continue
+            cancelled.append((job_id, dispatch))
+            _queued_dispatches.pop(job_id, None)
+            _running_job_ids.discard(job_id)
+            _running_since.pop(job_id, None)
+            _running_futures.pop(job_id, None)
+
+    for job_id, dispatch in cancelled:
+        def _finalize_cancelled() -> None:
+            execution_id = dispatch.get("execution_id")
+            if execution_id:
+                try:
+                    finish_execution(
+                        execution_id,
+                        success=False,
+                        error=f"Deferred before dispatch: {reason}",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Could not finalize deferred execution for job '%s': %s",
+                        job_id,
+                        exc,
+                    )
+            job = dispatch.get("job") or {}
+            schedule = job.get("schedule")
+            if isinstance(schedule, dict) and schedule.get("kind") == "once":
+                try:
+                    clear_run_claim(job_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Could not clear run_claim for queued one-shot '%s' "
+                        "during shutdown: %s (claim will expire at TTL)",
+                        job.get("name", job_id),
+                        exc,
+                    )
+
+        context = dispatch.get("context")
+        if context is not None:
+            context.run(_finalize_cancelled)
+        else:
+            _finalize_cancelled()
+        logger.info(
+            "Deferred queued cron job '%s' before gateway shutdown",
+            (dispatch.get("job") or {}).get("name", job_id),
+        )
+
+    return [job_id for job_id, _dispatch in cancelled]
 
 
 def _inflight_min_allowance_minutes() -> float:
@@ -8005,11 +8080,22 @@ def tick(
                 return None
 
             def _run_and_release(j=dispatched_job, ctx=_ctx):
+                # Once the executor starts this callback it is no longer safe
+                # for shutdown reconciliation to cancel it as queued.
+                with _running_lock:
+                    _queued_dispatches.pop(j["id"], None)
                 try:
                     return ctx.run(_process_job, j)
                 finally:
                     release_running_job(j["id"])
 
+            with _running_lock:
+                _queued_dispatches[job_id] = {
+                    "future": _FUTURE_PENDING,
+                    "execution_id": execution["id"],
+                    "job": dispatched_job,
+                    "context": _ctx,
+                }
             try:
                 fut = pool.submit(_run_and_release)
             except Exception as submit_err:
@@ -8040,6 +8126,9 @@ def tick(
             with _running_lock:
                 if job_id in _running_job_ids:
                     _running_futures[job_id] = fut
+                    dispatch = _queued_dispatches.get(job_id)
+                    if dispatch is not None:
+                        dispatch["future"] = fut
             return fut
 
         # Sequential pass for env-mutating (workdir) jobs.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -8089,15 +8089,23 @@ def tick(
                 finally:
                     release_running_job(j["id"])
 
-            with _running_lock:
-                _queued_dispatches[job_id] = {
-                    "future": _FUTURE_PENDING,
-                    "execution_id": execution["id"],
-                    "job": dispatched_job,
-                    "context": _ctx,
-                }
             try:
-                fut = pool.submit(_run_and_release)
+                # Publish the real Future under the same lock that exposes the
+                # queued record.  Otherwise shutdown can observe
+                # _FUTURE_PENDING after submit has enqueued the callback but
+                # before this thread records the cancellable Future, skip it,
+                # and misclassify the tick as interrupted.
+                with _running_lock:
+                    _queued_dispatches[job_id] = {
+                        "future": _FUTURE_PENDING,
+                        "execution_id": execution["id"],
+                        "job": dispatched_job,
+                        "context": _ctx,
+                    }
+                    fut = pool.submit(_run_and_release)
+                    if job_id in _running_job_ids:
+                        _running_futures[job_id] = fut
+                        _queued_dispatches[job_id]["future"] = fut
             except Exception as submit_err:
                 release_running_job(job_id)
                 _clear_run_claim_best_effort()
@@ -8121,14 +8129,6 @@ def tick(
                 )
                 return None
 
-            # Record the owning future so the stale sweep can distinguish
-            # "still executing" from "claim leaked before/after the future".
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    _running_futures[job_id] = fut
-                    dispatch = _queued_dispatches.get(job_id)
-                    if dispatch is not None:
-                        dispatch["future"] = fut
             return fut
 
         # Sequential pass for env-mutating (workdir) jobs.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15632,6 +15632,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 one subsystem's failure doesn't block the rest.
                 """
                 try:
+                    # Jobs waiting in the cron executor have not started and
+                    # own no tool subprocess. Cancel them first so the broad
+                    # interruption sweep below cannot turn a routine restart
+                    # into a false user-visible failure. One-shots are restored
+                    # to due state by clearing their pre-dispatch run claim.
+                    from cron.scheduler import cancel_queued_jobs_for_shutdown
+
+                    _deferred = cancel_queued_jobs_for_shutdown(
+                        f"gateway shutdown ({phase})"
+                    )
+                    if _deferred:
+                        logger.info(
+                            "Shutdown (%s): deferred %d queued cron job(s): %s",
+                            phase,
+                            len(_deferred),
+                            ", ".join(_deferred),
+                        )
+                except Exception as _e:
+                    logger.debug(
+                        "cancel_queued_jobs_for_shutdown (%s) error: %s", phase, _e
+                    )
+                try:
                     from tools.process_registry import process_registry
                     _killed = process_registry.kill_all()
                     if _killed:

--- a/tests/cron/test_shutdown_queued_dispatch.py
+++ b/tests/cron/test_shutdown_queued_dispatch.py
@@ -1,0 +1,112 @@
+"""Queued cron dispatch recovery during gateway shutdown (#99120)."""
+
+from __future__ import annotations
+
+import concurrent.futures
+from unittest.mock import patch
+
+import pytest
+
+import cron.jobs as jobs_mod
+import cron.scheduler as sched
+
+
+@pytest.fixture
+def cron_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    cron_dir = hermes_home / "cron"
+    cron_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: hermes_home)
+    yield hermes_home
+    sched._running_job_ids.clear()
+    sched._running_since.clear()
+    sched._running_futures.clear()
+    sched._queued_dispatches.clear()
+
+
+class DeferredPool:
+    def __init__(self):
+        self.futures: list[concurrent.futures.Future] = []
+
+    def submit(self, _callback):
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        self.futures.append(future)
+        return future
+
+
+def _queue_without_starting(job: dict, pool: DeferredPool, monkeypatch) -> concurrent.futures.Future:
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [dict(job)])
+    monkeypatch.setattr(sched, "_get_parallel_pool", lambda _workers: pool)
+    monkeypatch.setattr(sched, "_get_sequential_pool", lambda: pool)
+
+    assert sched.tick(verbose=False, sync=False) == 1
+    assert len(pool.futures) == 1
+    assert job["id"] in sched.get_running_job_ids()
+    return pool.futures[0]
+
+
+def test_shutdown_cancels_queued_recurring_tick_without_marking_job_failed(
+    cron_store, monkeypatch
+):
+    job = jobs_mod.create_job(prompt="poll", schedule="every 10m", deliver="local")
+    pool = DeferredPool()
+    future = _queue_without_starting(job, pool, monkeypatch)
+    next_scheduled_run = jobs_mod.get_job(job["id"])["next_run_at"]
+
+    cancelled = sched.cancel_queued_jobs_for_shutdown("gateway restart")
+
+    assert cancelled == [job["id"]]
+    assert future.cancelled()
+    assert job["id"] not in sched.get_running_job_ids()
+    reloaded = jobs_mod.get_job(job["id"])
+    assert reloaded["enabled"] is True
+    assert reloaded.get("last_status") is None
+    assert reloaded["next_run_at"] == next_scheduled_run
+
+
+def test_shutdown_clears_queued_oneshot_claim_so_next_gateway_can_fire(
+    cron_store, monkeypatch
+):
+    job = jobs_mod.create_job(prompt="remind me", schedule="in 30m", deliver="local")
+    stored = jobs_mod.load_jobs()
+    for row in stored:
+        if row["id"] == job["id"]:
+            row["run_claim"] = {"at": "2026-08-31T00:00:00+00:00", "by": "test:1"}
+            job = dict(row)
+    jobs_mod.save_jobs(stored)
+
+    pool = DeferredPool()
+    future = _queue_without_starting(job, pool, monkeypatch)
+
+    cancelled = sched.cancel_queued_jobs_for_shutdown("gateway restart")
+
+    assert cancelled == [job["id"]]
+    assert future.cancelled()
+    reloaded = jobs_mod.get_job(job["id"])
+    assert reloaded["enabled"] is True
+    assert reloaded.get("run_claim") is None
+    assert reloaded["next_run_at"] == job["next_run_at"]
+
+
+def test_shutdown_does_not_cancel_a_worker_that_already_started(cron_store):
+    job_id = "running-job"
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    assert future.set_running_or_notify_cancel() is True
+    sched._running_job_ids.add(job_id)
+    sched._running_futures[job_id] = future
+    sched._queued_dispatches[job_id] = {
+        "future": future,
+        "execution_id": "execution-running",
+        "job": {"id": job_id, "schedule": {"kind": "interval", "minutes": 10}},
+        "context": None,
+    }
+
+    assert sched.cancel_queued_jobs_for_shutdown("gateway restart") == []
+    assert not future.cancelled()
+    assert job_id in sched.get_running_job_ids()
+    future.set_result(True)

--- a/tests/cron/test_shutdown_queued_dispatch.py
+++ b/tests/cron/test_shutdown_queued_dispatch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +38,18 @@ class DeferredPool:
         future: concurrent.futures.Future = concurrent.futures.Future()
         self.futures.append(future)
         return future
+
+
+class BlockingSubmitPool:
+    def __init__(self):
+        self.future: concurrent.futures.Future = concurrent.futures.Future()
+        self.submit_entered = threading.Event()
+        self.allow_submit_return = threading.Event()
+
+    def submit(self, _callback):
+        self.submit_entered.set()
+        assert self.allow_submit_return.wait(timeout=5)
+        return self.future
 
 
 def _queue_without_starting(job: dict, pool: DeferredPool, monkeypatch) -> concurrent.futures.Future:
@@ -110,3 +123,27 @@ def test_shutdown_does_not_cancel_a_worker_that_already_started(cron_store):
     assert not future.cancelled()
     assert job_id in sched.get_running_job_ids()
     future.set_result(True)
+
+
+def test_shutdown_cancels_during_submit_to_future_publication(cron_store, monkeypatch):
+    job = jobs_mod.create_job(prompt="poll", schedule="every 10m", deliver="local")
+    pool = BlockingSubmitPool()
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [dict(job)])
+    monkeypatch.setattr(sched, "_get_parallel_pool", lambda _workers: pool)
+    monkeypatch.setattr(sched, "_get_sequential_pool", lambda: pool)
+    tick_result: list[int] = []
+
+    tick_thread = threading.Thread(
+        target=lambda: tick_result.append(sched.tick(verbose=False, sync=False))
+    )
+    tick_thread.start()
+    assert pool.submit_entered.wait(timeout=5)
+    assert sched._running_lock.locked()
+    pool.allow_submit_return.set()
+    tick_thread.join(timeout=5)
+
+    assert not tick_thread.is_alive()
+    assert tick_result == [1]
+    assert sched.cancel_queued_jobs_for_shutdown("gateway restart") == [job["id"]]
+    assert pool.future.cancelled()
+    assert job["id"] not in sched.get_running_job_ids()

--- a/tests/gateway/test_cron_interrupt_notification.py
+++ b/tests/gateway/test_cron_interrupt_notification.py
@@ -13,6 +13,8 @@ adapters are still connected — the same window
 saw cron work because cron runs outside ``_running_agents`` (#60432).
 """
 
+import concurrent.futures
+import time
 from unittest.mock import patch
 
 import pytest
@@ -26,9 +28,15 @@ def _reset_cron_running_set():
     import cron.scheduler as sched
 
     sched._running_job_ids.clear()
+    sched._running_since.clear()
+    sched._running_futures.clear()
+    sched._queued_dispatches.clear()
     sched._interrupted_job_ids.clear()
     yield
     sched._running_job_ids.clear()
+    sched._running_since.clear()
+    sched._running_futures.clear()
+    sched._queued_dispatches.clear()
     sched._interrupted_job_ids.clear()
 
 
@@ -163,6 +171,47 @@ class TestNotifyInterruptedCronJobs:
 
 
 class TestShutdownDeliversNoticeBeforeDisconnect:
+    @pytest.mark.asyncio
+    async def test_queued_recurring_tick_is_deferred_without_interrupt_notice(
+        self, monkeypatch
+    ):
+        import cron.scheduler as sched
+        import tools.browser_tool as _bt
+        import tools.process_registry as _pr
+        import tools.terminal_tool as _tt
+
+        runner, adapter = make_restart_runner()
+        runner._restart_drain_timeout = 0.01
+        runner._cron_drain_timeout = 0.01
+        queued = concurrent.futures.Future()
+        job_id = "queued-recurring"
+        sched._running_job_ids.add(job_id)
+        sched._running_since[job_id] = time.time()
+        sched._running_futures[job_id] = queued
+        sched._queued_dispatches[job_id] = {
+            "future": queued,
+            "execution_id": None,
+            "job": {
+                "id": job_id,
+                "name": "quiet-monitor",
+                "schedule": {"kind": "interval", "minutes": 10},
+            },
+            "context": None,
+        }
+
+        monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 0)
+        monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+        monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+        with patch("gateway.status.remove_pid_file"), \
+             patch("gateway.status.write_runtime_status"), \
+             patch("cron.scheduler.mark_job_run"):
+            await runner.stop()
+
+        assert queued.cancelled()
+        assert job_id not in sched.get_running_job_ids()
+        assert adapter.sent == []
+
     @pytest.mark.asyncio
     async def test_notice_is_sent_while_the_adapter_is_still_connected(self, monkeypatch):
         """The whole point is ordering: a notice sent after teardown is lost,


### PR DESCRIPTION
## What does this PR do?

Gateway restarts no longer report executor-queued cron ticks as interrupted runs. Queued recurring ticks are cancelled silently after their next schedule has already been advanced, while queued one-shot jobs have their pre-dispatch claim cleared so the replacement gateway can still fire them.

### Symptom

A cron tick queued behind the scheduler executor limit was counted as in-flight during shutdown. When the drain expired, the gateway announced that run as interrupted even though its worker had never started.

### Impact

Routine gateway restarts could generate false cron failure notifications. One-shot jobs could also retain a pre-dispatch claim until its TTL expired, delaying the only scheduled run.

### Bug Cause

**Trigger:** `cron/scheduler.py` / `_submit_with_guard()` combined with `gateway/run.py` / `_kill_tool_subprocesses()` during a timed-out shutdown drain.

**Causal chain:**
1. The scheduler registers a due job in `_running_job_ids` before its executor worker starts.
2. Gateway shutdown treats every registered job as started and calls `mark_running_jobs_interrupted()` after the drain timeout.
3. The ownerless queued job id is returned to `_notify_interrupted_cron_jobs()`, producing a false user-visible failure, while a one-shot's `run_claim` remains set.

**Why it is wrong:** An executor-queued future owns no running agent or tool subprocess, so it should be deferred rather than classified as an interrupted execution.

**Working sibling / contrast:** A future whose worker has started cannot be cancelled and continues through the existing durable fire-owner interruption and notification path.

**Ruled out:** The notification is not caused by a genuinely running cron worker. The controlled regression keeps the future pending and proves that no fire claim or worker callback has started before shutdown reconciliation.

### Fix

Track executor-queued dispatch metadata until the worker starts. Shutdown now uses `Future.cancel()` as the race authority, removes only successfully cancelled jobs from the in-flight guard, records their attempt as deferred before dispatch, and clears one-shot run claims under the original copied context. Started futures remain untouched and retain the existing interruption behavior.

## Related Issue

Closes #99120

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` - track and safely cancel jobs that are still waiting in an executor queue; restore queued one-shot claims.
- `gateway/run.py` - reconcile queued cron dispatches before killing tools and marking active runs interrupted.
- `tests/cron/test_shutdown_queued_dispatch.py` - cover recurring recovery, one-shot recovery, and the started-worker race boundary.
- `tests/gateway/test_cron_interrupt_notification.py` - prove gateway shutdown does not send an interruption notice for a queued recurring tick.

## How to Test

1. Queue a recurring or one-shot cron job in a deferred executor without starting its worker.
2. Trigger gateway shutdown reconciliation and confirm the queued future is cancelled without an interruption delivery.
3. Confirm recurring scheduling remains enabled and a one-shot's `run_claim` is cleared.
4. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/cron/test_shutdown_queued_dispatch.py tests/gateway/test_cron_interrupt_notification.py -q
scripts/run_tests.sh tests/cron/test_parallel_pool.py tests/cron/test_oneshot_dispatch_failure_run_claim.py tests/cron/test_shutdown_interrupt.py tests/gateway/test_cron_active_work_drain.py -q
```

Result: 64 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and recovery contracts are documented in code and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no contributor workflow changed
- [x] I've considered cross-platform impact; the implementation uses `concurrent.futures.Future.cancel()` and existing cross-platform locks
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - automated queue and shutdown regression coverage exercises the failure path directly.
