### PR TITLE
fix: worker turn bookkeeping — abandoned cards, request shape, run records

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3874,6 +3874,15 @@ _empty_heal_user_notified: set = set()
 # loop through ``consume_pending_sanitizer_heal_notice`` and delivered via
 # the status/warning callback (the normal delivery channel).
 _empty_heal_pending_notice: Dict[str, str] = {}
+# Substituted as a whole user turn when a request would otherwise carry none.
+# Worded as an instruction rather than a marker because the model does read
+# it: it lands where the original request would have been, so it has to leave
+# the agent pointed at the work already in the transcript instead of inviting
+# it to start something new.
+_MISSING_USER_TURN_PLACEHOLDER = (
+    "[System: the original request is no longer in this transcript. "
+    "Continue the task shown in the messages above.]"
+)
 
 
 def _msg_has_payload(msg: Dict[str, Any]) -> bool:
@@ -4606,6 +4615,74 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "tool_call function name (%s)",
             len(realigned),
             ", ".join(f"{was} -> {now}" for was, now in realigned),
+        )
+    # --- Guarantee at least one user turn -------------------------------
+    # Ollama's built-in renderers (routes.go) reject a request with HTTP 500
+    # "no user query found in messages" when no user turn *carries content*.
+    # Measured against qwen3.8:27b:
+    #
+    #     content="hi"                  OK
+    #     content=""                    OK     (empty string still counts)
+    #     content=[{"type":"text",...}] OK
+    #     content=[]                    500    <- counts as absent
+    #     content=None                  400    (different error entirely)
+    #
+    # So presence of the role is necessary but not sufficient: an empty
+    # content LIST reads as no user query even though an empty STRING does
+    # not. A first version of this guard tested the role alone and let a
+    # ``content: []`` user turn straight through — the 500 still fired in
+    # production with the guard silent.
+    #
+    # A transcript can arrive here without a user turn after compression folds
+    # the only one into the summary, after head truncation, or on a lineage
+    # resumed from an assistant/tool boundary. Rather than chase every
+    # producer, restore the invariant at the last point before the wire.
+    # This runs on the per-call copy, so the synthesized turn never enters the
+    # persisted transcript.
+    #
+    # Inserted after the leading system block rather than appended, because a
+    # ``tool`` message must keep following its assistant ``tool_calls`` — a
+    # trailing insert would break that pairing.
+    def _counts_as_user_query(m: Dict[str, Any]) -> bool:
+        if m.get("role") != "user":
+            return False
+        content = m.get("content")
+        # Mirrors the table above: None and [] do not register as a query;
+        # an empty string does. Anything else (str, non-empty list) counts.
+        if content is None:
+            return False
+        if isinstance(content, (list, tuple)) and not content:
+            return False
+        return True
+
+    if messages and not any(_counts_as_user_query(m) for m in messages):
+        insert_at = 0
+        while insert_at < len(messages) and messages[insert_at].get("role") == "system":
+            insert_at += 1
+        messages = list(messages)
+        messages.insert(insert_at, {
+            "role": "user",
+            "content": _MISSING_USER_TURN_PLACEHOLDER,
+        })
+        # Roles only — never content. The role sequence is what distinguishes
+        # the candidate upstream causes (a compression fold leaves
+        # system+tail, head truncation opens mid-sequence, a resumed lineage
+        # opens on assistant/tool), and it is the one thing the logs did not
+        # record when this was first investigated. Capped so a long transcript
+        # cannot flood the log.
+        _roles = [m.get("role") for m in messages if m.get("role") != "user"]
+        _role_sig = ",".join(_roles[:12]) + (f",…(+{len(_roles) - 12})" if len(_roles) > 12 else "")
+        _counts = {r: _roles.count(r) for r in dict.fromkeys(_roles)}
+        _ra().logger.warning(
+            "Pre-call sanitizer: request had no user turn — inserted a "
+            "placeholder at index %d. Without it Ollama rejects the call with "
+            "HTTP 500 'no user query found in messages', which is "
+            "deterministic (retrying sends the identical array). Upstream "
+            "cause is usually compression folding the only user message into "
+            "the summary, head truncation, or a resumed assistant/tool "
+            "lineage — the role sequence below tells which: "
+            "msgs=%d roles=%s counts=%s",
+            insert_at, len(messages) - 1, _role_sig, _counts,
         )
     return messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1274,13 +1274,42 @@ _LENGTH_CONTINUATION_OUTPUT_LIMIT = (
     "length limit. Continue exactly where you left off. Do not "
     "restart or repeat prior text. Finish the answer directly.]"
 )
+# Sent from the second continuation onward. The plain nudge above only says
+# "continue" — a model that just emitted a full-length chunk and got cut will
+# emit another full-length chunk and get cut again, and after four identical
+# attempts the turn is abandoned (observed: a long report task burned all four
+# and lost 47 minutes of work). Repeating the same instruction against the same
+# failure is not a retry strategy, so escalate to one that changes what the
+# model does: stop trying to emit the whole artifact in one response.
+_LENGTH_CONTINUATION_OUTPUT_LIMIT_ESCALATED = (
+    "[System: Your response was truncated by the output length limit "
+    "again — the previous continuation hit the same wall, so continuing "
+    "in the same shape will keep failing. Change approach now: if you are "
+    "producing a file, write it in several smaller tool calls that append "
+    "successive sections instead of emitting it all in one response; "
+    "otherwise make this response substantially shorter and finish the "
+    "remaining part in the next turn. Do not repeat text you already sent.]"
+)
 # The dropped-tools variant interpolates the tool name list right after this
 # prefix, so it can't be exact-matched — this stable prefix is what
 # _is_synthetic_compression_user_turn checks with str.startswith instead.
 _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX = "[System: Your previous tool call "
 
 
