### PR TITLE
fix(gateway): retain launch-profile env under multiplex

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -286,15 +286,45 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     return secrets
 
 
-def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from its ``<home>/.env``.
+def build_profile_secret_scope(
+    hermes_home: Path,
+    *,
+    include_process_env: bool = False,
+) -> Dict[str, str]:
+    """Build an isolated secret mapping for one profile.
 
     Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
     global vars are intentionally NOT copied in — ``get_secret`` reads those
     from ``os.environ`` directly, so the scope holds only profile secrets.
+
+    ``include_process_env`` is reserved for the profile that owns the running
+    process. Managed deployments commonly inject that launch profile's secrets
+    directly into the service environment instead of persisting ``.env``.
+    Multiplex callers must never enable it for a secondary profile: doing so
+    would copy the launch profile's credentials across the isolation boundary.
+
+    Precedence mirrors normal Hermes startup: process environment first, then
+    the profile's ``.env``, then configured external secret sources.
     """
     home = Path(hermes_home)
-    secrets = load_env_file(home / ".env")
+    secrets: Dict[str, str] = {}
+    if include_process_env:
+        from hermes_constants import (
+            get_process_hermes_home,
+            hermes_home_key,
+        )
+
+        if hermes_home_key(home) != hermes_home_key(get_process_hermes_home()):
+            raise ValueError(
+                "process environment credentials may only be included in "
+                "the process launch profile's secret scope"
+            )
+        secrets.update(
+            (key, value)
+            for key, value in os.environ.items()
+            if not _is_global_env(key)
+        )
+    secrets.update(load_env_file(home / ".env"))
 
     try:
         from hermes_cli.env_loader import get_secret_source_values

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2465,18 +2465,24 @@ def _profile_runtime_scope(profile_home: "Path"):
       1. ``set_hermes_home_override`` — redirects ``get_hermes_home()`` (config,
          skills, memory, SOUL, sessions) to the profile's home. Contextvar, so
          it propagates into the agent worker thread via ``copy_context()``.
-      2. ``set_secret_scope`` — installs the profile's ``.env`` secrets as the
-         authoritative credential source, so ``get_secret`` reads this profile's
-         keys and never the process-global ``os.environ`` (which in a
-         multiplexer may hold another profile's values).
+      2. ``set_secret_scope`` — installs an authoritative credential mapping.
+         The process launch profile receives its own deployment-injected env
+         plus profile sources; secondary profiles receive only their own
+         sources and never the process-global ``os.environ`` (which belongs to
+         the launch profile).
 
     Only used on the multiplexed inbound path. Single-profile gateways never
-    enter this scope, so their behavior is unchanged. Loading the profile's
-    ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
-    returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
-    from inheriting cross-profile secrets.
+    enter this scope, so their behavior is unchanged. Building the mapping
+    here does NOT mutate ``os.environ`` —
+    ``build_profile_secret_scope`` returns an isolated dict — which is what
+    keeps subprocesses (MCP, kanban) from inheriting cross-profile secrets.
     """
-    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from hermes_constants import (
+        get_process_hermes_home,
+        hermes_home_key,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
     from agent.secret_scope import (
         build_profile_secret_scope,
         set_secret_scope,
@@ -2484,9 +2490,17 @@ def _profile_runtime_scope(profile_home: "Path"):
     )
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
+    is_launch_profile = (
+        hermes_home_key(profile_home) == hermes_home_key(get_process_hermes_home())
+    )
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secret_token = set_secret_scope(
+        build_profile_secret_scope(
+            Path(profile_home),
+            include_process_env=is_launch_profile,
+        )
+    )
     try:
         yield
     finally:

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -87,6 +87,49 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert a_seen == prof_a / "skills"
         assert b_seen == prof_b / "skills"
 
+    def test_launch_profile_keeps_process_injected_credentials(
+        self, tmp_path, monkeypatch
+    ):
+        """The gateway owner keeps its deployment env without leaking it.
+
+        Managed gateways commonly inject the launch profile's provider keys
+        from a secret manager directly into the process environment instead
+        of persisting them in ``<home>/.env``.  Multiplex scoping must retain
+        those keys for that exact profile while a secondary profile remains
+        authoritative for its own credentials.
+        """
+        from agent.auxiliary_client import _scoped_key_env
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli.runtime_provider import _getenv
+
+        launch_home = tmp_path / "launch"
+        secondary_home = launch_home / "profiles" / "secondary"
+        launch_home.mkdir()
+        secondary_home.mkdir(parents=True)
+        (secondary_home / ".env").write_text(
+            "META_API_KEY=secondary-meta-key\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(launch_home))
+        monkeypatch.setenv("META_API_KEY", "launch-meta-key")
+        monkeypatch.setenv("PROCESS_ONLY_API_KEY", "launch-only-key")
+        ss.set_multiplex_active(True)
+
+        with _profile_runtime_scope(launch_home):
+            assert _getenv("META_API_KEY") == "launch-meta-key"
+            assert _scoped_key_env("META_API_KEY") == "launch-meta-key"
+            assert ss.get_secret("PROCESS_ONLY_API_KEY") == "launch-only-key"
+
+        with _profile_runtime_scope(secondary_home):
+            assert _getenv("META_API_KEY") == "secondary-meta-key"
+            assert _scoped_key_env("META_API_KEY") == "secondary-meta-key"
+            assert ss.get_secret("PROCESS_ONLY_API_KEY") is None
+
+        with pytest.raises(ValueError, match="process launch profile"):
+            ss.build_profile_secret_scope(
+                secondary_home,
+                include_process_env=True,
+            )
+
 
 def test_cold_profile_hydrates_external_source_without_global_env(
     tmp_path, monkeypatch
@@ -164,5 +207,3 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
-
-


### PR DESCRIPTION
## Summary

- include process-injected credentials in the multiplex secret scope only for the process launch profile
- keep secondary profile scopes authoritative and isolated
- fail closed if process credentials are requested for any other profile
- cover both main-model and auxiliary resolver paths

## Production failure

A managed multiplex gateway injected provider keys through its service environment and did not persist them in the launch profile .env. The per-turn launch-profile scope therefore hid its own credentials, so the main request and context compaction used a placeholder API key and received HTTP 401.

## Validation

- focused regression was red before the fix and green after it
- 37 secret-scope, multiplex, and manual-compression tests pass
- ruff passes on all changed files
- git diff --check passes
- broad local suite reached 1,441 passing tests before it was stopped because the reused deployment venv lacks optional acp and anthropic packages; those dependency collection failures are unrelated to this change