### PR TITLE
fix(kanban): reap the worker complete_task and block_task stop tracking

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5370,6 +5370,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5396,6 +5397,12 @@ def complete_task(
     ``completion_blocked_hallucination`` event is emitted so the rejected
     attempt is auditable. When all ids verify, they are recorded on the
     ``completed`` event payload.
+
+    A ``running`` task's worker is reaped before the transition (see
+    :func:`_reap_forgotten_worker`) so completing a card never leaves an
+    unsupervised child behind with no pid on the board. A worker completing
+    its own card is left alone; ``signal_fn`` is a test hook mirroring
+    :func:`reclaim_task`.
 
     After a successful completion, ``summary`` and ``result`` are scanned
     for prose references like ``t_deadbeefcafe`` that do not resolve.
@@ -5439,6 +5446,8 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    # Outside the write txn: termination polls the pid with time.sleep.
+    worker_reap = _reap_forgotten_worker(conn, task_id, signal_fn=signal_fn)
     with write_txn(conn):
         # Parent completion is a hard invariant even for direct human review
         # approval. A parent may have been reopened after this task entered
@@ -5539,6 +5548,8 @@ def complete_task(
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
         }
+        if worker_reap:
+            completed_payload["worker_reap"] = worker_reap
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
         # Carry artifact paths in the event payload so the gateway
@@ -6261,6 +6272,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -6286,6 +6298,12 @@ def block_task(
       can use it to signal "this might clear on its own"; it still participates
       in the loop breaker so a forever-flaky task eventually escalates.
 
+    A ``running`` task's worker is reaped before the transition (see
+    :func:`_reap_forgotten_worker`) so blocking a card never leaves an
+    unsupervised child behind with no pid on the board. A worker blocking
+    its own card is left alone; ``signal_fn`` is a test hook mirroring
+    :func:`reclaim_task`.
+
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
@@ -6294,6 +6312,8 @@ def block_task(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
     recurrences = 0
+    # Outside the write txn: termination polls the pid with time.sleep.
+    worker_reap = _reap_forgotten_worker(conn, task_id, signal_fn=signal_fn)
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -6350,6 +6370,7 @@ def block_task(
                     "reason": reason,
                     "kind": kind,
                     "source_status": source_status,
+                    **({"worker_reap": worker_reap} if worker_reap else {}),
                 },
                 run_id=run_id,
             )
@@ -6410,6 +6431,7 @@ def block_task(
                     "recurrences": recurrences,
                     "limit": BLOCK_RECURRENCE_LIMIT,
                     "source_status": source_status,
+                    **({"worker_reap": worker_reap} if worker_reap else {}),
                 },
                 run_id=run_id,
             )
@@ -6467,6 +6489,7 @@ def block_task(
                     "kind": kind,
                     "recurrences": recurrences,
                     "source_status": source_status,
+                    **({"worker_reap": worker_reap} if worker_reap else {}),
                 },
                 run_id=run_id,
             )
