### PR TITLE
feat(providers): recognise llmman as a local runner alias

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -2,7 +2,7 @@
 
 Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
-Volcengine ARK, vLLM, llama.cpp). Key quirks:
+Volcengine ARK, vLLM, llama.cpp, llmman). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
   - reasoning_config disabled → top-level reasoning_effort="none"
     (Ollama /v1/chat/completions ignores think=False — ollama#14820)
@@ -136,6 +136,7 @@ custom = CustomProfile(
         "llamacpp",
         "llama.cpp",
         "llama-cpp",
+        "llmman",
     ),
     env_vars=(),  # No fixed key — custom endpoint
     base_url="",  # User-configured

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -260,6 +260,37 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestLocalRunnerAliases:
+    """Local OpenAI-compatible runners resolve through the `custom` profile
+    rather than each carrying its own profile. An unrecognised name is not
+    inert: per #27132 a `provider:` the registry doesn't know falls through to
+    another provider's credentials, so the alias is what keeps the request on
+    the user's own endpoint."""
+
+    def test_llmman_resolves_to_custom(self):
+        p = get_provider_profile("llmman")
+        assert p is not None and p.name == "custom"
+
+    def test_llmman_alias_matches_sibling_runners(self):
+        """Same resolution as the runners already aliased here."""
+        assert get_provider_profile("llmman") is get_provider_profile("vllm")
+        assert get_provider_profile("llmman") is get_provider_profile("llamacpp")
+
+    def test_llmman_does_not_get_ollama_think_quirk(self):
+        """`think` is Ollama-native and strict hosts reject it with 422. The
+        detector keys off port 11434 / an `ollama` hostname label, so llmman's
+        port must not opt into it."""
+        # ``plugins.model_providers.custom`` is a synthetic module name the
+        # registry installs during discovery, so resolve a profile first.
+        assert get_provider_profile("llmman") is not None
+        from plugins.model_providers.custom import _looks_like_ollama_endpoint
+
+        assert _looks_like_ollama_endpoint("http://localhost:17434/v1") is False
+        assert _looks_like_ollama_endpoint("http://127.0.0.1:17434/v1") is False
+        # Control: the real Ollama port still opts in.
+        assert _looks_like_ollama_endpoint("http://localhost:11434/v1") is True
+
+
 class TestAlibabaRegionalAndTokenPlanProfiles:
     """#73265: the models.dev catalog advertises alibaba-cn /
     alibaba-token-plan(-cn) / alibaba-coding-plan-cn, but none were registered


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman) — runs local models distributed as OCI artifacts, serves an OpenAI-compatible API on port 17434 — as an alias on the `custom` profile.

**Why an alias and not a new profile.** I started to write `plugins/model-providers/llmman/`, then read `custom/__init__.py`: local runners aren't separate profiles here, they're aliases (`ollama`, `local`, `vllm`, `llamacpp`, `llama.cpp`, `llama-cpp`). Adding a 41st profile directory would also have run straight into the CONTRIBUTING rule about third-party product directories under `plugins/`. A one-line alias is the pattern the tree already uses, so that's what this is.

**It isn't cosmetic.** I checked before and after:

```
vllm       -> custom
llamacpp   -> custom
ollama     -> custom
llmman     -> None      # before this change
```

Per the #27132 note in `test_runtime_provider_resolution.py`, a `provider:` the registry doesn't recognise doesn't fail cleanly — it falls through to another provider's credentials (the issue describes `provider: ollama` landing on OpenRouter with a 401). So the alias is what keeps the request pointed at the user's own endpoint with `no-key-required`.

**No new quirks.** llmman is a plain OpenAI-compatible endpoint — no `think`, no `num_ctx` handling needed. I specifically verified it doesn't inherit the Ollama-native `think` quirk: `_looks_like_ollama_endpoint` keys off port 11434 or an `ollama` hostname label and deliberately not arbitrary localhost, so 17434 stays out of it. There's a test asserting that, with the 11434 case as a control so the test would fail if the detector were ever loosened to match any localhost port.

### Testing

```
$ pytest tests/providers/
78 passed

$ pytest tests/providers/test_provider_profiles.py -k LocalRunnerAliases
3 passed
```

The new `TestLocalRunnerAliases` class sits next to `TestAlibabaRegionalAndTokenPlanProfiles`, which documents the same "Unknown provider" failure mode from #73265.

`tests/hermes_cli/test_runtime_provider_resolution.py` reports **2 failed, 63 passed both with and without this change** (verified against a stashed baseline) — both are `boto3` import errors in `agent/bedrock_adapter.py`, unrelated.

One incidental observation while I was in there: the `#27132` comment block in `test_runtime_provider_resolution.py` (around line 1335) describes the alias routing tests but the body beneath it is empty — looks like the tests were lost at some point. Not touching it here, but flagging it since it's the exact behaviour this PR relies on.

Not verified: no request against a live llmman server.

> AI-assisted, reviewed before submitting. Happy to explain any part of it.
