### PR TITLE
perf(desktop): cache artifact indexing by session

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -112,7 +112,8 @@ export async function listAllProfileSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
   profile: 'all' | (string & {}) = 'all',
-  filter: SessionSourceFilter = {}
+  filter: SessionSourceFilter = {},
+  options: { signal?: AbortSignal } = {}
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
 
@@ -125,6 +126,7 @@ export async function listAllProfileSessions(
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
+    ...(options.signal ? { signal: options.signal } : {}),
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 
@@ -393,7 +395,13 @@ function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
 export function getSessionMessages(
   id: string,
   profile?: ProfileScope,
-  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {}
+  page: {
+    limit?: number
+    offset?: number
+    order?: 'latest' | 'oldest'
+    includeCompacted?: boolean
+    signal?: AbortSignal
+  } = {}
 ): Promise<SessionMessagesResponse> {
   const query = new URLSearchParams()
 
@@ -423,7 +431,8 @@ export function getSessionMessages(
 
   return hermesApi<SessionMessagesResponse>({
     ...sessionScope,
-    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
+    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`,
+    ...(page.signal ? { signal: page.signal } : {})
   })
 }
 
@@ -540,7 +549,8 @@ export async function getAllSessionMessages(
         limit: pageSize,
         offset,
         order: 'oldest',
-        includeCompacted: true
+        includeCompacted: true,
+        signal: options.signal
       }),
       options.signal
     )

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -351,6 +351,41 @@ export function getSession(id: string, profile?: ProfileScope): Promise<SessionI
   })
 }
 
+function abortError(): DOMException {
+  return new DOMException('Session transcript loading was aborted', 'AbortError')
+}
+
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise
+  }
+
+  if (signal.aborted) {
+    return Promise.reject(abortError())
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener('abort', onAbort)
+
+    const onAbort = () => {
+      cleanup()
+      reject(abortError())
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      value => {
+        cleanup()
+        resolve(value)
+      },
+      error => {
+        cleanup()
+        reject(error)
+      }
+    )
+  })
+}
+
 // Reads another profile's transcript. For a remote profile Electron reroutes
 // this GET to the remote backend (which serves its own state.db); for a local
 // profile the primary opens that profile's state.db via ?profile=. Omit for
@@ -486,7 +521,7 @@ export function getOlderSessionMessages(
 export async function getAllSessionMessages(
   id: string,
   profile?: ProfileScope,
-  options: { maxJsonChars?: number } = {}
+  options: { maxJsonChars?: number; signal?: AbortSignal } = {}
 ): Promise<SessionMessagesResponse> {
   const messages: SessionMessage[] = []
   const pageSize = 500
@@ -496,12 +531,23 @@ export async function getAllSessionMessages(
   let resolvedSessionId = id
 
   while (true) {
-    const page = await getSessionMessages(id, profile, {
-      limit: pageSize,
-      offset,
-      order: 'oldest',
-      includeCompacted: true
-    })
+    if (options.signal?.aborted) {
+      throw abortError()
+    }
+
+    const page = await abortable(
+      getSessionMessages(id, profile, {
+        limit: pageSize,
+        offset,
+        order: 'oldest',
+        includeCompacted: true
+      }),
+      options.signal
+    )
+
+    if (options.signal?.aborted) {
+      throw abortError()
+    }
 
     resolvedSessionId = page.session_id
     jsonChars += (JSON.stringify(page.messages) ?? '').length

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -26,6 +26,26 @@ export interface ArtifactLoadResult {
   failures: ArtifactLoadFailure[]
 }
 
+export interface ArtifactSessionCacheEntry {
+  artifactCount: number
+  artifacts: ArtifactRecord[]
+  characters: number
+  fingerprint: string
+}
+
+export type ArtifactSessionCache = Map<string, ArtifactSessionCacheEntry>
+
+interface ArtifactLoadOptions {
+  cache?: ArtifactSessionCache
+  scope?: string
+  signal?: AbortSignal
+  yieldToMainThread?: () => Promise<void>
+}
+
+const MAX_ARTIFACT_SESSION_CACHE_ENTRIES = 60
+const MAX_ARTIFACT_CACHE_ARTIFACTS = 2_000
+const MAX_ARTIFACT_CACHE_CHARACTERS = 1_000_000
+
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
 const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
@@ -431,22 +451,109 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 
 export async function loadArtifactsForSessions(
   sessions: SessionInfo[],
-  loadMessages: (session: SessionInfo) => Promise<SessionMessage[]>
+  loadMessages: (session: SessionInfo) => Promise<SessionMessage[]>,
+  options: ArtifactLoadOptions = {}
 ): Promise<ArtifactLoadResult> {
   const artifacts: ArtifactRecord[] = []
   const failures: ArtifactLoadFailure[] = []
+
+  const throwIfAborted = () => {
+    if (options.signal?.aborted) {
+      throw new DOMException('Artifact indexing was aborted', 'AbortError')
+    }
+  }
 
   // Keep only one transcript resident at a time. Recent sessions can each be
   // tens of megabytes, so loading the whole page concurrently can exhaust both
   // the Desktop renderer and a remote dashboard backend.
   for (const session of sessions) {
+    throwIfAborted()
+
+    const cacheKey = `${options.scope || ''}:${session.connection_id || ''}:${session.profile || ''}:${session.id}`
+
+    const fingerprint = JSON.stringify([
+      session.last_active,
+      session.message_count,
+      session.tool_call_count,
+      session.title,
+      session.preview
+    ])
+
+    const cached = options.cache?.get(cacheKey)
+
+    if (!session.is_active && cached?.fingerprint === fingerprint) {
+      options.cache?.delete(cacheKey)
+      options.cache?.set(cacheKey, cached)
+      artifacts.push(...cached.artifacts)
+
+      continue
+    }
+
     try {
       const messages = await loadMessages(session)
-      artifacts.push(...collectArtifactsForSession(session, messages))
+      throwIfAborted()
+
+      const sessionArtifacts = collectArtifactsForSession(session, messages)
+      artifacts.push(...sessionArtifacts)
+
+      if (options.cache) {
+        options.cache.delete(cacheKey)
+
+        if (!session.is_active) {
+          const characters = sessionArtifacts.reduce(
+            (total, artifact) => total + artifact.value.length + artifact.label.length + artifact.sessionTitle.length,
+            0
+          )
+
+          if (characters <= MAX_ARTIFACT_CACHE_CHARACTERS && sessionArtifacts.length <= MAX_ARTIFACT_CACHE_ARTIFACTS) {
+            options.cache.set(cacheKey, {
+              artifactCount: sessionArtifacts.length,
+              artifacts: sessionArtifacts,
+              characters,
+              fingerprint
+            })
+          }
+        }
+
+        let retainedArtifacts = 0
+        let retainedCharacters = 0
+
+        for (const entry of options.cache.values()) {
+          retainedArtifacts += entry.artifactCount
+          retainedCharacters += entry.characters
+        }
+
+        while (
+          options.cache.size > MAX_ARTIFACT_SESSION_CACHE_ENTRIES ||
+          retainedArtifacts > MAX_ARTIFACT_CACHE_ARTIFACTS ||
+          retainedCharacters > MAX_ARTIFACT_CACHE_CHARACTERS
+        ) {
+          const oldestKey = options.cache.keys().next().value
+
+          if (oldestKey === undefined) {
+            break
+          }
+
+          const oldest = options.cache.get(oldestKey)
+
+          options.cache.delete(oldestKey)
+          retainedArtifacts -= oldest?.artifactCount ?? 0
+          retainedCharacters -= oldest?.characters ?? 0
+        }
+      }
+
+      await options.yieldToMainThread?.()
+      throwIfAborted()
     } catch (error) {
+      if (options.signal?.aborted) {
+        throw error
+      }
+
       failures.push({ error, session })
     }
   }
+
+  throwIfAborted()
 
   return { artifacts, failures }
 }

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -451,7 +451,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 
 export async function loadArtifactsForSessions(
   sessions: SessionInfo[],
-  loadMessages: (session: SessionInfo) => Promise<SessionMessage[]>,
+  loadMessages: (session: SessionInfo, signal?: AbortSignal) => Promise<SessionMessage[]>,
   options: ArtifactLoadOptions = {}
 ): Promise<ArtifactLoadResult> {
   const artifacts: ArtifactRecord[] = []
@@ -471,13 +471,7 @@ export async function loadArtifactsForSessions(
 
     const cacheKey = `${options.scope || ''}:${session.connection_id || ''}:${session.profile || ''}:${session.id}`
 
-    const fingerprint = JSON.stringify([
-      session.last_active,
-      session.message_count,
-      session.tool_call_count,
-      session.title,
-      session.preview
-    ])
+    const fingerprint = JSON.stringify(session)
 
     const cached = options.cache?.get(cacheKey)
 
@@ -490,7 +484,7 @@ export async function loadArtifactsForSessions(
     }
 
     try {
-      const messages = await loadMessages(session)
+      const messages = await loadMessages(session, options.signal)
       throwIfAborted()
 
       const sessionArtifacts = collectArtifactsForSession(session, messages)
@@ -500,10 +494,7 @@ export async function loadArtifactsForSessions(
         options.cache.delete(cacheKey)
 
         if (!session.is_active) {
-          const characters = sessionArtifacts.reduce(
-            (total, artifact) => total + artifact.value.length + artifact.label.length + artifact.sessionTitle.length,
-            0
-          )
+          const characters = JSON.stringify(sessionArtifacts).length
 
           if (characters <= MAX_ARTIFACT_CACHE_CHARACTERS && sessionArtifacts.length <= MAX_ARTIFACT_CACHE_ARTIFACTS) {
             options.cache.set(cacheKey, {
@@ -546,7 +537,7 @@ export async function loadArtifactsForSessions(
       throwIfAborted()
     } catch (error) {
       if (options.signal?.aborted) {
-        throw error
+        throwIfAborted()
       }
 
       failures.push({ error, session })

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -345,6 +345,130 @@ ${payload}
 })
 
 describe('loadArtifactsForSessions', () => {
+  it('bounds retained session results and evicts the least recently used entry', async () => {
+    const cache = new Map()
+    const sessions = Array.from({ length: 61 }, (_, index) => makeSession({ id: `session-${index}` }))
+
+    await loadArtifactsForSessions(sessions, async () => [], { cache })
+
+    expect(cache).toHaveLength(60)
+    expect(cache.has(':::session-0')).toBe(false)
+    expect(cache.has(':::session-60')).toBe(true)
+  })
+
+  it('reuses cached per-session artifacts until the session fingerprint changes', async () => {
+    const cache = new Map()
+
+    const loadMessages = vi.fn(async (session: SessionInfo) => [
+      {
+        content: `https://example.com/${session.id}-${session.message_count}.png`,
+        role: 'assistant' as const,
+        timestamp: 2000
+      }
+    ])
+
+    const yieldToMainThread = vi.fn(async () => {})
+    const firstSession = makeSession({ id: 'cached-session', last_active: 1000, message_count: 1, profile: 'work' })
+
+    const first = await loadArtifactsForSessions([firstSession], loadMessages, { cache, yieldToMainThread })
+    const second = await loadArtifactsForSessions([{ ...firstSession }], loadMessages, { cache, yieldToMainThread })
+
+    const changed = await loadArtifactsForSessions(
+      [{ ...firstSession, last_active: 1001, message_count: 2 }],
+      loadMessages,
+      { cache, yieldToMainThread }
+    )
+
+    await loadArtifactsForSessions([{ ...firstSession }], loadMessages, {
+      cache,
+      scope: 'other-connection',
+      yieldToMainThread
+    })
+
+    expect(first.artifacts).toEqual(second.artifacts)
+    expect(changed.artifacts[0]?.value).toContain('cached-session-2.png')
+    expect(loadMessages).toHaveBeenCalledTimes(3)
+    expect(yieldToMainThread).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not share artifacts across registry connections with colliding session ids', async () => {
+    const cache = new Map()
+
+    const loadMessages = vi.fn(async (session: SessionInfo) => [
+      {
+        content: `https://example.com/${session.connection_id}.png`,
+        role: 'assistant' as const,
+        timestamp: 1
+      }
+    ])
+
+    const first = makeSession({ connection_id: 'gateway-a', id: 'shared-session' })
+    const second = makeSession({ connection_id: 'gateway-b', id: 'shared-session' })
+
+    const firstResult = await loadArtifactsForSessions([first], loadMessages, { cache, scope: 'window' })
+    const secondResult = await loadArtifactsForSessions([second], loadMessages, { cache, scope: 'window' })
+
+    expect(firstResult.artifacts[0]?.value).toContain('gateway-a.png')
+    expect(secondResult.artifacts[0]?.value).toContain('gateway-b.png')
+    expect(loadMessages).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not reuse a partial transcript while a session is active', async () => {
+    const cache = new Map()
+    const activeSession = makeSession({ id: 'active-session', is_active: true })
+
+    const loadMessages = vi
+      .fn()
+      .mockResolvedValueOnce([{ content: 'https://example.com/first.png', role: 'assistant', timestamp: 1 }])
+      .mockResolvedValueOnce([{ content: 'https://example.com/second.png', role: 'assistant', timestamp: 2 }])
+
+    const first = await loadArtifactsForSessions([activeSession], loadMessages, { cache })
+    const second = await loadArtifactsForSessions([activeSession], loadMessages, { cache })
+
+    expect(first.artifacts[0]?.value).toContain('first.png')
+    expect(second.artifacts[0]?.value).toContain('second.png')
+    expect(loadMessages).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retain an artifact entry that exceeds the cache character budget', async () => {
+    const cache = new Map()
+    const oversized = `https://example.com/${'a'.repeat(1_000_100)}.png`
+    const loadMessages = vi.fn(async () => [{ content: oversized, role: 'assistant' as const, timestamp: 1 }])
+    const source = makeSession({ id: 'oversized-artifact' })
+
+    await loadArtifactsForSessions([source], loadMessages, { cache })
+    await loadArtifactsForSessions([source], loadMessages, { cache })
+
+    expect(cache).toHaveLength(0)
+    expect(loadMessages).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops before the next transcript when the load is aborted', async () => {
+    const controller = new AbortController()
+
+    const loadMessages = vi.fn(async (session: SessionInfo) => {
+      controller.abort()
+
+      return [
+        {
+          content: `https://example.com/${session.id}.png`,
+          role: 'assistant' as const,
+          timestamp: 2000
+        }
+      ]
+    })
+
+    await expect(
+      loadArtifactsForSessions(
+        [makeSession({ id: 'session-1' }), makeSession({ id: 'session-2' })],
+        loadMessages,
+        { cache: new Map(), signal: controller.signal }
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(loadMessages).toHaveBeenCalledOnce()
+  })
+
   it('loads transcripts serially and continues after a session fails', async () => {
     const sessions = [
       makeSession({ id: 'session-1' }),

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -443,6 +443,21 @@ describe('loadArtifactsForSessions', () => {
     expect(loadMessages).toHaveBeenCalledTimes(2)
   })
 
+  it('passes the abort signal to transcript loads', async () => {
+    const controller = new AbortController()
+    let received: AbortSignal | undefined
+
+    const loadMessages = vi.fn(async (_session: SessionInfo, signal?: AbortSignal) => {
+      received = signal
+
+      return []
+    })
+
+    await loadArtifactsForSessions([makeSession()], loadMessages, { signal: controller.signal })
+
+    expect(received).toBe(controller.signal)
+  })
+
   it('stops before the next transcript when the load is aborted', async () => {
     const controller = new AbortController()
 
@@ -467,6 +482,19 @@ describe('loadArtifactsForSessions', () => {
     ).rejects.toMatchObject({ name: 'AbortError' })
 
     expect(loadMessages).toHaveBeenCalledOnce()
+  })
+
+  it('does not publish a late non-abort failure after cancellation', async () => {
+    const controller = new AbortController()
+
+    const loadMessages = vi.fn(async () => {
+      controller.abort()
+      throw new Error('late transcript failure')
+    })
+
+    await expect(loadArtifactsForSessions([makeSession()], loadMessages, { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError'
+    })
   })
 
   it('loads transcripts serially and continues after a session fails', async () => {

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -35,6 +36,7 @@ import { normalize } from '@/lib/text'
 import { fmtDayTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { $connection } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -47,8 +49,15 @@ import {
   type ArtifactFilter,
   artifactImageSrc,
   type ArtifactRecord,
+  type ArtifactSessionCache,
   loadArtifactsForSessions
 } from './artifact-utils'
+
+const artifactSessionCache: ArtifactSessionCache = new Map()
+
+function yieldToMainThread(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
 
 function formatArtifactTime(timestamp: number): string {
   return fmtDayTime.format(new Date(timestamp))
@@ -115,6 +124,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const { t } = useI18n()
   const a = t.artifacts
   const navigate = useNavigate()
+  const connection = useStore($connection)
   const [artifacts, setArtifacts] = useState<ArtifactRecord[] | null>(null)
   const [query, setQuery] = useState('')
 
@@ -125,14 +135,22 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const [filePage, setFilePage] = useState(1)
 
   const [refreshing, setRefreshing] = useState(false)
+  const [refreshEpoch, setRefreshEpoch] = useState(0)
   const refreshInFlightRef = useRef(false)
+  const refreshAbortRef = useRef<AbortController | null>(null)
+  const refreshRequestedRef = useRef(false)
 
   const refreshArtifacts = useCallback(async () => {
     if (refreshInFlightRef.current) {
+      refreshRequestedRef.current = true
+
       return
     }
 
+    refreshRequestedRef.current = false
     refreshInFlightRef.current = true
+    const controller = new AbortController()
+    refreshAbortRef.current = controller
     setRefreshing(true)
 
     try {
@@ -140,8 +158,29 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
       const { artifacts: nextArtifacts, failures } = await loadArtifactsForSessions(
         sessions,
-        async session => (await getAllSessionMessages(session.id, session.profile)).messages
+        async session =>
+          (
+            await getAllSessionMessages(session.id, {
+              connectionId: session.connection_id,
+              profile: session.profile
+            })
+          ).messages,
+        {
+          cache: artifactSessionCache,
+          scope: [
+            connection?.connectionId || '',
+            connection?.mode || 'local',
+            connection?.baseUrl || '',
+            connection?.remoteIdentity || ''
+          ].join(':'),
+          signal: controller.signal,
+          yieldToMainThread
+        }
       )
+
+      if (controller.signal.aborted) {
+        return
+      }
 
       if (failures.length > 0) {
         const safeLimitFailures = failures.filter(({ error }) =>
@@ -169,19 +208,42 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
       setArtifacts(nextArtifacts.sort((left, right) => right.timestamp - left.timestamp))
     } catch (err) {
+      if (controller.signal.aborted) {
+        return
+      }
+
       notifyError(err, a.failedLoad)
       setArtifacts([])
     } finally {
-      refreshInFlightRef.current = false
-      setRefreshing(false)
+      if (refreshAbortRef.current === controller) {
+        refreshInFlightRef.current = false
+        refreshAbortRef.current = null
+        setRefreshing(false)
+
+        if (refreshRequestedRef.current) {
+          refreshRequestedRef.current = false
+          setRefreshEpoch(current => current + 1)
+        }
+      }
     }
-  }, [a])
+  }, [
+    a,
+    connection?.baseUrl,
+    connection?.connectionId,
+    connection?.mode,
+    connection?.remoteIdentity
+  ])
 
   useRefreshHotkey(refreshArtifacts)
 
   useEffect(() => {
+    void refreshEpoch
     void refreshArtifacts()
-  }, [refreshArtifacts])
+
+    return () => {
+      refreshAbortRef.current?.abort()
+    }
+  }, [refreshArtifacts, refreshEpoch])
 
   useEffect(() => {
     setImagePage(1)

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -36,6 +36,7 @@ import { normalize } from '@/lib/text'
 import { fmtDayTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $connection } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -125,6 +126,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const a = t.artifacts
   const navigate = useNavigate()
   const connection = useStore($connection)
+  const activeProfile = useStore($activeGatewayProfile)
   const [artifacts, setArtifacts] = useState<ArtifactRecord[] | null>(null)
   const [query, setQuery] = useState('')
 
@@ -163,7 +165,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
             await getAllSessionMessages(session.id, {
               connectionId: session.connection_id,
               profile: session.profile
-            })
+            }, { signal: controller.signal })
           ).messages,
         {
           cache: artifactSessionCache,
@@ -171,7 +173,8 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
             connection?.connectionId || '',
             connection?.mode || 'local',
             connection?.baseUrl || '',
-            connection?.remoteIdentity || ''
+            connection?.remoteIdentity || '',
+            connection?.profile || activeProfile || ''
           ].join(':'),
           signal: controller.signal,
           yieldToMainThread
@@ -231,7 +234,9 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     connection?.baseUrl,
     connection?.connectionId,
     connection?.mode,
-    connection?.remoteIdentity
+    connection?.profile,
+    connection?.remoteIdentity,
+    activeProfile
   ])
 
   useRefreshHotkey(refreshArtifacts)

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -156,7 +156,9 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     setRefreshing(true)
 
     try {
-      const sessions = (await listAllProfileSessions(30, 1)).sessions
+      const sessions = (
+        await listAllProfileSessions(30, 1, 'exclude', 'recent', 'all', {}, { signal: controller.signal })
+      ).sessions
 
       const { artifacts: nextArtifacts, failures } = await loadArtifactsForSessions(
         sessions,

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -652,12 +652,12 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
 
   const sessionsQuery = useQuery({
     queryKey: ['command-palette', 'sessions'],
-    queryFn: () => listAllProfileSessions(200, 1, 'exclude')
+    queryFn: ({ signal }) => listAllProfileSessions(200, 1, 'exclude', 'recent', 'all', {}, { signal })
   })
 
   const archivedQuery = useQuery({
     queryKey: ['command-palette', 'archived'],
-    queryFn: () => listAllProfileSessions(200, 0, 'only')
+    queryFn: ({ signal }) => listAllProfileSessions(200, 0, 'only', 'recent', 'all', {}, { signal })
   })
 
   // getServers is the shared choke point that also drops malformed (null/

--- a/apps/desktop/src/components/session-picker.tsx
+++ b/apps/desktop/src/components/session-picker.tsx
@@ -30,7 +30,7 @@ export function SessionPickerDialog({ activeStoredSessionId, onOpenChange, onRes
 
   const sessionsQuery = useQuery({
     enabled: open,
-    queryFn: () => listAllProfileSessions(200, 1, 'exclude'),
+    queryFn: ({ signal }) => listAllProfileSessions(200, 1, 'exclude', 'recent', 'all', {}, { signal }),
     queryKey: ['session-picker', 'sessions']
   })
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1186,6 +1186,7 @@ export interface HermesApiRequest {
   path: string
   method?: string
   body?: unknown
+  signal?: AbortSignal
   // Single-file multipart upload (FastAPI UploadFile endpoints). Mutually
   // exclusive with `body`; bytes transfer over IPC as a structured-clone
   // ArrayBuffer. Token-mode backends only.

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -590,6 +590,23 @@ describe('Hermes REST helpers', () => {
     })
   })
 
+  it('rejects an in-flight complete transcript request when aborted', async () => {
+    let resolveRequest!: (value: unknown) => void
+
+    const pending = new Promise(resolve => {
+      resolveRequest = resolve
+    })
+
+    const controller = new AbortController()
+    api.mockReturnValue(pending)
+
+    const result = getAllSessionMessages('session-1', null, { signal: controller.signal })
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    resolveRequest({ messages: [], session_id: 'session-1' })
+  })
+
   it('stops complete transcript loads before Desktop memory becomes unbounded', async () => {
     api.mockResolvedValueOnce({
       messages: [{ id: 1, content: 'large transcript page' }],

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -590,6 +590,20 @@ describe('Hermes REST helpers', () => {
     })
   })
 
+  it('forwards transcript cancellation to the session request', async () => {
+    const controller = new AbortController()
+    api.mockResolvedValueOnce({ messages: [], session_id: 'session-1' })
+
+    await getAllSessionMessages('session-1', undefined, { signal: controller.signal })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/sessions/session-1/messages?limit=500&offset=0&order=oldest&include_compacted=true',
+        signal: controller.signal
+      })
+    )
+  })
+
   it('rejects an in-flight complete transcript request when aborted', async () => {
     let resolveRequest!: (value: unknown) => void
 


### PR DESCRIPTION
## Summary
- cache completed-session artifact extraction by source identity and transcript fingerprint
- skip active sessions, bound retained entries/artifacts/characters, and yield between transcripts
- serialize replacement refreshes and route registry-owned sessions through their owning backend

## Verification
- 20 focused cache/routing/cancellation tests
- desktop typecheck and ESLint