### PR TITLE
fix(custom): add per-provider parallel_tool_calls control

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -471,6 +471,51 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+def _custom_provider_parallel_tool_calls_for_agent(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+) -> Optional[bool]:
+    provider_norm = (provider or "").strip().lower()
+    if provider_norm == "custom":
+        provider_key_filter = ""
+    elif provider_norm.startswith("custom:"):
+        provider_key_filter = provider_norm.split(":", 1)[1].strip()
+    else:
+        return None
+
+    target_url = _normalized_custom_base_url(base_url)
+    if not target_url:
+        return None
+
+    fallback: Optional[bool] = None
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        if provider_key_filter:
+            entry_keys = {
+                str(entry.get("provider_key", "") or "").strip().lower(),
+                str(entry.get("name", "") or "").strip().lower(),
+            }
+            if provider_key_filter not in entry_keys:
+                continue
+        if _normalized_custom_base_url(entry.get("base_url")) != target_url:
+            continue
+        configured = entry.get("parallel_tool_calls")
+        if not isinstance(configured, bool):
+            continue
+        provider_model = str(entry.get("model", "") or "").strip()
+        if provider_model:
+            if _custom_provider_model_matches(model, entry):
+                return configured
+        elif fallback is None:
+            fallback = configured
+
+    return fallback
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
@@ -478,15 +523,24 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
         base_url=agent.base_url,
         custom_providers=custom_providers,
     )
-    if not extra_body:
+    parallel_tool_calls = _custom_provider_parallel_tool_calls_for_agent(
+        provider=agent.provider,
+        model=agent.model,
+        base_url=agent.base_url,
+        custom_providers=custom_providers,
+    )
+    if not extra_body and parallel_tool_calls is None:
         return
 
     overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    merged_extra_body = dict(extra_body)
-    existing_extra_body = overrides.get("extra_body")
-    if isinstance(existing_extra_body, dict):
-        merged_extra_body.update(existing_extra_body)
-    overrides["extra_body"] = merged_extra_body
+    if extra_body:
+        merged_extra_body = dict(extra_body)
+        existing_extra_body = overrides.get("extra_body")
+        if isinstance(existing_extra_body, dict):
+            merged_extra_body.update(existing_extra_body)
+        overrides["extra_body"] = merged_extra_body
+    if parallel_tool_calls is not None and "parallel_tool_calls" not in overrides:
+        overrides["parallel_tool_calls"] = parallel_tool_calls
     agent.request_overrides = overrides
 
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -720,7 +720,13 @@ class ChatCompletionsTransport(ProviderTransport):
         # Request overrides last (service_tier etc.)
         overrides = params.get("request_overrides")
         if overrides:
