### PR TITLE
fix(tools): unwrap single-key dicts for scalar-array tool arguments

### DIFF
--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -51,6 +51,7 @@ class TestCoerceNumber:
 
 
 
+
 class TestCoerceBoolean:
     """Unit tests for _coerce_boolean."""
 
@@ -61,12 +62,10 @@ class TestCoerceBoolean:
 
 
 
-
     def test_one_zero_not_coerced(self):
         """'1' and '0' are not boolean values."""
         assert _coerce_boolean("1") == "1"
         assert _coerce_boolean("0") == "0"
-
 
 
 class TestCoerceValue:
@@ -79,15 +78,10 @@ class TestCoerceValue:
 
 
 
-
-
-
     def test_array_type_parsed_from_json_string(self):
         """Stringified JSON arrays are parsed into native lists."""
         assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
         assert _coerce_value("[1, 2, 3]", "array") == [1, 2, 3]
-
-
 
 
 
@@ -120,7 +114,6 @@ class TestCoerceToolArgs:
 
 
 
-
     def test_leaves_already_correct_types(self):
         schema = self._mock_schema({"limit": {"type": "integer"}})
         with patch("tools.arg_coercion.registry.get_schema", return_value=schema):
@@ -131,8 +124,6 @@ class TestCoerceToolArgs:
 
     def test_empty_args(self):
         assert coerce_tool_args("test_tool", {}) == {}
-
-
 
 
 
@@ -172,7 +163,6 @@ class TestSchemaAcceptsKind:
         assert _schema_accepts_kind({"type": "string"}, "array") is False
 
 
-
     def test_non_dict(self):
         assert _schema_accepts_kind(None, "array") is False
 
@@ -184,7 +174,6 @@ class TestNormalizeJsonStringsForSchema:
         schema = {"type": "array", "items": {"type": "string"}}
         out = _normalize_json_strings_for_schema('["git status", "bun test"]', schema)
         assert out == ["git status", "bun test"]
-
 
 
 
@@ -240,10 +229,110 @@ class TestCoerceToolArgsNested:
             assert result["items"][0]["content"] == '{"not": "parsed"}'
 
 
-
     def test_real_todo_schema_element_strings(self):
         """Against the real todo schema from the registry."""
         import json as _json
         args = {"todos": [_json.dumps({"id": "1", "content": "x", "status": "pending"})]}
         result = coerce_tool_args("todo_list", args)
         assert result["todos"][0] == {"id": "1", "content": "x", "status": "pending"}
