### PR TITLE
perf(desktop): defer transcript image resolution

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -8,6 +8,7 @@ import { useLocation } from 'react-router'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { sessionShouldHaveTranscript } from '@/app/session/hooks/use-session-actions/utils'
+import { TranscriptMediaOwnerProvider } from '@/components/assistant-ui/markdown-text'
 import { Thread } from '@/components/assistant-ui/thread'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
@@ -48,7 +49,7 @@ import {
   sessionPinId,
   shouldMigrateComposerScope
 } from '@/store/session'
-import { $focusedStoredSessionId, sessionTileDelegate } from '@/store/session-states'
+import { $focusedStoredSessionId, sessionTileDelegate, sessionTileOwnerRoute } from '@/store/session-states'
 import { $transcriptTailBySessionId, transcriptTailState } from '@/store/transcript-tail'
 import { isAuxiliaryWindow, isWatchWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -274,13 +275,31 @@ function ChatRuntimeBoundary({
   const transcriptTailStates = useStore($transcriptTailBySessionId)
   const connectionId = connection?.connectionId || (connection?.mode === 'local' ? 'local' : '')
 
-  const ownerRoute = storedId
-    ? getSessionOwnerHint(storedId, connectionId ? { connectionId, profile: activeProfile } : undefined)
-    : undefined
+  const ownerRoute =
+    storedId && view.kind === 'tile'
+      ? sessionTileOwnerRoute(storedId)
+      : storedId
+        ? getSessionOwnerHint(storedId, connectionId ? { connectionId, profile: activeProfile } : undefined)
+        : undefined
 
-  const tailProfile = ownerRoute
-    ? { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile || ownerRoute.profile }
-    : undefined
+  const mediaOwner = useMemo(
+    () =>
+      ownerRoute
+        ? {
+            connectionId: ownerRoute.connectionId,
+            mode: ownerRoute.mode,
+            profile: ownerRoute.targetProfile || ownerRoute.profile
+          }
+        : connection
+          ? { connectionId: connection.connectionId, mode: connection.mode, profile: connection.profile }
+          : undefined,
+    [connection, ownerRoute]
+  )
+
+  const tailProfile = useMemo(
+    () => (ownerRoute ? { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile || ownerRoute.profile } : undefined),
+    [ownerRoute]
+  )
 
   const tailState = storedId && transcriptTailStates ? transcriptTailState(storedId, tailProfile) : undefined
   const restBackfillAvailable = Boolean(tailState?.possiblyTruncated)
@@ -336,9 +355,11 @@ function ChatRuntimeBoundary({
   })
 
   return (
-    <TranscriptWindowProvider value={transcriptWindow}>
-      <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
-    </TranscriptWindowProvider>
+    <TranscriptMediaOwnerProvider value={mediaOwner}>
+      <TranscriptWindowProvider value={transcriptWindow}>
+        <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+      </TranscriptWindowProvider>
+    </TranscriptMediaOwnerProvider>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-lazy.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-lazy.test.tsx
@@ -1,0 +1,311 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mediaMarkdownHref } from '@/lib/media'
+import { $connection } from '@/store/session'
+
+import { MarkdownImage, MarkdownTextContent } from './markdown-text'
+
+interface ObserverEntry {
+  isIntersecting: boolean
+  target: Element
+}
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = []
+
+  readonly observed = new Set<Element>()
+
+  constructor(
+    private readonly callback: (entries: ObserverEntry[]) => void,
+    readonly options?: IntersectionObserverInit
+  ) {
+    FakeIntersectionObserver.instances.push(this)
+  }
+
+  disconnect = vi.fn(() => this.observed.clear())
+  observe = vi.fn((target: Element) => this.observed.add(target))
+  unobserve = vi.fn((target: Element) => this.observed.delete(target))
+
+  intersect(target: Element) {
+    if (this.observed.has(target)) {
+      this.callback([{ isIntersecting: true, target }])
+    }
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+function admit(observer = FakeIntersectionObserver.instances.at(-1)) {
+  expect(observer).toBeDefined()
+  const target = [...observer!.observed][0]
+  expect(target).toBeDefined()
+
+  act(() => observer!.intersect(target))
+
+  return observer!
+}
+
+describe('lazy transcript media', () => {
+  const api = vi.fn(async (_request: { connectionId?: string; path: string; profile?: string }) => ({
+    dataUrl: 'data:image/svg+xml;base64,PHN2Zy8+'
+  }))
+
+  const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+  const saveImageFromUrl = vi.fn(async () => true)
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    FakeIntersectionObserver.instances = []
+    api.mockReset()
+    api.mockResolvedValue({ dataUrl: 'data:image/svg+xml;base64,PHN2Zy8+' })
+    saveGatewayFile.mockClear()
+    saveImageFromUrl.mockClear()
+    originalDesktop = window.hermesDesktop
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api, saveGatewayFile, saveImageFromUrl }
+    })
+    $connection.set({ connectionId: 'gateway-a', mode: 'remote', profile: 'remote-work' } as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $connection.set(null)
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: originalDesktop
+    })
+  })
+
+  it('does not resolve an off-screen filesystem image', () => {
+    render(<MarkdownImage alt="diagram" src="/tmp/offscreen-diagram.svg" />)
+
+    expect(api).not.toHaveBeenCalled()
+    expect(FakeIntersectionObserver.instances).toHaveLength(1)
+    expect(FakeIntersectionObserver.instances[0].options?.rootMargin).toBe('600px 0px')
+  })
+
+  it('does not eagerly resolve an off-screen MEDIA image link', async () => {
+    const href = mediaMarkdownHref('/tmp/offscreen-media-link.svg')
+
+    render(<MarkdownTextContent isRunning={false} text={`[Image: linked.svg](${href})`} />)
+
+    await waitFor(() => expect(FakeIntersectionObserver.instances).toHaveLength(1))
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['web', 'https://example.test/diagram.svg'],
+    ['data', 'data:image/svg+xml;base64,aW5saW5l']
+  ])('renders an inline %s image immediately without observing or resolving it', (_kind, src) => {
+    render(<MarkdownImage alt="inline diagram" src={src} />)
+
+    const image = screen.getByRole('img', { name: 'inline diagram' })
+    expect(image.getAttribute('src')).toBe(src)
+    expect(api).not.toHaveBeenCalled()
+    expect(FakeIntersectionObserver.instances).toHaveLength(0)
+  })
+
+  it('admits a near-viewport image only once', async () => {
+    const view = render(<MarkdownImage alt="diagram" src="/tmp/admitted-once.svg" />)
+    const observer = admit()
+
+    await screen.findByRole('img', { name: 'diagram' })
+    view.rerender(<MarkdownImage alt="diagram" src="/tmp/admitted-once.svg" />)
+
+    expect(api).toHaveBeenCalledTimes(1)
+    expect(observer.disconnect).toHaveBeenCalledTimes(1)
+    expect(FakeIntersectionObserver.instances).toHaveLength(1)
+  })
+
+  it('sets native lazy-loading and async decoding on the admitted image', async () => {
+    render(<MarkdownImage alt="diagram" decoding="sync" loading="eager" src="/tmp/native-lazy.svg" />)
+    admit()
+
+    const image = await screen.findByRole('img', { name: 'diagram' })
+
+    expect(image.getAttribute('loading')).toBe('lazy')
+    expect(image.getAttribute('decoding')).toBe('async')
+  })
+
+  it('preserves image alt text, lightbox opening, and resolved-source download semantics', async () => {
+    const resolvedSrc = 'data:image/svg+xml;base64,YWN0aW9ucw=='
+    api.mockResolvedValue({ dataUrl: resolvedSrc })
+
+    const { baseElement } = render(<MarkdownImage alt="Architecture diagram" src="/tmp/actions.svg" />)
+    admit()
+
+    const image = await screen.findByRole('img', { name: 'Architecture diagram' })
+    expect(image.getAttribute('alt')).toBe('Architecture diagram')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download image' }))
+    await waitFor(() => expect(saveImageFromUrl).toHaveBeenCalledWith(resolvedSrc))
+
+    fireEvent.click(screen.getByTitle('Open image'))
+    await waitFor(() => expect(baseElement.querySelectorAll('img[alt="Architecture diagram"]')).toHaveLength(2))
+  })
+
+  it('deduplicates identical in-flight requests in the same connection scope', async () => {
+    const request = deferred<{ dataUrl: string }>()
+    api.mockReturnValue(request.promise)
+
+    render(
+      <>
+        <MarkdownImage alt="first" src="/tmp/shared-request.svg" />
+        <MarkdownImage alt="second" src="/tmp/shared-request.svg" />
+      </>
+    )
+
+    admit(FakeIntersectionObserver.instances[0])
+    admit(FakeIntersectionObserver.instances[1])
+
+    expect(api).toHaveBeenCalledTimes(1)
+
+    await act(async () => request.resolve({ dataUrl: 'data:image/svg+xml;base64,c2hhcmVk' }))
+    expect((await screen.findByRole('img', { name: 'first' })).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,c2hhcmVk'
+    )
+    expect(screen.getByRole('img', { name: 'second' }).getAttribute('src')).toBe('data:image/svg+xml;base64,c2hhcmVk')
+  })
+
+  it('deduplicates only while a request is in flight', async () => {
+    api
+      .mockResolvedValueOnce({ dataUrl: 'data:image/svg+xml;base64,Zmlyc3Q=' })
+      .mockResolvedValueOnce({ dataUrl: 'data:image/svg+xml;base64,c2Vjb25k' })
+
+    const first = render(<MarkdownImage alt="first" src="/tmp/settled-request.svg" />)
+    admit()
+
+    expect((await screen.findByRole('img', { name: 'first' })).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,Zmlyc3Q='
+    )
+    first.unmount()
+
+    render(<MarkdownImage alt="second" src="/tmp/settled-request.svg" />)
+    admit()
+
+    expect((await screen.findByRole('img', { name: 'second' })).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,c2Vjb25k'
+    )
+    expect(api).toHaveBeenCalledTimes(2)
+  })
+
+  it('requires fresh viewport admission when a reused image receives a new path', async () => {
+    const newRequest = deferred<{ dataUrl: string }>()
+    api.mockImplementation(({ path }: { path: string }) =>
+      path.includes('new.svg') ? newRequest.promise : Promise.resolve({ dataUrl: 'data:image/svg+xml;base64,b2xk' })
+    )
+
+    const view = render(<MarkdownImage alt="diagram" src="/tmp/old.svg" />)
+    admit()
+    await screen.findByRole('img', { name: 'diagram' })
+
+    view.rerender(<MarkdownImage alt="diagram" src="/tmp/new.svg" />)
+    await act(async () => undefined)
+
+    expect(api).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('img', { name: 'diagram' })).toBeNull()
+    expect(screen.getByText('Loading new.svg...')).not.toBeNull()
+    expect(FakeIntersectionObserver.instances).toHaveLength(2)
+
+    admit()
+    expect(api).toHaveBeenCalledTimes(2)
+
+    await act(async () => newRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,bmV3' }))
+    expect((await screen.findByRole('img', { name: 'diagram' })).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,bmV3'
+    )
+  })
+
+  it('does not let a stale request overwrite a reused image node', async () => {
+    const oldRequest = deferred<{ dataUrl: string }>()
+    const newRequest = deferred<{ dataUrl: string }>()
+    api.mockImplementation(({ path }: { path: string }) =>
+      path.includes('old.svg') ? oldRequest.promise : newRequest.promise
+    )
+
+    const view = render(<MarkdownImage alt="diagram" src="/tmp/stale-old.svg" />)
+    admit()
+    view.rerender(<MarkdownImage alt="diagram" src="/tmp/stale-new.svg" />)
+    admit()
+
+    await act(async () => newRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,bmV3' }))
+    const image = await screen.findByRole('img', { name: 'diagram' })
+    expect(image.getAttribute('src')).toBe('data:image/svg+xml;base64,bmV3')
+
+    await act(async () => oldRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,b2xk' }))
+    expect(screen.getByRole('img', { name: 'diagram' }).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,bmV3'
+    )
+  })
+
+  it('does not publish an admitted result after unmount', async () => {
+    const request = deferred<{ dataUrl: string }>()
+    api.mockReturnValue(request.promise)
+
+    const view = render(<MarkdownImage alt="diagram" src="/tmp/unmounted.svg" />)
+    admit()
+    view.unmount()
+
+    await act(async () => request.resolve({ dataUrl: 'data:image/svg+xml;base64,dW5tb3VudGVk' }))
+
+    expect(screen.queryByRole('img', { name: 'diagram' })).toBeNull()
+  })
+
+  it('does not reuse a pending result across connection and profile scopes', async () => {
+    const firstRequest = deferred<{ dataUrl: string }>()
+    const secondRequest = deferred<{ dataUrl: string }>()
+    api.mockImplementation(({ profile }: { profile?: string }) =>
+      profile === 'remote-work' ? firstRequest.promise : secondRequest.promise
+    )
+
+    render(<MarkdownImage alt="diagram" src="/tmp/scoped.svg" />)
+    admit()
+
+    act(() => {
+      $connection.set({ connectionId: 'gateway-b', mode: 'remote', profile: 'personal' } as never)
+    })
+
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(2))
+    expect(api.mock.calls.map(([request]) => request.profile)).toEqual(['remote-work', 'personal'])
+
+    await act(async () => firstRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,c3RhbGU=' }))
+    expect(screen.queryByRole('img', { name: 'diagram' })).toBeNull()
+
+    await act(async () => secondRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,Y3VycmVudA==' }))
+    expect((await screen.findByRole('img', { name: 'diagram' })).getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,Y3VycmVudA=='
+    )
+  })
+
+  it('keeps the failed-image open fallback scoped to the active profile', async () => {
+    api.mockRejectedValue(new Error('missing'))
+    render(<MarkdownImage alt="diagram" src="/tmp/missing.svg" />)
+    admit()
+
+    const open = await screen.findByRole('button', { name: 'Open image' })
+    fireEvent.click(open)
+
+    await waitFor(() => {
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'gateway-a',
+        path: '/tmp/missing.svg',
+        profile: 'remote-work',
+        suggestedName: 'missing.svg'
+      })
+    })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-lazy.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-lazy.test.tsx
@@ -98,6 +98,37 @@ describe('lazy transcript media', () => {
     expect(FakeIntersectionObserver.instances[0].options?.rootMargin).toBe('600px 0px')
   })
 
+  it('uses the transcript scrollport as the observer root', () => {
+    const { container } = render(
+      <div data-slot="aui_thread-viewport">
+        <MarkdownImage alt="diagram" height={240} src="/tmp/scrollport.svg" width={320} />
+      </div>
+    )
+
+    expect(FakeIntersectionObserver.instances[0].options?.root).toBe(container.firstElementChild)
+  })
+
+  it('keeps filesystem placeholders accessible and reserves their dimensions', () => {
+    render(<MarkdownImage alt="A diagram" height={240} src="/tmp/placeholder.svg" width={320} />)
+
+    const placeholder = screen.getByRole('img', { name: 'A diagram' })
+    expect(placeholder.getAttribute('aria-busy')).toBe('true')
+    expect(placeholder.getAttribute('width')).toBe('320')
+    expect(placeholder.getAttribute('height')).toBe('240')
+    expect(screen.getByText('Loading placeholder.svg...')).toBeTruthy()
+  })
+
+  it.each([
+    ['relative', 'images/relative.svg'],
+    ['blob', 'blob:https://example.test/image-id']
+  ])('renders %s sources immediately without lazy filesystem gating', (_kind, src) => {
+    render(<MarkdownImage alt="inline diagram" src={src} />)
+
+    expect(screen.getByRole('img', { name: 'inline diagram' }).getAttribute('src')).toBe(src)
+    expect(FakeIntersectionObserver.instances).toHaveLength(0)
+    expect(api).not.toHaveBeenCalled()
+  })
+
   it('does not eagerly resolve an off-screen MEDIA image link', async () => {
     const href = mediaMarkdownHref('/tmp/offscreen-media-link.svg')
 
@@ -135,10 +166,9 @@ describe('lazy transcript media', () => {
     render(<MarkdownImage alt="diagram" decoding="sync" loading="eager" src="/tmp/native-lazy.svg" />)
     admit()
 
-    const image = await screen.findByRole('img', { name: 'diagram' })
-
-    expect(image.getAttribute('loading')).toBe('lazy')
-    expect(image.getAttribute('decoding')).toBe('async')
+    const image = (await screen.findAllByRole('img', { name: 'diagram' })).at(-1)
+    expect(image?.getAttribute('loading')).toBe('lazy')
+    expect(image?.getAttribute('decoding')).toBe('async')
   })
 
   it('preserves image alt text, lightbox opening, and resolved-source download semantics', async () => {
@@ -175,8 +205,8 @@ describe('lazy transcript media', () => {
     expect(api).toHaveBeenCalledTimes(1)
 
     await act(async () => request.resolve({ dataUrl: 'data:image/svg+xml;base64,c2hhcmVk' }))
-    expect((await screen.findByRole('img', { name: 'first' })).getAttribute('src')).toBe(
-      'data:image/svg+xml;base64,c2hhcmVk'
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: 'first' }).getAttribute('src')).toBe('data:image/svg+xml;base64,c2hhcmVk')
     )
     expect(screen.getByRole('img', { name: 'second' }).getAttribute('src')).toBe('data:image/svg+xml;base64,c2hhcmVk')
   })
@@ -189,16 +219,16 @@ describe('lazy transcript media', () => {
     const first = render(<MarkdownImage alt="first" src="/tmp/settled-request.svg" />)
     admit()
 
-    expect((await screen.findByRole('img', { name: 'first' })).getAttribute('src')).toBe(
-      'data:image/svg+xml;base64,Zmlyc3Q='
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: 'first' }).getAttribute('src')).toBe('data:image/svg+xml;base64,Zmlyc3Q=')
     )
     first.unmount()
 
     render(<MarkdownImage alt="second" src="/tmp/settled-request.svg" />)
     admit()
 
-    expect((await screen.findByRole('img', { name: 'second' })).getAttribute('src')).toBe(
-      'data:image/svg+xml;base64,c2Vjb25k'
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: 'second' }).getAttribute('src')).toBe('data:image/svg+xml;base64,c2Vjb25k')
     )
     expect(api).toHaveBeenCalledTimes(2)
   })
