### PR TITLE
fix(tests): stop test_dashboard_auth_gate.py from hard-exiting the pytest process

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,6 +324,26 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     # shell override leaked "myhost" into the full suite and flipped 20
     # otherwise-unrelated config tests away from the default "hermes" host.
     "HERMES_HONCHO_HOST",
+    # Desktop parent-death watchdog + spawn-lineage identity. A developer
+    # running pytest from a Desktop-spawned Hermes session (terminal tool,
+    # in-app shell) inherits these from the Desktop backend's environment.
+    # If they leak into an in-process test that calls
+    # ``web_server.start_server`` (the dashboard auth-gate tests do), the
+    # PRODUCTION parent-death watchdog arms inside the pytest process — and
+    # because this conftest pins TZ=UTC while the Desktop captured
+    # ``HERMES_PARENT_START_MARKER`` via ``ps -o lstart=`` in the developer's
+    # local timezone, the marker probe "mismatches" against a perfectly alive
+    # parent and the watchdog ``os._exit(0)``s the whole pytest run mid-file:
+    # exit code 0, no summary, no junit XML, every later test silently
+    # skipped. CI never sets these; tests must not see them either. Tests
+    # that exercise the watchdog/identity paths set them explicitly.
+    "HERMES_DESKTOP",
+    "HERMES_PARENT_PID",
+    "HERMES_PARENT_START_MARKER",
+    "HERMES_PARENT_NONCE",
+    "HERMES_SERVE_WATCHDOG_POLL_S",
+    "HERMES_SERVE_HEADLESS",
+    "HERMES_SPAWN",
     # Dashboard OAuth auth gate (PR #30156). When set, the bundled
     # dashboard-auth `nous` plugin auto-registers itself on plugin discovery,
     # which is triggered by any `/api/status` call. That leaks a provider

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -2,7 +2,103 @@
 
 from __future__ import annotations
 
+import os
+import threading
+
 import pytest
+
+
+# ---------------------------------------------------------------------------
+# os._exit tripwire (silent pytest-kill regression guard)
+# ---------------------------------------------------------------------------
+# In Aug 2026 the dashboard auth-gate tests silently killed the whole pytest
+# process mid-file with exit code 0 (no summary, no junit XML): leaked
+# HERMES_PARENT_* env from a Desktop-spawned developer shell armed
+# web_server's production parent-death watchdog inside the test process, and
+# its TZ-skewed start-marker mismatch fired ``os._exit(0)`` from a daemon
+# thread. Any in-process ``os._exit`` during these tests is that bug class —
+# the tests in this package that exercise real ``os._exit`` behavior do so in
+# SUBPROCESSES (test_signal_handler_kanban_worker) or monkeypatch ``os._exit``
+# themselves (test_update_handoff_exit, which simply replaces this wrapper for
+# the test's duration). So: record the call, refuse to exit, and fail a test
+# loudly instead of vanishing.
+#
+# The tripwire is installed for the WHOLE session (pytest_configure), not per
+# test: the watchdog fires from a daemon thread tens of milliseconds after the
+# test body finishes (a ``ps`` probe subprocess is in flight), which lands in
+# the teardown/setup gap where a per-test patch has already been removed — the
+# exact race that made a fixture-scoped version of this guard miss the kill.
+
+_os_exit_tripped: list[tuple[int, str]] = []
+_real_os_exit = os._exit
+
+
+def _tripwire_os_exit(code: int) -> None:
+    _os_exit_tripped.append((code, threading.current_thread().name))
+    os.write(
+        2,
+        (
+            "\n[tests/hermes_cli tripwire] os._exit(%r) called in-process "
+            "(thread %r) — refusing to kill pytest; failing the active test "
+            "instead. See tests/hermes_cli/conftest.py.\n"
+            % (code, threading.current_thread().name)
+        ).encode(),
+    )
+    raise RuntimeError(
+        f"os._exit({code!r}) called inside the pytest process "
+        f"(thread {threading.current_thread().name!r})"
+    )
+
+
+def pytest_configure(config):
+    os._exit = _tripwire_os_exit
+
+
+def pytest_unconfigure(config):
+    os._exit = _real_os_exit
+
+
+@pytest.fixture(autouse=True)
+def _os_exit_tripwire():
+    """Turn an in-process ``os._exit`` into a visible test failure.
+
+    Without this, library code calling ``os._exit`` from any thread kills the
+    interpreter with the given code — pytest prints no failure, no summary,
+    writes no junit XML, and (exit code 0) a CI runner would report success
+    while every test after the exit point silently never ran.
+
+    The check runs per test so the failure is attributed close to the culprit;
+    a trip that lands between tests is reported by the NEXT test's teardown,
+    which is still a loud, non-zero-exit failure.
+    """
+    if _os_exit_tripped:
+        # A trip from a previous test's background thread landed in the gap.
+        calls = ", ".join(
+            f"os._exit({code!r}) from thread {thread!r}"
+            for code, thread in _os_exit_tripped
+        )
+        _os_exit_tripped.clear()
+        pytest.fail(
+            f"os._exit was called in-process before this test started: {calls}. "
+            "A previous test armed a hard-exit path (production watchdog / "
+            "signal handler) inside the pytest process."
+        )
+    try:
+        yield
+    finally:
+        if _os_exit_tripped:
+            calls = ", ".join(
+                f"os._exit({code!r}) from thread {thread!r}"
+                for code, thread in _os_exit_tripped
+            )
+            _os_exit_tripped.clear()
+            pytest.fail(
+                "os._exit was called inside the pytest process during this "
+                f"test: {calls}. This would have silently killed the entire "
+                "pytest run (exit 0, no summary). Find and isolate the "
+                "hard-exit path (production watchdogs/signal handlers must "
+                "not arm inside in-process tests)."
+            )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