+
+
+# ── Scalar-array single-key dict unwrapping (#99270) ──────────────────────
+
+
+class TestCoerceToolArgsSingleKeyDictArray:
+    """Models sometimes emit a scalar-array argument as a single-key dict
+    (``{"ids": {"item": 14}}``). With a scalar ``items`` schema the sole
+    value is unwrapped; every other shape keeps the legacy wrap behavior."""
+
+    def _schema(self, items_schema):
+        return {
+            "name": "test_tool",
+            "description": "test",
+            "parameters": {
+                "type": "object",
+                "properties": {"ids": {"type": "array", "items": items_schema}},
+            },
+        }
+
+    def test_integer_items_unwrapped(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": "integer"})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 14}})
+            assert result["ids"] == [14]
+
+    def test_string_items_unwrapped(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": "string"})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": "https://a.com"}})
+            assert result["ids"] == ["https://a.com"]
+
+    def test_enum_string_items_unwrapped(self):
+        """``array<enum>`` shape from a live MCP report (Firecrawl ``formats``):
+        the ``enum`` facet does not change the declared scalar item type."""
+        schema = self._schema({"type": "string", "enum": ["markdown", "html", "rawHtml"]})
+        with patch("tools.arg_coercion.registry.get_schema", return_value=schema):
+            result = coerce_tool_args("test_tool", {"ids": {"item": "markdown"}})
+            assert result["ids"] == ["markdown"]
+
+    def test_inner_list_not_double_wrapped(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": "integer"})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": [1, 2]}})
+            assert result["ids"] == [1, 2]
+
+    def test_object_items_schema_left_alone(self):
+        """``array<object>`` legitimately accepts single-key dict elements."""
+        schema = self._schema({"type": "object", "properties": {"item": {"type": "integer"}}})
+        with patch("tools.arg_coercion.registry.get_schema", return_value=schema):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 1}})
+            assert result["ids"] == [{"item": 1}]
+
+    def test_multi_key_dict_left_alone(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": "integer"})):
+            result = coerce_tool_args("test_tool", {"ids": {"a": 1, "b": 2}})
+            assert result["ids"] == [{"a": 1, "b": 2}]
+
+    def test_missing_items_schema_left_alone(self):
+        schema = {
+            "name": "test_tool",
+            "description": "test",
+            "parameters": {"type": "object", "properties": {"ids": {"type": "array"}}},
+        }
+        with patch("tools.arg_coercion.registry.get_schema", return_value=schema):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 14}})
+            assert result["ids"] == [{"item": 14}]
+
+    def test_union_array_type_with_null_unwrapped(self):
+        """JSON-Schema union array form ``["integer", "null"]``: some MCP
+        servers emit it and ``strip_nullable_unions`` only folds ``anyOf``/
+        ``oneOf``, so the union form reaches the registry verbatim (#99270
+        live report: the unwrap branch never fired for an MCP tool)."""
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": ["integer", "null"]})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 14}})
+            assert result["ids"] == [14]
+
+    def test_union_array_type_all_scalar_unwrapped(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": ["string"]})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": "a"}})
+            assert result["ids"] == ["a"]
+
+    def test_union_array_type_with_object_left_alone(self):
+        """A union mixing in a non-scalar member can legitimately carry dict
+        elements — the unwrap must not apply."""
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": ["integer", "object"]})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 1}})
+            assert result["ids"] == [{"item": 1}]
+
+    def test_union_array_type_empty_left_alone(self):
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": []})):
+            result = coerce_tool_args("test_tool", {"ids": {"item": 14}})
+            assert result["ids"] == [{"item": 14}]
+
+    def test_wrapped_dict_logs_keys_not_values(self, caplog):
+        """When the unwrap does not apply, the wrap logs the dict's KEYS so
+        the next live report shows what the model actually emitted — without
+        echoing values, which may carry user content."""
+        with patch("tools.arg_coercion.registry.get_schema", return_value=self._schema({"type": "integer"})):
+            with caplog.at_level("INFO", logger="model_tools"):
+                coerce_tool_args("test_tool", {"ids": {"item": 14, "extra": "secret-value"}})
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "keys: ['extra', 'item']" in joined
+        assert "secret-value" not in joined

--- a/tools/arg_coercion.py
+++ b/tools/arg_coercion.py
@@ -8,7 +8,7 @@ conservative: originals are kept whenever a repair is not unambiguous.
 
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from tools.registry import registry
 
@@ -17,8 +17,49 @@ from tools.registry import registry
 logger = logging.getLogger("model_tools")
 
 
+# ``items`` types whose single-key-dict unwrap is safe: a dict landing on an
+# array of scalars can only be the model's serialization of one element, so
+# the sole value is extracted; object/unknown item types keep the wrap.
+_SCALAR_ITEM_TYPES = ("integer", "number", "string", "boolean")
+
+
+def _array_items_type(prop_schema: Any) -> Optional[str]:
+    """Return the declared scalar ``items`` type of an array property schema.
+
+    ``None`` when the schema has no ``items`` or a non-scalar-announced
+    ``items`` (missing/union types) — callers treat that as "unknown, do
+    not unwrap". JSON Schema also allows the union array form; a union of
+    scalar members plus optional ``"null"`` (``["integer", "null"]``, the
+    shape ``strip_nullable_unions`` leaves untouched because it only folds
+    ``anyOf``/``oneOf``) resolves to its first non-null scalar member, while
+    a union mixing in a non-scalar type (``["integer", "object"]``) stays
+    unknown so object-ish elements are never unwrapped.
+    """
+    items = prop_schema.get("items") if isinstance(prop_schema, dict) else None
+    if not isinstance(items, dict):
+        return None
+    declared = items.get("type")
+    if isinstance(declared, str):
+        return declared
+    if isinstance(declared, list):
+        non_null = [t for t in declared if isinstance(t, str) and t != "null"]
+        if non_null and all(t in _SCALAR_ITEM_TYPES for t in non_null):
+            return non_null[0]
+    return None
+
+
 def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
