### PR TITLE
fix(gateway): block sensitive bare-path auto attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1979,17 +1979,16 @@ SUPPORTED_IMAGE_DOCUMENT_TYPES = {
 
 
 # ---------------------------------------------------------------------------
-# Media-delivery extension allowlist — SINGLE SOURCE OF TRUTH
+# Media-delivery extension allowlists
 #
-# Both extractors that turn response text into native attachments derive their
-# extension set from this tuple:
-#   * ``extract_media()``       — explicit ``MEDIA:<path>`` tags
-#   * ``extract_local_files()`` — bare absolute/home paths the agent mentions
+# Explicit ``MEDIA:<path>`` tags use the broad MEDIA_DELIVERY_EXTS set: a tag is
+# an intentional upload instruction, so generated YAML/JSON/etc. should still be
+# deliverable. Bare path auto-attach uses BARE_LOCAL_FILE_EXTS, a narrower subset
+# that excludes YAML/YML and runs an additional sensitive-path guard before any
+# file is uploaded.
 #
-# Historically these two carried independently-maintained extension lists.
-# ``extract_media`` had a narrow list (no .md/.json/.yaml/.xml/.html/...) while
-# ``extract_local_files`` had a broad one. Combined with the unconditional
-# ``MEDIA:\\s*\\S+`` cleanup at the dispatch sites, that mismatch created a
+# Historically ``extract_media`` had a narrow list (no .md/.json/.yaml/.xml/.html/...)
+# while ``extract_local_files`` had a broad one. Combined with the unconditional
 # silent black hole: a ``MEDIA:/report.md`` tag failed the narrow extract_media
 # match, got stripped from the body by the loose cleanup regex, and was then
 # invisible to extract_local_files — the file was never delivered (issue
@@ -2024,6 +2023,84 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Web / rendered output
     ".html", ".htm",
 )
+
+# Bare-path auto-attach is intentionally narrower than explicit MEDIA: tags.
+# YAML is overwhelmingly configuration, not a safe generated artifact. Agents can
+# still intentionally send YAML with an explicit MEDIA: tag, which uses
+# MEDIA_DELIVERY_EXTS above.
+BARE_LOCAL_FILE_EXTS: Tuple[str, ...] = tuple(
+    ext for ext in MEDIA_DELIVERY_EXTS if ext not in {".yaml", ".yml"}
+)
+
+_SENSITIVE_BARE_FILE_NAMES = frozenset({
+    "config.yaml",
+    "config.yml",
+    ".env",
+    "auth.json",
+    "credentials.json",
+    "secrets.json",
+    "known_hosts",
+})
+_SENSITIVE_BARE_FILE_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
+_SENSITIVE_BARE_FILE_PREFIXES = ("id_rsa", "id_ed25519", ".env")
+# Sensitive *words* are matched as whole filename components (split on dots,
+# dashes, underscores and spaces), never as bare substrings, and only on
+# extensions that can plausibly HOLD a credential. A raw substring test rejects
+# legitimate artifacts whose names merely contain one of these words --
+# ``tokenization.json``, ``tokenizer.json`` -- and applying it to binary render
+# formats rejects ``token_counts.png`` / ``secret-santa.pdf``, which are charts
+# and documents, not credential stores.
+_SENSITIVE_BARE_FILE_WORDS = frozenset({
+    "secret", "secrets",
+    "credential", "credentials",
+    "token", "tokens",
+    "password", "passwords",
+})
+
+# Extensions the word heuristic applies to: text/config formats that can
+# actually contain a secret. Binary render/artifact formats (images, video,
+# audio, pdf, office, archives) are exempt -- a chart named
+# ``token_counts.png`` is not a credential. Name-, prefix- and suffix-based
+# rules (``.env*``, ``id_rsa*``, ``*.pem``, ``*.key``, ``.hermes/``) are NOT
+# scoped this way and still apply to every extension.
+_SENSITIVE_WORD_SCOPED_EXTS = frozenset({
+    ".json", ".txt", ".yaml", ".yml", ".xml", ".toml", ".ini", ".conf",
+    ".cfg", ".csv", ".tsv", ".log", ".md", ".env", ".properties", ".sh",
+})
+
+# Filename component separators: dots, dashes, underscores and spaces.
+_FILENAME_COMPONENT_RE = re.compile(r"[.\-_ ]+")
+
+
+def _sensitive_name_components(name: str) -> set:
+    """Split a filename into lowercase word components for exact matching."""
+    return {part for part in _FILENAME_COMPONENT_RE.split(name) if part}
+
+
+def _is_sensitive_bare_local_file_path(path: str) -> bool:
+    """Return True when a bare path should never be auto-attached.
+
+    This guard applies only to automatic bare-path extraction. Explicit MEDIA:
+    tags remain the deliberate escape hatch for attachments that happen to look
+    config-like.
+    """
+    lowered = os.path.expanduser(path).lower()
+    parts = {part for part in re.split(r"[/\\]+", lowered) if part}
+    name = next((part for part in reversed(re.split(r"[/\\]+", lowered)) if part), "")
+
+    if ".hermes" in parts:
+        return True
+    if name in _SENSITIVE_BARE_FILE_NAMES:
+        return True
+    if name.endswith(_SENSITIVE_BARE_FILE_SUFFIXES):
+        return True
+    if name.startswith(_SENSITIVE_BARE_FILE_PREFIXES):
+        return True
+    _, _, ext = name.rpartition(".")
+    if ext and f".{ext}" not in _SENSITIVE_WORD_SCOPED_EXTS:
+        # Binary render/artifact format -- word heuristic does not apply.
+        return False
+    return bool(_sensitive_name_components(name) & _SENSITIVE_BARE_FILE_WORDS)
 
 # Regex alternation fragment of bare extensions (no leading dot), e.g.
 # ``png|jpe?g|...``. ``jpe?g`` collapses jpg/jpeg into one branch. Sorted
