### PR TITLE
docs(issue-template): expand platform choices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
       multiple: true
       options:
         - CLI (interactive chat)
-        - Gateway (Telegram/Discord/Slack/WhatsApp)
+        - Gateway (messaging platforms, API server, and webhooks)
         - Setup / Installation
         - Tools (terminal, file ops, web, code execution, etc.)
         - Skills (skill loading, skill hub, skill guard)
@@ -82,6 +82,24 @@ body:
         - Discord
         - Slack
         - WhatsApp
+        - WhatsApp Cloud
+        - Signal
+        - Mattermost
+        - Matrix
+        - Home Assistant
+        - Email
+        - SMS
+        - DingTalk
+        - Feishu / Lark
+        - WeCom
+        - WeCom Callback
+        - Weixin
+        - BlueBubbles
+        - QQBot
+        - Yuanbao
+        - API Server
+        - Webhook
+        - Microsoft Graph Webhook
 
   - type: textarea
     id: debug-report


### PR DESCRIPTION
## Summary
- broaden the bug report component label beyond four gateway platforms
- align the messaging platform choices with the current gateway platform enum

## Validation
- Ruby Psych YAML parse and field assertions passed (23 platform options)
- `git diff --check`

This changes only the GitHub issue form; runtime behavior is unchanged.