### PR TITLE
fix(security): gate .envrc writes and sed -i on project env files

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -471,6 +471,94 @@ class TestSensitiveCopyMovePattern:
             assert dangerous is False, cmd
 
 
+class TestEnvrcAndProjectEnvInPlaceEdits:
+    """``.envrc`` and ``sed -i`` on project env/config must require approval.
+
+    Two separate gaps, both against files the read guard already refuses to
+    read by basename (``_BLOCKED_PROJECT_ENV_BASENAMES``):
+
+    1. ``_PROJECT_ENV_PATH`` matched ``.env`` and its dotted variants, but the
+       suffix group requires a leading ``.``, so ``.envrc`` matched only its
+       ``.env`` prefix and the write-target boundary anchors rejected the
+       partial match. Every write vector was ungated. ``.envrc`` is shell that
+       direnv sources on cd, so a write to it is arbitrary code execution.
+    2. No ``sed -i`` rule covered project paths — the in-place rules use
+       ``_USER_SENSITIVE_WRITE_TARGET``, which omits them — so
+       ``sed -i 's/KEY=.*/KEY=stolen/' .env`` mutated a secret-bearing file.
+    """
+
+    def test_envrc_write_vectors_are_gated(self):
+        for path in ("~/.envrc", "./.envrc", "app/.envrc", ".envrc"):
+            for vector in (
+                "echo x >> {p}",
+                "echo x > {p}",
+                "echo x | tee -a {p}",
+                "cp /tmp/evil {p}",
+                "mv /tmp/evil {p}",
+                "install -m600 /tmp/c {p}",
+                "sed -i 's/a/b/' {p}",
+            ):
+                command = vector.format(p=path)
+                dangerous, key, _ = detect_dangerous_command(command)
+                assert dangerous is True, command
+                assert key is not None, command
+
+    def test_sed_in_place_on_project_env_is_gated(self):
+        for command in (
+            "sed -i 's/KEY=.*/KEY=stolen/' .env",
+            "sed -i '' 's/a/b/' app/.env",
+            "sed --in-place 's/a/b/' ./.env.production",
+            "sed -i 's/a/b/' app/.envrc",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_env_variants_still_gated(self):
+        """The pre-existing ``.env`` / ``.env.*`` coverage must survive the
+        regex change that added the ``rc`` alternative."""
+        for command in (
+            "echo x >> .env",
+            "cp /tmp/evil app/.env",
+            "echo x > ~/.env.local",
+            "install -m600 /tmp/c ./.env.production",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is True, command
+
+    def test_near_miss_env_names_stay_safe(self):
+        """The ``rc`` alternative must not swallow unrelated names."""
+        for command in (
+            "echo x >> ~/.environment",
+            "echo x >> .env-sample",
+            "echo x >> .envrc.example",
+            "cp a.txt ~/.envoy/config",
+            "echo x >> notes.envrc.md",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+            assert key is None, command
+
+    def test_ordinary_sed_and_env_reads_stay_safe(self):
+        """The new in-place rule must not gate unrelated edits, and reading a
+        project env file is not a write."""
+        for command in (
+            "sed -i 's/a/b/' README.md",
+            "sed -i 's/a/b/' src/main.py",
+            "sed --in-place 's/a/b/' docs/guide.txt",
+            "sed -i 's/a/b/' docker-compose.yaml",
+            "sed -i 's/a/b/' .github/workflows/ci.yml",
+            "sed -n '1,5p' .env",
+            "sed 's/a/b/' .env > /tmp/out",
+            # A non-Hermes config.yaml is ordinary application config. Scoping
+            # the in-place rule to env files (not the full project target) keeps
+            # TestHermesConfigWriteProtection's contract intact.
+            "sed -i 's/a/b/' /srv/app/config.yaml",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+
 class TestSensitiveInPlaceEditPattern:
     """Detect in-place edits to user startup and credential files."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -407,7 +407,16 @@ _HERMES_CONFIG_PATH = (
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
 )
-_PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
+# ``.env``, its dotted variants (``.env.local``), and ``.envrc``. The ``rc``
+# tail needs its own alternative because the dotted-suffix group requires a
+# leading ``.``: ``.envrc`` used to match only its ``.env`` prefix, and the
+# write-target boundary anchors then rejected that partial match. So direnv's
+# ``.envrc`` was ungated on every write vector even though the read guard
+# blocks it by basename — and it is shell direnv sources on cd, making a write
+# arbitrary code execution.
+_PROJECT_ENV_PATH = (
+    r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:rc\b|(?:\.[^/\s"\'`]+)*))'
+)
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
 _SHELL_RC_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
@@ -1198,6 +1207,17 @@ DANGEROUS_PATTERNS = [
     # the terminal side is not an open door. See #14639.
     (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
+    # Project-local env files. The tee/redirection/cp-mv-install rules already
+    # cover project paths, but the in-place rules above use
+    # _USER_SENSITIVE_WRITE_TARGET, which omits them — so
+    # `sed -i 's/KEY=.*/KEY=stolen/' .env` mutated a file the read guard will
+    # not even read. Keyed on _PROJECT_ENV_PATH, not the full project target:
+    # a bare config.yaml is ordinary app config unless it is the Hermes one
+    # (covered above), so widening it would gate `sed -i /srv/app/config.yaml`.
+    # perl/ruby -i need no companion rule; `perl -e` is already gated wholesale
+    # by the script-execution pattern.
+    (rf'\bsed\s+-[^\s]*i.*(?:{_PROJECT_ENV_PATH})[^\s"\']*', "in-place edit of project env file"),
+    (rf'\bsed\s+--in-place\b.*(?:{_PROJECT_ENV_PATH})[^\s"\']*', "in-place edit of project env file (long flag)"),
     # perl -i and ruby -i perform the same in-place mutation as sed -i but are
     # not caught by the -e/-c script-execution pattern above (which targets code
     # evaluation, not file mutation). Pairs the sed -i coverage from #14639.


### PR DESCRIPTION
## What does this PR do?

Two gaps in the terminal write guard, both against files the read guard **already refuses to read** by basename (`agent/file_safety._BLOCKED_PROJECT_ENV_BASENAMES` includes `.envrc`).

### 1. `.envrc` was ungated on every write vector

`_PROJECT_ENV_PATH` matched `.env` plus its dotted variants, but the suffix group requires a leading `.`, so `.envrc` matched only the `.env` prefix and the write-target boundary anchors then rejected the partial match:

```python
re.search(_PROJECT_ENV_PATH, "~/.envrc").group(0)   # '~/.env'  — not the full token
re.search(_PROJECT_ENV_PATH, "~/.env").group(0)     # '~/.env'  — full token, matches
```

`.envrc` is shell that direnv **sources on cd**, so a write to it is arbitrary code execution at the next directory change — a persistence vector, not just a secret leak. An `rc\b` alternative makes the match cover the full token.

### 2. No `sed -i` rule covered project env files

The tee/redirection and cp/mv/install rules use `_PROJECT_SENSITIVE_WRITE_TARGET`, but the in-place rules use `_USER_SENSITIVE_WRITE_TARGET`, which deliberately omits project paths. So `sed -i 's/KEY=.*/KEY=stolen/' .env` was auto-approved.

### Measured

`HOME=/home/alice`, 8 write vectors (`>>`, `>`, `tee -a`, `cp`, `mv`, `install`, `sed -i`, `sed --in-place`):

| Target | Before | After |
|---|---|---|
| `~/.envrc`, `./.envrc`, `app/.envrc`, `.envrc` | **0/8** | 8/8 |
| `~/.env` and `.env.*` variants | 7/8 (`sed -i` missing) | 8/8 |

Env-file matrix: **51/72 → 64/64**.

## Scope

The in-place rule is keyed on `_PROJECT_ENV_PATH`, **not** the full project target. My first draft used the full target and that broke `TestHermesConfigWriteProtection::test_reads_and_unrelated_writes_are_safe`, which asserts `sed -i ... /srv/app/config.yaml` stays safe — a bare `config.yaml` is ordinary application config unless it is the Hermes one, already covered by `_HERMES_CONFIG_PATH`. The existing suite caught it, the rule was narrowed, and that case is now in this change's negative controls too.

No perl/ruby companion rule. `perl -e`/`ruby -e` are already gated wholesale by the script-execution pattern — verified on unmodified `main` — so an in-place perl invocation never reaches these rules. A first draft added one; it was redundant and removed.

## How Has This Been Tested?

`tests/tools/test_approval.py` → **123 passed, 0 failed** under a normal multi-segment `HOME`.

- **Positive control** — reverting `tools/approval.py` while keeping the new tests fails *exactly* the two gating tests (`test_envrc_write_vectors_are_gated`, `test_sed_in_place_on_project_env_is_gated`) while the three negative-control tests still pass. They discriminate.
- **Negative controls, 14 commands unflagged 0/14** — near-miss names (`~/.environment`, `.env-sample`, `.envrc.example`, `~/.envoy/config`, `notes.envrc.md`); ordinary in-place edits (`README.md`, `src/main.py`, `docker-compose.yaml`, `.github/workflows/ci.yml`, `/srv/app/config.yaml`); and **reads** of `.env` (`sed -n '1,5p' .env`, `sed 's/a/b/' .env > /tmp/out`), which are not writes to the file.

`ruff check` clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

No existing issue — I searched issues and PRs for the `.envrc` and project `sed -i` gaps and found none. Happy to file one first if you prefer that order.

Adjacent to #59044 (project `.env` deliverable as media — the read/exfil side of the same file class) and sibling of #99201 / #99182. Disjoint changes; this one only touches `tools/approval.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious parts (why `rc` needs its own alternative, why the rule is scoped to env files rather than the full project target)
