### PR TITLE
perf(desktop): bound markdown cache by retained text

### DIFF
--- a/apps/desktop/src/lib/markdown-blocks.test.ts
+++ b/apps/desktop/src/lib/markdown-blocks.test.ts
@@ -68,6 +68,16 @@ function mulberry32(seed: number) {
 const LONG_CORPUS = Array.from({ length: 6 }, () => CORPUS).join('\n')
 
 describe('parseMarkdownIntoBlocksCached', () => {
+  it('evicts old exact results when retained source text exceeds the character budget', () => {
+    const firstText = `weighted-cache-a:${'a'.repeat(600_000)}`
+    const secondText = `weighted-cache-b:${'b'.repeat(600_000)}`
+    const first = parseMarkdownIntoBlocksCached(firstText)
+
+    parseMarkdownIntoBlocksCached(secondText)
+
+    expect(parseMarkdownIntoBlocksCached(firstText)).not.toBe(first)
+  })
+
   it('matches a full lex at every random streaming cut (property)', () => {
     for (let seed = 1; seed <= 5; seed++) {
       const rand = mulberry32(seed)

--- a/apps/desktop/src/lib/markdown-blocks.ts
+++ b/apps/desktop/src/lib/markdown-blocks.ts
@@ -36,7 +36,9 @@ import { parseMarkdownIntoBlocks } from '@assistant-ui/react-streamdown'
  */
 
 const EXACT_CACHE_MAX = 256
+const EXACT_CACHE_MAX_CHARACTERS = 1_000_000
 const exactCache = new Map<string, string[]>()
+let exactCacheCharacters = 0
 
 // Streaming messages grow monotonically, and only a handful stream at once
 // (main reply + reasoning part, maybe a tile). A tiny ring is enough; each
@@ -129,9 +131,20 @@ export function parseMarkdownIntoBlocksCached(markdown: string): string[] {
 
   rememberAppend(markdown, blocks)
   exactCache.set(markdown, blocks)
+  exactCacheCharacters += markdown.length
 
-  if (exactCache.size > EXACT_CACHE_MAX) {
-    exactCache.delete(exactCache.keys().next().value as string)
+  // Entry count protects the short-message case; retained source characters
+  // protect long streaming prefixes, where 256 distinct keys can otherwise
+  // pin tens of megabytes. Keep the newest result even when one message alone
+  // exceeds the budget so unchanged-text identity remains stable.
+  while (
+    exactCache.size > 1 &&
+    (exactCache.size > EXACT_CACHE_MAX || exactCacheCharacters > EXACT_CACHE_MAX_CHARACTERS)
+  ) {
+    const oldest = exactCache.keys().next().value as string
+
+    exactCache.delete(oldest)
+    exactCacheCharacters -= oldest.length
   }
 
   return blocks


### PR DESCRIPTION
## Summary
- bound exact markdown-block cache retention by source characters as well as entry count
- preserve LRU behavior and the newest oversized singleton

## Verification
- 32 markdown-block parity/cache tests
- full desktop UI suite: 692 files / 6,769 tests
- desktop typecheck and ESLint