### PR TITLE
feat(desktop): add a persistent Needs Attention center

### DIFF
--- a/apps/desktop/src/app/command-center/attention.test.ts
+++ b/apps/desktop/src/app/command-center/attention.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionDotState } from '@/store/session-dot-state'
+import type { SessionInfo } from '@/types/hermes'
+
+import { buildAttentionItems } from './attention'
+
+type TestSession = Pick<
+  SessionInfo,
+  | '_lineage_root_id'
+  | 'archived'
+  | 'connection_id'
+  | 'id'
+  | 'last_active'
+  | 'preview'
+  | 'profile'
+  | 'source'
+  | 'started_at'
+  | 'title'
+  | 'unread'
+>
+
+const session = (id: string, extra: Partial<TestSession> = {}): TestSession => ({
+  _lineage_root_id: null,
+  archived: false,
+  connection_id: undefined,
+  id,
+  last_active: 100,
+  preview: null,
+  profile: 'default',
+  source: 'desktop',
+  started_at: 90,
+  title: id,
+  ...extra
+})
+
+const state = (id: string, value: SessionDotState): Readonly<Record<string, SessionDotState>> => ({ [id]: value })
+
+describe('buildAttentionItems', () => {
+  it('builds actionable and unread items from the existing dot state', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: ['approval'],
+      dotStates: { ...state('approval', 'needs-input'), ...state('done', 'unread') },
+      messagingSessions: [],
+      sessions: [session('approval'), session('done', { last_active: 200 })]
+    })
+
+    expect(result.map(item => [item.kind, item.sessionId])).toEqual([
+      ['needs-input', 'approval'],
+      ['unread', 'done']
+    ])
+  })
+
+  it('deduplicates a session across lists and compression aliases', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: ['root'],
+      dotStates: { tip: 'needs-input' },
+      messagingSessions: [session('root', { source: 'telegram' })],
+      sessions: [session('tip', { _lineage_root_id: 'root' })]
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.sessionId).toBe('tip')
+  })
+
+  it('keeps identical ids separate when they belong to different profiles', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: [],
+      dotStates: { shared: 'unread' },
+      messagingSessions: [session('shared', { profile: 'ops', last_active: 300 })],
+      sessions: [session('shared')]
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result.map(item => item.profile).sort()).toEqual(['default', 'ops'])
+    expect(result.map(item => item.owner?.profile).sort()).toEqual(['default', 'ops'])
+  })
+
+  it('scopes waiting state to the matching owner when ids collide', () => {
+    const result = buildAttentionItems({
+      attentionOwners: {
+        shared: [{ connectionId: 'remote-1', profile: 'ops' }]
+      },
+      attentionSessionIds: ['shared'],
+      dotStates: {},
+      messagingSessions: [session('shared', { connection_id: 'remote-1', profile: 'ops' })],
+      sessions: [session('shared')]
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ kind: 'needs-input', profile: 'ops' })
+  })
+
+  it('does not classify ambiguous duplicate ids as waiting without an owner', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: ['shared'],
+      dotStates: {},
+      messagingSessions: [session('shared', { profile: 'ops' })],
+      sessions: [session('shared')]
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('includes persisted unread state carried by messaging rows', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: [],
+      dotStates: {},
+      messagingSessions: [session('message', { source: 'telegram', unread: true })],
+      sessions: []
+    })
+
+    expect(result).toMatchObject([{ kind: 'unread', sessionId: 'message' }])
+  })
+
+  it('ignores archived and non-actionable rows', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: [],
+      dotStates: {
+        archived: 'unread',
+        running: 'working',
+        quiet: 'idle'
+      },
+      messagingSessions: [],
+      sessions: [session('archived', { archived: true }), session('running'), session('quiet')]
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('does not recreate an archived waiting session as a synthetic item', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: ['archived'],
+      dotStates: {},
+      messagingSessions: [],
+      sessions: [session('archived', { archived: true })]
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('keeps a waiting session visible when its row has not loaded yet', () => {
+    const result = buildAttentionItems({
+      attentionSessionIds: ['unloaded-session'],
+      dotStates: {},
+      messagingSessions: [],
+      sessions: []
+    })
+
+    expect(result).toMatchObject([
+      {
+        kind: 'needs-input',
+        owner: undefined,
+        sessionId: 'unloaded-session',
+        title: 'Session unloaded-session'
+      }
+    ])
+  })
+})

