### PR TITLE
perf(desktop): lazy-load active locale catalog

### DIFF
--- a/apps/desktop/src/i18n/catalog.test.ts
+++ b/apps/desktop/src/i18n/catalog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createTranslationCatalog } from './catalog'
+import type { Locale, Translations } from './types'
+
+const translations = (label: string) => ({ settings: { language: { label } } }) as unknown as Translations
+
+describe('createTranslationCatalog', () => {
+  it('returns English synchronously without importing another locale', () => {
+    const english = translations('Language')
+    const importJa = vi.fn()
+    const catalog = createTranslationCatalog(english, { ja: importJa })
+
+    expect(catalog.get('en')).toBe(english)
+    expect(catalog.get('ja')).toBe(english)
+    expect(importJa).not.toHaveBeenCalled()
+  })
+
+  it('loads only the requested locale and deduplicates concurrent loads', async () => {
+    const japanese = translations('言語')
+    const importJa = vi.fn(async () => japanese)
+    const importZh = vi.fn(async () => translations('语言'))
+    const catalog = createTranslationCatalog(translations('Language'), { ja: importJa, zh: importZh })
+
+    const [first, second] = await Promise.all([catalog.load('ja'), catalog.load('ja')])
+
+    expect(first).toBe(japanese)
+    expect(second).toBe(japanese)
+    expect(catalog.get('ja')).toBe(japanese)
+    expect(importJa).toHaveBeenCalledOnce()
+    expect(importZh).not.toHaveBeenCalled()
+  })
+
+  it('does not re-request a locale module URL that Chromium has already poisoned', async () => {
+    const failure = new Error('chunk failed')
+    const importJa = vi.fn().mockRejectedValue(failure)
+    const catalog = createTranslationCatalog(translations('Language'), { ja: importJa })
+
+    await expect(catalog.load('ja')).rejects.toBe(failure)
+    await expect(catalog.load('ja')).rejects.toBe(failure)
+    expect(importJa).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a locale without an importer instead of committing mixed-language state', async () => {
+    const catalog = createTranslationCatalog(translations('Language'), {})
+
+    await expect(catalog.load('ar' as Locale)).rejects.toThrow('No translation catalog for ar')
+  })
+})

--- a/apps/desktop/src/i18n/catalog.test.ts
+++ b/apps/desktop/src/i18n/catalog.test.ts
@@ -1,18 +1,29 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createTranslationCatalog } from './catalog'
+import { createTranslationCatalog, type TranslationImporters, TRANSLATIONS } from './catalog'
 import type { Locale, Translations } from './types'
 
 const translations = (label: string) => ({ settings: { language: { label } } }) as unknown as Translations
