### PR TITLE
perf(desktop): defer brand icon catalog

### DIFF
--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -20,7 +20,7 @@ import { RowButton } from '@/components/ui/row-button'
 import { Tip } from '@/components/ui/tooltip'
 import { getAllSessionMessages, listAllProfileSessions } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { resolveBrandIcon } from '@/lib/brand-icon'
+import { hasBrandIconHost, useBrandIcon } from '@/lib/brand-icon-loader'
 import {
   ExternalLink,
   ExternalLinkIcon,
@@ -582,8 +582,9 @@ function ArtifactCellAction({
 
 const PrimaryCell = memo(function PrimaryCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx }) {
   const isLink = artifact.kind === 'link'
-  const brand = isLink ? resolveBrandIcon(shortHostLabel(artifact.href)) : null
-  const Icon = brand ?? (isLink ? Link2 : FileText)
+  const hostname = isLink ? shortHostLabel(artifact.href) : ''
+  const brand = useBrandIcon(hostname)
+  const Icon = brand ?? (isLink && hasBrandIconHost(hostname) ? null : isLink ? Link2 : FileText)
   const fetchedTitle = useLinkTitle(isLink ? artifact.href : null)
   const label = isLink ? fetchedTitle || urlSlugTitleLabel(artifact.href) : artifact.label
 
@@ -594,7 +595,7 @@ const PrimaryCell = memo(function PrimaryCell({ artifact, ctx }: { artifact: Art
       title={label}
     >
       <span className="mt-0.5 grid size-6 shrink-0 place-items-center self-start rounded-md bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)">
-        <Icon className="size-3.5" />
+        {Icon && <Icon className="size-3.5" />}
       </span>
       <span className={cn('min-w-0 flex-1', isLink ? 'wrap-anywhere' : 'truncate')}>
         {label}

--- a/apps/desktop/src/lib/brand-icon-loader.test.tsx
+++ b/apps/desktop/src/lib/brand-icon-loader.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BRAND_ICON_HOSTNAMES } from './brand-icon'
+import type { BrandIcon, BrandIconLoader } from './brand-icon-loader'
+import {
+  createBrandIconLoader,
+  DEFERRED_BRAND_ICON_HOSTNAMES,
+  hasBrandIconHost,
+  useBrandIcon
+} from './brand-icon-loader'
+
+const GithubIcon = (() => null) as BrandIcon
+const GoogleDocsIcon = (() => null) as BrandIcon
+
+const resolver = {
+  resolveBrandIcon: (host: string) => {
+    if (host.endsWith('github.com')) {
+      return GithubIcon
+    }
+
+    if (host === 'docs.google.com') {
+      return GoogleDocsIcon
+    }
+
+    return null
+  }
+}
+
+describe('hasBrandIconHost', () => {
+  it('keeps the cheap admission table aligned with the deferred catalog', () => {
+    expect(BRAND_ICON_HOSTNAMES.length).toBeGreaterThan(0)
+    expect(DEFERRED_BRAND_ICON_HOSTNAMES.length).toBeGreaterThan(0)
+    expect(new Set(DEFERRED_BRAND_ICON_HOSTNAMES)).toEqual(new Set(BRAND_ICON_HOSTNAMES))
+  })
+
+  it('admits exact and inherited branded hosts without importing the catalog', () => {
+    expect(hasBrandIconHost('github.com')).toBe(true)
+    expect(hasBrandIconHost('api.github.com')).toBe(true)
+    expect(hasBrandIconHost('docs.google.com')).toBe(true)
+  })
+
+  it('rejects unknown hosts and bare public suffixes', () => {
+    expect(hasBrandIconHost('example.com')).toBe(false)
+    expect(hasBrandIconHost('localhost')).toBe(false)
+    expect(hasBrandIconHost('com')).toBe(false)
+  })
+})
+
+describe('createBrandIconLoader', () => {
+  it('does not import the icon catalog for unknown hosts', async () => {
+    const importer = vi.fn()
+    const loader = createBrandIconLoader(importer)
+
+    await expect(loader.load('example.com')).resolves.toBeNull()
+    expect(importer).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates concurrent imports and reuses the completed catalog', async () => {
+    const importer = vi.fn(async () => resolver)
+    const loader = createBrandIconLoader(importer)
+
+    const [first, second] = await Promise.all([loader.load('github.com'), loader.load('api.github.com')])
+
+    expect(first).toBe(GithubIcon)
+    expect(second).toBe(GithubIcon)
+    await expect(loader.load('docs.google.com')).resolves.toBe(GoogleDocsIcon)
+    expect(importer).toHaveBeenCalledOnce()
+  })
+
+  it('does not re-request a catalog module URL that Chromium has already poisoned', async () => {
+    const failure = new Error('chunk failed')
+    const importer = vi.fn().mockRejectedValue(failure)
+    const loader = createBrandIconLoader(importer)
+
+    await expect(loader.load('github.com')).rejects.toBe(failure)
+    await expect(loader.load('github.com')).rejects.toBe(failure)
+    expect(importer).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useBrandIcon', () => {
+  it('does not show a previous host icon while the next host is loading', () => {
+    const loader: BrandIconLoader = {
+      load: () => new Promise(() => undefined),
+      peek: host => (host === 'github.com' ? GithubIcon : null)
+    }
+
+    const { result, rerender } = renderHook(({ host }) => useBrandIcon(host, loader), {
+      initialProps: { host: 'github.com' }
+    })
+
+    expect(result.current).toBe(GithubIcon)
+
+    rerender({ host: 'docs.google.com' })
+
+    expect(result.current).toBeNull()
+  })
+
+  it('publishes the icon after a recognized host loads the deferred catalog', async () => {
+    const importer = vi.fn(async () => resolver)
+    const loader = createBrandIconLoader(importer)
+
+    const { result, rerender } = renderHook(({ host }) => useBrandIcon(host, loader), {
+      initialProps: { host: 'example.com' }
+    })
+
+    expect(result.current).toBeNull()
+    expect(importer).not.toHaveBeenCalled()
+
+    rerender({ host: 'github.com' })
+
+    await waitFor(() => expect(result.current).toBe(GithubIcon))
+    expect(importer).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/lib/brand-icon-loader.ts
+++ b/apps/desktop/src/lib/brand-icon-loader.ts
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react'
+
+import type { BrandIcon } from './brand-icon'
+
+export type { BrandIcon } from './brand-icon'
+
+interface BrandIconModule {
+  resolveBrandIcon: (hostname: string) => BrandIcon | null
+}
+
+type BrandIconImporter = () => Promise<BrandIconModule>
+
+export interface BrandIconLoader {
+  load: (hostname: string) => Promise<BrandIcon | null>
+  peek: (hostname: string) => BrandIcon | null
+}
+
+// This string-only admission table is intentionally kept separate from the
+// Simple Icons components. It lets unknown links stay cheap while the actual
+// SVG catalog remains behind a dynamic import.
+export const DEFERRED_BRAND_ICON_HOSTNAMES =
+  `github.com github.io githubusercontent.com gitlab.com gitlab.io bitbucket.org codeberg.org gitea.com gitea.io
+forgejo.org sr.ht npmjs.com pypi.org crates.io huggingface.co hf.co stackoverflow.com stackexchange.com
+serverfault.com superuser.com developer.mozilla.org readthedocs.io readthedocs.org wikipedia.org archive.org
+arxiv.org semanticscholar.org scholar.google.com researchgate.net zotero.org overleaf.com anthropic.com
+claude.ai gemini.google.com perplexity.ai openrouter.ai mistral.ai ollama.com replicate.com wandb.ai
+kaggle.com x.com twitter.com t.co reddit.com redd.it news.ycombinator.com bsky.app mastodon.social
+joinmastodon.org facebook.com instagram.com tiktok.com pinterest.com discord.com discord.gg t.me telegram.org
+producthunt.com crunchbase.com quora.com medium.com substack.com dev.to hashnode.dev hashnode.com
+wordpress.com wordpress.org ghost.org youtube.com youtu.be vimeo.com twitch.tv soundcloud.com spotify.com
+netflix.com imdb.com goodreads.com unsplash.com behance.net store.steampowered.com itch.io linear.app
+notion.so notion.site figma.com atlassian.net atlassian.com confluence.com asana.com trello.com obsidian.md
+miro.com excalidraw.com tldraw.com zoom.us google.com goo.gl docs.google.com drive.google.com mail.google.com
+maps.google.com openstreetmap.org vercel.com vercel.app netlify.com netlify.app cloudflare.com pages.dev
+workers.dev railway.app render.com digitalocean.com firebase.google.com supabase.com docker.com kubernetes.io
+grafana.com datadoghq.com sentry.io snyk.io codecov.io circleci.com jenkins.io python.org nodejs.org react.dev
+typescriptlang.org tailwindcss.com vite.dev vitejs.dev rust-lang.org go.dev golang.org ruby-lang.org
+rubyonrails.org php.net laravel.com djangoproject.com flask.palletsprojects.com fastapi.tiangolo.com swift.org
+kotlinlang.org deno.com bun.sh pnpm.io turborepo.com eslint.org storybook.js.org graphql.org prisma.io
+postgresql.org redis.io mongodb.com pytorch.org tensorflow.org scikit-learn.org jupyter.org threejs.org
+blender.org godotengine.org unity.com electronjs.org tauri.app brew.sh archlinux.org debian.org ubuntu.com
+raspberrypi.com nvidia.com codesandbox.io stackblitz.com replit.com cursor.com windsurf.com zed.dev warp.dev
+raycast.com postman.com stripe.com paypal.com patreon.com ko-fi.com buymeacoffee.com shopify.com webflow.com
+dropbox.com leetcode.com coursera.org udemy.com yelp.com`.split(/\s+/)
+
+const BRAND_ICON_HOSTS = new Set(DEFERRED_BRAND_ICON_HOSTNAMES)
+
+function normalizedHost(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^www\./, '')
+}
+
+export function hasBrandIconHost(hostname: string): boolean {
+  const host = normalizedHost(hostname)
+
+  if (!host.includes('.')) {
+    return false
+  }
+
+  const parts = host.split('.')
+
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    if (BRAND_ICON_HOSTS.has(parts.slice(i).join('.'))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function createBrandIconLoader(
+  importer: BrandIconImporter = () => import('./brand-icon')
+): BrandIconLoader {
+  let completed: BrandIconModule | undefined
+  let pending: Promise<BrandIconModule> | undefined
+
+  const peek = (hostname: string) => {
+    if (!hasBrandIconHost(hostname) || !completed) {
+      return null
+    }
+
+    return completed.resolveBrandIcon(hostname)
+  }
+
+  return {
+    async load(hostname) {
+      if (!hasBrandIconHost(hostname)) {
+        return null
+      }
+
+      if (completed) {
+        return completed.resolveBrandIcon(hostname)
+      }
+
+      if (!pending) {
+        const operation = importer().then(module => {
+          completed = module
+          pending = undefined
+
+          return module
+        })
+
+        pending = operation
+      }
+
+      const module = await pending
+
+      return module.resolveBrandIcon(hostname)
+    },
+    peek
+  }
+}
+
+export const brandIconLoader = createBrandIconLoader()
+
+export function useBrandIcon(
+  hostname: string,
+  loader: BrandIconLoader = brandIconLoader
+): BrandIcon | null {
+  const eligible = hasBrandIconHost(hostname)
+  const cached = eligible ? loader.peek(hostname) : null
+  const [loadedHostname, setLoadedHostname] = useState<string | null>(() => (cached ? hostname : null))
+  const icon = cached ?? (loadedHostname === hostname ? loader.peek(hostname) : null)
+
+  useEffect(() => {
+    if (!eligible || icon) {
+      return undefined
+    }
+
+    let active = true
+
+    void loader
+      .load(hostname)
+      .then(() => {
+        if (active) {
+          setLoadedHostname(hostname)
+        }
+      })
+      .catch(() => undefined)
+
+    return () => {
+      active = false
+    }
+  }, [eligible, hostname, icon, loader])
+
+  return icon
+}

--- a/apps/desktop/src/lib/brand-icon.ts
+++ b/apps/desktop/src/lib/brand-icon.ts
@@ -401,6 +401,8 @@ const BRAND_ICONS: Record<string, BrandIcon> = {
   'yelp.com': SiYelp
 }
 
+export const BRAND_ICON_HOSTNAMES = Object.keys(BRAND_ICONS)
+
 // Resolve a hostname to its brand glyph, walking suffixes so subdomains inherit
 // their parent's mark (`api.github.com` → `github.com`). Longest match wins, so
 // a subdomain entry like `docs.google.com` beats the `google.com` fallback. The

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -333,7 +333,7 @@ describe('external link helpers', () => {
     expect(link.getAttribute('href')).toBe('https://agent.log')
   })
 
-  it('prefixes a pretty link to a known host with its brand glyph', () => {
+  it('prefixes a pretty link to a known host with its brand glyph', async () => {
     installDesktopBridge()
 
     const url = 'https://github.com/NousResearch/hermes-agent/pull/123'
@@ -342,7 +342,7 @@ describe('external link helpers', () => {
 
     const link = screen.getByTitle(url)
 
-    expect(link.querySelector('svg')).toBeTruthy()
+    await waitFor(() => expect(link.querySelector('svg')).toBeTruthy())
     // The glyph is decorative — it must not pollute the link's accessible name.
     expect(link.textContent).toBe('#123')
   })

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { ArrowUpRight } from '@/lib/icons'
 import { IS_MAC } from '@/lib/keybinds/combo'
 
-import { resolveBrandIcon } from './brand-icon'
+import { hasBrandIconHost, useBrandIcon } from './brand-icon-loader'
 import { cn } from './utils'
 
 const titleCache = new Map<string, string>()
@@ -280,11 +280,18 @@ export function ExternalLinkIcon({ className }: { className?: string }) {
 // to the brand name, which lands in the anchor's textContent and accessible
 // name — a PR link would read "GitHub#123".
 export function LinkBrandIcon({ className, href }: { className?: string; href: string }) {
-  const Icon = resolveBrandIcon(shortHostLabel(href))
+  const hostname = shortHostLabel(href)
+  const Icon = useBrandIcon(hostname)
 
-  return Icon ? (
-    <Icon aria-hidden className={cn('mr-1 inline size-[0.85em] align-[-0.12em] opacity-80', className)} title="" />
-  ) : null
+  if (!hasBrandIconHost(hostname)) {
+    return null
+  }
+
+  return (
+    <span aria-hidden className={cn('mr-1 inline-block size-[0.85em] align-[-0.12em]', className)}>
+      {Icon && <Icon className="size-full opacity-80" title="" />}
+    </span>
+  )
 }
 
 export function ExternalLink({


### PR DESCRIPTION
## Summary
- keep a cheap hostname admission table on the entry path
- dynamically import the Simple Icons catalog only for recognized branded links
- deduplicate loads and reserve icon space while the catalog arrives

## Verification
- 52 focused loader/link/artifact tests
- desktop typecheck, ESLint, and production build; brand catalog is not preloaded