### PR TITLE
perf(desktop): avoid unused Streamdown Shiki load

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.code-plugin.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.code-plugin.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { codeModuleFactory, streamdownRenders } = vi.hoisted(() => ({
+  codeModuleFactory: vi.fn(),
+  streamdownRenders: vi.fn()
+}))
+
+vi.mock('@assistant-ui/react-streamdown', () => ({
+  StreamdownTextPrimitive: (props: { components: Record<string, unknown>; plugins: unknown }) => {
+    streamdownRenders(props)
+
+    return null
+  },
+  tailBoundedRemend: (text: string) => text
+}))
+
+vi.mock('@streamdown/code', () => {
+  codeModuleFactory()
+
+  return { code: { name: 'unused-code-plugin' } }
+})
+
+import { MarkdownTextContent } from './markdown-text'
+
+describe('MarkdownTextContent code highlighting', () => {
+  afterEach(() => {
+    cleanup()
+    codeModuleFactory.mockClear()
+    streamdownRenders.mockClear()
+  })
+
+  it.each([
+    ['ordinary prose', 'Just an ordinary prose answer.'],
+    ['top-level fenced code', '```ts\nconst answer = 42\n```'],
+    ['quoted fenced code', '> ```ts\n> const answer = 42\n> ```']
+  ])('uses the custom SyntaxHighlighter without importing @streamdown/code for %s', async (_label, text) => {
+    render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    await vi.dynamicImportSettled()
+
+    expect(codeModuleFactory).not.toHaveBeenCalled()
+    expect(streamdownRenders).toHaveBeenCalledOnce()
+    expect(streamdownRenders).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        components: expect.objectContaining({ SyntaxHighlighter: expect.any(Function) }),
+        plugins: expect.not.objectContaining({ code: expect.anything() })
+      })
+    )
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -7,7 +7,6 @@ import {
   type SyntaxHighlighterProps,
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
-import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
@@ -56,41 +55,10 @@ import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } fr
 // `singleDollarTextMath: true` enables `$x^2$` for inline math (de-facto
 // LLM convention). The default false-setting only accepts `$$...$$`.
 const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
-
-// `@streamdown/code` statically imports ALL of shiki (every grammar + theme —
-// the single largest chunk in the renderer), so it must never sit on the
-// entry graph. Load it on first markdown mount and swap it into the plugin
-// table when it lands; until then fenced code renders through the
-// `SyntaxHighlighter` override's plain path (same output Shiki's own
-// `delay` fallback shows), so nothing flashes or reflows unexpectedly.
-type CodePlugin = typeof streamdownCode
-let codePluginCache: CodePlugin | null = null
-
-function useCodePlugin(): CodePlugin | null {
-  const [plugin, setPlugin] = useState(codePluginCache)
-
-  useEffect(() => {
-    if (plugin) {
-      return
-    }
-
-    let cancelled = false
-
-    void import('@streamdown/code').then(({ code }) => {
-      codePluginCache = code
-
-      if (!cancelled) {
-        setPlugin(code)
-      }
-    })
-
-    return () => {
-      cancelled = true
-    }
-  }, [plugin])
-
-  return plugin
-}
+// This surface always installs its own SyntaxHighlighter adapter below, which
+// bypasses Streamdown's code plugin. Passing @streamdown/code would therefore
+// download every Shiki grammar/theme without using its highlighter.
+const MARKDOWN_PLUGINS = { math: mathPlugin }
 
 // Replaces Streamdown's `parseIncompleteMarkdown` (full-text remend per
 // flush) with a tail-bounded repair. Must stay module-scope so the prop
@@ -542,13 +510,6 @@ function MarkdownTextSurface({
   const { status, text } = useMessagePartText()
   const isStreaming = status.type === 'running'
 
-  // Keep code parsing enabled while streaming so incomplete fenced blocks still
-  // render as code cards. The expensive Shiki pass is deferred by
-  // `SyntaxHighlighter` below when `isStreaming` is true, and the code plugin
-  // itself arrives async (useCodePlugin) so shiki never blocks cold start.
-  const code = useCodePlugin()
-  const plugins = useMemo(() => (code ? { math: mathPlugin, code } : { math: mathPlugin }), [code])
-
   const components = useMemo(
     () =>
       ({
@@ -690,7 +651,7 @@ function MarkdownTextSurface({
         // remend pass.
         parseIncompleteMarkdown={false}
         parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
-        plugins={plugins}
+        plugins={MARKDOWN_PLUGINS}
         preprocess={preprocessWithTailRepair}
       />
     </ErrorBoundary>

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -530,8 +530,8 @@ function MarkdownTextSurface({
         // Inline code must not vote when an ancestor resolves `dir="auto"`
         // (HTML's algorithm skips descendants that carry their own dir),
         // mirroring the CSS isolate that already keeps it out of the
-        // plaintext scan. Fenced code never reaches this override; it goes
-        // through the code plugin's CodeCard path.
+        // plaintext scan. Fenced code reaches the SyntaxHighlighter override
+        // below instead.
         inlineCode: ({ className, ...props }: ComponentProps<'code'>) => (
           <code className={className} dir="ltr" {...props} />
         ),

--- a/apps/desktop/src/lib/markdown-preprocess.container.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.container.test.ts
@@ -14,4 +14,24 @@ describe('preprocessMarkdown container fences', () => {
     expect(output).toContain('const value = 1;')
     expect(output).toContain('```')
   })
+
+  it.each([
+    [
+      'list then blockquote',
+      ['- > ```ts', '  > const value = 1;', '  > ```'].join('\n'),
+      ['- > ```ts', '  > const value = 1;', '- > ```'].join('\n')
+    ],
+    [
+      'blockquote then list',
+      ['> - ```ts', '>   const value = 1;', '>   ```'].join('\n'),
+      ['> - ```ts', '>   const value = 1;', '> - ```'].join('\n')
+    ],
+    [
+      'deeply nested containers',
+      ['> - > 1. ```ts', '>   >   1. const value = 1;', '>   >   1. ```'].join('\n'),
+      ['> - > 1. ```ts', '>   >   1. const value = 1;', '> - > 1. ```'].join('\n')
+    ]
+  ])('preserves %s fence marker and language', (_label, input, expected) => {
+    expect(preprocessMarkdown(input)).toBe(expected)
+  })
 })

--- a/apps/desktop/src/lib/markdown-preprocess.container.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.container.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from './markdown-preprocess'
+
+describe('preprocessMarkdown container fences', () => {
+  it.each([
+    ['blockquote', ['> ```ts', '> const value = 1;', '> ```'].join('\n')],
+    ['unordered list', ['- ```ts', '  const value = 1;', '  ```'].join('\n')],
+    ['ordered list', ['1. ```ts', '   const value = 1;', '   ```'].join('\n')]
+  ])('keeps valid %s container fences intact', (_label, input) => {
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('```ts')
+    expect(output).toContain('const value = 1;')
+    expect(output).toContain('```')
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -10,7 +10,7 @@ import { linkifySessionRefs } from '@/lib/session-refs'
 const REASONING_BLOCK_RE = /<(think|thinking|reasoning|scratchpad|analysis)>[\s\S]*?<\/\1>\s*/gi
 const PREVIEW_MARKER_RE = /\[Preview:[^\]]+\]\(#preview[:/][^)]+\)/gi
 
-const FENCE_LINE_RE = /^([ \t]*)(`{3,}|~{3,})([^\n]*)$/
+const FENCE_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)(`{3,}|~{3,})([^\n]*)$/
 const EMPTY_FENCE_BLOCK_RE = /(^|\n)[ \t]*(?:`{3,}|~{3,})[^\n]*\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\n|$)/g
 const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~))/g
 const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
@@ -75,20 +75,14 @@ function hasCloseFenceLine(body: string, marker: string): boolean {
   // first line of `body` (which has no preceding newline within `body`)
   // cannot itself be the close fence.
   for (let i = 1; i < lines.length; i += 1) {
-    const line = lines[i]
-    let lo = 0
-    let hi = line.length
+    const closeMatch = lines[i]?.match(FENCE_LINE_RE)
 
-    while (lo < hi && (line[lo] === ' ' || line[lo] === '\t')) {
-      lo += 1
-    }
+    if (closeMatch && !closeMatch[3]?.trim()) {
+      const closeMarker = closeMatch[2] || ''
 
-    while (hi > lo && (line[hi - 1] === ' ' || line[hi - 1] === '\t')) {
-      hi -= 1
-    }
-
-    if (line.slice(lo, hi) === marker) {
-      return true
+      if (closeMarker[0] === marker[0] && closeMarker.length >= marker.length) {
+        return true
+      }
     }
   }
 
@@ -96,7 +90,9 @@ function hasCloseFenceLine(body: string, marker: string): boolean {
 }
 
 function scrubBacktickNoise(text: string): string {
-  const balancedFenceRe = /(^|\n)([ \t]*)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n[ \t]*\3[ \t]*(?=\n|$)/g
+  const balancedFenceRe =
+    /(^|\n)([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n[ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*\3[ \t]*(?=\n|$)/g
+
   const protectedRanges: { end: number; start: number }[] = []
   let match: RegExpExecArray | null
 
@@ -106,7 +102,8 @@ function scrubBacktickNoise(text: string): string {
     protectedRanges.push({ end: balancedFenceRe.lastIndex, start })
   }
 
-  const danglingCodeFenceRe = /(^|\n)[ \t]*(`{3,}|~{3,})([a-z0-9][a-z0-9+#-]{0,15})[ \t]*\n([\s\S]*)$/gi
+  const danglingCodeFenceRe =
+    /(^|\n)[ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*(`{3,}|~{3,})([a-z0-9][a-z0-9+#-]{0,15})[ \t]*\n([\s\S]*)$/gi
 
   while ((match = danglingCodeFenceRe.exec(text)) !== null) {
     const start = match.index + match[1].length

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -10,7 +10,7 @@ import { linkifySessionRefs } from '@/lib/session-refs'
 const REASONING_BLOCK_RE = /<(think|thinking|reasoning|scratchpad|analysis)>[\s\S]*?<\/\1>\s*/gi
 const PREVIEW_MARKER_RE = /\[Preview:[^\]]+\]\(#preview[:/][^)]+\)/gi
 
-const FENCE_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)(`{3,}|~{3,})([^\n]*)$/
+const FENCE_LINE_RE = /^([ \t]*(?:(?:>[ \t]*)|(?:(?:[-+*]|\d+[.)])[ \t]+))*)(`{3,}|~{3,})([^\n]*)$/
 const EMPTY_FENCE_BLOCK_RE = /(^|\n)[ \t]*(?:`{3,}|~{3,})[^\n]*\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\n|$)/g
 const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~))/g
 const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
@@ -91,7 +91,7 @@ function hasCloseFenceLine(body: string, marker: string): boolean {
 
 function scrubBacktickNoise(text: string): string {
   const balancedFenceRe =
-    /(^|\n)([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n[ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*\3[ \t]*(?=\n|$)/g
+    /(^|\n)([ \t]*(?:(?:>[ \t]*)|(?:(?:[-+*]|\d+[.)])[ \t]+))*)(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)\n[ \t]*(?:(?:>[ \t]*)|(?:(?:[-+*]|\d+[.)])[ \t]+))*\3[ \t]*(?=\n|$)/g
 
   const protectedRanges: { end: number; start: number }[] = []
   let match: RegExpExecArray | null
@@ -103,7 +103,7 @@ function scrubBacktickNoise(text: string): string {
   }
 
   const danglingCodeFenceRe =
-    /(^|\n)[ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*(`{3,}|~{3,})([a-z0-9][a-z0-9+#-]{0,15})[ \t]*\n([\s\S]*)$/gi
+    /(^|\n)[ \t]*(?:(?:>[ \t]*)|(?:(?:[-+*]|\d+[.)])[ \t]+))*(`{3,}|~{3,})([a-z0-9][a-z0-9+#-]{0,15})[ \t]*\n([\s\S]*)$/gi
 
   while ((match = danglingCodeFenceRe.exec(text)) !== null) {
     const start = match.index + match[1].length


### PR DESCRIPTION
## Summary
- stop loading `@streamdown/code` on every markdown surface
- keep the existing custom SyntaxHighlighter as the sole code renderer
- add coverage proving prose and fenced code never import the unused plugin

## Verification
- focused markdown tests
- desktop typecheck and ESLint
- production build; Shiki remains off the preload path