### PR TITLE
fix(cli): don't let a setproctitle UnicodeDecodeError abort startup (#98620)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -252,7 +252,12 @@ def _set_process_title() -> None:
 
         setproctitle.setproctitle("hermes")
         return
-    except ImportError:
+    except (ImportError, UnicodeDecodeError):
+        # UnicodeDecodeError: setproctitle 1.3.x on Darwin truncates the
+        # argv buffer one byte short; if argv ends in a multibyte character
+        # the module-level getproctitle() decode blows up at import. A
+        # cosmetic title-setter must never abort startup — fall through to
+        # the ctypes fallback below.
         pass
 
     # Strategy 2/3: platform-specific ctypes fallback

--- a/tests/hermes_cli/test_set_process_title_multibyte.py
+++ b/tests/hermes_cli/test_set_process_title_multibyte.py
@@ -1,0 +1,56 @@
+"""Regression for #98620: a UnicodeDecodeError from setproctitle must not
+abort startup.
+
+setproctitle 1.3.x on Darwin (PS_USE_CLOBBER_ARGV) truncates the argv buffer
+one byte short of the title. When the last argv entry ends in a multibyte
+character the cut lands mid-sequence, and setproctitle's module-level
+``getproctitle()`` decode raises ``UnicodeDecodeError`` at import time — which
+used to escape ``_set_process_title``'s ``except ImportError`` guard and kill
+``main()`` before the agent started. The title setter is purely cosmetic and
+must fall through to the ctypes fallback instead.
+"""
+
+import builtins
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import main as hmain
+
+
+def _unicode_decode_error() -> UnicodeDecodeError:
+    return UnicodeDecodeError("utf-8", b"\x80", 0, 1, "unexpected end of data")
+
+
+def test_import_setproctitle_unicodedecodeerror_does_not_abort():
+    """The crash the issue reports: `import setproctitle` itself raises."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "setproctitle":
+            raise _unicode_decode_error()
+        return real_import(name, *args, **kwargs)
+
+    with patch("ctypes.CDLL", MagicMock()), patch.object(builtins, "__import__", fake_import):
+        # Must return None, not propagate UnicodeDecodeError.
+        assert hmain._set_process_title() is None
+
+
+def test_setproctitle_call_unicodedecodeerror_does_not_abort():
+    """Same guard when the import succeeds but the call raises."""
+    fake_mod = types.SimpleNamespace(
+        setproctitle=MagicMock(side_effect=_unicode_decode_error())
+    )
+    with patch("ctypes.CDLL", MagicMock()), patch.dict(sys.modules, {"setproctitle": fake_mod}):
+        assert hmain._set_process_title() is None
+    fake_mod.setproctitle.assert_called_once_with("hermes")
+
+
+def test_setproctitle_success_path_still_used():
+    """When setproctitle works, it is used and the ctypes fallback is skipped."""
+    fake_mod = types.SimpleNamespace(setproctitle=MagicMock())
+    cdll = MagicMock()
+    with patch("ctypes.CDLL", cdll), patch.dict(sys.modules, {"setproctitle": fake_mod}):
+        assert hmain._set_process_title() is None
+    fake_mod.setproctitle.assert_called_once_with("hermes")
+    cdll.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`_set_process_title()` (`hermes_cli/main.py`) is documented as *"Purely cosmetic —
non-fatal on any platform."* But its Strategy‑1 guard only catches `ImportError`:

```python
try:
    import setproctitle
    setproctitle.setproctitle("hermes")
    return
except ImportError:
    pass
```

setproctitle 1.3.x on Darwin (`PS_USE_CLOBBER_ARGV`) reserves one byte for the
NUL terminator and silently truncates the joined title. When the last argv entry
ends in a **multibyte character** (Chinese, emoji) the cut lands mid‑sequence,
and setproctitle's module‑level `getproctitle()` (the #113 fork workaround) fails
to decode the truncated buffer and raises `UnicodeDecodeError` **at import**. That
escapes the `except ImportError` and kills `main()` at its first statement — the
agent never starts:

```
hermes -p <profile> chat -q '<prompt ending in a CJK char / emoji>'
...
  File "hermes_cli/main.py", line 251, in _set_process_title
    import setproctitle
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 310-311: unexpected end of data
```

Fix: widen the guard to `(ImportError, UnicodeDecodeError)` so it falls through to
the existing ctypes fallback (Strategy 2/3), which sets the title without issue.
Only behavior change: a crash in the optional cosmetic dependency no longer aborts
startup.

## Related Issue

Fixes #98620

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_set_process_title()`: `except ImportError` →
  `except (ImportError, UnicodeDecodeError)`, with a comment explaining the
  setproctitle/Darwin truncation.
- `tests/hermes_cli/test_set_process_title_multibyte.py` — new regression tests:
  `UnicodeDecodeError` raised at `import setproctitle` and at the
  `setproctitle.setproctitle()` call are both swallowed; the success path still
  uses setproctitle and skips the ctypes fallback. (First two fail on `main`
  without the guard.)

## How to Test

```bash
pytest tests/hermes_cli/test_set_process_title_multibyte.py -q
```

Real-world repro from the issue (Darwin): `SPT_NOENV=1 hermes model <~80 CJK chars>`
crashes at `import setproctitle` before the fix, proceeds after.

Adjacent suites still green: `tests/hermes_cli/test_process_identity.py`,
`tests/hermes_cli/test_gateway_proc_fallback.py`.

## What platforms

Verified on macOS (arm64, Python 3.11). The bug is Darwin-specific; the fix is a
platform-neutral `except` clause and the ctypes fallback path is unchanged for
Linux/Windows.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched existing issues/PRs — no open PR references #98620
- [x] PR contains only changes related to this fix
- [x] Ran the relevant `pytest tests/hermes_cli/…` suites, all pass
- [x] Added regression tests (verified they fail without the fix)
- [x] Tested on my platform: macOS (arm64) / Python 3.11.16

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — fix is a wider `except`; ctypes fallback path unchanged
- [x] Tool descriptions/schemas — N/A
