### PR TITLE
fix(tui): drop unbound ctrl keypresses instead of typing them into the composer

### DIFF
--- a/ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx
+++ b/ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx
@@ -1,0 +1,177 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@hermes/ink'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeInput extends EventEmitter {
+  chunks: string[] = []
+  isRaw = false
+  isTTY = true
+  readableLength = 0
+
+  read() {
+    const next = this.chunks.shift() ?? null
+    this.readableLength = this.chunks.length
+
+    return next
+  }
+
+  ref = vi.fn()
+
+  send(...chunks: string[]) {
+    this.chunks.push(...chunks)
+    this.readableLength = this.chunks.length
+
+    this.emit('readable')
+  }
+
+  setEncoding = vi.fn()
+
+  setRawMode = vi.fn((enabled: boolean) => {
+    this.isRaw = enabled
+  })
+
+  unref = vi.fn()
+}
+
+const settle = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms))
+
+function makeStreams() {
+  const stdin = new FakeInput()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stderr, { columns: 80, isTTY: false, rows: 24 })
+
+  return { stderr, stdin, stdout }
+}
+
+// The dashboard gateway writes \x0c (Ctrl+L) to the chat PTY on every
+// reattach force-redraw (hermes_cli/pty_session.py TUI_FORCE_REDRAW).
+// hermes-ink parses it as {name: 'l', ctrl: true} and InputEvent surfaces
+// input='l'; without the ctrl guard in the composer's insert gate a literal
+// "l" lands at the cursor (#101393: every model-switcher reload appended
+// one "l" to the chat input).
+describe('TextInput ctrl-letter leak', () => {
+  it('does not insert a literal letter for the reattach force-redraw byte \\x0c (ctrl+l)', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    streams.stdin.send('\x0c', '\x0c')
+    await settle(25)
+
+    expect(changes).toEqual([])
+
+    instance.unmount()
+  })
+
+  it('keeps existing draft text intact when \\x0c arrives mid-typing', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('hello')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    expect(changes).toEqual([])
+
+    instance.unmount()
+  })
+
+  it('still types a bare letter l and other ctrl-branch keys keep working', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('l')
+    await settle(25)
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    expect(changes).toEqual(['l'])
+
+    instance.unmount()
+  })
+})

