### PR TITLE
fix: schema-invalid subagent results report status=failed, not a false completed ✓ (salvage #87530)

### DIFF
--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -263,6 +263,52 @@ class TestRunSingleChildSchemaValidation:
         assert len(child.calls) == 1
         assert entry.get("schema_valid") is False
 
+    def test_schema_failure_reported_as_failed_not_completed(self):
+        """Regression: a final answer that still violates the declared
+        output contract after the bounded retry (here the classic empty
+        ``{}`` fallback) must be reported status="failed", not
+        "completed". Otherwise the batch report prints a ✓ and
+        orchestrators that read only status/icon accept an empty verdict
+        — schema_valid/schema_errors carry the detail, but status must
+        agree with them."""
+        child = _StubChild(["not json at all", "{}"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["schema_valid"] is False
+        assert entry["schema_errors"]
+        assert entry["status"] == "failed"
+        # the failed entry names the schema violation, not the generic
+        # "no response" error — the child DID respond, unusably
+        assert "output_schema" in entry.get("error", "")
+        # the invalid final text is still propagated for debugging
+        assert entry["summary"] == "{}"
+
+    def test_schema_failure_without_retry_reported_as_failed(self):
+        """Same class, first-try path: retry turn raises, leaving the
+        original non-JSON answer in place — status must still be failed."""
+        child = _StubChild(["nope"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        original = child.run_conversation
+
+        def flaky(user_message, task_id=None, **kw):
+            if child.calls:
+                raise RuntimeError("child died on retry")
+            return original(user_message, task_id=task_id, **kw)
+
+        child.run_conversation = flaky
+        entry = _run(child)
+        assert entry["schema_valid"] is False
+        assert entry["status"] == "failed"
+
+    def test_schema_valid_entry_still_completed(self):
+        """Guard: schema_valid=True keeps status="completed" untouched."""
+        child = _StubChild(['{"city": "Berlin"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "completed"
+        assert "error" not in entry
+
 
 # ---------------------------------------------------------------------------
 # delegate_task dispatch-time schema handling

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3193,6 +3193,17 @@ def _run_single_child(
             # legacy/mock results that omit the structured failure fields.
             # (Community report Aug 2026; #97655.)
             status = "failed"
+        elif _schema_valid is False:
+            # T1-24 follow-up: a schema was declared and the final answer —
+            # after the one bounded retry — still violates it (empty `{}`
+            # fallback included). A summary exists, but it is unusable under
+            # the contract the caller asked for, so it must not be reported
+            # as a completed delegation: the batch line would print ✓ and
+            # orchestrators that read only status/icon would accept an
+            # empty verdict. schema_valid/schema_errors (below) carry the
+            # detail; status has to agree with them. _schema_valid stays
+            # None on schema-less runs, which never take this branch.
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -3316,7 +3327,22 @@ def _run_single_child(
             else "unknown"
         )
         if status == "failed":
-            entry["error"] = result.get("error", "Subagent did not produce a response.")
+            if _schema_valid is False and summary and not _empty_sentinel:
+                # The child DID respond — the response just violates the
+                # declared contract. Name that instead of the generic
+                # "no response" error; schema_errors (below) hold the
+                # validator's specifics verbatim.
+                entry["error"] = (
+                    "Final answer does not satisfy the declared "
+                    "output_schema (after 1 retry)."
+                    if _schema_retries
+                    else "Final answer does not satisfy the declared "
+                    "output_schema."
+                )
+            else:
+                entry["error"] = result.get(
+                    "error", "Subagent did not produce a response."
+                )
             # Classified reason from the child loop (e.g. "rate_limit",
             # "billing", "server_error") — lets the parent distinguish a
             # quota wall from a real task error without parsing prose.


### PR DESCRIPTION
## Summary
Salvage of #87530 by @itskaism (last member of the failed-subagent-status cluster): a child whose final answer still violates the declared `output_schema` after the bounded retry now reports `status: "failed"` instead of `"completed"` ✓. Previously an orchestrator reading only status/icon accepted an empty `{}` verdict — `schema_valid: false` was carried but status contradicted it. Follow-up to #99049/#99067/#99098.

## Changes
- `tools/delegate_tool.py` (cherry-picked with @itskaism's authorship): `_schema_valid is False` forces `status: "failed"` (schema-less runs keep `None` and never take the branch); the failed entry names the actual problem ("Final answer does not satisfy the declared output_schema (after 1 retry).") instead of the generic "no response" error, since the child DID respond — unusably.
- `tests/tools/test_delegate_output_schema.py`: his three regression tests — schema failure after retry → failed, first-try schema failure with dead retry → failed, valid schema → completed untouched.
- Conflict resolution: his branch ordered after the (then-nonexistent) structured-failure branch from #99067; the structured failure check stays first, schema check second — a child that both crashed AND has an invalid answer reports the crash.

## Validation
| | Before (main) | After |
|---|---|---|
| Live E2E: real delegate_task (gpt-4o-mini via OpenRouter) with unsatisfiable schema `{"not": {}}` | `status: "completed"` ✓, `schema_valid: false` (contradiction) | `status: "failed"`, `error: "Final answer does not satisfy the declared output_schema (after 1 retry)."`, `schema_retries: 1`, `api_calls: 3` |
| Targeted suites | — | 128 passed (output_schema + delegate + notice); full delegate/delegation sweep 300 passed, 2 skipped |
| Interaction with #99049's failure notice | — | schema failures now also trigger the user-facing `⚠ Subagent failed` line for free (status is what gates it) |

## Infographic

![Contract violated — status failed](https://v3b.fal.media/files/b/0aa8839f/CZP1X_6CCVIoOlxPKfkqq_0gLiJBBN.png)
