### PR TITLE
fix(security): gate the shell startup files 69dd0f7cf1 missed

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -471,6 +471,96 @@ class TestSensitiveCopyMovePattern:
             assert dangerous is False, cmd
 
 
+class TestShellStartupFileParity:
+    """Every shell-EXECUTED startup file must be gated, not just five of them.
+
+    ``_SHELL_RC_FILES`` originally listed ``.bashrc``, ``.zshrc``, ``.profile``,
+    ``.bash_profile``, ``.zprofile`` (69dd0f7cf1, to stop unprompted backdoor
+    installs). Siblings with identical execution semantics were left ungated, so
+    the same backdoor landed under a different filename:
+
+    * ``.bash_aliases`` is sourced BY ``.bashrc`` — the stock Debian/Ubuntu
+      ``/etc/skel/.bashrc`` does exactly that — so it substitutes directly for a
+      gated file.
+    * ``.zshenv`` is sourced for EVERY zsh invocation including non-interactive
+      scripts, strictly broader than the gated ``.zshrc``.
+    * ``.zlogin`` / ``.bash_login`` / ``.login`` (login) and ``.zlogout`` /
+      ``.bash_logout`` (logout) share the trigger class of ``.profile``.
+    * ``.kshrc`` / ``.cshrc`` / ``.tcshrc`` are the ksh/csh/tcsh ``.bashrc``.
+
+    Measured before: 0/7 write vectors gated for each of the ten.
+    """
+
+    NEWLY_GATED = (
+        ".zshenv", ".zlogin", ".zlogout", ".bash_aliases", ".bash_login",
+        ".bash_logout", ".kshrc", ".cshrc", ".tcshrc", ".login",
+    )
+    ALREADY_GATED = (
+        ".bashrc", ".zshrc", ".profile", ".bash_profile", ".zprofile",
+    )
+    WRITE_VECTORS = (
+        "echo x >> {p}",
+        "echo x > {p}",
+        "echo x | tee -a {p}",
+        "cp /tmp/evil {p}",
+        "mv /tmp/evil {p}",
+        "install -m600 /tmp/c {p}",
+        "sed -i 's/a/b/' {p}",
+    )
+
+    def test_sibling_startup_files_are_gated(self):
+        for name in self.NEWLY_GATED:
+            for vector in self.WRITE_VECTORS:
+                command = vector.format(p=f"~/{name}")
+                dangerous, key, _ = detect_dangerous_command(command)
+                assert dangerous is True, command
+                assert key is not None, command
+
+    def test_original_five_still_gated(self):
+        """Widening the alternation must not regress the pre-existing five."""
+        for name in self.ALREADY_GATED:
+            for vector in self.WRITE_VECTORS:
+                command = vector.format(p=f"~/{name}")
+                dangerous, key, _ = detect_dangerous_command(command)
+                assert dangerous is True, command
+
+    def test_letter_continuation_near_misses_stay_safe(self):
+        """A longer name that merely starts with a gated one must not match.
+
+        Only letter-continuation forms are asserted. ``~/.bashrc.bak`` and
+        ``~/.zshrc-template`` DO flag, because ``\\b`` treats ``.`` and ``-`` as
+        word boundaries — pre-existing behaviour of this shared pattern on
+        unmodified main, not a property of this change.
+        """
+        for command in (
+            "echo x >> ~/.logins.json",
+            "echo x >> ~/.zshenvrc-notes",
+            "echo x >> ~/.kshrcx",
+            "echo x >> ~/.loginx",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+            assert key is None, command
+
+    def test_unrelated_dotfiles_and_reads_stay_safe(self):
+        """Non-executed dotfiles, non-$HOME paths, and reads are not writes to a
+        startup file. ``.inputrc`` is readline config, not shell code, so it is
+        deliberately out of scope."""
+        for command in (
+            "echo x >> ~/.gitconfig",
+            "echo x >> ~/.vimrc",
+            "echo x >> ~/.tmux.conf",
+            "echo x >> ~/.inputrc",
+            "echo x >> /opt/app/.bashrc",
+            "echo x >> ./project/.zshenv",
+            "cat ~/.zshenv",
+            "grep alias ~/.bash_aliases",
+            "sed -n '1,5p' ~/.zshrc",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+
 class TestSensitiveInPlaceEditPattern:
     """Detect in-place edits to user startup and credential files."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -407,11 +407,37 @@ _HERMES_CONFIG_PATH = (
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
 )
-_PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
+# ``.env``, its dotted variants (``.env.local``), and ``.envrc``. The ``rc``
+# tail needs its own alternative because the dotted-suffix group requires a
+# leading ``.``: ``.envrc`` used to match only its ``.env`` prefix, and the
+# write-target boundary anchors then rejected that partial match. So direnv's
+# ``.envrc`` was ungated on every write vector even though the read guard
+# blocks it by basename — and it is shell direnv sources on cd, making a write
+# arbitrary code execution.
+_PROJECT_ENV_PATH = (
+    r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:rc\b|(?:\.[^/\s"\'`]+)*))'
+)
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
+# Shell startup files: writing one installs a command that runs on the user's
+# next shell. The original five (69dd0f7cf1) left siblings with identical
+# execution semantics ungated, so the same backdoor landed unprompted under a
+# different filename:
+#   * ``.bash_aliases`` is sourced BY ``.bashrc`` — the stock Debian/Ubuntu
+#     ``/etc/skel/.bashrc`` does exactly that — so it is a direct substitute
+#     for a file already gated.
+#   * ``.zshenv`` is sourced for EVERY zsh invocation including non-interactive
+#     scripts, making it strictly broader than the gated ``.zshrc``.
+#   * ``.zlogin`` / ``.bash_login`` / ``.login`` run at login, and
+#     ``.zlogout`` / ``.bash_logout`` at logout, the same trigger class as the
+#     gated ``.profile`` / ``.zprofile``.
+#   * ``.kshrc`` / ``.cshrc`` / ``.tcshrc`` are the ksh/csh/tcsh equivalents of
+#     ``.bashrc``.
+# ``.env``-style and credential files are handled by their own patterns; this
+# group is only about files a shell EXECUTES.
 _SHELL_RC_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
-    r'(?:bashrc|zshrc|profile|bash_profile|zprofile)\b'
+    r'(?:bashrc|zshrc|profile|bash_profile|zprofile|zshenv|zlogin|zlogout'
+    r'|bash_aliases|bash_login|bash_logout|kshrc|cshrc|tcshrc|login)\b'
 )
 _CREDENTIAL_FILES = (
     r'(?:~|\$home|\$\{home\})/\.'
@@ -1198,6 +1224,17 @@ DANGEROUS_PATTERNS = [
     # the terminal side is not an open door. See #14639.
     (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
+    # Project-local env files. The tee/redirection/cp-mv-install rules already
+    # cover project paths, but the in-place rules above use
+    # _USER_SENSITIVE_WRITE_TARGET, which omits them — so
+    # `sed -i 's/KEY=.*/KEY=stolen/' .env` mutated a file the read guard will
+    # not even read. Keyed on _PROJECT_ENV_PATH, not the full project target:
+    # a bare config.yaml is ordinary app config unless it is the Hermes one
+    # (covered above), so widening it would gate `sed -i /srv/app/config.yaml`.
+    # perl/ruby -i need no companion rule; `perl -e` is already gated wholesale
+    # by the script-execution pattern.
+    (rf'\bsed\s+-[^\s]*i.*(?:{_PROJECT_ENV_PATH})[^\s"\']*', "in-place edit of project env file"),
+    (rf'\bsed\s+--in-place\b.*(?:{_PROJECT_ENV_PATH})[^\s"\']*', "in-place edit of project env file (long flag)"),
     # perl -i and ruby -i perform the same in-place mutation as sed -i but are
     # not caught by the -e/-c script-execution pattern above (which targets code
     # evaluation, not file mutation). Pairs the sed -i coverage from #14639.


### PR DESCRIPTION
## What does this PR do?

69dd0f7cf1 added `_SHELL_RC_FILES` to stop terminal writes installing a persistent backdoor via a shell startup file, listing `.bashrc`, `.zshrc`, `.profile`, `.bash_profile`, `.zprofile`. Ten siblings with **identical execution semantics** were left out, so the same backdoor lands unprompted under a different filename.

Measured on `main` with `HOME=/home/alice`, across 7 write vectors (`>>`, `>`, `tee -a`, `cp`, `mv`, `install`, `sed -i`):

| Files | Before | After |
|---|---|---|
| `.zshenv` `.zlogin` `.zlogout` `.bash_aliases` `.bash_login` `.bash_logout` `.kshrc` `.cshrc` `.tcshrc` `.login` | **0/70** | 70/70 |
| original five (`.bashrc` etc.) | 35/35 | 35/35 |

## Why these are equivalent, not speculative

- **`.bash_aliases` is sourced BY `.bashrc`.** Verified on this host — stock `/etc/skel/.bashrc` line 104:
  ```
  if [ -f ~/.bash_aliases ]; then . ~/.bash_aliases
  ```
  Writing it is a direct substitute for writing a file already gated.
- **`.zshenv` is sourced for EVERY zsh invocation**, including non-interactive scripts, making it strictly broader than the gated `.zshrc`.
- **`.zlogin` / `.bash_login` / `.login`** (login) and **`.zlogout` / `.bash_logout`** (logout) share the trigger class of the gated `.profile` / `.zprofile`.
- **`.kshrc` / `.cshrc` / `.tcshrc`** are the ksh/csh/tcsh equivalents of `.bashrc`.

Deliberately **not** included: `.inputrc` is readline configuration, not shell code. `.direnvrc` and `~/.config/direnv/direnvrc` are direnv's own config rather than a shell startup file, and direnv's `.envrc` is a separate path.

## Scope note on the neighbouring policy

Worth stating plainly, because it changes how this should be read: 81e42335a1 (#45947) **intentionally** relaxed the file-write hard deny for shell startup files — "files the user can already modify directly" — and `build_write_approval_paths` contains only `~/.ssh/config`. So the file-write side denies **none** of these, `.bashrc` included, and this is **not** an unpaired-guard argument like #99201.

This PR does not reopen that decision. It only makes the **terminal** guard internally consistent: whatever justifies prompting on `.bashrc` applies identically to the file `.bashrc` itself sources. If you'd rather the terminal guard match the relaxed file-write policy by *narrowing* instead, that is a coherent alternative and I'm happy to close this.

## How Has This Been Tested?

**122 passed, 0 failed** in `tests/tools/test_approval.py`; **279 passed, 0 failed** across six approval-consuming suites (`test_write_deny`, `test_file_write_safety`, `test_request_tool_approval`, `test_file_operations`, `test_approvals_suggest`), under a normal multi-segment `HOME`.

- **Positive control** — reverting `tools/approval.py` while keeping the new tests fails *exactly* `test_sibling_startup_files_are_gated` while the other three pass. They discriminate.
- **Negative controls, 0/15 over-flagged** — letter-continuation near-misses (`~/.logins.json`, `~/.zshenvrc-notes`, `~/.kshrcx`, `~/.loginx`); non-executed dotfiles (`~/.gitconfig`, `~/.vimrc`, `~/.tmux.conf`, `~/.inputrc`); non-`$HOME` paths (`/opt/app/.bashrc`, `./project/.zshenv`); and reads.

One honest caveat: `~/.bashrc.bak` and `~/.zshrc-template` **do** flag, because `\b` treats `.` and `-` as word boundaries. I verified that on unmodified `main` — it is pre-existing behaviour of this shared pattern, not introduced here — so those forms are excluded from the negative controls rather than asserted either way. Happy to tighten the boundary separately if you consider it a bug.

`ruff check` clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

No existing issue — I searched for the `.zshenv` / `.bash_aliases` gap and found none. Happy to file one first if you prefer that order.

Sibling of #99228, #99201, #99182, #98868; all touch `tools/approval.py` in disjoint places.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious parts (why each name is equivalent, and what is deliberately excluded)