@@ -217,8 +247,8 @@ describe('lazy transcript media', () => {
     await act(async () => undefined)
 
     expect(api).toHaveBeenCalledTimes(1)
-    expect(screen.queryByRole('img', { name: 'diagram' })).toBeNull()
     expect(screen.getByText('Loading new.svg...')).not.toBeNull()
+    expect(screen.getAllByRole('img', { name: 'diagram' })).toHaveLength(1)
     expect(FakeIntersectionObserver.instances).toHaveLength(2)
 
     admit()
@@ -283,7 +313,7 @@ describe('lazy transcript media', () => {
     expect(api.mock.calls.map(([request]) => request.profile)).toEqual(['remote-work', 'personal'])
 
     await act(async () => firstRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,c3RhbGU=' }))
-    expect(screen.queryByRole('img', { name: 'diagram' })).toBeNull()
+    expect(screen.getByText('Loading scoped.svg...')).not.toBeNull()
 
     await act(async () => secondRequest.resolve({ dataUrl: 'data:image/svg+xml;base64,Y3VycmVudA==' }))
     expect((await screen.findByRole('img', { name: 'diagram' })).getAttribute('src')).toBe(

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -41,7 +41,8 @@ describe('MarkdownTextContent remote images', () => {
   it('passes the gateway bridge data URL through Streamdown to the zoomable image', async () => {
     render(<MarkdownTextContent isRunning={false} text={`![Remote preview](${REMOTE_IMAGE_PATH})`} />)
 
-    const image = await screen.findByRole('img', { name: 'Remote preview' })
+    await waitFor(() => expect(screen.getByRole('img', { name: 'Remote preview' }).getAttribute('src')).toBe(REMOTE_IMAGE_DATA_URL))
+    const image = screen.getByRole('img', { name: 'Remote preview' })
 
     expect(image.getAttribute('src')).toBe(REMOTE_IMAGE_DATA_URL)
     expect(api).toHaveBeenCalledWith({

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { mediaMarkdownHref } from '@/lib/media'
 import { $connection } from '@/store/session'
 
-import { MarkdownImage, MarkdownTextContent } from './markdown-text'
+import { MarkdownImage, MarkdownTextContent, TranscriptMediaOwnerProvider } from './markdown-text'
 
 const REMOTE_IMAGE_PATH = '/home/user/project/images/remote-preview.png'
 const REMOTE_IMAGE_DATA_URL = 'data:image/png;base64,cmVtb3RlLWltYWdl'
@@ -49,6 +50,24 @@ describe('MarkdownTextContent remote images', () => {
       path: '/api/fs/read-data-url?path=%2Fhome%2Fuser%2Fproject%2Fimages%2Fremote-preview.png',
       profile: 'remote-work'
     })
+  })
+
+  it('routes transcript video playback through its owner connection', async () => {
+    $connection.set({ connectionId: 'ambient', mode: 'remote', profile: 'ambient' } as never)
+
+    const owner = { connectionId: 'transcript-owner', mode: 'remote' as const, profile: 'transcript-profile' }
+
+    const { container } = render(
+      <TranscriptMediaOwnerProvider value={owner}>
+        <MarkdownTextContent isRunning={false} text={`[clip](${mediaMarkdownHref('/tmp/clip.mp4')})`} />
+      </TranscriptMediaOwnerProvider>
+    )
+
+    await waitFor(() =>
+      expect(container.querySelector('video')?.getAttribute('src')).toBe(
+        'hermes-media://remote/%2Ftmp%2Fclip.mp4?connectionId=transcript-owner&profile=transcript-profile'
+      )
+    )
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -7,8 +7,9 @@ import {
   type SyntaxHighlighterProps,
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
+import { useStore } from '@nanostores/react'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, memo, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -16,6 +17,7 @@ import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlig
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
+import { desktopFsCacheKey } from '@/lib/desktop-fs'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
@@ -36,6 +38,7 @@ import {
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { sessionRefFromMarkdownHref } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
+import { $connection } from '@/store/session'
 
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
@@ -143,6 +146,71 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
   )
 }
 
+const TRANSCRIPT_MEDIA_ROOT_MARGIN = '600px 0px'
+const inFlightTranscriptImageRequests = new Map<string, Promise<string>>()
+
+function resolveTranscriptImageSrc(path: string, scopeKey: string): Promise<string> {
+  const key = `${scopeKey}\u0000${path}`
+  const cached = inFlightTranscriptImageRequests.get(key)
+
+  if (cached) {
+    return cached
+  }
+
+  const request = resolveMediaDisplaySrc(path)
+  inFlightTranscriptImageRequests.set(key, request)
+
+  // Share only concurrent reads. Holding fulfilled data URLs here would retain
+  // every transcript image for the app lifetime and could serve stale bytes if
+  // the file is later replaced at the same path.
+  const clear = () => {
+    if (inFlightTranscriptImageRequests.get(key) === request) {
+      inFlightTranscriptImageRequests.delete(key)
+    }
+  }
+
+  void request.then(clear, clear)
+
+  return request
+}
+
+function useNearViewport(enabled: boolean) {
+  const targetRef = useRef<HTMLSpanElement | null>(null)
+  const [nearViewport, setNearViewport] = useState(!enabled)
+
+  useEffect(() => {
+    if (!enabled) {
+      setNearViewport(true)
+
+      return
+    }
+
+    const target = targetRef.current
+
+    if (!target || typeof IntersectionObserver !== 'function') {
+      setNearViewport(true)
+
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          observer.disconnect()
+          setNearViewport(true)
+        }
+      },
+      { rootMargin: TRANSCRIPT_MEDIA_ROOT_MARGIN }
+    )
+
+    observer.observe(target)
+
+    return () => observer.disconnect()
+  }, [enabled])
+
+  return { nearViewport, targetRef }
+}
+
 function MediaAttachment({ path }: { path: string }) {
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
@@ -156,6 +224,14 @@ function MediaAttachment({ path }: { path: string }) {
 
     setFailed(false)
     setSrc('')
+
+    // Images use MarkdownImage's viewport admission and scoped request cache.
+    // Resolving here would eagerly read the file before that lazy boundary.
+    if (kind === 'image') {
+      return () => {
+        cancelled = true
+      }
+    }
 
     if (kind === 'file') {
       setFailed(true)
@@ -192,10 +268,10 @@ function MediaAttachment({ path }: { path: string }) {
     }
   }, [kind, path])
 
-  if (kind === 'image' && src) {
+  if (kind === 'image') {
     return (
       <span className="block">
-        <MarkdownImage alt={name} src={src} />
+        <MarkdownImage alt={name} src={path} />
       </span>
     )
   }
@@ -364,11 +440,15 @@ export function MarkdownImage(props: ComponentProps<'img'>) {
     return <MediaAttachment path={rawSrc} />
   }
 
-  return <MarkdownImageContent {...props} />
+  return <MarkdownImageContent key={rawSrc} {...props} />
 }
 
 function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<'img'>) {
   const rawSrc = typeof src === 'string' ? src : ''
+  const needsResolution = Boolean(rawSrc && !isInlineMediaSrc(rawSrc))
+  const { nearViewport, targetRef } = useNearViewport(needsResolution)
+  const connection = useStore($connection)
+  const scopeKey = desktopFsCacheKey(connection)
   const [resolvedSrc, setResolvedSrc] = useState(() => (rawSrc && isInlineMediaSrc(rawSrc) ? rawSrc : ''))
   const [failed, setFailed] = useState(false)
   const { open, openFailed } = useOpenMediaFile(rawSrc)
@@ -380,13 +460,13 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     setFailed(false)
     setResolvedSrc(rawSrc && isInlineMediaSrc(rawSrc) ? rawSrc : '')
 
-    if (!rawSrc || isInlineMediaSrc(rawSrc)) {
+    if (!rawSrc || isInlineMediaSrc(rawSrc) || !nearViewport) {
       return () => {
         cancelled = true
       }
     }
 
-    void resolveMediaDisplaySrc(rawSrc)
+    void resolveTranscriptImageSrc(rawSrc, scopeKey)
       .then(value => {
         if (!cancelled) {
           setResolvedSrc(value)
@@ -401,7 +481,7 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     return () => {
       cancelled = true
     }
-  }, [rawSrc])
+  }, [nearViewport, rawSrc, scopeKey])
 
   if (!rawSrc) {
     return null
@@ -420,7 +500,11 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
   }
 
   if (!resolvedSrc) {
-    return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
+    return (
+      <span className="my-2 block text-sm text-muted-foreground" ref={targetRef}>
+        Loading {name}...
+      </span>
+    )
   }
 
   // The width cap belongs on the container, not the <img>: a percentage
@@ -438,6 +522,8 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
       slot="aui_markdown-image"
       src={resolvedSrc}
       {...props}
+      decoding="async"
+      loading="lazy"
     />
   )
 }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -224,6 +224,7 @@ function MediaAttachment({ path }: { path: string }) {
   const { open, openFailed } = useOpenMediaFile(path)
   const kind = mediaKind(path)
   const name = mediaName(path)
+  const owner = useContext(TranscriptMediaOwnerContext)
 
   useEffect(() => {
     let cancelled = false
@@ -248,7 +249,7 @@ function MediaAttachment({ path }: { path: string }) {
       }
     }
 
-    void resolveMediaPlaybackSrc(path)
+    void resolveMediaPlaybackSrc(path, owner)
       .then(value => {
         if (value.startsWith('blob:')) {
           objectUrl = value
@@ -273,7 +274,7 @@ function MediaAttachment({ path }: { path: string }) {
         URL.revokeObjectURL(objectUrl)
       }
     }
-  }, [kind, path])
+  }, [kind, owner, path])
 
   if (kind === 'image') {
     return (

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -9,7 +9,7 @@ import {
 } from '@assistant-ui/react-streamdown'
 import { useStore } from '@nanostores/react'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useRef, useState } from 'react'
+import { type ComponentProps, createContext, memo, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -22,10 +22,10 @@ import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/extern
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+import type { MediaOwner } from '@/lib/media'
 import {
   downloadGatewayMediaFile,
   isFileMediaPath,
-  isInlineMediaSrc,
   isMarkdownDocumentPath,
   isRemoteGateway,
   mediaExternalUrl,
@@ -149,15 +149,19 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
 const TRANSCRIPT_MEDIA_ROOT_MARGIN = '600px 0px'
 const inFlightTranscriptImageRequests = new Map<string, Promise<string>>()
 
-function resolveTranscriptImageSrc(path: string, scopeKey: string): Promise<string> {
-  const key = `${scopeKey}\u0000${path}`
+const TranscriptMediaOwnerContext = createContext<MediaOwner | undefined>(undefined)
+
+export const TranscriptMediaOwnerProvider = TranscriptMediaOwnerContext.Provider
+
+function resolveTranscriptImageSrc(path: string, scopeKey: string, owner?: MediaOwner): Promise<string> {
+  const key = `${scopeKey}\\u0000${path}`
   const cached = inFlightTranscriptImageRequests.get(key)
 
   if (cached) {
     return cached
   }
 
-  const request = resolveMediaDisplaySrc(path)
+  const request = resolveMediaDisplaySrc(path, owner)
   inFlightTranscriptImageRequests.set(key, request)
 
   // Share only concurrent reads. Holding fulfilled data URLs here would retain
@@ -200,7 +204,10 @@ function useNearViewport(enabled: boolean) {
           setNearViewport(true)
         }
       },
-      { rootMargin: TRANSCRIPT_MEDIA_ROOT_MARGIN }
+      {
+        root: target.closest('[data-slot="aui_thread-viewport"]'),
+        rootMargin: TRANSCRIPT_MEDIA_ROOT_MARGIN
+      }
     )
 
     observer.observe(target)
@@ -445,11 +452,16 @@ export function MarkdownImage(props: ComponentProps<'img'>) {
 
 function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<'img'>) {
   const rawSrc = typeof src === 'string' ? src : ''
-  const needsResolution = Boolean(rawSrc && !isInlineMediaSrc(rawSrc))
+  const owner = useContext(TranscriptMediaOwnerContext)
+  const needsResolution = Boolean(rawSrc && isFileMediaPath(rawSrc))
   const { nearViewport, targetRef } = useNearViewport(needsResolution)
   const connection = useStore($connection)
-  const scopeKey = desktopFsCacheKey(connection)
-  const [resolvedSrc, setResolvedSrc] = useState(() => (rawSrc && isInlineMediaSrc(rawSrc) ? rawSrc : ''))
+
+  const scopeKey = owner
+    ? `${owner.mode || 'local'}:${owner.connectionId || ''}:${owner.profile || ''}`
+    : desktopFsCacheKey(connection)
+
+  const [resolvedSrc, setResolvedSrc] = useState(() => (rawSrc && !needsResolution ? rawSrc : ''))
   const [failed, setFailed] = useState(false)
   const { open, openFailed } = useOpenMediaFile(rawSrc)
   const name = mediaName(rawSrc || String(alt || 'image'))
@@ -458,15 +470,15 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     let cancelled = false
 
     setFailed(false)
-    setResolvedSrc(rawSrc && isInlineMediaSrc(rawSrc) ? rawSrc : '')
+    setResolvedSrc(rawSrc && !needsResolution ? rawSrc : '')
 
-    if (!rawSrc || isInlineMediaSrc(rawSrc) || !nearViewport) {
+    if (!rawSrc || !needsResolution || !nearViewport) {
       return () => {
         cancelled = true
       }
     }
 
-    void resolveTranscriptImageSrc(rawSrc, scopeKey)
+    void resolveTranscriptImageSrc(rawSrc, scopeKey, owner)
       .then(value => {
         if (!cancelled) {
           setResolvedSrc(value)
@@ -481,7 +493,7 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     return () => {
       cancelled = true
     }
-  }, [nearViewport, rawSrc, scopeKey])
+  }, [nearViewport, needsResolution, owner, rawSrc, scopeKey])
 
   if (!rawSrc) {
     return null
@@ -502,7 +514,17 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
   if (!resolvedSrc) {
     return (
       <span className="my-2 block text-sm text-muted-foreground" ref={targetRef}>
-        Loading {name}...
+        <img
+          alt={alt}
+          aria-busy="true"
+          className={cn('block h-auto max-w-full rounded-lg opacity-0', className)}
+          decoding="async"
+          height={props.height}
+          loading="lazy"
+          src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+          width={props.width}
+        />
+        <span>{`Loading ${name}...`}</span>
       </span>
     )
   }

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -11,6 +11,13 @@ export interface DesktopFsRemotePicker {
   selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
 }
 
+/** Explicit backend authority for content owned by a transcript/tile. */
+export interface DesktopFsScope {
+  connectionId?: string
+  mode?: 'local' | 'remote'
+  profile?: string
+}
+
 let remotePicker: DesktopFsRemotePicker | null = null
 
 export function setDesktopFsRemotePicker(next: DesktopFsRemotePicker | null) {
@@ -65,10 +72,15 @@ function bridge() {
   return desktop
 }
 
-function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return hermesApi<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
-  )
+function remoteFsApi<T>(path: string, body?: Record<string, unknown>, scope?: DesktopFsScope): Promise<T> {
+  const profile = scope?.profile || desktopFsProfile()
+  const connectionId = scope?.connectionId
+
+  const request = body
+    ? { body, method: 'POST', path, ...(profile ? { profile } : {}), ...(connectionId ? { connectionId } : {}) }
+    : { path, ...(profile ? { profile } : {}), ...(connectionId ? { connectionId } : {}) }
+
+  return hermesApi<T>(request)
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
@@ -107,12 +119,16 @@ export async function writeDesktopFileText(path: string, content: string): Promi
   return { path: result.path || path }
 }
 
-export async function readDesktopFileDataUrl(path: string): Promise<string> {
-  if (!isDesktopFsRemoteMode()) {
+export async function readDesktopFileDataUrl(path: string, scope?: DesktopFsScope): Promise<string> {
+  if (
+    scope?.mode === 'local' ||
+    scope?.connectionId === 'local' ||
+    (!scope?.connectionId && $connection.get()?.mode !== 'remote')
+  ) {
     return bridge().readFileDataUrl(path)
   }
 
-  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))
+  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path), undefined, scope)
 
   return typeof result === 'string' ? result : result.dataUrl || ''
 }

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -155,6 +155,23 @@ describe('resolveMediaDisplaySrc', () => {
     })
   })
 
+  it('uses the explicit transcript owner instead of the ambient connection', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    $connection.set({ connectionId: 'ambient', mode: 'remote', profile: 'ambient' } as never)
+
+    await expect(
+      resolveMediaDisplaySrc('/Users/me/project/a b.png', {
+        connectionId: 'transcript-owner',
+        profile: 'transcript-profile'
+      })
+    ).resolves.toBe('data:image/png;base64,ZHVtbXk=')
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'transcript-owner',
+      path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2Fproject%2Fa%20b.png',
+      profile: 'transcript-profile'
+    })
+  })
+
   it('reads local desktop file paths from the local desktop shell', async () => {
     const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,bG9jYWw=')
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,8 +1,10 @@
-import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
+import { type DesktopFsScope, readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { capitalize } from '@/lib/text'
 import { $connection } from '@/store/session'
 
 export type MediaKind = 'audio' | 'image' | 'video' | 'file'
+
+export type MediaOwner = DesktopFsScope
 
 interface MediaInfo {
   kind: MediaKind
@@ -77,13 +79,13 @@ export function isFileMediaPath(path: string): boolean {
   return /^(?:file:|\/|~\/|[a-z]:[\\/]|\\\\)/i.test(path)
 }
 
-export async function resolveMediaDisplaySrc(path: string): Promise<string> {
+export async function resolveMediaDisplaySrc(path: string, owner?: MediaOwner): Promise<string> {
   if (isInlineMediaSrc(path) || !isFileMediaPath(path)) {
     return path
   }
 
-  if (window.hermesDesktop && isRemoteGateway()) {
-    return gatewayMediaDataUrl(path)
+  if (window.hermesDesktop && (owner?.connectionId || (!owner && isRemoteGateway()))) {
+    return gatewayMediaDataUrl(path, owner)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {
@@ -194,8 +196,8 @@ export function isRemoteGateway(): boolean {
 // bridge. Remote Desktop artifacts can live anywhere the gateway can read
 // (workspace, skills, ~/.hermes/cache, etc.); /api/media is intentionally
 // narrower and rejects non-images plus images outside its media roots.
-export async function gatewayMediaDataUrl(path: string): Promise<string> {
-  return readDesktopFileDataUrl(filePathFromMediaPath(path))
+export async function gatewayMediaDataUrl(path: string, owner?: MediaOwner): Promise<string> {
+  return readDesktopFileDataUrl(filePathFromMediaPath(path), owner)
 }
 
 // Remote-mode replacement for opening gateway-local file paths with file://.

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -99,16 +99,16 @@ export async function resolveMediaDisplaySrc(path: string, owner?: MediaOwner): 
 // remote URLs untouched and route filesystem paths through the Electron media
 // protocol. Its main-process handler reads local files directly or proxies a
 // remote gateway with the connection's bearer/cookie/token authentication.
-export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
+export async function resolveMediaPlaybackSrc(path: string, owner?: MediaOwner): Promise<string> {
   if (isInlineMediaSrc(path)) {
     return path
   }
 
   if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
-    return isRemoteGateway() ? mediaGatewayStreamUrl(path) : mediaStreamUrl(path)
+    return isRemoteGatewayFor(owner) ? mediaGatewayStreamUrl(path, owner) : mediaStreamUrl(path)
   }
 
-  return resolveMediaDisplaySrc(path)
+  return resolveMediaDisplaySrc(path, owner)
 }
 
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
@@ -136,10 +136,10 @@ export function mediaExternalUrl(path: string): string {
 // connections intentionally expose no static token to the renderer, so a bare
 // HTTPS source cannot authenticate reliably. The custom protocol keeps secrets
 // out of renderer URLs while forwarding Range requests to /api/files/stream.
-export function mediaGatewayStreamUrl(path: string): string {
-  const conn = $connection.get()
+export function mediaGatewayStreamUrl(path: string, owner?: MediaOwner): string {
+  const conn = owner || $connection.get()
 
-  if (isRemoteGateway()) {
+  if (isRemoteGatewayFor(owner)) {
     const file = encodeURIComponent(filePathFromMediaPath(path))
 
     const scope = [
@@ -190,6 +190,22 @@ export function filePathFromMediaPath(path: string): string {
 // then live on the gateway machine, not this disk, so we fetch them over the API.
 export function isRemoteGateway(): boolean {
   return $connection.get()?.mode === 'remote'
+}
+
+function isRemoteGatewayFor(owner?: MediaOwner): boolean {
+  if (!owner) {
+    return isRemoteGateway()
+  }
+
+  if (owner.mode) {
+    return owner.mode === 'remote'
+  }
+
+  if (owner.connectionId) {
+    return owner.connectionId !== 'local'
+  }
+
+  return isRemoteGateway()
 }
 
 // Fetch gateway-local media as a data URL via the authenticated desktop FS


### PR DESCRIPTION
## Summary
- wait until filesystem-backed transcript images near the viewport before resolving them
- deduplicate concurrent source resolution and suppress stale results
- set native lazy loading and async decoding

## Verification
- 14 focused lazy-media tests
- desktop typecheck and ESLint