### PR TITLE
fix(gateway): preserve Windows agent-triggered relaunch

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1609,7 +1609,7 @@ def _collect_gateway_stop_pids(primary_pid: int | None = None) -> list[int]:
     return pids
 
 
-def stop() -> None:
+def stop(*, replacement_armed: bool = False) -> None:
     """Stop the gateway.
 
     Writes the planned-stop marker first so the gateway can drain
@@ -1644,7 +1644,13 @@ def stop() -> None:
     # Phase 3: hard-kill any still-known gateway processes. Avoid the generic
     # process sweep here: Windows direct-spawn starts are profile-scoped, and a
     # stop command must be bounded even if the scanner or shutdown path is wedged.
-    stop_pids.extend(pid for pid in _collect_gateway_stop_pids() if pid not in stop_pids)
+    # A restart watcher may already have observed the clean exit and spawned the
+    # replacement. In that case a fresh scan would mistake the new gateway for a
+    # straggler and kill it, recreating the outage the watcher prevents.
+    if not replacement_armed:
+        stop_pids.extend(
+            pid for pid in _collect_gateway_stop_pids() if pid not in stop_pids
+        )
     killed = _force_terminate_known_gateway_pids(stop_pids)
     if killed:
         stopped_any = True
@@ -1677,6 +1683,37 @@ def _wait_for_gateway_absent(timeout_s: float = 30.0, interval_s: float = 0.5) -
     return get_running_pid() is None and not _gateway_pids()
 
 
+def _arm_gateway_restart(old_pid: int) -> bool:
+    """Detach a watcher that relaunches this profile after ``old_pid`` exits."""
+    if old_pid <= 0:
+        return False
+    try:
+        from hermes_cli.gateway import launch_detached_gateway_restart_by_cmdline
+
+        run_argv, _working_dir, _env_overlay = _build_gateway_argv()
+        return launch_detached_gateway_restart_by_cmdline(old_pid, run_argv)
+    except Exception as exc:
+        logger.warning(
+            "Could not arm detached gateway restart watcher (%s); falling back "
+            "to synchronous relaunch",
+            type(exc).__name__,
+        )
+        return False
+
+
+def _wait_for_gateway_replacement(
+    old_pid: int, timeout_s: float = 45.0, interval_s: float = 0.4
+) -> list[int]:
+    """Wait until a gateway PID other than ``old_pid`` is running."""
+    deadline = time.monotonic() + max(timeout_s, interval_s)
+    while time.monotonic() < deadline:
+        replacements = [pid for pid in _gateway_pids() if pid != old_pid]
+        if replacements:
+            return replacements
+        time.sleep(interval_s)
+    return [pid for pid in _gateway_pids() if pid != old_pid]
+
+
 def restart() -> None:
     """Stop the gateway then start it again.
 
