### PR TITLE
fix(backup): include mcp-tokens/ in quick snapshot so MCP OAuth tokens survive self-update

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1456,6 +1456,13 @@ _QUICK_STATE_FILES = (
     "verification_evidence.db",         # agent verification audit trail
     "kanban.db",                        # default board (back-compat <root>/kanban.db)
     "kanban/boards",                    # non-default boards: each <slug>/kanban.db + board metadata (workspaces/ + attachments/ are skipped as regenerable)
+    # MCP OAuth client registrations and access/refresh tokens.
+    # Dynamic client registration (RFC 7591) binds a client_id to a specific
+    # redirect_uri port; losing client.json on update forces re-registration
+    # which issues a new client_id.  The old token was issued for the old
+    # client_id and can no longer be refreshed, breaking all cron/background
+    # MCP calls until the user runs 'hermes mcp login' interactively (#84843).
+    "mcp-tokens",
     # Pairing stores (generic + per-platform JSONs outside state.db)
     "pairing",                          # legacy location (gateway/pairing.py)
     "platforms/pairing",                # new location (gateway/pairing.py)

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿mcp-tokens/ was not in _QUICK_STATE_FILES. After self-update, if client.json is lost, re-registration creates a new client_id that can't refresh the old token. Add mcp-tokens to quick snapshot. Fixes #84843.
