### PR TITLE
fix(docker): require exact workspace volume target

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -102,6 +102,19 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+@pytest.mark.parametrize(
+    ("volume", "expected"),
+    [
+        ("/host/project:/workspace", True),
+        ("/host/project:/workspace:ro", True),
+        ("/host/project:/workspace/projects", False),
+        ("/host/project:/workspace-cache", False),
+    ],
+)
+def test_workspace_volume_detection_requires_exact_container_target(volume, expected):
+    assert docker_env._volume_targets_workspace(volume) is expected
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -666,6 +666,17 @@ def _extra_args_egress_collisions(
     return sorted(set(collisions))
 
 
+def _volume_targets_workspace(volume: str) -> bool:
+    """Return whether a Docker ``-v`` spec targets exactly ``/workspace``.
+
+    A prefix check would also match nested paths such as
+    ``/workspace/projects`` and unrelated paths such as ``/workspace-cache``.
+    The target is followed by either Docker's optional mount-mode separator or
+    the end of the volume specification.
+    """
+    return re.search(r":/workspace(?::|$)", volume) is not None
+
+
 def _build_security_args(run_as_host_user: bool, run_exec: bool = False) -> list[str]:
     """Return the security/cap/tmpfs args tailored to the privilege mode.
 
@@ -993,7 +1004,7 @@ class DockerEnvironment(BaseEnvironment):
                 continue
             if ":" in vol:
                 volume_args.extend(["-v", vol])
-                if ":/workspace" in vol:
+                if _volume_targets_workspace(vol):
                     workspace_explicitly_mounted = True
             else:
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)


### PR DESCRIPTION
## Summary\n- require configured Docker volume mounts to target exactly  before suppressing the managed workspace mount\n- add regression coverage for exact, read-only, nested, and prefix-collision targets\n\n## Testing\n- .................................................................        [100%]
65 passed in 1.60s (65 passed)\n- \n