### PR TITLE
fix(qqbot): deliver quota-blocked C2C replies on the next turn

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -168,6 +168,14 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "photon":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
+    # QQ C2C passive replies share a small, time-boxed reply quota per inbound
+    # msg_id (official docs put it at 5 calls within the reply window), and the
+    # wakeup/"recall" channel QQ falls back to once that's exhausted is capped
+    # even tighter (about 1 per interval — error 40034122 once it's spent). The
+    # adapter has no edit_message implementation, so progress/commentary/
+    # heartbeat sends are permanent messages that eat into both budgets and can
+    # starve the final answer of any delivery channel at all.
+    "qqbot":           _TIER_LOW,
     # WeCom is technically non-editable but exposes a native streaming
     # transport (msgtype: "stream" via aibot_respond_msg) that the gateway
     # consumer routes mid-stream content through. Enable streaming by default

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5730,6 +5730,12 @@ class BasePlatformAdapter(ABC):
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 
+        # A structured rate-limit rejection cannot be repaired by changing
+        # message formatting. Return it unchanged; adapter-level ``retryable``
+        # still decides whether the retry loop above is appropriate.
+        if not is_network and result.error_kind == "rate_limited":
+            return result
+
         # Timeout errors are not safe to retry (message may have been
         # delivered) and not formatting errors — return the failure as-is.
         if not is_network and self._is_timeout_error(error_str):

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -265,6 +265,15 @@ class QQAdapter(BasePlatformAdapter):
         # Typing debounce: chat_id → last send_typing timestamp
         self._typing_sent_at: Dict[str, float] = {}
 
+        # Content dropped by a permanent C2C quota failure (_is_c2c_quota_error),
+        # keyed by chat_id → (content, dropped_at). Both the passive-reply and
+        # wakeup budgets are scoped to a stale msg_id/time window and cannot be
+        # recovered by retrying — see send()/_send_chunk(). Carried forward and
+        # prepended to the next message this adapter manages to deliver to the
+        # same chat, so a quota-exhaustion incident degrades to "answer arrives
+        # late, attached to the next reply" instead of silent data loss.
+        self._quota_undelivered: Dict[str, Tuple[str, float]] = {}
+
         # Token cache
         self._access_token: Optional[str] = None
         self._token_expires_at: float = 0.0
@@ -2492,17 +2501,87 @@ class QQAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True)
 
+        had_carried_content = chat_id in self._quota_undelivered
+        content = self._prepend_undelivered(chat_id, content)
+
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
         last_result = SendResult(success=False, error="No chunks")
-        for chunk in chunks:
+        for chunk_index, chunk in enumerate(chunks):
             last_result = await self._send_chunk(chat_id, chunk, reply_to)
             if not last_result.success:
+                if last_result.error_kind == "rate_limited":
+                    self._stash_undelivered(
+                        chat_id, "\n\n".join(chunks[chunk_index:])
+                    )
                 return last_result
             # Only reply_to the first chunk
             reply_to = None
+        if had_carried_content:
+            self._quota_undelivered.pop(chat_id, None)
         return last_result