-    """Coerce string-typed args to their JSON-Schema types; originals kept on failure."""
+    """Coerce string-typed args to their JSON-Schema types; originals kept on failure.
+
+    Some models go one step further than bare scalars and emit a scalar-array
+    argument as a single-key dict (``{"ids": {"item": 14}}``) — their
+    serialization of the array's inner slot.  When the declared ``items``
+    type is scalar (including the JSON-Schema union array form
+    ``["integer", "null"]``, which some MCP servers emit and the sanitizer
+    leaves as-is), the sole value is unwrapped before wrapping so the tool
+    receives ``[14]`` instead of ``[{"item": 14}]``; object-item schemas are
+    untouched because single-key dicts are legitimate elements there.
+    """
     if not args or not isinstance(args, dict):
         return args
 
@@ -60,6 +101,31 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                 args[key] = [value]
                 logger.info("coerce_tool_args: wrapped bare string in list for %s.%s", tool_name, key)
                 continue
+            # Single-key dict for a scalar-items array (e.g. ``{"item": 14}``
+            # for ``array<integer>``): unwrap the sole value instead of
+            # wrapping the whole dict. Sending ``[{"item": 14}]`` makes strict
+            # servers reject the call — or silently coerce it to ``[]``.
+            if (
+                isinstance(value, dict)
+                and len(value) == 1
+                and _array_items_type(prop_schema) in _SCALAR_ITEM_TYPES
+            ):
+                inner = next(iter(value.values()))
+                args[key] = list(inner) if isinstance(inner, (list, tuple)) else [inner]
+                logger.info(
+                    "coerce_tool_args: unwrapped single-key dict into list for %s.%s",
+                    tool_name, key,
+                )
+                continue
+            if isinstance(value, dict):
+                # Keys only, never values: the dict shape is the diagnostic
+                # that decides whether the unwrap rule needs widening — the
+                # payload itself may carry user content.
+                logger.info(
+                    "coerce_tool_args: wrapping bare dict {keys: %s} in list for %s.%s "
+                    "— scalar-array unwrap did not apply (item schema or key count)",
+                    sorted(str(k) for k in value.keys()), tool_name, key,
+                )
             args[key] = [value]
             logger.info("coerce_tool_args: wrapped bare %s in list for %s.%s", type(value).__name__, tool_name, key)
             continue


### PR DESCRIPTION
## What does this PR do?

Fixes a tool-argument coercion bug where a scalar-array argument emitted by the model as a single-key dict — e.g. `handlerIds={"item": 14}` against an `array<integer>` schema — was blindly wrapped into `[{"item": 14}]` by `coerce_tool_args()` and forwarded to the tool as-is. Remote MCP servers (and any tool that validates arrays strictly) reject the wrapped form; worse, some servers silently coerce it to `[]` and report success with zero items written (see #99270 for the audit-log evidence: five MCP-channel calls received `handlerIds=[item]` while the direct-HTTP control call received `handlerIds=[14]`).

The fix is schema-aware, per the RCA agreed in the issue thread: when a property declares `type: array` and its `items` schema is a scalar type (`integer`/`number`/`string`/`boolean`), and the model emitted a single-key dict, the sole value is unwrapped before list-wrapping — `[14]`, not `[{"item": 14}]`. If the unwrapped value is itself a list, it is used directly (no double wrap). This deliberately avoids the lossy "blindly unwrap `{"item": ...}` everywhere" approach: object-item schemas, multi-key dicts, and schemas without a scalar `items` type keep the legacy wrap behavior, so a tool whose schema legitimately declares `items: {type: object, properties: {item: ...}}` is untouched.

## Related Issue

Fixes #99270

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py`: added `_array_items_type()` helper (returns the declared `items.type` of an array property, `None` when absent/non-scalar); in `coerce_tool_args()`'s bare-value array branch, unwrap single-key dicts before wrapping when `items` is scalar; updated the docstring.
- `tests/run_agent/test_tool_arg_coercion.py`: new `TestCoerceToolArgsSingleKeyDictArray` class — integer/string unwrap, inner-list passthrough, and the three no-unwrap guards (object items schema, multi-key dict, missing `items`).

## How to Test

1. `.venv/bin/python -m pytest tests/run_agent/test_tool_arg_coercion.py -q` — Observed result: 25 passed (19 pre-existing + 6 new).
2. `.venv/bin/python -m pytest tests/test_model_tools.py tests/test_model_tools_async_bridge.py tests/run_agent/test_tool_arg_coercion.py tests/test_sanitize_tool_error.py -q` — Observed result: 70 passed, 0 failed.
3. End-to-end reproduction of the issue scenario (fake `create_worklog` schema, `handlerIds: {"item": 14}` against `array<number>`): `coerce_tool_args` now returns `handlerIds=[14]`; an `array<object>` field passed through unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
