### PR TITLE
fix(memory): adopt legacy section-delimited stores instead of freezing them

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 from tools.memory_tool import (
+    ENTRY_DELIMITER,
     MemoryStore,
     memory_tool,
     _scan_memory_content,
@@ -487,6 +488,89 @@ class TestExternalDriftGuard:
 
         result = store.replace("memory", "Entry two", "Entry two replaced.")
         assert result["success"] is True
+
+    def test_legacy_sectioned_file_is_adopted_not_refused(self, store):
+        """A pre-§ ``##``-sectioned MEMORY.md stays writable (#94121).
+
+        It parses as ONE entry the size of the whole file, so the
+        entry-size signal used to fire on every call and freeze the store
+        with a .bak snapshot and no migration path.
+        """
+        path = store._path_for("memory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "## Vendors\nAcme ships on Tuesdays.\n\n"
+            "## Standing orders\nAlways confirm totals.\n\n"
+            "## Pin board\nQ3 review is on the 14th.\n",
+            encoding="utf-8",
+        )
+
+        store.load_from_disk()
+        assert len(store.memory_entries) == 3
+        assert store.memory_entries[0].startswith("## Vendors")
+
+        result = store.replace("memory", "Acme ships", "## Vendors\nAcme ships daily.")
+
+        assert result["success"] is True, result.get("error")
+        # The successful write persists the store in § form; every legacy
+        # section survives it.
+        updated = path.read_text(encoding="utf-8")
+        assert ENTRY_DELIMITER in updated
+        assert "Acme ships daily." in updated
+        assert "Standing orders" in updated
+        assert "Pin board" in updated
+
+    def test_legacy_preamble_is_kept_as_an_entry(self, store):
+        """Content above the first heading is content, not something to drop."""
+        path = store._path_for("memory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "User prefers brevity.\n\n## Vendors\nAcme.\n\n## Pin board\nQ3.\n",
+            encoding="utf-8",
+        )
+
+        store.load_from_disk()
+
+        assert store.memory_entries[0] == "User prefers brevity."
+        assert len(store.memory_entries) == 3
+
+    def test_oversized_legacy_section_is_still_drift(self, store):
+        """Adoption does not weaken the guard against free-form appends.
+
+        A section larger than the whole-store limit is the shape #26045
+        cares about: an external writer dumping a blob the tool would
+        truncate on flush. It is still refused, with the backup.
+        """
+        path = store._path_for("memory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "## Vendors\n" + "x" * 800 + "\n\n## Pin board\nQ3 review.\n",
+            encoding="utf-8",
+        )
+        original = path.read_text(encoding="utf-8")
+
+        result = store.replace("memory", "Q3 review", "Q3 review moved.")
+
+        assert result["success"] is False
+        assert "drift_backup" in result
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_single_heading_entry_is_not_split(self, store):
+        """One heading is an entry that starts with markdown, not a document."""
+        store.add("memory", "## Deploy runbook\nRun the smoke tests first.")
+
+        store.load_from_disk()
+
+        assert store.memory_entries == ["## Deploy runbook\nRun the smoke tests first."]
+
+    def test_delimited_store_with_headings_keeps_its_entries(self, store):
+        """A § file is a tool-written store however its entries are written."""
+        store.add("memory", "## Vendors\nAcme.")
+        store.add("memory", "## Pin board\nQ3.")
+
+        store.load_from_disk()
+
+        assert store.memory_entries == ["## Vendors\nAcme.", "## Pin board\nQ3."]
 
     def test_drift_guard_also_protects_user_target(self, store):
         """USER.md gets the same guarantee as MEMORY.md."""

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,6 +26,7 @@ Design:
 import copy
 import json
 import logging
+import re
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -76,6 +77,12 @@ MEMORY_BLOCK_HEADERS = {
 }
 
 ENTRY_DELIMITER = "\n§\n"
+
+# Heading of a section in a pre-§ MEMORY.md. Stores written before the
+# delimited format (and files people still write by hand) separate their
+# facts with markdown headings and nothing else, so that is the one legacy
+# shape the parser adopts - see MemoryStore._legacy_sections.
+_LEGACY_SECTION_RE = re.compile(r"^#{2,6} \S", re.MULTILINE)
 
 
 # ---------------------------------------------------------------------------
@@ -803,10 +810,48 @@ class MemoryStore:
             return "", False
 
     @staticmethod
+    def _legacy_sections(raw: str) -> Optional[List[str]]:
+        """Split a pre-§ ``##``-sectioned memory file into entries.
+
+        A MEMORY.md in the legacy markdown format carries no § at all, so
+        the delimiter parse yields ONE entry holding the whole file. That
+        blob is larger than the store's char limit by construction on any
+        store with history, which trips the entry-size drift signal, and
+        every replace/remove is then refused with a .bak snapshot: the
+        store is permanently read-only with no way back through the tool
+        (#94121). Adopting the sections as entries instead makes the file
+        round-trippable, so the content survives the next flush (the
+        concern behind the guard in #26045) and the store becomes editable
+        again. The first successful write persists it in § form.
+
+        Returns ``None`` when *raw* is not in that shape: a file that
+        already holds a delimiter is a tool-written store, and one lone
+        heading is just an entry that happens to start with markdown, not
+        a sectioned document.
+        """
+        if ENTRY_DELIMITER in raw:
+            return None
+        starts = [m.start() for m in _LEGACY_SECTION_RE.finditer(raw)]
+        if len(starts) < 2:
+            return None
+        # Anything before the first heading is content too (a title line, or
+        # entries a tool wrote before the file was hand-edited); keep it as
+        # its own entry rather than dropping it.
+        bounds = starts if starts[0] == 0 else [0] + starts
+        sections = [
+            raw[start:end].strip()
+            for start, end in zip(bounds, bounds[1:] + [len(raw)])
+        ]
+        return [s for s in sections if s]
+
+    @staticmethod
     def _parse_entries(raw: str) -> List[str]:
         """Split raw memory-file text into stripped, non-empty entries."""
         if not raw.strip():
             return []
+        legacy = MemoryStore._legacy_sections(raw)
+        if legacy is not None:
+            return legacy
         # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
         # alone would incorrectly split entries that contain "§" in their content.
         entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
@@ -851,7 +896,11 @@ class MemoryStore:
 
         1. Round-trip mismatch — re-parsing and re-serializing the file
            doesn't produce identical bytes (rare; would catch oddly-encoded
-           delimiters).
+           delimiters). A legacy ``##``-sectioned file is exempt: the parser
+           adopts its sections as entries (see ``_legacy_sections``), so the
+           content DOES survive a flush and refusing the write would only
+           freeze the store (#94121). Signal 2 still applies to it, which is
+           what keeps a free-form external append out.
         2. Entry-size overflow — any single parsed entry exceeds the
            store's whole-file char limit. The tool budgets the ENTIRE store
            against that limit; no single tool-written entry can exceed it.
@@ -871,13 +920,18 @@ class MemoryStore:
         if not raw.strip():
             return None
 
-        parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-        roundtrip = ENTRY_DELIMITER.join(parsed)
+        legacy = self._legacy_sections(raw)
+        if legacy is not None:
+            parsed = legacy
+            roundtrip_ok = True
+        else:
+            parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+            roundtrip_ok = raw.strip() == ENTRY_DELIMITER.join(parsed)
 
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        drift_detected = (not roundtrip_ok) or (max_entry_len > char_limit)
         if not drift_detected:
             return None
 


### PR DESCRIPTION
## What does this PR do?

A `MEMORY.md` written in the legacy `##`-sectioned format carries no `§` at all, so `_parse_entries` returns the whole file as a single entry. On any store with history that one entry is larger than `memory.memory_char_limit`, which trips signal 2 of the drift guard (`max_entry_len > char_limit`). Every `replace` and `remove` is then refused with a `.bak` snapshot, and the store is permanently read-only with no way back through the tool:

```
Refusing to write MEMORY.md: file on disk has content that wouldn't round-trip
through the memory tool ... A snapshot was saved to <path>.bak.<ts>
```

The root cause is that one number serves two purposes: `memory_char_limit` is both the whole-store write budget and the per-entry drift threshold, so the guard cannot tell a good store in an old format from a free-form external append, and it has no branch that adopts a legacy shape.

`_legacy_sections()` recognises that shape (no delimiter anywhere, two or more markdown section headings) and splits it into one entry per section, keeping anything above the first heading as its own entry. Such a file is exempt from the round-trip signal, because after adoption its content round-trips and therefore survives a flush, which is exactly what that signal exists to protect. The first successful write persists the store in `§` form, so the migration happens through the normal write path with no rewrite-on-read.

The entry-size signal still applies to adopted files, so the case the guard was added for in #26045 (an external writer appending a blob larger than the limit, which a flush would truncate) is refused exactly as before. `TestExternalDriftGuard`'s existing tests plant 800-char sections against a 500-char limit and still fail closed.

Effect for the reporter: the store loads as real entries, `remove` and `replace` work again, and an over-budget `add` returns the normal actionable "consolidate now" error with `current_entries` instead of a drift refusal. Recovery no longer requires hand-rewriting the file.

## Related Issue

Fixes #94121

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`
  - `_LEGACY_SECTION_RE` next to `ENTRY_DELIMITER`, plus `import re`.
  - `MemoryStore._legacy_sections()` — returns the sections of a pre-`§` file, or `None` when the file is not in that shape (a delimiter is present, or there is at most one heading, which is just an entry that starts with markdown).
  - `MemoryStore._parse_entries()` — adopts the legacy sections when they are found.
  - `MemoryStore._detect_external_drift()` — skips the round-trip signal for an adopted file and keeps the entry-size signal for it, with the reasoning recorded in the docstring.
- `tests/tools/test_memory_tool.py` — five tests: a legacy file is adopted and `replace` succeeds and migrates it to `§` form, preamble above the first heading is kept, an oversized legacy section is still drift, a single-heading entry is not split, and a delimited store whose entries contain headings keeps its entries.

## How to Test

1. `pytest tests/tools/test_memory_tool.py -q` (46 passed). Reverting only `tools/memory_tool.py` makes the two new bug-reproducing tests fail, and the pre-existing drift tests keep passing either way.
2. `pytest tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool_import_fallback.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_memory_status.py tests/agent/test_memory_write_bridge.py tests/agent/test_learning_mutations.py tests/agent/test_skip_memory_store_65429.py tests/tools/test_write_approval.py -q` (79 passed).
3. Manually: write a `##`-sectioned `MEMORY.md` larger than `memory.memory_char_limit` with sections smaller than the limit, then call `memory(action="remove", ...)`. Before this change every call returns the drift refusal and a `.bak`; after it, the store loads as one entry per section, the write lands, and the file on disk is rewritten in `§` form.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the memory suites listed above rather than the whole tree. The 6 failures in `tests/plugins/memory/test_hindsight_provider.py` are present on an unmodified checkout of the same base commit and are unrelated.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper and the drift guard)
- [x] N/A — no config keys changed. This PR deliberately does not touch the `memory_char_limit` default or split it into a separate per-entry threshold; those are the issue's suggestions 2 and 3 and are a behaviour change for every user, so they belong in their own PR.
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: parsing only, no platform-specific paths
- [x] N/A — no tool descriptions or schemas changed
