### PR TITLE
fix(browser): use get_real_home() in real_profile_data_dir to find OS account home under profiles

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -265,7 +265,17 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
         return None
     system = system or platform.system()
     mac_parts, win_parts, linux_name = _real_profile_relparts(browser)
-    home = os.path.expanduser("~")
+    # Use get_real_home() not os.path.expanduser("~").  Under a Hermes profile
+    # (HERMES_HOME = ~/.hermes/profiles/<name>) $HOME is redirected to the
+    # profile's sandboxed home dir; expanduser("~") would then resolve to that
+    # directory (e.g. ~/.hermes/profiles/coder/home) instead of the OS account
+    # home, so the Chromium/Brave profile data directory cannot be found (#98815).
+    # get_real_home() returns the actual OS account home regardless of $HOME.
+    try:
+        from hermes_constants import get_real_home as _get_real_home
+        home = str(_get_real_home())
+    except Exception:
+        home = os.path.expanduser("~")
     if system == "Darwin":
         return posixpath.join(home, "Library", "Application Support", *mac_parts)
     if system == "Windows":

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿Under profiles, C:\Users\salma redirects to profile sandbox. real_profile_data_dir() used expanduser('~') finding wrong dir. Use get_real_home() instead. Fixes #98815.
