### PR TITLE
test(metadata): keep package version in sync

### DIFF
--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -10,6 +10,16 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
+def test_project_version_matches_runtime_package_version():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        project_version = tomllib.load(handle)["project"]["version"]
+
+    from hermes_cli import __version__
+
+    assert project_version == __version__
+
+
 def _load_package_data():
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as handle:


### PR DESCRIPTION
## Summary
- assert the runtime `hermes_cli.__version__` matches `pyproject.toml`
- prevent release metadata drift from reaching packaging artifacts

## Validation
- `uv run --no-project --with pytest pytest -q tests/test_project_metadata.py` (8 passed)
- `git diff --check`