### PR TITLE
fix(qqbot): notify gateway when max reconnect attempts exhausted instead of silent return

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -672,7 +672,17 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
-                        self._mark_disconnected()
+                        # Notify the gateway that this adapter has died so it
+                        # can surface the outage, restart the process via systemd
+                        # Restart=on-failure, and stop reporting the platform as
+                        # connected (#14539).  A silent return here left the
+                        # gateway healthy-looking indefinitely.
+                        self._set_fatal_error(
+                            "qq_max_reconnect_attempts",
+                            f"QQ Bot WebSocket reconnect exhausted after "
+                            f"{MAX_RECONNECT_ATTEMPTS} attempts",
+                            retryable=True,
+                        )
                         return
 
             except Exception as exc:
@@ -684,7 +694,14 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
-                    self._mark_disconnected()
+                    # Notify gateway of permanent failure so it can surface the
+                    # outage and let systemd Restart=on-failure trigger (#14539).
+                    self._set_fatal_error(
+                        "qq_max_reconnect_attempts",
+                        f"QQ Bot WebSocket reconnect exhausted after "
+                        f"{MAX_RECONNECT_ATTEMPTS} attempts",
+                        retryable=True,
+                    )
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿QQ Bot silently returned from _listen_loop after MAX_RECONNECT_ATTEMPTS, leaving gateway believing platform was still connected. Replace _mark_disconnected() with _set_fatal_error(retryable=True) so gateway surfaces the outage and systemd Restart=on-failure can trigger. Fixes #14539.