@@ -1688,7 +1725,29 @@ def restart() -> None:
     """
     _assert_windows()
 
-    stop()
+    from gateway.status import get_running_pid
+
+    old_pid = get_running_pid()
+    replacement_armed = old_pid is not None and _arm_gateway_restart(old_pid)
+
+    # Arm before requesting shutdown. A gateway-hosted agent executes this CLI
+    # as a child of the gateway being drained; that child can be terminated with
+    # its parent before synchronous code below ever reaches start(). The detached
+    # watcher is therefore the owner of relaunch whenever a live PID is known.
+    stop(replacement_armed=replacement_armed)
+
+    if replacement_armed:
+        replacements = _wait_for_gateway_replacement(old_pid, timeout_s=45.0)
+        if replacements:
+            print(
+                "✓ Gateway restarted via detached watcher "
+                f"(PID: {', '.join(map(str, replacements))})"
+            )
+            return
+        raise RuntimeError(
+            "Gateway restart watcher did not produce a replacement process. "
+            "Check logs/gateway.log and run `hermes gateway status`."
+        )
 
     if not _wait_for_gateway_absent(timeout_s=30.0):
         print("⚠ Gateway still present after stop; forcing termination before restart...")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -174,6 +174,131 @@ def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
     assert str(tmp_path) not in warnings[0].getMessage()
 
 
+@pytest.mark.windows_only
+def test_restart_arms_relaunch_before_stopping_gateway(monkeypatch):
+    """The replacement must survive the gateway tearing down its CLI child."""
+    events = []
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_arm_gateway_restart",
+        lambda pid: events.append(("arm", pid)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "stop",
+        lambda *, replacement_armed=False: events.append(
+            ("stop", replacement_armed)
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_wait_for_gateway_replacement",
+        lambda pid, timeout_s=45.0: events.append(("wait", pid, timeout_s))
+        or [5252],
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "start",
+        lambda: pytest.fail("an armed watcher owns the replacement start"),
+    )
+
+    gateway_windows.restart()
+
+    assert events == [
+        ("arm", 4242),
+        ("stop", True),
+        ("wait", 4242, 45.0),
+    ]
+
+
+@pytest.mark.windows_only
+def test_arm_restart_reuses_detached_gateway_watcher(monkeypatch):
+    run_argv = ["python.exe", "-m", "hermes_cli.main", "gateway", "run"]
+    calls = []
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_build_gateway_argv",
+        lambda: (run_argv, r"C:\Hermes", {"HERMES_HOME": r"C:\Hermes"}),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda pid, argv: calls.append((pid, argv)) or True,
+    )
+
+    assert gateway_windows._arm_gateway_restart(4242) is True
+    assert calls == [(4242, run_argv)]
+
+
+@pytest.mark.windows_only
+def test_restart_falls_back_to_synchronous_start_when_watcher_cannot_arm(
+    monkeypatch,
+):
+    events = []
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(gateway_windows, "_arm_gateway_restart", lambda pid: False)
+    monkeypatch.setattr(
+        gateway_windows,
+        "stop",
+        lambda *, replacement_armed=False: events.append(
+            ("stop", replacement_armed)
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_wait_for_gateway_absent",
+        lambda timeout_s=30.0: events.append(("absent", timeout_s)) or True,
+    )
+    monkeypatch.setattr(gateway_windows.time, "sleep", lambda delay: events.append(("sleep", delay)))
+    monkeypatch.setattr(gateway_windows, "start", lambda: events.append(("start",)))
+    monkeypatch.setattr(
+        gateway_windows,
+        "_wait_for_gateway_ready",
+        lambda timeout_s=15.0: events.append(("ready", timeout_s)) or [5252],
+    )
+
+    gateway_windows.restart()
+
+    assert events == [
+        ("stop", False),
+        ("absent", 30.0),
+        ("sleep", 1.0),
+        ("start",),
+        ("ready", 15.0),
+    ]
+
+
+@pytest.mark.windows_only
+def test_stop_does_not_kill_replacement_armed_during_clean_drain(monkeypatch):
+    collect_calls = []
+    killed = []
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(gateway_windows, "_drain_gateway_pid", lambda *_args: True)
+    monkeypatch.setattr(gateway_windows, "_windows_stop_drain_timeout", lambda: 5.0)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+
+    def collect(primary_pid=None):
+        collect_calls.append(primary_pid)
+        return [4242] if primary_pid else [5252]
+
+    monkeypatch.setattr(gateway_windows, "_collect_gateway_stop_pids", collect)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_force_terminate_known_gateway_pids",
+        lambda pids: killed.extend(pids) or 0,
+    )
+
+    gateway_windows.stop(replacement_armed=True)
+
+    assert collect_calls == [4242]
+    assert killed == [4242]
+
+
 class TestStableWindowsGatewayWorkingDir:
     def test_stable_gateway_working_dir_uses_hermes_home(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

- arm the existing detached gateway restart watcher before requesting Windows shutdown
- prevent the stop cleanup from mistaking an already-spawned replacement for a stale gateway
- retain the synchronous restart path when no live gateway or watcher is available

## Root cause

The Windows restart path stopped the current gateway before starting its replacement. When invoked by a gateway-hosted agent tool, the restart CLI is a child of the gateway being drained and can terminate with that process before reaching the relaunch step.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_spawn_gateway_restart_reap.py tests/hermes_cli/test_spawn_gateway_restart_cooldown.py -q` (55 passed, 5 skipped)

## Related Issue

N/A
