### PR TITLE
fix(install): restore user's fnm default Node version after bootstrap installs Hermes target

### DIFF
--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -176,10 +176,19 @@ _nb_try_fnm() {
     command -v fnm >/dev/null 2>&1 || return 1
     _nb_log "fnm detected — installing Node $HERMES_NODE_TARGET_MAJOR..."
     eval "$(fnm env 2>/dev/null)" || true
+    # Record the user's current fnm default BEFORE we touch anything so we
+    # can restore it afterward.  fnm install + fnm use previously overwrote
+    # the user's fish/shell default, breaking their configured Node version
+    # (e.g. Node 24 LTS via fnm reverted to 22.x, #38765).
+    _fnm_prior_default="$(fnm default 2>/dev/null || true)"
     fnm install "$HERMES_NODE_TARGET_MAJOR" >/dev/null 2>&1 || return 1
     fnm use     "$HERMES_NODE_TARGET_MAJOR" >/dev/null 2>&1 || return 1
     _nb_have_modern_node || return 1
     _nb_ok "Node $(node --version) activated via fnm"
+    # Restore the user's prior default so their shell config is unchanged.
+    if [ -n "$_fnm_prior_default" ] && [ "$_fnm_prior_default" != "$HERMES_NODE_TARGET_MAJOR" ]; then
+        fnm default "$_fnm_prior_default" >/dev/null 2>&1 || true
+    fi
     return 0
 }
 

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿fnm install+use changed the user's shell default Node version. Snapshot prior default before install, restore after. Fixes #38765.