--- a/apps/desktop/src/app/command-center/attention.ts
+++ b/apps/desktop/src/app/command-center/attention.ts
@@ -1,0 +1,183 @@
+import type { SessionDotState } from '@/store/session-dot-state'
+import type { SessionInfo } from '@/types/hermes'
+
+export type AttentionKind = 'needs-input' | 'unread'
+export type AttentionSource = 'messaging' | 'session'
+
+export interface AttentionOwner {
+  connectionId?: string
+  profile: string
+}
+
+export type AttentionSession = Pick<
+  SessionInfo,
+  | '_lineage_root_id'
+  | 'archived'
+  | 'connection_id'
+  | 'id'
+  | 'last_active'
+  | 'preview'
+  | 'profile'
+  | 'source'
+  | 'started_at'
+  | 'title'
+  | 'unread'
+>
+
+export interface AttentionItem {
+  connectionId?: string
+  id: string
+  kind: AttentionKind
+  owner?: AttentionOwner
+  profile: string
+  sessionId: string
+  source: AttentionSource
+  timestamp: number
+  title: string
+}
+
+export interface BuildAttentionItemsOptions {
+  attentionOwners?: Readonly<Record<string, readonly AttentionOwner[]>>
+  attentionSessionIds: readonly string[]
+  dotStates: Readonly<Record<string, SessionDotState>>
+  messagingSessions: readonly AttentionSession[]
+  sessions: readonly AttentionSession[]
+}
+
+const ATTENTION_PRIORITY: Record<AttentionKind, number> = {
+  'needs-input': 0,
+  unread: 1
+}
+
+const profileKey = (row: AttentionSession): string => row.profile?.trim() || 'default'
+
+const connectionKey = (row: AttentionSession): string => row.connection_id?.trim() || 'local'
+
+const lineageId = (row: AttentionSession): string => row._lineage_root_id?.trim() || row.id
+
+const matchesSessionId = (row: AttentionSession, id: string): boolean => row.id === id || row._lineage_root_id === id
+
+const ownerMatches = (row: AttentionSession, owner: AttentionOwner): boolean =>
+  profileKey(row) === owner.profile && connectionKey(row) === (owner.connectionId?.trim() || 'local')
+
+const isWaitingRow = (
+  row: AttentionSession,
+  id: string,
+  rows: readonly { row: AttentionSession }[],
+  attentionOwners: Readonly<Record<string, readonly AttentionOwner[]>> | undefined
+): boolean => {
+  const hintedOwners = Object.entries(attentionOwners ?? {})
+    .filter(([candidateId]) => matchesSessionId(row, candidateId))
+    .flatMap(([, owners]) => owners)
+
+  if (hintedOwners.length > 0) {
+    return hintedOwners.some(owner => ownerMatches(row, owner))
+  }
+
+  const matchingRows = rows.filter(({ row: candidate }) => !candidate.archived && matchesSessionId(candidate, id))
+
+  const matchingOwners = new Set(
+    matchingRows.map(({ row: candidate }) => `${profileKey(candidate)}\u0000${connectionKey(candidate)}`)
+  )
+
+  return matchingOwners.size === 1
+}
+
+const rowTitle = (row: AttentionSession): string => row.title?.trim() || row.preview?.trim() || `Session ${row.id}`
+
+const rowTimestamp = (row: AttentionSession): number => row.last_active || row.started_at || 0
+
+const itemKey = (row: AttentionSession): string =>
+  `${profileKey(row)}\u0000${row.connection_id?.trim() || 'local'}\u0000${lineageId(row)}`
+
+const itemFromRow = (row: AttentionSession, kind: AttentionKind, source: AttentionSource): AttentionItem => ({
+  connectionId: row.connection_id?.trim() || undefined,
+  id: itemKey(row),
+  kind,
+  owner: {
+    connectionId: row.connection_id?.trim() || undefined,
+    profile: profileKey(row)
+  },
+  profile: profileKey(row),
+  sessionId: row.id,
+  source,
+  timestamp: rowTimestamp(row),
+  title: rowTitle(row)
+})
+
+const syntheticWaitingItem = (sessionId: string): AttentionItem => ({
+  id: `default\u0000local\u0000${sessionId}`,
+  kind: 'needs-input',
+  owner: undefined,
+  profile: 'default',
+  sessionId,
+  source: 'session',
+  timestamp: 0,
+  title: `Session ${sessionId}`
+})
+
+/**
+ * Build the persistent Desktop attention list from existing session state.
+ *
+ * This function deliberately owns no state and performs no navigation. It is
+ * the single precedence/deduplication policy used by the Command Center and
+ * its titlebar count, keeping those surfaces from drifting apart.
+ */
+export function buildAttentionItems({
+  attentionOwners,
+  attentionSessionIds,
+  dotStates,
+  messagingSessions,
+  sessions
+}: BuildAttentionItemsOptions): AttentionItem[] {
+  const rows: Array<{ row: AttentionSession; source: AttentionSource }> = [
+    ...sessions.map(row => ({ row, source: 'session' as const })),
+    ...messagingSessions.map(row => ({ row, source: 'messaging' as const }))
+  ]
+
+  const waitingIds = new Set(attentionSessionIds)
+  const byKey = new Map<string, AttentionItem>()
+
+  const add = (item: AttentionItem): void => {
+    const existing = byKey.get(item.id)
+
+    if (!existing || ATTENTION_PRIORITY[item.kind] < ATTENTION_PRIORITY[existing.kind]) {
+      byKey.set(item.id, item)
+    }
+  }
+
+  for (const { row, source } of rows) {
+    if (row.archived) {
+      continue
+    }
+
+    const kind = [...waitingIds].some(id => matchesSessionId(row, id) && isWaitingRow(row, id, rows, attentionOwners))
+      ? 'needs-input'
+      : dotStates[row.id] === 'unread' || row.unread === true
+        ? 'unread'
+        : null
+
+    if (kind) {
+      add(itemFromRow(row, kind, source))
+    }
+  }
+
+  for (const sessionId of attentionSessionIds) {
+    const hasVisibleRow = rows.some(({ row }) => matchesSessionId(row, sessionId) && !row.archived)
+    const hasArchivedRow = rows.some(({ row }) => matchesSessionId(row, sessionId) && row.archived)
+
+    if (!hasVisibleRow && !hasArchivedRow) {
+      add(syntheticWaitingItem(sessionId))
+    }
+  }
+
+  return [...byKey.values()].sort((left, right) => {
+    const priority = ATTENTION_PRIORITY[left.kind] - ATTENTION_PRIORITY[right.kind]
+
+    if (priority !== 0) {
+      return priority
+    }
+
+    return right.timestamp - left.timestamp || left.title.localeCompare(right.title)
+  })
+}

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -16,6 +16,7 @@ import {
   Activity,
   AlertCircle,
   BarChart3,
+  Bell,
   Bookmark,
   BookmarkFilled,
   Download,
@@ -28,6 +29,7 @@ import { fmtDateTime } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
+import { $attentionItems } from '@/store/attention'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $sessions, sessionPinId } from '@/store/session'
 
