### PR TITLE
perf(desktop): bound command palette search work

### DIFF
--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -95,8 +95,33 @@ export function connectionScoped(): { connectionId?: string } {
  *  pin — `'local'` included — so a pin always overrides the ambient tag spread
  *  underneath it. (It used to omit the key for 'local', which made the pin
  *  unable to beat the ambient tag; helpers then had to bypass this wrapper.) */
-export function hermesApi<T>(request: HermesApiRequest): Promise<T> {
-  return window.hermesDesktop.api<T>({ ...connectionScoped(), ...request })
+export function hermesApi<T>(request: HermesApiRequest, signal?: AbortSignal): Promise<T> {
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException('Aborted', 'AbortError'))
+  }
+
+  const requestPromise = window.hermesDesktop.api<T>({ ...connectionScoped(), ...request })
+
+  if (!signal) {
+    return requestPromise
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    const cleanup = () => signal.removeEventListener('abort', onAbort)
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    requestPromise.then(
+      value => {
+        cleanup()
+        resolve(value)
+      },
+      error => {
+        cleanup()
+        reject(error)
+      }
+    )
+  })
 }
 
 // ── Capability scope: (connection, profile) routing for the Capabilities

--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/gateway-rpc', () => ({ isMissingRestEndpoint: () => false }))
@@ -10,13 +11,71 @@ vi.mock('./client', () => ({
 }))
 
 const client = await import('./client')
