### PR TITLE
fix(gateway): forward media attachments to cross-platform deliver: targets from webhook routes

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,7 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional, Tuple
 
 try:
     from aiohttp import web
@@ -385,15 +385,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return await self._deliver_github_comment(content, delivery)
 
         # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
-        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
-        if not _is_known_platform:
-            try:
-                from gateway.platform_registry import platform_registry
-                _is_known_platform = platform_registry.is_registered(deliver_type)
-            except Exception:
-                pass
-        if self.gateway_runner and _is_known_platform:
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
             return await self._deliver_cross_platform(
                 deliver_type, content, delivery
             )
@@ -401,6 +393,223 @@ class WebhookAdapter(BasePlatformAdapter):
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
         return SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
+        )
+
+    def _known_cross_platform(self, deliver_type: str) -> bool:
+        """True if *deliver_type* names a platform with a live gateway adapter.
+
+        Checks both built-in platform names and plugin-registered ones.
+        Shared by ``send()`` and the media-send overrides below so a
+        route's ``deliver:`` target is recognized identically for text and
+        attachments.
+        """
+        if deliver_type in _BUILTIN_DELIVER_PLATFORMS:
+            return True
+        try:
+            from gateway.platform_registry import platform_registry
+            return platform_registry.is_registered(deliver_type)
+        except Exception:
+            return False
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Forward a local image file to the route's cross-platform ``deliver:`` target.
+
+        Webhook itself has no native photo transport. Without this override,
+        MEDIA: attachments extracted by ``_process_message_background`` would
+        hit ``BasePlatformAdapter``'s fallback (a "couldn't deliver" text
+        notice) even when the route is configured to forward everything else
+        to a real platform via ``deliver:``. Mirrors ``send()``'s resolution
+        of the deliver target and falls back to the base behaviour for any
+        deliver type ``send()`` itself would fall back for (log,
+        github_comment, unknown, or no gateway_runner).
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
+            resolved = self._resolve_cross_platform_target(deliver_type, delivery)
+            if isinstance(resolved, SendResult):
+                return resolved
+            adapter, target_chat_id, cp_metadata = resolved
+            target_method = getattr(adapter, "send_image_file", None)
+            if target_method is not None:
+                return await target_method(
+                    chat_id=target_chat_id,
+                    image_path=image_path,
+                    caption=caption,
+                    reply_to=reply_to,
+                    metadata=cp_metadata,
+                    **kwargs,
+                )
+            # Target adapter has no native image-file sender — fall through
+            # to the base "couldn't deliver" notice rather than raising.
+
+        return await super().send_image_file(
+            chat_id=chat_id, image_path=image_path, caption=caption,
+            reply_to=reply_to, metadata=metadata, **kwargs,
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Forward a local file to the route's cross-platform ``deliver:`` target.
+
+        See ``send_image_file`` for why webhook must forward rather than use
+        the base fallback notice.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
+            resolved = self._resolve_cross_platform_target(deliver_type, delivery)
+            if isinstance(resolved, SendResult):
+                return resolved
+            adapter, target_chat_id, cp_metadata = resolved
+            target_method = getattr(adapter, "send_document", None)
+            if target_method is not None:
+                return await target_method(
+                    chat_id=target_chat_id,
+                    file_path=file_path,
+                    caption=caption,
+                    file_name=file_name,
+                    reply_to=reply_to,
+                    metadata=cp_metadata,
+                    **kwargs,
+                )
+            # Target adapter has no native document sender — fall through
+            # to the base "couldn't deliver" notice rather than raising.
+
+        return await super().send_document(
+            chat_id=chat_id, file_path=file_path, caption=caption,
+            file_name=file_name, reply_to=reply_to, metadata=metadata, **kwargs,
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Forward a local video file to the route's cross-platform ``deliver:`` target.
+
+        See ``send_image_file`` for why webhook must forward rather than use
+        the base fallback notice.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
+            resolved = self._resolve_cross_platform_target(deliver_type, delivery)
+            if isinstance(resolved, SendResult):
+                return resolved
+            adapter, target_chat_id, cp_metadata = resolved
+            target_method = getattr(adapter, "send_video", None)
+            if target_method is not None:
+                return await target_method(
+                    chat_id=target_chat_id,
+                    video_path=video_path,
+                    caption=caption,
+                    reply_to=reply_to,
+                    metadata=cp_metadata,
+                    **kwargs,
+                )
+            # Target adapter has no native video sender — fall through to
+            # the base "couldn't deliver" notice rather than raising.
+
+        return await super().send_video(
+            chat_id=chat_id, video_path=video_path, caption=caption,
+            reply_to=reply_to, metadata=metadata, **kwargs,
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Forward a local audio file to the route's cross-platform ``deliver:`` target.
+
+        See ``send_image_file`` for why webhook must forward rather than use
+        the base fallback notice.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
+            resolved = self._resolve_cross_platform_target(deliver_type, delivery)
+            if isinstance(resolved, SendResult):
+                return resolved
+            adapter, target_chat_id, cp_metadata = resolved
+            target_method = getattr(adapter, "send_voice", None)
+            if target_method is not None:
+                return await target_method(
+                    chat_id=target_chat_id,
+                    audio_path=audio_path,
+                    caption=caption,
+                    reply_to=reply_to,
+                    metadata=cp_metadata,
+                    **kwargs,
+                )
+            # Target adapter has no native voice sender — fall through to
+            # the base "couldn't deliver" notice rather than raising.
+
+        return await super().send_voice(
+            chat_id=chat_id, audio_path=audio_path, caption=caption,
+            reply_to=reply_to, metadata=metadata, **kwargs,
+        )
+
+    async def send_multiple_images(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> None:
+        """Forward a batch of images to the route's cross-platform ``deliver:`` target.
+
+        Base signature returns ``None`` (it sends each image individually
+        and only logs failures), so this override does the same — unlike
+        the other media overrides there is no ``SendResult`` to hand back.
+        See ``send_image_file`` for why webhook must forward at all.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        deliver_type = delivery.get("deliver", "log")
+        if self.gateway_runner and self._known_cross_platform(deliver_type):
+            resolved = self._resolve_cross_platform_target(deliver_type, delivery)
+            if isinstance(resolved, SendResult):
+                return
+            adapter, target_chat_id, cp_metadata = resolved
+            target_method = getattr(adapter, "send_multiple_images", None)
+            if target_method is not None:
+                await target_method(
+                    chat_id=target_chat_id,
+                    images=images,
+                    metadata=cp_metadata,
+                    human_delay=human_delay,
+                )
+                return
+            # Target adapter has no native batch-image sender — fall
+            # through to the base per-image loop rather than raising.
+
+        await super().send_multiple_images(
+            chat_id=chat_id, images=images, metadata=metadata, human_delay=human_delay,
         )
 
     def _prune_delivery_info(self, now: float) -> None:
@@ -1426,16 +1635,19 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.error("[webhook] github_comment delivery error: %s", e)
             return SendResult(success=False, error=str(e))
 
-    async def _deliver_cross_platform(
-        self, platform_name: str, content: str, delivery: dict
-    ) -> SendResult:
-        """Route response to another platform (telegram, discord, etc.)."""
-        if not self.gateway_runner:
-            return SendResult(
-                success=False,
-                error="No gateway runner for cross-platform delivery",
-            )
+    def _resolve_cross_platform_target(
+        self, platform_name: str, delivery: dict
+    ):
+        """Resolve the adapter/chat_id/metadata for a ``deliver:`` target.
 
+        Extracted from ``_deliver_cross_platform`` so the media-send
+        overrides (``send_image_file`` etc.) resolve the target identically
+        to text responses instead of duplicating adapter-lookup logic.
+
+        Returns a ``(adapter, chat_id, metadata)`` tuple on success, or a
+        ``SendResult(success=False, ...)`` describing why resolution failed
+        — callers distinguish the two with ``isinstance(x, SendResult)``.
+        """
         try:
             target_platform = Platform(platform_name)
         except ValueError:
@@ -1479,5 +1691,22 @@ class WebhookAdapter(BasePlatformAdapter):
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}
+
+        return adapter, chat_id, metadata
+
+    async def _deliver_cross_platform(
+        self, platform_name: str, content: str, delivery: dict
+    ) -> SendResult:
+        """Route response to another platform (telegram, discord, etc.)."""
+        if not self.gateway_runner:
+            return SendResult(
+                success=False,
+                error="No gateway runner for cross-platform delivery",
+            )
+
+        resolved = self._resolve_cross_platform_target(platform_name, delivery)
+        if isinstance(resolved, SendResult):
+            return resolved
+        adapter, chat_id, metadata = resolved
 
         return await adapter.send(chat_id, content, metadata=metadata)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -832,6 +832,178 @@ class TestDeliverCrossPlatformThreadId:
         )
 
 
+# ===================================================================
+# Media forwarding to cross-platform deliver: targets
+# ===================================================================
+
+
+class TestWebhookMediaForwarding:
+    """WebhookAdapter must forward media (not just text) to a route's
+    cross-platform ``deliver:`` target. Without overrides for
+    send_image_file / send_document / send_video / send_voice /
+    send_multiple_images, MEDIA: attachments hit BasePlatformAdapter's
+    fallback stubs and silently never reach the target platform."""
+
+    CHAT_ID = "webhook:r1:abc123"
+
+    def _setup_adapter_with_mock_target(self, deliver=None):
+        """Webhook adapter with a mocked gateway_runner and target adapter,
+        plus delivery info for CHAT_ID routing to that target."""
+        adapter = _make_adapter()
+        adapter._delivery_info[self.CHAT_ID] = (
+            {"deliver": "telegram", "deliver_extra": {"chat_id": "999"}}
+            if deliver is None
+            else deliver
+        )
+
+        mock_target = AsyncMock()
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform("telegram"): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+        return adapter, mock_target
+
+    # -- forwards to the resolved target adapter ---------------------
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_forwards_to_target(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_image_file = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send_image_file(
+            self.CHAT_ID, "/tmp/photo.jpg", caption="look"
+        )
+
+        mock_target.send_image_file.assert_awaited_once_with(
+            chat_id="999", image_path="/tmp/photo.jpg", caption="look",
+            reply_to=None, metadata=None,
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_document_forwards_to_target(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_document = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send_document(
+            self.CHAT_ID, "/tmp/report.pdf", file_name="report.pdf"
+        )
+
+        mock_target.send_document.assert_awaited_once_with(
+            chat_id="999", file_path="/tmp/report.pdf", caption=None,
+            file_name="report.pdf", reply_to=None, metadata=None,
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_video_forwards_to_target(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_video = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send_video(self.CHAT_ID, "/tmp/clip.mp4")
+
+        mock_target.send_video.assert_awaited_once_with(
+            chat_id="999", video_path="/tmp/clip.mp4", caption=None,
+            reply_to=None, metadata=None,
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_voice_forwards_to_target(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_voice = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send_voice(self.CHAT_ID, "/tmp/note.ogg")
+
+        mock_target.send_voice.assert_awaited_once_with(
+            chat_id="999", audio_path="/tmp/note.ogg", caption=None,
+            reply_to=None, metadata=None,
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_forwards_to_target(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_multiple_images = AsyncMock(return_value=None)
+        images = [("file:///tmp/a.jpg", "a"), ("file:///tmp/b.jpg", "b")]
+
+        result = await adapter.send_multiple_images(self.CHAT_ID, images)
+
+        mock_target.send_multiple_images.assert_awaited_once_with(
+            chat_id="999", images=images, metadata=None, human_delay=0.0,
+        )
+        assert result is None
+
+    # -- falls back to base behaviour ---------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("deliver_type", ["log", "not-a-real-platform"])
+    async def test_send_image_file_falls_back_when_deliver_not_cross_platform(
+        self, deliver_type
+    ):
+        """deliver: log (or an unrecognized platform name) never reaches
+        the target adapter — base's fallback notice path runs instead."""
+        adapter, mock_target = self._setup_adapter_with_mock_target(
+            deliver={"deliver": deliver_type}
+        )
+        mock_target.send_image_file = AsyncMock(return_value=SendResult(success=True))
+
+        with patch.object(
+            adapter, "send", new=AsyncMock(return_value=SendResult(success=True))
+        ) as mock_send:
+            await adapter.send_image_file(self.CHAT_ID, "/tmp/photo.jpg")
+
+        mock_target.send_image_file.assert_not_called()
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_falls_back_when_no_gateway_runner(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        adapter.gateway_runner = None
+        mock_target.send_image_file = AsyncMock(return_value=SendResult(success=True))
+
+        with patch.object(
+            adapter, "send", new=AsyncMock(return_value=SendResult(success=True))
+        ) as mock_send:
+            await adapter.send_image_file(self.CHAT_ID, "/tmp/photo.jpg")
+
+        mock_target.send_image_file.assert_not_called()
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_falls_back_when_target_lacks_method(self):
+        """Target adapter exists but has no native send_image_file — fall
+        through to the base notice rather than raising AttributeError."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target_limited = AsyncMock(spec=["send"])
+        adapter.gateway_runner.adapters = {Platform("telegram"): mock_target_limited}
+
+        with patch.object(
+            adapter, "send", new=AsyncMock(return_value=SendResult(success=True))
+        ) as mock_send:
+            result = await adapter.send_image_file(self.CHAT_ID, "/tmp/photo.jpg")
+
+        mock_send.assert_awaited_once()
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_falls_back_when_target_lacks_method(self):
+        """send_multiple_images has no SendResult return value, so its
+        fall-through must be exercised separately from the other overrides."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target_limited = AsyncMock(spec=["send"])
+        adapter.gateway_runner.adapters = {Platform("telegram"): mock_target_limited}
+        images = [("file:///tmp/a.jpg", "a")]
+
+        with patch.object(
+            adapter, "send", new=AsyncMock(return_value=SendResult(success=True))
+        ) as mock_send:
+            result = await adapter.send_multiple_images(self.CHAT_ID, images)
+
+        mock_send.assert_awaited_once()
+        assert result is None
+
+
 class TestInsecureNoAuthSafetyRail:
     """connect() refuses to start when INSECURE_NO_AUTH is combined with a
     non-loopback bind. Guards against accidentally exposing an unauthenticated


### PR DESCRIPTION
## What does this PR do?

Fixes media delivery for webhook routes that cross-forward to another
platform via `deliver:` (e.g. `deliver: telegram`, `deliver: discord`,
`deliver: slack`, `deliver: signal`, ...).

`WebhookAdapter` only overrides `send()` for cross-platform delivery. It
does **not** override `send_image_file`, `send_document`, `send_video`,
`send_voice`, or `send_multiple_images`. `_process_message_background`
extracts `MEDIA:` attachment paths from a response and dispatches them
through those methods — and since webhook doesn't override them, the calls
land on `BasePlatformAdapter`'s fallback stubs, which just log a warning
and emit a `"⚠️ Couldn't deliver the ... attachment."` text notice instead
of the actual file. Text responses cross-deliver correctly; every media
type silently does not.

This isn't specific to one platform or media type — any webhook route with
a `deliver:` target loses every kind of attachment (images, documents,
video, voice) the same way.

### Reproduction

1. Configure a webhook route with `deliver: telegram` (or any other
   platform with a live gateway adapter).
2. Trigger a response that includes a `MEDIA:` image attachment.
3. Observe: the target chat gets `"⚠️ Couldn't deliver the image
   attachment."` in the log, not the image. `send_image_file fallback`
   is logged instead of a native send.

### Fix

Add matching overrides for the five media-send methods, mirroring how
`send()` already resolves and forwards to the `deliver:` target. Each
override:
- Resolves the target adapter/chat_id/metadata for the route's `deliver:`
  value (same rules `send()` uses: built-in platform names or
  registry-registered plugin platforms, only when `gateway_runner` is
  set).
- If the target adapter has a native method for that media type, forwards
  the call to it.
- Otherwise (deliver: `log`, `github_comment`, an unrecognized platform,
  no `gateway_runner`, or a target adapter with no native method for that
  media type) falls through to `super().<method>()`, i.e. the exact same
  base-class behaviour as before this change.

**Deliberate DRY choice, called out for review:** the target-resolution
logic that `_deliver_cross_platform` already had inline is extracted into
two small helpers — `_known_cross_platform()` (the built-in/registry check
`send()` already did) and `_resolve_cross_platform_target()` (the
adapter/chat_id/metadata lookup `_deliver_cross_platform` already did) —
so all six send methods (the pre-existing `send()` plus the five new
overrides) resolve a `deliver:` target identically instead of five copies
of the same lookup. This touches existing code (`_deliver_cross_platform`
now calls the extracted helper) beyond the minimal new-methods diff. A
reviewer preferring the smallest possible diff could reasonably ask for
the resolution logic to be inlined into each new override instead and
`_deliver_cross_platform` left untouched — happy to split it out into a
separate refactor commit, or inline it, whichever this repo prefers.

Verified live against a running Hermes gateway: a webhook route configured
with `deliver: telegram` receiving an inbound photo now delivers the image
to Telegram via `send_media_group`, with no `send_image_file fallback`
warning in the logs.

## Related Issue

No existing issue — happy to open one first if preferred.

Fixes #99299
## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py`: add `WebhookAdapter.send_image_file`,
  `send_document`, `send_video`, `send_voice`, `send_multiple_images`
  overrides that forward to the resolved `deliver:` target; extract
  `_known_cross_platform()` and `_resolve_cross_platform_target()`
  helpers, shared with the existing `send()` / `_deliver_cross_platform()`
  path.
- `tests/gateway/test_webhook_adapter.py`: add `TestWebhookMediaForwarding`
  — forwarding to the resolved target adapter for each of the five new
  overrides, and fallback to base behaviour when `deliver:` is
  `log`/unrecognized, `gateway_runner` is unset, or the target adapter
  lacks the corresponding native method.

## How to Test

1. Configure a webhook route with `deliver: <platform>` pointing at a
   platform with a live gateway adapter (e.g. `deliver: telegram`).
2. Trigger a response containing a `MEDIA:` image/document/video/voice
   attachment.
3. Before this fix: the target chat receives a `"⚠️ Couldn't deliver the
   ... attachment."` text notice and the log shows a `send_image_file
   fallback` (or equivalent) warning. After this fix: the attachment is
   delivered natively via the target platform's send method.
4. `scripts/run_tests.sh tests/gateway/ tests/hermes_cli/test_webhook_cli.py tests/agent/test_outbound_webhooks.py -q`
   — 145 tests pass (0 failed), including the new
   `TestWebhookMediaForwarding` coverage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (production gateway); test suite additionally run on macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings added on the new overrides; no user-facing docs describe the media fallback path)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no OS-specific code paths touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (fallback stub logged, no image delivered):
```
[webhook] send_image_file fallback: native image send unavailable for <path>
```

After (forwarded and delivered natively, no fallback warning):
```
[telegram] Sent media group to <chat>
```



