### PR TITLE
fix(desktop): preserve profile scope on reused gateways

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11151,7 +11151,8 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return {
         ...primaryDescriptor,
         profile: profileKey,
-        connectionId: id
+        connectionId: id,
+        sharedRemote: true
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes model-setting cross-talk between profiles on a shared remote gateway in Hermes Desktop.

When the registry's remote or cloud source was also the already-running primary backend, `ensureRegistryBackend()` reused that descriptor without marking it as `sharedRemote`. Desktop requests such as `/api/model/options` then omitted the selected `profile`, so every gateway profile read and updated the default profile's model settings.

The reused descriptor now carries the same `sharedRemote: true` marker as a newly opened remote or cloud registry connection.

## Related Issue

None. I searched open and closed issues and PRs for the symptom and routing identifiers before opening this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Mark the reused primary remote registry descriptor as shared in `apps/desktop/electron/main.ts` so REST requests retain the selected gateway profile.

## How to Test

1. Connect Hermes Desktop to one gateway with at least two profiles that use different default models.
2. Open Settings > Model and switch between the gateway profiles under "Applies to". Confirm each profile shows its own provider and model.
3. Change one profile, click Apply, and confirm the other profiles remain unchanged.
4. Run `npx vitest run --project electron electron/connection-registry.test.ts electron/connection-config.test.ts` from `apps/desktop`.
5. Run `npm run typecheck` and `npm run build` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing interface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — descriptor routing is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live reproduction used one remote gateway with distinct saved models:

- `default`: `anthropic/claude-opus-5`
- `thanos`: `openai-codex/gpt-5.6-luna`
- `vultr`: `openai-codex/gpt-5.6-sol`

Before the fix, Desktop returned the default model for all three gateway profiles. After the fix, it returned the three distinct values above on two consecutive checks. The focused routing suite passed twice with 202 tests each time. Desktop type-checking and the production build also passed.