`tests/hermes_cli/test_dashboard_auth_gate.py` could silently kill the entire pytest process mid-run: the interpreter exited with **code 0**, no pytest summary was printed, and `--junitxml` never wrote its file. Every test collected after the exit point (the rest of the gate file plus every alphabetically-later file in `tests/hermes_cli/`) silently never ran. Found while working on PR #99176 — pre-existing on `main`, not caused by it.

## Root cause

`hermes_cli/web_server.py:19246` — the `os._exit(0)` inside `_start_parent_death_watchdog`'s `_loop`, armed by `start_server()` at `hermes_cli/web_server.py:19760`.

Chain of events:

1. A pytest run launched from a Desktop-spawned Hermes shell inherits the Desktop backend's env: `HERMES_PARENT_PID`, `HERMES_PARENT_START_MARKER` (e.g. `ps:Mon Aug 31 10:37:55 2026`), `HERMES_PARENT_NONCE`.
2. `test_start_server_loopback_sets_auth_required_false` is the first gate test to call `web_server.start_server()` in-process with a stubbed uvicorn that lets `_serve()` run to completion — which arms the **production** parent-death watchdog because the leaked env passes all its validity checks.
3. The watchdog's probe (`_process_start_marker`, `web_server.py:147`) re-reads the parent's start time via `ps -p <pid> -o lstart=`. `tests/conftest.py` pins `TZ=UTC` for determinism (`monkeypatch.setenv("TZ", "UTC")`), but the Desktop captured the expected marker in the developer's local timezone (AEST). `ps` renders `lstart` in the current TZ, so a **perfectly alive** parent probes as `ps:Mon Aug 31 00:37:55 2026` vs expected `ps:Mon Aug 31 10:37:55 2026`.
4. `_is_serve_orphaned` returns True on the first poll and the daemon thread runs `os._exit(0)`: interpreter gone, exit 0, no summary, no junit XML.

Captured stack (via an `os._exit` shim writing to a file before delegating):

```
os._exit(0) thread=serve-parent-watchdog
  File ".../threading.py", line 982, in run
  File "hermes_cli/web_server.py", line 19246, in _loop
    os._exit(0)
```

Probe log for the same run: `pid=4420 marker='ps:Mon Aug 31 10:37:55 2026' -> orphaned=True` while `ps -p 4420` showed the process alive; `TZ=UTC ps -p 4420 -o lstart=` reproduced the shifted timestamp exactly.

## Fix (two layers, zero production code touched)

1. **`tests/conftest.py`** — added the desktop parent-watchdog env family (`HERMES_DESKTOP`, `HERMES_PARENT_PID`, `HERMES_PARENT_START_MARKER`, `HERMES_PARENT_NONCE`, `HERMES_SERVE_WATCHDOG_POLL_S`, `HERMES_SERVE_HEADLESS`, `HERMES_SPAWN`) to `_HERMES_BEHAVIORAL_VARS`, so the existing hermetic-environment autouse fixture blanks them for every test — same mechanism already used for `HERMES_KANBAN_*`, `HERMES_DASHBOARD_OAUTH_CLIENT_ID`, etc. Tests that exercise the watchdog/spawn-lineage identity set these explicitly (verified: `test_process_identity.py`, `test_serve_port_in_use.py` pass).
2. **`tests/hermes_cli/conftest.py`** — session-wide `os._exit` tripwire: records the call, refuses to kill the interpreter, and fails the active (or next) test loudly. Installed via `pytest_configure` rather than per-test because the watchdog fires from a daemon thread milliseconds after the test body finishes — a per-fixture patch has a teardown/setup gap the kill can land in (observed during development). Compatibility audited: every test exercising real `os._exit` semantics does so in a subprocess (`test_signal_handler_kanban_worker.py`, `test_install_identity.py` and friends use spawn-context multiprocessing / `subprocess`); `test_update_handoff_exit.py` monkeypatches `os._exit` itself, which simply replaces the wrapper for that test's duration. All pass with the tripwire active.

