### PR TITLE
fix(whatsapp): fall back to the WhatsApp Web version when Baileys returns a stale build

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -20,6 +20,7 @@
  */
 
 import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
+import * as baileys from '@whiskeysockets/baileys';
 import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
@@ -396,7 +397,17 @@ function emitPairEvent(event) {
 }
 
 const scheduleReconnect = createReconnectScheduler(() => startSocket());
-const getWAVersion = createVersionResolver(fetchLatestBaileysVersion);
+// fetchLatestWaWebVersion() reads the build web.whatsapp.com is actually
+// serving, so it stays correct while the version list Baileys ships from
+// GitHub is unreachable or behind. Resolve it off the namespace rather than
+// naming it in the import list: an older Baileys without the export would
+// otherwise fail the whole module at link time instead of degrading to the
+// single-resolver behaviour (#88516).
+const fetchLatestWaWebVersion =
+  baileys.fetchLatestWaWebVersion || baileys.default?.fetchLatestWaWebVersion || null;
+const getWAVersion = createVersionResolver(fetchLatestBaileysVersion, {
+  fallbackFetchVersionFn: fetchLatestWaWebVersion,
+});
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -147,4 +147,84 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
   assert.ok(Date.now() - before < 1000);
 }
 
+// A stale answer (isLatest: false, the build baked into the library) is the
+// shape fetchLatestBaileysVersion() returns when its own fetch fails, and
+// WhatsApp rejects pairing against it with HTTP 405. The fallback resolver
+// runs and its fresh version wins (#88516).
+{
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 1035194821], isLatest: false }),
+    {
+      log: line => logs.push(line),
+      fallbackFetchVersionFn: async () => ({ version: [2, 3000, 1045340097], isLatest: true }),
+    },
+  );
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1045340097]);
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /stale WhatsApp build \(2\.3000\.1035194821\)/);
+  assert.match(logs[0], /trying the next resolver/);
+}
+
+// A failing primary hands over to the fallback rather than giving up on the
+// library default.
+{
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => { throw new Error('version host 503'); },
+    {
+      log: line => logs.push(line),
+      fallbackFetchVersionFn: async () => ({ version: [2, 3000, 1045340097], isLatest: true }),
+    },
+  );
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1045340097]);
+  assert.match(logs[0], /version host 503/);
+  assert.match(logs[0], /trying the next resolver/);
+}
+
+// With no fallback configured a stale answer is still returned: it is what
+// Baileys itself would have used, and it beats sending no version at all.
+{
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => ({ version: [2, 3000, 1035194821], isLatest: false }),
+    { log: line => logs.push(line) },
+  );
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1035194821]);
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /library default/);
+}
+
+// When both resolvers come back stale, a version cached from an earlier
+// success is preferred over either stale answer.
+{
+  let primaryCalls = 0;
+  const resolveVersion = createVersionResolver(
+    async () => {
+      primaryCalls += 1;
+      return primaryCalls === 1
+        ? { version: [2, 3000, 42], isLatest: true }
+        : { version: [2, 3000, 1035194821], isLatest: false };
+    },
+    {
+      log: () => {},
+      fallbackFetchVersionFn: async () => ({ version: [2, 3000, 7], isLatest: false }),
+    },
+  );
+  assert.deepEqual(await resolveVersion(), [2, 3000, 42]);
+  assert.deepEqual(await resolveVersion(), [2, 3000, 42]);
+}
+
+// A response without a version field is treated as a failure, not as a
+// version of `undefined` handed to makeWASocket().
+{
+  const logs = [];
+  const resolveVersion = createVersionResolver(
+    async () => ({ isLatest: true }),
+    { log: line => logs.push(line) },
+  );
+  assert.equal(await resolveVersion(), null);
+  assert.match(logs[0], /version missing from response/);
+}
+
 console.log('bridge.reconnect.test.mjs: all assertions passed');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -600,27 +600,62 @@ export function createReconnectScheduler(startFn, {
  * pend forever and wedge the reconnect path (the scheduler above cannot
  * retry past an await that never settles). Bound the fetch and fall back to
  * the last known-good version, or the Baileys default before first success.
+ *
+ * A fetch can also "succeed" with a build WhatsApp no longer accepts:
+ * fetchLatestBaileysVersion() swallows its own transport errors (a 503 from
+ * the version host, say) and resolves with the version baked into the
+ * library plus `isLatest: false`. Pairing against that stale build is
+ * rejected with HTTP 405 before a QR code is ever drawn (#88516), so a
+ * stale answer is treated as a failed one: `fallbackFetchVersionFn` (the
+ * caller passes Baileys' own fetchLatestWaWebVersion, which reads the live
+ * web.whatsapp.com build) is tried next, and the stale version is used only
+ * when nothing fresher is available.
  */
 export function createVersionResolver(fetchVersionFn, {
   timeoutMs = 15000,
   log = console.log,
+  fallbackFetchVersionFn = null,
 } = {}) {
+  const fetchers = [fetchVersionFn, fallbackFetchVersionFn].filter(
+    fn => typeof fn === 'function',
+  );
   let cachedVersion = null;
   return async function resolveVersion() {
-    let timer = null;
-    try {
-      const { version } = await Promise.race([
-        fetchVersionFn(),
-        new Promise((_, reject) => {
-          timer = setTimeout(() => reject(new Error('version fetch timed out')), timeoutMs);
-        }),
-      ]);
-      cachedVersion = version;
-    } catch (err) {
-      log(`⚠️  Baileys version fetch failed (${err?.message || err}); using ${cachedVersion ? 'cached version' : 'library default'}.`);
-    } finally {
-      if (timer) clearTimeout(timer);
+    let staleVersion = null;
+    for (let i = 0; i < fetchers.length; i++) {
+      const isLastFetcher = i === fetchers.length - 1;
+      const nextHint = isLastFetcher
+        ? `using ${cachedVersion ? 'cached version' : 'library default'}`
+        : 'trying the next resolver';
+      let timer = null;
+      try {
+        const result = await Promise.race([
+          fetchers[i](),
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error('version fetch timed out')), timeoutMs);
+          }),
+        ]);
+        const version = result?.version || null;
+        if (!version) {
+          throw new Error('version missing from response');
+        }
+        if (result.isLatest === false) {
+          staleVersion = staleVersion || version;
+          const printable = Array.isArray(version) ? version.join('.') : String(version);
+          log(`⚠️  Baileys version fetch returned a stale WhatsApp build (${printable}); WhatsApp rejects it with HTTP 405, ${nextHint}.`);
+          continue;
+        }
+        cachedVersion = version;
+        return cachedVersion;
+      } catch (err) {
+        log(`⚠️  Baileys version fetch failed (${err?.message || err}); ${nextHint}.`);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
     }
-    return cachedVersion;
+    // Every resolver came back stale or failed. A previously cached version
+    // is the best answer; without one, the stale build still beats no
+    // version at all (it is what Baileys would have used anyway).
+    return cachedVersion || staleVersion;
   };
 }


### PR DESCRIPTION
## What does this PR do?

`fetchLatestBaileysVersion()` swallows its own transport errors. When the version list it fetches from GitHub is unreachable (the reporter saw a 503) it still resolves, handing back the version baked into the library together with `isLatest: false`. The bridge accepted that answer, WhatsApp rejected the connection with HTTP 405, and pairing never reached a QR code:

```
Baileys version fetch failed (version fetch timed out); using library default.
Connection closed (reason: 405). Reconnecting in 3s...
```

`createVersionResolver()` now treats a stale answer the same way it already treats a failed one and moves on to the next resolver. `bridge.js` passes Baileys' own `fetchLatestWaWebVersion`, which reads the build `web.whatsapp.com` is actually serving, as that fallback.

Two deliberate details:

* The stale version is still returned when nothing fresher is available, and a version cached from an earlier success still wins over any stale answer. A bridge with no fallback configured behaves exactly as before.
* `fetchLatestWaWebVersion` is resolved off the module namespace rather than named in the import list. A Baileys build without that export would otherwise fail the whole module at link time instead of degrading to the previous single-resolver behaviour.

## Related Issue

Fixes #88516

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` — `createVersionResolver()` takes an optional `fallbackFetchVersionFn`, iterates its resolvers, treats `isLatest: false` and a missing `version` field as failures, and keeps the stale answer only as a last resort. Log lines now say whether the next resolver is being tried or the resolver is falling back.
- `scripts/whatsapp-bridge/bridge.js` — imports the Baileys namespace, resolves `fetchLatestWaWebVersion` defensively, and passes it as the fallback resolver.
- `scripts/whatsapp-bridge/bridge.reconnect.test.mjs` — five assertions covering: stale primary plus fresh fallback, failing primary plus fresh fallback, stale primary with no fallback configured, both resolvers stale with a cached version present, and a response with no `version` field.

## How to Test

1. `node scripts/whatsapp-bridge/bridge.reconnect.test.mjs` (all assertions pass, including the pre-existing ones for the reconnect scheduler).
2. To reproduce the original failure, point the primary resolver at a host that answers 503 so `fetchLatestBaileysVersion()` returns `isLatest: false` with the baked-in build, then run `hermes whatsapp`. Before this change the socket is closed with reason 405 and no QR code is drawn; after it, the WhatsApp Web version is used and pairing proceeds.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — this change is JS only; I ran the bridge's own node test file instead
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Node 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the helper) — no user-facing docs describe this resolver
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: the change is platform independent, and the defensive namespace lookup keeps older Baileys installs working
- [x] N/A — no tool descriptions or schemas changed
