### PR TITLE
fix(gateway): route multiplex cron through profile adapters

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -554,6 +554,7 @@ class InProcessCronScheduler(CronScheduler):
         stop_event,
         *,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -582,6 +583,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -653,6 +655,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -711,13 +714,23 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in _existing_profile_homes(profile_homes):
+                        profile_name = (
+                            entry[0]
+                            if isinstance(entry, tuple) and entry
+                            else None
+                        )
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                tick_adapters = adapters
+                                if isinstance(profile_adapters, dict):
+                                    tick_adapters = profile_adapters.get(
+                                        profile_name, adapters
+                                    )
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32673,6 +32673,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                cron_start_kwargs["profile_adapters"] = {
+                    "default": runner.adapters,
+                    **(getattr(runner, "_profile_adapters", None) or {}),
+                }
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,6 +640,64 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_selects_each_profile_adapter_map(tmp_path):
+    """Each multiplex profile tick uses its live adapter map.
+
+    A profile without an entry in ``profile_adapters`` keeps the legacy
+    default-adapters behavior, while a mapped profile gets its own transport
+    registry.
+    """
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / "default"
+    muse_home = tmp_path / "muse"
+    for home in (default_home, muse_home):
+        (home / "cron").mkdir(parents=True)
+
+    default_adapters = {"mattermost": object()}
+    muse_adapters = {"mattermost": object()}
+    profile_homes = [("default", default_home), ("muse", muse_home)]
+    profile_adapters = {"muse": muse_adapters}
+    calls = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        calls.append(
+            (
+                jobs._current_cron_store().cron_dir.parent.resolve(),
+                kwargs.get("adapters"),
+            )
+        )
+        if len(calls) >= len(profile_homes):
+            stop.set()
+        return 0
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        thread = threading.Thread(
+            target=InProcessCronScheduler().start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "adapters": default_adapters,
+                "profile_adapters": profile_adapters,
+                "profile_homes": profile_homes,
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert [home for home, _adapters in calls] == [
+        default_home.resolve(),
+        muse_home.resolve(),
+    ]
+    assert calls[0][1] is default_adapters
+    assert calls[1][1] is muse_adapters
+
+
 def test_multiplex_ticker_skips_deleted_profile_from_startup_snapshot(tmp_path):
     """A stale profile_homes entry must not recreate a deleted profile."""
     import cron.jobs as jobs

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
+import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
@@ -97,6 +98,115 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
     ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
 
     assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_passes_live_profile_adapters_to_builtin_cron(
+    monkeypatch, tmp_path
+):
+    """The production gateway door forwards both live adapter registries.
+
+    This deliberately captures the built-in provider's real ``start`` call
+    instead of calling the scheduler directly.  The profile homes/config files
+    make the multiplex startup branch resolve its normal served-profile set.
+    """
+    hermes_home = tmp_path / "hermes-home"
+    profile_home = hermes_home / "profiles" / "worker"
+    hermes_home.mkdir()
+    profile_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n", encoding="utf-8"
+    )
+    (profile_home / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    secondary_adapters = {Platform.DISCORD: object()}
+    started_runners = []
+    waited_runners = []
+
+    async def fake_runner_start(runner):
+        started_runners.append(runner)
+        runner._profile_adapters["worker"] = secondary_adapters
+        runner._running = True
+        return True
+
+    async def fake_wait_for_shutdown(runner):
+        waited_runners.append(runner)
+        runner._running = False
+
+    monkeypatch.setattr(GatewayRunner, "start", fake_runner_start)
+    monkeypatch.setattr(GatewayRunner, "wait_for_shutdown", fake_wait_for_shutdown)
+    monkeypatch.setattr(GatewayRunner, "_start_systemd_watchdog", lambda self: None)
+
+    cron_starts = []
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    def capture_builtin_start(provider, stop_event, **kwargs):
+        cron_starts.append((provider, stop_event, kwargs))
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: InProcessCronScheduler(),
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.InProcessCronScheduler.start",
+        capture_builtin_start,
+    )
+    monkeypatch.setattr(
+        gateway_run, "_start_gateway_housekeeping", lambda *a, **kw: None
+    )
+
+    class NoControlSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def start(self):
+            return False
+
+    monkeypatch.setattr("gateway.control_socket.GatewayControlServer", NoControlSocket)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.nous_auth_keepalive.start_nous_auth_keepalive",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.nous_auth_keepalive.stop_nous_auth_keepalive",
+        lambda: None,
+    )
+
+    config = GatewayConfig(
+        multiplex_profiles=True,
+        sessions_dir=hermes_home / "sessions",
+    )
+    result = await gateway_run.start_gateway(config=config, verbosity=None)
+
+    assert result is True
+    assert len(started_runners) == 1
+    assert waited_runners == started_runners
+    assert len(cron_starts) == 1
+    _provider, _stop_event, cron_kwargs = cron_starts[0]
+    runner = started_runners[0]
+    assert cron_kwargs["adapters"] is runner.adapters
+    assert cron_kwargs["profile_adapters"]["default"] is runner.adapters
+    assert (
+        cron_kwargs["profile_adapters"]["worker"]
+        is runner._profile_adapters["worker"]
+    )
+    assert cron_kwargs["profile_homes"] == [
+        ("default", hermes_home),
+        ("worker", profile_home),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Routes each multiplexed profile's cron tick through that profile's live adapter map instead of always reusing the default profile's adapters.

Before this change, a secondary profile could execute its own cron job under the correct profile scope but deliver the result through the default profile's bot identity. A concrete Mattermost deployment reproduced this as a Muse-profile report being authored by the default Vega bot.

The built-in scheduler now accepts the runner's profile adapter registry and selects the exact profile map for each profile tick. Missing or unknown profile maps retain the legacy default-adapter fallback, and single-profile and external scheduler-provider paths remain unchanged.

## Related Issue

No issue — this is a reproduced multiplex gateway bug with a focused behavioral fix. Searches for existing open and closed PRs/issues using both the user-facing symptom and implementation terms found no match.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: pass the live secondary-profile adapter registry to the built-in multiplex cron scheduler.
- `cron/scheduler_provider.py`: select each profile's exact adapter map while preserving the default fallback.
- `tests/cron/test_scheduler_provider.py`: behaviorally assert that default and secondary profile ticks receive the correct live map identities.
- `tests/gateway/test_runner_startup_failures.py`: execute the real `start_gateway()` production door and prove it forwards both live adapter registries to the built-in scheduler.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_scheduler_provider.py -q` — 33 passed.
2. Run `scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_multiplex_lifecycle.py -q` — 31 passed.
3. Run `scripts/run_tests.sh tests/gateway/test_runner_startup_failures.py -k live_profile_adapters -q` — 1 passed; removing only the production wiring makes this fail with `KeyError: 'profile_adapters'`.
4. Run `python3 scripts/check-windows-footguns.py --diff origin/main..HEAD` and `git diff --check` — both clean.
5. In a multiplex gateway with different bot tokens for default and a secondary profile, fire a cron job from the secondary profile and verify delivery uses that profile's adapter identity.

Independent exact-head review: PASS for `5a99f3554ef64e4ed2384289ea9be035eaa474f6`, including mutation verification of the production wiring tripwire.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused CI-parity suites above passed; the maker's broad gateway run had unrelated environment-sensitive failures
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no user-facing configuration or behavior contract changed
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture/workflow policy changed
- [x] I've considered cross-platform impact — pure Python mapping selection; Windows footgun check passed
- [x] I've updated tool descriptions/schemas — N/A; no model tools changed

## Screenshots / Logs

Not applicable. The regression is covered by adapter-map identity assertions and was verified against a live multiplexed Mattermost deployment.