+
+const importers = (overrides: Partial<TranslationImporters> = {}): TranslationImporters => ({
+  ar: async () => translations('ar'),
+  ja: async () => translations('ja'),
+  zh: async () => translations('zh'),
+  'zh-hant': async () => translations('zh-hant'),
+  ...overrides
+})
 
 describe('createTranslationCatalog', () => {
   it('returns English synchronously without importing another locale', () => {
     const english = translations('Language')
     const importJa = vi.fn()
-    const catalog = createTranslationCatalog(english, { ja: importJa })
+    const catalog = createTranslationCatalog(english, importers({ ja: importJa }))
 
     expect(catalog.get('en')).toBe(english)
-    expect(catalog.get('ja')).toBe(english)
+    expect(catalog.get('ja')).not.toBe(english)
+    expect(catalog.get('ja')).toStrictEqual(english)
+    expect(TRANSLATIONS.ja).not.toBe(TRANSLATIONS.en)
+    expect(TRANSLATIONS.ja).toStrictEqual(TRANSLATIONS.en)
     expect(importJa).not.toHaveBeenCalled()
   })
 
@@ -20,7 +31,7 @@ describe('createTranslationCatalog', () => {
     const japanese = translations('言語')
     const importJa = vi.fn(async () => japanese)
     const importZh = vi.fn(async () => translations('语言'))
-    const catalog = createTranslationCatalog(translations('Language'), { ja: importJa, zh: importZh })
+    const catalog = createTranslationCatalog(translations('Language'), importers({ ja: importJa, zh: importZh }))
 
     const [first, second] = await Promise.all([catalog.load('ja'), catalog.load('ja')])
 
@@ -31,18 +42,33 @@ describe('createTranslationCatalog', () => {
     expect(importZh).not.toHaveBeenCalled()
   })
 
-  it('does not re-request a locale module URL that Chromium has already poisoned', async () => {
+  it('allows a failed locale import to be retried after the failure settles', async () => {
     const failure = new Error('chunk failed')
-    const importJa = vi.fn().mockRejectedValue(failure)
-    const catalog = createTranslationCatalog(translations('Language'), { ja: importJa })
+    const japanese = translations('言語')
+    const importJa = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce(japanese)
+    const catalog = createTranslationCatalog(translations('Language'), importers({ ja: importJa }))
 
     await expect(catalog.load('ja')).rejects.toBe(failure)
-    await expect(catalog.load('ja')).rejects.toBe(failure)
-    expect(importJa).toHaveBeenCalledOnce()
+    await expect(catalog.load('ja')).resolves.toBe(japanese)
+    expect(importJa).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives each unloaded locale an isolated English fallback', () => {
+    const english = translations('Language')
+    const catalog = createTranslationCatalog(english, importers({ ja: vi.fn() }))
+    const fallback = catalog.get('ja')
+
+    expect(fallback).not.toBe(english)
+    ;(fallback.settings as unknown as { language: { label: string } }).language.label = 'Mutated fallback'
+
+    expect((catalog.get('en').settings as unknown as { language: { label: string } }).language.label).toBe('Language')
+    expect((catalog.get('ja').settings as unknown as { language: { label: string } }).language.label).toBe(
+      'Mutated fallback'
+    )
   })
 
   it('rejects a locale without an importer instead of committing mixed-language state', async () => {
-    const catalog = createTranslationCatalog(translations('Language'), {})
+    const catalog = createTranslationCatalog(translations('Language'), {} as never)
 
     await expect(catalog.load('ar' as Locale)).rejects.toThrow('No translation catalog for ar')
   })

--- a/apps/desktop/src/i18n/catalog.ts
+++ b/apps/desktop/src/i18n/catalog.ts
@@ -1,14 +1,65 @@
-import { ar } from './ar'
 import { en } from './en'
-import { ja } from './ja'
 import type { Locale, Translations } from './types'
-import { zh } from './zh'
-import { zhHant } from './zh-hant'
 
-export const TRANSLATIONS: Record<Locale, Translations> = {
-  en,
-  zh,
-  'zh-hant': zhHant,
-  ja,
-  ar
+type TranslationImporter = () => Promise<Translations>
+type TranslationImporters = Partial<Record<Exclude<Locale, 'en'>, TranslationImporter>>
+
+export interface TranslationCatalog {
+  get: (locale: Locale) => Translations
+  load: (locale: Locale) => Promise<Translations>
 }
+
+export function createTranslationCatalog(
+  english: Translations,
+  importers: TranslationImporters
+): TranslationCatalog {
+  const loaded: Partial<Record<Locale, Translations>> = { en: english }
+  const pending: Partial<Record<Locale, Promise<Translations>>> = {}
+
+  const get = (locale: Locale) => loaded[locale] ?? english
+
+  const load = (locale: Locale): Promise<Translations> => {
+    const completed = loaded[locale]
+
+    if (completed) {
+      return Promise.resolve(completed)
+    }
+
+    const inFlight = pending[locale]
+
+    if (inFlight) {
+      return inFlight
+    }
+
+    const importer = locale === 'en' ? undefined : importers[locale]
+
+    if (!importer) {
+      return Promise.reject(new Error(`No translation catalog for ${locale}`))
+    }
+
+    const operation = importer().then(translations => {
+      loaded[locale] = translations
+      delete pending[locale]
+
+      return translations
+    })
+
+    pending[locale] = operation
+
+    return operation
+  }
+
+  return { get, load }
+}
+
+const localeImporters = {
+  ar: () => import('./ar').then(module => module.ar),
+  ja: () => import('./ja').then(module => module.ja),
+  zh: () => import('./zh').then(module => module.zh),
+  'zh-hant': () => import('./zh-hant').then(module => module.zhHant)
+} satisfies Record<Exclude<Locale, 'en'>, TranslationImporter>
+
+const catalog = createTranslationCatalog(en, localeImporters)
+
+export const getTranslations = catalog.get
+export const loadTranslations = catalog.load

--- a/apps/desktop/src/i18n/catalog.ts
+++ b/apps/desktop/src/i18n/catalog.ts
@@ -2,11 +2,28 @@ import { en } from './en'
 import type { Locale, Translations } from './types'
 
 type TranslationImporter = () => Promise<Translations>
-type TranslationImporters = Partial<Record<Exclude<Locale, 'en'>, TranslationImporter>>
+export type TranslationImporters = Record<Exclude<Locale, 'en'>, TranslationImporter>
 
 export interface TranslationCatalog {
+  /** Return the loaded catalog, or an isolated English fallback while loading. */
   get: (locale: Locale) => Translations
   load: (locale: Locale) => Promise<Translations>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cloneTranslationTree<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneTranslationTree(item)) as T
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneTranslationTree(item)])) as T
+  }
+
+  return value
 }
 
 export function createTranslationCatalog(
@@ -14,11 +31,37 @@ export function createTranslationCatalog(
   importers: TranslationImporters
 ): TranslationCatalog {
   const loaded: Partial<Record<Locale, Translations>> = { en: english }
-  const pending: Partial<Record<Locale, Promise<Translations>>> = {}
+  const fallbacks: Partial<Record<Exclude<Locale, 'en'>, Translations>> = {}
+  const pending: Partial<Record<Exclude<Locale, 'en'>, Promise<Translations>>> = {}
 
-  const get = (locale: Locale) => loaded[locale] ?? english
+  const get = (locale: Locale) => {
+    if (locale === 'en') {
+      return english
+    }
+
+    const completed = loaded[locale]
+
+    if (completed) {
+      return completed
+    }
+
+    const fallback = fallbacks[locale]
+
+    if (fallback) {
+      return fallback
+    }
+
+    const isolatedFallback = cloneTranslationTree(english)
+    fallbacks[locale] = isolatedFallback
+
+    return isolatedFallback
+  }
 
   const load = (locale: Locale): Promise<Translations> => {
+    if (locale === 'en') {
+      return Promise.resolve(english)
+    }
+
     const completed = loaded[locale]
 
     if (completed) {
@@ -31,18 +74,22 @@ export function createTranslationCatalog(
       return inFlight
     }
 
-    const importer = locale === 'en' ? undefined : importers[locale]
+    const importer = importers[locale]
 
     if (!importer) {
       return Promise.reject(new Error(`No translation catalog for ${locale}`))
     }
 
-    const operation = importer().then(translations => {
-      loaded[locale] = translations
-      delete pending[locale]
+    const operation = Promise.resolve()
+      .then(() => importer())
+      .then(translations => {
+        loaded[locale] = translations
 
-      return translations
-    })
+        return translations
+      })
+      .finally(() => {
+        delete pending[locale]
+      })
 
     pending[locale] = operation
 
@@ -63,3 +110,27 @@ const catalog = createTranslationCatalog(en, localeImporters)
 
 export const getTranslations = catalog.get
 export const loadTranslations = catalog.load
+
+/**
+ * Backwards-compatible synchronous view of the locale catalogs. A locale that
+ * has not finished loading returns a detached English fallback; loading it
+ * replaces that view with the real catalog without sharing mutable trees with
+ * English.
+ */
+export const TRANSLATIONS: Record<Locale, Translations> = {
+  get en() {
+    return getTranslations('en')
+  },
+  get zh() {
+    return getTranslations('zh')
+  },
+  get 'zh-hant'() {
+    return getTranslations('zh-hant')
+  },
+  get ja() {
+    return getTranslations('ja')
+  },
+  get ar() {
+    return getTranslations('ar')
+  }
+}

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConfigRecord } from '@/hermes'
@@ -19,6 +19,22 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
       <p data-testid="save-error">{saveError?.message ?? ''}</p>
       <button onClick={() => void setLocale(target).catch(() => undefined)} type="button">
         switch
+      </button>
+    </div>
+  )
+}
+
+function RapidSwitchProbe() {
+  const { locale, setLocale } = useI18n()
+
+  return (
+    <div>
+      <p data-testid="locale">{locale}</p>
+      <button onClick={() => void setLocale('ja').catch(() => undefined)} type="button">
+        Japanese
+      </button>
+      <button onClick={() => void setLocale('zh').catch(() => undefined)} type="button">
+        Chinese
       </button>
     </div>
   )
@@ -48,7 +64,7 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
-    expect(screen.getByTestId('locale').textContent).toBe('zh')
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'))
     expect(screen.getByTestId('label').textContent).toBe('语言')
 
     fireEvent.click(screen.getByRole('button', { name: 'switch' }))
@@ -209,6 +225,71 @@ describe('I18nProvider', () => {
     expect(screen.getByTestId('locale').textContent).toBe('ja')
   })
 
+  it('does not let a late config load overwrite an explicit locale choice', async () => {
+    let resolveInitialConfig!: (config: HermesConfigRecord) => void
+
+    const initialConfig = new Promise<HermesConfigRecord>(resolve => {
+      resolveInitialConfig = resolve
+    })
+
+    const saveConfig = vi.fn().mockResolvedValue({ ok: true })
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockReturnValueOnce(initialConfig).mockResolvedValueOnce({ display: { language: 'en' } }),
+      saveConfig
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe target="ja" />
+      </I18nProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }))
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('ja'))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+
+    resolveInitialConfig({ display: { language: 'zh' } })
+    await act(async () => Promise.resolve())
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('ja')
+  })
+
+  it('serializes saves so a slower earlier switch cannot overwrite the latest choice', async () => {
+    let finishFirstSave!: (result: { ok: boolean }) => void
+
+    const firstSave = new Promise<{ ok: boolean }>(resolve => {
+      finishFirstSave = resolve
+    })
+
+    const saveConfig = vi.fn().mockReturnValueOnce(firstSave).mockResolvedValueOnce({ ok: true })
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'en' } }),
+      saveConfig
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <RapidSwitchProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('en'))
+    fireEvent.click(screen.getByRole('button', { name: 'Japanese' }))
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('ja'))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chinese' }))
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'))
+    expect(saveConfig).toHaveBeenCalledTimes(1)
+
+    finishFirstSave({ ok: true })
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(2))
+    expect(saveConfig.mock.calls[1]?.[0]).toMatchObject({ display: { language: 'zh' } })
+  })
+
   it('applies RTL direction for Arabic and restores LTR on switch back', async () => {
     render(
       <I18nProvider configClient={null} initialLocale="ar">
@@ -216,15 +297,15 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
-    expect(screen.getByTestId('locale').textContent).toBe('ar')
-    expect(document.documentElement.dir).toBe('rtl')
-    expect(document.documentElement.lang).toBe('ar')
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('ar'))
+    expect(window.document.documentElement.dir).toBe('rtl')
+    expect(window.document.documentElement.lang).toBe('ar')
 
     fireEvent.click(screen.getByRole('button', { name: 'switch' }))
 
     await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('en'))
-    expect(document.documentElement.dir).toBe('ltr')
-    expect(document.documentElement.lang).toBe('en')
+    expect(window.document.documentElement.dir).toBe('ltr')
+    expect(window.document.documentElement.lang).toBe('en')
   })
 
   it('rolls back the visible locale when saving fails', async () => {

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConfigRecord } from '@/hermes'
@@ -25,11 +26,13 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
 }
 
 function RapidSwitchProbe() {
-  const { locale, setLocale } = useI18n()
+  const { isSavingLocale, locale, saveError, setLocale } = useI18n()
 
   return (
     <div>
       <p data-testid="locale">{locale}</p>
+      <p data-testid="saving">{String(isSavingLocale)}</p>
+      <p data-testid="save-error">{saveError?.message ?? ''}</p>
       <button onClick={() => void setLocale('ja').catch(() => undefined)} type="button">
         Japanese
       </button>
@@ -40,10 +43,35 @@ function RapidSwitchProbe() {
   )
 }
 
+function ImmediateSwitchProbe() {
+  const { locale, setLocale } = useI18n()
+
+  useLayoutEffect(() => {
+    void setLocale('ar').catch(() => undefined)
+  }, [setLocale])
+
+  return <p data-testid="locale">{locale}</p>
+}
+
 describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+  })
