### PR TITLE
fix(dashboard): keep branch children out of resume lineage

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -106,6 +106,11 @@ from gateway.status import (
     read_runtime_status,
     resolve_gateway_liveness,
 )
+from hermes_state_common import (
+    _RESET_END_REASONS_SQL,
+    _legacy_branch_child_sql,
+    _legacy_reset_child_sql,
+)
 from utils import env_var_enabled
 
 try:
@@ -12171,12 +12176,18 @@ def _session_latest_descendant(session_id: str, db):
                 WHERE COALESCE(
                     json_extract(COALESCE(s.model_config, '{}'), '$._branched_from'), ''
                 ) != d.id
+                  AND NOT (
+                    """ + _legacy_branch_child_sql("s") + """
+                  )
                   AND COALESCE(
                     json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from'), ''
                 ) != d.id
                   AND COALESCE(
                     json_extract(COALESCE(s.model_config, '{}'), '$._reset_from'), ''
                 ) != d.id
+                  AND NOT (
+                    """ + _legacy_reset_child_sql("s", _RESET_END_REASONS_SQL) + """
+                  )
                   AND COALESCE(s.source, '') != 'tool'
             )
             SELECT id, parent_session_id, started_at FROM descendants

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12129,10 +12129,12 @@ async def cancel_oauth_session(
 
 
 def _session_latest_descendant(session_id: str, db):
-    """Resolve a session id to the newest child leaf session.
+    """Resolve a session id to the newest continuation leaf session.
 
     /model may create child sessions. Dashboard refresh should continue the
-    newest child instead of reopening the old parent.
+    newest child instead of reopening the old parent. User-created branches,
+    delegate/reset children, and tool sessions are separate conversations and
+    must not redirect a resume of their parent.
     """
     def row_get(row, key, index):
         if isinstance(row, dict):
@@ -12166,6 +12168,16 @@ def _session_latest_descendant(session_id: str, db):
                 SELECT s.id, s.parent_session_id, s.started_at
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
+                WHERE COALESCE(
+                    json_extract(COALESCE(s.model_config, '{}'), '$._branched_from'), ''
+                ) != d.id
+                  AND COALESCE(
+                    json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from'), ''
+                ) != d.id
+                  AND COALESCE(
+                    json_extract(COALESCE(s.model_config, '{}'), '$._reset_from'), ''
+                ) != d.id
+                  AND COALESCE(s.source, '') != 'tool'
             )
             SELECT id, parent_session_id, started_at FROM descendants
             """,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7229,10 +7229,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed.
 
-        Before clearing a reset boundary, stabilize markerless legacy reset
-        children that still depend on the parent's mutable end_reason.
+        Before clearing a branch or reset boundary, stabilize markerless
+        legacy children that still depend on the parent's mutable end_reason.
         """
         def _do(conn):
+            # WHERE shape shared with _BRANCH_CHILD_SQL's fallback arm via
+            # _legacy_branch_child_sql so stamping and classification cannot
+            # drift when the mutable parent boundary is cleared below.
+            conn.execute(
+                "UPDATE sessions AS child SET model_config = json_set("
+                "COALESCE(child.model_config, '{}'), '$._branched_from', "
+                "child.parent_session_id) "
+                "WHERE child.parent_session_id = ? "
+                "AND json_extract(COALESCE(child.model_config, '{}'), "
+                "                 '$._branched_from') IS NULL "
+                f"AND {_legacy_branch_child_sql('child')}",
+                (session_id,),
+            )
             placeholders = ",".join("?" for _ in _RESET_END_REASONS)
             # WHERE shape shared with _RESET_CHILD_SQL's fallback arm via
             # _legacy_reset_child_sql so the stamping and the listing

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -70,6 +70,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
+    _legacy_branch_child_sql,
     _legacy_reset_child_sql,
     _shape_preview,
     _sql_session_last_active,
@@ -12295,9 +12296,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is not None:
                     best = current
 
-                # Walk to the most-recently-started child — but skip explicit
-                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
-                # reset-continuation (`_reset_from` or the legacy same-key
+                # Walk to the most-recently-started child — but skip branch
+                # (`_branched_from` or the legacy parent-end heuristic),
+                # delegate/subagent (`_delegate_from`), reset-continuation
+                # (`_reset_from` or the legacy same-key
                 # heuristic — a post-reset conversation must never be reached
                 # by resuming the parent the user reset away), and tool
                 # children. They also carry a ``parent_session_id`` yet
@@ -12308,7 +12310,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     child_row = conn.execute(
                         "SELECT id FROM sessions AS child "
                         "WHERE child.parent_session_id = ? "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
+                        "  AND COALESCE(json_extract(COALESCE(child.model_config, '{}'), '$._branched_from'), '') "
+                        "      != child.parent_session_id "
+                        f"  AND NOT {_legacy_branch_child_sql('child')} "
                         "  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
                         "  AND json_extract(COALESCE(child.model_config, '{}'), '$._reset_from') IS NULL "
                         f"  AND NOT {_legacy_reset_child_sql('child', _RESET_END_REASONS_SQL)} "

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -171,14 +171,21 @@ def _shape_preview(raw: Any) -> str:
     return text
 
 
+def _legacy_branch_child_sql(alias: str) -> str:
+    """Pre-marker branch-child heuristic shared by lineage classifiers."""
+    return (
+        f"EXISTS (SELECT 1 FROM sessions p"
+        f"            WHERE p.id = {alias}.parent_session_id"
+        f"            AND p.end_reason = 'branched'"
+        f"            AND {alias}.started_at >= p.ended_at)"
+    )
+
+
 # A child session counts as a /branch (kept visible, never cascade-deleted) if
 # it carries the stable marker OR the legacy end_reason heuristic holds.
 _BRANCH_CHILD_SQL = (
     "json_extract(COALESCE({a}.model_config, '{{}}'), '$._branched_from') IS NOT NULL"
-    " OR EXISTS (SELECT 1 FROM sessions p"
-    "            WHERE p.id = {a}.parent_session_id"
-    "            AND p.end_reason = 'branched'"
-    "            AND {a}.started_at >= p.ended_at)"
+    " OR " + _legacy_branch_child_sql("{a}")
 )
 
 

--- a/tests/hermes_cli/test_web_session_latest_descendant.py
+++ b/tests/hermes_cli/test_web_session_latest_descendant.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from hermes_cli.web_server import _session_latest_descendant
+from hermes_cli.web_routers import sessions as web_sessions
 from hermes_state import SessionDB
 
 
@@ -88,3 +91,44 @@ def test_latest_descendant_still_follows_model_child_with_inherited_marker(
         "model-child",
         ["branch", "model-child"],
     )
+
+
+def test_messages_endpoint_keeps_legacy_branch_parent_transcript(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    try:
+        seed.create_session("parent", source="webui")
+        seed.append_message("parent", "user", "parent transcript")
+        seed.end_session("parent", "branched")
+        seed.create_session(
+            "legacy-branch",
+            source="webui",
+            parent_session_id="parent",
+        )
+        seed.append_message("legacy-branch", "user", "branch transcript")
+    finally:
+        seed.close()
+
+    def _open_db(profile=None, *, read_only):
+        assert profile is None
+        return SessionDB(db_path=db_path, read_only=read_only)
+
+    monkeypatch.setattr(web_sessions, "_open_session_db_for_profile", _open_db)
+
+    payload = asyncio.run(
+        web_sessions.get_session_messages(
+            "parent",
+            limit=None,
+            offset=0,
+            order=None,
+            include_compacted=False,
+        )
+    )
+
+    assert payload["session_id"] == "parent"
+    assert [message["content"] for message in payload["messages"]] == [
+        "parent transcript"
+    ]

--- a/tests/hermes_cli/test_web_session_latest_descendant.py
+++ b/tests/hermes_cli/test_web_session_latest_descendant.py
@@ -109,6 +109,18 @@ def test_messages_endpoint_keeps_legacy_branch_parent_transcript(
             parent_session_id="parent",
         )
         seed.append_message("legacy-branch", "user", "branch transcript")
+        seed.reopen_session("parent")
+
+        marker = seed._conn.execute(
+            "SELECT json_extract(model_config, '$._branched_from') "
+            "FROM sessions WHERE id = 'legacy-branch'"
+        ).fetchone()[0]
+        assert marker == "parent"
+        assert _session_latest_descendant("parent", seed) == (
+            "parent",
+            ["parent"],
+        )
+        assert seed.resolve_resume_session_id("parent") == "parent"
     finally:
         seed.close()
 

--- a/tests/hermes_cli/test_web_session_latest_descendant.py
+++ b/tests/hermes_cli/test_web_session_latest_descendant.py
@@ -43,6 +43,36 @@ def test_latest_descendant_does_not_follow_non_continuation_children(
     assert _session_latest_descendant("parent", db) == ("parent", ["parent"])
 
 
+def test_latest_descendant_does_not_follow_legacy_branch_child(
+    db: SessionDB,
+) -> None:
+    db.create_session("parent", source="webui")
+    db.end_session("parent", "branched")
+    db.create_session(
+        "legacy-branch",
+        source="webui",
+        parent_session_id="parent",
+    )
+
+    assert _session_latest_descendant("parent", db) == ("parent", ["parent"])
+
+
+def test_latest_descendant_does_not_follow_legacy_reset_child(
+    db: SessionDB,
+) -> None:
+    session_key = "agent:main:webui:dm:lane"
+    db.create_session("parent", source="webui", session_key=session_key)
+    db.end_session("parent", "session_reset")
+    db.create_session(
+        "legacy-reset",
+        source="webui",
+        session_key=session_key,
+        parent_session_id="parent",
+    )
+
+    assert _session_latest_descendant("parent", db) == ("parent", ["parent"])
+
+
 def test_latest_descendant_still_follows_model_child_with_inherited_marker(
     db: SessionDB,
 ) -> None:

--- a/tests/hermes_cli/test_web_session_latest_descendant.py
+++ b/tests/hermes_cli/test_web_session_latest_descendant.py
@@ -1,0 +1,60 @@
+"""Dashboard session-resume lineage regression tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.web_server import _session_latest_descendant
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+@pytest.mark.parametrize(
+    ("child_id", "source", "model_config"),
+    [
+        ("branch", "webui", {"_branched_from": "parent"}),
+        ("delegate", "subagent", {"_delegate_from": "parent"}),
+        ("reset", "webui", {"_reset_from": "parent"}),
+        ("tool", "tool", {}),
+    ],
+)
+def test_latest_descendant_does_not_follow_non_continuation_children(
+    db: SessionDB,
+    child_id: str,
+    source: str,
+    model_config: dict,
+) -> None:
+    db.create_session("parent", source="webui")
+    db.create_session(
+        child_id,
+        source=source,
+        parent_session_id="parent",
+        model_config=model_config,
+    )
+
+    assert _session_latest_descendant("parent", db) == ("parent", ["parent"])
+
+
+def test_latest_descendant_still_follows_model_child_with_inherited_marker(
+    db: SessionDB,
+) -> None:
+    db.create_session("branch", source="webui")
+    db.create_session(
+        "model-child",
+        source="webui",
+        parent_session_id="branch",
+        model_config={"_branched_from": "original-parent"},
+    )
+
+    assert _session_latest_descendant("branch", db) == (
+        "model-child",
+        ["branch", "model-child"],
+    )

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2528,6 +2528,31 @@ class TestListSessionsRich:
         db.append_message("legacy_child", "user", "after reset")
         assert db.resolve_resume_session_id("legacy_parent") == "legacy_parent"
 
+    def test_resume_walker_does_not_cross_legacy_branch_boundary(self, db):
+        db.create_session("branch_parent", "webui")
+        db.append_message("branch_parent", "user", "parent transcript")
+        db.end_session("branch_parent", "branched")
+        db.create_session(
+            "legacy_branch_child",
+            "webui",
+            parent_session_id="branch_parent",
+        )
+        db.append_message("legacy_branch_child", "user", "branch transcript")
+
+        assert db.resolve_resume_session_id("branch_parent") == "branch_parent"
+
+    def test_resume_walker_follows_child_with_inherited_branch_marker(self, db):
+        db.create_session("branch", "webui")
+        db.create_session(
+            "model_child",
+            "webui",
+            parent_session_id="branch",
+            model_config={"_branched_from": "original_parent"},
+        )
+        db.append_message("model_child", "assistant", "continued transcript")
+
+        assert db.resolve_resume_session_id("branch") == "model_child"
+
     # Compression-tip following (the walker's original purpose) is pinned by
     # tests/hermes_state/test_resolve_resume_session_id.py
     # ::test_follows_compression_tip_when_parent_retains_messages.


### PR DESCRIPTION
## Summary

- keep dashboard resume resolution on the requested parent when its direct child is a branch, delegate, reset, or tool session
- preserve traversal through legitimate model-switch children, including children that inherit lineage metadata from an older ancestor
- add focused regression coverage for each excluded child kind and the continuation path

## Root cause

The dashboard's latest-descendant recursive CTE followed every `parent_session_id` edge. `/branch` children use that same edge for ancestry, so selecting a parent caused the REST endpoint to return the branch as the newest leaf and the dashboard rewrote `?resume=<parent>` to the branch id.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_web_session_latest_descendant.py tests/test_web_server_sessiondb_eventloop.py -q` (8 passed)
- `tests/test_web_server.py` was also run; its unrelated POSIX-only assertion fails on this Windows host because the file is not Windows-gated

## Related Issue

Closes #99276
