### PR TITLE
fix(dashboard-auth): redirect to path-prefix root not bare / after OAuth login

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -587,7 +587,12 @@ async def auth_callback(
     # cookie is server-set so this is defence in depth, but a regression
     # that lets attacker-controlled bytes into the cookie would otherwise
     # produce an open redirect.
-    landing = _validate_post_login_target(next_from_cookie) or "/"
+    #
+    # Fall back to the path-prefix root rather than "/" so that deploys
+    # behind a reverse proxy at /hermes don't redirect to /  (outside the
+    # prefix, 404) instead of /hermes/ (#99123).
+    _default_landing = (_prefix(request) or "") + "/"
+    landing = _validate_post_login_target(next_from_cookie) or _default_landing
     resp = RedirectResponse(url=landing, status_code=302)
     set_session_cookies(
         resp,

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿auth_callback defaulted to '/' when no next cookie, sending users outside the path-prefix to 404. Use _prefix(request)+'/' as the default landing. Fixes #99123.
