### PR TITLE
fix(cli): escape user query text in the single-query "Query:" banner (#98789)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22237,7 +22237,11 @@ def main(
                 # invocations are fast.
                 _query_label = query or ("[image attached]" if single_query_images else "")
                 if _query_label:
-                    cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+                    # The label is user-controlled (``-q`` text or ``--query-file``
+                    # contents) and must be rendered literally — square brackets in
+                    # test IDs, paths, regexes, or Markdown otherwise parse as Rich
+                    # markup and raise MarkupError before the agent turn starts.
+                    cli.console.print(f"[bold blue]Query:[/] {_escape(_query_label)}")
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()

--- a/tests/cli/test_chat_q_query_label_markup.py
+++ b/tests/cli/test_chat_q_query_label_markup.py
@@ -1,0 +1,67 @@
+"""Regression for #98789: query-file / -q text that looks like Rich markup.
+
+The single-query path echoes a ``Query: <text>`` line before the agent turn.
+The ``<text>`` half is user-controlled (``-q`` string or ``--query-file``
+contents). It used to be interpolated into a markup-enabled ``console.print``,
+so a pytest-style token like ``test_case[/fb-images/a/../b.webp?w=336]`` parsed
+as an unmatched closing tag and raised ``rich.errors.MarkupError`` before the
+run started. The label must render literally instead.
+"""
+
+import io
+from types import SimpleNamespace
+
+from rich.console import Console
+
+import cli as cli_mod
+
+
+# A path-like token with a bracketed segment that opens with '/', i.e. a Rich
+# closing tag with no matching open tag — the exact shape from the bug report.
+HOSTILE_LABEL = "test_case[/fb-images/a/../b.webp?w=336]"
+
+
+def _run_single_query(monkeypatch, query):
+    """Drive cli.main()'s human-facing single-query branch with a real Console.
+
+    Returns the text written to the fake console.
+    """
+    buf = io.StringIO()
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = Console(file=buf, force_terminal=False, width=200)
+            self.session_id = "sq-markup-test"
+            self.agent = SimpleNamespace(session_id="sq-markup-test", platform="cli")
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, query, images=None):
+            return "done"
+
+        def _print_exit_summary(self, clear_screen=True):
+            pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+
+    cli_mod.main(query=query, quiet=False, toolsets="terminal")
+    return buf.getvalue()
+
+
+def test_bracketed_query_label_does_not_raise_markup_error(monkeypatch):
+    # Without the escape this call raises rich.errors.MarkupError before the
+    # agent turn; with it, main() completes and the label renders verbatim.
+    out = _run_single_query(monkeypatch, HOSTILE_LABEL)
+    assert "Query:" in out
+    assert "test_case[/fb-images/a/../b.webp?w=336]" in out
+
+
+def test_plain_query_label_still_renders(monkeypatch):
+    out = _run_single_query(monkeypatch, "summarize the repo")
+    assert "Query: summarize the repo" in out


### PR DESCRIPTION
## What does this PR do?

`hermes chat -q "…"` / `hermes chat --query-file …` echoes a `Query: <text>` line
before the agent turn starts. The `<text>` half is user-controlled (the `-q`
string or the file contents) but it was interpolated straight into a
markup-enabled `console.print`:

```python
cli.console.print(f"[bold blue]Query:[/] {_query_label}")
```

Any query text containing a bracketed segment that Rich parses as an **unmatched
closing tag** — a pytest parametrize ID, a path-like token, a regex, Markdown —
raises `rich.errors.MarkupError` and the CLI exits with status 1 **before the
run starts**. From the issue:

```
test_case[/fb-images/a/../b.webp?w=336]
```
```
rich.errors.MarkupError: closing tag '[/fb-images/a/../b.webp?w=336]' ... doesn't match any open tag
```

Fix: wrap the user-controlled label in `rich.markup.escape` (already imported in
`cli.py` as `_escape`) so it always renders literally. The static
`[bold blue]Query:[/]` prefix stays real markup. The `[image attached]` sentinel
is unchanged (escaping only makes its literal rendering explicit).

## Related Issue

Fixes #98789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — escape `_query_label` with `_escape(...)` in the single-query
  `Query:` banner print (single line + explanatory comment).
- `tests/cli/test_chat_q_query_label_markup.py` — new regression test that drives
  `cli.main()`'s single-query branch with a real `rich.console.Console` and a
  hostile bracketed label, asserting no `MarkupError` and that the text renders
  verbatim; plus a plain-label sanity case.

## How to Test

1. `printf 'test_case[/fb-images/a/../b.webp?w=336]\n' > /tmp/q.md`
2. Before the fix: `hermes chat --query-file /tmp/q.md --max-turns 1` exits 1 with
   `rich.errors.MarkupError` before any turn.
3. After the fix: the `Query:` line prints literally and the run proceeds.
4. Automated: `pytest tests/cli/test_chat_q_query_label_markup.py -q` (fails on
   `main` without the `cli.py` change, passes with it).

Also ran the adjacent single-query suites green:
`tests/cli/test_chat_q_exit_clear.py`, `tests/hermes_cli/test_chat_query_file.py`,
`tests/cli/test_single_query_session_finalize.py`.

## What platforms

Tested on macOS (Python 3.11). Change is pure string escaping with no OS-specific
behavior.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched existing issues/PRs — no open PR references #98789
- [x] PR contains only changes related to this fix
- [x] Ran the relevant `pytest tests/cli/…` suites, all pass
- [x] Added a regression test (verified it fails without the fix)
- [x] Tested on my platform: macOS 15 / Python 3.11.16

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing config or API change)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — N/A (string escaping only)
- [x] Tool descriptions/schemas — N/A
