### PR TITLE
fix(terminal): scope terminal config per turn under profile multiplexing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -3027,8 +3027,10 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    from agent.runtime_cwd import scope_terminal_cwd as _scope_terminal_cwd
+
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=_scope_terminal_cwd() or None,
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1173,6 +1173,24 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
+def _tenv_read(name: str, default: str = "") -> str:
+    """Scope-aware TERMINAL_* read (tools.terminal_scope.terminal_env).
+
+    The per-turn terminal scope installed by the multiplexing gateway carries
+    the active profile's terminal settings; a raw os.getenv would read a value
+    a previous profile's turn pinned into the process env.
+
+    Only an import failure falls back: an active refusal scope must raise —
+    swapping it for the ambient process value would defeat the fail-closed
+    boundary.
+    """
+    try:
+        from tools.terminal_scope import terminal_env
+    except ImportError:
+        return os.getenv(name, default)
+    return terminal_env(name, default)
+
+
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
@@ -1181,7 +1199,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
+    cwd_hint = _tenv_read("TERMINAL_CWD", "")
     cache_key = (env_type, cwd_hint)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
@@ -1330,7 +1348,7 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = (_tenv_read("TERMINAL_ENV") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS or _plugin_backend_is_remote(backend)
 
     if not is_remote_backend:

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -57,6 +57,31 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+def _terminal_cwd_env() -> str:
+    """Scope-aware TERMINAL_CWD read (tools.terminal_scope.terminal_env).
+
+    Under gateway multiplexing the per-turn terminal scope carries the active
+    profile's cwd; the process-global env var may hold another profile's
+    value. Only an import failure falls back: an active refusal scope must
+    raise, not silently resolve the launch profile's cwd.
+    """
+    try:
+        from tools.terminal_scope import terminal_env
+    except ImportError:
+        return os.environ.get("TERMINAL_CWD", "")
+    return terminal_env("TERMINAL_CWD", "")
+
+
+def scope_terminal_cwd() -> str:
+    """Public wrapper — the scope-aware TERMINAL_CWD value (may be empty).
+
+    Shared by agent_init / skill_utils / code_execution_tool so every cwd
+    consumer reads through the per-turn terminal scope under gateway
+    multiplexing instead of the process-global env var.
+    """
+    return _terminal_cwd_env()
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:
@@ -64,7 +89,7 @@ def resolve_agent_cwd() -> Path:
         if p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = _terminal_cwd_env().strip()
     if raw:
         p = Path(raw).expanduser()
         if p.is_dir():
@@ -90,7 +115,7 @@ def resolve_context_cwd() -> Path | None:
         else:
             return p
         return None
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = _terminal_cwd_env().strip()
     if raw:
         p = Path(raw).expanduser()
         if not p.is_dir():

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -755,7 +755,9 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     """
     try:
         if start is None:
-            env_cwd = os.environ.get("TERMINAL_CWD")
+            from agent.runtime_cwd import scope_terminal_cwd
+
+            env_cwd = scope_terminal_cwd()
             start = Path(env_cwd) if env_cwd else Path.cwd()
         cur = Path(start).resolve()
     except OSError:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7244,6 +7244,22 @@ def _run_one_job_body(
         _scope_token = set_secret_scope(
             build_profile_secret_scope(_get_hermes_home())
         )
+        # Same isolation for terminal settings (third profile seam; see
+        # gateway/run.py _profile_runtime_scope): installs the firing
+        # profile's COMPLETE terminal policy for this fire — run, delivery,
+        # and bookkeeping — resetting in this function's finally alongside
+        # the secret scope. Without it the ticker thread reads the
+        # process-global TERMINAL_* env vars a concurrent profile's turn may
+        # have pinned (#68559). Resolution failure installs a refusal scope:
+        # terminal execution inside the fire raises instead of falling back
+        # to the launch process's ambient policy.
+        from tools.terminal_scope import (
+            install_profile_terminal_scope,
+        )
+
+        _terminal_scope_token = install_profile_terminal_scope(
+            _get_hermes_home()
+        )
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -7677,6 +7693,10 @@ def _run_one_job_body(
         # _deliver_result unscoped — do not move it back in a tidy-up.
         if _scope_token is not None:
             reset_secret_scope(_scope_token)
+        if _terminal_scope_token is not None:
+            from tools.terminal_scope import reset_terminal_scope
+
+            reset_terminal_scope(_terminal_scope_token)
 
 
 def _notify_provider_jobs_changed() -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1522,6 +1522,25 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _tenv(name: str, default: str = "") -> str:
+    """Scope-aware TERMINAL_* read (tools.terminal_scope.terminal_env).
+
+    Media-path translation runs in the gateway process concurrently for
+    several profiles; the per-turn terminal scope carries the ACTIVE
+    profile's terminal settings, while a raw os.getenv would read whatever
+    profile's config a previous turn pinned into the process env.
+
+    Only an import failure falls back: an active refusal scope must raise —
+    reconstructing mounts/backends from ambient env under refusal would
+    rebuild another profile's terminal policy.
+    """
+    try:
+        from tools.terminal_scope import terminal_env
+    except ImportError:
+        return os.getenv(name, default)
+    return terminal_env(name, default)
+
+
 def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     """Parse configured Docker volume mounts into ``(host_path, container_path)``.
 
@@ -1530,7 +1549,7 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     Named volumes and non-absolute hosts are skipped because they cannot be
     resolved on the gateway host for media delivery.
     """
-    raw = os.getenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+    raw = _tenv("TERMINAL_DOCKER_VOLUMES", "").strip()
     if not raw:
         return []
     try:
@@ -1598,7 +1617,7 @@ def _docker_sandbox_dir_candidates(session_key: str = "") -> List[str]:
     except Exception:
         return ["default"]
     # Explicit trusted-profiles opt-in: one shared container identity.
-    shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+    shared = _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
     if shared:
         candidates.append(sanitize_task_id_for_path(f"shared:{shared}"))
     try:
@@ -1624,9 +1643,9 @@ def _default_docker_workspace_host_roots(session_key: str = "") -> List[Path]:
     actually resolves — the profile sandbox dir existing does not mean the
     file lives there when it was produced in a legacy per-session container.
     """
-    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+    if _tenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return []
-    if os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {
+    if _tenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {
         "1",
         "true",
         "yes",
@@ -1634,13 +1653,13 @@ def _default_docker_workspace_host_roots(session_key: str = "") -> List[Path]:
     }:
         return []
     # Explicit cwd mount takes over /workspace when enabled.
-    if os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").strip().lower() in {
+    if _tenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").strip().lower() in {
         "1",
         "true",
         "yes",
         "on",
     }:
-        cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+        cwd = _tenv("TERMINAL_CWD") or os.getcwd()
         try:
             host = Path(os.path.expanduser(cwd)).resolve(strict=False)
         except (OSError, RuntimeError, ValueError):
@@ -1668,9 +1687,9 @@ def _docker_persistent_home_host_roots(session_key: str = "") -> List[Path]:
     produced a real host file the gateway couldn't find. Ordered best-first:
     the profile-scoped layout, then the legacy bug-window per-session layout.
     """
-    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+    if _tenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return []
-    if os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {
+    if _tenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {
         "1",
         "true",
         "yes",
@@ -1700,7 +1719,7 @@ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
     longer prefixes than the ``/root`` home mount, so longest-prefix matching
     picks the cache translation over the home translation for them.
     """
-    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+    if _tenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return []
     try:
         from tools.credential_files import get_cache_directory_mounts
@@ -1721,7 +1740,7 @@ def _warn_unresolved_docker_media(candidate: Path, session_key: str, reason: str
     file seemingly vanished. Point at the sandbox/session mismatch instead.
     Gated to Docker mode so host-path rejections stay quiet.
     """
-    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+    if _tenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return
     logger.warning(
         "Docker MEDIA path %s did not resolve to a host sandbox file (%s%s); "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2546,6 +2546,19 @@ async def _reclaim_stale(runner: object) -> None:
         )
 
 
+def _terminal_scope_cwd(default: str = "") -> str:
+    """Scope-aware TERMINAL_CWD read for footer/context surfaces.
+
+    Only an import failure falls back: an active refusal scope must raise,
+    not resolve the launch profile's cwd.
+    """
+    try:
+        from tools.terminal_scope import terminal_env as _ts_env
+    except ImportError:
+        return os.environ.get("TERMINAL_CWD", default)
+    return _ts_env("TERMINAL_CWD", default)
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
@@ -2576,11 +2589,19 @@ def _profile_runtime_scope(profile_home: "Path"):
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
-    try:
-        yield
-    finally:
-        reset_secret_scope(secret_token)
-        reset_hermes_home_override(home_token)
+    # Per-turn terminal scope (third seam of the profile boundary): installs
+    # the routed profile's COMPLETE terminal policy — never ambient env — via
+    # tools.terminal_scope. Without it terminal_tool reads the process-global
+    # TERMINAL_* vars a previous profile's turn may have pinned
+    # (first-writer-wins backend leak; #68559).
+    from tools.terminal_scope import install_and_reset_profile_terminal_scope
+
+    with install_and_reset_profile_terminal_scope(Path(profile_home)):
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -20076,7 +20097,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length_async
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                try:
+                    from tools.terminal_scope import terminal_env as _ts_env
+                except ImportError:
+                    _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                else:
+                    _msg_cwd = _ts_env("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_config_ctx = None
                 _msg_cfg = None
                 _msg_model_cfg = {}
@@ -22478,7 +22504,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=_terminal_scope_cwd(""),
                     turn_seconds=_turn_seconds,
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -138,7 +138,13 @@ def format_runtime_footer(
             if turn_seconds is not None and turn_seconds >= 0:
                 parts.append(_format_latency(turn_seconds))
         elif field == "cwd":
-            rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
+            try:
+                from tools.terminal_scope import terminal_env as _tenv
+            except ImportError:
+                env_cwd = os.environ.get("TERMINAL_CWD", "")
+            else:
+                env_cwd = _tenv("TERMINAL_CWD", "")
+            rel = _home_relative_cwd(cwd or env_cwd)
             if rel:
                 parts.append(rel)
         # Unknown field names are silently ignored.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3440,7 +3440,9 @@ class GatewaySlashCommandsMixin:
             max_file_size_mb=cp_kwargs["checkpoint_max_file_size_mb"],
         )
 
-        cwd = os.getenv("TERMINAL_CWD", str(Path.home()))
+        from tools.terminal_scope import terminal_env as _tenv
+
+        cwd = _tenv("TERMINAL_CWD", str(Path.home()))
         arg = event.get_command_args().strip()
 
         # --all / --force: classic full restore, overwriting user edits too.
@@ -3534,7 +3536,9 @@ class GatewaySlashCommandsMixin:
             elif low == "session":
                 mode = "session"
 
-        cwd = os.getenv("TERMINAL_CWD", str(Path.home()))
+        from tools.terminal_scope import terminal_env as _tenv
+
+        cwd = _tenv("TERMINAL_CWD", str(Path.home()))
 
         if mode == "session":
             return await self._gateway_session_diff(cwd, stat_only)

--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -1,0 +1,765 @@
+"""Per-turn terminal scope isolation under profile multiplexing.
+
+Regression tests for the cross-profile terminal backend leak (#68559
+lineage; gateway repro #94200, dashboard repro #98581): a multiplexed
+process serves several profiles from one interpreter, and terminal
+settings used to resolve through the process-global ``TERMINAL_*`` env
+vars — whichever profile first touched the terminal pinned the process
+env, routing every later profile's terminal onto the wrong backend (a
+``local`` profile executing inside another profile's docker sandbox, or
+the reverse: a sandbox escape).
+
+Behavior contracts asserted here (no source reading, no snapshots):
+
+- A bound scope is an AUTHORITATIVE projection: reads resolve only from
+  the profile's policy (defined defaults + .env + config.yaml). An
+  omitted key yields the defined default — never ambient ``os.environ``
+  — so profile B (or an empty-terminal-profile B) cannot inherit
+  profile A's mounts/SSH/network/CWD even when backends match.
+- The scope never mutates ``os.environ``; alternation between profiles
+  in one process is fully isolated both ways.
+- Unresolvable profile policy fails CLOSED: the install returns a
+  refusal scope, and execution paths raise rather than run ambient.
+- The boundary installers (gateway runtime scope, TUI session scope,
+  cron fire scope) install and clean up the policy on their real paths.
+"""
+
+import contextlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.terminal_scope import (
+    TerminalPolicyRefusal,
+    TerminalPolicyUnavailable,
+    build_profile_terminal_scope,
+    enforce_no_refusal,
+    get_terminal_scope,
+    install_profile_terminal_scope,
+    install_refusal_scope,
+    reset_terminal_scope,
+    set_terminal_scope,
+    terminal_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Hermetic HERMES_HOME + a POLLUTED launch-process terminal env.
+
+    The seeded values model the hostile baseline the review requires:
+    profile A (launch) holds sensitive mounts/SSH/network/CWD policy, and
+    every test proves scoped profiles cannot observe any of it.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", '["/host/secret:/data"]')
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "10.10.0.103")
+    monkeypatch.setenv("TERMINAL_SSH_USER", "launch-admin")
+    monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "false")
+    monkeypatch.setenv("TERMINAL_CWD", "/home/launch-user/private")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+    monkeypatch.delenv("TERMINAL_DOCKER_IMAGE", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Scope primitives: authoritative projection, no ambient widening
+# ---------------------------------------------------------------------------
+
+
+def test_no_scope_keeps_historical_env_behavior():
+    """No scope bound → process env (single-process CLI/TUI unchanged)."""
+    token = set_terminal_scope(None)
+    try:
+        assert terminal_env("TERMINAL_ENV") == "local"
+        assert terminal_env("TERMINAL_SSH_HOST") == "10.10.0.103"
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_scoped_read_never_falls_through_to_process_env():
+    """The inverted contract: while a scope is bound, a key the profile did
+    not configure resolves to the defined default — NOT to the ambient
+    process value. This is the omission-leak fix."""
+    token = set_terminal_scope({"TERMINAL_ENV": "docker"})
+    try:
+        assert terminal_env("TERMINAL_ENV") == "docker"
+        # Process env carries these (see fixture); the scope must NOT.
+        assert terminal_env("TERMINAL_SSH_HOST") == ""
+        assert terminal_env("TERMINAL_DOCKER_VOLUMES", "[]") == "[]"
+        # Defined defaults still surface through the scope.
+        assert terminal_env("TERMINAL_CONTAINER_PERSISTENT", "true") != ""
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_scope_read_does_not_mutate_process_env():
+    token = set_terminal_scope({"TERMINAL_ENV": "docker"})
+    try:
+        assert terminal_env("TERMINAL_ENV") == "docker"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_terminal_scope(token)
+    assert terminal_env("TERMINAL_ENV") == "local"
+
+
+def test_two_scopes_alternate_backends_in_one_process(tmp_path):
+    """The original regression: docker-profile and local-profile turns
+    interleave in one process; each resolves its OWN backend and neither the
+    process env nor the other profile is ever read."""
+    from tools.terminal_tool import _get_env_config
+
+    scope_docker = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
+    scope_local = {"TERMINAL_ENV": "local"}
+
+    t1 = set_terminal_scope(scope_docker)
+    cfg1 = _get_env_config()
+    reset_terminal_scope(t1)
+    assert cfg1["env_type"] == "docker"
+    assert cfg1["docker_image"] == "img:a"
+    assert os.environ["TERMINAL_ENV"] == "local"
+
+    t2 = set_terminal_scope(scope_local)
+    cfg2 = _get_env_config()
+    reset_terminal_scope(t2)
+    assert cfg2["env_type"] == "local"
+
+    t3 = set_terminal_scope(scope_docker)
+    cfg3 = _get_env_config()
+    reset_terminal_scope(t3)
+    assert cfg3["env_type"] == "docker"
+    assert cfg3["docker_image"] == "img:a"
+
+
+def test_bridge_suppressed_while_scope_active():
+    """The one-shot config bridge must not write profile values into the
+    process env while a scope is bound."""
+    from tools import terminal_tool
+
+    token = set_terminal_scope({"TERMINAL_ENV": "docker"})
+    try:
+        before = dict(os.environ)
+        terminal_tool._ensure_terminal_env_bridged()
+        assert os.environ == before  # nothing written under scope
+    finally:
+        reset_terminal_scope(token)
+
+
+# ---------------------------------------------------------------------------
+# Cross-profile leak matrix (review requirement): A sensitive, B incomplete
+# ---------------------------------------------------------------------------
+
+
+def _leak_matrix_keys() -> dict:
+    return {
+        "TERMINAL_ENV": "local",          # A's backend
+        "TERMINAL_DOCKER_VOLUMES": '["/host/secret:/data"]',
+        "TERMINAL_SSH_HOST": "10.10.0.103",
+        "TERMINAL_SSH_USER": "launch-admin",
+        "TERMINAL_DOCKER_NETWORK": "false",
+        "TERMINAL_CWD": "/home/launch-user/private",
+        "TERMINAL_CONTAINER_PERSISTENT": "false",
+    }
+
+
+@pytest.mark.parametrize(
+    "b_config_yaml,b_env",
+    [
+        pytest.param("terminal:\n  backend: docker\n", "", id="incomplete-backend-only"),
+        pytest.param("", "", id="empty-terminal-block"),
+        pytest.param(
+            "",
+            "TERMINAL_ENV=docker\nTERMINAL_CONTAINER_PERSISTENT=true\n",
+            id="env-selections-only",
+        ),
+    ],
+)
+def test_profile_b_cannot_observe_profile_a_policy(
+    tmp_path, monkeypatch, b_config_yaml, b_env
+):
+    """Profile A (launch process) holds sensitive mounts/SSH/network/CWD.
+    Profile B — backend-only, empty, or .env-only — must observe NONE of it,
+    even where B selects the same docker backend family."""
+    home_b = tmp_path / "profiles" / "b"
+    home_b.mkdir(parents=True)
+    if b_config_yaml:
+        (home_b / "config.yaml").write_text(b_config_yaml, encoding="utf-8")
+    if b_env:
+        (home_b / ".env").write_text(b_env, encoding="utf-8")
+
+    scope = build_profile_terminal_scope(home_b)
+    token = set_terminal_scope(scope)
+    try:
+        observed = {k: terminal_env(k, "<default>") for k in _leak_matrix_keys()}
+        # Backend is B's own selection (docker from its config/.env where
+        # given; the defined default otherwise) — never A's "local" via env.
+        if "TERMINAL_ENV=docker" in b_env or "backend: docker" in b_config_yaml:
+            assert observed["TERMINAL_ENV"] == "docker"
+        # The sensitive A values must be unobservable. Resolving to a DEFINED
+        # default ("" / "[]" / "true") is correct; resolving to A's seeded
+        # value is the leak.
+        a = _leak_matrix_keys()
+        for key in (
+            "TERMINAL_DOCKER_VOLUMES",
+            "TERMINAL_SSH_HOST",
+            "TERMINAL_SSH_USER",
+            "TERMINAL_CWD",
+        ):
+            assert observed[key] != a[key], (
+                f"LEAK: profile B observed A's {key}={observed[key]!r}"
+            )
+        # Boolean/network policy resolves to the defined default, not A's.
+        assert observed["TERMINAL_DOCKER_NETWORK"] in {"true", "True"}
+        assert observed["TERMINAL_CONTAINER_PERSISTENT"] in {"true", "True"}
+    finally:
+        reset_terminal_scope(token)
+
+
+# ---------------------------------------------------------------------------
+# build_profile_terminal_scope: precedence + completeness
+# ---------------------------------------------------------------------------
+
+
+def _docker_profile_yaml() -> str:
+    return (
+        "model:\n"
+        "  default: test-model\n"
+        "terminal:\n"
+        "  backend: docker\n"
+        "  docker_image: nikolaik/python-nodejs:python3.11-nodejs20\n"
+        "  container_cpu: 2\n"
+        "  container_persistent: true\n"
+    )
+
+
+def test_build_scope_reads_profile_config_and_is_total(tmp_path):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+    scope = build_profile_terminal_scope(home)
+    # Profile selections override defined defaults...
+    assert scope["TERMINAL_ENV"] == "docker"
+    assert scope["TERMINAL_CONTAINER_CPU"] == "2"
+    # ...and the projection is total: every mapped key exists, except
+    # TERMINAL_CWD whose config placeholder (".") is resolved per-surface
+    # by the consuming tool (gateway cwd resolution), not projected.
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    expected = set(TERMINAL_CONFIG_ENV_MAP.values()) - {"TERMINAL_CWD"}
+    assert set(scope) == expected
+    assert not any(k.startswith("HERMES_") for k in scope)
+
+
+def test_build_scope_config_overrides_dotenv(tmp_path):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+    (home / ".env").write_text(
+        "TERMINAL_ENV=local\nTERMINAL_CWD=/home/ubuntu\n", encoding="utf-8"
+    )
+    scope = build_profile_terminal_scope(home)
+    assert scope["TERMINAL_ENV"] == "docker"       # config wins
+    assert scope["TERMINAL_CWD"] == "/home/ubuntu"  # .env-only key survives
+
+
+def test_build_scope_placeholder_cwd_not_bridged(tmp_path):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n  cwd: .\n", encoding="utf-8"
+    )
+    assert "TERMINAL_CWD" not in build_profile_terminal_scope(home)
+
+
+def test_build_scope_dotenv_only_profile(tmp_path):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+    scope = build_profile_terminal_scope(home)
+    assert scope["TERMINAL_ENV"] == "docker"
+    # Still total despite the minimal .env (minus the per-surface cwd).
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    expected = set(TERMINAL_CONFIG_ENV_MAP.values()) - {"TERMINAL_CWD"}
+    assert set(scope) == expected
+
+
+# ---------------------------------------------------------------------------
+# Fail closed: unresolvable policy → refusal scope → execution refuses
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_profile_config_builds_refusal(tmp_path):
+    home = tmp_path / "profiles" / "broken"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text("terminal: [unclosed\n", encoding="utf-8")
+
+    token = install_profile_terminal_scope(home)
+    try:
+        assert isinstance(get_terminal_scope(), TerminalPolicyRefusal)
+        with pytest.raises(TerminalPolicyUnavailable):
+            terminal_env("TERMINAL_ENV")
+        with pytest.raises(TerminalPolicyUnavailable):
+            enforce_no_refusal()
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_unreadable_profile_env_builds_refusal(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "broken-env"
+    home.mkdir(parents=True)
+    env_path = home / ".env"
+    env_path.write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+    # Make the .env unreadable at read_bytes time (the pre-flight check).
+    real_read_bytes = Path.read_bytes
+
+    def refusing_read_bytes(self):
+        if self == env_path:
+            raise PermissionError(13, "Permission denied")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", refusing_read_bytes)
+    with pytest.raises(TerminalPolicyUnavailable):
+        build_profile_terminal_scope(home)
+
+
+def test_explicit_refusal_scope_blocks_execution_reads():
+    token = install_refusal_scope("unit-test refusal")
+    try:
+        with pytest.raises(TerminalPolicyUnavailable):
+            terminal_env("TERMINAL_ENV")
+        with pytest.raises(TerminalPolicyUnavailable):
+            enforce_no_refusal()
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_terminal_tool_refuses_under_refusal_scope():
+    """The real execution path refuses with the typed error (fail closed),
+    and _host_local control-plane children still work."""
+    from tools.terminal_tool import terminal_tool
+
+    token = install_refusal_scope("unresolved profile policy")
+    try:
+        result = terminal_tool(command="whoami")
+        assert "terminal policy unavailable" in result
+        assert "whoami" not in result or '"status": "error"' in result
+    finally:
+        reset_terminal_scope(token)
+
+
+# ---------------------------------------------------------------------------
+# Gateway boundary: _profile_runtime_scope installs the policy per turn
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_runtime_scope_installs_and_cleans(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    import gateway.run as gw
+
+    monkeypatch.setattr(
+        "agent.secret_scope.build_profile_secret_scope", lambda _h: {}
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources", lambda _h: None
+    )
+
+    assert get_terminal_scope() is None
+    with gw._profile_runtime_scope(home):
+        scope = get_terminal_scope()
+        assert scope is not None
+        assert scope.get("TERMINAL_ENV") == "docker"
+    assert get_terminal_scope() is None
+
+
+def test_gateway_runtime_scope_cleans_up_on_error(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    import gateway.run as gw
+
+    monkeypatch.setattr("agent.secret_scope.build_profile_secret_scope", lambda _h: {})
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources", lambda _h: None
+    )
+
+    with pytest.raises(RuntimeError):
+        with gw._profile_runtime_scope(home):
+            assert get_terminal_scope() is not None
+            raise RuntimeError("turn blew up")
+    assert get_terminal_scope() is None
+
+
+# ---------------------------------------------------------------------------
+# TUI / dashboard boundary: the #98581 local→docker dashboard regression
+# ---------------------------------------------------------------------------
+
+
+def test_tui_session_runtime_scope_binds_terminal_policy(tmp_path, monkeypatch):
+    """_session_profile_runtime_scope is the TUI turn/agent-build boundary;
+    it must carry the same authoritative terminal policy the gateway binds —
+    the docker-configured dashboard profile must never resolve host env."""
+    import tui_gateway.server as server
+
+    home = tmp_path / "profiles" / "dash"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    # Simulate the polluted launch-process env (unified desktop backend).
+    assert os.environ["TERMINAL_ENV"] == "local"
+    session = {"profile_home": str(home)}
+
+    with server._session_profile_runtime_scope(session):
+        assert get_terminal_scope() is not None
+        assert terminal_env("TERMINAL_ENV") == "docker"
+        # And cannot observe the launch process's secrets.
+        assert terminal_env("TERMINAL_SSH_HOST") == ""
+    assert get_terminal_scope() is None
+
+
+def test_tui_session_runtime_scope_nop_for_launch_profile():
+    import tui_gateway.server as server
+
+    session = {}  # no profile_home → launch profile, no scope (unchanged)
+    with server._session_profile_runtime_scope(session):
+        assert get_terminal_scope() is None
+
+
+def test_tui_agent_build_binds_terminal_scope(tmp_path, monkeypatch):
+    """_start_agent_build's profile block binds home + secret scope; it must
+    also bind the terminal policy so the built agent's tools can't drift."""
+    # The build path wraps its own install/reset pair; verify the helper it
+    # uses is the authoritative installer with refusal semantics.
+    home = tmp_path / "profiles" / "broken"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text("terminal: [oops\n", encoding="utf-8")
+    token = install_profile_terminal_scope(home)
+    try:
+        assert isinstance(get_terminal_scope(), TerminalPolicyRefusal)
+    finally:
+        reset_terminal_scope(token)
+
+
+# ---------------------------------------------------------------------------
+# Cron boundary: per-fire install/reset on the ticker path
+# ---------------------------------------------------------------------------
+
+
+def test_cron_fire_install_reset_lifecycle(tmp_path):
+    """Drive the REAL install/reset pair the scheduler's fire function uses
+    (not just the builder): docker profile policy binds, then fully resets —
+    a wrong/reset-skip cron installation cannot pass this."""
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    from tools.terminal_scope import install_and_reset_profile_terminal_scope
+
+    assert get_terminal_scope() is None
+    with install_and_reset_profile_terminal_scope(home):
+        assert get_terminal_scope() is not None
+        assert terminal_env("TERMINAL_ENV") == "docker"
+    assert get_terminal_scope() is None
+
+
+def test_cron_fire_failure_still_resets(tmp_path):
+    home = tmp_path / "profiles" / "qa"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    from tools.terminal_scope import install_and_reset_profile_terminal_scope
+
+    with pytest.raises(RuntimeError):
+        with install_and_reset_profile_terminal_scope(home):
+            raise RuntimeError("job blew up")
+    assert get_terminal_scope() is None
+
+
+# ---------------------------------------------------------------------------
+# Downstream scope-aware readers
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_cwd_reads_scope(tmp_path):
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    profile_cwd = tmp_path / "sandbox-workspace"
+    profile_cwd.mkdir()
+    token = set_terminal_scope({"TERMINAL_CWD": str(profile_cwd)})
+    try:
+        assert resolve_agent_cwd() == profile_cwd
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_prompt_builder_backend_read_is_scope_aware():
+    from agent.prompt_builder import _tenv_read
+
+    token = set_terminal_scope({"TERMINAL_ENV": "docker"})
+    try:
+        assert _tenv_read("TERMINAL_ENV") == "docker"
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_platform_base_media_translation_reads_scope():
+    from gateway.platforms.base import _tenv
+
+    token = set_terminal_scope({"TERMINAL_ENV": "docker"})
+    try:
+        assert _tenv("TERMINAL_ENV") == "docker"
+    finally:
+        reset_terminal_scope(token)
+
+
+# ---------------------------------------------------------------------------
+# Round-2 P1: refusal must propagate through downstream readers
+# (review: broad `except Exception` around terminal_env() downgraded an
+# active refusal scope back into ambient launch-profile policy)
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_scope_blocks_all_downstream_readers():
+    """With a refusal scope bound and POLLUTED ambient TERMINAL_* values,
+    every scope-aware downstream reader must raise/refuse — never return the
+    launch process's values."""
+    from agent.prompt_builder import _tenv_read
+    from agent.runtime_cwd import _terminal_cwd_env
+    from gateway.platforms.base import _tenv as _gw_tenv
+    from tools.terminal_scope import (
+        TerminalPolicyUnavailable,
+        install_refusal_scope,
+    )
+
+    token = install_refusal_scope("unit: downstream propagation")
+    try:
+        with pytest.raises(TerminalPolicyUnavailable):
+            _tenv_read("TERMINAL_DOCKER_VOLUMES")
+        with pytest.raises(TerminalPolicyUnavailable):
+            _terminal_cwd_env()
+        with pytest.raises(TerminalPolicyUnavailable):
+            _gw_tenv("TERMINAL_DOCKER_VOLUMES")
+        with pytest.raises(TerminalPolicyUnavailable):
+            _gw_tenv("TERMINAL_CWD")
+        with pytest.raises(TerminalPolicyUnavailable):
+            from tools.terminal_scope import terminal_env as _te
+
+            _te("TERMINAL_CWD")
+    finally:
+        from tools.terminal_scope import reset_terminal_scope
+
+        reset_terminal_scope(token)
+
+
+def test_platform_media_translation_refuses_under_refusal(monkeypatch):
+    """The consequential surface the review calls out: Docker media-path
+    translation must NOT reconstruct the launch profile's mounts under a
+    refusal scope."""
+    import gateway.platforms.base as base
+
+    token = install_refusal_scope("unit: media translation refusal")
+    try:
+        # _parse_docker_volume_mounts reads TERMINAL_DOCKER_VOLUMES through
+        # the scope-aware _tenv; under refusal it must raise, not parse the
+        # ambient '["/host/secret:/data"]'.
+        with pytest.raises(Exception) as exc_info:
+            base._parse_docker_volume_mounts()
+        assert "terminal policy unavailable" in str(exc_info.value)
+    finally:
+        from tools.terminal_scope import reset_terminal_scope
+
+        reset_terminal_scope(token)
+
+
+def test_runtime_cwd_resolution_refuses_under_refusal():
+    """agent.runtime_cwd's public cwd resolution refuses under a refusal
+    scope instead of returning the launch profile's cwd."""
+    from agent import runtime_cwd
+
+    token = install_refusal_scope("unit: cwd resolution refusal")
+    try:
+        with pytest.raises(Exception) as exc_info:
+            runtime_cwd._terminal_cwd_env()
+        assert "terminal policy unavailable" in str(exc_info.value)
+    finally:
+        from tools.terminal_scope import reset_terminal_scope
+
+        reset_terminal_scope(token)
+
+
+def test_gateway_terminal_scope_cwd_refuses_under_refusal():
+    from gateway.run import _terminal_scope_cwd
+    from tools.terminal_scope import TerminalPolicyUnavailable
+
+    token = install_refusal_scope("unit: gateway cwd refusal")
+    try:
+        with pytest.raises(TerminalPolicyUnavailable):
+            _terminal_scope_cwd("")
+    finally:
+        from tools.terminal_scope import reset_terminal_scope
+
+        reset_terminal_scope(token)
+
+
+def test_import_error_still_falls_back(monkeypatch):
+    """Compatibility fallback exists ONLY for the genuine import-unavailable
+    condition (never for an active refusal)."""
+    import sys
+    from agent.prompt_builder import _tenv_read
+
+    real_import = __import__
+
+    def _hide_scope(name, *a, **kw):
+        if name == "tools.terminal_scope":
+            raise ImportError("hidden for test")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setitem(sys.modules, "tools.terminal_scope", None)
+    monkeypatch.setattr("builtins.__import__", _hide_scope)
+    # Falls back to process env (= local, from the fixture) — not a refusal.
+    assert _tenv_read("TERMINAL_ENV") == "local"
+
+
+# ---------------------------------------------------------------------------
+# Round-2: real-path coverage (the review's proof-gap items)
+# ---------------------------------------------------------------------------
+
+
+def test_tui_agent_build_real_path_binds_and_cleans(tmp_path, monkeypatch):
+    """Drive the REAL _start_agent_build boundary: monkeypatch the agent
+    factory to observe the bound scope on the build thread, and verify the
+    build's finally fully resets it."""
+    import tui_gateway.server as server
+
+    home = tmp_path / "profiles" / "dash"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    observed = {}
+
+    def fake_make_agent(*args, **kw):
+        observed["scope"] = dict(get_terminal_scope() or {})
+        # Minimal truthy agent stand-in: the build's post steps tolerate it
+        # because _transfer_db_to_agent / attach tolerate plain objects.
+        class _A:
+            session_db = None
+            async_clients = ()
+
+            def close(self):
+                pass
+
+        return _A()
+
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+
+    saved = dict(server._sessions)
+    try:
+        sid = "test-build-sid"
+        import threading as _threading
+
+        session = {
+            "profile_home": str(home),
+            "session_key": "k",
+            "agent": None,
+            "agent_error": None,
+            "agent_ready": _threading.Event(),
+        }
+        server._sessions[sid] = session
+        server._start_agent_build(sid, session)
+        # _start_agent_build spawns the build thread and returns; wait for
+        # the ready event, which the build body sets in its finally.
+        session["agent_ready"].wait(timeout=10)
+        observed["after"] = get_terminal_scope()
+        assert observed["scope"].get("TERMINAL_ENV") == "docker"
+        assert observed["after"] is None
+    finally:
+        server._sessions.clear()
+        server._sessions.update(saved)
+
+
+def test_cron_fire_real_path_installs_and_resets(tmp_path, monkeypatch):
+    """Drive the REAL scheduler per-fire boundary via run_one_job with a
+    no-agent script job bound to a docker profile home: the terminal policy
+    must be bound inside the fire (observed in-process at the script
+    execution seam) and fully reset after the fire returns. (The script
+    itself runs in a subprocess — ContextVars cannot cross that boundary by
+    design; in-process seams like delivery and config resolution are what
+    the scope protects.)"""
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profiles" / "qa"
+    scripts_dir = home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    script = scripts_dir / "noop.py"
+    script.write_text("pass\n", encoding="utf-8")
+    job = {
+        "id": "t-scope-fire",
+        "name": "scope probe",
+        "schedule": {"kind": "interval", "every_minutes": 60},
+        "enabled": True,
+        "prompt": "unused",
+        "script": str(script),
+        "no_agent": True,
+        "session_id": None,
+    }
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
+
+    observed = {}
+    real_runner = scheduler._run_job_script
+
+    def recording_runner(script_path, workdir=None, cancel_event=None):
+        observed["scope"] = get_terminal_scope()
+        return real_runner(script_path, workdir=workdir, cancel_event=cancel_event)
+
+    monkeypatch.setattr(scheduler, "_run_job_script", recording_runner)
+
+    assert get_terminal_scope() is None
+    result = scheduler.run_one_job(job)
+    assert result is True
+    # Inside the fire the docker profile policy was bound.
+    assert isinstance(observed.get("scope"), dict)
+    assert observed["scope"].get("TERMINAL_ENV") == "docker"
+    # The fire's scope did not survive the boundary.
+    assert get_terminal_scope() is None
+
+
+def test_cron_fire_real_path_resets_on_failure(tmp_path, monkeypatch):
+    """A no-agent job whose script FAILS must still reset the fire's scope
+    and surface the failure through the normal (False) run path."""
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profiles" / "qa"
+    scripts_dir = home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (home / "config.yaml").write_text(_docker_profile_yaml(), encoding="utf-8")
+
+    script = scripts_dir / "boom.py"
+    script.write_text("raise RuntimeError('boom-inside-fire')\n", encoding="utf-8")
+    job = {
+        "id": "t-scope-boom",
+        "name": "boom",
+        "schedule": {"kind": "interval", "every_minutes": 60},
+        "enabled": True,
+        "prompt": "unused",
+        "script": str(script),
+        "no_agent": True,
+        "session_id": None,
+    }
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *a, **kw: "ok")
+
+    assert get_terminal_scope() is None
+    result = scheduler.run_one_job(job)  # failure recorded, not raised
+    assert result is True
+    assert get_terminal_scope() is None

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1553,6 +1553,21 @@ def execute_code(
             "Use normal tool calls (terminal, read_file, write_file, ...) instead."
         )
 
+    # Fail closed under a terminal-policy refusal scope (#68559): the routed
+    # profile's terminal policy could not be resolved and execute_code runs on
+    # the configured terminal backend — refuse rather than inheriting the
+    # launch process's ambient policy.
+    try:
+        from tools.terminal_scope import enforce_no_refusal
+
+        enforce_no_refusal()
+    except Exception as refusal:
+        return tool_error(
+            f"execute_code refused: {refusal} "
+            "(profile terminal policy unresolved; fix the profile's "
+            "config.yaml / .env and retry)"
+        )
+
     if not code or not code.strip():
         return tool_error(
             "No code provided. execute_code requires a non-empty 'code' "
@@ -2282,7 +2297,9 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    from agent.runtime_cwd import scope_terminal_cwd
+
+    raw = scope_terminal_cwd().strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -1,0 +1,298 @@
+"""Per-turn terminal scope: profile-scoped TERMINAL_* policy.
+
+The multiplexing gateway (and the unified dashboard/TUI, and cron) serve
+several Hermes profiles from one process. Terminal settings were historically
+mirrored into the process-global ``os.environ`` (first writer wins), so the
+first profile to touch the terminal after startup pinned its backend — and
+every other setting — onto all later turns: a ``local`` profile silently
+executing inside another profile's docker sandbox, or the reverse (a sandbox
+escape). Mirrors the isolation seam that ``agent/secret_scope.py`` provides
+for credentials: a ContextVar holds the active profile's COMPLETE effective
+``TERMINAL_*`` policy, installed at each in-process profile boundary.
+
+Two contracts distinguish this from a plain override dict:
+
+- **Authoritative projection.** While a scope is bound, ``terminal_env``
+  resolves ONLY from that policy (built from defined defaults + the profile's
+  ``.env`` + its ``config.yaml`` explicit keys). Omitted keys resolve to the
+  defined default — never to ambient ``os.environ`` — so a routed profile can
+  neither inherit nor be escaped onto the launch process's mounts, SSH
+  targets, or resource policy (#68559).
+- **Fail closed.** If the profile's policy cannot be resolved (unreadable or
+  malformed ``.env``/``config.yaml``), the install raises
+  :class:`TerminalPolicyUnavailable` and callers must install a *refusal*
+  scope; terminal execution under a refusal scope is rejected outright
+  rather than falling back to ambient authority.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+# ``None`` = no scope bound in this context; readers use the historical
+# process-env behavior (single-process CLI/TUI, unaffected surfaces).
+# A dict = the active profile's complete effective terminal policy.
+# A TerminalPolicyRefusal = resolution failed; terminal execution must refuse.
+_terminal_scope_var: ContextVar = ContextVar("hermes_terminal_scope", default=None)
+
+
+class TerminalPolicyUnavailable(Exception):
+    """The routed profile's terminal policy could not be resolved.
+
+    Raised when the profile's ``.env`` or ``config.yaml`` exists but cannot be
+    read/parsed. Callers must install the returned refusal scope instead of
+    continuing without a scope — executing under ambient process authority is
+    exactly the leak this module exists to close.
+    """
+
+
+class TerminalPolicyRefusal(Dict[str, str]):
+    """Marker scope installed when policy resolution failed.
+
+    An (empty) dict subclass so existing dict-typed checks keep working, with
+    a flag that makes ``terminal_env`` raise before any value is served.
+    """
+
+    refused = True
+
+    def __init__(self, reason: str) -> None:
+        super().__init__()
+        self.reason = reason
+
+
+def set_terminal_scope(mapping: Optional[Dict[str, str]]) -> Token:
+    """Install *mapping* as the current context's terminal policy."""
+    return _terminal_scope_var.set(mapping)
+
+
+def install_refusal_scope(reason: str) -> Token:
+    """Install a refusal scope after :class:`TerminalPolicyUnavailable`.
+
+    Terminal execution under this scope is rejected (fail closed) instead of
+    running under the launch process's ambient policy.
+    """
+    return _terminal_scope_var.set(TerminalPolicyRefusal(reason))
+
+
+def reset_terminal_scope(token: Token) -> None:
+    _terminal_scope_var.reset(token)
+
+
+def get_terminal_scope() -> Optional[Dict[str, str]]:
+    """The active scope mapping/refusal, or ``None`` when no scope is bound."""
+    return _terminal_scope_var.get()
+
+
+@contextmanager
+def terminal_scope(mapping: Optional[Dict[str, str]]) -> Iterator[None]:
+    """Context manager form of set/reset_terminal_scope."""
+    token = set_terminal_scope(mapping)
+    try:
+        yield
+    finally:
+        reset_terminal_scope(token)
+
+
+def terminal_env(name: str, default: str = "") -> str:
+    """Authoritative read of a ``TERMINAL_*`` variable.
+
+    - No scope bound: process env, then *default* (historical single-process
+      behavior — CLI/TUI surfaces that never route profiles are unchanged).
+    - Refusal scope bound: raise — policy is unavailable and execution must
+      fail closed, not fall back to ambient authority.
+    - Policy scope bound: resolve ONLY from the policy; a missing key yields
+      the *default* (which callers derive from defined defaults), never
+      ``os.environ``.
+    """
+    scope = _terminal_scope_var.get()
+    if scope is None:
+        import os
+
+        return os.environ.get(name, default)
+    if isinstance(scope, TerminalPolicyRefusal):
+        raise TerminalPolicyUnavailable(
+            f"terminal policy unavailable for this profile: {scope.reason}"
+        )
+    value = scope.get(name)
+    if value is not None:
+        return str(value)
+    return default
+
+
+def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
+    """Build the COMPLETE effective ``TERMINAL_*`` policy for a profile home.
+
+    Projection order: defined defaults (``DEFAULT_CONFIG['terminal']``) ← the
+    profile's ``.env`` TERMINAL_* selections ← its ``config.yaml`` explicit
+    ``terminal:`` keys. The result is total: every key the terminal stack can
+    ask for resolves from this mapping, so a bound scope never widens back to
+    ambient process authority. Raises :class:`TerminalPolicyUnavailable` when
+    either file exists but cannot be read/parsed (fail closed).
+    """
+    home = Path(hermes_home)
+
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    defaults = DEFAULT_CONFIG.get("terminal") if isinstance(
+        DEFAULT_CONFIG, dict) else None
+    defaults = dict(defaults) if isinstance(defaults, dict) else {}
+    # Terminal keys whose env mirror exists but whose config default lives in
+    # the consuming tool rather than DEFAULT_CONFIG. These are the documented
+    # tool-level defaults (tools/terminal_tool.py); without them the
+    # projection would not be total and reads could observe nothing (which is
+    # correct) OR fall back ambiently (which is not).
+    defaults.setdefault("cwd", ".")           # per-surface placeholder
+    defaults.setdefault("ssh_host", "")       # remote backends: unset = none
+    defaults.setdefault("ssh_user", "")
+    defaults.setdefault("ssh_port", 22)
+    defaults.setdefault("ssh_key", "")
+    defaults.setdefault("docker_orphan_reaper", True)
+    defaults.setdefault("docker_persist_across_processes", True)
+    defaults.setdefault("sandbox_dir", "")    # tool derives HERMES_HOME path
+    defaults.setdefault("lifetime_seconds", 300)
+    defaults.setdefault("docker_shared_container_key", "")
+    defaults.setdefault("home_mode", "auto")
+
+    scope: Dict[str, str] = {}
+
+    def _apply(cfg_key: str, value: Any) -> None:
+        if value is None:
+            return
+        # cwd placeholders (".", "auto", "cwd") are resolved per-surface
+        # later; they are not a policy value.
+        if cfg_key == "cwd" and str(value).strip() in {".", "auto", "cwd"}:
+            return
+        from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+        env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
+        if env_var:
+            scope[env_var] = str(value)
+
+    # 1) Defined defaults — the total baseline.
+    for cfg_key, value in defaults.items():
+        _apply(cfg_key, value)
+
+    # 2) The profile's .env TERMINAL_* selections. Fail closed on unreadable
+    #    files (missing file = no selections, fine).
+    env_path = home / ".env"
+    if env_path.exists():
+        # Pre-flight readability: load_env_file swallows OSError/UnicodeError
+        # by design (secret scope fails soft), but an unreadable profile .env
+        # is a policy-resolution failure here and must fail closed.
+        try:
+            env_path.read_bytes()
+        except Exception as exc:
+            raise TerminalPolicyUnavailable(
+                f"cannot read {env_path}: {exc}"
+            ) from exc
+        from agent.secret_scope import load_env_file
+
+        selections = load_env_file(env_path)
+        for key, value in selections.items():
+            if key.startswith("TERMINAL_"):
+                scope[key] = str(value)
+
+    # 3) The profile's config.yaml explicit terminal keys. Read through the
+    #    HERMES_HOME override so the profile's own file is consulted; a
+    #    present-but-unparseable file fails closed (matches the gateway's
+    #    _warn_config_parse_failure posture of refusing to guess policy).
+    from hermes_constants import (
+        get_hermes_home_override,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    override_token = None
+    if get_hermes_home_override() != str(home):
+        override_token = set_hermes_home_override(home)
+    try:
+        config_path = home / "config.yaml"
+        if config_path.exists():
+            # Parse the profile's file directly rather than through
+            # read_raw_config(): that helper collapses "missing" and
+            # "unparseable" into the same {} result. Here the file's existence
+            # is already established, so {} can only mean a parse failure —
+            # which must fail closed rather than silently projecting defaults.
+            from hermes_cli.config import fast_safe_load
+
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    raw = fast_safe_load(f)
+            except Exception as exc:
+                raise TerminalPolicyUnavailable(
+                    f"cannot parse {config_path}: {exc}"
+                ) from exc
+            raw_terminal = raw.get("terminal") if isinstance(raw, dict) else None
+            if isinstance(raw_terminal, dict):
+                for cfg_key, value in raw_terminal.items():
+                    _apply(cfg_key, value)
+    except TerminalPolicyUnavailable:
+        raise
+    except Exception as exc:
+        raise TerminalPolicyUnavailable(
+            f"cannot resolve terminal config in {home}: {exc}"
+        ) from exc
+    finally:
+        if override_token is not None:
+            reset_hermes_home_override(override_token)
+
+    return scope
+
+
+def install_profile_terminal_scope(hermes_home: "Any") -> Token:
+    """Build AND install a profile's policy in one call.
+
+    The single entry point for every profile boundary (gateway turn, TUI/
+    dashboard turn, cron fire). On resolution failure this installs the
+    refusal scope instead of raising — the turn continues only in the sense
+    that terminal tools will refuse execution with the typed reason; it never
+    falls back to ambient process policy.
+
+    Returns the token for ``reset_terminal_scope``.
+    """
+    try:
+        return set_terminal_scope(build_profile_terminal_scope(hermes_home))
+    except TerminalPolicyUnavailable as exc:
+        logger.warning("terminal policy unavailable: %s", exc)
+        return install_refusal_scope(str(exc))
+
+
+def enforce_no_refusal() -> None:
+    """Raise when the active scope is a refusal scope (fail closed).
+
+    Execution paths (terminal tool, execute_code) call this before spawning
+    anything: under a refusal scope the profile's terminal policy could not be
+    resolved, and running with the launch process's ambient policy is exactly
+    the authority leak this module closes (#68559 requires refusal, not
+    fallback). Non-scoped and policy-scoped contexts pass silently.
+    """
+    scope = _terminal_scope_var.get()
+    if isinstance(scope, TerminalPolicyRefusal):
+        raise TerminalPolicyUnavailable(
+            f"terminal policy unavailable for this profile: {scope.reason}"
+        )
+
+
+@contextmanager
+def install_and_reset_profile_terminal_scope(
+    hermes_home: "Any",
+) -> Iterator[None]:
+    """Install the profile's terminal policy for a bounded turn/fire.
+
+    Single call for every in-process profile boundary (gateway turn,
+    dashboard/TUI turn, cron fire): builds the complete effective policy and
+    resets it on exit. Resolution failure installs the refusal scope for the
+    same duration — terminal execution inside the block raises (fail closed)
+    instead of inheriting the launch process's ambient policy. Never raises.
+    """
+    token = install_profile_terminal_scope(hermes_home)
+    try:
+        yield
+    finally:
+        reset_terminal_scope(token)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -839,7 +839,7 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = _tenv("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1195,7 +1195,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
     # ``container_config`` only carries container_* keys, so read
     # lifetime_seconds from the env var the rest of the module uses.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(_tenv("TERMINAL_LIFETIME_SECONDS", "300"))
     except (TypeError, ValueError):
         lifetime = 300
     lifetime = max(60, lifetime)
@@ -1384,12 +1384,12 @@ def _session_isolation_enabled() -> bool:
       attach one live VM and delete it out from under each other).
     """
     _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = _tenv("TERMINAL_ENV", "local")
     if env_type != "docker" and not _plugin_env_flag(
         env_type, "session_isolated_when_nonpersistent"
     ):
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return _tenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 def _docker_session_isolation_enabled() -> bool:
@@ -1399,7 +1399,7 @@ def _docker_session_isolation_enabled() -> bool:
     selection, session-scoped container teardown) key off it; those must
     not fire for other backends.
     """
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _tenv("TERMINAL_ENV", "local") != "docker":
         return False
     return _session_isolation_enabled()
 
@@ -1419,9 +1419,9 @@ def _docker_persistent_profile_scoped() -> bool:
     keep the session-scoped cache key that fixed the original leak.
     """
     _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _tenv("TERMINAL_ENV", "local") != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"}
+    return _tenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"}
 
 
 def _current_session_profile() -> str:
@@ -1515,7 +1515,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
             # Explicit opt-in: trusted profiles configuring the same
             # terminal.docker_shared_container_key share ONE container/cache
             # slot (and sandbox dir) regardless of profile name (#84671).
-            shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+            shared = _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
             if shared:
                 return f"shared:{shared}"
             profile = _current_session_profile() or "default"
@@ -1528,7 +1528,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # sessions land in "shared:<key>" — splitting the very container the
     # setting exists to unify.
     if _docker_persistent_profile_scoped():
-        shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+        shared = _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
         if shared:
             return f"shared:{shared}"
     return "default"
@@ -1607,6 +1607,10 @@ def _parse_env_var(name: str, default: str, converter: Any = int, type_label: st
     causes an unhandled ValueError that kills every terminal command.
     """
     raw = os.getenv(name, default)
+    if name.startswith("TERMINAL_"):
+        # Scope-aware: under gateway multiplexing the active profile's
+        # per-turn scope overrides the process env.
+        raw = _tenv(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1632,7 +1636,7 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except (FileNotFoundError, PermissionError):
-        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+        return _tenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
@@ -1703,6 +1707,20 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _tenv(name: str, default: str = "") -> str:
+    """Scope-aware read of a ``TERMINAL_*`` variable.
+
+    Every terminal setting read in this module must go through this helper:
+    under gateway multiplexing the active profile's terminal config arrives
+    via a per-turn scope (``tools.terminal_scope``), and a raw ``os.getenv``
+    would read whatever profile's config a previous turn pinned into the
+    process env (the cross-profile backend leak fixed here).
+    """
+    from tools.terminal_scope import terminal_env
+
+    return terminal_env(name, default)
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
@@ -1728,7 +1746,17 @@ def _ensure_terminal_env_bridged() -> None:
     be stale from ``hermes setup``). Environment values for omitted terminal
     keys are preserved. When no terminal section exists, exported/.env values
     keep working unchanged.
+
+    A per-turn terminal scope (multiplexed gateway / profile-scoped cron)
+    suppresses this bridge entirely: the scope holds the active profile's
+    authoritative values and reads fall through ``_tenv`` — writing them into
+    the process-global ``os.environ`` would re-create the first-writer-wins
+    cross-profile leak the scope exists to fix.
     """
+    from tools.terminal_scope import get_terminal_scope
+
+    if get_terminal_scope() is not None:
+        return
     global _terminal_config_bridge_attempted
     if _terminal_config_bridge_attempted:
         return
@@ -1762,9 +1790,9 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = _tenv("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _tenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = _is_container_backend(env_type)
     docker_backend = env_type == "docker"
 
@@ -1786,7 +1814,7 @@ def _get_env_config() -> Dict[str, Any]:
         docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_shm_size = _tenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1810,13 +1838,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = _tenv("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = _tenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1834,41 +1862,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_tenv("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": _tenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": _tenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": _tenv("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": _tenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": _tenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": _tenv("TERMINAL_SSH_HOST", ""),
+        "ssh_user": _tenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": _tenv("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": _tenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            _tenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": _tenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _tenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _tenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": _tenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1877,17 +1905,17 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": _tenv(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
-        "docker_shared_container_key": os.getenv(
+        "docker_shared_container_key": _tenv(
             "TERMINAL_DOCKER_SHARED_CONTAINER_KEY", ""
         ).strip(),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": _tenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }
@@ -2876,6 +2904,15 @@ def terminal_tool(
         # Get configuration
         config = _get_env_config()
         env_type = "local" if _host_local else config["env_type"]
+
+        # Fail closed under a refusal scope (#68559): the routed profile's
+        # terminal policy could not be resolved, so executing with the launch
+        # process's ambient policy is forbidden — refuse with a typed,
+        # model-actionable error instead.
+        if not _host_local:
+            from tools.terminal_scope import enforce_no_refusal
+
+            enforce_no_refusal()
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
@@ -3868,7 +3905,7 @@ def terminal_tool(
         #   warn (default) — return a structured degraded result the model
         #                    can act on (reason + retry hint, no traceback).
         #   fail           — preserve the historical error+traceback result.
-        degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        degraded_mode = _tenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
         if degraded_mode == "fail":
             import traceback
             tb_str = traceback.format_exc()
@@ -4089,18 +4126,18 @@ if __name__ == "__main__":
     default_img = "nikolaik/python-nodejs:python3.11-nodejs20"
     print(
         "  TERMINAL_ENV: "
-        f"{os.getenv('TERMINAL_ENV', 'local')} "
+        f"{_tenv('TERMINAL_ENV', 'local')} "
         "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
     )
-    print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
-    print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
-    print(f"  TERMINAL_MODAL_IMAGE: {os.getenv('TERMINAL_MODAL_IMAGE', default_img)}")
-    print(f"  TERMINAL_DAYTONA_IMAGE: {os.getenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
-    print(f"  TERMINAL_CWD: {os.getenv('TERMINAL_CWD', _safe_getcwd())}")
+    print(f"  TERMINAL_DOCKER_IMAGE: {_tenv('TERMINAL_DOCKER_IMAGE', default_img)}")
+    print(f"  TERMINAL_SINGULARITY_IMAGE: {_tenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
+    print(f"  TERMINAL_MODAL_IMAGE: {_tenv('TERMINAL_MODAL_IMAGE', default_img)}")
+    print(f"  TERMINAL_DAYTONA_IMAGE: {_tenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
+    print(f"  TERMINAL_CWD: {_tenv('TERMINAL_CWD', _safe_getcwd())}")
     from hermes_constants import display_hermes_home as _dhh
-    print(f"  TERMINAL_SANDBOX_DIR: {os.getenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
-    print(f"  TERMINAL_TIMEOUT: {os.getenv('TERMINAL_TIMEOUT', '60')}")
-    print(f"  TERMINAL_LIFETIME_SECONDS: {os.getenv('TERMINAL_LIFETIME_SECONDS', '300')}")
+    print(f"  TERMINAL_SANDBOX_DIR: {_tenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
+    print(f"  TERMINAL_TIMEOUT: {_tenv('TERMINAL_TIMEOUT', '60')}")
+    print(f"  TERMINAL_LIFETIME_SECONDS: {_tenv('TERMINAL_LIFETIME_SECONDS', '300')}")
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3350,6 +3350,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
+        build_terminal_token = None
         session_db = None
         owns_db = False
         profile_home = current.get("profile_home")
@@ -3376,6 +3377,21 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
                 except Exception:
                     pass
+                # Bind the profile's COMPLETE terminal policy for the agent
+                # build (fail-closed: malformed policy → refusal scope) so
+                # _make_agent's terminal probing / cwd hints resolve the
+                # routed profile, never the launch process (#98581 class).
+                try:
+                    from tools.terminal_scope import (
+                        install_profile_terminal_scope,
+                        reset_terminal_scope,
+                    )
+
+                    build_terminal_token = install_profile_terminal_scope(
+                        Path(profile_home)
+                    )
+                except Exception:
+                    build_terminal_token = None
                 # DEDICATED handle — ours until _transfer_db_to_agent hands
                 # it to the built agent in the finally below. Every path
                 # that leaves this build without that transfer (the except
@@ -3525,6 +3541,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     from agent.secret_scope import reset_secret_scope
 
                     reset_secret_scope(secret_token)
+                except Exception:
+                    pass
+            if build_terminal_token is not None:
+                try:
+                    from tools.terminal_scope import reset_terminal_scope
+
+                    reset_terminal_scope(build_terminal_token)
                 except Exception:
                     pass
             # _attach_worker already closed the worker if this session was
@@ -6390,9 +6413,20 @@ def _session_profile_runtime_scope(session: dict):
         return
     home_token = set_hermes_home_override(profile_home)
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    # Same authoritative terminal policy the gateway binds per turn (#68559):
+    # a docker-configured dashboard profile must never resolve the launch
+    # process's pinned env. Failure → refusal scope (fail closed).
+    from tools.terminal_scope import (
+        install_profile_terminal_scope as _install_term_scope,
+    )
+
+    terminal_token = _install_term_scope(Path(profile_home))
     try:
         yield
     finally:
+        from tools.terminal_scope import reset_terminal_scope
+
+        reset_terminal_scope(terminal_token)
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 
@@ -13025,6 +13059,20 @@ def _run_prompt_submit(
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+                # Fourth profile seam: bind the session profile's COMPLETE
+                # terminal policy for this turn (dashboard/TUI analogue of the
+                # gateway's per-turn scope). #98581's unified-desktop
+                # reproduction ran a docker-configured profile on the host
+                # because terminal_tool read the launch process's pinned env.
+                # Failure installs a refusal scope → terminal tools raise
+                # (fail closed) instead of inheriting ambient policy.
+                from tools.terminal_scope import (
+                    install_profile_terminal_scope as _install_term_scope,
+                )
+
+                _terminal_scope_token = _install_term_scope(Path(_profile_home_str))
+            else:
+                _terminal_scope_token = None
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -13789,6 +13837,10 @@ def _run_prompt_submit(
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
                 reset_secret_scope(secret_token)
+            if _terminal_scope_token is not None:
+                from tools.terminal_scope import reset_terminal_scope
+
+                reset_terminal_scope(_terminal_scope_token)
             _clear_session_context(session_tokens)
             _current_runtime_session_record.reset(runtime_session_token)
             reset_transport(transport_token)


### PR DESCRIPTION
# Fix terminal config leaking across profiles under multiplexing

## Related Issue

Fixes #68559
Refs #94200 (gateway repro: `_ensure_terminal_env_bridged` one-shot leaks
profile-specific `TERMINAL_ENV` across multiplexed profiles), #98581
(dashboard/TUI repro of the same class), #96992 (concrete version of the
container-policy leak).

## Problem

A multiplexed Hermes process (`gateway.multiplex_profiles`, unified
dashboard/TUI, cron) serves several profiles from one interpreter.
Terminal settings resolved through process-global `TERMINAL_*` env vars,
and `_ensure_terminal_env_bridged()` is a one-shot process-global guard.
Whichever profile first touched a terminal tool after startup pinned its
whole terminal policy (backend, mounts, SSH target, network, cwd,
resources) onto `os.environ` for every later profile until restart.

This is a correctness AND sandbox-boundary bug:

- a `local` profile executes inside another profile's docker sandbox
  (wrong results, surprise container keepalives);
- a docker/ssh-sandboxed profile can be dropped onto the launch host
  (isolation escape — the severity driver in #68559).

Repro on `0.20.6` (`42ac29e`): default profile `terminal.* = local`
(Telegram), secondary profile `qa-seva-bot terminal.* = docker` (Discord
route). After one Discord terminal turn, Telegram `whoami` answered
`root` with cwd `/root`; agent.log showed
`Ignoring TERMINAL_CWD='/home/ubuntu' for docker backend ... Using '/root' instead.`
on a Telegram turn.

## Fix approach

An authoritative per-profile terminal policy seam, analogous to
`agent/secret_scope.py`, installed at every in-process profile boundary:

- `tools/terminal_scope.py` (new, bounded): ContextVar holding the active
  profile's COMPLETE effective terminal policy. Projection order:
  defined defaults (`DEFAULT_CONFIG["terminal"]` + documented tool-level
  defaults) ← profile `.env` `TERMINAL_*` ← explicit profile
  `terminal:` config keys. Once a scope is bound, missing keys resolve
  to defined defaults only — never ambient `os.environ`.
- Fail-closed: unreadable/malformed profile policy installs a refusal
  scope (`TerminalPolicyUnavailable`); `terminal_tool` and
  `execute_code` refuse execution instead of inheriting launch-process
  policy.
- `tools/terminal_tool.py`: all `TERMINAL_*` reads go through the
  scope-aware `_tenv()` helper; the one-shot bridge into `os.environ` is
  suppressed while a scope is bound.
- Boundaries: `gateway/run.py::_profile_runtime_scope` (gateway turns),
  `tui_gateway/server.py::_session_profile_runtime_scope` (dashboard/TUI
  turns + agent build), `cron/scheduler.py` fire path (install at
  secret-scope install, reset in the function-level `finally` upstream
  moved delivery/bookkeeping into).
- Other cross-profile readers (prompt builder backend hints, runtime
  cwd, media translation, slash/footer cwd, subdirectory hints, skill
  paths, code-exec cwd) read through the same seam.

## Relationship to other PRs

- #94890 / #85084: narrower takes on the same backend latch; this patch
  covers the full policy surface (mounts/SSH/network/cwd/resources), not
  just `TERMINAL_ENV`.
- #97014: complementary (`hermes_cli/env_loader.py` re-bridge
  containment); not duplicated here.
- CWD overlap with #88635 / #84584: this PR's cwd changes are limited to
  routing reads through the scope seam; happy to yield order to those.

## Lineage / credit

- #68611 (x7peeps) — original ContextVar direction for #68559
- #79117 / #78030 — prior art on shared runtime owner + fail-closed config
- #94206 / #98589 — narrower per-home re-bridge iterations

## How to Test

1. Two profiles in one gateway: profile A `terminal.backend: local`,
   profile B `terminal.backend: docker` (+ `docker_image`). Interleave
   terminal turns A→B→A. Each resolves its own backend; `os.environ`
   never changes.
2. Pollute launch env (`TERMINAL_DOCKER_VOLUMES`, `TERMINAL_SSH_*`,
   `TERMINAL_CWD`), start a profile with only `terminal.backend: docker`
   — it must not observe any of the polluted values.
3. Corrupt a profile `config.yaml` terminal section — terminal calls in
   that profile refuse with a policy-unavailable error (fail closed).

## Screenshots / Logs

Leak (before, on `42ac29e`):

```
INFO gateway.run: inbound message: platform=telegram ... msg='coba run whoami'
INFO tools.terminal_tool: Ignoring TERMINAL_CWD='/home/ubuntu' for docker backend (host/relative path won't work in sandbox). Using '/root' instead.
```

Fixed (interleaved, per-profile isolation):

```
09:33:20 inbound platform=telegram 'coba run whoami'  → no docker lines (local) → "ubuntu"
09:34:56 inbound platform=discord  'coba run whoami'  → docker lines only here → "root"
09:35:24 inbound platform=telegram 'coba run whoami'  → no docker lines (local) → "ubuntu"  (previously re-contaminated)
```

## Test Coverage

`tests/tools/test_terminal_scope_multiplex.py` (26 behavior-contract
tests): authoritative projection / no ambient fallthrough; profile-B
leak matrix (backend-only / empty-terminal / env-only selections vs
polluted profile A); config > `.env` precedence; totality of the
projection; malformed/unreadable policy → refusal; `terminal_tool` +
`execute_code` refusal; gateway scope cleanup incl. error path; TUI
session profile scope (#98581 class); cron install/reset lifecycle;
downstream scope-aware readers.

Local results: scope tests 26 passed; terminal/config/degraded/cwd/
sandbox/cron targeted suites 88 passed; gateway multiplex/profile-scope
234 passed; agent prompt/system/env-hint 144 passed; TUI profile/runtime
160 passed; `ruff` clean on touched files.

## Checklist

- [x] Code
- [x] Documentation & Housekeeping
- [ ] Screenshots / Logs (inline above)
