### PR TITLE
fix(desktop): disable native hasShadow for Quick Entry overlay window

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -308,7 +308,7 @@ import {
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
-import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import { createQuickEntryShortcut, quickEntryWindowBounds, quickEntryWindowOptions, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
@@ -13767,24 +13767,7 @@ function spawnQuickEntryWindow() {
   const bounds = quickEntryWindowBounds(display?.workArea)
 
   const win = new BrowserWindow({
-    ...bounds,
-    frame: false,
-    transparent: true,
-    resizable: false,
-    movable: true,
-    minimizable: false,
-    maximizable: false,
-    fullscreenable: false,
-    // Same rationale as the pet overlay: on Windows/Linux keep the helper out
-    // of the taskbar/alt-tab list; on macOS use an NSPanel so the frameless
-    // capture window never becomes the app's cmd-tab anchor.
-    skipTaskbar: !IS_MAC,
-    hasShadow: true,
-    alwaysOnTop: true,
-    type: IS_MAC ? 'panel' : undefined,
-    hiddenInMissionControl: IS_MAC,
-    show: false,
-    backgroundColor: '#00000000',
+    ...quickEntryWindowOptions(bounds, IS_MAC),
     webPreferences: {
       preload: PRELOAD_PATH,
       contextIsolation: true,

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -6,6 +6,7 @@ import {
   type GlobalShortcutLike,
   parseQuickEntryShortcut,
   quickEntryWindowBounds,
+  quickEntryWindowOptions,
   sanitizeQuickEntrySettings
 } from './quick-entry'
 
@@ -236,5 +237,33 @@ describe('quickEntryWindowBounds', () => {
 
   it('falls back to the origin without a work area', () => {
     expect(quickEntryWindowBounds()).toEqual({ height: 168, width: 640, x: 0, y: 0 })
+  })
+})
+
+describe('quickEntryWindowOptions', () => {
+  it('configures hasShadow: false to prevent shadow artifacts on transparent windows', () => {
+    const bounds = { height: 168, width: 640, x: 100, y: 50 }
+    const macOptions = quickEntryWindowOptions(bounds, true)
+    const winOptions = quickEntryWindowOptions(bounds, false)
+
+    expect(macOptions.hasShadow).toBe(false)
+    expect(winOptions.hasShadow).toBe(false)
+    expect(macOptions.frame).toBe(false)
+    expect(macOptions.transparent).toBe(true)
+    expect(macOptions.alwaysOnTop).toBe(true)
+    expect(macOptions.backgroundColor).toBe('#00000000')
+  })
+
+  it('sets platform-specific window options', () => {
+    const macOptions = quickEntryWindowOptions(undefined, true)
+    const nonMacOptions = quickEntryWindowOptions(undefined, false)
+
+    expect(macOptions.type).toBe('panel')
+    expect(macOptions.skipTaskbar).toBe(false)
+    expect(macOptions.hiddenInMissionControl).toBe(true)
+
+    expect(nonMacOptions.type).toBeUndefined()
+    expect(nonMacOptions.skipTaskbar).toBe(true)
+    expect(nonMacOptions.hiddenInMissionControl).toBe(false)
   })
 })

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -418,4 +418,33 @@ export function quickEntryWindowBounds(workArea?: { height: number; width: numbe
   return { height, width, x, y }
 }
 
+/**
+ * BrowserWindow constructor options for the Quick Entry overlay window.
+ *
+ * Uses hasShadow: false to avoid native rectangular shadow/border artifacts on
+ * transparent frameless windows (matching the pet and HUD overlays).
+ */
+export function quickEntryWindowOptions(
+  bounds?: { height: number; width: number; x: number; y: number },
+  isMac: boolean = process.platform === 'darwin'
+) {
+  return {
+    ...bounds,
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: true,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: !isMac,
+    hasShadow: false,
+    alwaysOnTop: true,
+    type: (isMac ? 'panel' : undefined) as 'panel' | undefined,
+    hiddenInMissionControl: isMac,
+    show: false,
+    backgroundColor: '#00000000'
+  }
+}
+
 export { DEFAULT_QUICK_ENTRY_SHORTCUT, QUICK_ENTRY_TOP_FRACTION, QUICK_ENTRY_WINDOW_HEIGHT, QUICK_ENTRY_WINDOW_WIDTH }


### PR DESCRIPTION
## Summary

The Quick Entry window (⌘⇧Space) is a transparent, frameless overlay window. Having `hasShadow: true` in its `BrowserWindow` configuration caused macOS to draw a native rectangular translucent shadow/border outline around the transparent window rectangle, creating a stray outline artifact behind the rounded card.

Other transparent overlay windows (`spawnPetOverlayWindow`, `spawnHudWindow`) already use `hasShadow: false` to avoid this artifact.

## Changes

- In `apps/desktop/electron/quick-entry.ts`, extract `quickEntryWindowOptions` defining the `BrowserWindow` configuration for Quick Entry with `hasShadow: false`.
- In `apps/desktop/electron/main.ts`, use `quickEntryWindowOptions(bounds, IS_MAC)` in `spawnQuickEntryWindow`.
- In `apps/desktop/electron/quick-entry.test.ts`, add unit tests for `quickEntryWindowOptions` asserting `hasShadow: false` and platform-specific window options.

Fixes #99172