### PR TITLE
fix(sandbox): tunnel non-fixture HTTPS end to end

### DIFF
--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -19,6 +19,7 @@ Usage: proxy.py <fixture-root> <certs-dir> <real-ca-bundle>
 
 import os
 import pathlib
+import selectors
 import socket
 import ssl
 import subprocess
@@ -150,6 +151,39 @@ def relay(source, destination):
         destination.sendall(chunk)
 
 
+def tunnel_connect(conn, host, port):
+    """Relay a CONNECT stream unchanged when the host has no fixtures.
+
+    npm opens many concurrent, persistent HTTPS connections. Intercepting those
+    connections needlessly terminates TLS in this proxy and creates a fresh
+    upstream TLS session for every request, which can exhaust or race the npm
+    registry/CDN and surface as repeated ``SSLEOFError`` handshakes. Hosts with
+    no fixture content do not need interception, so preserve their native TLS
+    connection end to end.
+    """
+    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as upstream:
+        upstream.settimeout(None)
+        conn.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+        with selectors.DefaultSelector() as ready:
+            ready.register(conn, selectors.EVENT_READ, 'client')
+            ready.register(upstream, selectors.EVENT_READ, 'upstream')
+            while True:
+                for key, _ in ready.select():
+                    source = key.fileobj
+                    destination = upstream if key.data == 'client' else conn
+                    chunk = source.recv(MAX_REQUEST_BYTES)
+                    if chunk:
+                        destination.sendall(chunk)
+                        continue
+                    if key.data == 'upstream':
+                        return
+                    ready.unregister(conn)
+                    try:
+                        upstream.shutdown(socket.SHUT_WR)
+                    except OSError:
+                        return
+
+
 def forward_https(conn, host, port, request):
     context = ssl.create_default_context(cafile=str(REAL_CA))
     with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as raw:
@@ -169,9 +203,12 @@ def forward_http(conn, host, port, request, target):
 
 
 def handle_connect(conn, target):
-    """Intercept a CONNECT tunnel, terminating TLS with a minted cert."""
+    """Intercept fixture hosts; tunnel every other CONNECT unchanged."""
     host, _, port_text = target.rpartition(':')
     port = int(port_text or '443')
+    if not (ROOT / host).is_dir():
+        tunnel_connect(conn, host, port)
+        return
     conn.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
     cert, key = cert_for(host)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -11,8 +11,9 @@ forwards to the real host:
   sandbox is isolated from the *host*, not from the internet: a real install
   still has to reach PyPI and npm.
 
