### PR TITLE
feat: default busy_input_mode to steer

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1662,7 +1662,7 @@ display:
   #              images are attached (steer only carries text).
   # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
   # Toggle at runtime with /busy <interrupt|queue|steer>.
-  busy_input_mode: interrupt
+  busy_input_mode: steer
 
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use

--- a/cli.py
+++ b/cli.py
@@ -502,7 +502,7 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": True,
             "reasoning_full": False,
             "streaming": True,
-            "busy_input_mode": "interrupt",
+            "busy_input_mode": "steer",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
             # Clear terminal scrollback as well as the visible viewport when the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1394,7 +1394,7 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "steer",  # interrupt | queue | steer
         # When busy_input_mode="steer", suppress only the visible
         # "Steered into current run" confirmation bubble by setting this false.
         # The mid-turn steering itself still happens.

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -121,9 +121,9 @@ class TestFallbackChainInit:
 
 
 class TestBusyInputMode:
-    def test_default_busy_input_mode_is_interrupt(self):
+    def test_default_busy_input_mode_is_steer(self):
         cli = _make_cli()
-        assert cli.busy_input_mode == "interrupt"
+        assert cli.busy_input_mode == "steer"
 
     def test_busy_input_mode_queue_is_honored(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})


### PR DESCRIPTION
Sets the default behavior to interpret messages while the agent is working as /steer instead of interrupt.