### PR TITLE
fix(agent): _vprint idle compaction status immediately so TUI shows feedback during pre-turn compact

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -925,6 +925,15 @@ def build_turn_context(
                 )
                 if _idle_status:
                     agent._emit_status(_idle_status)
+                    # Also _vprint so the TUI always shows the status.
+                    # _emit_status alone is buffered until the turn stream
+                    # opens; pre-turn idle compaction can run for minutes
+                    # with no visible feedback because the stream hasn't
+                    # started yet (#97239).
+                    agent._vprint(
+                        f"{agent.log_prefix}🗜  {_idle_status}",
+                        force=True,
+                    )
                 _idle_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_idle_tokens,

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Pre-turn idle compaction blocked for minutes with no TUI feedback. _emit_status is buffered until API starts. Add _vprint(force=True) so status appears immediately. Fixes #97239.
