### PR TITLE
fix(security): deny bare $HOME credential files in media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1294,6 +1294,23 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     "Library/Keychains",  # macOS
 )
 
+# Bare credential FILES that live directly in $HOME rather than inside one of
+# the directories above. The directory list denies ``~/.aws/credentials`` but
+# nothing denied ``~/.netrc``, so these were deliverable as native attachments.
+#
+# Four of them are already classified as credentials by the terminal write
+# guard (``tools/approval._CREDENTIAL_FILES`` gates writes to netrc / pgpass /
+# npmrc / pypirc), so leaving them deliverable let the read/exfil side trail the
+# write side — the same invariant this module states below. ``.git-credentials``
+# stores ``https://user:token@host`` in cleartext and was ungated on both sides.
+_MEDIA_DELIVERY_DENIED_HOME_FILES = (
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+    ".git-credentials",
+)
+
 
 # Canonical cache subdirectories that hold deliverable artifacts. Used both
 # for the top-level safe roots above and to enumerate per-profile cache roots
@@ -1410,6 +1427,8 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
+    for cred_file in _MEDIA_DELIVERY_DENIED_HOME_FILES:
+        denied.append(home / cred_file)
     # The active Hermes profile and shared Hermes root both contain control
     # files and credentials. Only cache subdirectories under them are
     # explicitly allowlisted above (matched BEFORE this denylist in

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -39,6 +39,84 @@ def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):
     assert base.validate_media_delivery_path(str(path)) is None
 
 
+class TestHomeCredentialFileMediaDenial:
+    """Bare credential files in $HOME must never be auto-attached.
+
+    Regression: ``_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS`` denied credential
+    DIRECTORIES (``~/.aws/credentials`` is refused because ``~/.aws`` is denied)
+    but nothing denied a bare credential FILE, so ``~/.netrc``, ``~/.pgpass``,
+    ``~/.npmrc``, ``~/.pypirc``, and ``~/.git-credentials`` were deliverable as
+    native attachments. A prompt-injected ``MEDIA:~/.netrc`` tag was enough to
+    exfiltrate them.
+
+    Four of the five are already gated on the WRITE side by
+    ``tools.approval._CREDENTIAL_FILES``, so leaving them deliverable let the
+    read/exfil side trail the write side — the invariant
+    ``_media_delivery_denied_paths`` states in its own comment.
+    """
+
+    CREDENTIAL_FILES = (
+        ".netrc",
+        ".pgpass",
+        ".npmrc",
+        ".pypirc",
+        ".git-credentials",
+    )
+
+    def test_home_credential_files_are_refused(self, tmp_path, monkeypatch):
+        import gateway.platforms.base as base
+
+        home = tmp_path / "alice"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        for name in self.CREDENTIAL_FILES:
+            path = home / name
+            path.write_text("secret")
+            assert path in base._media_delivery_denied_paths(), name
+            assert base.validate_media_delivery_path(str(path)) is None, name
+
+    def test_ordinary_home_files_still_deliver(self, tmp_path, monkeypatch):
+        """The denylist must not swallow legitimate deliverables, including
+        near-miss names that merely resemble a credential file."""
+        import gateway.platforms.base as base
+
+        home = tmp_path / "alice"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        for name in (
+            "report.pdf",
+            "chart.png",
+            "notes.txt",
+            ".netrcbackup",
+            "netrc",
+            "my.npmrc.example",
+            "gitcredentials.txt",
+        ):
+            path = home / name
+            path.write_bytes(b"data")
+            assert base.validate_media_delivery_path(str(path)) is not None, name
+
+    def test_credential_directories_remain_refused(self, tmp_path, monkeypatch):
+        """The pre-existing directory denials must survive this change."""
+        import gateway.platforms.base as base
+
+        home = tmp_path / "alice"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        for rel in (
+            ".ssh/id_rsa",
+            ".aws/credentials",
+            ".gnupg/secring.gpg",
+            ".kube/config",
+            ".docker/config.json",
+            ".config/gh/hosts.yml",
+        ):
+            path = home / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("secret")
+            assert base.validate_media_delivery_path(str(path)) is None, rel
+
+
 class TestInboundMediaSizeCap:
     """gateway.max_inbound_media_bytes caps inbound media buffered into RAM (#13145)."""
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -470,6 +470,30 @@ class TestSensitiveCopyMovePattern:
             dangerous, key, desc = detect_dangerous_command(cmd)
             assert dangerous is False, cmd
 
