### PR TITLE
fix(agent): insert empty assistant bridge between tool->user turns for Mistral models

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -59,6 +59,8 @@ from agent.message_sanitization import (
     _sanitize_structure_surrogates,
     _sanitize_surrogates,
     _sanitize_tools_non_ascii,
+    insert_assistant_bridge_for_mistral,
+    is_mistral_model,
     _looks_like_image_content_rejection,
     _strip_images_from_messages,
     _strip_non_ascii,
@@ -2520,6 +2522,14 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Mistral-family models enforce strict tool → assistant → user role
+        # alternation.  Other providers (OpenAI, NVIDIA Nemotron) are lenient;
+        # Mistral returns HTTP 400 "Unexpected role 'user' after role 'tool'"
+        # without the bridge.  Insert a synthetic empty assistant message at
+        # every tool→user transition when the active model is Mistral (#20154).
+        if is_mistral_model(getattr(agent, "model", "")):
+            insert_assistant_bridge_for_mistral(api_messages)
 
         # NOTE (empty-content class fix): no send-time pad loop here.  The
         # single owner for "never send a turn strict wire validation rejects

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -1047,3 +1047,57 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
 # The one genuinely shared image POLICY — removing images when a server
 # rejects them while preserving tool_call_id pairing — already has a single
 # owner here: ``_strip_images_from_messages`` above.
+
+
+_MISTRAL_MODEL_PREFIXES = (
+    "mistral",
+    "devstral",
+    "codestral",
+    "magistral",
+    "ministral",
+    "pixtral",
+)
+
+
+def is_mistral_model(model: str) -> bool:
+    """Return True when *model* names a Mistral-family model.
+
+    Mistral's chat API enforces strict role alternation: a ``user`` message
+    MUST NOT immediately follow a ``tool`` message — an ``assistant`` stub
+    must bridge them.  Other providers (OpenAI, NVIDIA Nemotron) are lenient.
+    """
+    lm = (model or "").lower().strip()
+    return any(lm.startswith(p) for p in _MISTRAL_MODEL_PREFIXES)
+
+
+def insert_assistant_bridge_for_mistral(messages: list) -> bool:
+    """Insert a synthetic empty assistant message between consecutive
+    ``tool`` → ``user`` transitions for Mistral-family models.
+
+    Mistral's chat API rejects ``Unexpected role 'user' after role 'tool'``
+    (HTTP 400) when a user turn follows tool results without an intervening
+    assistant message.  OpenAI and NVIDIA Nemotron are lenient; Mistral is not.
+
+    Mutates *messages* in place.  Returns True if any bridging was inserted.
+
+    Usage::
+
+        if is_mistral_model(agent.model):
+            insert_assistant_bridge_for_mistral(api_messages)
+
+    Fixes #20154.
+    """
+    i = 1
+    inserted = False
+    while i < len(messages):
+        prev_role = messages[i - 1].get("role", "")
+        curr_role = messages[i].get("role", "")
+        if prev_role == "tool" and curr_role == "user":
+            # Insert a synthetic empty assistant message to satisfy Mistral's
+            # strict tool → assistant → user alternation rule.
+            messages.insert(i, {"role": "assistant", "content": ""})
+            inserted = True
+            i += 2  # skip past the inserted stub and the original user msg
+        else:
+            i += 1
+    return inserted

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Mistral returns HTTP 400 when user follows tool without assistant bridge. Add is_mistral_model() + insert_assistant_bridge_for_mistral() and wire into pre-send sanitization. Fixes #20154.
