### PR TITLE
perf(desktop): window diff syntax highlighting

### DIFF
--- a/apps/desktop/src/components/chat/diff-highlight-cache.test.ts
+++ b/apps/desktop/src/components/chat/diff-highlight-cache.test.ts
@@ -1,0 +1,200 @@
+import type { GrammarState, ThemedToken } from 'shiki'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DiffHighlightCache } from './diff-highlight-cache'
+
+const TOKENS: ThemedToken[][] = [[{ content: 'const', offset: 0 }]]
+const RESULT = { tokens: TOKENS }
+const INPUT = { code: 'const answer = 42', language: 'typescript', theme: 'github-light-default' }
+
+describe('DiffHighlightCache', () => {
+  it('yields before starting highlight work', async () => {
+    const highlight = vi.fn(async () => RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const pending = cache.request(INPUT)
+
+    expect(highlight).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(1)
+
+    scheduled.shift()?.()
+    await expect(pending.promise).resolves.toBe(RESULT)
+    expect(highlight).toHaveBeenCalledOnce()
+  })
+
+  it('gives each distinct expensive job its own yield point', async () => {
+    const highlight = vi.fn(async () => RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const alpha = cache.request({ ...INPUT, code: 'alpha' })
+    const beta = cache.request({ ...INPUT, code: 'beta' })
+
+    expect(scheduled).toHaveLength(2)
+    expect(highlight).not.toHaveBeenCalled()
+
+    scheduled.shift()?.()
+    await alpha.promise
+    expect(highlight).toHaveBeenCalledTimes(1)
+    expect(scheduled).toHaveLength(1)
+
+    scheduled.shift()?.()
+    await beta.promise
+    expect(highlight).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates in-flight work and reuses its completed result', async () => {
+    let finish!: (result: typeof RESULT) => void
+    const highlight = vi.fn(() => new Promise<typeof RESULT>(resolve => (finish = resolve)))
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const first = cache.request(INPUT)
+    const duplicate = cache.request(INPUT)
+
+    expect(scheduled).toHaveLength(1)
+    scheduled.shift()?.()
+    expect(highlight).toHaveBeenCalledOnce()
+
+    finish(RESULT)
+    await expect(first.promise).resolves.toBe(RESULT)
+    await expect(duplicate.promise).resolves.toBe(RESULT)
+
+    const completed = cache.request(INPUT)
+    await expect(completed.promise).resolves.toBe(RESULT)
+    expect(highlight).toHaveBeenCalledOnce()
+  })
+
+  it('bounds completed entries and evicts the least-recently-used result', async () => {
+    const highlight = vi.fn(async ({ code }: { code: string }) => ({ tokens: [[{ content: code, offset: 0 }]] }))
+    const scheduled: Array<() => void> = []
+
+    const cache = new DiffHighlightCache({
+      highlight,
+      maxCompleted: 2,
+      schedule: task => scheduled.push(task)
+    })
+
+    const request = async (code: string) => {
+      const pending = cache.request({ ...INPUT, code })
+      scheduled.shift()?.()
+
+      return pending.promise
+    }
+
+    await request('alpha')
+    await request('beta')
+    await request('alpha') // refresh alpha's LRU position
+    await request('gamma')
+    await request('beta')
+
+    expect(highlight.mock.calls.map(([input]) => input.code)).toEqual(['alpha', 'beta', 'gamma', 'beta'])
+  })
+
+  it('keys completed work by language and theme as well as code', async () => {
+    const highlight = vi.fn(async () => RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const request = async (language: string, theme: string) => {
+      const pending = cache.request({ ...INPUT, language, theme })
+
+      scheduled.shift()?.()
+      await pending.promise
+    }
+
+    await request('typescript', 'github-light-default')
+    await request('typescript', 'github-dark-dimmed')
+    await request('javascript', 'github-light-default')
+    await request('typescript', 'github-light-default')
+
+    expect(highlight).toHaveBeenCalledTimes(3)
+  })
+
+  it('deduplicates the same grammar continuation without mixing distinct continuation states', async () => {
+    const firstState = ({ id: 'first' } as unknown) as GrammarState
+    const secondState = ({ id: 'second' } as unknown) as GrammarState
+    const highlight = vi.fn(async (_input: typeof INPUT & { grammarState?: GrammarState }) => RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const first = cache.request({ ...INPUT, grammarState: firstState })
+    const duplicate = cache.request({ ...INPUT, grammarState: firstState })
+    const distinct = cache.request({ ...INPUT, grammarState: secondState })
+
+    expect(scheduled).toHaveLength(2)
+    scheduled.splice(0).forEach(run => run())
+    await Promise.all([first.promise, duplicate.promise, distinct.promise])
+
+    expect(highlight).toHaveBeenCalledTimes(2)
+    expect(highlight.mock.calls.map(([input]) => input.grammarState)).toEqual([firstState, secondState])
+  })
+
+  it('does not cache failures so a later request retries', async () => {
+    const failure = new Error('grammar failed to load')
+    const highlight = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce(RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const failed = cache.request(INPUT)
+
+    scheduled.shift()?.()
+    await expect(failed.promise).rejects.toBe(failure)
+
+    const retry = cache.request(INPUT)
+
+    scheduled.shift()?.()
+    await expect(retry.promise).resolves.toBe(RESULT)
+    expect(highlight).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips scheduled work that no longer has an observer', async () => {
+    const highlight = vi.fn(async () => RESULT)
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+
+    const stale = cache.request(INPUT)
+
+    stale.release()
+    scheduled.shift()?.()
+
+    await expect(stale.promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(highlight).not.toHaveBeenCalled()
+  })
+
+  it('aborts released work after scheduling while an async import is pending', async () => {
+    let finishImport!: () => void
+    const importGate = new Promise<void>(resolve => (finishImport = resolve))
+
+    const highlight = vi.fn(async (_input: typeof INPUT, signal: AbortSignal) => {
+      await importGate
+
+      if (signal.aborted) {
+        const error = new Error('highlight aborted')
+
+        error.name = 'AbortError'
+        throw error
+      }
+
+      return RESULT
+    })
+
+    const scheduled: Array<() => void> = []
+    const cache = new DiffHighlightCache({ highlight, schedule: task => scheduled.push(task) })
+    const stale = cache.request(INPUT)
+
+    scheduled.shift()?.()
+    expect(highlight).toHaveBeenCalledOnce()
+    stale.release()
+    finishImport()
+
+    await expect(stale.promise).rejects.toMatchObject({ name: 'AbortError' })
+
+    const retry = cache.request(INPUT)
+
+    scheduled.shift()?.()
+    await expect(retry.promise).resolves.toBe(RESULT)
+    expect(highlight).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/components/chat/diff-highlight-cache.ts
+++ b/apps/desktop/src/components/chat/diff-highlight-cache.ts
@@ -1,0 +1,208 @@
+import type { GrammarState, ThemedToken } from 'shiki'
+
+export interface DiffHighlightInput {
+  code: string
+  grammarState?: GrammarState
+  language: string
+  theme: string
+}
+
+export interface DiffHighlightResult {
+  grammarState?: GrammarState
+  tokens: ThemedToken[][]
+}
+
+export interface DiffHighlightRequest {
+  promise: Promise<DiffHighlightResult>
+  release: () => void
+}
+
+type Highlight = (input: DiffHighlightInput, signal: AbortSignal) => Promise<DiffHighlightResult>
+type Schedule = (task: () => void) => void
+
+interface DiffHighlightCacheOptions {
+  highlight: Highlight
+  maxCompleted?: number
+  schedule?: Schedule
+}
+
+interface InFlightHighlight {
+  controller: AbortController
+  key: string
+  observers: number
+  promise: Promise<DiffHighlightResult>
+  reject: (reason?: unknown) => void
+}
+
+function abortError(): Error {
+  const error = new Error('Highlight request no longer has an observer')
+
+  error.name = 'AbortError'
+
+  return error
+}
+
+export class DiffHighlightCache {
+  private readonly completed = new Map<string, DiffHighlightResult>()
+  private readonly grammarStateIds = new WeakMap<GrammarState, number>()
+  private readonly highlight: Highlight
+  private readonly inFlight = new Map<string, InFlightHighlight>()
+  private readonly maxCompleted: number
+  private nextGrammarStateId = 1
+  private readonly schedule: Schedule
+
+  constructor({
+    highlight,
+    maxCompleted = 64,
+    schedule = task => void setTimeout(task, 0)
+  }: DiffHighlightCacheOptions) {
+    this.highlight = highlight
+    this.maxCompleted = Math.max(0, maxCompleted)
+    this.schedule = schedule
+  }
+
+  request(input: DiffHighlightInput): DiffHighlightRequest {
+    const key = this.cacheKey(input)
+    const completed = this.completed.get(key)
+
+    if (completed) {
+      // Map insertion order gives us a compact LRU: move cache hits to the end.
+      this.completed.delete(key)
+      this.completed.set(key, completed)
+
+      return { promise: Promise.resolve(completed), release: () => undefined }
+    }
+
+    const current = this.inFlight.get(key)
+
+    if (current) {
+      current.observers += 1
+
+      return this.handle(current)
+    }
+
+    let resolve!: (result: DiffHighlightResult) => void
+    let reject!: (reason?: unknown) => void
+
+    const promise = new Promise<DiffHighlightResult>((onResolve, onReject) => {
+      resolve = onResolve
+      reject = onReject
+    })
+
+    const entry: InFlightHighlight = {
+      controller: new AbortController(),
+      key,
+      observers: 1,
+      promise,
+      reject
+    }
+
+    this.inFlight.set(key, entry)
+    this.schedule(() => {
+      // A window can move again before this yielded task gets CPU time. Do not
+      // tokenize a chunk that every observer has already released.
+      if (entry.controller.signal.aborted) {
+        if (this.inFlight.get(key) === entry) {
+          this.inFlight.delete(key)
+        }
+
+        return
+      }
+
+      let work: Promise<DiffHighlightResult>
+
+      try {
+        work = this.highlight(input, entry.controller.signal)
+      } catch (error) {
+        if (this.inFlight.get(key) === entry) {
+          this.inFlight.delete(key)
+        }
+
+        reject(error)
+
+        return
+      }
+
+      void work.then(
+        result => {
+          if (this.inFlight.get(key) === entry) {
+            this.inFlight.delete(key)
+          }
+
+          if (entry.controller.signal.aborted) {
+            reject(abortError())
+
+            return
+          }
+
+          if (this.maxCompleted > 0) {
+            this.completed.set(key, result)
+
+            while (this.completed.size > this.maxCompleted) {
+              const oldest = this.completed.keys().next().value
+
+              if (oldest === undefined) {
+                break
+              }
+
+              this.completed.delete(oldest)
+            }
+          }
+
+          resolve(result)
+        },
+        error => {
+          if (this.inFlight.get(key) === entry) {
+            this.inFlight.delete(key)
+          }
+
+          reject(error)
+        }
+      )
+    })
+
+    return this.handle(entry)
+  }
+
+  private cacheKey({ code, grammarState, language, theme }: DiffHighlightInput): string {
+    let grammarStateId = 0
+
+    if (grammarState) {
+      const known = this.grammarStateIds.get(grammarState)
+
+      if (known) {
+        grammarStateId = known
+      } else {
+        grammarStateId = this.nextGrammarStateId
+        this.nextGrammarStateId += 1
+        this.grammarStateIds.set(grammarState, grammarStateId)
+      }
+    }
+
+    return `${language}\u0000${theme}\u0000${grammarStateId}\u0000${code}`
+  }
+
+  private handle(entry: InFlightHighlight): DiffHighlightRequest {
+    let released = false
+
+    return {
+      promise: entry.promise,
+      release: () => {
+        if (!released) {
+          released = true
+          entry.observers -= 1
+
+          if (entry.observers === 0) {
+            entry.controller.abort()
+
+            if (this.inFlight.get(entry.key) === entry) {
+              this.inFlight.delete(entry.key)
+            }
+
+            entry.reject(abortError())
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/src/components/chat/diff-lines.highlighting.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.highlighting.test.tsx
@@ -1,0 +1,191 @@
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import type * as Shiki from 'shiki'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const grammarStates = new Map<string, Shiki.GrammarState>()
+
+const highlightNormally = async (
+  code: string,
+  _options?: { grammarState?: Shiki.GrammarState }
+): Promise<{
+  grammarState?: Shiki.GrammarState
+  tokens: Array<Array<{ content: string; offset: number }>>
+}> => {
+  const grammarState = ({ code } as unknown) as Shiki.GrammarState
+
+  grammarStates.set(code, grammarState)
+
+  return {
+    grammarState,
+    tokens: code.split('\n').map(line => [{ content: line, offset: 0 }])
+  }
+}
+
+const codeToTokens = vi.fn(highlightNormally)
+
+vi.mock('shiki', async importOriginal => {
+  const actual = await importOriginal<typeof Shiki>()
+
+  return { ...actual, codeToTokens }
+})
+
+import { FileDiffPanel } from './diff-lines'
+
+afterEach(() => {
+  cleanup()
+  codeToTokens.mockReset()
+  codeToTokens.mockImplementation(highlightNormally)
+  grammarStates.clear()
+})
+
+describe('FileDiffPanel windowed syntax highlighting', () => {
+  it('tokenizes only the visible and overscan chunks, not the whole permitted diff', async () => {
+    const diff = Array.from({ length: 1_000 }, (_, index) => `+const line${index} = ${index}`).join('\n')
+
+    render(<FileDiffPanel diff={diff} path="file.ts" virtualized />)
+
+    await waitFor(() => expect(codeToTokens).toHaveBeenCalledTimes(3))
+
+    const highlightedChunks = codeToTokens.mock.calls.map(([code]) => code)
+    const highlighted = highlightedChunks.join('\n')
+
+    expect(highlightedChunks).toHaveLength(3)
+    expect(highlightedChunks.every(code => code.split('\n').length <= 200)).toBe(true)
+    expect(highlighted).toContain('const line0 = 0')
+    expect(highlighted).toContain('const line599 = 599')
+    expect(highlighted).not.toContain('const line600 = 600')
+    expect(highlighted).not.toContain('const line999 = 999')
+  })
+
+  it('continues tokenizer grammar state across visible chunk boundaries', async () => {
+    const diff = Array.from({ length: 600 }, (_, index) => `+const continuity${index} = ${index}`).join('\n')
+
+    render(<FileDiffPanel diff={diff} path="continuity.ts" virtualized />)
+
+    await waitFor(() => expect(codeToTokens).toHaveBeenCalledTimes(3))
+
+    const [first, second, third] = codeToTokens.mock.calls
+
+    expect(second?.[1]).toMatchObject({ grammarState: grammarStates.get(first?.[0] ?? '') })
+    expect(third?.[1]).toMatchObject({ grammarState: grammarStates.get(second?.[0] ?? '') })
+  })
+
+  it('continues from the preceding cached boundary when the visible window moves', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+    try {
+      const diff = [
+        '@@ -0,0 +1,1600 @@',
+        ...Array.from({ length: 1_600 }, (_, index) => `+const scrolled${index} = ${index}`)
+      ].join('\n')
+
+      const { container } = render(<FileDiffPanel diff={diff} path="scrolled.ts" showLineNumbers />)
+
+      await waitFor(() => expect(codeToTokens).toHaveBeenCalledTimes(3))
+
+      const initialThirdCode = codeToTokens.mock.calls[2]?.[0] ?? ''
+      const initialThirdState = grammarStates.get(initialThirdCode)
+      const scroller = container.querySelector('[data-slot="file-diff-panel"] > div')
+
+      expect(scroller).toBeInstanceOf(HTMLElement)
+      Object.defineProperties(scroller, {
+        clientHeight: { configurable: true, value: 800 },
+        scrollTop: { configurable: true, value: 16_000, writable: true }
+      })
+      fireEvent.scroll(scroller as HTMLElement)
+
+      await waitFor(() => expect(codeToTokens.mock.calls.length).toBeGreaterThan(3))
+
+      const firstNewCall = codeToTokens.mock.calls[3]
+
+      expect(firstNewCall?.[0]).toContain('const scrolled600 = 600')
+      expect(firstNewCall?.[1]).toMatchObject({ grammarState: initialThirdState })
+      expect(container.querySelector('[data-glass-opaque]')?.textContent).toMatch(/^401402/)
+
+      await waitFor(() => {
+        const row = [...container.querySelectorAll('span.block')].find(
+          candidate => candidate.textContent === 'const scrolled600 = 600'
+        )
+
+        expect(row?.querySelector('span')).not.toBeNull()
+      })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('leaves a hard-jumped window plain when no preceding grammar boundary is cached', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+    try {
+      const diff = [
+        '@@ -0,0 +1,2400 @@',
+        ...Array.from({ length: 2_400 }, (_, index) => `+const jumped${index} = ${index}`)
+      ].join('\n')
+
+      const { container } = render(<FileDiffPanel diff={diff} path="jumped.ts" showLineNumbers />)
+
+      await waitFor(() => expect(codeToTokens).toHaveBeenCalledTimes(3))
+      const scroller = container.querySelector('[data-slot="file-diff-panel"] > div')
+
+      expect(scroller).toBeInstanceOf(HTMLElement)
+      Object.defineProperties(scroller, {
+        clientHeight: { configurable: true, value: 800 },
+        scrollTop: { configurable: true, value: 40_000, writable: true }
+      })
+      fireEvent.scroll(scroller as HTMLElement)
+
+      await waitFor(() => expect(container.querySelector('[data-glass-opaque]')?.textContent).toMatch(/^16011602/))
+      expect(codeToTokens).toHaveBeenCalledTimes(3)
+
+      const visibleRow = [...container.querySelectorAll('span.block')].find(
+        candidate => candidate.textContent === 'const jumped1600 = 1600'
+      )
+
+      expect(visibleRow?.querySelector('span')).toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('does not let a stale highlight overwrite a newer diff', async () => {
+    let resolveOld!: (result: Awaited<ReturnType<typeof highlightNormally>>) => void
+    let resolveNew!: (result: Awaited<ReturnType<typeof highlightNormally>>) => void
+    const oldDiff = Array.from({ length: 100 }, (_, index) => `+const old${index} = ${index}`).join('\n')
+    const newDiff = Array.from({ length: 100 }, (_, index) => `+const new${index} = ${index}`).join('\n')
+
+    codeToTokens.mockImplementation(
+      code =>
+        new Promise(resolve => {
+          if (code.includes('old0')) {
+            resolveOld = resolve
+          } else {
+            resolveNew = resolve
+          }
+        })
+    )
+
+    const { container, rerender } = render(<FileDiffPanel diff={oldDiff} path="stale.ts" virtualized />)
+
+    await waitFor(() => expect(resolveOld).toBeTypeOf('function'))
+    rerender(<FileDiffPanel diff={newDiff} path="stale.ts" virtualized />)
+    await waitFor(() => expect(resolveNew).toBeTypeOf('function'))
+
+    resolveNew({ tokens: [[{ content: 'new highlight won', offset: 0 }]] })
+    await waitFor(() => expect(container.textContent).toContain('new highlight won'))
+
+    await act(async () => {
+      resolveOld({ tokens: [[{ content: 'stale highlight won', offset: 0 }]] })
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('new highlight won')
+    expect(container.textContent).not.toContain('stale highlight won')
+  })
+})

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import * as React from 'react'
-import type { BundledLanguage, ShikiTransformer, ThemedToken } from 'shiki'
+import type { BundledLanguage, GrammarState, ShikiTransformer, ThemedToken } from 'shiki'
 
+import { DiffHighlightCache } from '@/components/chat/diff-highlight-cache'
 import { chunkLines, type LineChunk, useFixedRowWindow } from '@/components/chat/fixed-row-window'
 import { exceedsHighlightBudget, SHIKI_THEME } from '@/components/chat/shiki-highlighter'
 import { ErrorBoundary } from '@/components/error-boundary'
@@ -56,6 +57,42 @@ const PREVIEW_DIFF_LINE_BASE = 'block h-5 min-w-max whitespace-pre px-2.5 leadin
 const PREVIEW_CHUNK_LINES = 200
 const PREVIEW_LINE_PX = 20
 const PREVIEW_OVERSCAN_LINES = 400
+
+function importShiki() {
+  return import('shiki')
+}
+
+let shikiModulePromise: null | ReturnType<typeof importShiki> = null
+
+async function loadShiki() {
+  shikiModulePromise ??= importShiki()
+
+  return shikiModulePromise
+}
+
+function throwIfHighlightAborted(signal: AbortSignal) {
+  if (signal.aborted) {
+    const error = new Error('Highlight request no longer has an observer')
+
+    error.name = 'AbortError'
+    throw error
+  }
+}
+
+const diffHighlightCache = new DiffHighlightCache({
+  highlight: async ({ code, grammarState, language, theme }, signal) => {
+    // Keep Shiki's multi-MB runtime out of the cold-start bundle. Cache work is
+    // scheduled, so even the first import yields to the browser before starting.
+    const { codeToTokens } = await loadShiki()
+
+    throwIfHighlightAborted(signal)
+
+    const result = await codeToTokens(code, { grammarState, lang: language as BundledLanguage, theme })
+
+    return result
+  },
+  maxCompleted: 64
+})
 
 // Bleed out of the tool-card body's `p-1.5` so tints/borders run flush to the
 // card edges (rounded corners clip via the card's overflow); compact height
@@ -325,12 +362,12 @@ function PreviewDiffRows({
   afterLines = 0,
   beforeLines = 0,
   chunks,
-  tokens
+  tokensByChunk
 }: {
   afterLines?: number
   beforeLines?: number
   chunks: Array<LineChunk<DiffLine>>
-  tokens?: ThemedToken[][] | null
+  tokensByChunk?: ReadonlyMap<number, ThemedToken[][]>
 }) {
   return (
     <>
@@ -339,7 +376,7 @@ function PreviewDiffRows({
         <div className="block" key={chunk.start}>
           {chunk.lines.map((line, offset) => {
             const index = chunk.start + offset
-            const rowTokens = tokens?.[index] ?? []
+            const rowTokens = tokensByChunk?.get(chunk.start)?.[offset] ?? []
 
             return (
               <span className={cn(PREVIEW_DIFF_LINE_BASE, DIFF_KIND_TINT[line.kind])} key={`${index}-${line.text}`}>
@@ -360,6 +397,21 @@ function PreviewDiffRows({
   )
 }
 
+interface TokenizedChunksState {
+  chunks: Array<LineChunk<DiffLine>> | null
+  language: string | null
+  theme: string | null
+  tokens: ReadonlyMap<number, ThemedToken[][]>
+}
+
+function newGrammarBoundaryMap(
+  _language: string,
+  _lines: DiffLine[],
+  _theme: string
+): Map<number, GrammarState | undefined> {
+  return new Map([[0, undefined]])
+}
+
 function TokenizedDiffBody({
   afterLines,
   beforeLines,
@@ -375,45 +427,114 @@ function TokenizedDiffBody({
   language: string
   lines: DiffLine[]
 }) {
-  const code = React.useMemo(() => lines.map(line => line.text).join('\n'), [lines])
+  const highlightedChunks = React.useMemo<Array<LineChunk<DiffLine>>>(
+    () => (chunked ? (chunks ?? chunkLines(lines, PREVIEW_CHUNK_LINES)) : [{ lines, start: 0 }]),
+    [chunked, chunks, lines]
+  )
+
   const theme = useThemeName()
-  const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null)
+
+  // The map is mutable continuation state. Replacing the source, language, or
+  // theme resets it; moving the visible window does not, so cached boundaries
+  // can seed the next overscan window.
+  const grammarBoundaries = React.useMemo(
+    () => newGrammarBoundaryMap(language, lines, theme),
+    [language, lines, theme]
+  )
+
+  const generationRef = React.useRef(0)
+
+  const [highlighted, setHighlighted] = React.useState<TokenizedChunksState>(() => ({
+    chunks: null,
+    language: null,
+    theme: null,
+    tokens: new Map()
+  }))
+
+  // Effects run after paint. Refuse tokens from the previous render even in
+  // that pre-effect gap, before its cleanup can invalidate the old generation.
+  const tokensByChunk =
+    highlighted.chunks === highlightedChunks && highlighted.language === language && highlighted.theme === theme
+      ? highlighted.tokens
+      : undefined
 
   React.useEffect(() => {
-    let cancelled = false
+    const generation = generationRef.current + 1
+    const activeRequests = new Set<ReturnType<typeof diffHighlightCache.request>>()
 
-    setTokens(null)
-    // Dynamic import so the multi-MB shiki chunk stays off the cold-start
-    // path — this effect only runs once a highlightable diff is on screen.
-    void import('shiki')
-      .then(({ codeToTokens }) => codeToTokens(code, { lang: language as BundledLanguage, theme }))
-      .then(result => {
-        if (!cancelled) {
-          setTokens(result.tokens)
+    generationRef.current = generation
+    setHighlighted({ chunks: highlightedChunks, language, theme, tokens: new Map() })
+
+    const highlightChunks = async () => {
+      const firstChunkStart = highlightedChunks[0]?.start ?? 0
+
+      // Starting Shiki with an unknown continuation can mis-color multiline
+      // strings/comments. A hard jump therefore stays plain until a prior
+      // overscan window has established this exact grammar boundary.
+      if (firstChunkStart > 0 && !grammarBoundaries.has(firstChunkStart)) {
+        return
+      }
+
+      let grammarState = grammarBoundaries.get(firstChunkStart)
+
+      for (const chunk of highlightedChunks) {
+        if (generationRef.current !== generation) {
+          return
         }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setTokens([])
+
+        const request = diffHighlightCache.request({
+          code: chunk.lines.map(line => line.text).join('\n'),
+          grammarState,
+          language,
+          theme
+        })
+
+        activeRequests.add(request)
+
+        try {
+          const result = await request.promise
+
+          if (generationRef.current !== generation) {
+            return
+          }
+
+          grammarState = result.grammarState
+          grammarBoundaries.set(chunk.start + chunk.lines.length, grammarState)
+
+          setHighlighted(current => {
+            if (current.chunks !== highlightedChunks || current.language !== language || current.theme !== theme) {
+              return current
+            }
+
+            const next = new Map(current.tokens)
+
+            next.set(chunk.start, result.tokens)
+
+            return { ...current, tokens: next }
+          })
+        } catch {
+          // A failed grammar/import stays plain. The result cache retains no
+          // failure; Chromium itself may retain a failed module URL.
+          return
+        } finally {
+          activeRequests.delete(request)
+          request.release()
         }
-      })
+      }
+    }
+
+    void highlightChunks()
 
     return () => {
-      cancelled = true
-    }
-  }, [code, language, theme])
+      if (generationRef.current === generation) {
+        generationRef.current += 1
+      }
 
-  if (!tokens) {
-    return chunked ? (
-      <PreviewDiffRows
-        afterLines={afterLines}
-        beforeLines={beforeLines}
-        chunks={chunks ?? chunkLines(lines, PREVIEW_CHUNK_LINES)}
-      />
-    ) : (
-      <DiffBody lines={lines} />
-    )
-  }
+      for (const request of activeRequests) {
+        request.release()
+      }
+    }
+  }, [grammarBoundaries, highlightedChunks, language, theme])
 
   if (chunked) {
     return (
@@ -421,9 +542,15 @@ function TokenizedDiffBody({
         afterLines={afterLines}
         beforeLines={beforeLines}
         chunks={chunks ?? chunkLines(lines, PREVIEW_CHUNK_LINES)}
-        tokens={tokens}
+        tokensByChunk={tokensByChunk}
       />
     )
+  }
+
+  const tokens = tokensByChunk?.get(0)
+
+  if (!tokens) {
+    return <DiffBody lines={lines} />
   }
 
   return (
@@ -602,7 +729,10 @@ export function FileDiffPanel({
     totalRows: lines.length
   })
 
-  const visibleLineChunks = lineChunks.slice(startChunk, endChunk + 1)
+  const visibleLineChunks = React.useMemo(
+    () => lineChunks.slice(startChunk, endChunk + 1),
+    [endChunk, lineChunks, startChunk]
+  )
 
   const language = shikiLanguageForFilename(path)
   const canHighlight = Boolean(language) && !exceedsHighlightBudget(fullText ?? diff)


### PR DESCRIPTION
## Summary
- tokenize only visible/overscan diff chunks
- deduplicate, pace, cancel, and bound completed Shiki results
- preserve grammar continuation where known and leave hard jumps plain rather than mis-coloring

## Verification
- 14 focused cache/window/continuation/cancellation tests
- desktop typecheck and ESLint