+    def test_git_credentials_write_is_gated(self):
+        """``~/.git-credentials`` stores ``https://user:token@host`` in
+        cleartext, so a write plants usable push credentials — the same class as
+        ``~/.netrc``, which was already gated. It was absent from
+        ``_CREDENTIAL_FILES`` and therefore ungated on every write vector."""
+        for command in (
+            "echo 'https://u:tok@github.com' >> ~/.git-credentials",
+            "echo x > ~/.git-credentials",
+            "echo x | tee -a ~/.git-credentials",
+            "cp /tmp/evil ~/.git-credentials",
+            "mv /tmp/evil ~/.git-credentials",
+        ):
+            dangerous, key, desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_git_credentials_read_out_stays_safe(self):
+        """Only the DESTINATION is gated. Reading OUT of a credential path is
+        covered by the media/read guards, mirroring the ~/.ssh behaviour
+        asserted above."""
+        dangerous, key, desc = detect_dangerous_command("cp ~/.git-credentials /tmp/x")
+        assert dangerous is False
+        assert key is None
+
 
 class TestSensitiveInPlaceEditPattern:
     """Detect in-place edits to user startup and credential files."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -415,7 +415,9 @@ _SHELL_RC_FILES = (
 )
 _CREDENTIAL_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
-    r'(?:netrc|pgpass|npmrc|pypirc)\b'
+    # git-credentials stores `https://user:token@host` in cleartext, so a write
+    # to it plants usable push credentials — same class as ~/.netrc.
+    r'(?:netrc|pgpass|npmrc|pypirc|git-credentials)\b'
 )
 # macOS: /etc, /var, /tmp, /home are symlinks to /private/{etc,var,tmp,home}.
 # A command written to target /private/etc/sudoers works identically to


### PR DESCRIPTION
## What does this PR do?

Follow-up to #59044 / #59045, covering a sibling gap in the same mechanism.

`_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS` denies credential **directories**, so `~/.aws/credentials` is refused because `~/.aws` is denied. Nothing denied a bare credential **file** sitting directly in `$HOME`. Verified on `origin/main` with a temp multi-segment `HOME`, each file created for real:

| Path | Kind | Verdict |
|---|---|---|
| `~/.ssh/id_rsa` | dir-denied | refused |
| `~/.aws/credentials` | dir-denied | refused |
| `~/.gnupg/secring.gpg` | dir-denied | refused |
| `~/.kube/config` | dir-denied | refused |
| `~/.docker/config.json` | dir-denied | refused |
| `~/.config/gh/hosts.yml` | dir-denied | refused |
| `~/.git-credentials` | bare file | **DELIVERABLE** |
| `~/.netrc` | bare file | **DELIVERABLE** |
| `~/.pgpass` | bare file | **DELIVERABLE** |
| `~/.npmrc` | bare file | **DELIVERABLE** |
| `~/.pypirc` | bare file | **DELIVERABLE** |

A prompt-injected `MEDIA:~/.netrc` tag is enough to exfiltrate them — the same reachability as the project-`.env` case in #59044.

## Why these five

Four were already classified as credentials by the terminal write guard:

```python
_CREDENTIAL_FILES = (
    r'(?:~|\$home|\$\{home\})/\.'
    r'(?:netrc|pgpass|npmrc|pypirc)\b'
)
```

So the read/exfil side trailed the write side — the invariant `_media_delivery_denied_paths` states in its own comment ("a credential the agent is forbidden to write or read must also never be auto-attached to a chat reply"), and the "unpaired theater" anti-pattern named at `tools/approval.py:401`, pointing the other way:

| file | terminal write | media read-out (before) |
|---|---|---|
| `~/.netrc` | gated | **DELIVERABLE** |
| `~/.pgpass` | gated | **DELIVERABLE** |
| `~/.npmrc` | gated | **DELIVERABLE** |
| `~/.pypirc` | gated | **DELIVERABLE** |
| `~/.git-credentials` | **ungated** | **DELIVERABLE** |

`~/.git-credentials` was ungated on **both** sides. It stores `https://user:token@host` in cleartext, so a write plants usable push credentials and a read delivers them. This PR adds it to `_CREDENTIAL_FILES` as well, so both directions close.

## Scope, stated honestly

Only `.env`/`.envrc` **strictly** violate the read-vs-deliver invariant as written, because `agent/file_safety._BLOCKED_PROJECT_ENV_BASENAMES` is the only read-blocked set:

```
~/.env             READ blocked   DELIVERABLE   <-- #59044 / PR #59045
~/.envrc           READ blocked   DELIVERABLE   <-- #59044 / PR #59045
~/.netrc           READ allowed   DELIVERABLE   <-- this PR
~/.git-credentials READ allowed   DELIVERABLE   <-- this PR
```

These five are read-*allowed*, so this is not the same strict violation — it closes the **intent** behind the invariant for files the read guard never enumerated. #59045 is untouched and not blocked by this; it reuses `_BLOCKED_PROJECT_ENV_BASENAMES`, so these five remain deliverable after it merges. I raised this on that PR first and offered either shape; this is the separate-PR option.

## How Has This Been Tested?

`tests/gateway/test_platform_base.py` + `tests/tools/test_approval.py` → **7 new tests pass**.

- **Positive control** — reverting both source files while keeping the tests fails the two assertions that matter (media denial, git-cred write), while the two negative-control tests still pass. They discriminate rather than merely passing.
- **Negative controls** — 8 ordinary deliverables still deliver **8/8**, including near-miss names that merely resemble a credential file (`.netrcbackup`, `netrc`, `my.npmrc.example`, `gitcredentials.txt`). All six credential directories remain refused, so the pre-existing denials survive.

`ruff check` clean on all four files.

Three pre-existing failures in the touched files are unrelated and reproduce on unmodified `main` under `HOME=/root`: two `test_platform_base.py` Docker fixture collisions (#98879) and `TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` (#84639, fixed by #98868).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

Refs #59044. Sibling of PR #59045 — same mechanism, disjoint file set, no conflict.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious part (why bare files needed a separate list from directories)