-            api_kwargs.update(overrides)
+            api_kwargs.update(
+                {
+                    k: v
+                    for k, v in overrides.items()
+                    if k != "parallel_tool_calls" or bool(tools)
+                }
+            )
 
         _add_prompt_cache_key(
             api_kwargs,
@@ -857,6 +863,8 @@ class ChatCompletionsTransport(ProviderTransport):
         overrides = params.get("request_overrides")
         if overrides:
             for k, v in overrides.items():
+                if k == "parallel_tool_calls" and not tools:
+                    continue
                 if k == "extra_body" and isinstance(v, dict):
                     extra_body.update(v)
                 else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1481,6 +1481,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers", "capabilities",
+        "parallel_tool_calls",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1631,6 +1632,10 @@ def _normalize_custom_provider_entry(
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
 
+    parallel_tool_calls = entry.get("parallel_tool_calls")
+    if isinstance(parallel_tool_calls, bool):
+        normalized["parallel_tool_calls"] = parallel_tool_calls
+
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials (e.g. CF-Access-Client-Secret) — never
     # log them anywhere downstream.
@@ -1677,6 +1682,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "parallel_tool_calls",
         "ssl_ca_cert",
         "ssl_verify",
     ):
@@ -2116,7 +2122,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "rate_limit_delay", "extra_body", "parallel_tool_calls",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -757,6 +757,12 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
         result["extra_headers"] = extra_headers
 
 
+def _lift_parallel_tool_calls(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
+    parallel_tool_calls = entry.get("parallel_tool_calls")
+    if isinstance(parallel_tool_calls, bool):
+        result["parallel_tool_calls"] = parallel_tool_calls
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm:
@@ -837,6 +843,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
+                    _lift_parallel_tool_calls(entry, result)
                     _lift_extra_headers(entry, result)
                     # Command that PRINTS a credential, for gateways issuing
                     # short-lived bearers instead of static keys. Propagated
@@ -898,6 +905,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         extra_body = entry.get("extra_body")
         if isinstance(extra_body, dict):
             result["extra_body"] = dict(extra_body)
+        _lift_parallel_tool_calls(entry, result)
         _lift_extra_headers(entry, result)
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
@@ -1185,10 +1193,14 @@ def _normalize_base_url_for_match(value) -> str:
 
 
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:
+    overrides: Dict[str, Any] = {}
     extra_body = custom_provider.get("extra_body")
-    if not isinstance(extra_body, dict) or not extra_body:
-        return {}
-    return {"extra_body": dict(extra_body)}
+    if isinstance(extra_body, dict) and extra_body:
+        overrides["extra_body"] = dict(extra_body)
+    parallel_tool_calls = custom_provider.get("parallel_tool_calls")
+    if isinstance(parallel_tool_calls, bool):
+        overrides["parallel_tool_calls"] = parallel_tool_calls
+    return overrides
 
 
 def _resolve_named_custom_runtime(

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -71,3 +71,102 @@ def test_named_custom_provider_extra_body_matches_provider_key():
     )
 
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+
+
+def test_custom_provider_parallel_tool_calls_preserves_false_and_caller_overrides():
+    agent = SimpleNamespace(
+        provider="custom:vendor",
+        model="vendor-model",
+        base_url="https://api.vendor.example.com/v1",
+        request_overrides={
+            "service_tier": "priority",
+            "extra_body": {"caller_only": True},
+        },
+    )
+
+    _merge_custom_provider_extra_body(
+        agent,
+        [
+            {
+                "provider_key": "vendor",
+                "name": "Vendor",
+                "base_url": "https://api.vendor.example.com/v1/",
+                "model": "vendor-model",
+                "parallel_tool_calls": False,
+                "extra_body": {"provider_only": True},
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "parallel_tool_calls": False,
+        "extra_body": {"provider_only": True, "caller_only": True},
+    }
+
+
+def test_custom_provider_parallel_tool_calls_merges_true_without_extra_body():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="vendor-model",
+        base_url="https://api.vendor.example.com/v1",
+        request_overrides={},
+    )
+
+    _merge_custom_provider_extra_body(
+        agent,
+        [
+            {
+                "name": "Vendor",
+                "base_url": "https://api.vendor.example.com/v1",
+                "model": "vendor-model",
+                "parallel_tool_calls": True,
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {"parallel_tool_calls": True}
+
+
+def test_parallel_tool_calls_does_not_change_non_custom_provider():
+    agent = SimpleNamespace(
+        provider="openrouter",
+        model="vendor-model",
+        base_url="https://api.vendor.example.com/v1",
+        request_overrides={"service_tier": "priority"},
+    )
+
+    _merge_custom_provider_extra_body(
+        agent,
+        [
+            {
+                "name": "Vendor",
+                "base_url": "https://api.vendor.example.com/v1",
+                "parallel_tool_calls": True,
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {"service_tier": "priority"}
+
+
+def test_parallel_tool_calls_does_not_change_non_matching_custom_endpoint():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="vendor-model",
+        base_url="https://other.example.com/v1",
+        request_overrides={"service_tier": "priority"},
+    )
+
+    _merge_custom_provider_extra_body(
+        agent,
+        [
+            {
+                "name": "Vendor",
+                "base_url": "https://api.vendor.example.com/v1",
+                "parallel_tool_calls": True,
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {"service_tier": "priority"}

--- a/tests/agent/test_custom_provider_parallel_tool_calls_integration.py
+++ b/tests/agent/test_custom_provider_parallel_tool_calls_integration.py
@@ -1,7 +1,11 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 
 import pytest
 import yaml
+from openai import OpenAI
 
 from agent.agent_init import _merge_custom_provider_extra_body
 from agent.transports.chat_completions import ChatCompletionsTransport
@@ -10,16 +14,80 @@ from hermes_cli.runtime_provider import resolve_runtime_provider
 from providers import get_provider_profile
 
 
-@pytest.mark.parametrize("configured", [True, False, None], ids=["true", "false", "unset"])
+@pytest.fixture
+def captured_openai_endpoint():
+    captured = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            captured.append(json.loads(self.rfile.read(length)))
+            body = json.dumps(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "vendor-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1", captured
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.mark.parametrize(
+    ("configured", "tools"),
+    [
+        pytest.param(
+            True,
+            [{"type": "function", "function": {"name": "test", "parameters": {}}}],
+            id="true-tools",
+        ),
+        pytest.param(
+            False,
+            [{"type": "function", "function": {"name": "test", "parameters": {}}}],
+            id="false-tools",
+        ),
+        pytest.param(
+            None,
+            [{"type": "function", "function": {"name": "test", "parameters": {}}}],
+            id="unset-tools",
+        ),
+        pytest.param(True, None, id="true-no-tools"),
+        pytest.param(False, [], id="false-empty-tools"),
+    ],
+)
 def test_temp_home_custom_provider_parallel_tool_calls_reaches_wire(
-    tmp_path, monkeypatch, configured
+    tmp_path, monkeypatch, captured_openai_endpoint, configured, tools
 ):
+    endpoint, captured = captured_openai_endpoint
     hermes_home = tmp_path / f"hermes-{configured}"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     provider_config = {
-        "api": "https://api.vendor.example.com/v1",
+        "api": endpoint,
         "api_key": "test-key",
         "default_model": "vendor-model",
         "extra_body": {"include_reasoning": True},
@@ -49,17 +117,29 @@ def test_temp_home_custom_provider_parallel_tool_calls_reaches_wire(
     kwargs = ChatCompletionsTransport().build_kwargs(
         model=agent.model,
         messages=[{"role": "user", "content": "Hi"}],
-        tools=[{"type": "function", "function": {"name": "test", "parameters": {}}}],
+        tools=tools,
         provider_profile=get_provider_profile("custom"),
         request_overrides=agent.request_overrides,
     )
+    OpenAI(api_key=resolved["api_key"], base_url=resolved["base_url"]).chat.completions.create(
+        **kwargs
+    )
 
     assert kwargs["extra_body"]["include_reasoning"] is True
+    assert len(captured) == 1
+    wire_payload = captured[0]
+    assert wire_payload["include_reasoning"] is True
     if configured is None:
         assert "parallel_tool_calls" not in resolved.get("request_overrides", {})
         assert "parallel_tool_calls" not in agent.request_overrides
         assert "parallel_tool_calls" not in kwargs
+        assert "parallel_tool_calls" not in wire_payload
     else:
         assert resolved["request_overrides"]["parallel_tool_calls"] is configured
         assert agent.request_overrides["parallel_tool_calls"] is configured
-        assert kwargs["parallel_tool_calls"] is configured
+        if tools:
+            assert kwargs["parallel_tool_calls"] is configured
+            assert wire_payload["parallel_tool_calls"] is configured
+        else:
+            assert "parallel_tool_calls" not in kwargs
+            assert "parallel_tool_calls" not in wire_payload

--- a/tests/agent/test_custom_provider_parallel_tool_calls_integration.py
+++ b/tests/agent/test_custom_provider_parallel_tool_calls_integration.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from agent.agent_init import _merge_custom_provider_extra_body
+from agent.transports.chat_completions import ChatCompletionsTransport
+from hermes_cli.config import get_compatible_custom_providers
+from hermes_cli.runtime_provider import resolve_runtime_provider
+from providers import get_provider_profile
+
+
+@pytest.mark.parametrize("configured", [True, False, None], ids=["true", "false", "unset"])
+def test_temp_home_custom_provider_parallel_tool_calls_reaches_wire(
+    tmp_path, monkeypatch, configured
+):
+    hermes_home = tmp_path / f"hermes-{configured}"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    provider_config = {
+        "api": "https://api.vendor.example.com/v1",
+        "api_key": "test-key",
+        "default_model": "vendor-model",
+        "extra_body": {"include_reasoning": True},
+    }
+    if configured is not None:
+        provider_config["parallel_tool_calls"] = configured
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {"provider": "vendor", "default": "vendor-model"},
+                "providers": {"vendor": provider_config},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    custom_providers = get_compatible_custom_providers()
+    resolved = resolve_runtime_provider(requested="vendor")
+    agent = SimpleNamespace(
+        provider=resolved["provider"],
+        model=resolved.get("model", "vendor-model"),
+        base_url=resolved["base_url"],
+        request_overrides={},
+    )
+    _merge_custom_provider_extra_body(agent, custom_providers)
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[{"type": "function", "function": {"name": "test", "parameters": {}}}],
+        provider_profile=get_provider_profile("custom"),
+        request_overrides=agent.request_overrides,
+    )
+
+    assert kwargs["extra_body"]["include_reasoning"] is True
+    if configured is None:
+        assert "parallel_tool_calls" not in resolved.get("request_overrides", {})
+        assert "parallel_tool_calls" not in agent.request_overrides
+        assert "parallel_tool_calls" not in kwargs
+    else:
+        assert resolved["request_overrides"]["parallel_tool_calls"] is configured
+        assert agent.request_overrides["parallel_tool_calls"] is configured
+        assert kwargs["parallel_tool_calls"] is configured

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -230,6 +230,45 @@ class TestChatCompletionsBuildKwargs:
         kw = transport.build_kwargs(model="gpt-4o", messages=msgs, tools=tools)
         assert kw["tools"] == tools
 
+    @pytest.mark.parametrize("profile_path", [True, False], ids=["profile", "legacy"])
+    @pytest.mark.parametrize("configured", [True, False, None], ids=["true", "false", "unset"])
+    @pytest.mark.parametrize("tools", [[{"type": "function", "function": {"name": "test", "parameters": {}}}], [], None], ids=["tools", "empty-tools", "no-tools"])
+    def test_parallel_tool_calls_requires_tools(
+        self, transport, profile_path, configured, tools
+    ):
+        from providers import get_provider_profile
+
+        request_overrides = {
+            "service_tier": "priority",
+            "extra_body": {"caller_only": True},
+        }
+        if configured is not None:
+            request_overrides["parallel_tool_calls"] = configured
+        original_overrides = {
+            "service_tier": "priority",
+            "extra_body": {"caller_only": True},
+        }
+        if configured is not None:
+            original_overrides["parallel_tool_calls"] = configured
+
+        profile = get_provider_profile("custom") if profile_path else None
+
+        kw = transport.build_kwargs(
+            model="vendor-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            request_overrides=request_overrides,
+            provider_profile=profile,
+        )
+
+        if tools and configured is not None:
+            assert kw["parallel_tool_calls"] is configured
+        else:
+            assert "parallel_tool_calls" not in kw
+        assert kw["service_tier"] == "priority"
+        assert kw["extra_body"]["caller_only"] is True
+        assert request_overrides == original_overrides
+
     def test_openrouter_provider_prefs(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("openrouter")

--- a/tests/gateway/test_custom_provider_request_overrides.py
+++ b/tests/gateway/test_custom_provider_request_overrides.py
@@ -169,6 +169,102 @@ def test_turn_route_merges_fast_mode_with_provider_request_overrides():
     }
 
 
+@pytest.mark.parametrize("configured", [True, False])
+def test_resolve_runtime_agent_kwargs_preserves_parallel_tool_calls(
+    monkeypatch, configured
+):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda: {
+            "api_key": "***",
+            "base_url": "https://example.test/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "request_overrides": {
+                "extra_body": {"include_reasoning": True},
+                "parallel_tool_calls": configured,
+            },
+        },
+    )
+
+    result = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert result["request_overrides"] == {
+        "extra_body": {"include_reasoning": True},
+        "parallel_tool_calls": configured,
+    }
+
+
+@pytest.mark.parametrize("configured", [True, False])
+def test_turn_route_preserves_parallel_tool_calls_without_fast_mode(configured):
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.test/v1",
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": {
+            "extra_body": {"include_reasoning": True},
+            "parallel_tool_calls": configured,
+        },
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "gpt-5.4",
+        runtime_kwargs,
+    )
+
+    assert route["request_overrides"] == {
+        "extra_body": {"include_reasoning": True},
+        "parallel_tool_calls": configured,
+    }
+
+
+@pytest.mark.parametrize("configured", [True, False])
+def test_turn_route_merges_fast_mode_with_parallel_tool_calls(configured):
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.test/v1",
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": {
+            "extra_body": {"include_reasoning": True},
+            "parallel_tool_calls": configured,
+        },
+    }
+
+    with patch(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        return_value={"service_tier": "priority"},
+    ):
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "gpt-5.4",
+            runtime_kwargs,
+        )
+
+    assert route["request_overrides"] == {
+        "extra_body": {"include_reasoning": True},
+        "parallel_tool_calls": configured,
+        "service_tier": "priority",
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_agent_preserves_provider_request_overrides_on_gateway_path(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -692,6 +692,81 @@ def test_named_custom_provider_filters_capabilities_at_lookup_boundary(monkeypat
     assert provider["capabilities"] == {"openai_native_compaction": True}
 
 
+@pytest.mark.parametrize("configured", [True, False])
+def test_named_custom_provider_propagates_parallel_tool_calls(monkeypatch, configured):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "vendor": {
+                    "api": "https://api.vendor.example.com/v1",
+                    "api_key": "vendor-key",
+                    "parallel_tool_calls": configured,
+                    "extra_body": {"include_reasoning": True},
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="vendor")
+
+    assert resolved["request_overrides"] == {
+        "extra_body": {"include_reasoning": True},
+        "parallel_tool_calls": configured,
+    }
+
+
+def test_named_custom_provider_omits_unset_parallel_tool_calls(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "_get_named_custom_provider",
+        lambda _requested: {
+            "name": "vendor",
+            "base_url": "https://api.vendor.example.com/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp._resolve_named_custom_runtime(requested_provider="vendor")
+
+    assert resolved is not None
+    assert "request_overrides" not in resolved
+
+
+@pytest.mark.parametrize("configured", [True, False])
+def test_named_custom_provider_pool_merges_parallel_tool_calls(monkeypatch, configured):
+    custom_provider = {
+        "name": "vendor",
+        "base_url": "https://api.vendor.example.com/v1",
+        "parallel_tool_calls": configured,
+        "extra_body": {"include_reasoning": True},
+    }
+    pool_result = {
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "base_url": custom_provider["base_url"],
+        "api_key": "pool-key",
+        "request_overrides": {"service_tier": "priority"},
+    }
+    monkeypatch.setattr(rp, "_get_named_custom_provider", lambda _requested: custom_provider)
+    monkeypatch.setattr(
+        rp,
+        "_try_resolve_from_custom_pool",
+        lambda *a, **k: dict(pool_result),
+    )
+
+    resolved = rp._resolve_named_custom_runtime(requested_provider="vendor")
+
+    assert resolved is not None
+    assert resolved["request_overrides"] == {
+        "service_tier": "priority",
+        "extra_body": {"include_reasoning": True},
+        "parallel_tool_calls": configured,
+    }
+
+
 def test_bare_custom_resolves_providers_dict_entry_named_custom(monkeypatch):
     """A request for bare ``provider="custom"`` must resolve a literal
     ``providers.custom`` entry (e.g. a cliproxy endpoint) instead of falling

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1249,6 +1249,59 @@ class TestProviderEntryApiKeyEnvAlias:
         assert normalized is not None
         assert "extra_body" in _VALID_CUSTOM_PROVIDER_FIELDS
         assert normalized["extra_body"] == entry["extra_body"]
+
+
+class TestProviderEntryParallelToolCalls:
+    @pytest.mark.parametrize("configured", [True, False])
+    def test_canonical_provider_preserves_explicit_boolean(self, configured):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        normalized = _normalize_custom_provider_entry(
+            {
+                "api": "https://api.vendor.example.com/v1",
+                "parallel_tool_calls": configured,
+            },
+            provider_key="vendor",
+        )
+
+        assert normalized is not None
+        assert normalized["parallel_tool_calls"] is configured
+
+    @pytest.mark.parametrize("configured", ["true", 1, 0, None, [], {}])
+    def test_non_boolean_value_is_omitted(self, configured):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        normalized = _normalize_custom_provider_entry(
+            {
+                "api": "https://api.vendor.example.com/v1",
+                "parallel_tool_calls": configured,
+            },
+            provider_key="vendor",
+        )
+
+        assert normalized is not None
+        assert "parallel_tool_calls" not in normalized
+
+    def test_legacy_schema_accepts_parallel_tool_calls(self):
+        from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
+
+        assert "parallel_tool_calls" in _VALID_CUSTOM_PROVIDER_FIELDS
+
+    @pytest.mark.parametrize("configured", [True, False])
+    def test_legacy_to_canonical_conversion_preserves_boolean(self, configured):
+        from hermes_cli.config import _custom_provider_entry_to_provider_config
+
+        provider_config = _custom_provider_entry_to_provider_config(
+            {
+                "name": "vendor",
+                "base_url": "https://api.vendor.example.com/v1",
+                "parallel_tool_calls": configured,
+            },
+            provider_key="vendor",
+        )
+
+        assert provider_config is not None
+        assert provider_config["parallel_tool_calls"] is configured
 # =============================================================================
 # Tencent TokenHub — API-key provider runtime resolution
 # =============================================================================

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1297,7 +1297,21 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `parallel_tool_calls`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+
+For OpenAI-compatible Chat Completions endpoints, `parallel_tool_calls` controls the top-level request field when tools are available:
+
+```yaml
+providers:
+  local:
+    api: http://localhost:8080/v1
+    transport: chat_completions
+    parallel_tool_calls: true   # send true when tools are present
+    # parallel_tool_calls: false  # send false when tools are present
+    # omitted                     # do not send the request field
+```
+
+Hermes omits the request field when no tools are present, regardless of the configured boolean.
 
 #### Command-minted credentials (`key_cmd`)
 


### PR DESCRIPTION
## What does this PR do?

Add an explicit custom-provider `parallel_tool_calls` control for OpenAI-compatible Chat Completions requests.

```yaml
providers:
  example:
    parallel_tool_calls: true   # emit top-level true when tools are present
    # parallel_tool_calls: false  # emit top-level false when tools are present
    # omitted                     # omit the request field
```

When no tools are present, the field is omitted regardless of the configured boolean. Explicit `false` is preserved through config, runtime, agent init, and transport; it is not collapsed into unset.

This does not set a global default, does not change Codex/Anthropic/MCP behavior, and does not add a temperature policy.

## Related Issue

Related to #18470 (the `parallel_tool_calls` portion only; temperature remains a separate policy decision).

This is a current-`main` salvage of the per-provider tri-state control discussed on the older overlapping PRs:

- #18483 — transport-only custom-provider defaults; sweeper review found it targets the bypassed legacy path
- #18489 — same root cause, also legacy `is_custom_provider` path
- #18492 — broader config/gateway/delegate scope, including a temperature default

Those PRs remain useful historical context. This branch is independently mergeable against current `main` and intentionally narrower: explicit `true` / `false` / unset, tools-present gating, no global default.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py` — accept and preserve an explicit boolean on canonical `providers:` and legacy `custom_providers:`
- `hermes_cli/runtime_provider.py` — carry the boolean in `request_overrides` for direct and credential-pool custom-provider resolution without dropping `extra_body`
- `agent/agent_init.py` — merge the matched custom-provider value into primary-agent request overrides, following the existing `extra_body` path (CLI still does not copy resolver `request_overrides`)
- `agent/transports/chat_completions.py` — emit the top-level field only when tools are present, on both profile and legacy paths
- `website/docs/integrations/providers.md` — document the canonical setting
- Focused tests for config, runtime, agent init, transport, gateway override merge, and a temporary-`HERMES_HOME` config-to-wire SDK capture

## How to Test

1. Focused suite:

```bash
HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/agent/transports/test_chat_completions.py \
  tests/agent/test_custom_provider_extra_body.py \
  tests/agent/test_custom_provider_parallel_tool_calls_integration.py \
  tests/providers/test_profile_wiring.py \
  tests/gateway/test_turn_request_overrides.py \
  tests/gateway/test_custom_provider_request_overrides.py \
  tests/gateway/test_fast_command.py \
  tests/gateway/test_model_command_request_overrides.py -q
```

2. Configure a custom Chat Completions provider with `parallel_tool_calls: true` and a prompt that needs multiple independent reads. The outgoing request should include `parallel_tool_calls: true` when tools are present.
3. Repeat with `false` and with the key omitted. `false` must appear as a real JSON boolean; omission must leave the key absent. No-tools requests must omit the field in all three cases.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(focused 201 passed; full suite not run in this package)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(canonical provider docs updated; example file has no custom-provider field list)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local focused verification on `1f99a4b2f2982fbef06df00ad673ade4e1895668` + this branch: 201 passed, 0 failed. `git diff --check` clean.

Transplanting the temporary-home integration test onto bare current `main` still fails for configured true/false (`unknown config keys ignored: parallel_tool_calls`) and still passes for unset.