@@ -8321,6 +8344,72 @@ def _terminate_reclaimed_worker(
 
     info["terminated"] = not _pid_alive(pid)
     return info
+
+
+def _pid_is_self_or_ancestor(pid: int) -> bool:
+    """True when ``pid`` is this process or one of its ancestors.
+
+    A worker reports its own outcome: ``kanban_complete`` / ``kanban_block``
+    run inside the very process the board recorded as ``worker_pid`` (or a
+    child of it). Signalling that pid would kill the worker mid-report, so
+    the reap in :func:`_reap_forgotten_worker` skips it. Falls back to the
+    direct parent when ``psutil`` cannot walk the tree.
+    """
+    if pid <= 0:
+        return False
+    if pid == os.getpid():
+        return True
+    try:
+        import psutil
+
+        for parent in psutil.Process(os.getpid()).parents():
+            if parent.pid == pid:
+                return True
+        return False
+    except Exception:
+        try:
+            return pid == os.getppid()
+        except Exception:
+            return False
+
+
+def _reap_forgotten_worker(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    signal_fn=None,
+) -> dict[str, Any]:
+    """Terminate the worker a ``done``/``blocked`` transition is about to drop.
+
+    ``complete_task`` and ``block_task`` NULL ``worker_pid`` in the same
+    UPDATE that moves the task out of ``running``. That used to be the end
+    of it: the child kept executing with full credentials, and the board no
+    longer held the pid, so ``reclaim``/``block``/``complete`` had nothing
+    left to signal (#90073). Reap it here, with the same host-local,
+    best-effort, SIGTERM-then-SIGKILL semantics the reclaim path already
+    uses.
+
+    Two cases are deliberately left alone:
+
+    * a task that is not ``running`` (a manual ``complete`` on a ``ready`` /
+      ``blocked`` / ``review`` card has no worker in flight), and
+    * a pid that is this process or one of its ancestors, which is the
+      normal shape of a worker reporting its own completion.
+
+    Returns the termination info dict (empty when nothing was reaped) for
+    the caller to attach to its event payload. Must be called BEFORE the
+    caller's write transaction: termination polls with ``time.sleep``.
+    """
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or row["status"] != "running" or not row["worker_pid"]:
+        return {}
+    pid = int(row["worker_pid"])
+    if _pid_is_self_or_ancestor(pid):
+        return {"prev_pid": pid, "self_reported": True}
+    return _terminate_reclaimed_worker(pid, row["claim_lock"], signal_fn=signal_fn)
 
 
 def _worker_survived_termination(termination: dict) -> bool:

--- a/tests/hermes_cli/test_kanban_complete_reaps_worker.py
+++ b/tests/hermes_cli/test_kanban_complete_reaps_worker.py
@@ -1,0 +1,148 @@
+"""complete_task / block_task must reap the worker they stop tracking (#90073).
+
+Both transitions NULL ``worker_pid`` in the same UPDATE that moves a task
+out of ``running``. Without a reap the child kept running unsupervised and
+the board had no pid left to signal, so ``reclaim`` / ``block`` / ``complete``
+could not stop it afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+FOREIGN_PID = 999_999
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    yield home
+
+
+@pytest.fixture
+def dead_after_sigterm(monkeypatch):
+    """Pretend the signalled worker exits at once so the poll loop is fast."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+
+
+def _running_task(conn, *, pid: int) -> str:
+    tid = kb.create_task(conn, title="long job", assignee="worker")
+    kb.claim_task(conn, tid)
+    kb._set_worker_pid(conn, tid, pid)
+    return tid
+
+
+def _event(conn, tid, kind):
+    return next(e for e in kb.list_events(conn, tid) if e.kind == kind)
+
+
+def test_complete_terminates_a_worker_it_did_not_spawn(
+    kanban_home, dead_after_sigterm
+):
+    killed = []
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, pid=FOREIGN_PID)
+
+        assert kb.complete_task(
+            conn, tid, result="done", signal_fn=lambda pid, sig: killed.append((pid, sig)),
+        ) is True
+
+        assert killed == [(FOREIGN_PID, signal.SIGTERM)]
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.worker_pid is None
+        reap = _event(conn, tid, "completed").payload["worker_reap"]
+        assert reap["prev_pid"] == FOREIGN_PID
+        assert reap["terminated"] is True
+    finally:
+        conn.close()
+
+
+def test_complete_does_not_signal_the_worker_reporting_itself(kanban_home):
+    """The worker calls kanban_complete from inside worker_pid's process."""
+    killed = []
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, pid=os.getpid())
+
+        assert kb.complete_task(
+            conn, tid, result="done", signal_fn=lambda pid, sig: killed.append((pid, sig)),
+        ) is True
+
+        assert killed == []
+        assert kb.get_task(conn, tid).status == "done"
+        reap = _event(conn, tid, "completed").payload["worker_reap"]
+        assert reap == {"prev_pid": os.getpid(), "self_reported": True}
+    finally:
+        conn.close()
+
+
+def test_complete_of_an_unclaimed_task_signals_nothing(kanban_home):
+    killed = []
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="manual card", assignee="worker")
+
+        assert kb.complete_task(
+            conn, tid, result="done", signal_fn=lambda pid, sig: killed.append((pid, sig)),
+        ) is True
+
+        assert killed == []
+        assert "worker_reap" not in _event(conn, tid, "completed").payload
+    finally:
+        conn.close()
+
+
+def test_block_terminates_a_worker_it_did_not_spawn(
+    kanban_home, dead_after_sigterm
+):
+    killed = []
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, pid=FOREIGN_PID)
+
+        assert kb.block_task(
+            conn, tid, reason="needs a key", kind="needs_input",
+            signal_fn=lambda pid, sig: killed.append((pid, sig)),
+        ) is True
+
+        assert killed == [(FOREIGN_PID, signal.SIGTERM)]
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.worker_pid is None
+        reap = _event(conn, tid, "blocked").payload["worker_reap"]
+        assert reap["prev_pid"] == FOREIGN_PID
+        assert reap["terminated"] is True
+    finally:
+        conn.close()
+
+
+def test_dependency_block_terminates_the_worker_too(
+    kanban_home, dead_after_sigterm
+):
+    killed = []
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, pid=FOREIGN_PID)
+
+        assert kb.block_task(
+            conn, tid, reason="waiting on parent", kind="dependency",
+            signal_fn=lambda pid, sig: killed.append((pid, sig)),
+        ) is True
+
+        assert killed == [(FOREIGN_PID, signal.SIGTERM)]
+        assert kb.get_task(conn, tid).worker_pid is None
+        assert _event(conn, tid, "dependency_wait").payload["worker_reap"]["prev_pid"] == FOREIGN_PID
+    finally:
+        conn.close()


