### PR TITLE
fix(desktop): stamp launch-profile sessions so they stay visible after a switch

### DIFF
--- a/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $previewTabs, closeRightRail } from '@/store/preview'
+import type * as ProfileModule from '@/store/profile'
 
 import { ComposerDirectiveActions } from './directive-actions'
 import { refChipElement } from './rich-editor'
@@ -14,7 +15,7 @@ const ensureGatewayProfile = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@/app/open-session', () => ({ openSession: (...args: unknown[]) => openSession(...args) }))
 vi.mock('@/store/profile', async importActual => ({
-  ...(await importActual<typeof import('@/store/profile')>()),
+  ...(await importActual<typeof ProfileModule>()),
   ensureGatewayProfile: (...args: unknown[]) => ensureGatewayProfile(...args)
 }))
 

--- a/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
@@ -10,8 +10,13 @@ import { refChipElement } from './rich-editor'
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 
 const openSession = vi.fn()
+const ensureGatewayProfile = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@/app/open-session', () => ({ openSession: (...args: unknown[]) => openSession(...args) }))
+vi.mock('@/store/profile', async importActual => ({
+  ...(await importActual<typeof import('@/store/profile')>()),
+  ensureGatewayProfile: (...args: unknown[]) => ensureGatewayProfile(...args)
+}))
 
 /** A live contenteditable holding real chips, with the watcher bound to it —
  *  the same pair both composers mount. */
@@ -50,6 +55,7 @@ afterEach(() => {
   closeRightRail()
   delete desktopWindow.hermesDesktop
   openSession.mockReset()
+  ensureGatewayProfile.mockClear()
   vi.useRealTimers()
 })
 