**Why this preserves the production intent:** the watchdog exists to reap orphaned Desktop backends (with PID-reuse safety via the start marker) and `os._exit` is deliberate there — the backend must die even with stuck non-daemon threads. The bug class is "production hard-exit path armed inside an in-process test", so the fix isolates tests from the env trigger instead of weakening the watchdog or adding pytest-sniffing to production code (explicitly rejected as test-environment sniffing). The TZ-sensitivity of `ps lstart` markers is a real (if narrow) production consideration — a macOS TZ change between Desktop spawn and probe could false-positive — but that redesign is out of scope here and carries its own risk; noted as residual risk below.

## Verification

**1. Pre-fix repro on the worktree (untouched origin/main @ 6681f9ebc3):**
```
$ .venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_gate.py -q; echo EXIT=$?
...........EXIT=0        # 11 dots of 33 tests, no summary line, exit 0
```

**2. Post-fix, gate file alone:**
```
$ pytest tests/hermes_cli/test_dashboard_auth_gate.py -q
33 passed in 0.88s        # exit 0
```

**3. Post-fix, full selection + junit:**
```
$ pytest tests/hermes_cli/ -k dashboard_auth -q --junitxml=/tmp/gate-junit.xml
179 passed, 7619 deselected, 8 warnings in 10.67s
$ ls -la /tmp/gate-junit.xml && grep -o 'tests="[0-9]*"' /tmp/gate-junit.xml | head -1
-rw-r--r-- 27498 /tmp/gate-junit.xml
tests="179"
```
(179, not the ~177 estimated in the report — that estimate came from a run that was itself being killed early.)

**4. Mutation check** — reverted the `tests/conftest.py` env-blanking (git stash) while keeping the tripwire, with the Desktop env present:
```
$ pytest tests/hermes_cli/test_dashboard_auth_gate.py -q; echo PYTEST_EXIT=$?
E  Failed: os._exit was called in-process before this test started:
   os._exit(0) from thread 'serve-parent-watchdog'. ...
32 passed, 4 errors in 2.51s
PYTEST_EXIT=1             # loud failure + real summary instead of silent exit 0
```
Then restored (`git stash pop`); gate file back to `33 passed`.

**5. No new failures** — `scripts/run_tests_parallel.py tests/hermes_cli` (the CI-equivalent per-file runner): `744 files, 7659 tests passed, 21 failed, 118 skipped`. All 21 failures reproduce identically on an untouched `origin/main` worktree in this environment (`test_cmd_update.py` 8/8 identical, spot-checked the other 8 files — same counts), i.e. pre-existing local-env failures, not from this change. Additionally, a single-process `pytest tests/hermes_cli/` run on the fixed branch (Desktop env present) produced byte-identical progress output through the first ~1300 tests to an untouched-main run with the env manually unset — the fix reproduces the "clean environment" behavior exactly.

Related suites re-run green with the tripwire active: `test_update_handoff_exit.py`, `test_signal_handler_kanban_worker.py`, `tests/gateway/test_gateway_process_exit.py`, `tests/cli/test_exit_watchdog_signal_arm.py` (15 passed).

## Was CI exposed?

**No — CI was not silently skipping tests.** Verified against `.github/workflows/`:
- `tests.yml` runs `scripts/run_tests.sh` → `run_tests_parallel.py`, which (a) executes **each test file in its own pytest subprocess** and launches via `env -i` with a scrubbed environment, and (b) counts a file with zero parsed summary as "no tests ran" and fails the run — two independent layers that would have caught this.
- `tests-os.yml` / `windows-venv-e2e.yml` use single pytest invocations, but GitHub runners never set `HERMES_PARENT_*` (grep of workflows confirms), so the watchdog can't arm there. Exit-5 is also explicitly failed.

The exposure is limited to **developers running `pytest tests/hermes_cli/...` directly from a Desktop-spawned Hermes shell** (e.g. an agent session's terminal tool): they'd see a green-looking exit 0 with most of the selection silently unexecuted. The tripwire now converts any recurrence of this bug class into a loud failure.

## Residual risk

The production watchdog still compares `ps lstart` strings that are TZ-rendering-sensitive; a timezone change on the host between Desktop spawn and a probe could in principle false-positive an orphan kill outside tests. `_is_serve_orphaned` already fails safe on probe *errors* but not on TZ-shifted *successes*. Left out of scope deliberately (production redesign with its own risk); this PR fully closes the test-suite kill.
