### PR TITLE
feat(tools): search all profiles from session_search

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -82,6 +82,8 @@ class TestSchema:
         assert "window" in params
         # Shared
         assert "role_filter" in params
+        assert "profile" in params
+        assert "all" in params["profile"]["description"]
         # Mode is inferred from which args are set — no explicit mode param
         assert "mode" not in params
 
@@ -538,6 +540,160 @@ class TestCrossProfileRead:
             assert result["success"] is True, kwargs
             assert result["mode"] == "read"
             assert result["session_id"] == "s_other"
+
+
+# =========================================================================
+# Discover / browse across every profile (profile=all)
+# =========================================================================
+
+class TestAllProfilesDiscover:
+    def _homes(self, tmp_path):
+        default_home = tmp_path / "default_home"
+        work_home = tmp_path / "work_home"
+        default_home.mkdir()
+        work_home.mkdir()
+        default_db = SessionDB(default_home / "state.db")
+        work_db = SessionDB(work_home / "state.db")
+        default_db.create_session("s_default", source="cli")
+        default_db.append_message(
+            "s_default", role="user", content="worked on the venom project in default"
+        )
+        default_db.append_message(
+            "s_default", role="assistant", content="venom milestone shipped here"
+        )
+        default_db._conn.commit()
+        work_db.create_session("s_work", source="cli")
+        work_db.append_message(
+            "s_work", role="user", content="worked on the venom project in work"
+        )
+        work_db.append_message(
+            "s_work", role="assistant", content="venom follow-up lives in work"
+        )
+        work_db._conn.commit()
+        return default_home, work_home, default_db, work_db
+
+    def _patch_homes(self, monkeypatch, default_home, work_home):
+        from collections import namedtuple
+
+        from hermes_cli import profiles as profiles_mod
+
+        Info = namedtuple("Info", "name path")
+        homes = {"default": default_home, "work": work_home}
+        monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: homes[n])
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [Info("default", default_home), Info("work", work_home)],
+        )
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n in homes)
+
+    def test_discover_merges_and_tags_each_profile(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        result = json.loads(
+            session_search(query="venom", profile="all", db=db, limit=10)
+        )
+        default_db.close()
+        work_db.close()
+
+        assert result["success"] is True
+        assert result["mode"] == "discover"
+        assert result["profiles_searched"] == 2
+        by_session = {row["session_id"]: row for row in result["results"]}
+        assert "s_default" in by_session
+        assert "s_work" in by_session
+        assert by_session["s_default"]["profile"] == "default"
+        assert by_session["s_work"]["profile"] == "work"
+        assert by_session["s_default"]["link"] == "@session:default/s_default"
+        assert by_session["s_work"]["link"] == "@session:work/s_work"
+
+    def test_star_sentinel_matches_all(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        result = json.loads(session_search(query="venom", profile="*", db=db, limit=10))
+        default_db.close()
+        work_db.close()
+
+        assert result["success"] is True
+        assert {row["session_id"] for row in result["results"]} == {"s_default", "s_work"}
+
+    def test_all_does_not_open_a_profile_named_all(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        def _fail_if_all(name):
+            if name == "all":
+                raise AssertionError("profile=all must not resolve a named profile")
+            return {"default": default_home, "work": work_home}[name]
+
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_profile_dir", _fail_if_all)
+
+        result = json.loads(session_search(query="venom", profile="all", db=db, limit=10))
+        default_db.close()
+        work_db.close()
+        assert result["success"] is True
+        assert result["count"] >= 2
+
+    def test_browse_merges_across_profiles(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        result = json.loads(session_search(profile="all", db=db, limit=10))
+        default_db.close()
+        work_db.close()
+
+        assert result["success"] is True
+        assert result["mode"] == "browse"
+        assert result["profiles_searched"] == 2
+        by_session = {row["session_id"]: row for row in result["results"]}
+        assert by_session["s_default"]["profile"] == "default"
+        assert by_session["s_work"]["profile"] == "work"
+
+    def test_newest_sort_is_global_across_profiles(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        now = int(time.time())
+        default_db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 10_000, "s_default"),
+        )
+        work_db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 100, "s_work"),
+        )
+        default_db._conn.commit()
+        work_db._conn.commit()
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        result = json.loads(
+            session_search(query="venom", profile="all", sort="newest", db=db, limit=10)
+        )
+        default_db.close()
+        work_db.close()
+
+        ids = [row["session_id"] for row in result["results"]]
+        assert ids[0] == "s_work"
+        assert "s_default" in ids
+
+    def test_single_named_profile_is_unchanged(self, db, tmp_path, monkeypatch):
+        default_home, work_home, default_db, work_db = self._homes(tmp_path)
+        self._patch_homes(monkeypatch, default_home, work_home)
+
+        result = json.loads(
+            session_search(query="venom", profile="work", db=db, limit=10)
+        )
+        default_db.close()
+        work_db.close()
+
+        assert result["success"] is True
+        ids = {row["session_id"] for row in result["results"]}
+        assert "s_work" in ids
+        assert "s_default" not in ids
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -388,6 +388,63 @@ def _session_link(session_id: str, profile: str = None) -> str:
     return f"@session:{name}/{session_id}" if name else f"@session:{session_id}"
 
 
+# Sentinel values for ``profile`` that mean "search every profile", not a
+# named profile. Checked before ``_resolve_profile_db`` so we never try to
+# open a profile literally named ``all``.
+_ALL_PROFILE_SENTINELS = frozenset({"all", "*"})
+
+
+def _is_all_profiles(profile: Optional[str]) -> bool:
+    return bool(profile) and str(profile).strip().lower() in _ALL_PROFILE_SENTINELS
+
+
+def _iter_profile_homes():
+    """Yield ``(name, home)`` for the default profile plus every named profile.
+
+    Deduplicates by ``state.db`` path so ``list_profiles()`` (which already
+    includes default) does not visit the same database twice.
+    """
+    from pathlib import Path
+
+    try:
+        from hermes_cli import profiles as profiles_mod
+    except Exception:
+        return []
+
+    targets = [("default", profiles_mod.get_profile_dir("default"))]
+    try:
+        targets += [(info.name, info.path) for info in profiles_mod.list_profiles()]
+    except Exception:
+        logging.debug("list_profiles failed during profile enumeration", exc_info=True)
+
+    seen: set = set()
+    homes = []
+    for name, home in targets:
+        db_path = Path(home) / "state.db"
+        key = str(db_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        homes.append((name, Path(home)))
+    return homes
+
+
+def _open_profile_state_db(home):
+    """Open ``state.db`` under *home* read-only, or None if missing/unreadable."""
+    from pathlib import Path
+
+    from hermes_state import SessionDB
+
+    db_path = Path(home) / "state.db"
+    if not db_path.exists():
+        return None
+    try:
+        return SessionDB(db_path=db_path, read_only=True)
+    except Exception:
+        logging.debug("failed to open profile state.db at %s", db_path, exc_info=True)
+        return None
+
+
 def _locate_session_db(session_id: str):
     """Scan every profile's ``state.db`` (read-only) for a session id.
 
@@ -397,30 +454,9 @@ def _locate_session_db(session_id: str):
     reads where the model dropped the owning profile from the link and passed a
     bare id — we find it wherever it actually lives instead of failing.
     """
-    from pathlib import Path
-
-    try:
-        from hermes_cli import profiles as profiles_mod
-        from hermes_state import SessionDB
-    except Exception:
-        return None, None
-
-    targets = [("default", profiles_mod.get_profile_dir("default"))]
-    try:
-        targets += [(info.name, info.path) for info in profiles_mod.list_profiles()]
-    except Exception:
-        logging.debug("list_profiles failed during session locate", exc_info=True)
-
-    seen: set = set()
-    for name, home in targets:
-        db_path = Path(home) / "state.db"
-        key = str(db_path)
-        if key in seen or not db_path.exists():
-            continue
-        seen.add(key)
-        try:
-            pdb = SessionDB(db_path=db_path, read_only=True)
-        except Exception:
+    for name, home in _iter_profile_homes():
+        pdb = _open_profile_state_db(home)
+        if pdb is None:
             continue
         try:
             if pdb.get_session(session_id):
@@ -758,6 +794,67 @@ def _title_match_result(
     return entry
 
 
+def _build_discover_entry(db, lineage_root, match_info, result_detail: str):
+    """Hydrate one discover hit from the owning database. Returns None on view failure."""
+    hit_sid = match_info.get("session_id") or lineage_root
+    msg_id = match_info.get("id")
+    try:
+        view = db.get_anchored_view(hit_sid, msg_id, window=5, bookend=3)
+    except Exception as e:
+        logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
+        return None
+
+    try:
+        session_meta = db.get_session(lineage_root) or {}
+    except Exception:
+        session_meta = {}
+
+    window_messages = view.get("window") or []
+    if result_detail == "compact":
+        window_messages = [m for m in window_messages if m.get("id") == msg_id]
+
+    entry = {
+        "session_id": hit_sid,
+        "when": _format_timestamp(
+            session_meta.get("started_at") or match_info.get("session_started")
+        ),
+        "source": session_meta.get("source") or match_info.get("source", "unknown"),
+        "model": session_meta.get("model") or match_info.get("model") or "unknown",
+        "title": session_meta.get("title") or None,
+        "matched_role": match_info.get("role"),
+        "match_message_id": msg_id,
+        "snippet": match_info.get("snippet") or "",
+        "bookend_start": (
+            [
+                _shape_message(m, max_content_len=1200)
+                for m in (view.get("bookend_start") or [])
+                if not _is_compaction_summary(m.get("content", ""))
+            ]
+            if result_detail == "full"
+            else []
+        ),
+        "messages": [
+            _shape_message(m, anchor_id=msg_id, max_content_len=4000)
+            for m in window_messages
+        ],
+        "bookend_end": (
+            [
+                _shape_message(m, max_content_len=1200)
+                for m in (view.get("bookend_end") or [])
+                if not _is_compaction_summary(m.get("content", ""))
+            ]
+            if result_detail == "full"
+            else []
+        ),
+        "messages_before": view.get("messages_before", 0),
+        "messages_after": view.get("messages_after", 0),
+        "detail": result_detail,
+    }
+    if lineage_root and lineage_root != hit_sid:
+        entry["parent_session_id"] = lineage_root
+    return entry
+
+
 def _discover(
     db,
     query: str,
@@ -868,64 +965,10 @@ def _discover(
     for lineage_root, match_info in seen_sessions.items():
         if match_info.get("_title_only"):
             continue
-        hit_sid = match_info.get("session_id") or lineage_root
-        msg_id = match_info.get("id")
-        try:
-            view = db.get_anchored_view(hit_sid, msg_id, window=5, bookend=3)
-        except Exception as e:
-            logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
-            continue
-
-        try:
-            session_meta = db.get_session(lineage_root) or {}
-        except Exception:
-            session_meta = {}
-
         result_detail = "full" if detail == "full" or not results else "compact"
-        window_messages = view.get("window") or []
-        if result_detail == "compact":
-            window_messages = [m for m in window_messages if m.get("id") == msg_id]
-
-        entry = {
-            "session_id": hit_sid,
-            "when": _format_timestamp(
-                session_meta.get("started_at") or match_info.get("session_started")
-            ),
-            "source": session_meta.get("source") or match_info.get("source", "unknown"),
-            "model": session_meta.get("model") or match_info.get("model") or "unknown",
-            "title": session_meta.get("title") or None,
-            "matched_role": match_info.get("role"),
-            "match_message_id": msg_id,
-            "snippet": match_info.get("snippet") or "",
-            "bookend_start": (
-                [
-                    _shape_message(m, max_content_len=1200)
-                    for m in (view.get("bookend_start") or [])
-                    if not _is_compaction_summary(m.get("content", ""))
-                ]
-                if result_detail == "full"
-                else []
-            ),
-            "messages": [
-                _shape_message(m, anchor_id=msg_id, max_content_len=4000)
-                for m in window_messages
-            ],
-            "bookend_end": (
-                [
-                    _shape_message(m, max_content_len=1200)
-                    for m in (view.get("bookend_end") or [])
-                    if not _is_compaction_summary(m.get("content", ""))
-                ]
-                if result_detail == "full"
-                else []
-            ),
-            "messages_before": view.get("messages_before", 0),
-            "messages_after": view.get("messages_after", 0),
-            "detail": result_detail,
-        }
-        if lineage_root and lineage_root != hit_sid:
-            entry["parent_session_id"] = lineage_root
-        results.append(entry)
+        entry = _build_discover_entry(db, lineage_root, match_info, result_detail)
+        if entry is not None:
+            results.append(entry)
 
     for entry in results:
         entry["link"] = _session_link(entry["session_id"], link_profile)
@@ -948,6 +991,213 @@ def _discover(
     }
     _annotate_rebuild_status(db, _final_payload)
     return json.dumps(_final_payload, ensure_ascii=False)
+
+
+def _tag_discover_entry(entry: Dict[str, Any], profile_name: str) -> Dict[str, Any]:
+    """Attach source-profile metadata used by the all-profiles discover path."""
+    entry["profile"] = profile_name
+    entry["link"] = _session_link(entry["session_id"], profile_name)
+    return entry
+
+
+def _discover_all_profiles(
+    query: str,
+    role_filter: Optional[List[str]],
+    limit: int,
+    sort: Optional[str],
+    detail: str,
+) -> str:
+    """Fan out FTS5 across every profile, merge, dedup, and tag each hit."""
+    role_list = role_filter if role_filter else ["user", "assistant"]
+    opened: Dict[str, Any] = {}
+    all_raw: List[Dict[str, Any]] = []
+    title_results: List[Dict[str, Any]] = []
+
+    try:
+        for name, home in _iter_profile_homes():
+            if name in opened:
+                continue
+            pdb = _open_profile_state_db(home)
+            if pdb is None:
+                continue
+            opened[name] = pdb
+            try:
+                title = _title_match_result(pdb, query, None)
+                if title:
+                    title_results.append(_tag_discover_entry(title, name))
+                raw = pdb.search_messages(
+                    query=query,
+                    role_filter=role_list,
+                    exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                    limit=_DISCOVER_SCAN_LIMIT,
+                    offset=0,
+                    sort=sort,
+                    fields=_DISCOVER_SEARCH_FIELDS,
+                )
+            except Exception as e:
+                logging.error("FTS5 search failed for profile %s: %s", name, e, exc_info=True)
+                continue
+            for row in raw:
+                tagged = dict(row)
+                tagged["_profile"] = name
+                all_raw.append(tagged)
+
+        # Re-apply temporal sort on the merged set so newest/oldest is
+        # global, not per-profile concatenation order.
+        if sort in ("newest", "oldest"):
+            all_raw.sort(
+                key=lambda r: r.get("session_started") or 0,
+                reverse=(sort == "newest"),
+            )
+        all_raw = _order_for_recall(all_raw)
+        profiles_searched = len(opened)
+
+        if not all_raw and not title_results:
+            return json.dumps({
+                "success": True,
+                "mode": "discover",
+                "query": query,
+                "detail": detail,
+                "results": [],
+                "count": 0,
+                "profiles_searched": profiles_searched,
+                "message": (
+                    "No matching sessions found across profiles. FTS5 ANDs all "
+                    "terms by default — broaden with OR (`alpha OR beta`), "
+                    "exact-match with quoted phrases, exclude with NOT, or "
+                    "prefix-match with `deploy*`."
+                ),
+            }, ensure_ascii=False)
+
+        seen_sessions: Dict[str, Dict[str, Any]] = {}
+        results: List[Dict[str, Any]] = []
+
+        for title in title_results:
+            lineage = title.pop("_lineage_root", None) or title.get("session_id")
+            if lineage and lineage not in seen_sessions:
+                seen_sessions[lineage] = {"_title_only": True, "_profile": title.get("profile")}
+                results.append(title)
+
+        for row in all_raw:
+            if len(seen_sessions) >= limit:
+                break
+            raw_sid = row["session_id"]
+            profile_name = row.get("_profile") or "default"
+            pdb = opened.get(profile_name)
+            if pdb is None:
+                continue
+            resolved_sid, _ = _resolve_to_parent(pdb, raw_sid)
+            if resolved_sid not in seen_sessions:
+                tagged = dict(row)
+                tagged["_lineage_root"] = resolved_sid
+                seen_sessions[resolved_sid] = tagged
+
+        for lineage_root, match_info in seen_sessions.items():
+            if match_info.get("_title_only"):
+                continue
+            profile_name = match_info.get("_profile") or "default"
+            pdb = opened.get(profile_name)
+            if pdb is None:
+                continue
+            result_detail = "full" if detail == "full" or not results else "compact"
+            entry = _build_discover_entry(pdb, lineage_root, match_info, result_detail)
+            if entry is None:
+                continue
+            results.append(_tag_discover_entry(entry, profile_name))
+
+        return json.dumps({
+            "success": True,
+            "mode": "discover",
+            "query": query,
+            "detail": detail,
+            "results": results,
+            "count": len(results),
+            "sessions_searched": len(seen_sessions),
+            "profiles_searched": profiles_searched,
+            "link_hint": (
+                "When referring the user to a session, write its `link` value "
+                "verbatim inline mid-sentence (it renders as a titled link) — never "
+                "as markdown, in backticks, on its own line, or next to the "
+                "title/id/date. To read more around a compact result, scroll: "
+                "session_search(session_id=..., around_message_id=match_message_id)."
+            ),
+        }, ensure_ascii=False)
+    finally:
+        for pdb in opened.values():
+            try:
+                pdb.close()
+            except Exception:
+                logging.debug("Failed to close all-profiles SessionDB", exc_info=True)
+
+
+def _browse_all_profiles(limit: int, current_session_id: str = None) -> str:
+    """Merge recent sessions from every profile, tagged with source profile."""
+    merged: List[Dict[str, Any]] = []
+    opened: Dict[str, Any] = {}
+    try:
+        for name, home in _iter_profile_homes():
+            if name in opened:
+                continue
+            pdb = _open_profile_state_db(home)
+            if pdb is None:
+                continue
+            opened[name] = pdb
+            try:
+                sessions = pdb.list_sessions_rich(
+                    limit=limit + 15,
+                    exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                    order_by_last_active=True,
+                )
+            except Exception:
+                logging.debug("list_sessions_rich failed for profile %s", name, exc_info=True)
+                continue
+            for session in sessions:
+                row = dict(session)
+                row["_profile"] = name
+                merged.append(row)
+    finally:
+        for pdb in opened.values():
+            try:
+                pdb.close()
+            except Exception:
+                logging.debug("Failed to close all-profiles browse SessionDB", exc_info=True)
+
+    def _activity_ts(row: Dict[str, Any]):
+        return row.get("last_active") or row.get("started_at") or 0
+
+    merged.sort(key=_activity_ts, reverse=True)
+
+    results = []
+    for session in merged:
+        sid = session.get("id", "")
+        if current_session_id and sid == current_session_id:
+            continue
+        profile_name = session.get("_profile") or "default"
+        results.append({
+            "session_id": sid,
+            "link": _session_link(sid, profile_name),
+            "profile": profile_name,
+            "title": session.get("title") or None,
+            "source": session.get("source", ""),
+            "started_at": session.get("started_at", ""),
+            "last_active": session.get("last_active", ""),
+            "message_count": session.get("message_count", 0),
+            "preview": session.get("preview", ""),
+        })
+        if len(results) >= limit:
+            break
+
+    return json.dumps({
+        "success": True,
+        "mode": "browse",
+        "results": results,
+        "count": len(results),
+        "profiles_searched": len(opened),
+        "message": (
+            f"Showing {len(results)} most recent sessions across profiles. "
+            "Pass a query= to search, or session_id+around_message_id to scroll."
+        ),
+    }, ensure_ascii=False)
 
 
 def _session_search_impl(
@@ -992,10 +1242,15 @@ def _session_search_impl(
             if emb_profile and (profile is None or not str(profile).strip()):
                 profile = emb_profile
 
+    # Cross-profile fan-out: ``profile=all`` (or ``*``) searches every
+    # profile's DB. Must run before ``_resolve_profile_db`` so we never try
+    # to open a profile literally named ``all``.
+    all_profiles = _is_all_profiles(profile)
+
     # Cross-profile read: swap in the named profile's DB (read-only) for every
     # shape below. The current-session-lineage guards no longer apply across
     # profiles, but they key off ids that won't collide, so they stay inert.
-    if profile is not None and str(profile).strip():
+    if (not all_profiles) and profile is not None and str(profile).strip():
         try:
             profile_db = _resolve_profile_db(profile)
         except Exception as e:
@@ -1044,6 +1299,31 @@ def _session_search_impl(
         except (TypeError, ValueError):
             limit = 3
     limit = max(1, min(limit, 10))
+
+    # Browse / discover across every profile.
+    if all_profiles:
+        if not query or not isinstance(query, str) or not query.strip():
+            return _browse_all_profiles(limit, current_session_id)
+        role_list: Optional[List[str]] = None
+        if isinstance(role_filter, str) and role_filter.strip():
+            role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
+        sort_norm: Optional[str] = None
+        if isinstance(sort, str):
+            candidate = sort.strip().lower()
+            if candidate in ("newest", "oldest"):
+                sort_norm = candidate
+        detail_norm = (
+            "full"
+            if isinstance(detail, str) and detail.strip().lower() == "full"
+            else "adaptive"
+        )
+        return _discover_all_profiles(
+            query=query.strip(),
+            role_filter=role_list,
+            limit=limit,
+            sort=sort_norm,
+            detail=detail_norm,
+        )
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
@@ -1239,7 +1519,9 @@ SESSION_SEARCH_SCHEMA = {
                     "Optional. Read sessions from another Hermes profile's database "
                     "(read-only). Use when resolving an `@session:<profile>/<id>` link: "
                     "pass the profile segment here with session_id as the id segment. "
-                    "Omit to use the current profile."
+                    "Pass 'all' to search across every profile's sessions and merge "
+                    "results tagged with their source profile. Omit to use the current "
+                    "profile."
                 ),
             },
         },


### PR DESCRIPTION
## What does this PR do?

`session_search` could already open one named profile's `state.db` via `profile=`, but discover/browse still searched only that single database. A profile-manager agent asking "which profile last worked on X?" had to raw-SQL every `~/.hermes/profiles/*/state.db`.

This adds `profile="all"` (and `profile="*"`) so discover fans FTS5 across every profile, merges and lineage-dedups the hits, tags each result with its source profile, and keeps the existing single-profile override unchanged.

## Related Issue

Fixes #98159

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py`: intercept `all`/`*` before `_resolve_profile_db`; `_discover_all_profiles` / `_browse_all_profiles` open each profile read-only, merge, `_order_for_recall`, global newest/oldest sort, tag `profile` + `@session:<profile>/<id>`; extract `_build_discover_entry` for shared hydration; update the `profile` schema description.
- `tests/tools/test_session_search.py`: two real `SessionDB`s — merge/tag, `*` sentinel, do not open a profile named `all`, browse-all, global `sort=newest`, single-profile `profile=` still isolated.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_session_search.py -q`
2. From a profile that is not the one that owns the session, call `session_search(query="…", profile="all")` and confirm hits include `profile` plus an `@session:<profile>/<id>` link.
3. Call `session_search(query="…", profile="<one-name>")` and confirm only that profile's sessions return.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
▶ launching test runner
[100.0% |    59/~59 | ✓59 | ✗ 0] ✓ tests/tools/test_session_search.py (59✓)
=== Summary: 1 files, 59 tests passed, 0 failed ===
```