@@ -36,11 +38,18 @@ import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { OverlayMain, OverlayNav, OverlaySplitLayout } from '../overlays/overlay-split-layout'
 import { OverlayView } from '../overlays/overlay-view'
 
+import type { AttentionItem, AttentionOwner } from './attention'
 import { MaintenancePanel } from './maintenance'
 
-export type CommandCenterSection = 'maintenance' | 'sessions' | 'system' | 'usage'
+export type CommandCenterSection = 'attention' | 'maintenance' | 'sessions' | 'system' | 'usage'
 
-const SECTIONS = ['sessions', 'system', 'usage', 'maintenance'] as const satisfies readonly CommandCenterSection[]
+const SECTIONS = [
+  'attention',
+  'sessions',
+  'system',
+  'usage',
+  'maintenance'
+] as const satisfies readonly CommandCenterSection[]
 
 const LOG_FILES = ['agent', 'errors', 'gateway', 'desktop'] as const
 const LOG_LEVELS = ['ALL', 'INFO', 'WARNING', 'ERROR'] as const
@@ -53,6 +62,7 @@ type UsagePeriod = (typeof USAGE_PERIODS)[number]
 // component never re-renders from $sessions ticks while on System/Usage/etc.
 const EMPTY_SESSIONS: readonly never[] = []
 const EMPTY_PINNED: readonly string[] = []