-HTTPS is intercepted by minting a per-host certificate from the sandbox's own
-throwaway CA, which the payload trusts via CURL_CA_BUNDLE / SSL_CERT_FILE.
+HTTPS fixture hosts are intercepted with certificates from the sandbox's
+throwaway CA. Other CONNECT streams remain end-to-end TLS, so the payload's CA
+bundle combines the throwaway CA with the host's real public roots.
 
 Usage: proxy.py <fixture-root> <certs-dir> <real-ca-bundle>
 """
@@ -33,6 +34,29 @@ LISTEN_ADDRESS = ('127.0.0.1', 8080)
 MAX_REQUEST_BYTES = 65536
 UPSTREAM_TIMEOUT_SECONDS = 30
 CERT_VALIDITY_DAYS = 2
+PEM_CERT_END = b'-----END CERTIFICATE-----'
+
+
+def prepare_client_ca_bundle():
+    """Trust both fixture certificates and real TLS used by raw tunnels.
+
+    ``ca.pem`` starts with the sandbox's one throwaway CA. Preserve only that
+    first certificate, then append the current host CA bundle. Rebuilding from
+    the first certificate keeps persistent sandbox restarts idempotent and
+    avoids retaining stale copies of the public roots.
+    """
+    client_ca = CERTS / 'ca.pem'
+    existing = client_ca.read_bytes()
+    certificate_end = existing.find(PEM_CERT_END)
+    if certificate_end < 0:
+        raise RuntimeError(f'sandbox CA is not a PEM certificate: {client_ca}')
+    sandbox_ca = existing[:certificate_end + len(PEM_CERT_END)].rstrip() + b'\n'
+    combined = sandbox_ca + REAL_CA.read_bytes().lstrip()
+    if existing == combined:
+        return
+    temporary = CERTS / f'ca.pem.{os.getpid()}.tmp'
+    temporary.write_bytes(combined)
+    os.replace(temporary, client_ca)
 
 
 def read_request(conn):
@@ -261,6 +285,7 @@ def handle(conn):
 
 
 def main():
+    prepare_client_ca_bundle()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         server.bind(LISTEN_ADDRESS)

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib.util
+import socket
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+PROXY_PATH = Path(__file__).parents[1] / "scripts" / "sandbox" / "proxy.py"
+
+
+def load_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    fixture_root = tmp_path / "http"
+    certs = tmp_path / "certs"
+    fixture_root.mkdir()
+    certs.mkdir()
+    real_ca = certs / "real-ca.pem"
+    real_ca.write_text("test-only", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(PROXY_PATH), str(fixture_root), str(certs), str(real_ca)],
+    )
+    spec = importlib.util.spec_from_file_location("sandbox_proxy_under_test", PROXY_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_connect_without_fixture_uses_raw_tunnel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proxy = load_proxy(tmp_path, monkeypatch)
+    tunneled: list[tuple[object, str, int]] = []
+
+    class Connection:
+        def sendall(self, _data: bytes) -> None:
+            pass
+
+    connection = Connection()
+
+    monkeypatch.setattr(
+        proxy,
+        "tunnel_connect",
+        lambda conn, host, port: tunneled.append((conn, host, port)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        proxy,
+        "cert_for",
+        lambda _host: pytest.fail("non-fixture HTTPS must not be intercepted"),
+    )
+
+    proxy.handle_connect(connection, "registry.npmjs.org:443")
+
+    assert tunneled == [(connection, "registry.npmjs.org", 443)]
+
+
+def test_connect_with_fixture_keeps_mitm_interception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proxy = load_proxy(tmp_path, monkeypatch)
+    host = "hermes-agent.nousresearch.com"
+    (proxy.ROOT / host).mkdir()
+    sent: list[bytes] = []
+    loaded: list[tuple[Path, Path]] = []
+
+    class Connection:
+        def sendall(self, data: bytes) -> None:
+            sent.append(data)
+
+    class EmptyTls:
+        def __enter__(self) -> EmptyTls:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def recv(self, _size: int) -> bytes:
+            return b""
+
+    class ServerContext:
+        def load_cert_chain(self, cert: Path, key: Path) -> None:
+            loaded.append((cert, key))
+
+        def wrap_socket(self, _conn: object, *, server_side: bool) -> EmptyTls:
+            assert server_side is True
+            return EmptyTls()
+
+    cert = tmp_path / "fixture.pem"
+    key = tmp_path / "fixture.key"
+    monkeypatch.setattr(
+        proxy,
+        "tunnel_connect",
+        lambda *_args: pytest.fail("fixture HTTPS must remain intercepted"),
+    )
+    monkeypatch.setattr(proxy, "cert_for", lambda _host: (cert, key))
+    monkeypatch.setattr(proxy.ssl, "SSLContext", lambda _protocol: ServerContext())
+
+    proxy.handle_connect(Connection(), f"{host}:443")
+
+    assert sent == [b"HTTP/1.1 200 Connection Established\r\n\r\n"]
+    assert loaded == [(cert, key)]
+
+
+def test_raw_tunnel_relays_both_directions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proxy = load_proxy(tmp_path, monkeypatch)
+    listener = socket.create_server(("127.0.0.1", 0))
+    target_port = listener.getsockname()[1]
+    client, proxy_side = socket.socketpair()
+    server_errors: list[BaseException] = []
+
+    def echo_once() -> None:
+        try:
+            upstream, _ = listener.accept()
+            with upstream:
+                request = upstream.recv(64)
+                upstream.sendall(b"echo:" + request)
+        except BaseException as error:  # pragma: no cover - surfaced below
+            server_errors.append(error)
+
+    echo_thread = threading.Thread(target=echo_once)
+    proxy_thread = threading.Thread(
+        target=proxy.tunnel_connect,
+        args=(proxy_side, "127.0.0.1", target_port),
+    )
+    echo_thread.start()
+    proxy_thread.start()
+    try:
+        response = b""
+        while b"\r\n\r\n" not in response:
+            response += client.recv(64)
+        assert response == b"HTTP/1.1 200 Connection Established\r\n\r\n"
+
+        client.sendall(b"ping")
+        assert client.recv(64) == b"echo:ping"
+        client.shutdown(socket.SHUT_WR)
+    finally:
+        client.close()
+        proxy_side.close()
+        listener.close()
+        echo_thread.join(timeout=2)
+        proxy_thread.join(timeout=2)
+
+    assert not server_errors
+    assert not echo_thread.is_alive()
+    assert not proxy_thread.is_alive()

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -32,6 +32,29 @@ def load_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     return module
 
 
+def test_prepare_client_ca_bundle_trusts_sandbox_and_public_cas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proxy = load_proxy(tmp_path, monkeypatch)
+    sandbox_ca = (
+        b"-----BEGIN CERTIFICATE-----\nsandbox\n-----END CERTIFICATE-----\n"
+    )
+    stale_public_ca = (
+        b"-----BEGIN CERTIFICATE-----\nstale\n-----END CERTIFICATE-----\n"
+    )
+    public_cas = b"-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----\n"
+    client_bundle = proxy.CERTS / "ca.pem"
+    client_bundle.write_bytes(sandbox_ca + stale_public_ca)
+    proxy.REAL_CA.write_bytes(public_cas)
+
+    proxy.prepare_client_ca_bundle()
+    first = client_bundle.read_bytes()
+    proxy.prepare_client_ca_bundle()
+
+    assert first == sandbox_ca + public_cas
+    assert client_bundle.read_bytes() == first
+
+
 def test_connect_without_fixture_uses_raw_tunnel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes the dev-sandbox fake-internet proxy so that HTTPS hosts **without fixture
content** are tunneled end-to-end instead of being MITM-intercepted.

The proxy currently terminates TLS for *every* CONNECT and opens a fresh
upstream TLS session per request. npm opens many concurrent, persistent HTTPS
connections during installs; re-terminating each one can exhaust or race the
registry/CDN and surfaces as repeated `SSLEOFError: UNEXPECTED_EOF_WHILE_READING`
in the proxy log, followed by `npm install failed or timed out` in the
install/update E2E matrix.

Two changes:

1. **`scripts/sandbox/proxy.py` — tunnel non-fixture HTTPS.** `handle_connect`
   now checks whether the host has a fixture directory. If it does, the existing
   MITM path (minted cert + fixture serving) is preserved unchanged. If it does
   not, the CONNECT stream is relayed byte-for-byte with a selector loop, so the
   payload keeps its native TLS session end to end.
2. **`scripts/sandbox/proxy.py` — trust public roots for raw tunnels.** Because
   raw tunnels now carry real public TLS, the payload's CA bundle must trust the
   host's public roots in addition to the sandbox's throwaway CA.
   `prepare_client_ca_bundle()` rebuilds `ca.pem` as *sandbox CA + host CA
   bundle*, idempotently (rebuilding from the first certificate on every start,
   so persistent sandbox restarts never accumulate stale copies).

## Related Issue

Fixes the `SSLEOFError` failures in the Install & Update E2E workflow
(observed on fork CI runs; affects upstream equally since the proxy is shared).

Related open approaches: #88420 and #94259 keep non-fixture traffic inside the
MITM proxy and repair its keep-alive/CA behavior; #97036 bypasses the proxy only
for npm; #96042 changes Node's trusted CA. This PR instead makes the fixture
boundary the interception boundary: fixture hosts retain the existing MITM
path, while every other CONNECT remains native end-to-end TLS. It therefore
does not special-case npm and avoids terminating unrelated public TLS at all.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `scripts/sandbox/proxy.py`
  - `handle_connect`: route fixture hosts to MITM interception, everything else
    to a raw `tunnel_connect` relay (selector-based, both directions, half-close
    handling).
  - `prepare_client_ca_bundle`: combine sandbox CA + real public roots into
    `ca.pem` idempotently; called from `main()`.
  - Docstring updated to describe the new split (fixture hosts intercepted,
    other CONNECT streams end-to-end TLS).
- `tests/test_sandbox_proxy.py` (new)
  - non-fixture CONNECT uses the raw tunnel and never mints a cert;
  - fixture CONNECT keeps MITM interception;
  - raw tunnel relays both directions and terminates cleanly;
  - CA bundle rebuild is idempotent and drops stale public roots.

## How to Test

1. `scripts/run_tests.sh tests/test_sandbox_proxy.py` — 4/4 pass.
2. `uv run --with ruff==0.15.10 ruff check scripts/sandbox/proxy.py tests/test_sandbox_proxy.py` — clean.
3. Full path: run the Install & Update E2E workflow
   (`.github/workflows/install-e2e.yml`); the installer route previously failed
   with `SSLEOFError` in the proxy log and `npm install failed or timed out`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused proxy suite run; full suite deferred to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu 24.04)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (fork CI, run 33369072766 — proxy without this fix):

```
proxy request failed: SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1000)')
```

After: `tests/test_sandbox_proxy.py` — 4 passed in 0.4s.

## Publication Boundary

This PR publication does not authorize merge, release, deployment, or any
production change; those remain separate maintainer decisions/gates.
