### PR TITLE
fix(line): surface the triggering message id on media turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19638,6 +19638,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
+        # LINE: a media message's binary is fetched from the LINE content API
+        # by message id, and a skill that keeps inbound files has no other way
+        # to name the file it was just sent. Injected per-turn for the same
+        # reason as Discord above — the id changes every turn, so it must stay
+        # out of the cached system prompt — and only when the message actually
+        # carries media, so ordinary text turns keep a byte-stable prefix and
+        # go on hitting the prompt cache. LINE is a plugin platform with no
+        # Platform enum member (Platform._missing_() creates it), so the
+        # comparison goes through .value rather than Platform.LINE.
+        if (
+            source is not None
+            and getattr(getattr(source, "platform", None), "value", None) == "line"
+            and getattr(event, "message_id", None)
+            and getattr(event, "media_urls", None)
+        ):
+            message_text = (
+                f"[Triggering message id: `{event.message_id}` — use as "
+                f"`message_id` to fetch this message's media from the LINE "
+                f"content API.]\n\n"
+                f"{message_text}"
+            )
+
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's

--- a/tests/gateway/test_line_media_message_id.py
+++ b/tests/gateway/test_line_media_message_id.py
@@ -1,0 +1,99 @@
+"""Tests for LINE triggering-message-id injection in _prepare_inbound_message_text.
+
+A LINE media message's binary is only reachable through the LINE content API,
+keyed by the id of the message that carried it. Without the id on the turn, a
+skill that keeps inbound files has nothing to name the file with. Discord
+already gets its triggering id this way; LINE did not, so any LINE file-keeping
+skill was uncallable however well it was written.
+
+The prefix is deliberately conditional on the message actually carrying media:
+text-only turns must keep a byte-stable prefix so prompt caching still hits.
+"""
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+LINE = Platform("line")
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _source(platform: Platform = LINE) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id="U0123456789abcdef",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+
+
+def _document_event(source: SessionSource, **kwargs) -> MessageEvent:
+    return MessageEvent(
+        text="",
+        source=source,
+        message_type=MessageType.DOCUMENT,
+        media_urls=["/tmp/hermes-cache/doc_abc_report.pdf"],
+        media_types=["application/pdf"],
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_id_injected_for_line_media_message():
+    runner = _make_runner()
+    source = _source()
+    event = _document_event(source, message_id="629694223050605090")
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+
+    assert result is not None
+    assert "[Triggering message id: `629694223050605090`" in result
+    assert "LINE content API" in result
+
+
+@pytest.mark.asyncio
+async def test_id_not_injected_for_line_text_message():
+    """Text turns must keep a byte-stable prefix so prompt caching still hits."""
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="เย็นนี้ประชุมกี่โมง",
+        source=source,
+        message_id="629694223050605091",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+
+    assert result is not None
+    assert "Triggering message id" not in result
+
+
+@pytest.mark.asyncio
+async def test_id_not_injected_for_non_line_media_message():
+    runner = _make_runner()
+    source = _source(Platform.TELEGRAM)
+    event = _document_event(source, message_id="4242")
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+
+    assert result is not None
+    assert "Triggering message id" not in result


### PR DESCRIPTION
## What does this PR do?

A LINE media message's binary lives only behind the LINE content API, keyed by the id of the message that carried it. The agent is never shown that id: `gateway/run.py` injects the triggering message id for **Discord only**, and `gateway/session.py` has platform blocks for Slack, Discord, iMessage and Yuanbao but none for LINE.

The consequence is that any skill which keeps or forwards an inbound LINE file is uncallable — it has no way to name the file it was just sent, however well its `SKILL.md` is written. The failure is silent: the model either guesses an id or quietly skips the call and answers about the image instead, and nothing on the agent side notices.

This mirrors the existing Discord block one screen above rather than inventing a new mechanism.

Two details worth calling out, both taken from the Discord block's own reasoning:

- **Per-turn, not in the system prompt.** The id changes every turn, so baking it into `build_session_context_prompt()` would bust the agent-cache signature and rebuild the `AIAgent` on every message.
- **Only when the message actually carries media.** Text turns keep a byte-stable prefix and go on hitting the prompt cache. Injecting unconditionally would cost cache hits on every LINE text message for no benefit.

One LINE-specific detail: LINE is a plugin platform with **no `Platform` enum member** — `Platform._missing_()` creates it on demand — so the comparison goes through `.value == "line"`. `Platform.LINE` raises `AttributeError`.

## Related Issue

No existing issue or PR found. Searched `gh search issues` / `gh search prs` (open and closed) for LINE + message id + media, and grepped `main` for `Triggering message id` — the only hit is the Discord block.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — in `_prepare_inbound_message_text`, inject `[Triggering message id: ...]` for LINE messages that carry media, directly after the existing Discord block (+22 lines)
- `tests/gateway/test_line_media_message_id.py` — new, modelled on the sibling `tests/gateway/test_reply_to_injection.py` (+99 lines)

No config keys, no tool schemas, no docs affected. Pure addition — no existing branch changes behavior.

## How to Test

1. `pytest tests/gateway/test_line_media_message_id.py -q` → 3 passed.
2. Revert only the `gateway/run.py` hunk and re-run → `test_id_injected_for_line_media_message` fails, the other two still pass. The test is not vacuous.
3. `pytest tests/gateway/ -q` → `6861 passed, 7 failed`. The same 7 fail on unpatched `main` in the same run (`test_discord_send` ×3, `test_send_multiple_images`, `test_session_store_prune`, `test_teams_dotenv_isolation`, `test_telegram_polling_health_confirmation`) — pre-existing and unrelated; several only fail in a full-directory run and pass in isolation, so they look like ordering pollution.

End-to-end on a live LINE channel: sending a photo previously produced only a vision answer; with the patch the agent reads the id off the turn and the file reaches storage. Log line from the skill call:

```
OK [attachment=cf94bfa4-...] [note=a9ff66b3-...] image image/jpeg 52585 bytes
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see caveat under How to Test: `tests/gateway/` run in full, 7 pre-existing failures reproduce identically on unpatched `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (string formatting only, no platform-dependent code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
