### PR TITLE
feat(desktop): add rebindable sidebar grouping cycle

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -31,6 +31,7 @@ import {
 import { toggleHud } from '@/store/hud'
 import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
 import {
+  cycleSidebarGrouping,
   requestSessionSearchFocus,
   setFileBrowserOpen,
   toggleFileBrowserOpen,
@@ -242,6 +243,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     // Narrow-viewport reveal is handled inside the store toggles now.
     'view.toggleSidebar': toggleSidebarOpen,
+    'view.cycleSidebarGrouping': cycleSidebarGrouping,
     // ⌘J toggles the right sidebar — but a layout with no right side (e.g.
     // terminal-on-bottom) would leave it a dead key, so it falls back to the
     // terminal there. The single "secondary panel" toggle.

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -307,6 +307,7 @@ export const en: Translations = {
       'composer.modelPicker': 'Open model picker',
       'composer.voice': 'Start / stop voice conversation',
       'view.toggleSidebar': 'Toggle sessions sidebar',
+      'view.cycleSidebarGrouping': 'Cycle session grouping',
       'view.toggleRightSidebar': 'Toggle file browser',
       'view.toggleReview': 'Toggle review pane',
       'view.toggleStatusbar': 'Toggle status bar',

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -31,3 +31,17 @@ describe('session.archive keybind action', () => {
     expect(matches).toHaveLength(1)
   })
 })
+
+describe('view.cycleSidebarGrouping keybind action', () => {
+  it('is an unbound view action with a panel label', () => {
+    const action = keybindAction('view.cycleSidebarGrouping')
+
+    expect(action).toEqual({ id: 'view.cycleSidebarGrouping', category: 'view', defaults: [] })
+    expect(defaultBindings()['view.cycleSidebarGrouping']).toEqual([])
+    expect(en.keybinds.actions['view.cycleSidebarGrouping']).toBe('Cycle session grouping')
+  })
+
+  it('appears exactly once in KEYBIND_ACTIONS', () => {
+    expect(KEYBIND_ACTIONS.filter(action => action.id === 'view.cycleSidebarGrouping')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -116,6 +116,9 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
 
   // ── View (layout + appearance + the shortcuts panel itself) ───────────────
   { id: 'view.toggleSidebar', category: 'view', defaults: ['mod+b'] },
+  // Expose the sidebar's mouse-only grouping control to keyboard-first users.
+  // Ships unbound so it is opt-in and cannot claim another global chord.
+  { id: 'view.cycleSidebarGrouping', category: 'view', defaults: [] },
   { id: 'view.toggleRightSidebar', category: 'view', defaults: ['mod+j'] },
   // ⌘⇧S — "s" for status bar. VS Code ships
   // `workbench.action.toggleStatusbarVisibility` unbound (it's a chord-free

--- a/apps/desktop/src/store/layout-sidebar-view.test.ts
+++ b/apps/desktop/src/store/layout-sidebar-view.test.ts
@@ -5,6 +5,7 @@ import {
   $sidebarOrdering,
   $sidebarRowMeta,
   $sidebarViewCustomized,
+  cycleSidebarGrouping,
   resetSidebarView,
   setSidebarGrouping,
   setSidebarOrdering,
@@ -74,5 +75,22 @@ describe('the sidebar as it ships', () => {
 
     expect($showAllProfiles.get()).toBe(true)
     expect($sidebarGrouping.get()).toBe('profile')
+  })
+
+  it('cycles through every grouping in the filter-menu order', () => {
+    expect($sidebarGrouping.get()).toBe('date')
+
+    cycleSidebarGrouping()
+    expect($sidebarGrouping.get()).toBe('project')
+
+    cycleSidebarGrouping()
+    expect($sidebarGrouping.get()).toBe('status')
+
+    cycleSidebarGrouping()
+    expect($sidebarGrouping.get()).toBe('profile')
+    expect($showAllProfiles.get()).toBe(true)
+
+    cycleSidebarGrouping()
+    expect($sidebarGrouping.get()).toBe('date')
   })
 })

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -245,6 +245,7 @@ export const $sidebarAgentsGrouped: ReadableAtom<boolean> = computed(
  *  default (Today / Yesterday / Last week dividers). `profile` only means
  *  anything while the sidebar is showing every profile at once. */
 export type SidebarGrouping = 'date' | 'profile' | 'project' | 'status'
+export const SIDEBAR_GROUPING_CYCLE: readonly SidebarGrouping[] = ['date', 'project', 'status', 'profile']
 /** What ranks rows within whatever grouping is active. */
 export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens' | 'updated'
 /** The sort keys the menu offers; `manual` is entered by dragging, not picked. */
@@ -611,6 +612,13 @@ export function setSidebarGrouping(grouping: SidebarGrouping) {
   }
 
   $sidebarFlatGrouping.set(grouping)
+}
+
+export function cycleSidebarGrouping() {
+  const currentIndex = SIDEBAR_GROUPING_CYCLE.indexOf($sidebarGrouping.get())
+  const nextIndex = (currentIndex + 1) % SIDEBAR_GROUPING_CYCLE.length
+
+  setSidebarGrouping(SIDEBAR_GROUPING_CYCLE[nextIndex])
 }
 
 export function setSidebarOrdering(ordering: SidebarOrdering) {


### PR DESCRIPTION
Closes #99235.

## What changed

- registers an unbound `view.cycleSidebarGrouping` action in the desktop keybind catalog
- wires it to cycle Updated → Project → Status → Profile through the existing grouping setter
- exposes the action in Settings → Keyboard Shortcuts without claiming a default chord
- adds registry and state-transition regressions, including the Profile/all-profiles boundary

## Validation

- 13 focused Vitest tests passed
- ESLint passed on all changed TypeScript files
- Prettier check passed on all changed files
- `git diff --check` passed