### PR TITLE
fix(gateway): write systemd service file to real user home not profile sandbox home

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2703,7 +2703,16 @@ def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
-    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+    # Use get_default_hermes_root().parent instead of Path.home() so that
+    # non-default profiles (whose $HOME may point to the profile's sandboxed
+    # home directory) write the .service file to the REAL user's
+    # ~/.config/systemd/user, not to the profile home's .config (#98699).
+    try:
+        from hermes_constants import get_default_hermes_root as _get_default_root
+        real_home = _get_default_root().parent
+    except Exception:
+        real_home = Path.home()
+    return real_home / ".config" / "systemd" / "user" / f"{name}.service"
 
 
 class UserSystemdUnavailableError(RuntimeError):

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿gateway install wrote .service file to profile home (.hermes/profiles/X/home/.config/systemd) instead of real home (~/.config/systemd). Use get_default_hermes_root().parent. Fixes #98699.
