### PR TITLE
fix(sandbox): resolve managed Node headers for native addons

### DIFF
--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -480,10 +480,18 @@ INTERACTIVE=false
 if [ -t 0 ] && [ -t 1 ]; then
   INTERACTIVE=true
 fi
-NODE_DIR="${DEV_SANDBOX_NODE_DIR:-}"
-if [ -z "$NODE_DIR" ] && command -v node >/dev/null; then
-  NODE_DIR="$(dirname "$(dirname "$(command -v node)")")"
-fi
+configure_node_dir() {
+  NODE_DIR="${DEV_SANDBOX_NODE_DIR:-}"
+  if [ -z "$NODE_DIR" ] && [ "$INSTALL_SHORTCUT" = true ]; then
+    # The installer may replace the startup runtime before npm builds native
+    # addons. Point node-gyp at that managed prefix: it will contain matching
+    # include/node headers by the time npm runs.
+    NODE_DIR="$SANDBOX_HOME/.hermes/node"
+  elif [ -z "$NODE_DIR" ] && command -v node >/dev/null; then
+    NODE_DIR="$(dirname "$(dirname "$(command -v node)")")"
+  fi
+}
+configure_node_dir
 WAYLAND_SOCKET=""
 if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -n "${WAYLAND_DISPLAY:-}" ] \
   && [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -47,10 +47,6 @@ if [ "$home_parent" != / ]; then
 fi
 home_mounts+=(--bind "$DEV_SANDBOX_ROOT/home" "$DEV_SANDBOX_HOME")
 
-node_env=()
-if [ -n "${DEV_SANDBOX_NODE_DIR:-}" ]; then
-  node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
-fi
 electron_env=()
 if [ -n "${DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH:-}" ]; then
   electron_env+=(
@@ -89,6 +85,26 @@ if [ -d /nix ] && [[ "$(readlink -f "$DEV_SANDBOX_BASH")" == /nix/* ]]; then
 else
   USE_HOST_RUNTIME=true
 fi
+
+# Only pass node-gyp a header prefix that remains visible in the sandbox. An
+# install shortcut targets the managed Node prefix under sandbox HOME; the
+# installer populates matching include/node headers there before npm runs. A
+# Nix store prefix is immutable and /nix is mounted read-only. Host prefixes
+# such as /usr/local are hidden by sandbox mounts and must not leak through.
+configure_node_env() {
+  node_env=()
+  case "${DEV_SANDBOX_NODE_DIR:-}" in
+    "$DEV_SANDBOX_HOME"/*)
+      node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
+      ;;
+    /nix/*)
+      if [ "$USE_HOST_RUNTIME" = false ]; then
+        node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
+      fi
+      ;;
+  esac
+}
+configure_node_env
 
 runtime_mounts=()
 shim_mounts=()

--- a/tests/test_sandbox_stage2.py
+++ b/tests/test_sandbox_stage2.py
@@ -1,0 +1,138 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[1]
+DEV_SANDBOX = REPO_ROOT / "scripts" / "dev-sandbox.sh"
+STAGE2 = REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh"
+
+
+def _extract_shell_function(source: str, name: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", source)
+    assert match is not None, f"missing shell function: {name}"
+    return match.group(0)
+
+
+def test_host_runtime_does_not_inject_host_node_headers(tmp_path: Path) -> None:
+    root = tmp_path / "sandbox"
+    (root / "root" / "logs").mkdir(parents=True)
+    (root / "root" / "logs" / "slirp.ready").write_text("1\n")
+    (root / "root" / "usr" / "local").mkdir(parents=True)
+    (root / "root" / "usr" / "bin").mkdir(parents=True)
+    (root / "root" / "bin").mkdir(parents=True)
+    (root / "root" / "lib64").mkdir(parents=True)
+    (root / "home").mkdir()
+    (root / "etc").mkdir()
+
+    capture = tmp_path / "bwrap-args"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_bwrap = fake_bin / "bwrap"
+    fake_bwrap.write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\0' \"$@\" > \"$CAPTURE\"\n",
+        encoding="utf-8",
+    )
+    fake_bwrap.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CAPTURE": str(capture),
+            "DEV_SANDBOX_ROOT": str(root),
+            "DEV_SANDBOX_BASH": "/usr/bin/bash",
+            "DEV_SANDBOX_INTERACTIVE": "false",
+            "DEV_SANDBOX_USER": "hermes",
+            "DEV_SANDBOX_HOME": "/home/hermes",
+            "DEV_SANDBOX_NODE_DIR": "/usr/local",
+            "DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH": "",
+            "DEV_SANDBOX_XDG_RUNTIME_DIR": "",
+            "DEV_SANDBOX_WAYLAND_DISPLAY": "",
+            "DEV_SANDBOX_WAYLAND_SOCKET": "",
+        }
+    )
+    subprocess.run(
+        ["bash", str(STAGE2), "true"],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    args = capture.read_bytes().rstrip(b"\0").decode().split("\0")
+    assert ("--setenv", "npm_config_nodedir", "/usr/local") not in zip(
+        args, args[1:], args[2:]
+    )
+
+
+def test_install_shortcut_targets_future_managed_node_headers() -> None:
+    source = DEV_SANDBOX.read_text(encoding="utf-8")
+    function = _extract_shell_function(source, "configure_node_dir")
+    command = f"""
+set -euo pipefail
+{function}
+INSTALL_SHORTCUT=true
+SANDBOX_HOME=/home/hermes
+DEV_SANDBOX_NODE_DIR=
+configure_node_dir
+printf '%s\\n' "$NODE_DIR"
+"""
+    result = subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == "/home/hermes/.hermes/node\n"
+
+
+def test_managed_node_headers_are_injected_after_install() -> None:
+    source = STAGE2.read_text(encoding="utf-8")
+    function = _extract_shell_function(source, "configure_node_env")
+    command = f"""
+set -euo pipefail
+{function}
+USE_HOST_RUNTIME=true
+DEV_SANDBOX_HOME=/home/hermes
+DEV_SANDBOX_NODE_DIR=/home/hermes/.hermes/node
+configure_node_env
+printf '%s\\n' "${{node_env[@]}}"
+"""
+    result = subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == (
+        "--setenv\n"
+        "npm_config_nodedir\n"
+        "/home/hermes/.hermes/node\n"
+    )
+
+
+def test_nix_runtime_preserves_immutable_node_headers() -> None:
+    source = STAGE2.read_text(encoding="utf-8")
+    function = _extract_shell_function(source, "configure_node_env")
+    command = f"""
+set -euo pipefail
+{function}
+USE_HOST_RUNTIME=false
+DEV_SANDBOX_HOME=/home/hermes
+DEV_SANDBOX_NODE_DIR=/nix/store/nodejs-22
+configure_node_env
+printf '%s\\n' "${{node_env[@]}}"
+"""
+    result = subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == (
+        "--setenv\n"
+        "npm_config_nodedir\n"
+        "/nix/store/nodejs-22\n"
+    )


### PR DESCRIPTION
## Resumo

Corrige os dois percursos `v2026.8.27` que falham no workflow **Install & Update E2E**: `node-pty@1.1.0` não tem prebuild `linux-x64` para Node 26, o fallback `node-gyp rebuild` recebia `npm_config_nodedir=/usr/local` e falhava porque `common.gypi` não existe dentro do sandbox.

## Correção

- O shortcut de instalação (`scripts/dev-sandbox.sh`) passa a apontar o node-gyp para o prefixo Node gerido sob o HOME do sandbox (`$SANDBOX_HOME/.hermes/node`), que o instalador popula com headers `include/node` correspondentes antes de o npm compilar addons nativos.
- `scripts/sandbox/stage2-run.sh` só injeta `npm_config_nodedir` quando o prefixo permanece visível dentro do sandbox: sob `DEV_SANDBOX_HOME`, ou um prefixo imutável `/nix/store` com runtime Nix.
- Prefixos de host ocultos como `/usr/local` deixam de ser propagados.
- Um `DEV_SANDBOX_NODE_DIR` explícito mantém precedência.

## Verificação

- `uv run pytest tests/test_sandbox_stage2.py -q` — 4 passed
- `uvx ruff check tests/test_sandbox_stage2.py` — PASS
- `python3 -m py_compile tests/test_sandbox_stage2.py` — PASS
- `bash -n scripts/dev-sandbox.sh scripts/sandbox/stage2-run.sh tests/install/install-update-e2e.sh` — PASS
- `git diff --check HEAD^ HEAD` — PASS
- As 5 tags de release selecionadas são todas <= versão alvo 0.20.6 (sem rotas de downgrade)

## Segurança e rollback

Sem alterações de credenciais, configuração ou dependências. Os downloads de headers continuam limitados pelo proxy existente do sandbox. Rollback: reverter o commit.

## Limites

- Sem alteração de dependências ou do workflow.
- Sem merge autorizado.
- Uma execução manual integral de **Install & Update E2E** será lançada nesta branch e avaliada separadamente.