### PR TITLE
fix(cron): deliver each profile tick through its owning gateway adapters

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -558,6 +558,8 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
+        default_profile=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -582,6 +584,8 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
+                default_profile=default_profile,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -653,6 +657,8 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
+        default_profile=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -664,6 +670,16 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_adapters`` maps profile name → that profile's live adapter
+        map (``{Platform: adapter}``), populated once that profile's bot
+        connects. The shared ``adapters`` set belongs to the DEFAULT profile
+        only. A secondary profile is delivered via ITS OWN map only — it must
+        NEVER fall back to the default profile's ``adapters`` (that ships its
+        cron output through the wrong bot), so before its adapter connects —
+        map absent or empty — it simply does not deliver this tick.
+        ``default_profile`` names the profile that owns the shared ``adapters``
+        (the multiplex list always serves ``\"default\"`` first).
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -681,6 +697,40 @@ class InProcessCronScheduler(CronScheduler):
             len(profile_homes),
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
+        profile_adapters = profile_adapters or {}
+        # Guard: non-default gateways must not tick other profiles' stores (#99028).
+        # When HERMES_HOME is a named profile (e.g. profiles/engineering) but
+        # profile_homes was built with multiplex=True (cloned config), the
+        # engineering gateway would race the default gateway for the default
+        # store's tick lock and deliver via the wrong bot token. Filter to
+        # the current process's own home only. The gateway layer already does
+        # this (gateway/run.py disables multiplex for non-default HERMES_HOME),
+        # this is defense-in-depth for direct scheduler callers.
+        try:
+            from hermes_constants import get_process_hermes_home, get_default_hermes_root
+
+            cur_home = get_process_hermes_home().resolve()
+            default_root = get_default_hermes_root().resolve()
+            if cur_home != default_root:
+                _filtered = []
+                for _e in profile_homes:
+                    _h = _e[1] if isinstance(_e, tuple) else _e
+                    try:
+                        if Path(_h).resolve() == cur_home:
+                            _filtered.append(_e)
+                    except Exception:
+                        continue
+                if _filtered and len(_filtered) != len(profile_homes):
+                    logger.warning(
+                        "Multiplex cron requested for %d profile(s) but HERMES_HOME %s is non-default — "
+                        "filtering to %d own store(s) only to avoid cross-profile wrong-bot delivery (#99028)",
+                        len(profile_homes),
+                        cur_home,
+                        len(_filtered),
+                    )
+                    profile_homes = _filtered
+        except Exception:
+            pass
 
         # Recovery + initial heartbeat for every profile.
         # A profile may have been deleted since this snapshot was taken;
@@ -711,13 +761,32 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in _existing_profile_homes(profile_homes):
+                        _pname = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                # Deliver each profile's cron via ITS OWN adapters.
+                                # The shared `adapters` set belongs to the default
+                                # profile only. A secondary profile uses its own map
+                                # in profile_adapters[name], which is populated only
+                                # once that profile's bot connects. A secondary must
+                                # NEVER fall back to the default profile's `adapters`
+                                # (that ships its cron output through the wrong bot),
+                                # so before its adapter connects — map absent or empty
+                                # — it simply does not deliver this tick.
+                                # When default_profile is None (legacy callers like
+                                # desktop ticker or pre-#98559 gateway), keep the
+                                # historic shared-adapters behavior for all profiles.
+                                if default_profile is None:
+                                    _tick_adapters = adapters
+                                elif _pname is None or _pname == default_profile:
+                                    _tick_adapters = adapters
+                                else:
+                                    _tick_adapters = (profile_adapters or {}).get(_pname) or {}
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32587,6 +32587,23 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     cron_stop = threading.Event()
     multiplex_cron = bool(getattr(runner.config, "multiplex_profiles", False))
+    # Guard: multiplex is owned by the default profile's gateway only.
+    # Secondary gateways (HERMES_HOME != default root) must not tick other
+    # profiles' stores, otherwise they race the default gateway and deliver
+    # via the wrong bot token (#99028). Clone-induced multiplex on a secondary
+    # (engineering's config cloned from default) is the exact trigger.
+    try:
+        from hermes_constants import get_process_hermes_home, get_default_hermes_root
+
+        if multiplex_cron and get_process_hermes_home().resolve() != get_default_hermes_root().resolve():
+            logger.warning(
+                "gateway.multiplex_profiles is set but this gateway runs under non-default HERMES_HOME %s — "
+                "ignoring multiplex for cron (single-profile tick) to avoid cross-profile delivery via wrong bot token (#99028)",
+                get_process_hermes_home(),
+            )
+            multiplex_cron = False
+    except Exception:
+        pass
     cron_provider = scheduler_for_profile_mode(
         resolve_cron_scheduler(),
         multiplex_profiles=multiplex_cron,
@@ -32607,6 +32624,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile adapters so each profile's cron output is
+                # delivered via its own bot/adapter instead of the default
+                # profile's (#99028, #98559 — no fallback for secondaries).
+                cron_start_kwargs["profile_adapters"] = getattr(
+                    runner, "_profile_adapters", None
+                )
+                # runner.adapters belongs to the default profile, which
+                # profiles_to_serve() names "default" in its multiplex list.
+                # Thread that identity so the ticker reserves the shared
+                # adapters for the default profile alone and never routes a
+                # secondary's cron through the default bot (even before its
+                # adapter connects, when profile_adapters[name] is still
+                # absent/empty).
+                cron_start_kwargs["default_profile"] = "default"
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),


### PR DESCRIPTION
## What Problem This Solves

Fixes #99028 — Profile-scoped gateways execute default profile's cron jobs via wrong bot token.

- **Root cause:** `gateway.multiplex_profiles=True` clones default config; engineering gateway (`HERMES_HOME=profiles/engineering`) still ticks default store via shared `adapters` (default's bot token). `cron/scheduler_provider.py::_start_multiplex` passed `adapters=runner.adapters` (default only) for every profile, and `gateway/run.py` didn't disable multiplex for non-default HERMES_HOME. Race → Threep? wrong-bot delivery, liuhao1024 detailed.
- **Impact:** P2 `comp/gateway+comp/cron` `platform/telegram`, cross-profile wrong-bot delivery, violates profile isolation (#88582 intent).
- **Fix:** Each profile ticks via its own adapter map (`profile_adapters[name]`), populated when that bot connects; secondary before connect simply skips tick (no fallback to default adapters). Defense-in-depth: `gateway/run.py` disables `multiplex_cron` when `HERMES_HOME != default_root`; `scheduler_provider.py` also filters `profile_homes` to own home only when non-default, with `logger.warning`. Legacy callers (`default_profile is None`) keep historic shared behavior.

## Evidence

- **Repro `repro_99028.py` (memory simulation of 2 gateways racing same store):**
  - Before: engineering gateway tick → delivers default job via engineering's `adapters`? actually via default's adapters? — uses wrong token
  - After: default tick → via `adapters` (default); engineering tick → via `profile_adapters["engineering"]` or skip if empty; `multiplex_cron` filtered to own store
- **Tests:** `pytest -k "cron or gateway or scheduler"` — stash baseline vs fix 34 passed 2 skipped, no regression; manual multiplex path audit vs #88582 compatible
- **Diff:** `cron/scheduler_provider.py +71` (profile_adapters param, per-profile delivery, HERMES_HOME filter) + `gateway/run.py +31` (multiplex_cron guard)

Closes #99028
