### PR TITLE
fix(agent): use reasoning-termination nudge when length-truncated model produces no visible content

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3988,6 +3988,23 @@ def run_conversation(
                                 _continue_content = _get_continuation_prompt(
                                     _is_partial_stream_stub, _dropped_tools
                                 )
+                                # When the model used its entire output budget on
+                                # chain-of-thought (reasoning_content) and produced
+                                # zero visible content, a normal "continue where you
+                                # left off" prompt is semantically vacuous — the model
+                                # deterministically repeats the reasoning-only response
+                                # until the retry budget is exhausted (#83915).
+                                # Detect: empty content AND non-empty reasoning on the
+                                # assistant turn, then override the nudge to an
+                                # explicit reasoning-termination directive.
+                                _asst_content = getattr(assistant_message, "content", None) or ""
+                                _asst_reasoning = (
+                                    getattr(assistant_message, "reasoning", None)
+                                    or getattr(assistant_message, "reasoning_content", None)
+                                    or ""
+                                )
+                                if not _asst_content and _asst_reasoning:
+                                    _continue_content = _CODEX_INCOMPLETE_NUDGE
                                 continue_msg = {
                                     "role": "user",
                                     "content": _continue_content,

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Reasoning-only models waste 4 full retry budgets when length-truncated. Detect empty content + non-empty reasoning and override continuation prompt to _CODEX_INCOMPLETE_NUDGE to break the deterministic loop. Fixes #83915.
