### PR TITLE
fix(desktop): avoid double-quoting the SSH update mutex path on remote hosts

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1506,6 +1506,29 @@ test('buildSpawnCommand lockfile publication is POSIX sh (no bash substitution)'
   assert.ok(cmd.includes('sed "s/__PID__/${child}/"'), 'pid substitution must use sed')
 })
 
+test('buildSpawnCommand does not double-quote the update mutex path', () => {
+  const cmdAbs = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '/home/hermes/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    ownershipId: OWNERSHIP_ID,
+    lockMetadata: { ownershipId: OWNERSHIP_ID, spawnNonce: SPAWN_NONCE }
+  })
+  // Absolute mutexPath is expandRemotePath output ('/home/hermes/.hermes/.hermes-update-in-progress.mutex').
+  // It must be embedded directly as sys.argv[1] without being wrapped in shq() again,
+  // which would pass literal quote characters to python and create a directory named `'`.
+  assert.match(cmdAbs, /python3 -c '[\s\S]+?' '\/home\/hermes\/\.hermes\/\.hermes-update-in-progress\.mutex'/)
+  assert.doesNotMatch(cmdAbs, /python3 -c '[\s\S]+?' ''\\''/)
+
+  const cmdTilde = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    ownershipId: OWNERSHIP_ID,
+    lockMetadata: { ownershipId: OWNERSHIP_ID, spawnNonce: SPAWN_NONCE }
+  })
+  // Tilde mutexPath is expandRemotePath output ("$HOME"'/.hermes/.hermes-update-in-progress.mutex').
+  assert.match(cmdTilde, /python3 -c '[\s\S]+?' "\$HOME"'\/\.hermes\/\.hermes-update-in-progress\.mutex'/)
+})
+
 test('spawnRemoteDashboard removes a token file when upload reporting fails', async () => {
   const failure = new Error('channel closed')
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -895,7 +895,8 @@ finally:
 // the marker check, spawns the backend, and publishes its initial lockfile.
 // Python keeps the descriptor close-on-exec by default and passes it explicitly
 // only to the intended outer shell; each detached child closes it before
-// execing Hermes.
+// execing Hermes. mutexPath is already expandRemotePath() output (shell-quoted
+// or "$HOME"'/…' fragment). Embed raw so $HOME expands and quotes are not duplicated.
 function withRemoteUpdateMutex(command, mutexPath) {
   const script = `
 import fcntl,os,subprocess,sys
@@ -913,7 +914,7 @@ finally:
 sys.exit(result.returncode if result is not None else 1)
 `.trim()
 
-  return `python3 -c ${shq(script)} ${shq(mutexPath)} ${shq(command)}`
+  return `python3 -c ${shq(script)} ${mutexPath} ${shq(command)}`
 }
 
 /**


### PR DESCRIPTION
## Summary

When connecting to a remote host over SSH, `withRemoteUpdateMutex` wrapped `mutexPath` in `shq()` even though `mutexPath` was already the output of `expandRemotePath()` (which already produces a shell-quoted string or `"$HOME"'/…'` fragment).

On remote Linux hosts, the extra `shq()` passed literal single-quote characters inside `sys.argv[1]` to the Python mutex helper. When Python evaluated `os.path.dirname(sys.argv[1])` on a path like `'/home/hermes/.hermes/…'`, it treated the path as relative because it began with `'` instead of `/`. Calling `os.makedirs(parent, exist_ok=True)` then created a literal directory named `'` under the user's home directory (e.g. `/home/hermes/'`).

## Changes

- In `apps/desktop/electron/remote-lifecycle.ts`, embed `mutexPath` directly into `withRemoteUpdateMutex`'s command string instead of wrapping it in `shq(mutexPath)`.
- In `apps/desktop/electron/remote-lifecycle.test.ts`, add regression test `buildSpawnCommand does not double-quote the update mutex path` asserting that both absolute and tilde `hermesHome` paths produce clean `python3 -c ... <path>` arguments without double-quoting or literal single quotes.

Fixes #99133