### PR TITLE
chore: map contributor email vaibhavdahiya28@gmail.com -> vsd2807

### DIFF
--- a/contributors/emails/vaibhavdahiya28@gmail.com
+++ b/contributors/emails/vaibhavdahiya28@gmail.com
@@ -1,0 +1,2 @@
+vsd2807
+# PR #99216 salvage


### PR DESCRIPTION
Mapping for `vaibhavdahiya28@gmail.com` → `vsd2807`.

This unblocks `check-attribution` for salvage PR #99216, whose first commit is authored as `VVV <vaibhavdahiya28@gmail.com>`.

No code or test changes.