### PR TITLE
docs(metadata): expose project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.11,<3.14"
 authors = [{ name = "Nous Research" }]
 license = "MIT"
 license-files = ["LICENSE"]
+
 dependencies = [
   # Core — every direct dep is exact-pinned to ==X.Y.Z (no ranges).
   # Rationale: ranges allow PyPI to ship a fresh version of a transitive
@@ -177,6 +178,12 @@ dependencies = [
   # before, worked around by installing with `--no-deps` or an older release.
   "nemo-relay>=0.7.1,<0.8; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64' and 'android' not in platform_release) or (sys_platform == 'linux' and platform_machine == 'aarch64' and 'android' not in platform_release) or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
 ]
+
+[project.urls]
+Homepage = "https://hermes-agent.nousresearch.com/"
+Documentation = "https://hermes-agent.nousresearch.com/docs/"
+Repository = "https://github.com/NousResearch/hermes-agent"
+Issues = "https://github.com/NousResearch/hermes-agent/issues"
 
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -3,11 +3,29 @@
 from pathlib import Path
 import tomllib
 
+
+def _load_project_metadata():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
 def _load_optional_dependencies():
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as handle:
         project = tomllib.load(handle)["project"]
     return project["optional-dependencies"]
+
+
+def test_project_urls_expose_stable_discovery_links():
+    project = _load_project_metadata()
+
+    assert project["urls"] == {
+        "Homepage": "https://hermes-agent.nousresearch.com/",
+        "Documentation": "https://hermes-agent.nousresearch.com/docs/",
+        "Repository": "https://github.com/NousResearch/hermes-agent",
+        "Issues": "https://github.com/NousResearch/hermes-agent/issues",
+    }
 
 
 def _load_package_data():


### PR DESCRIPTION
## Summary
- expose stable Homepage, Documentation, Repository, and Issues links through PEP 621 project metadata
- add a focused regression test to keep the PyPI discovery links present and correct

## Validation
- `uv run --no-project --with pytest pytest -q tests/test_project_metadata.py` (8 passed)
- `git diff --check`
- `tomllib` metadata parse passed