### PR TITLE
fix(desktop): show bot names in canonical chat tabs

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat-adopt-on-conflict.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat-adopt-on-conflict.test.ts
@@ -29,6 +29,7 @@ vi.mock('@hermes/plugin-sdk', () => ({
 }))
 
 vi.mock('./routing', () => ({
+  aliasIdentityFor: () => null,
   backendTargetProfile: (route: { targetProfile?: string } | null, name: string) => route?.targetProfile ?? name,
   botConnectionRoute: () => null,
   botRosterMeta: () => ({}),

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat-creation.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat-creation.test.ts
@@ -37,6 +37,7 @@ vi.mock('@hermes/plugin-sdk', () => ({
 }))
 
 vi.mock('./routing', () => ({
+  aliasIdentityFor: () => null,
   backendTargetProfile: (route: { targetProfile?: string } | null, name: string) => route?.targetProfile ?? name,
   botConnectionRoute: () => null,
   botRosterMeta: () => ({}),
@@ -195,11 +196,11 @@ describe('the lazy row is materialized before anything else touches it', () => {
 
     const { createCanonicalChat } = await loadModule()
 
-    await createCanonicalChat('ops', { kickoff: true })
+    await createCanonicalChat({ display_name: 'Operations Agent', name: 'ops' }, { kickoff: true })
 
     expect(hostMock.openSession).toHaveBeenCalledWith(
       'stored-1',
-      expect.objectContaining({ tabTitle: 'Bot Chat', workspaceMode: 'bots', workspaceOwnerKey: 'bot:ops' })
+      expect.objectContaining({ tabTitle: 'Operations Agent', workspaceMode: 'bots', workspaceOwnerKey: 'bot:ops' })
     )
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
@@ -43,6 +43,7 @@ vi.mock('@hermes/plugin-sdk', () => ({
 }))
 
 vi.mock('./routing', () => ({
+  aliasIdentityFor: () => null,
   backendTargetProfile: (route: { targetProfile?: string } | null, name: string) => route?.targetProfile ?? name,
   botConnectionRoute: () => null,
   botRosterMeta: () => ({}),
@@ -105,7 +106,7 @@ describe('the registry row wins, always', () => {
     })
 
     const { openBotCanonicalChat } = await loadModule()
-    const opened = await openBotCanonicalChat('ops')
+    const opened = await openBotCanonicalChat({ display_name: 'Operations Agent', name: 'ops' })
 
     expect(opened).toEqual({ openedId: 'forever-chat', registryId: 'forever-chat' })
     expect(hostMock.openSession).toHaveBeenCalledTimes(1)
@@ -117,7 +118,9 @@ describe('the registry row wins, always', () => {
       profile: 'ops',
       // Opening a bot leaves the Sessions workspace on its current gateway.
       keepAllProfilesScope: true,
-      tabTitle: 'Bot Chat',
+      // The stored title remains the canonical registry identity, while the
+      // renderer-only tab title tells concurrently open bots apart.
+      tabTitle: 'Operations Agent',
       workspaceMode: 'bots',
       workspaceOwnerKey: 'bot:ops'
     })

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -12,6 +12,7 @@ import * as sdk from '@hermes/plugin-sdk'
 import { host } from '@hermes/plugin-sdk'
 
 import { $botMeta, botMetaKey, botOwner, persistBotMetaSnapshot } from './data'
+import { displayName } from './labels'
 import { backendTargetProfile, botConnectionRoute, botRosterMeta, botWorkspaceOwnerKey, requestForBot } from './routing'
 import type { RpcErrorLike } from './routing'
 import { getPluginCtx } from './shared'
@@ -46,6 +47,12 @@ export const PROFILE_SESSION_LIST_LIMIT = 200
  *  click path's tile-staleness probe (hermes-agent#90102), which must
  *  recognize canonical-titled tabs without restating the literal. */
 export const CANONICAL_CHAT_TITLE = 'Bot Chat'
+
+/** Keep the durable registry title canonical while the renderer labels each
+ *  open tab with the same friendly identity shown in the Bots roster. */
+function botTabTitle(bot: RosterRow): string {
+  return displayName(bot, botRosterMeta(bot, $botMeta.get())) || CANONICAL_CHAT_TITLE
+}
 
 /** A `session.list` row as the registry lookup reads it. CanonicalSession
  *  models the roster's `canonical_session` field, which carries no
@@ -135,7 +142,7 @@ async function openStoredBotChat(
     workspaceMode: 'bots',
     workspaceOwnerKey: ownerKey,
     retryHydrationTimeoutOnce: true,
-    tabTitle: CANONICAL_CHAT_TITLE
+    tabTitle: botTabTitle(bot)
   })
 
   return storedId
@@ -292,7 +299,7 @@ export function createCanonicalChat(
       keepAllProfilesScope: route ? true : false,
       workspaceMode: 'bots',
       workspaceOwnerKey: botWorkspaceOwnerKey(bot),
-      tabTitle: CANONICAL_CHAT_TITLE
+      tabTitle: botTabTitle(bot)
     })
 
   if (inflight) {

--- a/apps/desktop/src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx
@@ -110,6 +110,7 @@ async function renderDialog(hasSkillsView: boolean) {
   const view = render(withQueryClient(<CreateAgentDialog onClose={() => undefined} open roster={roster} />))
 
   fireEvent.change(screen.getByPlaceholderText('inbox-triage'), { target: { value: 'inbox-triage' } })
+  fireEvent.change(screen.getByPlaceholderText('Inbox Triage'), { target: { value: 'Operations Agent' } })
   fireEvent.click(screen.getByRole('button', { name: /Advanced/ }))
 
   return view
@@ -175,7 +176,12 @@ describe('materializing the draft profile', () => {
     // Create Bot goes through the same helper — no duplicate profiles.create.
     fireEvent.click(screen.getByRole('button', { name: 'Create Bot' }))
 
-    await waitFor(() => expect(mocks.createCanonicalChat).toHaveBeenCalledWith('inbox-triage', { kickoff: true }))
+    await waitFor(() =>
+      expect(mocks.createCanonicalChat).toHaveBeenCalledWith(
+        { name: 'inbox-triage', title: 'Operations Agent' },
+        { kickoff: true }
+      )
+    )
     expect(createCalls()).toHaveLength(1)
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -546,7 +546,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
         // the ONE caller allowed to request the intro turn — genuine New
         // Agent creation. Click-path resolution (openBotCanonicalChat) mints
         // silently so a resolution miss never burns a turn (ScottFive).
-        const sid = await createCanonicalChat(slug, {
+        const sid = await createCanonicalChat({ name: slug, title }, {
           kickoff: true
         })
 


### PR DESCRIPTION
## What does this PR do?

Bot Mode tabs now use the bot's friendly display name instead of showing the same `BOT CHAT` label for every canonical chat.

The backend identity contract is unchanged: the stored session title remains exactly `Bot Chat`. Only the renderer-owned `tabTitle` passed to `host.openSession()` changes, using the same `displayName()` resolver as the Bots roster so Bot Mode titles, profile display names, aliases, remote labels, and the default Hermes name stay consistent.

## Related Issue

Fixes #99152

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added a focused `botTabTitle()` presentation helper in `canonical-chat.ts`.
- Applied it when opening both an existing canonical chat and a newly created one.
- Added regression coverage proving a friendly profile label reaches `tabTitle` while the canonical registry title remains `Bot Chat`.

## How to Test

1. Open two Bot Mode chats whose bots have different display names.
2. Confirm each workspace tab shows its bot's name rather than `BOT CHAT`.
3. Confirm reopening each bot still resolves the same canonical session.

Automated checks run:

```bash
npm test --workspace apps/desktop -- src/plugins/hermes-bots
npm run typecheck --workspace apps/desktop
npx eslint apps/desktop/src/plugins/hermes-bots/canonical-chat.ts \
  apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts \
  apps/desktop/src/plugins/hermes-bots/canonical-chat-creation.test.ts \
  apps/desktop/src/plugins/hermes-bots/canonical-chat-adopt-on-conflict.test.ts
```

Results: 59 test files and 570 tests passed; typecheck and ESLint passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs before starting.
- [x] My PR contains only changes related to this bug.
- [x] I've added regression tests for the change.
- [ ] Manual Desktop verification has not been run in this checkout.

### Documentation & Housekeeping

- [x] Documentation updates are not required; this restores the existing intended UI behavior.
- [x] No configuration keys or tool schemas changed.
- [x] Cross-platform behavior is unchanged; this is renderer-only presentation state.

