### PR TITLE
fix(gemini): omit `role` from native systemInstruction for strict proxies

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -552,14 +552,15 @@ def _build_gemini_contents(
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        # Gemini's ``systemInstruction`` is a Content object, but the ``role``
-        # field must be omitted here. Public Google (generativelanguage /
-        # Vertex) tolerates a stray ``role: system`` and ignores it, but
-        # strict OpenAI-/Gemini-compatible proxy validators reject any
+        # Gemini's ``systemInstruction`` is a Content object, and sending
+        # ``role: system`` there is the incompatible shape. Public Google
+        # (generativelanguage / Vertex) tolerates that stray role and ignores
+        # it, but strict OpenAI-/Gemini-compatible proxy validators reject a
         # systemInstruction carrying ``role`` with an opaque HTTP 422
         # ``INVALID_ARGUMENT`` — which, because Hermes always sends a system
         # prompt, breaks every Gemini request routed through such a gateway.
-        # Emit just ``parts`` so the payload is valid on both.
+        # Omitting ``role`` and emitting just ``parts`` is the most compatible
+        # payload for both strict and permissive Gemini surfaces.
         system_instruction = {"parts": [{"text": joined_system}]}
     return contents, system_instruction
 

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -552,7 +552,15 @@ def _build_gemini_contents(
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
+        # Gemini's ``systemInstruction`` is a Content object, but the ``role``
+        # field must be omitted here. Public Google (generativelanguage /
+        # Vertex) tolerates a stray ``role: system`` and ignores it, but
+        # strict OpenAI-/Gemini-compatible proxy validators reject any
+        # systemInstruction carrying ``role`` with an opaque HTTP 422
+        # ``INVALID_ARGUMENT`` — which, because Hermes always sends a system
+        # prompt, breaks every Gemini request routed through such a gateway.
+        # Emit just ``parts`` so the payload is valid on both.
+        system_instruction = {"parts": [{"text": joined_system}]}
     return contents, system_instruction
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -131,6 +131,43 @@ def test_consecutive_user_messages_merge_for_gemini_alternation():
     assert roles == ["user", "model"], roles
 
 
+def test_system_instruction_omits_role_for_strict_proxies():
+    """Gemini's ``systemInstruction`` is a Content object, but its ``role``
+    field must be omitted. Public Google (generativelanguage / Vertex)
+    tolerates a stray ``role: system`` and ignores it, but strict
+    OpenAI-/Gemini-compatible proxy validators reject a systemInstruction
+    carrying ``role`` with an opaque HTTP 422 ``INVALID_ARGUMENT`` — and
+    since Hermes always sends a system prompt, that breaks *every* Gemini
+    request routed through such a gateway. Emit only ``parts`` so the
+    payload validates everywhere.
+    """
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    messages = [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "hi"},
+    ]
+    _, system_instruction = _build_gemini_contents(messages)
+    assert system_instruction is not None
+    assert "role" not in system_instruction, system_instruction
+    assert system_instruction == {"parts": [{"text": "You are concise."}]}
+
+
+def test_system_instruction_joins_multiple_system_messages_without_role():
+    """Multiple system messages are joined, still with no ``role`` field."""
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    messages = [
+        {"role": "system", "content": "Rule one."},
+        {"role": "system", "content": "Rule two."},
+        {"role": "user", "content": "hi"},
+    ]
+    _, system_instruction = _build_gemini_contents(messages)
+    assert system_instruction is not None
+    assert "role" not in system_instruction, system_instruction
+    assert system_instruction["parts"] == [{"text": "Rule one.\nRule two."}]
+
+
 def test_schema_bearing_tool_result_is_wrapped_as_opaque_text():
     """A tool result whose content is itself a JSON Schema must not be
     forwarded as a structured functionResponse.response.

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -132,14 +132,15 @@ def test_consecutive_user_messages_merge_for_gemini_alternation():
 
 
 def test_system_instruction_omits_role_for_strict_proxies():
-    """Gemini's ``systemInstruction`` is a Content object, but its ``role``
-    field must be omitted. Public Google (generativelanguage / Vertex)
-    tolerates a stray ``role: system`` and ignores it, but strict
-    OpenAI-/Gemini-compatible proxy validators reject a systemInstruction
-    carrying ``role`` with an opaque HTTP 422 ``INVALID_ARGUMENT`` — and
-    since Hermes always sends a system prompt, that breaks *every* Gemini
-    request routed through such a gateway. Emit only ``parts`` so the
-    payload validates everywhere.
+    """Gemini's ``systemInstruction`` is a Content object, and sending
+    ``role: system`` there is the incompatible shape. Public Google
+    (generativelanguage / Vertex) tolerates that stray role and ignores it,
+    but strict OpenAI-/Gemini-compatible proxy validators reject a
+    systemInstruction carrying ``role`` with an opaque HTTP 422
+    ``INVALID_ARGUMENT`` — and since Hermes always sends a system prompt,
+    that breaks *every* Gemini request routed through such a gateway.
+    Omitting ``role`` and emitting only ``parts`` is the most compatible
+    payload for both strict and permissive Gemini surfaces.
     """
     from agent.gemini_native_adapter import _build_gemini_contents
 
@@ -154,7 +155,7 @@ def test_system_instruction_omits_role_for_strict_proxies():
 
 
 def test_system_instruction_joins_multiple_system_messages_without_role():
-    """Multiple system messages are joined, still with no ``role`` field."""
+    """Multiple system messages are joined in the role-less form."""
     from agent.gemini_native_adapter import _build_gemini_contents
 
     messages = [


### PR DESCRIPTION
## Problem

The native Gemini adapter builds `systemInstruction` with a `role` field:

```python
system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
```

Gemini's `systemInstruction` is a `Content` object, but the `role` field is meant to be omitted there. Public Google surfaces (generativelanguage / Vertex) tolerate a stray `role: "system"` and silently ignore it, so this has gone unnoticed. Strict OpenAI-/Gemini-compatible proxy validators, however, reject any `systemInstruction` carrying `role` with an opaque **HTTP 422 `INVALID_ARGUMENT`**.

Because Hermes **always** sends a system prompt, this breaks **every** Gemini request routed through such a gateway via the native `generateContent` adapter — not an edge case, a total outage on those surfaces.

## Fix

`_build_gemini_contents` now emits `{"parts": [...]}` without `role`. This is valid on both permissive (public Google) and strict (proxy) Gemini surfaces, so it's a safe unconditional change.

```python
system_instruction = {"parts": [{"text": joined_system}]}
```

## Verification

Reproduced and fixed against a live strict Gemini proxy:

| systemInstruction | result |
|---|---|
| `{"role": "system", "parts": [...]}` | **HTTP 422** `INVALID_ARGUMENT` |
| `{"parts": [...]}` (this PR) | **HTTP 200 OK** |

End-to-end through `GeminiNativeClient` with a system prompt: after the fix, both `gemini-3-1-pro` and `gemini-3-5-flash` return content (previously every call 422'd).

## Tests

Adds two regression tests to `tests/agent/test_gemini_native_adapter.py`:
- `test_system_instruction_omits_role_for_strict_proxies` — single system message, asserts no `role` key.
- `test_system_instruction_joins_multiple_system_messages_without_role` — multiple system messages joined, still no `role`.
