### PR TITLE
fix(desktop): separate auto-speak from gateway voice.auto_tts to prevent double-speech

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -708,7 +708,11 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.enabled',
       'stt.echo_transcripts',
       'stt.provider',
-      'voice.auto_tts',
+      // Use desktop.voice.auto_speak (Desktop-only) not voice.auto_tts
+      // (gateway-level): the gateway's auto_tts fires its own TTS pipeline
+      // independently of the Desktop renderer's audio path, causing double-
+      // speech when both are true (#99076).
+      'desktop.voice.auto_speak',
       'tts.edge.voice',
       'tts.openai.model',
       'tts.openai.voice',

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Desktop auto-speak toggle synced to voice.auto_tts causing gateway TTS also to fire. Use desktop.voice.auto_speak (Desktop-only key). Fixes #99076.
