### PR TITLE
fix(computer_use): use Windows named-pipe socket path when driver_cmd is a Windows .exe (WSL2)

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -353,6 +353,20 @@ def _computer_use_max_image_dimension() -> Optional[int]:
     return dim if dim > 0 else None
 
 
+def _driver_cmd_is_windows_exe(cmd: str) -> bool:
+    """True when *cmd* points at a Windows PE executable.
+
+    Used by _EmbeddedCuaDaemon to detect the WSL2 cross-OS case: the Hermes
+    host is Linux (sys.platform == 'linux') but the configured cua-driver is a
+    Windows .exe.  Windows processes cannot create a Unix-domain socket — they
+    need a named-pipe path (#80227).
+    """
+    if not cmd:
+        return False
+    lower = cmd.lower()
+    return lower.endswith(".exe") or "\\\\wsl$" in lower or "/mnt/" in lower.replace("\\", "/")
+
+
 def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Return the environment dict for spawning cua-driver.
 
@@ -733,6 +747,13 @@ class _EmbeddedCuaDaemon:
         self._stderr_thread: Optional[threading.Thread] = None
         token = uuid.uuid4().hex[:12]
         if sys.platform == "win32":
+            self.socket_path = rf"\\.\pipe\hermes-cua-{token}"
+        elif _driver_cmd_is_windows_exe(driver_cmd):
+            # WSL2: the Python host is Linux (sys.platform == "linux") but the
+            # driver is a Windows .exe.  Windows processes cannot create a
+            # Unix-domain socket under /tmp — they need a named pipe path.
+            # Generating a Unix socket path here caused OS error 123
+            # (ERROR_INVALID_NAME) on every embedded-daemon launch (#80227).
             self.socket_path = rf"\\.\pipe\hermes-cua-{token}"
         else:
             self.socket_path = os.path.join(


### PR DESCRIPTION
﻿WSL2: sys.platform==linux but driver_cmd is cua-driver.exe. Generates Unix socket path that Windows exe can't create. Detect .exe cmd and use named-pipe path instead. Fixes #80227.
