### PR TITLE
fix(gateway): gate loop tick socket on asyncio.start_unix_server availability

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -535,51 +535,56 @@ async def loop_heartbeat_forever(
     # #90502 incident environment — is Linux and arms the socket normally.)
     tick_server = None
     tick_socket_path = None
-    try:
-        tick_socket_path = get_loop_tick_socket_path(home)
-        tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
-        # Re-bind over a leftover node from a dead process (os._exit(75) /
-        # SIGKILL skip the finally-unlink; PID reuse re-lands on this
-        # PID-suffixed path) is handled by asyncio itself:
-        # create_unix_server os.remove()s an existing socket node before
-        # binding — guarded by test_producer_rebinds_over_stale_socket_node.
-        # What asyncio does NOT do is clean up SIBLING nodes from other
-        # dead PIDs, so sweep those to keep state/ from accumulating
-        # gateway.loop-tick.*.sock nodes across crash-restart cycles.
-        # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
-        # Windows os.kill calls TerminateProcess for non-CTRL signals —
-        # and AF_UNIX server nodes are never created there anyway.
-        if os.name == "posix":
-            try:
-                for _stale in tick_socket_path.parent.glob(
-                    "gateway.loop-tick.*.sock"
-                ):
-                    if _stale == tick_socket_path:
-                        continue
-                    try:
-                        _stale_pid = int(_stale.name.split(".")[-2])
-                    except (ValueError, IndexError):
-                        _stale.unlink(missing_ok=True)
-                        continue
-                    try:
-                        os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
-                    except OSError:
-                        _stale.unlink(missing_ok=True)
-            except Exception:
-                logger.debug(
-                    "stale loop-tick socket sweep failed", exc_info=True
-                )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
+    if hasattr(asyncio, "start_unix_server"):
+        try:
+            tick_socket_path = get_loop_tick_socket_path(home)
+            tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
+            # Re-bind over a leftover node from a dead process (os._exit(75) /
+            # SIGKILL skip the finally-unlink; PID reuse re-lands on this
+            # PID-suffixed path) is handled by asyncio itself:
+            # create_unix_server os.remove()s an existing socket node before
+            # binding — guarded by test_producer_rebinds_over_stale_socket_node.
+            # What asyncio does NOT do is clean up SIBLING nodes from other
+            # dead PIDs, so sweep those to keep state/ from accumulating
+            # gateway.loop-tick.*.sock nodes across crash-restart cycles.
+            # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
+            # Windows os.kill calls TerminateProcess for non-CTRL signals —
+            # and AF_UNIX server nodes are never created there anyway.
+            if os.name == "posix":
+                try:
+                    for _stale in tick_socket_path.parent.glob(
+                        "gateway.loop-tick.*.sock"
+                    ):
+                        if _stale == tick_socket_path:
+                            continue
+                        try:
+                            _stale_pid = int(_stale.name.split(".")[-2])
+                        except (ValueError, IndexError):
+                            _stale.unlink(missing_ok=True)
+                            continue
+                        try:
+                            os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
+                        except OSError:
+                            _stale.unlink(missing_ok=True)
+                except Exception:
+                    logger.debug(
+                        "stale loop-tick socket sweep failed", exc_info=True
+                    )
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        except Exception:
+            tick_server = None
+            logger.warning(
+                "Loop tick socket unavailable — liveness probes will have no "
+                "loop-scheduling witness and will not escalate on a stale heartbeat",
+                exc_info=True,
+            )
+    else:
+        logger.debug(
+            "Loop tick socket not supported on this platform (no asyncio.start_unix_server); "
+            "probes will classify UNKNOWN rather than WEDGED"
         )
-    except Exception:
-        tick_server = None
-        logger.warning(
-            "Loop tick socket unavailable — liveness probes will have no "
-            "loop-scheduling witness and will not escalate on a stale heartbeat",
-            exc_info=True,
-        )
-
     async def _write_off_loop() -> None:
         # write_loop_heartbeat never raises, so a failure here is an executor
         # problem (shutdown, saturation) and must not kill the heartbeat task.

--- a/tests/gateway/test_shutdown_watchdog.py
+++ b/tests/gateway/test_shutdown_watchdog.py
@@ -66,3 +66,23 @@ def test_arm_shutdown_watchdog_fires_with_dump_and_exit(tmp_path):
     assert get_shutdown_watchdog_dump_path(tmp_path).name == "gateway-shutdown-watchdog.log"
 
 
+@pytest.mark.asyncio
+async def test_loop_heartbeat_forever_without_unix_server_does_not_warn(tmp_path):
+    with patch("gateway.shutdown_watchdog.asyncio", spec=asyncio) as mock_asyncio, \
+         patch("gateway.shutdown_watchdog.logger.warning") as mock_warn, \
+         patch("gateway.shutdown_watchdog.logger.debug") as mock_debug:
+        del mock_asyncio.start_unix_server
+        mock_asyncio.to_thread = asyncio.to_thread
+
+        task = asyncio.create_task(
+            loop_heartbeat_forever(
+                interval_s=0.01,
+                home=tmp_path,
+                should_continue=lambda: False,
+            )
+        )
+        await task
+
+        mock_warn.assert_not_called()
+        assert any("Loop tick socket not supported" in str(c) for c in mock_debug.call_args_list)
+


### PR DESCRIPTION
## Summary

On native Windows (and any platform without AF_UNIX event-loop support), `asyncio.start_unix_server` does not exist. In `gateway/shutdown_watchdog.py::loop_heartbeat_forever`, unconditionally calling `asyncio.start_unix_server` raised an `AttributeError` on every single gateway startup, logging an alarming `WARNING` with a full Python traceback for a known-permanent, documented platform condition.

## Changes

- In `gateway/shutdown_watchdog.py`, check `if hasattr(asyncio, "start_unix_server"):` before attempting to bind the loop tick socket. When unsupported (e.g. native Windows), log at `debug` level.
- Preserve `logger.warning(..., exc_info=True)` on supported platforms when a real bind error occurs (permissions, path length, etc.).
- In `tests/gateway/test_shutdown_watchdog.py`, add regression test `test_loop_heartbeat_forever_without_unix_server_does_not_warn` asserting that environments lacking `start_unix_server` do not log warnings/tracebacks.

Fixes #98846