### PR TITLE
fix(hooks): validate manifest event lists

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -113,8 +113,17 @@ class HookRegistry:
 
                 hook_name = manifest.get("name", hook_dir.name)
                 events = manifest.get("events", [])
-                if not events:
-                    print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)
+                if not isinstance(events, list) or not events:
+                    print(
+                        f"[hooks] Skipping {hook_name}: events must be a non-empty list of non-empty strings",
+                        flush=True,
+                    )
+                    continue
+                if any(not isinstance(event, str) or not event.strip() for event in events):
+                    print(
+                        f"[hooks] Skipping {hook_name}: events must be a non-empty list of non-empty strings",
+                        flush=True,
+                    )
                     continue
 
                 # Dynamically load the handler module.

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -59,6 +59,30 @@ class TestDiscoverAndLoad:
         assert len(reg.loaded_hooks) == 0
 
 
+    @pytest.mark.parametrize(
+        "events_yaml",
+        [
+            "agent:start",
+            "[agent:start, 42]",
+            "['agent:start', '   ']",
+        ],
+    )
+    def test_skips_invalid_events_manifest(self, tmp_path, events_yaml, capsys):
+        _create_hook(
+            tmp_path,
+            "invalid-events",
+            events_yaml,
+            "def handle(event_type, context):\n    pass\n",
+        )
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert reg.loaded_hooks == []
+        assert "events must be a non-empty list of non-empty strings" in capsys.readouterr().out
+
+
 class TestEmit:
 
     @pytest.mark.asyncio
@@ -138,5 +162,4 @@ class TestEmitCollect:
         results = await reg.emit_collect("command:x", {})
 
         assert results == [{"decision": "deny"}]
-
 


### PR DESCRIPTION
## Summary
- reject scalar, empty, or mixed-type `events` values in `HOOK.yaml`
- prevent YAML scalar strings from registering one handler per character
- add focused regression coverage for malformed manifests

## Validation
- `uv run --with pytest --with pytest-asyncio pytest -q tests/gateway/test_hooks.py`
- `git diff --check`

This is a focused bug fix with no dependency or public API changes.