### PR TITLE
fix(gateway): expose merged-forward message ID in fallback text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3873,7 +3873,7 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> tuple[str, MessageType, List[str], List[str], List[FeishuMentionRef]]:
         raw_content = getattr(message, "content", "") or ""
         raw_type = getattr(message, "message_type", "") or ""
-        message_id = str(getattr(message, "message_id", "") or "")
+        message_id = str(getattr(message, "message_id", "") or "").strip()
         logger.info("[Feishu] Received raw message type=%s message_id=%s", raw_type, message_id)
 
         normalized = normalize_feishu_message(
@@ -3888,6 +3888,12 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         inbound_type = self._resolve_normalized_message_type(normalized, media_types)
         text = normalized.text_content
+        if (
+            normalized.relation_kind == "merge_forward"
+            and message_id
+            and text == FALLBACK_FORWARD_TEXT
+        ):
+            text = f"{FALLBACK_FORWARD_TEXT}\n\n[Message ID: `{message_id}`]"
 
         if (
             inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO, MessageType.VIDEO, MessageType.PHOTO}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -67,6 +67,68 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
 class TestFeishuMessageNormalization(unittest.TestCase):
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_fallback_includes_message_id(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            message_type="merge_forward",
+            content="{}",
+            message_id="om_merged_forward",
+        )
+
+        text, _message_type, _media_urls, _media_types, _mentions = asyncio.run(
+            adapter._extract_message_content(message)
+        )
+
+        self.assertEqual(
+            text,
+            "[Merged forward message]\n\n[Message ID: `om_merged_forward`]",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_parsed_content_does_not_include_message_id(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        for content, expected in (
+            ({"title": "Forwarded incident"}, "Forwarded incident"),
+            ({"messages": [{"text": "Forwarded body"}]}, "- Forwarded body"),
+        ):
+            with self.subTest(content=content):
+                message = SimpleNamespace(
+                    message_type="merge_forward",
+                    content=json.dumps(content),
+                    message_id="om_merged_forward",
+                )
+
+                text, _message_type, _media_urls, _media_types, _mentions = asyncio.run(
+                    adapter._extract_message_content(message)
+                )
+
+                self.assertEqual(text, expected)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_merge_forward_fallback_without_message_id_is_unchanged(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            message_type="merge_forward",
+            content="{}",
+            message_id="",
+        )
+
+        text, _message_type, _media_urls, _media_types, _mentions = asyncio.run(
+            adapter._extract_message_content(message)
+        )
+
+        self.assertEqual(text, "[Merged forward message]")
+
 
     def test_normalize_interactive_card_preserves_title_body_and_actions(self):
         from plugins.platforms.feishu.adapter import normalize_feishu_message
@@ -2465,5 +2527,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 


### PR DESCRIPTION
## Problem

When a merged-forward event does not contain a usable title or message body, the adapter currently falls back to:

```text
[Merged forward message]
```

At that point, Hermes already has the container message ID, but the ID is not included in the content visible to the agent. As a result, the agent only sees an opaque placeholder, and downstream tools or skills have no locator they can use to retrieve the forwarded messages through the platform API.

This affects both Lark and Feishu deployments, so the visible label is intentionally platform-neutral.

## Solution

Append the gateway-provided message ID when, and only when, merged-forward normalization falls back to the unresolved placeholder:

```text
[Merged forward message]

[Message ID: `om_xxx`]
```

The ID is added during adapter content extraction, before inbound text batching. This preserves the ID of the merged-forward container even when a subsequent message updates the batched event's top-level `message_id`.

## Behavior

- Unresolved merged-forward messages with an ID include the ID in the fallback text.
- Successfully parsed titles and message bodies remain unchanged.
- Messages without an ID retain the existing fallback.
- Other message types are unaffected.

## Scope

This change does not fetch, recursively expand, or otherwise alter merged-forward payloads. It only exposes an identifier Hermes already receives, allowing downstream integrations to resolve the content when needed.

The change is intentionally small and complementary to future native merged-forward expansion.

## Testing

Added coverage for:

- unresolved merged-forward messages with a message ID;
- successfully parsed merged-forward titles and bodies;
- unresolved merged-forward messages without a message ID.

```bash
scripts/run_tests.sh tests/gateway/test_feishu.py
```

Related to #25620 and #27477.