-def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List[str]] = None) -> str:
+def _get_continuation_prompt(
+    is_partial_stub: bool,
+    dropped_tools: Optional[List[str]] = None,
+    attempt: int = 1,
+) -> str:
+    """Build the nudge sent after a truncated response.
+
+    ``attempt`` is the continuation number (1-based). The first attempt keeps
+    the plain "continue where you left off" wording; from the second onward the
+    output-limit path escalates to strategy guidance, because repeating an
+    identical instruction against an identical failure just burns the budget.
+    The partial-stream paths already carry their own corrective advice and are
+    left alone.
+    """
     if is_partial_stub and dropped_tools:
         tool_list = ", ".join(dropped_tools[:3])
         return (
@@ -1298,6 +1327,8 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
         )
     elif is_partial_stub:
         return _LENGTH_CONTINUATION_NETWORK_STUB
+    elif attempt >= 2:
+        return _LENGTH_CONTINUATION_OUTPUT_LIMIT_ESCALATED
     else:
         return _LENGTH_CONTINUATION_OUTPUT_LIMIT
 
@@ -1977,7 +2008,63 @@ def _notify_context_engine_turn_complete(
         )
 
 
-def run_conversation(
+def _record_unfinalized_turn(agent, how: str) -> None:
+    """Last-resort board annotation for a turn that skipped ``finalize_turn``.
+
+    ``_run_conversation_inner`` has ~25 ``return`` statements that leave before
+    the finalizer. Two of them annotate the card themselves with a precise
+    reason; the rest did not, so a dispatcher-spawned worker leaving through
+    one of those abandoned its card in silence and the orphan reconciler later
+    wrote ``crashed: pid N not alive`` — a label that describes the corpse and
+    sends the next investigation after a killer that never existed.
+
+    Patching each return site was rejected: every one has different local
+    state, a new return added later would not be covered, and the guarantee we
+    want is not "these particular exits record" but "no exit escapes without
+    recording". So the check lives here, once, where it cannot be forgotten.
+
+    Never raises — this runs on a path that is already failing.
+    """
+    try:
+        from agent.kanban_abandon import block_abandoned_kanban_task
+
+        block_abandoned_kanban_task(
+            getattr(agent, "_session_messages", None),
+            f"The turn ended without reaching finalize_turn ({how}) and without "
+            f"any kanban_complete/kanban_block call, so the card was left open. "
+            f"Work done before that point may still be on disk — check the "
+            f"workspace. No more specific reason was recorded, which means the "
+            f"exit path taken does not yet annotate the board itself.",
+        )
+    except Exception:
+        logger.debug("unfinalized-turn board annotation failed", exc_info=True)
+
+
+def run_conversation(agent, *args, **kwargs) -> Dict[str, Any]:
+    """Thin wrapper enforcing one invariant over the whole turn.
+
+    The invariant: a kanban worker must never leave ``run_conversation``
+    without either closing its card or recording why it could not. See
+    :func:`_record_unfinalized_turn` for why this is a wrapper rather than a
+    change at each exit.
+
+    Signature is deliberately ``*args, **kwargs`` so it stays correct as the
+    inner function's parameters evolve; callers are unaffected.
+    """
+    agent._turn_finalized = False
+    try:
+        result = _run_conversation_inner(agent, *args, **kwargs)
+    except BaseException:
+        # Includes KeyboardInterrupt / SystemExit: an interrupted worker has
+        # just as open a card as a crashed one.
+        _record_unfinalized_turn(agent, "raised")
+        raise
+    if not getattr(agent, "_turn_finalized", False):
+        _record_unfinalized_turn(agent, "early return")
+    return result
+
+
+def _run_conversation_inner(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -4343,7 +4430,8 @@ def run_conversation(
                                     )
 
                                 _continue_content = _get_continuation_prompt(
-                                    _is_partial_stream_stub, _dropped_tools
+                                    _is_partial_stream_stub, _dropped_tools,
+                                    attempt=length_continue_retries,
                                 )
                                 continue_msg = {
                                     "role": "user",
@@ -4389,6 +4477,33 @@ def run_conversation(
                             agent._session_messages = messages
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
+                            # This return skips finalize_turn, so a kanban
+                            # worker leaving here abandons its card silently:
+                            # no terminal board call, clean exit, and the
+                            # orphan reconciler later writes "crashed: pid N
+                            # not alive" — a label that sends every later
+                            # investigation looking for a killer that does not
+                            # exist. Record the real reason on the card first.
+                            try:
+                                from agent.kanban_abandon import (
+                                    block_abandoned_kanban_task,
+                                )
+
+                                block_abandoned_kanban_task(
+                                    messages,
+                                    "Model output stayed truncated "
+                                    "(finish_reason='length') after 4 continuation "
+                                    "attempts, so the turn was abandoned before any "
+                                    "kanban_complete/kanban_block call. The work may "
+                                    "be partly done — check the workspace for files "
+                                    "written before the cut. Retrying is more likely "
+                                    "to succeed if the task asks for shorter output.",
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "abandoned-turn board annotation failed",
+                                    exc_info=True,
+                                )
                             return {
                                 "final_response": partial_response or None,
                                 "messages": messages,
@@ -4459,6 +4574,41 @@ def run_conversation(
                             # never reaches finalize_turn (#48879 class).
                             close_interrupted_tool_sequence(messages, _final_response)
                             agent._persist_session(messages, conversation_history)
+                            # Second early return that skips finalize_turn. The
+                            # sibling path (a truncated response with no tool
+                            # calls) already records the abandonment; this one
+                            # is the branch a worker actually hits when it is
+                            # writing a long file, because the truncation lands
+                            # in the tool-call arguments rather than in prose.
+                            # Without this the card goes back to looking like
+                            # "crashed: pid N not alive".
+                            try:
+                                from agent.kanban_abandon import (
+                                    block_abandoned_kanban_task,
+                                )
+
+                                block_abandoned_kanban_task(
+                                    messages,
+                                    "Tool-call arguments stayed truncated after 4 "
+                                    "retries (output cap raised on each), so the "
+                                    "turn was abandoned before any "
+                                    "kanban_complete/kanban_block call and the tool "
+                                    "was never executed. Files written by earlier "
+                                    "successful calls are still on disk. A task that "
+                                    "emits one very large tool call is the usual "
+                                    "trigger — splitting the write into several "
+                                    "smaller calls avoids it."
+                                    if not _is_stub_stall else
+                                    "The stream dropped mid tool-call four times "
+                                    "(network, not an output cap), so the tool was "
+                                    "never executed and the turn was abandoned "
+                                    "before any kanban_complete/kanban_block call.",
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "abandoned-turn board annotation failed",
+                                    exc_info=True,
+                                )
                             return {
                                 "final_response": _final_response,
                                 "messages": messages,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1458,8 +1458,26 @@ def _classify_by_status(
         # the provider/proxy itself, so the rejection is not deterministic and
         # the generic retryable-5xx handling is correct. Mirrors the guard in
         # _classify_400 — see _is_server_injected_param_rejection.
+        #
+        # _INVALID_MESSAGE_BODY_PATTERNS belongs here for the same reason.
+        # Ollama surfaces the Qwen chat template's
+        # raise_exception("No user query found in messages") as HTTP 500, so
+        # without this the message-shape check further down (the 400 path) is
+        # unreachable and the request falls through to "5xx → retryable
+        # server_error" — the exact retry flood this branch exists to prevent.
+        # Measured over six days of worker logs: 162 occurrences, of which
+        # only 6 (3.7%) were followed by a successful call in the same
+        # session. Compression cannot invent a user turn the template already
+        # rejected, so the retries are near-always futile; fail fast and fall
+        # back instead of spending the budget on an identical rejection.
+        #
+        # The injected-parameter exception above does not reach these
+        # patterns: _SERVER_INJECTED_PARAM_SENDERS keys on
+        # "prompt_cache_retention", which no _INVALID_MESSAGE_BODY_PATTERNS
+        # entry contains, so the guard is a no-op for this route.
         if (
             any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
+            or any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
             or error_code.lower() in {"invalid_request_error", "unknown_parameter",
                                       "unsupported_parameter"}
         ) and not _is_server_injected_param_rejection(error_msg, provider):

--- a/agent/kanban_abandon.py
+++ b/agent/kanban_abandon.py
@@ -1,0 +1,100 @@
+"""Record an abandoned kanban turn on the board instead of exiting silently.
+
+``run_conversation`` has bail-out paths that ``return`` early without reaching
+``finalize_turn`` — currently the "response stayed truncated after every
+continuation attempt" path in :mod:`agent.conversation_loop`. A dispatcher-
+spawned worker that leaves through one of them abandons its card: the process
+exits cleanly, the turn is never finalized, and no terminal board tool is
+called. The dispatcher's orphan reconciler later finds the pid gone and writes
+``crashed: pid N not alive``.
+
+That label describes the corpse, not the cause. It reads as "the process was
+killed", so every investigation starts by looking for a killer that does not
+exist — memory pressure, an external dependency, someone's cleanup script.
+Meanwhile the real reason (the model blew past its output cap) is recorded
+nowhere on the card, and the operator sees a task that looks crashed but whose
+work may be complete.
+
+This module converts that silent abandonment into a ``blocked`` row carrying
+the actual reason. Blocking (rather than completing) is deliberate: the turn
+did not finish, so the card genuinely needs a human or a retry — we are only
+making the failure legible, not claiming success.
+
+Policy lives in :mod:`agent.kanban_stop`, which is side-effect free. This
+module is the side-effecting counterpart and is kept separate so that contract
+holds.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable, Optional
+
+from agent.kanban_stop import session_called_kanban_terminal
+
+logger = logging.getLogger(__name__)
+
+# Truncation is retryable in principle — a shorter answer may fit — so the
+# recurrence breaker should be allowed to see it repeat and route the card to
+# triage rather than us pre-judging it as a hard capability limit.
+_DEFAULT_KIND = "transient"
+
+_MAX_REASON_CHARS = 2000
+
+
+def block_abandoned_kanban_task(
+    messages: Iterable[dict] | None,
+    reason: str,
+    *,
+    kind: str = _DEFAULT_KIND,
+    task_id: Optional[str] = None,
+) -> bool:
+    """Mark this worker's kanban task ``blocked`` with ``reason``.
+
+    Returns True only when a block was actually written. Returns False —
+    without raising — in every other case:
+
+    * not a dispatcher-spawned kanban worker (``HERMES_KANBAN_TASK`` unset);
+    * the session already called ``kanban_complete`` / ``kanban_block``, so the
+      card has a terminal state the worker chose and we must not overwrite it;
+    * the board write failed.
+
+    Never raises. It is called on a path that is already giving up; a failure
+    to annotate the card must not turn a bad turn into a crash.
+    """
+    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not tid:
+        return False
+
+    if session_called_kanban_terminal(messages):
+        # The worker closed its own card before this bail-out. Its verdict wins.
+        return False
+
+    text = (reason or "").strip() or "Turn abandoned without a terminal board call."
+    if len(text) > _MAX_REASON_CHARS:
+        text = text[: _MAX_REASON_CHARS - 1] + "…"
+
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            ok = kb.block_task(conn, tid, reason=text, kind=kind)
+    except Exception:
+        logger.warning(
+            "could not record abandoned kanban turn for task=%s — the card will "
+            "fall to the orphan reconciler and show as 'pid not alive'",
+            tid,
+            exc_info=True,
+        )
+        return False
+
+    if ok:
+        logger.info("recorded abandoned kanban turn as blocked task=%s kind=%s", tid, kind)
+    else:
+        # Not running/ready any more — another writer already moved it.
+        logger.info("abandoned kanban turn not recorded (task=%s not blockable)", tid)
+    return bool(ok)
+
+
+__all__ = ["block_abandoned_kanban_task"]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -151,6 +151,13 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    # Reaching here means the turn ended through the normal path. The wrapper
+    # around run_conversation reads this to tell a finalized turn from one of
+    # the ~25 early returns inside the loop, which skip this function entirely
+    # and would otherwise let a kanban worker abandon its card in silence.
+    # Set first, before any of the work below can raise.
+    agent._turn_finalized = True
+
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0

--- a/contributors/emails/antony.cheng.kh@gmail.com
+++ b/contributors/emails/antony.cheng.kh@gmail.com
@@ -1,0 +1,2 @@
+antonychengkh-code
+# PR #99234 (worker turn bookkeeping)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -926,6 +926,27 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="With --state-type: keep runs whose column equals this value",
     )
 
+    # --- runs-latest (one run per task, board-wide, single process) ---
+    p_runs_latest = sub.add_parser(
+        "runs-latest",
+        help="For every task, the most recent run in a given state (default: "
+             "status=done). Read-only. Exists so dashboards can avoid one CLI "
+             "launch per card.",
+    )
+    p_runs_latest.add_argument("--json", action="store_true")
+    p_runs_latest.add_argument(
+        "--state-type",
+        choices=("status", "outcome"),
+        default="status",
+        help="task_runs column to match (default: status)",
+    )
+    p_runs_latest.add_argument(
+        "--state-name",
+        default="done",
+        metavar="VALUE",
+        help="Value that column must equal (default: done)",
+    )
+
     # --- heartbeat (worker liveness signal) ---
     p_hb = sub.add_parser(
         "heartbeat",
@@ -1180,6 +1201,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "stats":    _cmd_stats,
             "log":      _cmd_log,
             "runs":     _cmd_runs,
+            "runs-latest": _cmd_runs_latest,
             "heartbeat": _cmd_heartbeat,
             "assignees": _cmd_assignees,
             "notify-subscribe":   _cmd_notify_subscribe,
@@ -3102,6 +3124,41 @@ def _cmd_log(args: argparse.Namespace) -> int:
     sys.stdout.write(content)
     if not content.endswith("\n"):
         sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_runs_latest(args: argparse.Namespace) -> int:
+    """Board-wide: the most recent run per task in a given state.
+
+    One process for the whole board instead of one per card. Output is keyed
+    by task id so a consumer can populate a cache in a single pass; tasks with
+    no matching run are simply absent.
+    """
+    with kb.connect_closing() as conn:
+        latest = kb.latest_runs_by_state(
+            conn,
+            state_type=args.state_type,
+            state_name=args.state_name,
+        )
+    if getattr(args, "json", False):
+        print(json.dumps({
+            task_id: {
+                "id": r.id, "profile": r.profile, "status": r.status,
+                "outcome": r.outcome, "started_at": r.started_at,
+                "ended_at": r.ended_at, "summary": r.summary,
+                "error": r.error, "metadata": r.metadata,
+                "worker_pid": r.worker_pid, "step_key": r.step_key,
+            } for task_id, r in latest.items()
+        }, indent=2, ensure_ascii=False))
+        return 0
+    if not latest:
+        print(f"(no runs with {args.state_type}={args.state_name})")
+        return 0
+    print(f"{'TASK':14s}  {'#':>5s}  {'OUTCOME':12s}  {'PROFILE':16s}  ENDED")
+    for task_id in sorted(latest):
+        r = latest[task_id]
+        print(f"{task_id:14s}  {r.id:5d}  {(r.outcome or '-'):12s}  "
+              f"{(r.profile or '-'):16s}  {_fmt_ts(r.ended_at) if r.ended_at else '-'}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1461,7 +1461,11 @@ CREATE TABLE IF NOT EXISTS task_runs (
     profile             TEXT,
     step_key            TEXT,
     status              TEXT NOT NULL,
-    -- status: running | done | blocked | crashed | timed_out | failed | released
+    -- status: see TASK_RUN_STATUSES — that frozenset is the definition, this
+    -- comment is not. The two drifted badly once already: the comment listed
+    -- "failed" and "released", neither of which any code path has ever
+    -- written, while omitting reclaimed / gave_up / stale / scheduled /
+    -- review / changes_requested / todo, all of which it does.
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
@@ -4332,6 +4336,50 @@ def _append_event(
     )
 
 
+# Every value ``task_runs.status`` is allowed to hold. This frozenset is the
+# definition — the schema comment on the column points here rather than
+# restating the list, because the restated version drifted out of date and
+# nothing caught it.
+#
+# ``status`` and ``outcome`` are NOT the same axis and must not be conflated:
+# outcome is the semantic result, status is the row state. They coincide for
+# every value except ``completed`` -> ``done`` and ``review_requested`` ->
+# ``review``. ``_synthesize_ended_run`` used to pass ``outcome`` for both,
+# which put four rows into the table with status='completed' — invisible to
+# every consumer filtering on 'done', including the fleet board's review
+# coverage check.
+TASK_RUN_STATUSES = frozenset({
+    "running",            # set on INSERT when the run is claimed
+    "done",               # outcome=completed
+    "review",             # outcome=review_requested
+    "blocked",
+    "crashed",
+    "reclaimed",
+    "timed_out",
+    "gave_up",
+    "stale",
+    "scheduled",
+    "todo",
+    "changes_requested",
+})
+
+
+def _validate_run_status(status: Optional[str], where: str) -> None:
+    """Warn (never raise) when a write would put an unknown value in the column.
+
+    Deliberately non-fatal: a bad status is a bookkeeping problem, and raising
+    here would turn it into a lost turn. The warning is enough to catch drift
+    the next time someone adds a state without updating TASK_RUN_STATUSES.
+    """
+    if status is not None and status not in TASK_RUN_STATUSES:
+        _log.warning(
+            "task_runs.status=%r written by %s is not in TASK_RUN_STATUSES %s "
+            "— either add it there or fix the caller; consumers that filter on "
+            "a known status will silently skip this row",
+            status, where, sorted(TASK_RUN_STATUSES),
+        )
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4358,6 +4406,7 @@ def _end_run(
     if not row or not row["current_run_id"]:
         return None
     run_id = int(row["current_run_id"])
+    _validate_run_status(status or outcome, "_end_run")
     conn.execute(
         """
         UPDATE task_runs
@@ -4404,6 +4453,7 @@ def _synthesize_ended_run(
     summary: Optional[str] = None,
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
+    status: Optional[str] = None,
 ) -> int:
     """Insert a zero-duration, already-closed run row.
 
@@ -4419,6 +4469,15 @@ def _synthesize_ended_run(
     stats. Caller is responsible for leaving ``current_run_id`` NULL
     (or for clearing it elsewhere in the same txn) since this
     function does NOT touch the tasks row.
+
+    ``status`` defaults to ``outcome``, which is correct for every
+    outcome whose row status matches it (blocked / scheduled /
+    reclaimed / timed_out / gave_up / stale). Two outcomes diverge and
+    MUST pass ``status`` explicitly, exactly as ``_end_run`` does:
+    ``completed`` -> ``done`` and ``review_requested`` -> ``review``.
+    Getting this wrong is silent — the row looks fine, but consumers
+    that filter on ``status == "done"`` (the fleet board's review
+    coverage check does) skip it, so the run's metadata never counts.
     """
     now = int(time.time())
     trow = conn.execute(
@@ -4427,6 +4486,7 @@ def _synthesize_ended_run(
     ).fetchone()
     profile = trow["assignee"] if trow else None
     step_key = trow["current_step_key"] if trow else None
+    _validate_run_status(status or outcome, "_synthesize_ended_run")
     cur = conn.execute(
         """
         INSERT INTO task_runs (
@@ -4438,7 +4498,7 @@ def _synthesize_ended_run(
         """,
         (
             task_id, profile, step_key,
-            outcome, outcome,
+            status or outcome, outcome,
             summary, error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now, now,
@@ -5523,6 +5583,7 @@ def complete_task(
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
+                status="done",
                 summary=synth_summary,
                 metadata=synth_metadata,
             )
@@ -6224,6 +6285,7 @@ def edit_completed_task_result(
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
+                status="done",
                 summary=handoff_summary,
                 metadata=metadata,
             )
@@ -6641,6 +6703,7 @@ def request_review(
                 conn,
                 task_id,
                 outcome="review_requested",
+                status="review",
                 summary=summary,
                 metadata=metadata,
             )
@@ -8981,12 +9044,30 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 elif kind == "signaled":
                     error_text = f"pid {pid} killed by signal {code}"
                 else:
-                    error_text = f"pid {pid} not alive"
+                    # ``unknown`` means the exit status was never captured —
+                    # the pid was not in the reap registry. Do NOT phrase this
+                    # as a kill. The registry is fed only by the
+                    # ``os.waitpid(-1, WNOHANG)`` reaper, which is Unix-only,
+                    # so on Windows *every* reclaim lands here and the old
+                    # "pid N not alive" wording made each one read as though
+                    # something had killed the process. It sent several
+                    # investigations hunting for a killer that did not exist
+                    # while the real cause (a worker that exited normally
+                    # without calling kanban_complete) went unrecorded.
+                    error_text = (
+                        f"pid {pid} gone without closing the task "
+                        f"(exit status not captured — cannot tell a crash "
+                        f"from a clean exit that skipped kanban_complete)"
+                    )
                 event_kind = "crashed"
                 event_payload = {"pid": pid, "claimer": row["claim_lock"]}
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+                else:
+                    # Let consumers distinguish "we know it crashed" from
+                    # "we never learned why it ended".
+                    event_payload["exit_status_known"] = False
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
@@ -12090,6 +12171,39 @@ def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
         (task_id,),
     ).fetchone()
     return Run.from_row(row) if row else None
+
+
+def latest_runs_by_state(
+    conn: sqlite3.Connection,
+    *,
+    state_type: str = "status",
+    state_name: str = "done",
+) -> dict[str, Run]:
+    """Board-wide counterpart to :func:`list_runs`: for every task, the most
+    recent run whose ``state_type`` column equals ``state_name``.
+
+    Exists so a consumer that needs one run per task does not have to launch
+    one process per task. The fleet board's ``/api/stage`` did exactly that —
+    ``_review_meta`` shelled out to ``hermes kanban runs <id> --json`` once per
+    card — and a 40-card board took 43-55 seconds to answer, past the ops
+    monitor's 45s probe timeout.
+
+    Ordering matches ``list_runs`` (``started_at ASC, id ASC``) and the last
+    row per task wins, so the result is identical to taking ``[-1]`` from a
+    per-task ``list_runs`` call. Tasks with no matching run are absent from
+    the mapping rather than mapped to ``None``.
+    """
+    if state_type not in ("status", "outcome"):
+        raise ValueError("state_type must be 'status' or 'outcome'")
+    rows = conn.execute(
+        f"SELECT * FROM task_runs WHERE {state_type} = ? "
+        "ORDER BY started_at ASC, id ASC",
+        (state_name,),
+    ).fetchall()
+    out: dict[str, Run] = {}
+    for row in rows:
+        out[row["task_id"]] = Run.from_row(row)
+    return out
 
 
 def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -441,6 +441,56 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.server_error
 
+    # ── Invalid message body surfaced as 5xx ──
+
+    def test_500_no_user_query_is_format_error_not_retryable(self):
+        """Ollama surfaces the Qwen template's "No user query found in
+        messages" as HTTP 500. Without the guard it falls through to
+        "5xx -> retryable server_error" and the identical request is sent
+        three times; the transcript cannot grow a user turn between
+        attempts, so every retry is spent on the same rejection."""
+        e = MockAPIError("no user query found in messages", status_code=500)
+        result = classify_api_error(e, provider="ollama")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_500_invalid_message_body_patterns_fail_fast(self):
+        """Every _INVALID_MESSAGE_BODY_PATTERNS entry is a request-shape
+        problem, so the status code it arrives under does not change the
+        verdict."""
+        for msg in (
+            "must have non-empty content",
+            "messages must have non-empty",
+            "invalid_request_body",
+            "text content blocks must be non-empty",
+            "content field is required",
+            "messages: at least one message is required",
+        ):
+            e = MockAPIError(msg, status_code=500)
+            result = classify_api_error(e, provider="ollama")
+            assert result.reason == FailoverReason.format_error, msg
+            assert result.retryable is False, msg
+
+    def test_500_without_body_pattern_stays_retryable(self):
+        """The guard must not swallow ordinary 500s — a genuine server
+        fault is still worth retrying."""
+        e = MockAPIError("Internal server error", status_code=500)
+        result = classify_api_error(e, provider="ollama")
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_no_user_query_same_verdict_across_statuses(self):
+        """Providers disagree about which status a template rejection gets
+        (ollama says 500, the OpenAI-compatible path can surface 400, a
+        proxy in front can turn it into 502). The shape of the request is
+        what is wrong, so all three classify the same way."""
+        for code in (400, 500, 502):
+            e = MockAPIError("no user query found in messages", status_code=code)
+            result = classify_api_error(e, provider="ollama")
+            assert result.reason == FailoverReason.format_error, code
+            assert result.retryable is False, code
+
     def test_503_overloaded(self):
         e = MockAPIError("Service Unavailable", status_code=503)
         result = classify_api_error(e)

--- a/tests/hermes_cli/test_kanban_run_record_status.py
+++ b/tests/hermes_cli/test_kanban_run_record_status.py
@@ -1,0 +1,119 @@
+"""Run-record bookkeeping: ``task_runs.status`` vs ``task_runs.outcome``.
+
+``_synthesize_ended_run`` writes the row for a terminal transition on a task
+that was never claimed — ``hermes kanban complete <ready-task>``, or the
+dashboard marking a ready task done. It used to pass ``outcome`` for both
+columns, which is only correct where the two names happen to coincide. They
+diverge for the two transitions that matter most:
+
+    complete        -> status='done'    outcome='completed'
+    request_review  -> status='review'  outcome='review_requested'
+
+With the columns conflated those rows landed as ``status='completed'`` and
+``status='review_requested'``, values no consumer filters on, so every query
+selecting ``status='done'`` skipped them without erroring.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path):
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    conn = kb.connect(db)
+    yield conn
+    conn.close()
+
+
+def _run_rows(conn, task_id):
+    return [
+        (r["status"], r["outcome"])
+        for r in conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE task_id = ?", (task_id,)
+        )
+    ]
+
+
+def test_complete_without_a_claimed_run_writes_status_done(board):
+    tid = kb.create_task(board, title="never claimed")
+    kb.complete_task(board, tid, summary="closed straight from ready")
+    board.commit()
+
+    assert _run_rows(board, tid) == [("done", "completed")]
+
+
+def test_request_review_without_a_claimed_run_writes_status_review(board):
+    tid = kb.create_task(board, title="never claimed")
+    kb.request_review(board, tid, summary="straight to review")
+    board.commit()
+
+    assert _run_rows(board, tid) == [("review", "review_requested")]
+
+
+def test_synthesized_run_is_visible_to_a_status_done_filter(board):
+    """The regression this guards against was silent: the row existed, so
+    nothing errored, but a consumer filtering on the documented terminal
+    status could not see it."""
+    tid = kb.create_task(board, title="never claimed")
+    kb.complete_task(board, tid, summary="s")
+    board.commit()
+
+    found = board.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ? AND status = 'done'",
+        (tid,),
+    ).fetchone()[0]
+    assert found == 1
+
+
+def test_synthesized_status_values_are_in_the_declared_domain(board):
+    """Whatever the transitions write must be a member of the frozenset that
+    now defines the column, otherwise the domain has drifted again."""
+    for title, fn in (
+        ("c", kb.complete_task),
+        ("r", kb.request_review),
+    ):
+        tid = kb.create_task(board, title=title)
+        fn(board, tid, summary="s")
+        board.commit()
+        for status, _outcome in _run_rows(board, tid):
+            assert status in kb.TASK_RUN_STATUSES, status
+
+
+def test_declared_domain_covers_the_statuses_the_writers_use(board):
+    """``TASK_RUN_STATUSES`` replaced a CREATE TABLE comment that had drifted
+    from the code — it listed values nothing writes and omitted values that
+    are written. Pin the two that the synthesize path depends on."""
+    assert "done" in kb.TASK_RUN_STATUSES
+    assert "review" in kb.TASK_RUN_STATUSES
+    # The pre-fix values were the outcome names; they are not row states.
+    assert "completed" not in kb.TASK_RUN_STATUSES
+    assert "review_requested" not in kb.TASK_RUN_STATUSES
+
+
+def test_unknown_status_warns_but_does_not_raise(caplog):
+    """The write-time check is deliberately non-fatal: a bad status is a
+    bookkeeping problem, and raising here would take down a worker that is
+    otherwise finishing correctly."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        kb._validate_run_status("not-a-real-status", "test")
+
+    assert any(
+        "TASK_RUN_STATUSES" in r.getMessage() for r in caplog.records
+    ), caplog.text
+
+
+def test_known_status_does_not_warn(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        kb._validate_run_status("done", "test")
+
+    assert not [
+        r for r in caplog.records if "TASK_RUN_STATUSES" in r.getMessage()
+    ]

--- a/tests/hermes_cli/test_kanban_runs_latest.py
+++ b/tests/hermes_cli/test_kanban_runs_latest.py
@@ -1,0 +1,136 @@
+"""Board-wide "latest run per task" query (``latest_runs_by_state``).
+
+Exists so a consumer needing one run per task does not launch one process
+per task. The contract it has to hold is equivalence: the row it returns for
+a task must be the same row a per-task ``list_runs(...)[-1]`` would pick,
+because callers are migrating from exactly that loop.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path):
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    conn = kb.connect(db)
+    yield conn
+    conn.close()
+
+
+def _finished_task(conn, title, *, rounds):
+    """Create a task and drive it through ``rounds`` claim/close cycles.
+
+    ``rounds`` is a list of callables taking (conn, task_id).
+    """
+    tid = kb.create_task(conn, title=title, assignee="w")
+    for close in rounds:
+        kb.claim_task(conn, tid)
+        close(conn, tid)
+    conn.commit()
+    return tid
+
+
+def _block(conn, tid):
+    kb.block_task(conn, tid, reason="r")
+
+
+def _complete(conn, tid):
+    kb.complete_task(conn, tid, summary="s")
+
+
+def test_matches_per_task_list_runs_last(board):
+    """The equivalence the query is a replacement for."""
+    tid = _finished_task(board, "multi", rounds=[_block, _complete])
+
+    per_task = [r for r in kb.list_runs(board, tid) if r.status == "done"][-1]
+    board_wide = kb.latest_runs_by_state(
+        board, state_type="status", state_name="done"
+    )[tid]
+
+    assert board_wide.id == per_task.id
+
+
+def test_picks_the_most_recent_matching_run(board):
+    """Two runs reach the same state; the later one wins.
+
+    Uses ``blocked`` rather than ``done`` because ``done`` is terminal — a
+    completed task cannot be re-claimed, so it can only ever carry one done
+    run. ``blocked`` is the state a task can genuinely re-enter.
+    """
+    tid = kb.create_task(board, title="twice", assignee="w")
+    for i in range(3):
+        kb.claim_task(board, tid)
+        kb.block_task(board, tid, reason=f"r{i}")
+        kb.unblock_task(board, tid)
+    board.commit()
+
+    runs = [r for r in kb.list_runs(board, tid) if r.status == "blocked"]
+    assert len(runs) > 1, [r.status for r in kb.list_runs(board, tid)]
+
+    got = kb.latest_runs_by_state(
+        board, state_type="status", state_name="blocked"
+    )
+    assert got[tid].id == runs[-1].id
+
+
+def test_earlier_run_in_another_state_is_not_returned(board):
+    """A task that was blocked and then completed must answer with the
+    completed run for status=done, and the blocked run for status=blocked —
+    the query filters, it does not just take the last run."""
+    tid = _finished_task(board, "mixed", rounds=[_block, _complete])
+
+    done = kb.latest_runs_by_state(board, state_type="status", state_name="done")
+    blocked = kb.latest_runs_by_state(
+        board, state_type="status", state_name="blocked"
+    )
+    assert done[tid].status == "done"
+    assert blocked[tid].status == "blocked"
+    assert done[tid].id != blocked[tid].id
+
+
+def test_task_with_no_matching_run_is_absent(board):
+    """Absent from the mapping rather than mapped to None, so callers can
+    use ``in`` without a second None check."""
+    blocked_only = _finished_task(board, "blocked only", rounds=[_block])
+
+    got = kb.latest_runs_by_state(board, state_type="status", state_name="done")
+    assert blocked_only not in got
+
+
+def test_covers_every_task_on_the_board(board):
+    """The point of the call is one query for the whole board, so a task
+    must not be missed just because another task has more runs."""
+    a = _finished_task(board, "a", rounds=[_complete])
+    b = _finished_task(board, "b", rounds=[_block, _complete])
+    c = _finished_task(board, "c", rounds=[_complete, _block, _complete])
+
+    got = kb.latest_runs_by_state(board, state_type="status", state_name="done")
+    assert set(got) == {a, b, c}
+    for tid in (a, b, c):
+        expected = [r for r in kb.list_runs(board, tid) if r.status == "done"][-1]
+        assert got[tid].id == expected.id, tid
+
+
+def test_outcome_axis_is_selectable(board):
+    """status and outcome are different columns — the caller says which."""
+    tid = _finished_task(board, "outcome", rounds=[_complete])
+
+    by_outcome = kb.latest_runs_by_state(
+        board, state_type="outcome", state_name="completed"
+    )
+    assert tid in by_outcome
+    # 'completed' is an outcome, never a status — asking on the wrong axis
+    # must not silently match.
+    by_status = kb.latest_runs_by_state(
+        board, state_type="status", state_name="completed"
+    )
+    assert by_status == {}
+
+
+def test_rejects_an_unknown_state_type(board):
+    with pytest.raises(ValueError):
+        kb.latest_runs_by_state(board, state_type="not_a_column", state_name="done")


### PR DESCRIPTION
Four independent fixes to worker turn bookkeeping, found while running
dispatcher-spawned kanban workers against a local Ollama backend. Each is a
separate commit and they can be cherry-picked individually — happy to split
into separate PRs if you prefer.

Environment all findings come from: Windows 11, Ollama 0.33.1, `qwen3.8:27b`
(Q4_K_M) at `context_length: 65536`. Numbers are measured on that setup.

> **Update 2026-09-02.** This PR originally carried a fifth commit fixing the
> compaction threshold dead zone just above `MINIMUM_CONTEXT_LENGTH`. While
> rebasing onto current `main` I found `4252aecc2` ("cap compaction threshold
> floor at 85% of the context window") already fixes exactly that — same 65,536
> case, same ~1.5K output room, same cap on the floor. It was not on `main` when
> this PR was opened, so the two were written in parallel. I dropped my commit;
> the remaining four are unaffected by it.

The four share one failure chain, which is why they arrived together:

> output truncates → `run_conversation` returns early → the worker's card is
> never closed → the reconciler records a crash that did not happen → every
> later investigation starts from a false premise

---

### 1. `fix(kanban)` — record why a turn ended without closing its card

`run_conversation` has ~25 `return`s that leave before `finalize_turn`. A worker
leaving through one abandons its card silently, and the reconciler writes
`crashed: pid N not alive`.

New `agent/kanban_abandon.py` marks the task blocked with a reason. Wired at the
truncated-prose return, the truncated-tool-call return (the branch a worker
writing a long file actually hits), and — so no exit escapes — a wrapper around
`run_conversation` that fires when `finalize_turn` did not run, including on
`BaseException`. Patching each site was rejected: a return added later would not
be covered, and the guarantee wanted is "no exit escapes", not "these exits
record".

**On the escalated length-continuation nudge.** The original PR text said we
could not confirm it fires and offered to drop it. We have since observed it:
on 2026-09-01 a report-writing worker hit `finish_reason='length'` four times in
one turn, so attempts 2–4 used the escalated wording. It did not rescue the run
— but the failure there was a local tool that only accepts base64 file content,
so the nudge's advice ("write it in several smaller tool calls") was correct and
simply not actionable. It is reachable; whether it earns its place is your call.

### 2. `fix(requests)` — guarantee a user turn

Ollama rejects a request with HTTP 500 `no user query found in messages` when no
user turn *carries content*:

| `content` | result |
|---|---|
| `"hi"` / `""` / `[{"type":"text",...}]` | OK |
| `[]` | **500** |
| `None` | 400 (different error) |

Presence of the role is necessary but not sufficient — an empty **list** reads
as absent where an empty **string** does not. Restored in
`sanitize_api_messages`, which already works on the per-call copy. Logs the role
sequence when it fires (roles only, never content).

### 3. `fix(errors)` — stop retrying that 500 three times

The 500/502 branch already fails fast on `_REQUEST_VALIDATION_PATTERNS` for
exactly this reason. `_INVALID_MESSAGE_BODY_PATTERNS` belongs in the same guard
and was not there, so the message-shape check on the 400 path is unreachable and
the request falls through to a retryable `server_error`. Over six days of logs:
162 occurrences, 6 (3.7%) followed by a successful call.

### 4. `fix(kanban)` — run-record bookkeeping

- `_synthesize_ended_run` inserted `outcome, outcome` for `(status, outcome)`,
  which diverge for `completed → done` and `review_requested → review`. Tasks
  closed with no run in flight landed as `status='completed'` and every consumer
  filtering on `'done'` skipped them silently.
- The status domain's only statement was a `CREATE TABLE` comment that had
  drifted (listed `failed`/`released`, which nothing writes; omitted seven
  values that are written). Added `TASK_RUN_STATUSES` next to the writers plus a
  write-time check that warns rather than raises.
- `pid N not alive` is a systematic mislabel on Windows: `_classify_worker_exit`
  reads a registry fed only by `os.waitpid(-1, os.WNOHANG)`, and Windows has
  neither `os.WNOHANG` nor `os.WIFEXITED` — so **every** reclaim on such a host
  carries that message regardless of cause. Now states what is known and adds
  `exit_status_known` to the payload.
- New read-only `kanban runs-latest --json` (one query for the latest run per
  task). Verified equal to per-task `list_runs()[-1]` across 40 tasks; 0.93s
  where the per-task loop took 43–55s.

---

**Testing.** 221 relevant tests pass on this branch:
`tests/agent/test_error_classifier.py`, `tests/agent/test_message_sanitization_policy.py`,
`tests/agent/transports/test_chat_completions_empty_tool_calls.py` and
`tests/tools/test_kanban_tools.py`.

`tests/hermes_cli/test_kanban*.py` (47 files) reports 287 passed / 27 failed —
but the same 27 fail on `main` at `bfbb34bbe` with no changes applied. I captured
the failure list on both and diffed it: identical, no additions and no removals.
They look environment-related (Windows); this PR neither causes nor fixes them.

After the 2026-09-02 rebase the one conflicting file
(`agent/agent_runtime_helpers.py`, where recent upstream work added a tool-result
name realignment pass next to this PR's user-turn guard — both kept, they are
independent) was additionally exercised directly: a transcript with no user turn
gets the placeholder inserted after the leading system block, a `content: []`
user turn is treated as absent, and a normal transcript passes through unchanged.

In production, the abandon-recording fired on three abandoned runs and a normal
run still reached `finalize_turn`.

**Tests for the fixes themselves** are in the last commit — 18 cases across
three files, covering fixes 2, 3 and 4. Each set was run against `main` first
to confirm it pins the behaviour rather than restating it: all of them fail
there and pass here.

`tests/hermes_cli/test_kanban*.py` goes 287 -> 301 passed with the same 27
pre-existing failures.

Fix 1 (`kanban_abandon`) is still untested. It needs `run_conversation` to
leave through one of its early returns, and I would rather not land a test
that mocks so much of the loop that it stops resembling the thing it guards.
Suggestions on how you would like that exercised are welcome.

CI has not run on this PR — as a first-time contributor the workflows are
waiting on a maintainer's approval.
