### PR TITLE
fix(agent): strip legacy `name` on tool-role messages in chat_completions wire

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -334,6 +334,19 @@ class ChatCompletionsTransport(ProviderTransport):
             ):
                 needs_sanitize = True
                 break
+            if msg.get("role") == "tool" and "name" in msg:
+                # ``name`` on a tool-result message is a legacy OpenAI
+                # function-calling field. The modern tool-message schema is
+                # {role, content, tool_call_id}; the tool→call linkage is
+                # carried by ``tool_call_id``, so ``name`` is redundant.
+                # Strict OpenAI-compatible proxies/gateways reject any request
+                # containing it with HTTP 400 ``unrecognizedProperty=name`` /
+                # "Request contained an unrecognized field". Permissive
+                # providers (real OpenAI, OpenRouter) silently ignore it,
+                # which masked the bug. Written by make_tool_result_message()
+                # / the conversation loop alongside ``tool_name``.
+                needs_sanitize = True
+                break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
@@ -411,6 +424,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
 
+            # ``name`` on a tool-result message — legacy function-calling
+            # field, redundant with ``tool_call_id``. Strict OpenAI-compatible
+            # proxies/gateways 400 with ``unrecognizedProperty=name``; drop
+            # it on tool messages only (assistant ``name`` is left untouched).
+            if msg.get("role") == "tool" and "name" in msg:
+                mutable_msg().pop("name", None)
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -101,6 +101,60 @@ class TestChatCompletionsBasic:
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
 
 
+    def test_convert_messages_strips_tool_message_name(self, transport):
+        """``name`` on a tool-result message is a legacy OpenAI
+        function-calling field, redundant with ``tool_call_id`` on the modern
+        tool-message schema. Strict OpenAI-compatible proxies/gateways reject
+        any request containing it with HTTP 400 ``unrecognizedProperty=name``;
+        permissive providers (real OpenAI, OpenRouter) silently ignore it,
+        which masked the bug. make_tool_result_message() / the conversation
+        loop write it alongside ``tool_name``, so drop it here for every
+        chat_completions target.
+        """
+        msgs = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "get_weather",
+                "content": "sunny",
+                "tool_call_id": "call_1",
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        # tool message loses ``name`` but keeps the linkage + content
+        assert "name" not in result[2]
+        assert result[2]["tool_call_id"] == "call_1"
+        assert result[2]["content"] == "sunny"
+        assert result[2]["role"] == "tool"
+        # assistant tool_calls[].function.name is untouched (not a message name)
+        assert result[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+        # original list untouched (deepcopy-on-demand)
+        assert msgs[2]["name"] == "get_weather"
+
+    def test_convert_messages_keeps_assistant_name(self, transport):
+        """Only tool-role ``name`` is stripped. A ``name`` on a user/assistant
+        message (multi-participant OpenAI convention) is a valid schema field
+        and must survive."""
+        msgs = [
+            {"role": "user", "name": "alice", "content": "hi"},
+            {"role": "assistant", "name": "bot", "content": "hello"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is msgs  # no tool-name / internal fields => no copy
+        assert result[0]["name"] == "alice"
+        assert result[1]["name"] == "bot"
+
     def test_convert_messages_no_codex_leaks(self, transport):
         msgs = [{"role": "user", "content": "hi"}]
         result = transport.convert_messages(msgs)


### PR DESCRIPTION
## Problem

Tool-result messages are constructed with a top-level `name` field (in `tool_dispatch_helpers.make_tool_result_message()` and in `conversation_loop.py`) alongside `tool_name`:

```python
message = stamp_message_timestamp({
    "role": "tool",
    "name": name,
    "tool_name": name,
    "content": wrapped,
    "tool_call_id": tool_call_id,
})
```

`name` is a legacy OpenAI **function-calling** field. The modern Chat Completions tool-message schema is `{role, content, tool_call_id}`, and the tool→call linkage is carried by `tool_call_id`, so `name` is redundant on `role: "tool"` messages.

Real OpenAI and permissive aggregators (OpenRouter, etc.) silently ignore the extra `name`, which hid the problem. **Strict OpenAI-compatible proxies/gateways reject it** with:

```
HTTP 400 INVALID_ARGUMENT
{unrecognizedProperty=name} — "Request contained an unrecognized field"
```

Because *every* tool result carries `name`, the first tool call in a session poisons every subsequent request on the `chat_completions` route — the session is stuck on HTTP 400 until `/new`. (An `anthropic_messages`-routed model in the same setup is unaffected, since that wire format never carries `name`.)

## Fix

This is the same class of leak already handled in `ChatCompletionsTransport.convert_messages` for `tool_name`, `timestamp`, etc. Strip `name` on **tool-role messages only**, in both the `needs_sanitize` detector and the copy-on-write pass. `name` on `user`/`assistant` messages (the valid multi-participant convention) is left untouched.

## Verification

Reproduced and verified against a live strict OpenAI-compatible proxy:

- Raw payload (tool message with `name`) → **HTTP 400** `unrecognizedProperty=name`
- Same payload routed through the patched `convert_messages` → **HTTP 200 OK**, with `tool_call_id` linkage and `content` preserved, original message list untouched.

## Tests

- `test_convert_messages_strips_tool_message_name` — tool-message `name` dropped; `tool_call_id`/content/role kept; assistant `tool_calls[].function.name` untouched; original list not mutated.
- `test_convert_messages_keeps_assistant_name` — `name` on user/assistant messages survives (no copy triggered).
