### PR TITLE
fix(import): keep restored scripts executable on fresh installs

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1078,6 +1078,14 @@ def _default_new_file_mode() -> Optional[int]:
     return 0o666 & ~current
 
 
+def _archive_execute_bits(zf: zipfile.ZipFile, member: str) -> int:
+    """Return safe Unix execute bits recorded for a zip member."""
+    info = zf.getinfo(member)
+    if info.create_system != 3:  # ZipInfo's Unix creator identifier.
+        return 0
+    return stat.S_IMODE(info.external_attr >> 16) & 0o111
+
+
 def _extract_member_atomically(
     zf: zipfile.ZipFile,
     member: str,
@@ -1107,7 +1115,9 @@ def _extract_member_atomically(
 
     Permission bits *and* ownership are carried across the replace so routing
     through mkstemp does not change the file the caller would otherwise have
-    produced.  ``os.replace`` swaps in a temp file owned by the *writing* user,
+    produced.  A newly created file also receives Unix execute bits recorded
+    by the archive while its read/write bits continue to come from the current
+    umask.  ``os.replace`` swaps in a temp file owned by the *writing* user,
     so without the chown a ``sudo hermes import`` would silently re-own every
     restored file to root — on the disaster-recovery path, and on exactly the
     Docker/NAS installs ``utils._restore_file_owner`` documents.  Both concerns
@@ -1131,6 +1141,11 @@ def _extract_member_atomically(
     owner = _preserve_file_owner(target)
     if mode is None:
         mode = new_file_mode
+        execute_bits = _archive_execute_bits(zf, member)
+        if execute_bits:
+            # When the umask probe failed, retain mkstemp's documented 0600
+            # fallback rather than turning an executable into execute-only.
+            mode = (mode if mode is not None else 0o600) | execute_bits
     else:
         # Deliberately NOT a faithful mode copy: setuid/setgid are dropped.
         # ``_preserve_file_mode`` returns ``stat.S_IMODE``, i.e. all twelve

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -744,6 +744,75 @@ class TestImportAtomicWrites:
             for name, content in files.items():
                 zf.writestr(name, content)
 
+    def test_new_file_inherits_archive_execute_bits(self, tmp_path, monkeypatch):
+        """A fresh restore keeps executable scripts runnable."""
+        zip_path = tmp_path / "backup.zip"
+        member = zipfile.ZipInfo("skills/demo/run.sh")
+        member.create_system = 3
+        member.external_attr = 0o106755 << 16
+        self._zip(zip_path, {member: "#!/bin/sh\nexit 0\n"})
+
+        restored_modes: list[int | None] = []
+        monkeypatch.setattr(
+            "hermes_cli.backup._restore_file_mode",
+            lambda _path, mode: restored_modes.append(mode),
+        )
+
+        from hermes_cli.backup import _extract_member_atomically
+
+        target = tmp_path / "run.sh"
+        with zipfile.ZipFile(zip_path) as zf:
+            _extract_member_atomically(zf, member.filename, target, 0o644)
+
+        assert target.read_text() == "#!/bin/sh\nexit 0\n"
+        assert restored_modes == [0o755]
+
+    def test_existing_file_ignores_archive_execute_bits(self, tmp_path, monkeypatch):
+        """Archive metadata must not change an existing target's mode."""
+        zip_path = tmp_path / "backup.zip"
+        member = zipfile.ZipInfo("config.yaml")
+        member.create_system = 3
+        member.external_attr = 0o100755 << 16
+        self._zip(zip_path, {member: "model: restored\n"})
+
+        target = tmp_path / "config.yaml"
+        target.write_text("model: original\n")
+        monkeypatch.setattr("hermes_cli.backup._preserve_file_mode", lambda _path: 0o640)
+        restored_modes: list[int | None] = []
+        monkeypatch.setattr(
+            "hermes_cli.backup._restore_file_mode",
+            lambda _path, mode: restored_modes.append(mode),
+        )
+
+        from hermes_cli.backup import _extract_member_atomically
+
+        with zipfile.ZipFile(zip_path) as zf:
+            _extract_member_atomically(zf, member.filename, target, 0o644)
+
+        assert restored_modes == [0o640]
+
+    def test_new_file_ignores_non_unix_mode_metadata(self, tmp_path, monkeypatch):
+        """DOS-created entries retain the normal umask-derived fallback."""
+        zip_path = tmp_path / "backup.zip"
+        member = zipfile.ZipInfo("notes.txt")
+        member.create_system = 0
+        member.external_attr = 0o100755 << 16
+        self._zip(zip_path, {member: "notes\n"})
+
+        restored_modes: list[int | None] = []
+        monkeypatch.setattr(
+            "hermes_cli.backup._restore_file_mode",
+            lambda _path, mode: restored_modes.append(mode),
+        )
+
+        from hermes_cli.backup import _extract_member_atomically
+
+        target = tmp_path / "notes.txt"
+        with zipfile.ZipFile(zip_path) as zf:
+            _extract_member_atomically(zf, member.filename, target, 0o644)
+
+        assert restored_modes == [0o644]
+
     def test_failed_member_leaves_existing_file_intact(self, tmp_path, monkeypatch):
         """A dying member must not destroy the file it was replacing."""
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## What does this PR do?

Fresh `hermes import` restores now keep executable scripts runnable instead of silently changing archive mode 0755 to 0644. The restore keeps read/write permissions derived from the destination umask, accepts only Unix execute bits from the archive, and leaves existing-target and secret-file permissions authoritative.

### Symptom

Importing a backup into a fresh HERMES_HOME restores executable members such as skill scripts without execute permission. Running those files then fails with permission denied.

### Impact

Fresh disaster-recovery imports can leave bundled executables, setup helpers, and skill scripts unusable until their permissions are repaired manually.

### Bug Cause

**Trigger:** `hermes_cli/backup.py:1141` in `_extract_member_atomically()` when the target does not exist.

**Causal chain:**
1. A ZIP member records Unix mode 0755 in `ZipInfo.external_attr`.
2. The fresh-file branch uses only `_default_new_file_mode()`, which contains umask-derived read/write bits and never reads the member metadata.
3. The staged and published file is explicitly restored as 0644, so the execute bits are lost.

**Why it is wrong:** ZIP extraction metadata was omitted from the new-file mode calculation.

**Working sibling / contrast:** Existing targets already preserve their destination mode through `_preserve_file_mode()` and should not adopt archive permissions.

**Ruled out:** The atomic replace itself is not dropping a correctly selected mode; the regression test captures the mode passed to the shared restore helper and showed that the selected mode was already 0644 before publication.

### Fix

Read execute bits only from ZIP entries created by Unix systems and merge those bits into the umask-derived mode only for newly created targets. Ignore archive read/write and special bits, ignore non-Unix mode metadata, retain existing target modes, and keep post-extraction secret-file chmods unchanged.

## Related Issue

Closes #99259

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py` - preserve safe Unix execute bits for newly created imported files.
- `tests/hermes_cli/test_backup.py` - cover fresh executable restores, existing-target mode preservation, non-Unix metadata fallback, and special-bit masking.

## How to Test

1. Create a ZIP with a Unix-created executable member whose mode is 0755.
2. Import it into a fresh HERMES_HOME and confirm the restored file remains executable while read/write bits follow the destination umask.
3. Automated verification run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_backup.py -k TestImportAtomicWrites -q
```

Result: 5 passed, 6 skipped on Windows 11. The full test file also reached 50 passed and 7 skipped; three unrelated pre-existing Windows-specific assertions failed outside the changed import-mode tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested the changed behavior on Windows 11 with platform-independent mode-selection assertions

### Documentation & Housekeeping

- [x] Documentation update is not applicable; the behavior is documented in the changed function
- [x] Config example update is not applicable; no config keys changed
- [x] Architecture guide update is not applicable; no architecture or workflow changed
- [x] I've considered cross-platform impact; Unix metadata is gated by `ZipInfo.create_system`
- [x] Tool schema update is not applicable; no tool schema changed

## Screenshots / Logs

Not applicable.