--- a/ui-tui/src/__tests__/textInputUnboundCtrl.test.ts
+++ b/ui-tui/src/__tests__/textInputUnboundCtrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldDropUnboundCtrlKeypress } from '../components/textInput.js'
+
+const key = (overrides: Record<string, unknown> = {}) => ({ ctrl: false, meta: false, ...overrides }) as any
+
+describe('shouldDropUnboundCtrlKeypress', () => {
+  it('drops the force-redraw byte: ctrl+l decodes with input "l" on PTY reattach (#99277)', () => {
+    expect(shouldDropUnboundCtrlKeypress(key({ ctrl: true }), false)).toBe(true)
+  })
+
+  it('keeps ordinary typing intact', () => {
+    expect(shouldDropUnboundCtrlKeypress(key(), false)).toBe(false)
+    expect(shouldDropUnboundCtrlKeypress(key({ shift: true }), false)).toBe(false)
+  })
+
+  it('keeps mac Cmd (meta) and Windows AltGr (ctrl+meta) keypresses as text', () => {
+    expect(shouldDropUnboundCtrlKeypress(key({ meta: true }), false)).toBe(false)
+    expect(shouldDropUnboundCtrlKeypress(key({ ctrl: true, meta: true }), false)).toBe(false)
+  })
+
+  it('exempts pastes: bracketed paste payloads legitimately carry control bytes', () => {
+    expect(shouldDropUnboundCtrlKeypress(key({ ctrl: true }), true)).toBe(false)
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -502,6 +502,25 @@ export function isLineKillModifier(key: { ctrl: boolean; meta: boolean; super?: 
 }
 
 /**
+ * Decide whether a ctrl-modified keypress that matched no composer
+ * binding should be dropped instead of falling through to the text
+ * path. hermes-ink assigns `keypress.name` as the input when ctrl is
+ * set, so e.g. \x0c — the byte the dashboard PTY bridge writes on
+ * every reattach to force a redraw — decodes as ctrl+'l' with input
+ * "l" and would type a stray "l" into the composer (#99277).
+ *
+ * Pastes are exempt: they legitimately carry control bytes alongside
+ * text. ctrl+meta is exempt too: Windows maps AltGr to Ctrl+Alt, and
+ * those keypresses are real text for European layouts.
+ */
+export function shouldDropUnboundCtrlKeypress(
+  key: { ctrl: boolean; meta: boolean },
+  isPasted: boolean
+): boolean {
+  return key.ctrl && !key.meta && !isPasted
+}
+
+/**
  * Pure computation for the fast-echo backspace bypass: given the
  * current value/cursor (already validated by `canFastBackspaceShape`),
  * returns what the new value/cursor should be, the exact stdout write
@@ -1574,6 +1593,13 @@ export function TextInput({
         } else {
           ;({ cursor: c, value: v } = killToLineEnd(v, c))
         }
+      } else if (shouldDropUnboundCtrlKeypress(k, event.keypress.isPasted === true)) {
+        // Every real ctrl binding has been checked above; what is left
+        // is a ctrl-modified keypress with no binding, and its input is
+        // the literal key name — never text.
+        flushKeyBurst()
+
+        return
       } else if (event.keypress.isPasted || inp.length > 0) {
         const bracketed = event.keypress.isPasted || inp.includes('[200~')
         const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')


### PR DESCRIPTION
## What does this PR do?

The dashboard PTY bridge writes a raw `\x0c` (`TUI_FORCE_REDRAW`, `hermes_cli/pty_session.py`) into the embedded TUI's stdin on every reattach to request one full redraw. hermes-ink assigns `keypress.name` as the input when the ctrl modifier is set, so that byte decodes as ctrl+'l' with input `"l"`. `TextInput` had no handling for an unbound ctrl-modified keypress, so its fallback text-append path typed a stray `l` into the composer on every reattach.

This PR drops ctrl-modified keypresses that matched no composer binding, right before the fallback text-append path (after all real ctrl bindings — a/e/u/k/w/z/y/b/f/d — have been checked). Two exemptions keep it safe:

- **Pastes** (`isPasted`): bracketed-paste payloads legitimately carry control bytes alongside text.
- **ctrl+meta**: Windows maps AltGr to Ctrl+Alt, and those keypresses are real text for European layouts.

The global layer is unaffected: `useInputHandlers.ts` still receives the same keypress and runs its `ctrl+L` → `clearSelection() + forceRedraw()` binding, so the forced redraw itself keeps working — it just no longer leaves a stray character behind.

## Related Issue

Fixes #99277
Fixes #101393
Fixes #104261

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: added exported pure predicate `shouldDropUnboundCtrlKeypress(key, isPasted)` and a new branch in the `useInput` handler that drops unbound ctrl-modified keypresses (flushing the key burst) before the fallback text-append path.
- `ui-tui/src/__tests__/textInputUnboundCtrl.test.ts`: regression tests for the force-redraw byte, ordinary typing, mac Cmd / Windows AltGr exemption, and paste exemption.
- `ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx`: component-level E2E regression test (ported from #101407) — a real `renderSync` harness feeds the raw `\x0c` reattach byte through a fake stdin and asserts no literal `l` lands in the composer; covers both the reattach (#99277) and model-switcher-reload (#101393) manifestations.

## How to Test

1. `cd ui-tui && npx vitest run src/__tests__/textInputUnboundCtrl.test.ts` — 4 tests pass (force-redraw byte dropped; ordinary typing, Cmd/AltGr, pastes preserved).
2. `cd ui-tui && npx vitest run src/__tests__/textInputCtrlLetterLeak.test.tsx` — 3 tests pass; verified fail-closed: all 3 fail with the upstream/main `textInput.tsx` and pass with this branch's drop guard.
3. `cd ui-tui && npx tsc --noEmit -p tsconfig.json` — passes.
4. `npx vitest run src/__tests__/textInput` — 127/133 pass; the 6 failures in `textInputFastEcho.test.ts` reproduce identically on a clean upstream/main checkout (pre-existing local-env failures, unrelated to this change).
5. Manual: open the dashboard chat page, let the PTY/WebSocket drop and reattach — the composer should stay clean; ctrl+L still repaints. Clicking the model switcher (top-right) repeatedly should not append `l` to the chat input (#101393). Switching to another session in the sidebar and back should not append `l` either (#104261).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (TS-only change; verified with `vitest` + `tsc --noEmit` per How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

