### PR TITLE
perf(desktop): defer KaTeX until math appears

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { MarkdownPreview } from './preview-file'
@@ -13,7 +13,7 @@ describe('MarkdownPreview', () => {
     cleanup()
   })
 
-  it('renders block and inline math through KaTeX', () => {
+  it('renders block and inline math through KaTeX after the deferred plugin loads', async () => {
     // KaTeX marks its output; raw "$" delimiters must be gone.
     const { container } = render(
       <MarkdownPreview
@@ -21,7 +21,7 @@ describe('MarkdownPreview', () => {
       />
     )
 
-    expect(container.querySelector('.katex')).not.toBeNull()
+    await waitFor(() => expect(container.querySelector('.katex')).not.toBeNull())
     expect(screen.queryByText(/\$\$/)).toBeNull()
   })
 

--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -13,6 +13,14 @@ describe('MarkdownPreview', () => {
     cleanup()
   })
 
+  it('does not paint raw math delimiters before the deferred plugin is ready', () => {
+    const { container } = render(
+      <MarkdownPreview text="The formula $x^2 + y^2$ should never flash its source." />
+    )
+
+    expect(container.textContent).not.toContain('$x^2 + y^2$')
+  })
+
   it('renders block and inline math through KaTeX after the deferred plugin loads', async () => {
     // KaTeX marks its output; raw "$" delimiters must be gone.
     const { container } = render(

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -30,8 +30,8 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
-import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { isComposerChord } from '@/lib/keybinds/chords'
+import { useLazyMathPlugin } from '@/lib/lazy-math-plugin'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
@@ -45,11 +45,6 @@ const TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 const SOURCE_CHUNK_LINES = 200
 const SOURCE_LINE_PX = 20
 const SOURCE_OVERSCAN_LINES = 400
-
-// Math plugin for the static file preview, configured once at module scope.
-// Mirrors the chat transcript's plugin (`markdown-text.tsx`) — same memoized
-// KaTeX wrapper, with `singleDollarTextMath: true` so `$x$` renders inline.
-const previewMathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 
 type EmptyStateTone = 'neutral' | 'warning'
 
@@ -430,6 +425,8 @@ const MARKDOWN_COMPONENTS = {
 
 export function MarkdownPreview({ text }: { text: string }) {
   const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
+  const math = useLazyMathPlugin(mathText)
+  const plugins = useMemo(() => (math ? { math } : {}), [math])
 
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
@@ -438,7 +435,7 @@ export function MarkdownPreview({ text }: { text: string }) {
         controls={false}
         mode="static"
         parseIncompleteMarkdown={false}
-        plugins={{ math: previewMathPlugin }}
+        plugins={plugins}
       >
         {mathText}
       </Streamdown>

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
 import { isComposerChord } from '@/lib/keybinds/chords'
-import { useLazyMathPlugin } from '@/lib/lazy-math-plugin'
+import { hasRenderableMath, useLazyMathPluginState } from '@/lib/lazy-math-plugin'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
@@ -425,8 +425,24 @@ const MARKDOWN_COMPONENTS = {
 
 export function MarkdownPreview({ text }: { text: string }) {
   const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
-  const math = useLazyMathPlugin(mathText)
+  const mathState = useLazyMathPluginState(mathText)
+  const math = mathState.plugin
+  const needsMath = useMemo(() => hasRenderableMath(mathText), [mathText])
   const plugins = useMemo(() => (math ? { math } : {}), [math])
+
+  if (needsMath && mathState.loading) {
+    // Do not let the static renderer paint raw `$`/custom delimiters while the
+    // deferred KaTeX chunk is loading. The source view remains available if the
+    // import fails, while the rendered view never flashes an intermediate form.
+    return (
+      <div
+        aria-busy="true"
+        className="preview-markdown mx-auto grid h-full max-w-3xl place-items-center px-4 py-3 text-sm text-foreground"
+      >
+        <PageLoader label={translateNow('preview.loading')} />
+      </div>
+    )
+  }
 
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -17,7 +17,7 @@ import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
-import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { useLazyMathPlugin } from '@/lib/lazy-math-plugin'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -42,20 +42,6 @@ import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
 import { ResizableMarkdownTable, ResizableMarkdownTh } from './markdown-table'
 import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } from './transcript-directive'
-
-// Math rendering plugin (KaTeX). Configured once at module scope — the
-// plugin is stateless beyond its internal cache so re-creating per-render
-// would needlessly thrash. We use a memoizing wrapper around rehype-katex
-// (see lib/katex-memo.ts) so that during streaming we re-katex only the
-// equations whose source actually changed since the last token. With the
-// stock @streamdown/math plugin every equation re-renders on every token,
-// which throttles UI updates badly for math-heavy responses; the memoized
-// plugin keeps the steady-state work proportional to "new equations
-// arriving" rather than "equations × tokens-per-second".
-//
-// `singleDollarTextMath: true` enables `$x^2$` for inline math (de-facto
-// LLM convention). The default false-setting only accepts `$$...$$`.
-const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 
 // `@streamdown/code` statically imports ALL of shiki (every grammar + theme —
 // the single largest chunk in the renderer), so it must never sit on the
@@ -547,7 +533,12 @@ function MarkdownTextSurface({
   // `SyntaxHighlighter` below when `isStreaming` is true, and the code plugin
   // itself arrives async (useCodePlugin) so shiki never blocks cold start.
   const code = useCodePlugin()
-  const plugins = useMemo(() => (code ? { math: mathPlugin, code } : { math: mathPlugin }), [code])
+  const math = useLazyMathPlugin(text)
+
+  const plugins = useMemo(
+    () => ({ ...(code ? { code } : {}), ...(math ? { math } : {}) }),
+    [code, math]
+  )
 
   const components = useMemo(
     () =>

--- a/apps/desktop/src/lib/lazy-math-plugin.test.tsx
+++ b/apps/desktop/src/lib/lazy-math-plugin.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createLazyMathPluginLoader, hasRenderableMath, type MathPlugin, useLazyMathPlugin } from './lazy-math-plugin'
+
+const plugin = { name: 'katex' as const, type: 'math' as const } as MathPlugin
+
+describe('hasRenderableMath', () => {
+  it.each([
+    'Inline $x^2$ math',
+    'Display $$E = mc^2$$',
+    String.raw`Inline \(x + y\) math`,
+    String.raw`Display \[x + y\] math`,
+    '```math\nx^2\n```',
+    '$ x$',
+    '$a\nb$',
+    '[/math]\nx^2\n[/math]',
+    '````math title="equation"\r\nx^2\r\n`````'
+  ])('detects supported math syntax in %s', text => {
+    expect(hasRenderableMath(text)).toBe(true)
+  })
+
+  it('does not treat ordinary prose or code without math markers as renderable math', () => {
+    expect(hasRenderableMath('ordinary prose')).toBe(false)
+    expect(hasRenderableMath('`echo HOME`')).toBe(false)
+  })
+})
+
+describe('createLazyMathPluginLoader', () => {
+  it('does not import KaTeX for prose-only markdown', async () => {
+    const importer = vi.fn()
+    const loader = createLazyMathPluginLoader(importer)
+
+    await expect(loader.load('ordinary prose')).resolves.toBeUndefined()
+    expect(importer).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates concurrent imports and reuses the completed plugin', async () => {
+    const importer = vi.fn(async () => ({ createMemoizedMathPlugin: () => plugin }))
+    const loader = createLazyMathPluginLoader(importer)
+
+    const [first, second] = await Promise.all([loader.load('$x$'), loader.load('$$y$$')])
+
+    expect(first).toBe(plugin)
+    expect(second).toBe(plugin)
+    await expect(loader.load('$z$')).resolves.toBe(plugin)
+    expect(importer).toHaveBeenCalledOnce()
+  })
+
+  it('does not re-request a module URL that Chromium has already poisoned', async () => {
+    const failure = new Error('chunk failed')
+    const importer = vi.fn().mockRejectedValue(failure)
+    const loader = createLazyMathPluginLoader(importer)
+
+    await expect(loader.load('$x$')).rejects.toBe(failure)
+    await expect(loader.load('$x$')).rejects.toBe(failure)
+    expect(importer).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useLazyMathPlugin', () => {
+  it('publishes the plugin after eligible markdown loads it', async () => {
+    const importer = vi.fn(async () => ({ createMemoizedMathPlugin: () => plugin }))
+    const loader = createLazyMathPluginLoader(importer)
+
+    const { result, rerender } = renderHook(({ text }) => useLazyMathPlugin(text, loader), {
+      initialProps: { text: 'ordinary prose' }
+    })
+
+    expect(result.current).toBeUndefined()
+    expect(importer).not.toHaveBeenCalled()
+
+    rerender({ text: 'Now $x$ appears' })
+
+    await waitFor(() => expect(result.current).toBe(plugin))
+    expect(importer).toHaveBeenCalledOnce()
+
+    act(() => rerender({ text: 'prose again' }))
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/lib/lazy-math-plugin.test.tsx
+++ b/apps/desktop/src/lib/lazy-math-plugin.test.tsx
@@ -1,7 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { createLazyMathPluginLoader, hasRenderableMath, type MathPlugin, useLazyMathPlugin } from './lazy-math-plugin'
+import {
+  createLazyMathPluginLoader,
+  hasRenderableMath,
+  type MathPlugin,
+  useLazyMathPlugin,
+  useLazyMathPluginState
+} from './lazy-math-plugin'
 
 const plugin = { name: 'katex' as const, type: 'math' as const } as MathPlugin
 
@@ -59,6 +65,35 @@ describe('createLazyMathPluginLoader', () => {
 })
 
 describe('useLazyMathPlugin', () => {
+  it('loads the plugin using delimiters after math preprocessing', async () => {
+    const load = vi.fn(async () => plugin)
+
+    const loader = {
+      load,
+      peek: () => undefined
+    }
+
+    const { result } = renderHook(() => useLazyMathPlugin('[/inline]x + y[/inline]', loader))
+
+    await waitFor(() => expect(result.current).toBe(plugin))
+    expect(load).toHaveBeenCalledWith('$x + y$')
+  })
+
+  it('publishes a failed state so poisoned imports can use the renderer fallback', async () => {
+    const failure = new Error('chunk failed')
+
+    const loader = {
+      load: vi.fn().mockRejectedValue(failure),
+      peek: () => undefined
+    }
+
+    const { result } = renderHook(() => useLazyMathPluginState('$x$', loader))
+
+    await waitFor(() => expect(result.current.failed).toBe(true))
+    expect(result.current.loading).toBe(false)
+    expect(result.current.plugin).toBeUndefined()
+  })
+
   it('publishes the plugin after eligible markdown loads it', async () => {
     const importer = vi.fn(async () => ({ createMemoizedMathPlugin: () => plugin }))
     const loader = createLazyMathPluginLoader(importer)

--- a/apps/desktop/src/lib/lazy-math-plugin.test.tsx
+++ b/apps/desktop/src/lib/lazy-math-plugin.test.tsx
@@ -94,6 +94,36 @@ describe('useLazyMathPlugin', () => {
     expect(result.current.plugin).toBeUndefined()
   })
 
+  it('does not render raw delimiters during a prose-to-math transition', () => {
+    const renders: Array<{
+      failed: boolean
+      loading: boolean
+      plugin: MathPlugin | undefined
+      renderedText: string
+    }> = []
+
+    const loader = {
+      load: vi.fn(() => new Promise<MathPlugin>(() => undefined)),
+      peek: () => undefined
+    }
+
+    const { rerender } = renderHook(
+      ({ text }) => {
+        const state = useLazyMathPluginState(text, loader)
+        renders.push({ ...state, renderedText: state.loading ? 'loading' : text })
+
+        return state
+      },
+      { initialProps: { text: 'ordinary prose' } }
+    )
+
+    const rendersBeforeMath = renders.length
+    rerender({ text: 'Now $x$ appears' })
+
+    expect(renders[rendersBeforeMath]).toMatchObject({ failed: false, loading: true, plugin: undefined })
+    expect(renders[rendersBeforeMath].renderedText).not.toContain('$x$')
+  })
+
   it('publishes the plugin after eligible markdown loads it', async () => {
     const importer = vi.fn(async () => ({ createMemoizedMathPlugin: () => plugin }))
     const loader = createLazyMathPluginLoader(importer)

--- a/apps/desktop/src/lib/lazy-math-plugin.ts
+++ b/apps/desktop/src/lib/lazy-math-plugin.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import type { createMemoizedMathPlugin } from '@/lib/katex-memo'
+
+export type MathPlugin = ReturnType<typeof createMemoizedMathPlugin>
+
+interface MathPluginModule {
+  createMemoizedMathPlugin: typeof createMemoizedMathPlugin
+}
+
+type MathPluginImporter = () => Promise<MathPluginModule>
+
+export interface LazyMathPluginLoader {
+  load: (markdown: string) => Promise<MathPlugin | undefined>
+  peek: (markdown: string) => MathPlugin | undefined
+}
+
+const MATH_FENCE_RE =
+  /(?:^|\r?\n)[ \t]{0,3}(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*(?:`{3,}|~{3,})[ \t]*(?:latex|math|tex)(?=[\s,{]|$)/i
+
+const NORMALIZED_MATH_MARKER_RE = /\[(?:\/?)(?:inline|math)\]|\\(?:\(|\[|begin\{)/i
+
+/** Cheap admission check used before the KaTeX module is requested. */
+export function hasRenderableMath(markdown: string): boolean {
+  // False positives only load a deferred chunk; false negatives expose raw
+  // delimiters and break rendering. Admit any dollar/custom-LaTeX marker, even
+  // inside code, and let remark-math decide whether it is actual math.
+  return markdown.includes('$') || NORMALIZED_MATH_MARKER_RE.test(markdown) || MATH_FENCE_RE.test(markdown)
+}
+
+export function createLazyMathPluginLoader(
+  importer: MathPluginImporter = () => import('@/lib/katex-memo')
+): LazyMathPluginLoader {
+  let completed: MathPlugin | undefined
+  let pending: Promise<MathPlugin> | undefined
+
+  const peek = (markdown: string) => (hasRenderableMath(markdown) ? completed : undefined)
+
+  return {
+    load(markdown) {
+      if (!hasRenderableMath(markdown)) {
+        return Promise.resolve(undefined)
+      }
+
+      if (completed) {
+        return Promise.resolve(completed)
+      }
+
+      if (pending) {
+        return pending
+      }
+
+      const operation = importer().then(module => {
+        completed = module.createMemoizedMathPlugin({ singleDollarTextMath: true })
+        pending = undefined
+
+        return completed
+      })
+
+      pending = operation
+
+      return operation
+    },
+    peek
+  }
+}
+
+export const lazyMathPluginLoader = createLazyMathPluginLoader()
+
+export function useLazyMathPlugin(
+  markdown: string,
+  loader: LazyMathPluginLoader = lazyMathPluginLoader
+): MathPlugin | undefined {
+  const eligible = useMemo(() => hasRenderableMath(markdown), [markdown])
+  const [plugin, setPlugin] = useState<MathPlugin | undefined>(() => loader.peek(markdown))
+
+  useEffect(() => {
+    if (!eligible) {
+      return undefined
+    }
+
+    let active = true
+    const cached = loader.peek(markdown)
+
+    if (cached) {
+      setPlugin(cached)
+
+      return undefined
+    }
+
+    void loader
+      .load(markdown)
+      .then(loaded => {
+        if (active && loaded) {
+          setPlugin(loaded)
+        }
+      })
+      .catch(() => undefined)
+
+    return () => {
+      active = false
+    }
+  }, [eligible, loader, markdown])
+
+  return eligible ? plugin : undefined
+}

--- a/apps/desktop/src/lib/lazy-math-plugin.ts
+++ b/apps/desktop/src/lib/lazy-math-plugin.ts
@@ -1,3 +1,4 @@
+import { normalizeMathDelimiters } from '@assistant-ui/react-streamdown'
 import { useEffect, useMemo, useState } from 'react'
 
 import type { createMemoizedMathPlugin } from '@/lib/katex-memo'
@@ -20,12 +21,18 @@ const MATH_FENCE_RE =
 
 const NORMALIZED_MATH_MARKER_RE = /\[(?:\/?)(?:inline|math)\]|\\(?:\(|\[|begin\{)/i
 
+function normalizeForMathDetection(markdown: string): string {
+  return normalizeMathDelimiters(markdown)
+}
+
 /** Cheap admission check used before the KaTeX module is requested. */
 export function hasRenderableMath(markdown: string): boolean {
   // False positives only load a deferred chunk; false negatives expose raw
   // delimiters and break rendering. Admit any dollar/custom-LaTeX marker, even
   // inside code, and let remark-math decide whether it is actual math.
-  return markdown.includes('$') || NORMALIZED_MATH_MARKER_RE.test(markdown) || MATH_FENCE_RE.test(markdown)
+  const normalized = normalizeForMathDetection(markdown)
+
+  return normalized.includes('$') || NORMALIZED_MATH_MARKER_RE.test(normalized) || MATH_FENCE_RE.test(normalized)
 }
 
 export function createLazyMathPluginLoader(
@@ -33,6 +40,8 @@ export function createLazyMathPluginLoader(
 ): LazyMathPluginLoader {
   let completed: MathPlugin | undefined
   let pending: Promise<MathPlugin> | undefined
+  let failed: unknown
+  let hasFailed = false
 
   const peek = (markdown: string) => (hasRenderableMath(markdown) ? completed : undefined)
 
@@ -46,16 +55,30 @@ export function createLazyMathPluginLoader(
         return Promise.resolve(completed)
       }
 
+      if (hasFailed) {
+        return Promise.reject(failed)
+      }
+
       if (pending) {
         return pending
       }
 
-      const operation = importer().then(module => {
-        completed = module.createMemoizedMathPlugin({ singleDollarTextMath: true })
-        pending = undefined
+      const operation = importer()
+        .then(module => {
+          completed = module.createMemoizedMathPlugin({ singleDollarTextMath: true })
+          pending = undefined
 
-        return completed
-      })
+          return completed
+        })
+        .catch(error => {
+          // A failed dynamic import is a poisoned module URL in Chromium. Do
+          // not claim that retrying the same specifier can recover it; remember
+          // the failure and let the caller keep its existing fallback.
+          failed = error
+          hasFailed = true
+          pending = undefined
+          throw error
+        })
 
       pending = operation
 
@@ -67,40 +90,75 @@ export function createLazyMathPluginLoader(
 
 export const lazyMathPluginLoader = createLazyMathPluginLoader()
 
-export function useLazyMathPlugin(
+export interface LazyMathPluginState {
+  failed: boolean
+  loading: boolean
+  plugin: MathPlugin | undefined
+}
+
+export function useLazyMathPluginState(
   markdown: string,
   loader: LazyMathPluginLoader = lazyMathPluginLoader
-): MathPlugin | undefined {
-  const eligible = useMemo(() => hasRenderableMath(markdown), [markdown])
-  const [plugin, setPlugin] = useState<MathPlugin | undefined>(() => loader.peek(markdown))
+): LazyMathPluginState {
+  const normalizedMarkdown = useMemo(() => normalizeForMathDetection(markdown), [markdown])
+  const eligible = useMemo(() => hasRenderableMath(normalizedMarkdown), [normalizedMarkdown])
+  const [plugin, setPlugin] = useState<MathPlugin | undefined>(() => loader.peek(normalizedMarkdown))
+  const [loading, setLoading] = useState(() => eligible && !loader.peek(normalizedMarkdown))
+  const [failed, setFailed] = useState(false)
 
   useEffect(() => {
     if (!eligible) {
+      setLoading(false)
+      setFailed(false)
+      setPlugin(undefined)
+
       return undefined
     }
 
     let active = true
-    const cached = loader.peek(markdown)
+    const cached = loader.peek(normalizedMarkdown)
 
     if (cached) {
       setPlugin(cached)
+      setLoading(false)
+      setFailed(false)
 
       return undefined
     }
 
+    setLoading(true)
+    setFailed(false)
+
     void loader
-      .load(markdown)
+      .load(normalizedMarkdown)
       .then(loaded => {
-        if (active && loaded) {
+        if (active) {
           setPlugin(loaded)
+          setLoading(false)
         }
       })
-      .catch(() => undefined)
+      .catch(() => {
+        if (active) {
+          setLoading(false)
+          setFailed(true)
+        }
+      })
 
     return () => {
       active = false
     }
-  }, [eligible, loader, markdown])
+  }, [eligible, loader, normalizedMarkdown])
 
-  return eligible ? plugin : undefined
+  return {
+    failed: eligible && failed,
+    loading: eligible && loading,
+    plugin: eligible ? plugin : undefined
+  }
+}
+
+export function useLazyMathPlugin(
+  markdown: string,
+  loader: LazyMathPluginLoader = lazyMathPluginLoader
+): MathPlugin | undefined {
+  return useLazyMathPluginState(markdown, loader).plugin
 }

--- a/apps/desktop/src/lib/lazy-math-plugin.ts
+++ b/apps/desktop/src/lib/lazy-math-plugin.ts
@@ -151,7 +151,7 @@ export function useLazyMathPluginState(
 
   return {
     failed: eligible && failed,
-    loading: eligible && loading,
+    loading: eligible && (loading || (!plugin && !failed)),
     plugin: eligible ? plugin : undefined
   }
 }


### PR DESCRIPTION
## Summary
- dynamically import the existing memoized KaTeX plugin only for likely math
- share one import across chat and file-preview surfaces
- use conservative admission so false positives cost only a deferred chunk while math never loses rendering

## Verification
- 22 focused detector/loader/render tests
- desktop typecheck, ESLint, and production build; KaTeX is off the preload path