+
+  it('does not let an initial config effect supersede an earlier explicit choice', async () => {
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'zh' } }),
+      saveConfig: vi.fn().mockResolvedValue({ ok: true })
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <ImmediateSwitchProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('ar'))
   })
 
   it('defaults to English without a config client', () => {
@@ -288,6 +316,47 @@ describe('I18nProvider', () => {
     finishFirstSave({ ok: true })
     await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(2))
     expect(saveConfig.mock.calls[1]?.[0]).toMatchObject({ display: { language: 'zh' } })
+  })
+
+  it('does not publish a stale save failure over a newer switch', async () => {
+    let finishFirstSave!: (error?: Error) => void
+    let finishSecondSave!: (result: { ok: boolean }) => void
+
+    const firstSave = new Promise<{ ok: boolean }>((_resolve, reject) => {
+      finishFirstSave = reject
+    })
+
+    const secondSave = new Promise<{ ok: boolean }>(resolve => {
+      finishSecondSave = resolve
+    })
+
+    const saveConfig = vi.fn().mockReturnValueOnce(firstSave).mockReturnValueOnce(secondSave)
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'en' } }),
+      saveConfig
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <RapidSwitchProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('en'))
+    fireEvent.click(screen.getByRole('button', { name: 'Japanese' }))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chinese' }))
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'))
+
+    finishFirstSave(new Error('stale save failed'))
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('save-error').textContent).toBe('')
+
+    finishSecondSave({ ok: true })
+    await waitFor(() => expect(screen.getByTestId('saving').textContent).toBe('false'))
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
   })
 
   it('applies RTL direction for Arabic and restores LTR on switch back', async () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -2,7 +2,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useM
 
 import { getHermesConfigRecord, type HermesConfigRecord, saveHermesConfig } from '@/hermes'
 
-import { TRANSLATIONS } from './catalog'
+import { getTranslations, loadTranslations } from './catalog'
 import { DEFAULT_LOCALE, localeConfigValue, normalizeLocale } from './languages'
 import { setRuntimeI18nLocale } from './runtime'
 import type { Locale, Translations } from './types'
@@ -83,7 +83,7 @@ const I18nContext = createContext<I18nContextValue>({
   locale: DEFAULT_LOCALE,
   saveError: null,
   setLocale: async () => {},
-  t: TRANSLATIONS[DEFAULT_LOCALE]
+  t: getTranslations(DEFAULT_LOCALE)
 })
 
 export interface I18nProviderProps {
@@ -93,12 +93,15 @@ export interface I18nProviderProps {
 }
 
 export function I18nProvider({ children, configClient = defaultConfigClient, initialLocale }: I18nProviderProps) {
-  const [locale, setLocaleState] = useState<Locale>(() => normalizeLocale(initialLocale))
+  const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE)
+  const [translations, setTranslations] = useState<Translations>(() => getTranslations(DEFAULT_LOCALE))
   const [isLoadingConfig, setIsLoadingConfig] = useState(false)
   const [isSavingLocale, setIsSavingLocale] = useState(false)
   const [configLoadError, setConfigLoadError] = useState<Error | null>(null)
   const [saveError, setSaveError] = useState<Error | null>(null)
   const localeRef = useRef(locale)
+  const localeRequestRef = useRef(0)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -107,34 +110,46 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     applyDocumentLocale(locale)
   }, [locale])
 
