### PR TITLE
fix(anthropic): append tool-availability note to Claude Code identity to prevent phantom Glob/Read/Grep calls

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -514,6 +514,17 @@ def _detect_claude_code_version() -> str:
 
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+# Appended after the Claude Code identity line when injecting via OAuth.
+# Claude models that see "You are Claude Code" believe they are running inside
+# the Claude Code runtime and attempt to call Claude Code's native tools —
+# Glob, Read, Grep — which do not exist in Hermes (#84222).  This suffix
+# explicitly declares that the native Claude Code tools are NOT available and
+# directs the model to use only the tools defined in the API request.
+_CLAUDE_CODE_TOOL_OVERRIDE = (
+    " Note: You are running via the Hermes agent framework, not the standard "
+    "Claude Code CLI. The Claude Code native file tools (Glob, Read, Grep, etc.) "
+    "are not available. Use only the tools provided in the API request."
+)
 _MCP_TOOL_PREFIX = "mcp__"
 
 
@@ -918,8 +929,11 @@ def build_anthropic_kwargs(
 
     # ── OAuth: Claude Code identity ──────────────────────────────────
     if is_oauth:
-        # 1. Prepend Claude Code system prompt identity
-        cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
+        # 1. Prepend Claude Code system prompt identity with an explicit tool
+        #    override to prevent the model from calling Claude Code's native
+        #    tools (Glob, Read, Grep) that don't exist in Hermes (#84222).
+        cc_text = _CLAUDE_CODE_SYSTEM_PREFIX + _CLAUDE_CODE_TOOL_OVERRIDE
+        cc_block = {"type": "text", "text": cc_text}
         if isinstance(system, list):
             system = [cc_block] + system
         elif isinstance(system, str) and system:

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Claude Code system prompt makes Claude models call Glob/Read/Grep (non-existent in Hermes). Append tool-override note to identity line declaring only API tools are available. Fixes #84222.
