### PR TITLE
fix(kanban): skip auto-review when sdlc-review is disabled

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2782,6 +2782,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_review_skill_disabled": [
+                {"task_id": tid, "assignee": who}
+                for (tid, who) in res.skipped_review_skill_disabled
+            ],
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2824,6 +2828,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.skipped_review_skill_disabled:
+        for tid, who in res.skipped_review_skill_disabled:
+            print(
+                f"Skipped (review skill disabled for {who}; "
+                f"card stays in review for a human): {tid}"
+            )
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -344,6 +344,7 @@ def _fire_dispatch_tick_hook(
             result.skipped_per_profile_capped,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
+            result.skipped_review_skill_disabled,
         )):
             outcome = "idle"
         invoke_hook(
@@ -8052,6 +8053,12 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_review_skill_disabled: list[tuple[str, str]] = field(default_factory=list)
+    """Review-lane task ids left unclaimed because the assignee profile has
+    ``sdlc-review`` in ``skills.disabled`` (#99251). Each entry is
+    ``(task_id, assignee)``. Operator-actionable: auto-review cannot run
+    without the review skill, so the card stays in ``review`` for a human
+    (same visible outcome as ``kanban.review_dispatch: false``)."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -9621,6 +9628,49 @@ def review_dispatch_enabled() -> bool:
         return True
 
 
+REVIEW_SKILL_NAME = "sdlc-review"
+
+
+def _sdlc_review_disabled_for_assignee(assignee: str) -> bool:
+    """Return True when the assignee profile has ``sdlc-review`` disabled.
+
+    Reads that profile's ``config.yaml`` directly (not the dispatcher's
+    ``HERMES_HOME``). A missing or unreadable config is treated as *not*
+    disabled so a healthy default profile still auto-reviews.
+
+    This is the #99251 gate: the review dispatcher must not force-inject a
+    skill the operator turned off. ``skills.disabled`` stays a load-time
+    deny; we honor it here instead of spawning a reviewer that crashes or
+    reviews with no review skill.
+    """
+    if not assignee:
+        return False
+    try:
+        from hermes_cli.profiles import get_profile_dir
+        from agent.skill_utils import parse_config_string_list
+        import yaml
+    except Exception:
+        return False
+    try:
+        cfg_path = get_profile_dir(assignee) / "config.yaml"
+        if not cfg_path.is_file():
+            return False
+        parsed = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        if not isinstance(parsed, dict):
+            return False
+        skills_cfg = parsed.get("skills")
+        if not isinstance(skills_cfg, dict):
+            return False
+        disabled = {
+            name.strip()
+            for name in parse_config_string_list(skills_cfg.get("disabled"))
+            if isinstance(name, str) and name.strip()
+        }
+        return REVIEW_SKILL_NAME in disabled
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Memory-aware dispatch guard (OOF-30 / OOF-77)
 #
@@ -10340,6 +10390,22 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _sdlc_review_disabled_for_assignee(row["assignee"]):
+            result.skipped_review_skill_disabled.append(
+                (row["id"], row["assignee"])
+            )
+            if not dry_run:
+                with write_txn(conn):
+                    _append_event(
+                        conn,
+                        row["id"],
+                        "review_skill_disabled",
+                        {
+                            "assignee": row["assignee"],
+                            "skill": REVIEW_SKILL_NAME,
+                        },
+                    )
+            continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
             if current >= _per_profile_cap:
@@ -10393,7 +10459,7 @@ def _dispatch_once_locked(
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
         claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
+            dict.fromkeys([*(claimed.skills or []), REVIEW_SKILL_NAME])
         )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -349,7 +349,7 @@ VALID_HOOKS: Set[str] = {
     #     promoted, reconciled_orphans, crashed, stale, timed_out,
     #     auto_blocked, rate_limited, auto_assigned_default,
     #     respawn_guarded, skipped_per_profile_capped, skipped_unassigned,
-    #     skipped_nonspawnable, skipped_locked).
+    #     skipped_nonspawnable, skipped_review_skill_disabled, skipped_locked).
     #   Privacy: result carries task ids, assignees, and workspace paths.
     "on_kanban_dispatch_tick",
     # Gateway platform-boundary observer hooks (#64176). Observer-only; each

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -708,3 +708,93 @@ def test_reviewer_reassigns_for_autonomous_dispatch(kanban_home: Path) -> None:
         ev = _events(conn, tid, kind="review_requested")[0][1]
         assert ev["reviewer"] == "lead-reviewer"
         assert ev["implementer"] == "worker"
+
+
+def test_review_dispatch_skips_when_sdlc_review_disabled(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#99251: disabled review skill must not spawn a reviewer.
+
+    The card stays in ``review`` (human lane). Spawn is not called, so a
+    card that also pins another skill cannot silently review without
+    ``sdlc-review``.
+    """
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    monkeypatch.setattr(kb, "_sdlc_review_disabled_for_assignee", lambda _n: True)
+    captured: list[list[str]] = []
+
+    def spawn(task, workspace):
+        captured.append(list(task.skills or []))
+        return None
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="needs review",
+            assignee="reviewer",
+            skills=["domain-specific-review"],
+        )
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.request_review(
+            conn, tid, summary="ready",
+            expected_run_id=claimed.current_run_id,
+        )
+        dry = kb.dispatch_once(conn, dry_run=True)
+        assert dry.spawned == []
+        assert dry.skipped_review_skill_disabled == [(tid, "reviewer")]
+        assert kb.get_task(conn, tid).status == "review"
+
+        live = kb.dispatch_once(conn, spawn_fn=spawn)
+        assert live.spawned == []
+        assert live.skipped_review_skill_disabled == [(tid, "reviewer")]
+        assert captured == []
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "review"
+        assert task.claim_lock is None
+        evs = _events(conn, tid, kind="review_skill_disabled")
+        assert len(evs) == 1
+        assert evs[0][1]["skill"] == "sdlc-review"
+        assert evs[0][1]["assignee"] == "reviewer"
+
+
+def test_sdlc_review_disabled_reads_assignee_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate reads the *assignee* profile file, not the dispatcher home."""
+    disabled_home = tmp_path / "disabled-profile"
+    disabled_home.mkdir()
+    (disabled_home / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - sdlc-review\n",
+        encoding="utf-8",
+    )
+    empty_home = tmp_path / "empty-profile"
+    empty_home.mkdir()
+    json_home = tmp_path / "json-disabled"
+    json_home.mkdir()
+    (json_home / "config.yaml").write_text(
+        'skills:\n  disabled: \'["sdlc-review"]\'\n',
+        encoding="utf-8",
+    )
+
+    def fake_dir(name: str):
+        return {
+            "disabled": disabled_home,
+            "empty": empty_home,
+            "json": json_home,
+        }.get(name, tmp_path / "missing")
+
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", fake_dir)
+    assert kb._sdlc_review_disabled_for_assignee("disabled") is True
+    assert kb._sdlc_review_disabled_for_assignee("empty") is False
+    assert kb._sdlc_review_disabled_for_assignee("json") is True
+    assert kb._sdlc_review_disabled_for_assignee("missing") is False
+    assert kb._sdlc_review_disabled_for_assignee("") is False


### PR DESCRIPTION
## Bug Description

The review dispatcher force-appends `sdlc-review` to every review worker without consulting the assignee profile's `skills.disabled`. The skill loader then treats that name as missing (#59156). Outcome:

- card skills empty → `ValueError: Unknown skill(s): sdlc-review`, exit 1, retries burn, card auto-blocks
- card pins another skill → warn-and-continue, reviewer runs **without** review logic

Fixes #99251

## Predicate

If `kanban.review_dispatch` is true **and** the assignee profile lists `sdlc-review` in `skills.disabled`, the dispatcher must **not** spawn a review worker. The card stays in `review` (human lane). It must not crash, and it must not review with a non-review skill only.

If the skill is **not** disabled, current behavior is unchanged: append `sdlc-review` and spawn.

## Current parameters (unchanged)

- `kanban.review_dispatch` (default true) — still the auto-review master switch
- `skills.disabled` — still a load-time deny; this PR reads it at dispatch instead of fighting it
- `ESSENTIAL_SKILLS` — still `{hermes-agent}` only (no context tax on every chat)

## Root Cause

Two unconditional rules: dispatch injects `sdlc-review`; the loader maps disabled → missing. Neither checks the other. Creation-time strip (#74125 / #74126) cannot see a name appended at **dispatch**.

## Fix

- `_sdlc_review_disabled_for_assignee` reads that profile's `config.yaml` (not the dispatcher home)
- if disabled: skip before claim, `skipped_review_skill_disabled`, event `review_skill_disabled`, CLI/JSON visible
- if not disabled: still force-append `REVIEW_SKILL_NAME` as today

Does not bypass the disabled-skill loader gate. Does not spawn a reviewer without the review skill.

## Files

- `hermes_cli/kanban_db.py` — gate + skip bucket + event
- `hermes_cli/kanban.py` — CLI/JSON
- `hermes_cli/plugins.py` — hook docstring
- `tests/hermes_cli/test_kanban_review_lifecycle.py` — regression

## Tests

- `test_review_dispatch_skips_when_sdlc_review_disabled` — mixed card skills, dry-run + live spawn, no claim, event
- `test_sdlc_review_disabled_reads_assignee_config` — YAML list + JSON-string disabled list
- existing `test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill` still expects append when not disabled
- sabotage: gating `if False` makes the new skip test fail (spawned non-empty)
- `tests/hermes_cli/test_kanban_review_lifecycle.py`: 21 passed locally

## Risk

Low. Review-lane only. Enabled profiles unchanged. Disabled profiles lose auto-review (intentional; same visible outcome as `review_dispatch: false`) instead of crash/silent review.

## Out of scope

- Adding `sdlc-review` to `ESSENTIAL_SKILLS`
- Native compact review protocol in the system prompt (#97965)
- Card-pinned disabled skills at `create_task` (#74126)