+  // eslint-disable-next-line no-restricted-syntax -- request-generation ref cancels stale async config/catalog loads
   useEffect(() => {
-    if (!configClient) {
-      return
+    if (!configClient && normalizeLocale(initialLocale) === DEFAULT_LOCALE) {
+      return undefined
     }
 
     let cancelled = false
+    const requestId = localeRequestRef.current + 1
+
+    localeRequestRef.current = requestId
 
     setIsLoadingConfig(true)
     setConfigLoadError(null)
 
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+    const loadInitialLocale = async () => {
+      try {
+        const next = configClient
+          ? normalizeLocale(getConfigDisplayLanguage(await configClient.getConfig()))
+          : normalizeLocale(initialLocale)
+
+        const nextTranslations = await loadTranslations(next)
+
+        if (!cancelled && localeRequestRef.current === requestId) {
+          setTranslations(nextTranslations)
+          setLocaleState(next)
         }
-      })
-      .catch(error => {
-        if (!cancelled) {
+      } catch (error) {
+        if (!cancelled && localeRequestRef.current === requestId) {
           setConfigLoadError(toError(error))
+          setTranslations(getTranslations(DEFAULT_LOCALE))
           setLocaleState(DEFAULT_LOCALE)
         }
-      })
-      .finally(() => {
-        if (!cancelled) {
+      } finally {
+        if (!cancelled && localeRequestRef.current === requestId) {
           setIsLoadingConfig(false)
         }
-      })
+      }
+    }
+
+    void loadInitialLocale()
 
     return () => {
       cancelled = true
@@ -143,33 +158,59 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
 
   const setLocale = useCallback(
     async (next: Locale) => {
+      const requestId = localeRequestRef.current + 1
       const previousLocale = localeRef.current
+      const previousTranslations = getTranslations(previousLocale)
 
+      localeRequestRef.current = requestId
       setSaveError(null)
-      setLocaleState(next)
-
-      if (!configClient) {
-        return
-      }
-
+      setIsLoadingConfig(false)
       setIsSavingLocale(true)
 
       try {
-        const latestConfig = await configClient.getConfig()
-        const result = await configClient.saveConfig(withConfigDisplayLanguage(latestConfig, next))
+        const nextTranslations = await loadTranslations(next)
 
-        if (!result.ok) {
-          throw new Error('Failed to save language')
+        if (localeRequestRef.current !== requestId) {
+          return
+        }
+
+        setTranslations(nextTranslations)
+        setLocaleState(next)
+
+        if (configClient) {
+          const saveOperation = saveQueueRef.current.then(async () => {
+            const latestConfig = await configClient.getConfig()
+
+            if (localeRequestRef.current !== requestId) {
+              return
+            }
+
+            const result = await configClient.saveConfig(withConfigDisplayLanguage(latestConfig, next))
+
+            if (localeRequestRef.current === requestId && !result.ok) {
+              throw new Error('Failed to save language')
+            }
+          })
+
+          saveQueueRef.current = saveOperation.catch(() => undefined)
+          await saveOperation
         }
       } catch (error) {
+        if (localeRequestRef.current !== requestId) {
+          return
+        }
+
         const nextError = toError(error)
 
+        setTranslations(previousTranslations)
         setLocaleState(previousLocale)
         setSaveError(nextError)
 
         throw nextError
       } finally {
-        setIsSavingLocale(false)
+        if (localeRequestRef.current === requestId) {
+          setIsSavingLocale(false)
+        }
       }
     },
     [configClient]
@@ -183,9 +224,9 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
       locale,
       saveError,
       setLocale,
-      t: TRANSLATIONS[locale]
+      t: translations
     }),
-    [configLoadError, isLoadingConfig, isSavingLocale, locale, saveError, setLocale]
+    [configLoadError, isLoadingConfig, isSavingLocale, locale, saveError, setLocale, translations]
   )
 
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -101,6 +101,7 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
   const [saveError, setSaveError] = useState<Error | null>(null)
   const localeRef = useRef(locale)
   const localeRequestRef = useRef(0)
+  const explicitLocaleChoiceRef = useRef(false)
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
@@ -112,6 +113,10 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
 
   // eslint-disable-next-line no-restricted-syntax -- request-generation ref cancels stale async config/catalog loads
   useEffect(() => {
+    if (explicitLocaleChoiceRef.current) {
+      return undefined
+    }
+
     if (!configClient && normalizeLocale(initialLocale) === DEFAULT_LOCALE) {
       return undefined
     }
@@ -162,6 +167,7 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
       const previousLocale = localeRef.current
       const previousTranslations = getTranslations(previousLocale)
 
+      explicitLocaleChoiceRef.current = true
       localeRequestRef.current = requestId
       setSaveError(null)
       setIsLoadingConfig(false)

--- a/apps/desktop/src/i18n/define-locale.test.ts
+++ b/apps/desktop/src/i18n/define-locale.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { defineLocale } from './define-locale'
+import { en } from './en'
+
+
+describe('defineLocale', () => {
+  it('does not share untouched nested trees with English', () => {
+    const japanese = defineLocale({ settings: { appearance: { title: '外観' } } })
+
+    japanese.settings.nav.providers = 'mutated'
+
+    expect(en.settings.nav.providers).toBe('Providers')
+  })
+})

--- a/apps/desktop/src/i18n/define-locale.ts
+++ b/apps/desktop/src/i18n/define-locale.ts
@@ -17,12 +17,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function cloneLocaleTree<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneLocaleTree(item)) as T
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneLocaleTree(item)])) as T
+  }
+
+  return value
+}
+
 function mergeTranslations<T>(base: T, overrides: TranslationOverride<T> | undefined): T {
   if (!isRecord(base) || !isRecord(overrides)) {
     return (overrides ?? base) as T
   }
 
-  const result: Record<string, unknown> = { ...base }
+  const result: Record<string, unknown> = cloneLocaleTree(base)
 
   for (const [key, value] of Object.entries(overrides)) {
     if (value === undefined) {

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -1,4 +1,4 @@
-export { TRANSLATIONS } from './catalog'
+export { getTranslations, loadTranslations } from './catalog'
 export {
   getConfigDisplayLanguage,
   type I18nConfigClient,

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -1,4 +1,4 @@
-export { getTranslations, loadTranslations } from './catalog'
+export { getTranslations, loadTranslations, type TranslationImporters, TRANSLATIONS } from './catalog'
 export {
   getConfigDisplayLanguage,
   type I18nConfigClient,

--- a/apps/desktop/src/i18n/plugin-i18n.test.tsx
+++ b/apps/desktop/src/i18n/plugin-i18n.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { I18nProvider, useI18n } from './context'
@@ -83,7 +83,7 @@ function SwitchToJa() {
 }
 
 describe('usePluginI18n', () => {
-  it('re-renders on a locale switch', () => {
+  it('re-renders on a locale switch', async () => {
     const dispose = registerPluginLocales('hooked', {
       en: { greet: 'hello' },
       ja: { greet: 'こんにちは' }
@@ -100,7 +100,7 @@ describe('usePluginI18n', () => {
 
     fireEvent.click(screen.getByRole('button'))
 
-    expect(screen.getByTestId('copy').textContent).toBe('こんにちは')
+    await waitFor(() => expect(screen.getByTestId('copy').textContent).toBe('こんにちは'))
 
     dispose()
   })

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { fieldCopyForSchemaKey } from '@/app/settings/field-copy'
 
-import { TRANSLATIONS } from './catalog'
+import { getTranslations, loadTranslations } from './catalog'
 import { setRuntimeI18nLocale, translateNow } from './runtime'
 import { zh } from './zh'
 
@@ -15,7 +15,9 @@ describe('desktop i18n runtime translator', () => {
     setRuntimeI18nLocale('en')
   })
 
-  it('translates string paths for the active runtime locale', () => {
+  it('translates string paths for the active runtime locale', async () => {
+    await loadTranslations('zh')
+
     setRuntimeI18nLocale('zh')
 
     expect(translateNow('boot.ready')).toBe('Hermes 桌面版已就绪')
@@ -28,7 +30,9 @@ describe('desktop i18n runtime translator', () => {
     expect(translateNow('notifications.updateReadyMessage', 2)).toBe('2 new changes available.')
   })
 
-  it('translates migrated overlap keys for newly supported locales', () => {
+  it('translates migrated overlap keys for newly supported locales', async () => {
+    await Promise.all([loadTranslations('ja'), loadTranslations('zh-hant')])
+
     setRuntimeI18nLocale('ja')
     expect(translateNow('common.save')).toBe('保存')
 
@@ -36,7 +40,9 @@ describe('desktop i18n runtime translator', () => {
     expect(translateNow('cron.promptPlaceholder')).toBe('代理每次執行時應做什麼？')
   })
 
-  it('translates settings copy for newly supported locales', () => {
+  it('translates settings copy for newly supported locales', async () => {
+    await Promise.all([loadTranslations('ar'), loadTranslations('ja'), loadTranslations('zh-hant')])
+
     setRuntimeI18nLocale('ja')
     expect(translateNow('settings.appearance.title')).toBe('外観')
     expect(translateNow('settings.nav.providers')).toBe('プロバイダー')
@@ -59,8 +65,10 @@ describe('desktop i18n runtime translator', () => {
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
   })
 
-  it('falls back to English when the active locale cannot resolve a key', () => {
-    const boot = TRANSLATIONS.ja.boot as { ready?: string }
+  it('falls back to English when the active locale cannot resolve a key', async () => {
+    await loadTranslations('ja')
+
+    const boot = getTranslations('ja').boot as { ready?: string }
     const originalReady = boot.ready
 
     try {

--- a/apps/desktop/src/i18n/runtime.ts
+++ b/apps/desktop/src/i18n/runtime.ts
@@ -1,4 +1,4 @@
-import { TRANSLATIONS } from './catalog'
+import { getTranslations } from './catalog'
 import { DEFAULT_LOCALE } from './languages'
 import type { Locale } from './types'
 
@@ -62,5 +62,5 @@ export function getRuntimeI18nLocale(): Locale {
 }
 
 export function translateNow(key: string, ...args: unknown[]): string {
-  return translateFrom(locale => TRANSLATIONS[locale], runtimeLocale, key, args)
+  return translateFrom(getTranslations, runtimeLocale, key, args)
 }

--- a/apps/desktop/src/i18n/runtime.ts
+++ b/apps/desktop/src/i18n/runtime.ts
@@ -27,7 +27,10 @@ function render(value: unknown, args: unknown[]): null | string {
 }
 
 /** The active → DEFAULT → key resolution every translator shares. `source`
- *  yields a message tree per locale — the app catalog, or a plugin's bundles. */
+ *  yields a message tree per locale — the app catalog, or a plugin's bundles.
+ *  The app catalog supplies an isolated English tree until a lazy locale load
+ *  completes, so synchronous callers remain usable without sharing mutations.
+ */
 export function translateFrom(
   source: (locale: Locale) => unknown,
   locale: Locale,


### PR DESCRIPTION
## Summary
- statically retain English and dynamically load only the selected locale catalog
- commit locale state only after its catalog loads
- order config/user intents and serialize persistence so the latest choice wins

## Verification
- 34 focused i18n tests
- desktop typecheck, ESLint, and production build; only English is preloaded