+
+    # Longest a dropped answer is carried forward before we give up on
+    # reattaching it to a later reply — long enough to span QQ's own C2C
+    # passive-reply window (60 min) with headroom, short enough that we never
+    # glue a stale answer onto an unrelated, much later conversation.
+    _UNDELIVERED_CARRY_SECONDS = 6 * 3600
+
+    def _stash_undelivered(self, chat_id: str, content: str) -> None:
+        """Remember content QQ permanently refused to deliver (quota exhausted).
+
+        Overwrites any previous stash for this chat — we carry forward the
+        most recent dropped answer only, so a repeatedly quota-starved chat
+        doesn't accumulate an unbounded backlog.
+        """
+        self._quota_undelivered[chat_id] = (content, time.time())
+        logger.warning(
+            "[%s] Dropped message for %s after quota exhaustion — will "
+            "prepend to the next deliverable send to this chat",
+            self._log_tag, chat_id,
+        )
+
+    def _prepend_undelivered(self, chat_id: str, content: str) -> str:
+        """Splice a previously stashed, undelivered answer onto ``content``.
+
+        Leaves the stash in place until the merged send succeeds. If quota is
+        exhausted again, ``send()`` replaces it with only the chunks that were
+        not delivered, avoiding both silent loss and duplicate delivered chunks.
+        """
+        carried = self._quota_undelivered.get(chat_id)
+        if not carried:
+            return content
+        carried_content, dropped_at = carried
+        if time.time() - dropped_at > self._UNDELIVERED_CARRY_SECONDS:
+            self._quota_undelivered.pop(chat_id, None)
+            logger.warning(
+                "[%s] Discarding stale undelivered message for %s (%.0fs old)",
+                self._log_tag, chat_id, time.time() - dropped_at,
+            )
+            return content
+        return (
+            f"{carried_content}\n\n"
+            f"—\n"
+            f"⚠️ The message above was delayed by QQ's reply rate limit and is "
+            f"being re-delivered now along with this reply.\n\n"
+            f"{content}"
+        )
+
+    @staticmethod
+    def _is_c2c_quota_error(error: str) -> bool:
+        """Return whether QQ rejected a C2C passive/wakeup quota."""
+        lowered = error.lower()
+        return any(
+            marker in lowered
+            for marker in (
+                "40034128",
+                "40034122",
+                "被动回复时间或次数超限",
+                "被动回复时间或者次数超过限制",
+                "召回消息已达区间上限",
+            )
+        )
 
     async def _send_chunk(
             self,
@@ -2529,8 +2608,14 @@ class QQAdapter(BasePlatformAdapter):
             except Exception as exc:
                 last_exc = exc
                 err = str(exc).lower()
+                # QQ C2C passive-reply and wakeup quota errors are permanent.
+                # Retrying cannot replenish either quota and only duplicates the
+                # same non-idempotent delivery attempt.
+                c2c_quota_exhausted = (
+                    chat_type == "c2c" and self._is_c2c_quota_error(err)
+                )
                 # Permanent errors — don't retry
-                if any(
+                if c2c_quota_exhausted or any(
                         k in err
                         for k in ("invalid", "forbidden", "not found", "bad request")
                 ):
@@ -2549,10 +2634,16 @@ class QQAdapter(BasePlatformAdapter):
 
         error_msg = (str(last_exc) or type(last_exc).__name__) if last_exc else "Unknown error"
         logger.error("[%s] Send failed: %s", self._log_tag, error_msg)
-        retryable = not any(
+        quota_exhausted = chat_type == "c2c" and self._is_c2c_quota_error(error_msg)
+        retryable = not quota_exhausted and not any(
             k in error_msg.lower() for k in ("invalid", "forbidden", "not found")
         )
-        return SendResult(success=False, error=error_msg, retryable=retryable)
+        return SendResult(
+            success=False,
+            error=error_msg,
+            retryable=retryable,
+            error_kind="rate_limited" if quota_exhausted else None,
+        )
 
     async def _send_c2c_text(
             self,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -140,6 +140,16 @@ class TestPlatformDefaults:
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
 
+    def test_qqbot_defaults_protect_finite_passive_reply_quota(self):
+        """QQ C2C cannot edit progress bubbles, so chatty surfaces stay off."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "qqbot", "tool_progress") == "off"
+        assert resolve_display_setting({}, "qqbot", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "qqbot", "long_running_notifications") is False
+        assert resolve_display_setting({}, "qqbot", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "qqbot", "streaming") is False
+
     def test_telegram_mobile_chatter_defaults(self):
         """Telegram keeps real mid-turn signal (interim commentary + heartbeats)
         but skips the verbose busy-ack iteration counter by default."""

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import time
 from types import SimpleNamespace
 from unittest import mock
 
@@ -9,6 +10,7 @@ import httpx
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +439,207 @@ class TestWaitForReconnection:
         result = await adapter.send("test_openid", "Hello, world!")
         assert result.success
         assert result.message_id == "msg_123"
+
+
+# ---------------------------------------------------------------------------
+# C2C passive-reply quota exhaustion
+# ---------------------------------------------------------------------------
+
+class TestQQC2CPassiveReplyQuota:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(
+            _make_config(app_id="a", client_secret="b", markdown_support=False, **extra)
+        )
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        return adapter
+
+    def test_passive_quota_error_is_bounded_and_permanent(self):
+        """One final C2C delivery makes one passive request and no fallback send."""
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_api_request(method, path, body):
+            calls.append((method, path, dict(body)))
+            raise RuntimeError(
+                "QQ Bot API error [400] /v2/users/u/messages: "
+                "40034128 被动回复时间或次数超限"
+            )
+
+        adapter._api_request = fake_api_request
+
+        result = asyncio.run(
+            adapter._send_with_retry(
+                "u", "final answer", reply_to="inbound-1", max_retries=2, base_delay=0
+            )
+        )
+
+        assert not result.success
+        assert result.retryable is False
+        assert len(calls) == 1
+        assert calls[0][2]["msg_id"] == "inbound-1"
+        assert calls[0][2]["message_reference"] == {"message_id": "inbound-1"}
+        assert "40034128" in (result.error or "")
+
+    def test_wakeup_quota_error_is_permanent_without_inner_retries(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_c2c(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise RuntimeError(
+                "QQ Bot API error [400] /v2/users/u/messages: "
+                "40034122 召回消息已达区间上限"
+            )
+
+        adapter._send_c2c_text = fake_c2c
+
+        result = asyncio.run(adapter._send_chunk("u", "final answer", "inbound-1"))
+
+        assert not result.success
+        assert result.retryable is False
+        assert len(calls) == 1
+        assert "40034122" in (result.error or "")
+
+    def test_success_path_still_sends_once(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_api_request(method, path, body):
+            calls.append((method, path, dict(body)))
+            return {"id": "sent-1"}
+
+        adapter._api_request = fake_api_request
+
+        result = asyncio.run(
+            adapter._send_with_retry("u", "final answer", reply_to="inbound-1")
+        )
+
+        assert result.success
+        assert result.message_id == "sent-1"
+        assert len(calls) == 1
+
+    def test_quota_codes_are_classified_without_localized_message(self):
+        adapter = self._make_adapter()
+
+        assert adapter._is_c2c_quota_error("QQ error code=40034128")
+        assert adapter._is_c2c_quota_error("QQ error code=40034122")
+
+    def test_dropped_answer_is_carried_forward_to_next_deliverable_send(self):
+        """A final answer permanently dropped by quota exhaustion (#agentic-rl-jd-
+        20260825 incident: 13 retries against an exhausted wakeup channel, then
+        silent loss) must not vanish — it rides along on the next message this
+        adapter actually manages to deliver to the same chat."""
+        adapter = self._make_adapter()
+        outcomes = [
+            RuntimeError(
+                "QQ Bot API error [400] /v2/users/u/messages: "
+                "40034128 被动回复时间或次数超限"
+            ),
+            {"id": "sent-2"},
+        ]
+        sent_bodies = []
+
+        async def fake_api_request(method, path, body):
+            sent_bodies.append(dict(body))
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        adapter._api_request = fake_api_request
+
+        dropped = asyncio.run(adapter.send("u", "final answer that got dropped"))
+        assert not dropped.success
+        assert dropped.error_kind == "rate_limited"
+        assert "u" in adapter._quota_undelivered
+
+        delivered = asyncio.run(adapter.send("u", "next turn's reply"))
+        assert delivered.success
+        merged_content = sent_bodies[-1]["content"]
+        assert "final answer that got dropped" in merged_content
+        assert "next turn's reply" in merged_content
+        # Consumed — a third, unrelated send must not repeat stale content.
+        assert "u" not in adapter._quota_undelivered
+
+    def test_stale_carried_content_is_discarded_not_reattached(self):
+        """Content dropped hours ago should not get glued onto a reply in an
+        unrelated, much later conversation turn."""
+        adapter = self._make_adapter()
+        adapter._quota_undelivered["u"] = (
+            "ancient dropped answer",
+            time.time() - (adapter._UNDELIVERED_CARRY_SECONDS + 60),
+        )
+
+        merged = adapter._prepend_undelivered("u", "fresh reply")
+
+        assert merged == "fresh reply"
+        assert "ancient dropped answer" not in merged
+
+    def test_repeated_quota_failure_keeps_carrying_merged_content(self):
+        """If the carried-forward retry also gets quota-rejected, the merged
+        text must be re-stashed rather than dropped a second time."""
+        adapter = self._make_adapter()
+        adapter._quota_undelivered["u"] = ("first dropped answer", time.time())
+
+        async def always_quota_exhausted(method, path, body):
+            raise RuntimeError(
+                "QQ Bot API error [400] /v2/users/u/messages: "
+                "40034122 召回消息已达区间上限"
+            )
+
+        adapter._api_request = always_quota_exhausted
+
+        result = asyncio.run(adapter.send("u", "second answer"))
+
+        assert not result.success
+        assert result.error_kind == "rate_limited"
+        carried_content, _ = adapter._quota_undelivered["u"]
+        assert "first dropped answer" in carried_content
+        assert "second answer" in carried_content
+
+    def test_non_quota_failure_does_not_consume_carried_content(self):
+        adapter = self._make_adapter()
+        adapter._quota_undelivered["u"] = ("first dropped answer", time.time())
+
+        async def transient_failure(*args, **kwargs):
+            return SendResult(success=False, error="connection reset", retryable=True)
+
+        adapter._send_chunk = transient_failure
+
+        result = asyncio.run(adapter.send("u", "second answer"))
+
+        assert not result.success
+        carried_content, _ = adapter._quota_undelivered["u"]
+        assert carried_content == "first dropped answer"
+
+    def test_partial_multi_chunk_send_stashes_only_undelivered_tail(self):
+        adapter = self._make_adapter()
+        adapter.MAX_MESSAGE_LENGTH = 80
+        sent_chunks = []
+
+        async def fail_second_chunk(chat_id, chunk, reply_to=None):
+            sent_chunks.append(chunk)
+            if len(sent_chunks) == 1:
+                return SendResult(success=True, message_id="sent-1")
+            return SendResult(
+                success=False,
+                error="40034128 passive reply quota exceeded",
+                retryable=False,
+                error_kind="rate_limited",
+            )
+
+        adapter._send_chunk = fail_second_chunk
+        content = "FIRST-PART " + ("x" * 80) + " UNDELIVERED-TAIL"
+
+        result = asyncio.run(adapter.send("u", content))
+
+        assert not result.success
+        carried_content, _ = adapter._quota_undelivered["u"]
+        assert "UNDELIVERED-TAIL" in carried_content
+        assert "FIRST-PART" not in carried_content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -168,6 +168,25 @@ class TestSendWithRetryFallback:
         assert "plain text" in adapter._send_calls[1][1].lower()
 
 
+    @pytest.mark.asyncio
+    async def test_structured_permanent_rate_limit_skips_plain_text_fallback(self):
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error="provider quota exhausted",
+                retryable=False,
+                error_kind="rate_limited",
+            ),
+        ]
+
+        result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
+
+        assert not result.success
+        assert result.error == "provider quota exhausted"
+        assert len(adapter._send_calls) == 1
+
+
 # ---------------------------------------------------------------------------
 # _send_with_retry — retry_after honor
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

QQBot C2C users can lose a completed final response when QQ closes the passive-reply window or exhausts the wakeup quota. This change stops retrying those permanent quota failures, retains the undelivered tail per chat for up to six hours, and prepends it to the next reply that QQ accepts.

### Symptom

After a long silent turn, Hermes finishes the response but QQ rejects delivery with quota codes `40034128` or `40034122`. The adapter retries the same permanent rejection through both its inner and base retry loops, then the user receives no final answer.

### Impact

Affected QQBot C2C users can spend minutes waiting for a completed turn and never receive its result. Long responses are especially exposed because a quota failure can occur after an earlier chunk was already delivered.

### Bug Cause

**Trigger:** `gateway/platforms/qqbot/adapter.py` in `QQAdapter._send_chunk()` when QQ returns a C2C passive-reply or wakeup-quota rejection.

**Causal chain:**
1. A long-running C2C turn reaches QQ after the reply quota or time window is exhausted.
2. `_send_chunk()` recognizes only generic English permanent-error text, so QQ's numeric codes and localized messages remain retryable.
3. The adapter retries three times, the base adapter retries the whole send again, and the final failed result is not attached to the next live turn.

**Why it is wrong:** These quota budgets cannot be replenished by retrying the same outbound response, and a plain-text fallback consumes the same exhausted transport.

**Working sibling / contrast:** Successful sends already stop after one accepted request. Structured non-retryable send failures can also bypass the base retry loop; QQBot was not classifying these quota failures into that contract.

**Ruled out:** The adjacent expired-reply-anchor path is not sufficient because this incident persists after QQ also rejects the standalone wakeup channel. The captured numeric quota codes identify a distinct permanent delivery failure.

### Fix

- Classify QQ C2C quota codes and localized variants as non-retryable `rate_limited` failures.
- Return structured permanent rate limits without a plain-text fallback in the shared base adapter.
- Retain only the undelivered chunks per chat, preserve them across unrelated transient send failures, expire stale entries, and clear them only after successful carry-forward delivery.
- Default QQBot to the low-chatter display tier so progress, interim, and heartbeat messages do not consume the finite reply budget ahead of the final answer.

## Related Issue

Closes #99144

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py` - classify permanent C2C quota failures and carry undelivered reply tails into the next successful send.
- `gateway/platforms/base.py` - skip formatting fallback for structured permanent rate limits.
- `gateway/display_config.py` - use low-chatter defaults for QQBot.
- `tests/gateway/test_qqbot.py` - cover bounded retries, carry-forward, expiry, repeated quota failures, transient failures, and partial multi-chunk delivery.
- `tests/gateway/test_send_retry.py` - cover the shared structured rate-limit short circuit.
- `tests/gateway/test_display_config.py` - cover QQBot's finite-quota display defaults.

## How to Test

1. Simulate QQ C2C quota codes `40034128` and `40034122` and verify one bounded attempt with a non-retryable result.
2. Simulate a quota-blocked response followed by a successful next turn and verify only the undelivered content is carried forward.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_qqbot.py tests/gateway/test_send_retry.py tests/gateway/test_display_config.py -q
```

Result: 109 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test runner on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; this restores existing delivery expectations
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact was considered; the change is platform-specific Python logic with OS-independent tests
- [x] Tool descriptions and schemas are N/A; no model tool changed

## Screenshots / Logs

N/A - automated adapter-level regression tests cover the failure and recovery paths.