+const EMPTY_ATTENTION: readonly AttentionItem[] = []
 
 interface CommandCenterViewProps {
   initialSection?: CommandCenterSection
@@ -60,7 +70,7 @@ interface CommandCenterViewProps {
   onDeleteSession: (sessionId: string) => Promise<void>
   // Accepted for call-site parity; navigation lives in the global Cmd+K palette.
   onNavigateRoute?: (path: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, owner?: AttentionOwner) => void
 }
 
 function formatTimestamp(value?: number | null): string {
@@ -141,6 +151,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const [section, setSection] = useRouteEnumParam('section', SECTIONS, initialSection ?? 'sessions')
   const sessions = useStoreSelector($sessions, s => (section === 'sessions' ? s : EMPTY_SESSIONS))
   const pinnedSessionIds = useStoreSelector($pinnedSessionIds, s => (section === 'sessions' ? s : EMPTY_PINNED))
+  const attentionItems = useStoreSelector($attentionItems, items => (section === 'attention' ? items : EMPTY_ATTENTION))
 
   const [query, setQuery] = useState('')
   const [status, setStatus] = useState<StatusResponse | null>(null)
@@ -307,13 +318,15 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
       SECTIONS.map(value => ({
         active: section === value,
         icon:
-          value === 'sessions'
-            ? MessageCircle
-            : value === 'system'
-              ? Activity
-              : value === 'maintenance'
-                ? Wrench
-                : BarChart3,
+          value === 'attention'
+            ? Bell
+            : value === 'sessions'
+              ? MessageCircle
+              : value === 'system'
+                ? Activity
+                : value === 'maintenance'
+                  ? Wrench
+                  : BarChart3,
         id: value,
         label: cc.sections[value],
         onSelect: () => setSection(value)
@@ -356,7 +369,9 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
             </div>
           </header>
 
-          {section === 'sessions' ? (
+          {section === 'attention' ? (
+            <AttentionPanel items={attentionItems} onOpenSession={onOpenSession} />
+          ) : section === 'sessions' ? (
             <div className="min-h-0 flex-1 overflow-y-auto">
               {!sessionListHasResults ? (
                 <EmptyPanel description={debouncedQuery ? cc.noResults : cc.noSessions} />
@@ -510,6 +525,96 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
         </OverlayMain>
       </OverlaySplitLayout>
     </OverlayView>
+  )
+}
+
+function AttentionPanel({
+  items,
+  onOpenSession
+}: {
+  items: readonly AttentionItem[]
+  onOpenSession: (sessionId: string, owner?: AttentionOwner) => void
+}) {
+  const { t } = useI18n()
+  const cc = t.commandCenter
+  const sidebar = t.sidebar
+
+  const groups = [
+    { icon: AlertCircle, kind: 'needs-input' as const, label: sidebar.row.needsInput },
+    { icon: MessageCircle, kind: 'unread' as const, label: sidebar.row.finishedUnread }
+  ]
+
+  if (items.length === 0) {
+    return <EmptyPanel description={cc.noAttention} title={cc.sections.attention} />
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="grid gap-5">
+        {groups.map(group => {
+          const groupedItems = items.filter(item => item.kind === group.kind)
+
+          if (groupedItems.length === 0) {
+            return null
+          }
+
+          return (
+            <section key={group.kind}>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <h3 className="text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                  {group.label}
+                </h3>
+                <span className="text-[0.65rem] tabular-nums text-(--ui-text-tertiary)">{groupedItems.length}</span>
+              </div>
+              <ul className="divide-y divide-(--ui-stroke-tertiary) rounded-lg border border-(--ui-stroke-tertiary)">
+                {groupedItems.map(item => {
+                  const Icon = group.icon
+                  const profile = item.profile === 'default' ? '' : ` · ${item.profile}`
+                  const timestamp = formatTimestamp(item.timestamp)
+
+                  return (
+                    <li key={item.id}>
+                      <button
+                        aria-label={`${group.label}: ${item.title}`}
+                        className="flex w-full items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-(--ui-control-hover-background) focus-visible:bg-(--ui-control-hover-background) focus-visible:outline-none"
+                        disabled={!item.owner}
+                        onClick={() => item.owner && onOpenSession(item.sessionId, item.owner)}
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            'grid size-7 shrink-0 place-items-center rounded-md',
+                            item.kind === 'needs-input'
+                              ? 'bg-amber-500/12 text-amber-600 dark:text-amber-400'
+                              : 'bg-emerald-500/12 text-emerald-600 dark:text-emerald-400'
+                          )}
+                        >
+                          <Icon className="size-3.5" />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+                            {item.title}
+                          </span>
+                          <span className="mt-0.5 block truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                            {group.label}
+                            {timestamp ? ` · ${timestamp}` : ''}
+                            {profile}
+                          </span>
+                        </span>
+                        <span aria-hidden="true" className="shrink-0 text-(--ui-text-tertiary)">
+                          ›
+                        </span>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -895,10 +895,10 @@ export function ContribController() {
               className="pointer-events-auto absolute z-10 flex w-max items-center gap-2 [-webkit-app-region:no-drag]"
               style={{
                 right:
-                  // Five static cluster buttons: four systemTools plus the
+                  // Six static cluster buttons: five systemTools plus the
                   // always-present right-sidebar toggle (titlebar-controls.tsx).
                   // Keep in sync with wiring.tsx's SYSTEM_TOOL_COUNT.
-                  'max(calc(var(--workspace-right, 0px) + 0.5rem), calc(var(--titlebar-tools-right, 0.75rem) + 5 * var(--titlebar-control-size, 24px) + 0.5rem))'
+                  'max(calc(var(--workspace-right, 0px) + 0.5rem), calc(var(--titlebar-tools-right, 0.75rem) + 6 * var(--titlebar-control-size, 24px) + 0.5rem))'
               }}
             />
           </div>

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1097,12 +1097,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Pane-registered tools (preview's monitor/devtools cluster) anchor flush
   // against the static system cluster — in the tree layout the titlebar band
   // sits ABOVE the grid, so AppShell's pane-width anchoring doesn't apply.
-  // Count every button the static cluster actually renders: four systemTools
-  // (layout, haptics, keybinds, settings) PLUS the always-present
-  // right-sidebar toggle (see titlebar-controls.tsx). A shared width that
-  // under-counts leaves the find bar, the titlebar header padding, and the
-  // pane-cluster anchor overlapping the fifth button.
-  const SYSTEM_TOOL_COUNT = 5
+  // Count every button the static cluster actually renders: five systemTools
+  // (attention, layout, haptics, keybinds, settings) PLUS the always-present
+  // right-sidebar toggle (see titlebar-controls.tsx).
+  const SYSTEM_TOOL_COUNT = 6
   const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
   const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
 
@@ -1130,6 +1128,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         {!isHudWindow() && !isBrowserWindow() && (
           <TitlebarControls
             leftTools={leftTitlebarTools}
+            onOpenAttention={() => openCommandCenterSection('attention')}
             onOpenSettings={() => navigate(SETTINGS_ROUTE)}
             tools={rightTitlebarTools}
           />
@@ -1197,7 +1196,20 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             onClose={closeOverlayToPreviousRoute}
             onDeleteSession={removeSession}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
+            onOpenSession={(sessionId, owner) => {
+              const rowProfile = owner?.profile?.trim()
+
+              if (rowProfile) {
+                requestSessionResume(sessionId, {
+                  connectionId: owner?.connectionId?.trim() || 'local',
+                  ...(owner?.connectionId?.trim() ? {} : { mode: 'local' as const }),
+                  profile: rowProfile,
+                  targetProfile: rowProfile
+                })
+              }
+
+              openSession(sessionId, navigate)
+            }}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -13,6 +13,7 @@ import { compactNumber } from '@/lib/format'
 import { triggerHaptic } from '@/lib/haptics'
 import { formatModifierToken } from '@/lib/keybinds/combo'
 import { cn } from '@/lib/utils'
+import { $attentionCount } from '@/store/attention'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import { toggleHud } from '@/store/hud'
 import {
@@ -62,6 +63,7 @@ export type SetTitlebarToolGroup = (id: string, tools: readonly TitlebarTool[], 
 interface TitlebarControlsProps extends ComponentProps<'div'> {
   leftTools?: readonly TitlebarTool[]
   tools?: readonly TitlebarTool[]
+  onOpenAttention: () => void
   onOpenSettings: () => void
 }
 
@@ -129,7 +131,12 @@ function useModifierHeld(): boolean {
   return held
 }
 
-export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }: TitlebarControlsProps) {
+export function TitlebarControls({
+  leftTools = [],
+  onOpenAttention,
+  onOpenSettings,
+  tools = []
+}: TitlebarControlsProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
   const location = useLocation()
@@ -139,7 +146,9 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
+  const attentionCount = useStore($attentionCount)
   const unreadBadge = unreadCount > 0 ? unreadCount : undefined
+  const attentionBadge = attentionCount > 0 ? attentionCount : undefined
   const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
 
   const toggleHaptics = () => {
@@ -204,6 +213,17 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   // Static system tools — always pinned to the screen's right edge.
   const systemTools: TitlebarTool[] = [
+    {
+      badge: attentionBadge,
+      icon: <TitlebarIcon name="notifications" />,
+      id: 'attention',
+      label: t.titlebar.needsAttention(attentionCount),
+      onSelect: () => {
+        triggerHaptic('open')
+        onOpenAttention()
+      },
+      title: t.titlebar.needsAttention(attentionCount)
+    },
     {
       className: 'group/tool',
       // Hover + held ⌘/Ctrl morphs the glyph into its reset form (see

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -212,6 +212,7 @@ export const ar = defineLocale({
     hideRightSidebar: 'إخفاء الشريط الأيمن',
     showRightSidebar: 'إظهار الشريط الأيمن',
     unreadSessions: count => (count === 1 ? 'جلسة واحدة غير مقروءة' : `${count} جلسات غير مقروءة`),
+    needsAttention: count => (count === 1 ? 'عنصر واحد يحتاج انتباهك' : `${count} عناصر تحتاج انتباهك`),
     muteHaptics: 'كتم الاهتزازات',
     unmuteHaptics: 'تفعيل الاهتزازات',
     openSettings: 'فتح الإعدادات',
@@ -1124,14 +1125,18 @@ export const ar = defineLocale({
     archivedChats: 'المحادثات المؤرشفة',
     commands: 'الأوامر',
     sections: {
+      attention: 'تحتاج إلى انتباه',
       sessions: 'الجلسات',
       system: 'النظام',
-      usage: 'الاستخدام'
+      usage: 'الاستخدام',
+      maintenance: 'الصيانة'
     },
     sectionDescriptions: {
+      attention: 'راجع الجلسات التي تنتظرك أو التي لديها نتائج جديدة',
       sessions: 'البحث في الجلسات وإدارتها',
       system: 'الحالة والسجلات وإجراءات النظام',
-      usage: 'نشاط الرموز والتكلفة والمهارات عبر الزمن'
+      usage: 'نشاط الرموز والتكلفة والمهارات عبر الزمن',
+      maintenance: 'التشخيص والنسخ الاحتياطية والذاكرة'
     },
     nav: {
       newChat: {
@@ -1156,6 +1161,10 @@ export const ar = defineLocale({
       }
     },
     sectionEntries: {
+      attention: {
+        title: 'لوحة تحتاج إلى انتباه',
+        detail: 'مراجعة الجلسات التي تنتظرك أو التي لديها نتائج جديدة'
+      },
       sessions: {
         title: 'لوحة الجلسات',
         detail: 'البحث في الجلسات وتثبيتها وإدارتها'
@@ -1179,6 +1188,7 @@ export const ar = defineLocale({
     exportSession: 'تصدير الجلسة',
     deleteSession: 'حذف الجلسة',
     noSessions: 'لا توجد جلسات',
+    noAttention: 'لا يوجد ما يحتاج إلى انتباهك الآن.',
     gatewayRunning: 'البوابة تعمل',
     gatewayStopped: 'البوابة متوقفة',
     hermesActiveSessions: (version, count) => `Hermes ${version} لديه ${count} جلسة نشطة`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -245,6 +245,7 @@ export const en: Translations = {
     hideRightSidebar: 'Hide right sidebar',
     showRightSidebar: 'Show right sidebar',
     unreadSessions: count => (count === 1 ? '1 unread session' : `${count} unread sessions`),
+    needsAttention: count => (count === 1 ? '1 item needs your attention' : `${count} items need your attention`),
     muteHaptics: 'Mute haptics',
     unmuteHaptics: 'Unmute haptics',
     openSettings: 'Open settings',
@@ -1511,8 +1512,15 @@ export const en: Translations = {
     settingsFields: 'Settings fields',
     mcpServers: 'MCP servers',
     archivedChats: 'Archived chats',
-    sections: { maintenance: 'Maintenance', sessions: 'Sessions', system: 'System', usage: 'Usage' },
+    sections: {
+      attention: 'Needs attention',
+      maintenance: 'Maintenance',
+      sessions: 'Sessions',
+      system: 'System',
+      usage: 'Usage'
+    },
     sectionDescriptions: {
+      attention: 'Review sessions waiting for you or with new results',
       maintenance: 'Diagnostics, backups, curator, and memory data',
       sessions: 'Search and manage sessions',
       system: 'Status, logs, and system actions',
@@ -1526,6 +1534,7 @@ export const en: Translations = {
       artifacts: { title: 'Artifacts', detail: 'Browse generated outputs' }
     },
     sectionEntries: {
+      attention: { title: 'Needs attention panel', detail: 'Review sessions waiting for you or with new results' },
       sessions: { title: 'Sessions panel', detail: 'Search, pin, and manage sessions' },
       system: { title: 'System panel', detail: 'Gateway status, logs, restart/update' },
       usage: { title: 'Usage panel', detail: 'Token, cost, and skill activity' }
@@ -1540,6 +1549,7 @@ export const en: Translations = {
     exportSession: 'Export session',
     deleteSession: 'Delete session',
     noSessions: 'No sessions yet.',
+    noAttention: 'Nothing needs your attention right now.',
     gatewayRunning: 'Messaging gateway running',
     gatewayStopped: 'Messaging gateway stopped',
     hermesActiveSessions: (version, count) => `Hermes ${version} · Active sessions ${count}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -246,6 +246,7 @@ export const ja = defineLocale({
     hideRightSidebar: '右サイドバーを非表示',
     showRightSidebar: '右サイドバーを表示',
     unreadSessions: count => (count === 1 ? '未読セッション 1 件' : `未読セッション ${count} 件`),
+    needsAttention: count => (count === 1 ? '要対応の項目が 1 件あります' : `要対応の項目が ${count} 件あります`),
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
@@ -1330,8 +1331,16 @@ export const ja = defineLocale({
     settingsFields: '設定フィールド',
     mcpServers: 'MCP サーバー',
     archivedChats: 'アーカイブ済みチャット',
-    sections: { sessions: 'セッション', system: 'システム', usage: '使用状況' },
+    sections: {
+      attention: '要対応',
+      maintenance: 'メンテナンス',
+      sessions: 'セッション',
+      system: 'システム',
+      usage: '使用状況'
+    },
     sectionDescriptions: {
+      attention: '対応が必要なセッションや新しい結果を確認',
+      maintenance: '診断、バックアップ、キュレーター、メモリデータ',
       sessions: 'セッションの検索と管理',
       system: 'ステータス、ログ、システムアクション',
       usage: 'トークン、コスト、スキルの活動履歴'
@@ -1344,6 +1353,7 @@ export const ja = defineLocale({
       artifacts: { title: 'アーティファクト', detail: '生成された出力を閲覧' }
     },
     sectionEntries: {
+      attention: { title: '要対応パネル', detail: '対応が必要なセッションや新しい結果を確認' },
       sessions: { title: 'セッションパネル', detail: 'セッションの検索、ピン留め、管理' },
       system: { title: 'システムパネル', detail: 'ゲートウェイのステータス、ログ、再起動/更新' },
       usage: { title: '使用状況パネル', detail: 'トークン、コスト、スキルの活動' }
@@ -1358,6 +1368,7 @@ export const ja = defineLocale({
     exportSession: 'セッションをエクスポート',
     deleteSession: 'セッションを削除',
     noSessions: 'セッションはまだありません。',
+    noAttention: '現在、対応が必要な項目はありません。',
     gatewayRunning: 'メッセージングゲートウェイが実行中',
     gatewayStopped: 'メッセージングゲートウェイが停止中',
     hermesActiveSessions: (version, count) => `Hermes ${version} · アクティブセッション ${count}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -283,6 +283,7 @@ export interface Translations {
     hideRightSidebar: string
     showRightSidebar: string
     unreadSessions: (count: number) => string
+    needsAttention: (count: number) => string
     muteHaptics: string
     unmuteHaptics: string
     openSettings: string
@@ -1341,10 +1342,10 @@ export interface Translations {
     settingsFields: string
     mcpServers: string
     archivedChats: string
-    sections: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
-    sectionDescriptions: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
+    sections: Record<'attention' | 'maintenance' | 'sessions' | 'system' | 'usage', string>
+    sectionDescriptions: Record<'attention' | 'maintenance' | 'sessions' | 'system' | 'usage', string>
     nav: Record<'newChat' | 'settings' | 'skills' | 'messaging' | 'artifacts', { title: string; detail: string }>
-    sectionEntries: Record<'sessions' | 'system' | 'usage', { title: string; detail: string }>
+    sectionEntries: Record<'attention' | 'sessions' | 'system' | 'usage', { title: string; detail: string }>
     providerNavigate: string
     providerSessions: string
     refresh: string
@@ -1355,6 +1356,7 @@ export interface Translations {
     exportSession: string
     deleteSession: string
     noSessions: string
+    noAttention: string
     gatewayRunning: string
     gatewayStopped: string
     hermesActiveSessions: (version: string, count: number) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -238,6 +238,7 @@ export const zhHant = defineLocale({
     hideRightSidebar: '隱藏右側邊欄',
     showRightSidebar: '顯示右側邊欄',
     unreadSessions: count => (count === 1 ? '1 個未讀工作階段' : `${count} 個未讀工作階段`),
+    needsAttention: count => (count === 1 ? '有 1 個項目需要注意' : `有 ${count} 個項目需要注意`),
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
@@ -1288,8 +1289,16 @@ export const zhHant = defineLocale({
     settingsFields: '設定欄位',
     mcpServers: 'MCP 伺服器',
     archivedChats: '已封存聊天',
-    sections: { sessions: '工作階段', system: '系統', usage: '使用量' },
+    sections: {
+      attention: '需要注意',
+      maintenance: '維護',
+      sessions: '工作階段',
+      system: '系統',
+      usage: '使用量'
+    },
     sectionDescriptions: {
+      attention: '查看等待你處理或有新結果的工作階段',
+      maintenance: '診斷、備份、維護器和記憶資料',
       sessions: '搜尋和管理工作階段',
       system: '狀態、記錄和系統動作',
       usage: '一段時間內的詞元、費用和技能活動'
@@ -1302,6 +1311,7 @@ export const zhHant = defineLocale({
       artifacts: { title: '成品', detail: '瀏覽產生的輸出' }
     },
     sectionEntries: {
+      attention: { title: '需要注意面板', detail: '查看等待你處理或有新結果的工作階段' },
       sessions: { title: '工作階段面板', detail: '搜尋、釘選和管理工作階段' },
       system: { title: '系統面板', detail: '閘道狀態、記錄、重新啟動/更新' },
       usage: { title: '使用量面板', detail: '詞元、費用和技能活動' }
@@ -1316,6 +1326,7 @@ export const zhHant = defineLocale({
     exportSession: '匯出工作階段',
     deleteSession: '刪除工作階段',
     noSessions: '暫無工作階段。',
+    noAttention: '目前沒有需要你注意的事項。',
     gatewayRunning: '訊息閘道執行中',
     gatewayStopped: '訊息閘道已停止',
     hermesActiveSessions: (version, count) => `Hermes ${version} · 活躍工作階段 ${count}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -238,6 +238,7 @@ export const zh: Translations = {
     hideRightSidebar: '隐藏右侧栏',
     showRightSidebar: '显示右侧栏',
     unreadSessions: count => (count === 1 ? '1 个未读会话' : `${count} 个未读会话`),
+    needsAttention: count => (count === 1 ? '有 1 项需要注意' : `有 ${count} 项需要注意`),
     muteHaptics: '关闭触感反馈',
     unmuteHaptics: '开启触感反馈',
     openSettings: '打开设置',
@@ -1697,8 +1698,15 @@ export const zh: Translations = {
     settingsFields: '设置字段',
     mcpServers: 'MCP 服务器',
     archivedChats: '已归档对话',
-    sections: { maintenance: '维护', sessions: '会话', system: '系统', usage: '用量' },
+    sections: {
+      attention: '需要注意',
+      maintenance: '维护',
+      sessions: '会话',
+      system: '系统',
+      usage: '用量'
+    },
     sectionDescriptions: {
+      attention: '查看等待你处理的会话或有新结果的会话',
       maintenance: '诊断、备份、维护器与记忆数据',
       sessions: '搜索与管理会话',
       system: '状态、日志与系统操作',
@@ -1712,6 +1720,7 @@ export const zh: Translations = {
       artifacts: { title: '产物', detail: '浏览生成的输出' }
     },
     sectionEntries: {
+      attention: { title: '需要注意面板', detail: '查看等待你处理的会话或有新结果的会话' },
       sessions: { title: '会话面板', detail: '搜索、置顶与管理会话' },
       system: { title: '系统面板', detail: '网关状态、日志、重启/更新' },
       usage: { title: '用量面板', detail: '词元、成本与技能活动' }
@@ -1726,6 +1735,7 @@ export const zh: Translations = {
     exportSession: '导出会话',
     deleteSession: '删除会话',
     noSessions: '暂无会话。',
+    noAttention: '目前没有需要你注意的事项。',
     gatewayRunning: '消息网关运行中',
     gatewayStopped: '消息网关已停止',
     hermesActiveSessions: (version, count) => `Hermes ${version} · 活跃会话 ${count}`,

--- a/apps/desktop/src/store/attention.ts
+++ b/apps/desktop/src/store/attention.ts
@@ -1,0 +1,36 @@
+import { computed } from 'nanostores'
+
+import { type AttentionItem, type AttentionOwner, buildAttentionItems } from '@/app/command-center/attention'
+
+import { $messagingSessions, $sessions, getSessionOwnerHints } from './session'
+import { $sessionDotStateById } from './session-dot-state'
+import { $attentionSessionIds } from './session-states'
+
+/** One attention list for the Desktop titlebar and Command Center. */
+export const $attentionItems = computed(
+  [$attentionSessionIds, $sessionDotStateById, $sessions, $messagingSessions],
+  (attentionSessionIds, dotStates, sessions, messagingSessions): AttentionItem[] => {
+    const attentionOwners: Record<string, AttentionOwner[]> = {}
+
+    for (const sessionId of attentionSessionIds) {
+      const owners = getSessionOwnerHints(sessionId).map(route => ({
+        connectionId: route.connectionId.trim() || undefined,
+        profile: route.profile.trim() || 'default'
+      }))
+
+      if (owners.length > 0) {
+        attentionOwners[sessionId] = owners
+      }
+    }
+
+    return buildAttentionItems({
+      attentionOwners,
+      attentionSessionIds,
+      dotStates,
+      messagingSessions,
+      sessions
+    })
+  }
+)
+
+export const $attentionCount = computed($attentionItems, items => items.length)


### PR DESCRIPTION
## Summary

Adds a small Desktop Needs Attention center that unifies existing actionable and unread session state without introducing a second notification backend.

- Adds a reactive attention selector shared by the titlebar badge and Command Center.
- Shows sessions needing user input and finished unread results in grouped sections.
- Deduplicates normal and messaging rows across compression lineage aliases.
- Preserves profile/connection ownership when opening an attention item.
- Fails closed for ambiguous duplicate IDs and keeps archived sessions out.
- Adds a persistent titlebar badge and updates contributed-slot clearance for the additional control.
- Adds English, Arabic, Japanese, Simplified Chinese, and Traditional Chinese strings.

## Related work

This is intentionally a small Desktop integration over existing session/unread state and does not duplicate a new notification backend. It can complement the existing session visibility/unread work and be extended later with cron result actions and durable snooze/settle lifecycle behavior.

## Verification

- `npx tsc -p apps/desktop --noEmit`
- ESLint on all changed TypeScript files
- Prettier check on all changed TypeScript files
- `npx vitest run --project ui src/app/command-center/attention.test.ts src/store/session-dot-state.test.ts` — 29 tests passed
- `git diff --check`
- `npm run build` from `apps/desktop` — passed, including Electron bundling and distribution assertion

## Scope exclusions

- No new backend notification service.
- No automatic approval/rejection.
- No cron lifecycle, snooze, settle, or history model in this first slice.