### PR DESCRIPTION
## What does this PR do?

`complete_task` and `block_task` set `worker_pid = NULL` in the same UPDATE that moves a task out of `running`, and never signal the child. The board then has no handle on a process that keeps executing with full credentials: `reclaim`, `block` and `complete` all have nothing left to signal. The reporter had a card marked done for hours while its worker kept provisioning live cloud resources.

Both paths now call `_reap_forgotten_worker()` before their write transaction, reusing the host-local, best-effort, SIGTERM-then-SIGKILL semantics that `reclaim_task` already gets from `_terminate_reclaimed_worker()`. The reap runs outside the transaction because termination polls with `time.sleep`, which has no business inside one. The outcome is recorded on the `completed` / `blocked` / `dependency_wait` / `block_loop_detected` event payloads as `worker_reap`, so it shows up in `hermes kanban tail`.

Two cases are deliberately left alone:

* A task that is not `running` has no worker in flight. A manual `hermes kanban complete` on a `ready`, `blocked` or `review` card signals nothing.
* A `worker_pid` that is this process or one of its ancestors is the normal shape of a worker reporting its own outcome through `kanban_complete` / `kanban_block`. Signalling that one would kill the worker mid-report, so it is skipped and recorded as `self_reported`.

On the design caveat raised in the issue: this PR deliberately does not add a grace period or a defer ladder. It gives completion and blocking exactly the termination semantics the reclaim path already has, so the board never loses a live pid. If maintainers want `_defer_reclaim_for_live_worker`-style deferral for state-mutating work, that is a follow-up that should apply to reclaim and to these two paths together rather than only here.

## Related Issue

Fixes #90073

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`
  - `_pid_is_self_or_ancestor()` — true when the recorded pid is this process or one of its ancestors, via `psutil` with a direct-parent fallback.
  - `_reap_forgotten_worker()` — reads status, claim lock and pid, skips non-running tasks and self-reported pids, otherwise delegates to `_terminate_reclaimed_worker()` and returns the info dict.
  - `complete_task()` and `block_task()` — take an optional `signal_fn` test hook (mirroring `reclaim_task`), call the reap before their write transaction, and attach the result to their event payloads.
- `tests/hermes_cli/test_kanban_complete_reaps_worker.py` — new file, five tests: complete reaps a foreign worker, complete does not signal a worker reporting itself, complete of an unclaimed card signals nothing, block reaps a foreign worker, and a dependency block reaps it too.

## How to Test

1. `pytest tests/hermes_cli/test_kanban_complete_reaps_worker.py -q` (5 passed).
2. `pytest tests/hermes_cli -k kanban -q` and `pytest tests/plugins/test_kanban_dashboard_plugin.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_wake_scope.py tests/tools/test_kanban_tools.py tests/tools/test_kanban_redaction.py -q` (96 passed).
3. Manually: dispatch a long-running task, confirm `worker_pid` is set, mark the card done from another process (`hermes kanban complete <id>`), and confirm the worker receives SIGTERM and the `completed` event carries a `worker_reap` payload. Completing the same card from inside the worker still leaves it running to finish its own report.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the kanban suites listed above rather than the whole tree. `tests/hermes_cli -k kanban` has 15 failures on an unmodified checkout of the same base commit, and this branch has the same 15 plus 5 new passes.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both entry points and the new helpers)
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: termination reuses the existing helper, which already handles the missing `SIGKILL` on Windows, and the ancestor walk falls back to `os.getppid()` when `psutil` cannot read the tree
- [x] N/A — no tool descriptions or schemas changed
