### PR TITLE
fix(gateway): detect active systemd service even when .service file not at expected profile path

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2480,6 +2480,32 @@ def supports_systemd_services() -> bool:
     return True
 
 
+def _systemd_unit_is_active(unit_name: str) -> bool:
+    """Return True when *unit_name*.service is active in systemd.
+
+    Used as a fallback when the .service file is not at the expected path —
+    e.g. when `hermes gateway status` is run from a profile TUI session
+    different from the one that installed the service (#16264).  Best-effort:
+    a subprocess failure or missing systemctl returns False.
+    """
+    try:
+        import subprocess as _sp
+        r = _sp.run(
+            ["systemctl", "--user", "is-active", f"{unit_name}.service"],
+            capture_output=True, text=True, timeout=3
+        )
+        if r.returncode == 0:
+            return True
+        # Also try system-wide
+        r2 = _sp.run(
+            ["systemctl", "is-active", f"{unit_name}.service"],
+            capture_output=True, text=True, timeout=3
+        )
+        return r2.returncode == 0
+    except Exception:
+        return False
+
+
 def is_macos() -> bool:
     return sys.platform == "darwin"
 
@@ -8754,6 +8780,11 @@ def _gateway_command_inner(args):
         if supports_systemd_services() and (
             get_systemd_unit_path(system=False).exists()
             or get_systemd_unit_path(system=True).exists()
+            # Also detect when the unit IS active but the .service file is not
+            # at the expected path — happens when `hermes gateway status` is
+            # run from a different profile's TUI session than the one that
+            # owns the active service (#16264).
+            or _systemd_unit_is_active(get_service_name())
         ):
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿gateway status showed 'Running manually' from inside a profile TUI when .service file not at expected profile path. Add _systemd_unit_is_active() fallback that checks systemctl is-active. Fixes #16264.