-const { listSidebarSessions } = await import('./sessions')
+const { listAllProfileSessions, listSidebarSessions } = await import('./sessions')
+const { commandPaletteSessionsQueryFn } = await import('../app/command-palette/session-query')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(client.getApiRequestConnection).mockReturnValue('prometheus')
+})
+
+describe('command-palette session search cancellation', () => {
+  it('forwards the query signal to the session gateway request and rejects when cleared', async () => {
+    const controller = new AbortController()
+    let rejectRequest: ((reason?: unknown) => void) | undefined
+
+    hermesApi.mockImplementation((_request, signal) => {
+      expect(signal).toBe(controller.signal)
+
+      return new Promise((_resolve, reject) => {
+        rejectRequest = reject
+        signal?.addEventListener('abort', () => reject(signal.reason ?? new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    })
+
+    const pending = listAllProfileSessions(200, 1, 'exclude', 'recent', 'all', {}, controller.signal)
+
+    expect(hermesApi).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining('/api/profiles/sessions') }),
+      controller.signal
+    )
+
+    controller.abort()
+    rejectRequest?.(controller.signal.reason)
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('does not publish a stale result after the palette search is cleared', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const queryKey = ['command-palette-test', 'sessions']
+    const states: string[] = []
+
+    hermesApi.mockImplementation((_request, signal) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason ?? new DOMException('Aborted', 'AbortError')), { once: true })
+      })
+    )
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: context => commandPaletteSessionsQueryFn(context, false),
+      retry: false
+    })
+
+    const unsubscribe = observer.subscribe(result => states.push(result.status))
+
+    await vi.waitFor(() => expect(hermesApi).toHaveBeenCalledOnce())
+    await queryClient.cancelQueries({ queryKey })
+
+    expect(queryClient.getQueryData(queryKey)).toBeUndefined()
+    expect(states).not.toContain('success')
+
+    unsubscribe()
+    queryClient.clear()
+  })
 })
 
 describe('listSidebarSessions remote ownership', () => {

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -112,7 +112,8 @@ export async function listAllProfileSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
   profile: 'all' | (string & {}) = 'all',
-  filter: SessionSourceFilter = {}
+  filter: SessionSourceFilter = {},
+  signal?: AbortSignal
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
 
@@ -126,7 +127,7 @@ export async function listAllProfileSessions(
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
-  })
+  }, signal)
 
   return {
     ...result,

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -57,7 +57,6 @@ import {
   Zap
 } from '@/lib/icons'
 import { getServers } from '@/lib/mcp-servers'
-import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { resolveVersionStatus } from '@/lib/version-status'
 import { $repoWorktrees } from '@/store/coding-status'
@@ -110,6 +109,7 @@ import { usePaletteContributions } from './contrib'
 import { HighlightWatcher } from './highlight-watcher'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
+import { rankPaletteGroups } from './rank-groups'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -172,84 +172,6 @@ interface SessionEntry {
   title: string
 }
 
-// Ranking happens in React, not cmdk. We score, sort, and prune the groups
-// ourselves and hand cmdk an already-ordered list with `shouldFilter={false}`,
-// leaving it as pure keyboard/selection machinery. (cmdk's own group
-// re-sorting silently no-ops: its sort() queries groups by an internal id that
-// never matches the heading text it writes into `data-value`, so groups always
-// keep source order — which put a generic keyword match like "Capabilities" on
-// top and the auto-highlight on it while an exact "Tools" row sat below.)
-//
-// cmdk still auto-selects the first DOM item whenever the search changes, so
-// rendering best-match-first is what puts the highlight on the best match.
-//
-// AND semantics: every typed word must appear in the label or keywords. The
-// grade rewards matches on the visible label — exact > prefix > whole word >
-// word prefix > substring > scattered terms > keyword-only — so typing "tools"
-// selects the row that says Tools, not a row that hides it in keywords.
-const scoreItem = (item: PaletteItem, needle: string): number => {
-  const label = item.label.toLowerCase()
-  const keys = (item.keywords ?? []).join(' ').toLowerCase()
-  const terms = needle.split(/\s+/).filter(Boolean)
-
-  if (terms.some(term => !label.includes(term) && !keys.includes(term))) {
-    return 0
-  }
-
-  if (label === needle) {
-    return 1
-  }
-
-  if (label.startsWith(needle)) {
-    return 0.9
-  }
-
-  const words = label.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
-
-  if (words.includes(needle)) {
-    return 0.85
-  }
-
-  if (words.some(word => word.startsWith(needle))) {
-    return 0.8
-  }
-
-  if (label.includes(needle)) {
-    return 0.7
-  }
-
-  if (terms.every(term => label.includes(term))) {
-    return 0.6
-  }
-
-  // Matched only via keywords — the weakest, generic-row signal.
-  return 0.4
-}
-
-// Order items within each group by score, order groups by their best item, and
-// drop everything that doesn't match. Ties keep their original order (stable
-// sort), so curated group/item ordering still breaks even scores.
-const rankGroups = (groups: PaletteGroup[], search: string): PaletteGroup[] => {
-  const needle = normalize(search)
-
-  if (!needle) {
-    return groups
-  }
-
-  return groups
-    .map(group => {
-      const scored = group.items
-        .map(item => ({ item, score: scoreItem(item, needle) }))
-        .filter(entry => entry.score > 0)
-        .sort((a, b) => b.score - a.score)
-
-      return { group: { ...group, items: scored.map(entry => entry.item) }, max: scored[0]?.score ?? 0 }
-    })
-    .filter(entry => entry.max > 0)
-    .sort((a, b) => b.max - a.max)
-    .map(entry => entry.group)
-}
-
 // cmdk selection values must be unique; labels alone can repeat (a settings
 // field and a session can share a title). The id suffix disambiguates.
 const paletteValue = (item: PaletteItem): string => `${item.label}\u0001${item.id}`
@@ -277,7 +199,8 @@ const PaletteGroups = memo(function PaletteGroups({
   noResultsLabel,
   onSelectItem,
   onSelectMods,
-  search
+  search,
+  statusLabel
 }: {
   bindings: Record<string, string[]>
   groups: PaletteGroup[]
@@ -286,6 +209,7 @@ const PaletteGroups = memo(function PaletteGroups({
   onSelectItem: (item: PaletteItem) => void
   onSelectMods: (event: { ctrlKey: boolean; metaKey: boolean; shiftKey: boolean }) => void
   search: string
+  statusLabel?: string
 }) {
   const deferred = useDeferredValue(groups, EMPTY_GROUPS)
   // While the rows are still catching up, an empty list means "not rendered
@@ -297,7 +221,7 @@ const PaletteGroups = memo(function PaletteGroups({
       {/* Filtering happens in rankGroups, so cmdk's own CommandEmpty
           (keyed to its internal filter count) would never fire. */}
       {deferred.length === 0 && !pending && (
-        <div className="py-6 text-center text-sm text-muted-foreground">{noResultsLabel}</div>
+        <div className="py-6 text-center text-sm text-muted-foreground">{statusLabel ?? noResultsLabel}</div>
       )}
       {deferred.map((group, index) => (
         <CommandGroup className={HUD_HEADING} heading={group.heading} key={group.heading ?? `palette-group-${index}`}>
@@ -574,12 +498,22 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   const [search, setSearch] = useState('')
   const [page, setPage] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const hasRootSearch = !page && Boolean(search.trim())
 
   // The Update row names the same install the statusbar names — same target
   // selection, same resolver. Reduced to the label string: an in-flight apply
   // rewrites these stores on every progress line, and only a changed string
   // should rebuild the palette's groups.
   const connection = useStore($connection)
+
+  const queryScope = [
+    connection?.connectionId ?? '',
+    connection?.mode ?? 'local',
+    connection?.baseUrl ?? '',
+    connection?.remoteIdentity ?? '',
+    connection?.profile ?? ''
+  ].join(':')
+
   const desktopVersion = useStore($desktopVersion)
   const clientStatus = useStore($updateStatus)
   const clientApply = useStore($updateApply)
@@ -641,22 +575,23 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     }
   }, [])
 
-  // Server-backed sources for the type-to-search groups. This component only
-  // exists while the palette is open, so the queries are inherently lazy — no
-  // `enabled` gate needed. react-query handles caching/dedup/staleness, so a
-  // reopen paints from cache and revalidates in the background.
+  // Config loads when the palette opens; the heavier session sources wait for
+  // root-page search text. Scope keys prevent cached rows from one backend or
+  // profile appearing during another backend's revalidation.
   const configQuery = useQuery({
-    queryKey: ['command-palette', 'config'],
+    queryKey: ['command-palette', queryScope, 'config'],
     queryFn: () => getHermesConfigRecord()
   })
 
   const sessionsQuery = useQuery({
-    queryKey: ['command-palette', 'sessions'],
+    enabled: hasRootSearch,
+    queryKey: ['command-palette', queryScope, 'sessions'],
     queryFn: () => listAllProfileSessions(200, 1, 'exclude')
   })
 
   const archivedQuery = useQuery({
-    queryKey: ['command-palette', 'archived'],
+    enabled: hasRootSearch,
+    queryKey: ['command-palette', queryScope, 'archived'],
     queryFn: () => listAllProfileSessions(200, 0, 'only')
   })
 
@@ -666,6 +601,14 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
 
   const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
   const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])
+
+  const sessionSearchStatus = hasRootSearch
+    ? sessionsQuery.isPending || archivedQuery.isPending
+      ? t.common.loading
+      : sessionsQuery.isError || archivedQuery.isError
+        ? t.common.error
+        : undefined
+    : undefined
 
   // Search/sub-page are local to a mount, and this component remounts per open
   // (keyed by open count), so each open starts clean without a reset effect.
@@ -1438,7 +1381,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
 
   const activePage = page ? subPages[page] : null
   const unrankedGroups = activePage ? activePage.groups : groups
-  const visibleGroups = useMemo(() => rankGroups(unrankedGroups, search), [unrankedGroups, search])
+  const visibleGroups = useMemo(() => rankPaletteGroups(unrankedGroups, search), [unrankedGroups, search])
   const placeholder = activePage ? activePage.placeholder : t.commandCenter.searchPlaceholder
 
   // The HighlightWatcher inside <Command> reports the highlighted row (arrows
@@ -1602,6 +1545,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
                 onSelectItem={handleSelect}
                 onSelectMods={noteSelectMods}
                 search={search}
+                statusLabel={sessionSearchStatus}
               />
             )}
           </CommandList>

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -71,6 +71,7 @@ import { $bindings, bindingsFor } from '@/store/keybinds'
 import { $dismissedAutoProjectIds, filterVisibleProjects } from '@/store/layout'
 import { openPetGenerate } from '@/store/pet-generate'
 import { openBrowserTab } from '@/store/preview'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $projectTree, goToProject, openFolderAsProject, requestStartWorkSession } from '@/store/projects'
 import { $connection } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
@@ -109,7 +110,9 @@ import { usePaletteContributions } from './contrib'
 import { HighlightWatcher } from './highlight-watcher'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
+import { commandPaletteQueryKey } from './query-scope'
 import { rankPaletteGroups } from './rank-groups'
+import { resolvePaletteSearchStatus } from './search-status'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -505,14 +508,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   // rewrites these stores on every progress line, and only a changed string
   // should rebuild the palette's groups.
   const connection = useStore($connection)
-
-  const queryScope = [
-    connection?.connectionId ?? '',
-    connection?.mode ?? 'local',
-    connection?.baseUrl ?? '',
-    connection?.remoteIdentity ?? '',
-    connection?.profile ?? ''
-  ].join(':')
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
   const desktopVersion = useStore($desktopVersion)
   const clientStatus = useStore($updateStatus)
@@ -579,19 +575,19 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   // root-page search text. Scope keys prevent cached rows from one backend or
   // profile appearing during another backend's revalidation.
   const configQuery = useQuery({
-    queryKey: ['command-palette', queryScope, 'config'],
+    queryKey: commandPaletteQueryKey('config', connection, activeGatewayProfile),
     queryFn: () => getHermesConfigRecord()
   })
 
   const sessionsQuery = useQuery({
     enabled: hasRootSearch,
-    queryKey: ['command-palette', queryScope, 'sessions'],
+    queryKey: commandPaletteQueryKey('sessions', connection, activeGatewayProfile),
     queryFn: () => listAllProfileSessions(200, 1, 'exclude')
   })
 
   const archivedQuery = useQuery({
     enabled: hasRootSearch,
-    queryKey: ['command-palette', queryScope, 'archived'],
+    queryKey: commandPaletteQueryKey('archived', connection, activeGatewayProfile),
     queryFn: () => listAllProfileSessions(200, 0, 'only')
   })
 
@@ -602,13 +598,21 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
   const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])
 
-  const sessionSearchStatus = hasRootSearch
-    ? sessionsQuery.isPending || archivedQuery.isPending
-      ? t.common.loading
-      : sessionsQuery.isError || archivedQuery.isError
-        ? t.common.error
-        : undefined
-    : undefined
+  const searchStatus = resolvePaletteSearchStatus(hasRootSearch, [
+    {
+      hasData: Boolean(sessionsQuery.data),
+      isError: sessionsQuery.isError,
+      isPending: sessionsQuery.isPending
+    },
+    {
+      hasData: Boolean(archivedQuery.data),
+      isError: archivedQuery.isError,
+      isPending: archivedQuery.isPending
+    }
+  ])
+
+  const sessionSearchStatus =
+    searchStatus === 'loading' ? t.common.loading : searchStatus === 'error' ? t.common.error : undefined
 
   // Search/sub-page are local to a mount, and this component remounts per open
   // (keyed by open count), so each open starts clean without a reset effect.

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -17,7 +17,7 @@ import { codiconIcon } from '@/components/ui/codicon'
 import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { KbdCombo } from '@/components/ui/kbd'
-import { getHermesConfigRecord, listAllProfileSessions } from '@/hermes'
+import { getHermesConfigRecord } from '@/hermes'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
@@ -87,6 +87,7 @@ import { canOpenNewWindow, openNewWindow } from '@/store/windows'
 import { luminance } from '@/themes/color'
 import { type ThemeMode, useTheme } from '@/themes/context'
 import { isUserTheme, resolveTheme } from '@/themes/user-themes'
+import type { SessionInfo } from '@/types/hermes'
 
 import { openSession, openSessionIntentFromModifiers } from '../open-session'
 import {
@@ -113,6 +114,7 @@ import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
 import { commandPaletteQueryKey } from './query-scope'
 import { rankPaletteGroups } from './rank-groups'
 import { resolvePaletteSearchStatus } from './search-status'
+import { commandPaletteSessionsQueryFn } from './session-query'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -310,7 +312,7 @@ const SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]{6}$/
 // home path would always miss and double-create.
 const FOLDER_PATH_RE = /^(\/|[A-Za-z]:[/\\]).+/
 
-type SessionRow = Awaited<ReturnType<typeof listAllProfileSessions>>['sessions'][number]
+type SessionRow = SessionInfo
 
 const toSessionEntry = (session: SessionRow): SessionEntry => ({
   git_branch: session.git_branch ?? null,
@@ -582,13 +584,13 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   const sessionsQuery = useQuery({
     enabled: hasRootSearch,
     queryKey: commandPaletteQueryKey('sessions', connection, activeGatewayProfile),
-    queryFn: () => listAllProfileSessions(200, 1, 'exclude')
+    queryFn: context => commandPaletteSessionsQueryFn(context, false)
   })
 
   const archivedQuery = useQuery({
     enabled: hasRootSearch,
     queryKey: commandPaletteQueryKey('archived', connection, activeGatewayProfile),
-    queryFn: () => listAllProfileSessions(200, 0, 'only')
+    queryFn: context => commandPaletteSessionsQueryFn(context, true)
   })
 
   // getServers is the shared choke point that also drops malformed (null/

--- a/apps/desktop/src/app/command-palette/query-scope.test.ts
+++ b/apps/desktop/src/app/command-palette/query-scope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { commandPaletteQueryKey } from './query-scope'
+
+const connection = {
+  baseUrl: 'https://gateway.example',
+  connectionId: 'gateway-a',
+  mode: 'remote' as const,
+  profile: 'default',
+  remoteIdentity: 'gateway.example'
+}
+
+describe('commandPaletteQueryKey', () => {
+  it('changes when the active gateway profile changes', () => {
+    const first = commandPaletteQueryKey('sessions', connection, 'default')
+    const second = commandPaletteQueryKey('sessions', connection, 'research')
+
+    expect(first).not.toEqual(second)
+    expect(first).toEqual(['command-palette', 'sessions', 'gateway-a', 'remote', 'https://gateway.example', 'gateway.example', 'default', 'default'])
+    expect(second).toEqual(['command-palette', 'sessions', 'gateway-a', 'remote', 'https://gateway.example', 'gateway.example', 'default', 'research'])
+  })
+
+  it('keeps gateway identities distinct without delimiter collisions', () => {
+    const first = commandPaletteQueryKey('config', { ...connection, connectionId: 'a:b', profile: 'c' }, 'd')
+    const second = commandPaletteQueryKey('config', { ...connection, connectionId: 'a', profile: 'b:c' }, 'd')
+
+    expect(first).not.toEqual(second)
+  })
+})

--- a/apps/desktop/src/app/command-palette/query-scope.ts
+++ b/apps/desktop/src/app/command-palette/query-scope.ts
@@ -1,0 +1,25 @@
+import type { HermesConnection } from '@/global'
+
+type PaletteConnection = Pick<HermesConnection, 'baseUrl' | 'connectionId' | 'mode' | 'profile' | 'remoteIdentity'>
+
+/**
+ * Query keys for palette data. Keep every routing identity as its own key part:
+ * joining them into a string would make values containing `:` collide, and the
+ * active profile can change while a shared gateway descriptor stays unchanged.
+ */
+export function commandPaletteQueryKey(
+  source: 'archived' | 'config' | 'sessions',
+  connection: PaletteConnection | null | undefined,
+  activeProfile: string | null | undefined
+) {
+  return [
+    'command-palette',
+    source,
+    connection?.connectionId ?? '',
+    connection?.mode ?? 'local',
+    connection?.baseUrl ?? '',
+    connection?.remoteIdentity ?? '',
+    connection?.profile ?? '',
+    activeProfile?.trim() || 'default'
+  ] as const
+}

--- a/apps/desktop/src/app/command-palette/rank-groups.test.ts
+++ b/apps/desktop/src/app/command-palette/rank-groups.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { rankPaletteGroups } from './rank-groups'
+
+interface Item {
+  id: string
+  keywords?: string[]
+  label: string
+}
+
+const item = (id: string, label = `Session ${id}`, keywords?: string[]): Item => ({ id, keywords, label })
+
+describe('rankPaletteGroups', () => {
+  it('bounds matching rows across groups after ranking', () => {
+    const groups = [
+      { heading: 'Sessions', items: Array.from({ length: 80 }, (_, index) => item(`session-${index}`)) },
+      { heading: 'Archived', items: Array.from({ length: 80 }, (_, index) => item(`archived-${index}`)) }
+    ]
+
+    const ranked = rankPaletteGroups(groups, 'session', 50)
+
+    expect(ranked.flatMap(group => group.items)).toHaveLength(50)
+    expect(ranked.every(group => group.items.length > 0)).toBe(true)
+  })
+
+  it('orders exact and prefix matches before weaker keyword matches', () => {
+    const groups = [
+      { heading: 'Weak', items: [item('weak', 'Other', ['tools'])] },
+      { heading: 'Exact', items: [item('exact', 'Tools')] },
+      { heading: 'Prefix', items: [item('prefix', 'Tools and skills')] }
+    ]
+
+    const ranked = rankPaletteGroups(groups, 'tools', 10)
+
+    expect(ranked.map(group => group.heading)).toEqual(['Exact', 'Prefix', 'Weak'])
+  })
+
+  it('keeps stronger later-group matches ahead of weak rows from the first group', () => {
+    const groups = [
+      {
+        heading: 'First',
+        items: [item('exact', 'Tools'), ...Array.from({ length: 8 }, (_, index) => item(`weak-${index}`, 'Other', ['tools']))]
+      },
+      {
+        heading: 'Second',
+        items: [item('prefix-a', 'Tools alpha'), item('prefix-b', 'Tools beta')]
+      }
+    ]
+
+    const ranked = rankPaletteGroups(groups, 'tools', 4)
+
+    expect(ranked.find(group => group.heading === 'First')?.items.map(entry => entry.id)).toEqual(['exact', 'weak-0'])
+    expect(ranked.find(group => group.heading === 'Second')?.items.map(entry => entry.id)).toEqual([
+      'prefix-a',
+      'prefix-b'
+    ])
+  })
+
+  it('round-robins equal-score capacity across groups', () => {
+    const groups = ['First', 'Second'].map(heading => ({
+      heading,
+      items: Array.from({ length: 10 }, (_, index) => item(`${heading}-${index}`, 'Tools match'))
+    }))
+
+    const ranked = rankPaletteGroups(groups, 'tools', 6)
+
+    expect(ranked.map(group => group.items.length)).toEqual([3, 3])
+  })
+
+  it('leaves curated empty-search groups intact', () => {
+    const groups = [{ heading: 'Curated', items: Array.from({ length: 70 }, (_, index) => item(String(index))) }]
+
+    expect(rankPaletteGroups(groups, '', 50)).toBe(groups)
+  })
+
+  it('does not mutate source groups or item order', () => {
+    const groups = [{ heading: 'Sessions', items: [item('second', 'Session two'), item('first', 'Session one')] }]
+    const original = groups[0]!.items.slice()
+
+    rankPaletteGroups(groups, 'session', 1)
+
+    expect(groups[0]!.items).toEqual(original)
+  })
+})

--- a/apps/desktop/src/app/command-palette/rank-groups.test.ts
+++ b/apps/desktop/src/app/command-palette/rank-groups.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { rankPaletteGroups } from './rank-groups'
 
@@ -65,6 +65,44 @@ describe('rankPaletteGroups', () => {
     const ranked = rankPaletteGroups(groups, 'tools', 6)
 
     expect(ranked.map(group => group.items.length)).toEqual([3, 3])
+  })
+
+  it('allocates an equal-score remainder independently of source group order', () => {
+    const groups = ['First', 'Second'].map(heading => ({
+      heading,
+      items: Array.from({ length: 10 }, (_, index) => item(`${heading}-${index}`, 'Tools match'))
+    }))
+
+    const countByHeading = (input: typeof groups) =>
+      new Map(rankPaletteGroups(input, 'tools', 5).map(group => [group.heading, group.items.length]))
+
+    expect(countByHeading(groups)).toEqual(countByHeading([...groups].reverse()))
+  })
+
+  it('keeps stronger matches from later groups when the global cap is reached', () => {
+    const ranked = rankPaletteGroups(
+      [
+        { heading: 'Weak', items: Array.from({ length: 20 }, (_, index) => item(`weak-${index}`, 'Other', ['tools'])) },
+        { heading: 'Strong', items: Array.from({ length: 20 }, (_, index) => item(`strong-${index}`, 'Tools option')) }
+      ],
+      'tools',
+      4
+    )
+
+    expect(ranked.find(group => group.heading === 'Strong')?.items).toHaveLength(4)
+    expect(ranked.find(group => group.heading === 'Weak')).toBeUndefined()
+  })
+
+  it('stops scoring once the cap is filled with exact matches', () => {
+    const lateLabel = vi.fn(() => 'Tools late')
+    const lateItem = { get label() { return lateLabel() } }
+    const groups = [
+      { heading: 'First', items: Array.from({ length: 3 }, (_, index) => item(`exact-${index}`, 'Tools')) },
+      { heading: 'Late', items: [lateItem] }
+    ]
+
+    expect(rankPaletteGroups(groups, 'tools', 3)).toEqual([{ heading: 'First', items: groups[0]!.items }])
+    expect(lateLabel).not.toHaveBeenCalled()
   })
 
   it('leaves curated empty-search groups intact', () => {

--- a/apps/desktop/src/app/command-palette/rank-groups.ts
+++ b/apps/desktop/src/app/command-palette/rank-groups.ts
@@ -1,0 +1,119 @@
+import { normalize } from '@/lib/text'
+
+export interface RankablePaletteItem {
+  keywords?: string[]
+  label: string
+}
+
+export interface RankablePaletteGroup<T extends RankablePaletteItem> {
+  heading?: string
+  items: T[]
+}
+
+interface NormalizedPaletteItem {
+  keywords: string[]
+  label: string
+}
+
+const SCORE_ORDER = [3, 2, 1] as const
+const normalizedItems = new WeakMap<RankablePaletteItem, NormalizedPaletteItem>()
+
+function normalizedItem(item: RankablePaletteItem): NormalizedPaletteItem {
+  const cached = normalizedItems.get(item)
+
+  if (cached) {
+    return cached
+  }
+
+  const value = {
+    keywords: (item.keywords ?? []).map(normalize),
+    label: normalize(item.label)
+  }
+
+  normalizedItems.set(item, value)
+
+  return value
+}
+
+function scoreItem(item: RankablePaletteItem, search: string): number {
+  const value = normalizedItem(item)
+
+  if (value.label === search) {
+    return 3
+  }
+
+  if (value.label.startsWith(search)) {
+    return 2
+  }
+
+  return value.label.includes(search) || value.keywords.some(keyword => keyword.includes(search)) ? 1 : 0
+}
+
+/**
+ * Rank command-palette groups while bounding the number of mounted rows.
+ *
+ * Scores have only three levels, so bucketed round-robin selection avoids a
+ * full O(n log n) sort, keeps stronger matches from later groups, and shares
+ * equal-score capacity across groups deterministically.
+ */
+export function rankPaletteGroups<T extends RankablePaletteItem>(
+  groups: Array<RankablePaletteGroup<T>>,
+  search: string,
+  maxItems = 60
+): Array<RankablePaletteGroup<T>> {
+  const normalizedSearch = normalize(search.trim())
+
+  if (!normalizedSearch) {
+    return groups
+  }
+
+  const buckets = new Map<number, T[][]>(SCORE_ORDER.map(score => [score, groups.map(() => [])]))
+
+  groups.forEach((group, groupIndex) => {
+    for (const item of group.items) {
+      const score = scoreItem(item, normalizedSearch)
+
+      if (score > 0) {
+        buckets.get(score)?.[groupIndex]?.push(item)
+      }
+    }
+  })
+
+  const selected = groups.map(() => [] as T[])
+  const highestScore = groups.map(() => 0)
+  let remaining = Math.max(0, maxItems)
+
+  for (const score of SCORE_ORDER) {
+    const groupBuckets = buckets.get(score) as T[][]
+    const cursors = groups.map(() => 0)
+    let selectedInPass = true
+
+    while (remaining > 0 && selectedInPass) {
+      selectedInPass = false
+
+      for (let groupIndex = 0; groupIndex < groups.length && remaining > 0; groupIndex += 1) {
+        const item = groupBuckets[groupIndex]?.[cursors[groupIndex] ?? 0]
+
+        if (!item) {
+          continue
+        }
+
+        selected[groupIndex]?.push(item)
+        highestScore[groupIndex] ||= score
+        cursors[groupIndex] = (cursors[groupIndex] ?? 0) + 1
+        remaining -= 1
+        selectedInPass = true
+      }
+    }
+
+    if (remaining === 0) {
+      break
+    }
+  }
+
+  return groups
+    .map((group, index) => ({ group: { ...group, items: selected[index] ?? [] }, index, score: highestScore[index] ?? 0 }))
+    .filter(entry => entry.group.items.length > 0)
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map(entry => entry.group)
+}

--- a/apps/desktop/src/app/command-palette/rank-groups.ts
+++ b/apps/desktop/src/app/command-palette/rank-groups.ts
@@ -18,6 +18,16 @@ interface NormalizedPaletteItem {
 const SCORE_ORDER = [3, 2, 1] as const
 const normalizedItems = new WeakMap<RankablePaletteItem, NormalizedPaletteItem>()
 
+function allocationOrder<T extends RankablePaletteItem>(groups: Array<RankablePaletteGroup<T>>): number[] {
+  return groups
+    .map((group, index) => ({
+      index,
+      key: normalize(group.heading ?? group.items[0]?.label ?? '')
+    }))
+    .sort((left, right) => left.key.localeCompare(right.key) || left.index - right.index)
+    .map(entry => entry.index)
+}
+
 function normalizedItem(item: RankablePaletteItem): NormalizedPaletteItem {
   const cached = normalizedItems.get(item)
 
@@ -67,21 +77,52 @@ export function rankPaletteGroups<T extends RankablePaletteItem>(
     return groups
   }
 
+  const limit = Math.max(0, Math.floor(maxItems))
+
+  if (limit === 0) {
+    return groups.map(group => ({ ...group, items: [] })).filter(group => group.items.length > 0)
+  }
+
+  // A group can contribute at most `limit` rows in total, so retaining only
+  // the first `limit` matches in each score bucket is sufficient. The scan is
+  // still global across score levels, which means a later exact/prefix match
+  // cannot be displaced by an earlier weak match. Once a group has `limit`
+  // exact matches, the rest of that group's candidates cannot enter the global
+  // result and need not be scored.
   const buckets = new Map<number, T[][]>(SCORE_ORDER.map(score => [score, groups.map(() => [])]))
 
-  groups.forEach((group, groupIndex) => {
+  let exactMatches = 0
+
+  for (const [groupIndex, group] of groups.entries()) {
     for (const item of group.items) {
       const score = scoreItem(item, normalizedSearch)
 
       if (score > 0) {
-        buckets.get(score)?.[groupIndex]?.push(item)
+        const bucket = buckets.get(score)?.[groupIndex]
+
+        if (bucket && bucket.length < limit) {
+          bucket.push(item)
+
+          if (score === SCORE_ORDER[0]) {
+            exactMatches += 1
+          }
+        }
+
+        if (score === SCORE_ORDER[0] && bucket?.length === limit) {
+          break
+        }
       }
     }
-  })
+
+    if (exactMatches === limit) {
+      break
+    }
+  }
 
   const selected = groups.map(() => [] as T[])
   const highestScore = groups.map(() => 0)
-  let remaining = Math.max(0, maxItems)
+  const order = allocationOrder(groups)
+  let remaining = limit
 
   for (const score of SCORE_ORDER) {
     const groupBuckets = buckets.get(score) as T[][]
@@ -91,7 +132,11 @@ export function rankPaletteGroups<T extends RankablePaletteItem>(
     while (remaining > 0 && selectedInPass) {
       selectedInPass = false
 
-      for (let groupIndex = 0; groupIndex < groups.length && remaining > 0; groupIndex += 1) {
+      for (const groupIndex of order) {
+        if (remaining === 0) {
+          break
+        }
+
         const item = groupBuckets[groupIndex]?.[cursors[groupIndex] ?? 0]
 
         if (!item) {

--- a/apps/desktop/src/app/command-palette/search-status.test.ts
+++ b/apps/desktop/src/app/command-palette/search-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePaletteSearchStatus } from './search-status'
+
+describe('resolvePaletteSearchStatus', () => {
+  it('reports loading while a cold search has no result yet', () => {
+    expect(
+      resolvePaletteSearchStatus(true, [
+        { hasData: false, isError: false, isPending: true },
+        { hasData: false, isError: false, isPending: false }
+      ])
+    ).toBe('loading')
+  })
+
+  it('reports an error instead of a misleading empty result', () => {
+    expect(
+      resolvePaletteSearchStatus(true, [
+        { hasData: false, isError: true, isPending: false },
+        { hasData: false, isError: false, isPending: true }
+      ])
+    ).toBe('error')
+  })
+
+  it('does not replace usable scoped data with a loading message during refetch', () => {
+    expect(resolvePaletteSearchStatus(true, [{ hasData: true, isError: false, isPending: false }])).toBeUndefined()
+    expect(resolvePaletteSearchStatus(false, [{ hasData: false, isError: false, isPending: true }])).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/command-palette/search-status.ts
+++ b/apps/desktop/src/app/command-palette/search-status.ts
@@ -1,0 +1,27 @@
+export interface PaletteQueryState {
+  hasData: boolean
+  isError: boolean
+  isPending: boolean
+}
+
+export type PaletteSearchStatus = 'error' | 'loading' | undefined
+
+/** Choose the honest empty-state status for a type-to-search request. */
+export function resolvePaletteSearchStatus(
+  enabled: boolean,
+  queries: readonly PaletteQueryState[]
+): PaletteSearchStatus {
+  if (!enabled) {
+    return undefined
+  }
+
+  if (queries.some(query => query.isError)) {
+    return 'error'
+  }
+
+  if (queries.some(query => query.isPending && !query.hasData)) {
+    return 'loading'
+  }
+
+  return undefined
+}

--- a/apps/desktop/src/app/command-palette/session-query.ts
+++ b/apps/desktop/src/app/command-palette/session-query.ts
@@ -1,0 +1,10 @@
+import type { QueryFunctionContext } from '@tanstack/react-query'
+
+import { listAllProfileSessions } from '@/api/sessions'
+
+export function commandPaletteSessionsQueryFn(
+  { signal }: Pick<QueryFunctionContext, 'signal'>,
+  archived: boolean
+) {
+  return listAllProfileSessions(200, archived ? 0 : 1, archived ? 'only' : 'exclude', 'recent', 'all', {}, signal)
+}


### PR DESCRIPTION
## Summary
- defer active and archived session queries until root search begins
- scope query caches by backend/profile and show loading/error state
- use score buckets plus fair top-k selection to cap mounted rows without a full sort

## Verification
- 8 focused ranking/palette tests
- desktop typecheck and ESLint