### PR TITLE
test(docs): guard Docker version command

### DIFF
--- a/tests/tools/test_docker_docs.py
+++ b/tests/tools/test_docker_docs.py
@@ -1,0 +1,14 @@
+"""Regression checks for user-facing Docker commands in the documentation."""
+
+from pathlib import Path
+
+
+DOCKER_GUIDE = Path(__file__).resolve().parents[2] / "website/docs/user-guide/docker.md"
+
+
+def test_health_check_uses_a_fresh_container_for_version_check():
+    """The health-check command must not assume a running container has the CLI on PATH."""
+    docs = DOCKER_GUIDE.read_text(encoding="utf-8")
+
+    assert "docker run -it --rm nousresearch/hermes-agent:latest version" in docs
+    assert "docker exec hermes hermes version" not in docs


### PR DESCRIPTION
## Summary
- add a regression test for the Docker guide health-check version command
- ensure the documented check uses a fresh `latest` container
- prevent the stale `docker exec hermes hermes version` form from returning

## Validation
- `uv run --no-project --with pytest pytest -q tests/tools/test_docker_docs.py` (1 passed)
- `git diff --check`