@@ -88,6 +94,7 @@ describe('ComposerDirectiveActions', () => {
     await vi.waitFor(() =>
       expect(openSession).toHaveBeenCalledWith('20260722_204335_d62c16', expect.any(Function), 'tab')
     )
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('default')
   })
 
   it('leaves kinds with no action alone', () => {

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -454,15 +454,26 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
  *  from under the chat you're reading). Lazy-imports so the composer's rich
  *  editor can pull this module in without booting the profile/REST stack. */
 export function openSessionRef(value: string) {
-  const { sessionId } = parseSessionRefValue(value)
+  const { profile, sessionId } = parseSessionRefValue(value)
 
   if (!sessionId) {
     return
   }
 
   triggerHaptic('selection')
-  // navigate is unused for the `tab` intent (focus-or-tile only).
-  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab'))
+  // navigate is unused for the `tab` intent (focus-or-tile only). A
+  // `@session:<profile>/<id>` ref names the owning profile — activate that
+  // gateway before open, otherwise a NULL-profile or cross-profile row
+  // resolves against the live backend and the click does nothing (#99222).
+  void import('@/app/open-session').then(async ({ openSession }) => {
+    if (profile) {
+      const { ensureGatewayProfile } = await import('@/store/profile')
+
+      await ensureGatewayProfile(profile)
+    }
+
+    openSession(sessionId, () => undefined, 'tab')
+  })
 }
 
 /** What activating a directive of a given kind does. The single source of truth

--- a/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
@@ -8,9 +8,14 @@ import { DirectiveContent } from './directive-text'
 import { MarkdownTextContent } from './markdown-text'
 
 const openSession = vi.fn()
+const ensureGatewayProfile = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@/app/open-session', () => ({
   openSession: (...args: unknown[]) => openSession(...args)
+}))
+vi.mock('@/store/profile', async importActual => ({
+  ...(await importActual<typeof import('@/store/profile')>()),
+  ensureGatewayProfile: (...args: unknown[]) => ensureGatewayProfile(...args)
 }))
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
@@ -19,6 +24,7 @@ afterEach(() => {
   cleanup()
   closeRightRail()
   openSession.mockClear()
+  ensureGatewayProfile.mockClear()
   delete desktopWindow.hermesDesktop
   __resetSessionLinkTitleCache()
 })
@@ -33,6 +39,7 @@ describe('session refs open the session', () => {
     fireEvent.click(await screen.findByTitle('work/20260101_abc123'))
 
     await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
   })
 
   it('opens the session from a chip in the user transcript', async () => {
@@ -44,6 +51,7 @@ describe('session refs open the session', () => {
     fireEvent.click(chip)
 
     await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('work')
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { __resetSessionLinkTitleCache } from '@/lib/session-link-title'
 import { $previewTabs, closeRightRail } from '@/store/preview'
+import type * as ProfileModule from '@/store/profile'
 
 import { DirectiveContent } from './directive-text'
 import { MarkdownTextContent } from './markdown-text'
@@ -14,7 +15,7 @@ vi.mock('@/app/open-session', () => ({
   openSession: (...args: unknown[]) => openSession(...args)
 }))
 vi.mock('@/store/profile', async importActual => ({
-  ...(await importActual<typeof import('@/store/profile')>()),
+  ...(await importActual<typeof ProfileModule>()),
   ensureGatewayProfile: (...args: unknown[]) => ensureGatewayProfile(...args)
 }))
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7639,6 +7639,28 @@ def test_ensure_session_db_row_stamps_profile_name(monkeypatch, tmp_path):
     assert created[0]["db_path"] == profile_home / "state.db"
 
 
+def test_ensure_session_db_row_stamps_launch_profile_instead_of_null(monkeypatch):
+    """Desktop sessions created on the launch backend omit profile_home.
+    Storing NULL made those rows disappear from the profile-scoped sidebar
+    after a switch (#99222). The process profile name must be written."""
+    created = []
+
+    class _LaunchDB:
+        def create_session(self, key, **kwargs):
+            created.append({"key": key, "profile_name": kwargs.get("profile_name")})
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "_get_db", lambda: _LaunchDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+
+    server._ensure_session_db_row({"session_key": "k-launch", "source": "desktop"})
+
+    assert created == [{"key": "k-launch", "profile_name": "default"}]
+
+
 def test_session_title_clears_pending_after_persist(monkeypatch):
     class _FakeDB:
         def __init__(self):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3218,12 +3218,9 @@ def _(rid, params: dict) -> dict:
                 cwd=_session_cwd(session),
                 # The branch stays on its parent's profile. Explicit stamp (not
                 # just the parent-backfill) so it holds even when the parent row
-                # predates the profile_name column.
-                profile_name=(
-                    Path(session["profile_home"]).name
-                    if session.get("profile_home")
-                    else None
-                ),
+                # predates the profile_name column. Launch-profile branches
+                # stamp the process profile rather than NULL (#99222).
+                profile_name=_session_persist_profile_name(session),
             )
             # Copy the whole parent history in bounded-chunk transactions —
             # a branch seed can be hundreds of rows, and per-row transactions

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3788,6 +3788,23 @@ def _register_session_cwd(session: dict | None) -> None:
         pass
 
 
+def _session_persist_profile_name(session: dict) -> str:
+    """Durable owner written on the session row at first persist.
+
+    Launch-profile creates used to store NULL (``profile_home`` is omitted so
+    the row lands in the process DB). Desktop then filters the sidebar by
+    ``profile_name``, so those rows vanish after a profile switch and
+    ``@session:`` links cannot resolve them (#99222). Always stamp a concrete
+    name: the profile home's leaf, or this backend's launch profile.
+    """
+    profile_home = session.get("profile_home")
+    if profile_home:
+        name = Path(profile_home).name.strip()
+        if name:
+            return name
+    return _current_profile_name()
+
+
 def _ensure_session_db_row(session: dict) -> None:
     """Idempotently persist the session's DB row on first real activity.
 
@@ -3916,9 +3933,10 @@ def _ensure_session_db_row(session: dict) -> None:
             parent_session_id=parent_session_id,
             cwd=_persisted_session_cwd(session),
             # Self-describing rows: aggregators that merge multiple profile DBs
-            # into one list can't rely on which file a row came from alone. NULL
-            # means the launch/default profile (matches run_agent's convention).
-            profile_name=Path(profile_home).name if profile_home else None,
+            # into one list can't rely on which file a row came from alone.
+            # Always write a concrete name — NULL used to mean "launch profile"
+            # but Desktop filters by profile_name and drops those rows (#99222).
+            profile_name=_session_persist_profile_name(session),
         )
         # A session can be born hidden (session.create hidden=true, or a
         # session.set_hidden that arrived before the row existed): apply the


### PR DESCRIPTION
## What does this PR do?

Desktop sessions created on the launch backend omitted `profile_home`, so `_ensure_session_db_row` wrote `sessions.profile_name = NULL`. After switching profiles and back, those rows drop out of the profile-scoped sidebar, and `@session:<profile>/<id>` clicks open against the live gateway instead of the named owner.

This stamps a concrete profile name at persist time (the profile-home leaf, or the backend's launch profile) and activates the named profile on `@session:` open before `openSession`.

## Related Issue

Fixes #99222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: add `_session_persist_profile_name`; `_ensure_session_db_row` always writes a concrete `profile_name` (never NULL).
- `tui_gateway/methods_session.py`: branch persist uses the same stamp.
- `apps/desktop/src/components/assistant-ui/directive-text.tsx`: `openSessionRef` calls `ensureGatewayProfile` for `@session:<profile>/<id>` before opening.
- Tests: `tests/test_tui_gateway_server.py` (launch persist writes `default`); `session-ref-open.test.tsx` and `directive-actions.test.tsx` (profile activation on click).

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_ensure_session_db_row_stamps -q` — 2 passed.
2. From `apps/desktop`: `npx vitest run src/app/chat/composer/directive-actions.test.tsx src/components/assistant-ui/session-ref-open.test.tsx src/app/chat/sidebar/profile-scope.test.ts` — 14 passed.
3. Desktop with two profiles: start a chat on the launch profile, send a message, switch away and back. The session stays in that profile's sidebar. Click `@session:default/<id>` from another profile — the named session opens.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_ensure_session_db_row_stamps
=== Summary: 1 files, 2 tests passed, 0 failed

npx vitest run src/app/chat/composer/directive-actions.test.tsx src/components/assistant-ui/session-ref-open.test.tsx src/app/chat/sidebar/profile-scope.test.ts
Test Files  3 passed (3)
     Tests  14 passed (14)
```