### PR TITLE
fix(agent): refresh memory on model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3326,7 +3326,9 @@ def switch_model(
         logger.debug("switch_model: could not re-resolve reasoning_config: %s", _reasoning_err)
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
-    agent._cached_system_prompt = None
+    # Use the shared invalidation boundary so a live model switch also reloads
+    # the current memory snapshot and refreshes any frozen prompt sections.
+    agent._invalidate_system_prompt()
 
     # Publish the destination capability map only after every runtime setup
     # above has succeeded. Failed switches must leave the old map intact.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -1073,8 +1073,9 @@ def invalidate_system_prompt(agent: Any) -> None:
     if hasattr(agent, _snapshot_attr):
         agent._plugin_system_prompt_sections_previous = getattr(agent, _snapshot_attr)
         delattr(agent, _snapshot_attr)
-    if agent._memory_store:
-        agent._memory_store.load_from_disk()
+    memory_store = getattr(agent, "_memory_store", None)
+    if memory_store:
+        memory_store.load_from_disk()
 
 
 def reconstruct_static_prefix(

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -119,6 +119,23 @@ def test_switch_model_clears_previous_config_context_length(mock_ctx_len):
     assert agent.context_compressor.context_length == 131_072
 
 
+def test_switch_model_reloads_memory_when_invalidating_system_prompt():
+    """A live model switch must refresh memory before the next prompt build."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._memory_store = MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model(
+            "new-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    agent._memory_store.load_from_disk.assert_called_once_with()
+    assert agent._cached_system_prompt is None
+
+
 def test_switch_model_without_config_context_length():
     """When switching models without config override, config_context_length should be None."""
     agent = _make_agent_with_compressor(config_context_length=None)


### PR DESCRIPTION
Summary:\n- route live model switches through the shared system-prompt invalidation boundary\n- reload the current memory snapshot before the next prompt build\n- tolerate lightweight agents without a memory store\n\nTesting:\n- uv run --no-project --with pytest pytest -q tests/run_agent/test_switch_model_context.py (10 passed)\n- uv run --no-project --with pytest pytest -q tests/run_agent/test_run_agent.py -k TestInvalidateSystemPrompt (2 passed)\n- git diff --check