### PR TITLE
fix(redact): stop large manual compressions from starving the gateway

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -158,8 +158,12 @@ _ENV_ASSIGN_RE = re.compile(
 # Lowercase env names: only underscore-boundary forms (``openai_key=…``,
 # ``FAL_KEY=…``, ``db_pw=…``) — NOT bare ``password=``/``token=``/``secret=``,
 # which appear in prose, URLs, and form bodies (issue #77484).
+# Anchor each attempt to the start of an identifier run.  Without the
+# lookbehind, ``re.sub`` retries the greedy ``[a-z0-9_]+`` prefix at every byte
+# of a long non-matching opaque payload, making strict compaction redaction
+# quadratic while holding the GIL (#99255).
 _ENV_ASSIGN_LOWER_RE = re.compile(
-    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    rf"(?<![a-z0-9_])([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
     re.IGNORECASE,
 )
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -677,6 +677,19 @@ class TestConfigKeyRedosResistance:
         assert "Sup3rS3cret!" not in result
         assert ".password=" in result
 
+    def test_long_opaque_assignment_run_completes_fast(self):
+        """Lowercase env scanning stays linear on compaction payload blobs."""
+        import time
+
+        # A serialized tool payload can contain a long opaque alphanumeric
+        # value followed by '=' without containing a secret-key suffix.  The
+        # old unanchored lowercase-env pattern retried its greedy prefix from
+        # every byte, making this quadratic while holding the GIL.
+        text = "a" * 20_000 + "=value"
+        t0 = time.perf_counter()
+        assert redact_sensitive_text(text, force=True) == text
+        assert time.perf_counter() - t0 < 2.0
+
     def test_yaml_assign_redos_resistance(self):
         """_YAML_ASSIGN_RE must not backtrack excessively on long inputs."""
         import time


### PR DESCRIPTION
## What does this PR do?

Manual `/compress` no longer spends quadratic CPU time scanning long opaque tool payloads before summary generation. Lowercase environment-assignment redaction now starts each match attempt at an identifier boundary, preserving secret masking while preventing a compression worker from monopolizing the GIL and starving gateway polling.

### Symptom

A large session containing MB-scale tool output can leave manual `/compress` consuming a CPU core for hours before any summary-model call. The gateway event loop then stops making useful progress and unrelated messages receive no response until the process is restarted.

### Impact

Operators running large gateway sessions can lose message delivery across the gateway while one compression worker remains CPU-bound in strict redaction.

### Bug Cause

**Trigger:** `agent/redact.py:165` / `_ENV_ASSIGN_LOWER_RE` scanning a long alphanumeric payload containing `=` but no lowercase secret-key suffix.

**Causal chain:**
1. Context compression serializes large opaque tool output and sends it through strict secret redaction.
2. The unanchored lowercase assignment regex retries its greedy identifier prefix at every byte of a non-matching run, producing quadratic CPU growth while holding the GIL.
3. The timeout host can fence a late commit, but it cannot preempt the executing regex, so gateway polling and message handling starve.

**Why it is wrong:** A no-match scan over serialized payload text must be linear in payload size; retrying the same identifier from each interior byte adds no redaction coverage.

**Working sibling / contrast:** Dotted and YAML config-key scanners already use linear pre-gates and possessive quantifiers. The measured hotspot was isolated to the lowercase environment-assignment pattern.

**Ruled out:** The summary provider was not responsible for this phase. The failing path occurs before any LLM request, and current main already applies the configured idle timeout and total ceiling around manual compression.

### Fix

Anchor lowercase assignment matching to the start of each identifier run with a negative lookbehind. Add a regression that exercises the long opaque no-match shape and retains the existing two-second redaction performance contract.

## Related Issue

Fixes #99255

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/redact.py` - prevent interior-byte retries in lowercase environment-assignment scanning.
- `tests/agent/test_redact.py` - cover long opaque compaction payloads and pin bounded scan time.

## How to Test

1. Run the targeted redaction regression and lowercase assignment checks.
2. Compare scan time for opaque assignment-like runs as input size grows.
3. Confirm ordinary lowercase secret assignments remain masked.

```bash
scripts/run_tests.sh tests/agent/test_redact.py -k 'long_opaque_assignment_run_completes_fast or lowercase_env_suffix or lower' -q
```

Locally: 4 passed. A direct benchmark reduced a 16,000-byte no-match scan from 5.072 seconds to 0.003 seconds; a 1,000,000-byte scan completes in 0.180 seconds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing behavior or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated timing and masking tests cover the behavior.
