### PR TITLE
fix(security): gate terminal writes into $HOME credential directories

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -471,6 +471,82 @@ class TestSensitiveCopyMovePattern:
             assert dangerous is False, cmd
 
 
+class TestCredentialDirectoryWrites:
+    """Writes into credential DIRECTORIES under $HOME must require approval.
+
+    ``agent/file_safety.build_write_denied_prefixes`` already denies every one
+    of these to write_file/patch, but the terminal path had no matching rule, so
+    ``echo x >> ~/.aws/credentials`` and ``cp evil ~/.kube/config`` were
+    auto-approved. That is the unpaired half-door shape described on
+    ``TestSensitiveCopyMovePattern`` — the file-write side gated, the terminal
+    side open — measured as 8 paths denied by the file guard but ungated in the
+    terminal across all seven write vectors.
+    """
+
+    CREDENTIAL_PATHS = (
+        "~/.aws/credentials",
+        "~/.gnupg/secring.gpg",
+        "~/.kube/config",
+        "~/.docker/config.json",
+        "~/.config/gh/hosts.yml",
+        "~/.azure/accessTokens.json",
+        "~/.config/gcloud/credentials.db",
+    )
+
+    def test_every_write_vector_is_gated(self):
+        vectors = (
+            "echo x >> {p}",
+            "echo x > {p}",
+            "echo x | tee -a {p}",
+            "cp /tmp/evil {p}",
+            "mv /tmp/evil {p}",
+            "install -m600 /tmp/c {p}",
+            "sed -i 's/a/b/' {p}",
+        )
+        for path in self.CREDENTIAL_PATHS:
+            for vector in vectors:
+                command = vector.format(p=path)
+                dangerous, key, _ = detect_dangerous_command(command)
+                assert dangerous is True, command
+                assert key is not None, command
+
+    def test_ordinary_config_subdirs_stay_safe(self):
+        """``~/.config`` holds ordinary application config. Only the ``gh`` and
+        ``gcloud`` credential subdirectories may be gated — gating all of
+        ``~/.config`` would prompt on routine editor and service files."""
+        for command in (
+            "echo x >> ~/.config/nvim/init.lua",
+            "cp theme.json ~/.config/Code/User/settings.json",
+            "echo x > ~/.config/htop/htoprc",
+            "sed -i 's/a/b/' ~/.config/systemd/user/app.service",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+            assert key is None, command
+
+    def test_near_miss_names_stay_safe(self):
+        """Prefix matching must not catch names that merely start the same."""
+        for command in (
+            "echo x >> ~/.awsome/notes.txt",
+            "echo x >> ~/.dockerignore",
+            "echo x >> ~/.kubeconfig-notes",
+            "cp a.txt ~/.gnupgnotes",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+    def test_reads_out_of_credential_dirs_stay_safe(self):
+        """Only the write DESTINATION is gated; reading out is covered by the
+        read and media guards, mirroring the existing ``~/.ssh`` behaviour."""
+        for command in (
+            "cp ~/.aws/credentials /tmp/x",
+            "cat ~/.kube/config",
+            "grep -r host ~/.docker/config.json",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+
 class TestSensitiveInPlaceEditPattern:
     """Detect in-place edits to user startup and credential files."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -417,6 +417,19 @@ _CREDENTIAL_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
     r'(?:netrc|pgpass|npmrc|pypirc)\b'
 )
+# Credential DIRECTORIES under $HOME. ``build_write_denied_prefixes`` in
+# agent/file_safety.py already denies every one of these to write_file/patch,
+# but the terminal path had no matching rule, so `echo x >> ~/.aws/credentials`,
+# `cp evil ~/.kube/config`, and `sed -i ... ~/.docker/config.json` were
+# auto-approved — an unpaired half-door of the same shape as the cp/mv gap
+# fixed in #14639. Mirrors _SSH_SENSITIVE_PATH (the .ssh member of this same
+# family) and stays a PREFIX match so any file beneath the directory is covered.
+# ``.config`` is enumerated, not taken wholesale: it also holds ordinary app
+# config, and gating all of it would prompt on routine editor/service edits.
+_CREDENTIAL_DIRS = (
+    r'(?:~|\$home|\$\{home\})/\.'
+    r'(?:aws|gnupg|kube|docker|azure|config/gh|config/gcloud)(?:/|$)'
+)
 # macOS: /etc, /var, /tmp, /home are symlinks to /private/{etc,var,tmp,home}.
 # A command written to target /private/etc/sudoers works identically to
 # /etc/sudoers on macOS but bypasses a plain "/etc/" pattern check. Match
@@ -434,11 +447,13 @@ _SENSITIVE_WRITE_TARGET = (
     rf'{_HERMES_ENV_PATH}|'
     rf'{_HERMES_CONFIG_PATH}|'
     rf'{_SHELL_RC_FILES}|'
+    rf'{_CREDENTIAL_DIRS}|'
     rf'{_CREDENTIAL_FILES})'
 )
 _USER_SENSITIVE_WRITE_TARGET = (
     rf'(?:{_SSH_SENSITIVE_PATH}|'
     rf'{_SHELL_RC_FILES}|'
+    rf'{_CREDENTIAL_DIRS}|'
     rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'


### PR DESCRIPTION
## What does this PR do?

Closes an unpaired guard: `agent/file_safety.build_write_denied_prefixes` already denies every `$HOME` credential directory to `write_file`/`patch`, but the terminal path had no matching rule, so shell writes into them were auto-approved.

Measured on `main` with `HOME=/home/alice`, across seven write vectors (`>>`, `>`, `tee -a`, `cp` dest, `mv` dest, `install`, `sed -i`):

| Path | file-write guard | terminal write |
|---|---|---|
| `~/.ssh/authorized_keys` | DENIED | gated |
| `~/.netrc` | DENIED | gated |
| `~/.aws/credentials` | DENIED | **UNGATED** |
| `~/.gnupg/secring.gpg` | DENIED | **UNGATED** |
| `~/.kube/config` | DENIED | **UNGATED** |
| `~/.docker/config.json` | DENIED | **UNGATED** |
| `~/.config/gh/hosts.yml` | DENIED | **UNGATED** |
| `~/.azure/accessTokens.json` | DENIED | **UNGATED** |
| `~/.config/gcloud/credentials.db` | DENIED | **UNGATED** |

All **49** vector/target combinations were ungated. All 49 are now gated.

This is the same shape as the gap `TestSensitiveCopyMovePattern` documents — "the tee/redirection forms were already gated ... but cp/mv/install on these targets was an unpaired half-door" — except here the *whole terminal side* was missing for a family the file-write side already protects. `~/.ssh` was covered because it has its own `_SSH_SENSITIVE_PATH` pattern; its siblings did not.

## Approach

`_CREDENTIAL_DIRS` mirrors `_SSH_SENSITIVE_PATH` (the `.ssh` member of this same family) and joins the two existing write-target alternations, `_SENSITIVE_WRITE_TARGET` and `_USER_SENSITIVE_WRITE_TARGET`. It stays a **prefix** match so any file beneath the directory is covered, not just the canonical filename — `~/.aws/config` and `~/.aws/sso/cache/*.json` matter as much as `~/.aws/credentials`.

`.config` needed care. It holds ordinary application config, so the pattern enumerates `config/gh` and `config/gcloud` rather than the whole tree. Gating all of `~/.config` would prompt on routine editor and service-unit edits, which is the "fix that destroys the feature it secures" failure mode.

## How Has This Been Tested?

`tests/tools/test_approval.py` → **122 passed, 0 failed** under a normal multi-segment `HOME`.

Four new tests in `TestCredentialDirectoryWrites`:

- **Positive control** — reverting `tools/approval.py` while keeping the tests fails *exactly* `test_every_write_vector_is_gated` while the three negative-control tests still pass. The tests discriminate rather than merely passing.
- **Negative controls, 13 commands stay unflagged 0/13** — `~/.config/nvim/init.lua`, `~/.config/Code/User/settings.json`, `~/.config/htop/htoprc`, `~/.config/systemd/user/app.service`; near-miss names `.awsome`, `.dockerignore`, `.kubeconfig-notes`, `.gnupgnotes`; and reads **out** of credential dirs (`cp ~/.aws/credentials /tmp/x`, `cat ~/.kube/config`, `grep -r host ~/.docker/config.json`), which the destination-only rule must leave alone.

`ruff check` clean.

Under `HOME=/root` one pre-existing failure remains — `TestSensitiveRedirectPattern::test_redirect_to_sensitive_target`. That is #84639, fixed separately by #98868, and it reproduces on unmodified `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

No existing issue — I searched issues and PRs for the credential-directory terminal gap and found none. Happy to file one first if you prefer that order.

Sibling of #99182 (bare `$HOME` credential *files* in media delivery) and #98868 (single-segment-home fold). Disjoint changes; this one only adds to `tools/approval.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious parts (why `.config` is enumerated rather than gated wholesale, and which guard this pairs with)