@@ -5267,6 +5344,11 @@ class BasePlatformAdapter(ABC):
         document extensions route through ``send_document``.  The dispatch
         partition lives in ``gateway/run.py``.
 
+        The bare-path allow-list is intentionally narrower than explicit
+        ``MEDIA:`` tags: YAML/YML is excluded, and config/credential-looking
+        paths (including anything under a ``.hermes`` directory) are never
+        auto-attached. Use explicit ``MEDIA:`` for intentional uploads.
+
         Paths inside fenced code blocks (``` ... ```) and inline code
         (`...`) are ignored so that code samples are never mutilated.
 
@@ -5274,7 +5356,7 @@ class BasePlatformAdapter(ABC):
             Tuple of (list of expanded file paths, cleaned text with the
             raw path strings removed).
         """
-        _LOCAL_MEDIA_EXTS = MEDIA_DELIVERY_EXTS
+        _LOCAL_MEDIA_EXTS = BARE_LOCAL_FILE_EXTS
         ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_MEDIA_EXTS)
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
@@ -5302,6 +5384,8 @@ class BasePlatformAdapter(ABC):
                 continue
             raw = match.group(0)
             expanded = os.path.expanduser(raw)
+            if _is_sensitive_bare_local_file_path(expanded):
+                continue
             if os.path.isfile(expanded):
                 found.append((raw, expanded))
             else:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2063,10 +2063,20 @@ _SENSITIVE_BARE_FILE_WORDS = frozenset({
 # ``token_counts.png`` is not a credential. Name-, prefix- and suffix-based
 # rules (``.env*``, ``id_rsa*``, ``*.pem``, ``*.key``, ``.hermes/``) are NOT
 # scoped this way and still apply to every extension.
+# Archive containers are NOT render artifacts. The exemption above is for
+# formats whose content is a picture/document of something (a chart named
+# ``token_counts.png``); an archive is an opaque container that can hold
+# anything, so ``secrets.zip`` / ``credentials.tar`` are exactly as dangerous
+# as ``secrets.json`` and must be word-scoped too. Without these, every
+# archive extension in BARE_LOCAL_FILE_EXTS bypassed the word heuristic.
+_SENSITIVE_ARCHIVE_EXTS = frozenset({
+    ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar",
+})
+
 _SENSITIVE_WORD_SCOPED_EXTS = frozenset({
     ".json", ".txt", ".yaml", ".yml", ".xml", ".toml", ".ini", ".conf",
     ".cfg", ".csv", ".tsv", ".log", ".md", ".env", ".properties", ".sh",
-})
+}) | _SENSITIVE_ARCHIVE_EXTS
 
 # Filename component separators: dots, dashes, underscores and spaces.
 _FILENAME_COMPONENT_RE = re.compile(r"[.\-_ ]+")

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -274,6 +274,17 @@ class TestSensitiveGuardDirect:
         "/Users/alice/data/service-secret.json",
         "/Users/alice/data/passwords.txt",
         "/Users/alice/data/credentials.json",
+        # Archive containers are opaque and can hold anything, so the word
+        # heuristic must apply to them exactly as it does to .json/.txt.
+        # These previously bypassed it because archive extensions were not
+        # in the word-scoped set, and every one of them is in
+        # BARE_LOCAL_FILE_EXTS -- i.e. auto-attachable.
+        "/Users/alice/out/secrets.zip",
+        "/Users/alice/out/credentials.tar",
+        "/Users/alice/out/passwords.gz",
+        "/Users/alice/out/secrets.7z",
+        "/Users/alice/out/api-tokens.zip",
+        "/Users/alice/out/token.tgz",
     ])
     def test_guard_blocks_sensitive_paths(self, path):
         assert _is_sensitive_bare_local_file_path(path) is True

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -14,6 +14,11 @@ import pytest
 
 from gateway.platforms.base import BasePlatformAdapter
 
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    _is_sensitive_bare_local_file_path,
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -85,6 +90,22 @@ class TestBasicDetection:
     def test_path_at_line_start(self):
         paths, _ = _extract("/var/data/image.png")
         assert paths == ["/var/data/image.png"]
+
+    def test_spreadsheet_and_data_extensions(self):
+        """Spreadsheets and non-sensitive structured data ship as file uploads."""
+        for ext in (".xlsx", ".xls", ".csv", ".tsv", ".json", ".xml"):
+            text = f"Data at /tmp/data{ext} ready"
+            paths, _ = _extract(text)
+            assert len(paths) == 1, f"Failed for {ext}"
+            assert paths[0] == f"/tmp/data{ext}"
+
+    def test_bare_yaml_paths_are_not_auto_attached(self):
+        """YAML is usually config; require explicit MEDIA: for upload."""
+        for ext in (".yaml", ".yml"):
+            text = f"Data at /tmp/data{ext} ready"
+            paths, cleaned = _extract(text)
+            assert paths == []
+            assert cleaned == text
 
 
 # ---------------------------------------------------------------------------
@@ -222,3 +243,135 @@ class TestEdgeCases:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestExplicitMediaTagStillWorks:
+
+    def test_explicit_media_tag_can_attach_yaml(self):
+        media, cleaned = BasePlatformAdapter.extract_media("Ship MEDIA:/tmp/generated.yaml now")
+        assert media == [("/tmp/generated.yaml", False)]
+        assert cleaned == "Ship  now"
+
+
+class TestSensitiveGuardDirect:
+    """Exercise ``_is_sensitive_bare_local_file_path`` directly.
+
+    The extraction suite above can only cover forms that survive the extension
+    regex. These cases pin the guard's own contract, including the
+    component-bounded word matching that replaced a raw substring test.
+    """
+
+    @pytest.mark.parametrize("path", [
+        "/Users/alice/.ssh/id_rsa",
+        "/Users/alice/.ssh/id_rsa.bak",
+        "/Users/alice/.ssh/id_ed25519",
+        "/Users/alice/certs/server.pem",
+        "/Users/alice/certs/server.key",
+        "/Users/alice/.hermes/config.yaml",
+        "/Users/alice/.hermes/plots/chart.png",
+        "/Users/alice/project/.env.local",
+        "/Users/alice/data/api-token.json",
+        "/Users/alice/data/service-secret.json",
+        "/Users/alice/data/passwords.txt",
+        "/Users/alice/data/credentials.json",
+    ])
+    def test_guard_blocks_sensitive_paths(self, path):
+        assert _is_sensitive_bare_local_file_path(path) is True
+
+    @pytest.mark.parametrize("path", [
+        # Component-bounded matching: these contain a sensitive WORD as a
+        # substring but not as a whole component.
+        "/Users/alice/out/tokenization.json",
+        "/Users/alice/out/tokenizer.json",
+        # Extension-scoped matching: the word IS a component, but the
+        # extension is a binary render/artifact format that cannot be a
+        # credential store.
+        "/Users/alice/plots/token_counts.png",
+        "/Users/alice/docs/secret-santa.pdf",
+        "/Users/alice/docs/password-policy-guide.pdf",
+        "/Users/alice/clips/tokens-per-second.mp4",
+        # Plain safe artifacts.
+        "/Users/alice/report.pdf",
+        "/Users/alice/chart.png",
+    ])
+    def test_guard_allows_legitimate_artifacts(self, path):
+        assert _is_sensitive_bare_local_file_path(path) is False
+
+    def test_sensitive_json_candidate_is_rejected_without_a_filesystem_probe(self):
+        """A matched sensitive candidate must never hit ``os.path.isfile()``."""
+        text = "See /Users/alice/data/api-token.json for details"
+
+        def exploding_isfile(p):
+            raise AssertionError(f"isfile() probed a sensitive candidate: {p}")
+
+        def fake_expanduser(p):
+            return "/home/user" + p[1:] if p.startswith("~/") else p
+
+        with patch("os.path.isfile", side_effect=exploding_isfile), \
+                patch("os.path.expanduser", side_effect=fake_expanduser):
+            paths, cleaned = BasePlatformAdapter.extract_local_files(text)
+
+        assert paths == []
+        assert cleaned == text
+
+    def test_safe_artifact_still_attaches_next_to_sensitive_path(self):
+        text = "Safe /tmp/report.pdf but do not send /Users/alice/.hermes/config.yaml"
+        paths, cleaned = _extract(text, existing_files={
+            "/tmp/report.pdf",
+            "/Users/alice/.hermes/config.yaml",
+        })
+        assert paths == ["/tmp/report.pdf"]
+        assert "/tmp/report.pdf" not in cleaned
+        assert "/Users/alice/.hermes/config.yaml" in cleaned
+
+
+class TestSensitivePathRejection:
+
+    @pytest.mark.parametrize("path", [
+        "/Users/alice/.hermes/config.yaml",
+        "/Users/alice/.hermes/profiles/aegis/config.yaml",
+        "/Users/alice/.hermes/.env",
+        "/Users/alice/.hermes/auth.json",
+        "/Users/alice/project/config.yaml",
+        "/Users/alice/project/config.yml",
+        "/Users/alice/project/.env",
+        "/Users/alice/project/.env.local",
+        # NOTE: id_rsa / id_ed25519 / *.pem are NOT extracted at all -- they
+        # carry no BARE_LOCAL_FILE_EXTS extension, so extract_local_files()
+        # never produces a candidate for the guard to reject. They are covered
+        # directly against the guard in TestSensitiveGuardDirect below; keeping
+        # them here would be a vacuous pass.
+        "/Users/alice/certs/server.key",
+        "/Users/alice/data/api-token.json",
+        "/Users/alice/data/passwords.txt",
+        "/Users/alice/data/service-secret.json",
+        "/Users/alice/data/credentials.json",
+    ])
+    def test_sensitive_bare_paths_are_not_attached_or_stripped(self, path):
+        text = f"The file is {path}"
+        paths, cleaned = _extract(text)
+        assert paths == []
+        assert cleaned == text
+
+    @pytest.mark.parametrize("path", [
+        "/Users/alice/.ssh/id_rsa",
+        "/Users/alice/.ssh/id_ed25519",
+        "/Users/alice/certs/server.pem",
+    ])
+    def test_extensionless_and_pem_paths_produce_no_candidate(self, path):
+        """Guard-independent proof: these forms never reach the guard.
+
+        ``extract_local_files()`` only matches BARE_LOCAL_FILE_EXTS, which has
+        no ``.pem`` and no extensionless form. Asserting "not attached" for
+        them in the guard suite above would pass even with the guard deleted,
+        so the real contract -- no candidate is ever produced -- is asserted
+        here instead.
+        """
+        text = f"The file is {path}"
+        with patch(
+            "gateway.platforms.base._is_sensitive_bare_local_file_path",
+            side_effect=AssertionError("guard must not be consulted"),
+        ):
+            paths, cleaned = _extract(text)
+        assert paths == []
+        assert cleaned == text

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -581,3 +581,34 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
     assert any(str(media_file) in img["image_path"] for img in adapter.images), (
         f"expected native image delivery via queued resend, got: {adapter.images!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_explicit_media_tag_can_attach_yaml(tmp_path, monkeypatch):
+    event = _event(thread_id="topic-1")
+    yaml_file = _allowed_media_path(tmp_path, monkeypatch, "generated.yaml")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="images")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}),
+        f"MEDIA:{yaml_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(yaml_file),
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_voice.assert_not_awaited()


### PR DESCRIPTION
`extract_local_files()` derives its extension set from the broad shared `MEDIA_DELIVERY_EXTS`, so a bare `.json` or `.yaml` path in response text is auto-attached and stripped from the message with no explicit `MEDIA:` tag. The existing denylist covers specific known secret files, so a generated `credentials.json`, `secrets.json`, or a `config.yaml` outside that named list still ships — verified on current `main`: all three are auto-attached today.

Sensitive names/words are now refused before the candidate is admitted. The word heuristic matches whole filename **components** (split on dots/dashes/underscores/spaces), not substrings, and only for text/config extensions — so `tokenization.json`, `tokenizer.json`, `token_counts.png` and `secret-santa.pdf` keep attaching, which the tests pin explicitly.

**One note on the test diff.** A PR-era test, `test_streaming_delivery_ignores_sensitive_bare_local_paths`, is retired here rather than carried. It asserted a delivery that no longer happens on `main` for sensitive *or* safe paths: `_deliver_media_from_response` has since been narrowed to an explicit-only uploader, so `send_document` is not awaited for any bare local path. Measured on pristine `main` and on this branch, both give an await count of 0 — so the test was no longer evidence about the guard. `main`'s own `test_queued_followup_delivery_keeps_bare_local_path_in_text` documents that narrowed behaviour. Its sibling using an explicit `MEDIA:` tag survives and still exercises a live path.

Replaces #37513, which has gone stale against `main`.
