### PR TITLE
fix(sessions): treat a zero-byte state.db as zeroed so total loss is not silent

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -441,15 +441,26 @@ def is_zeroed_sqlite_file(
 ) -> bool:
     """True when *path* looks like the #68474 zeroed-state.db signature.
 
-    Signature: size > 0, first *probe_bytes* are all NUL (no ``SQLite format 3``
-    header). Used at SessionDB open and for snapshot diagnostics so a silent
-    all-zero file becomes a guided recovery instead of a generic failure.
+    Signature: the file carries no ``SQLite format 3`` header and no data —
+    either it is empty (size 0) or its first *probe_bytes* are all NUL. Used
+    at SessionDB open and for snapshot diagnostics so a silent wiped file
+    becomes a guided recovery instead of a generic failure.
+
+    A zero-length file is the MOST complete form of this condition (#97568):
+    every message is gone, and it was previously excluded by a ``size <= 0``
+    guard, so total loss stayed silent for days. SQLite's own minimum viable
+    file is 100 bytes (``verify_sqlite_integrity``), so anything below that
+    cannot hold a database — treat the empty file as zeroed, not as healthy.
     """
     try:
         size = path.stat().st_size
     except OSError:
         return False
-    if size <= 0:
+    if size == 0:
+        # Empty file: no header, no data — the wiped case. Quarantine it so
+        # the operator gets the ERROR log and the restore guidance.
+        return True
+    if size < 0:
         return False
     from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1186,6 +1186,69 @@ class TestSafeCopyDb:
         p.write_bytes(bytes(4096))  # all NULs
         assert is_zeroed_sqlite_file(p) is True
 
+    def test_is_zeroed_sqlite_file_detects_empty_file(self, tmp_path):
+        """A zero-byte state.db is the most complete form of the wipe.
+
+        #97568: the ``size <= 0`` guard excluded it, so a deployment that
+        lost 100% of its history got no ERROR log, no quarantine, and no
+        restore hint — indistinguishable from a brand-new install.
+        """
+        from hermes_cli.backup import is_zeroed_sqlite_file
+        p = tmp_path / "state.db"
+        p.write_bytes(b"")  # truncated to nothing
+        assert is_zeroed_sqlite_file(p) is True
+
+    def test_is_zeroed_sqlite_file_agrees_with_integrity_check(self, tmp_path):
+        """Invariant: 'zeroed' and 'integrity-valid' never both hold.
+
+        Both read the same bytes and both feed the SessionDB open path, so a
+        file one calls healthy and the other calls broken is a contradiction
+        that silently picks the wrong recovery branch. SQLite's minimum
+        viable file is 100 bytes (header + one page), which is the shared
+        boundary this asserts.
+        """
+        from hermes_cli.backup import is_zeroed_sqlite_file, verify_sqlite_integrity
+
+        valid_header = b"SQLite format 3\x00"
+        cases = {
+            "empty.db": b"",
+            "nul_16.db": bytes(16),
+            "nul_99.db": bytes(99),
+            "nul_4096.db": bytes(4096),
+            "valid_min_100.db": valid_header + bytes(84),
+            "valid.db": valid_header + bytes(4080),
+            "garbage.db": b"\xde\xad\xbe\xef" + bytes(4092),
+        }
+        for name, data in cases.items():
+            p = tmp_path / name
+            p.write_bytes(data)
+            zeroed = is_zeroed_sqlite_file(p)
+            # run_pragma=False: the header + size probe is the part that
+            # shares a boundary with is_zeroed; PRAGMA walks every b-tree
+            # page and is capped at 2 GiB (irrelevant at these sizes).
+            intact = verify_sqlite_integrity(p, run_pragma=False)["valid"]
+            assert not (zeroed and intact), f"{name}: zeroed and intact"
+
+    def test_is_zeroed_sqlite_file_never_flags_a_healthy_db(self, tmp_path):
+        """A real SQLite database must never be reported as zeroed.
+
+        Regression guard in the costly direction: a false positive here
+        quarantines a perfectly good state.db on every startup.
+        """
+        import sqlite3
+
+        from hermes_cli.backup import is_zeroed_sqlite_file
+        p = tmp_path / "state.db"
+        conn = sqlite3.connect(str(p))
+        try:
+            conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT)")
+            conn.execute("INSERT INTO messages (body) VALUES ('hello')")
+            conn.commit()
+        finally:
+            conn.close()
+        assert p.stat().st_size > 0
+        assert is_zeroed_sqlite_file(p) is False
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests


