### PR TITLE
fix(send_message): record outbound message in source session when target channel session not found

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -511,15 +511,39 @@ def _handle_send(args):
                 from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
                 user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
-                if mirror_to_session(
+                mirrored = mirror_to_session(
                     platform_name,
                     chat_id,
                     mirror_text,
                     source_label=source_label,
                     thread_id=thread_id,
                     user_id=user_id,
-                ):
+                )
+                if mirrored:
                     result["mirrored"] = True
+                else:
+                    # Target session not found (expired/cleaned up).  Record
+                    # the outbound message in the AGENT'S OWN session so it
+                    # has context about what it sent when the recipient replies
+                    # asking "why did you send that?" (#33530).
+                    own_session_id = get_session_env("HERMES_SESSION_ID", "") or None
+                    if own_session_id:
+                        from gateway.mirror import _append_to_sqlite
+                        import datetime as _dt_mod
+                        _note = (
+                            f"[Outbound to {platform_name} {chat_id}"
+                            + (f" thread={thread_id}" if thread_id else "")
+                            + f"]: {mirror_text}"
+                        )
+                        _append_to_sqlite(own_session_id, {
+                            "role": "assistant",
+                            "content": _note,
+                            "timestamp": _dt_mod.datetime.now().isoformat(),
+                            "mirror": True,
+                            "mirror_source": source_label,
+                            "cross_channel_record": True,
+                        })
+                        result["mirrored_to_self"] = True
             except Exception:
                 pass
 


### PR DESCRIPTION
﻿When target session not found, agent has no record of what it sent. Write cross-channel record to own session so agent can answer 'why did you send that?' Fixes #33530.
