### PR TITLE
fix(telegram): add clarify inline-button hint to platform prompt to prevent copy_text button simulations

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -821,7 +821,12 @@ PLATFORM_HINTS = {
         "inline; image URLs via ![alt](url) send as photos. Audio: add "
         "[[audio_as_voice]] on its own line to send ANY audio file as a "
         "native voice bubble (non-Opus transcodes automatically); without "
-        "it, .mp3/.m4a arrive as audio files, other formats as documents."
+        "it, .mp3/.m4a arrive as audio files, other formats as documents. "
+        "For multiple-choice questions use the clarify tool — Telegram "
+        "renders each choice as a native inline button that sends the "
+        "user's selection back to you automatically; do NOT simulate "
+        "choice menus with copy_text buttons, numbered lists, or "
+        "Markdown-formatted options (#98911)."
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -3,8 +3,14 @@
 Clarify Tool Module - Interactive Clarifying Questions
 
 Allows the agent to present structured multiple-choice questions or open-ended
-prompts to the user. In CLI mode, choices are navigable with arrow keys. On
-messaging platforms, choices are rendered as a numbered list.
+prompts to the user. In CLI mode, choices are navigable with arrow keys.
+
+Platform rendering per adapter:
+- Telegram: native inline keyboard buttons (one per choice) — each button
+  sends the user's selection back automatically.  Do NOT simulate menus
+  with copy_text buttons or numbered lists (#98911).
+- Discord: native component buttons.
+- Other messaging platforms: numbered list fallback.
 
 Supports both single-select (radio) and multi-select (checkbox) modes via the
 ``multi_select`` parameter.
@@ -47,7 +53,7 @@ def _flatten_choice(c) -> str:
     dict-shaped choices like ``[{"description": "..."}]``. A naive ``str(c)``
     turns the whole dict into its Python repr — ``{'description': '...'}`` —
     which then leaks onto every surface that renders the choice (CLI panel,
-    Discord buttons, Telegram numbered list) AND is returned verbatim as the
+    Discord buttons, Telegram inline buttons) AND is returned verbatim as the
     user's answer. Normalising here, at the one platform-agnostic entry point,
     fixes the whole class in one place instead of per-adapter.
 


### PR DESCRIPTION
﻿Add clarify-button guidance to Telegram platform hint. Model was simulating approvals with copy_text buttons instead of using clarify tool. Fixes #98911.