### PR DESCRIPTION
## Summary

`is_zeroed_sqlite_file()` opened with a `size <= 0` guard, so a `state.db` truncated to zero bytes was reported as **not** zeroed. Its own docstring declared the signature as "size > 0, all-NUL header" — the guard excluded the most complete form of the condition the function is named after (#97568).

A wiped file therefore took the healthy path at the SessionDB open site (`hermes_state.py:4672`):

- no `logger.error`,
- no `quarantine_zeroed_state_db()` rename (bytes not preserved),
- no `_set_last_init_error`,
- no "restore from `state-snapshots/`" hint.

A fresh empty database opened silently, byte-for-byte indistinguishable from a brand-new install: same empty schema, same `schema_version`, ids restarting at 1. #97568 records a deployment that ran without its history for **seven days** because nothing was there to notice.

## Fix

```python
-    if size <= 0:
+    if size == 0:
+        # Empty file: no header, no data — the wiped case. Quarantine it so
+        # the operator gets the ERROR log and the restore guidance.
+        return True
+    if size < 0:
         return False
```

The guard is **narrowed, not removed**. `verify_sqlite_integrity()` in the same module already holds that SQLite's minimum viable file is 100 bytes (`if st.st_size < 100`), and a negative `st_size` is not a real file — so only `size == 0` flips.

Both secondary call sites (`backup.py:1596`, `backup.py:1628`) sit inside `if not _safe_copy_db(...)`, i.e. after the copy has already failed; they only print a diagnostic, so the change strictly improves their message.

## Reproduction (before)

```
file                size  is_zeroed?
zero.db                0  False       <-- total loss undetected
nul_4096.db         4096  True
valid.db            4096  False
garbage.db         4096  False
```

## Tests

Invariants, per AGENTS.md — no source reading, no snapshot literals:

- `test_is_zeroed_sqlite_file_detects_empty_file` — the reported case.
- `test_is_zeroed_sqlite_file_agrees_with_integrity_check` — `is_zeroed_sqlite_file()` and `verify_sqlite_integrity()["valid"]` can never both hold for one file. They read the same bytes and both feed the open path; before this change they **contradicted** each other on a 0-byte file (`is_zeroed=False` vs `integrity_valid=False`).
- `test_is_zeroed_sqlite_file_never_flags_a_healthy_db` — a real `sqlite3` database is never quarantined (the costly false-positive direction).

## Verification

Ran in a venv created **outside** the source tree, per the Contributing Guide (the working `hermes-agent` venv was not touched):

```
# with the fix
4 passed, 56 deselected

# with the fix reverted (proves the test catches the bug)
>   assert is_zeroed_sqlite_file(p) is True
E   AssertionError: assert False is True
1 failed, 3 passed
```

Regression check against a clean `git clone --shared` at `cd2bd16` — the failure sets are **identical** (`diff` empty), so all 5 pre-existing failures in `test_backup.py` are unrelated to this change:

```
base=5 failures   mine=5 failures
*** IDENTICAL — zero regressions ***
```

`ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py` → **All checks passed**.

(`ruff format --check` reports these files as unformatted, but it reports the same for the **untouched originals** on a clean tree — a global formatter-version difference, so I deliberately did not run `ruff format` and pollute the diff with unrelated lines.)

Fixes #97568
