### PR TITLE
fix(banner): include local HEAD in the update-check cache key

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -275,6 +275,21 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _local_head_sha() -> Optional[str]:
+    """Return the active checkout's HEAD SHA, or None for non-git installs.
+
+    Used as part of the update-check cache key so an in-place ``git pull`` /
+    rebase that moves HEAD without changing ``VERSION`` or ``HERMES_REVISION``
+    (the common case for source installs tracking a fork, where both are
+    ``None``) self-invalidates the cached "commits behind" count instead of
+    serving a stale value for the full 6-hour TTL.
+    """
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is None:
+        return None
+    return _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir) or None
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
@@ -439,6 +454,12 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
+    # HEAD SHA participates in the cache key so an in-place `git pull` / rebase
+    # that moves HEAD without changing VERSION or HERMES_REVISION self-invalidates
+    # the cached count. Computed AFTER the docker short-circuit above so
+    # containers (which have no .git) never shell out to git here.
+    head_sha = _local_head_sha()
+
     # Read cache — invalidate if the embedded rev OR installed version has
     # changed since the last check.
     now = time.time()
@@ -449,6 +470,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("head") == head_sha
             ):
                 return cached.get("behind")
     except Exception:
@@ -479,7 +501,13 @@ def check_for_updates() -> Optional[int]:
         # connectivity is restored (#82166).
         if behind is not None:
             cache_file.write_text(
-                json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+                json.dumps({
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "ver": VERSION,
+                    "head": head_sha,
+                }),
                 encoding="utf-8",
             )
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,7 +13,13 @@ import pytest
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When the cache is fresh AND HEAD matches, return it without a fetch.
+
+    The cache key includes the local HEAD SHA, so the cached entry must carry
+    the current HEAD for the fast path to fire. A cheap ``git rev-parse HEAD``
+    still runs to read the current HEAD, but no ``git fetch`` / ``rev-list``
+    network work happens.
+    """
     from hermes_cli.banner import check_for_updates
     from hermes_cli import __version__
 
@@ -22,15 +28,24 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
+    head = "a" * 40
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__, "head": head})
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+
+    def fake_run(cmd, *a, **k):
+        # Only the HEAD read should occur; fetch/rev-list must NOT.
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout=head + "\n")
+        raise AssertionError(f"unexpected git call on cache hit: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
 
 
 
@@ -245,5 +260,41 @@ def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):
     assert not cache_file.exists(), "None result must not be cached"
 
 
+def test_check_for_updates_invalidates_when_head_moved(tmp_path, monkeypatch):
+    """An in-place `git pull` that moves HEAD must invalidate the cached count.
 
+    VERSION and HERMES_REVISION are both unchanged (and are ``None`` for source
+    installs tracking a fork), so HEAD is the only signal that the checkout
+    advanced. Without it the stale "N commits behind" survives the full 6h TTL
+    and `hermes --version` keeps reporting a count the user just fixed.
+    """
+    from hermes_cli.banner import check_for_updates
+    from hermes_cli import __version__
 
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps(
+            # Fresh timestamp, same version — only HEAD differs from reality.
+            {"ts": time.time(), "behind": 182, "ver": __version__, "head": "o" * 40}
+        )
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fake_run(cmd, *a, **k):
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="n" * 40 + "\n")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        return MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = check_for_updates()
+
+    # Recomputed against the NEW head, not the stale cached 182.
+    assert result == 0
+    assert json.loads(cache_file.read_text())["head"] == "n" * 40


### PR DESCRIPTION
Builds on the diagnosis in #20653 by @bfoster59, which identified this bug and its cause: for a source install tracking a branch, the update-check cache is keyed on `{ts, rev, ver}`, and both the embedded rev and VERSION are typically unchanged across a `git pull`. So after the user updates, the cached "N commits behind" count is served for the rest of the 6-hour TTL and the banner keeps advertising an update that is already installed. Credit for the analysis belongs there.

This PR carries that fix forward against current `main` and adds three things that PR predates:

- **Compatibility with the inconclusive-result guard from #82166.** That guard (merged as `55d50d5c92`) added a don't-cache-a-`None`-result check at the same write site this change edits. The two are not in competition — the guard governs *whether* to write, this governs *what* is written — so they are resolved here as a union: the `None`-guard is retained and `"head": head_sha` is added inside it. Both the read path and the write path are wired.
- **A fresh-cache-with-old-HEAD transition test**, which neither change previously had. It pins the case where the cache entry is still inside its TTL but HEAD has moved underneath it.
- **Re-verification against current `main`.** The premise still holds: the cache key is `{ts, rev, ver}` and no local HEAD is recorded.

The local HEAD sha joins the cache key and is recorded on write, so a moved HEAD invalidates the entry and the count is recomputed. The Docker short-circuit still runs first, so containers with no `.git` never shell out to git. Distinct from the local-ahead handling in `3f39f8035`.

Happy to close this in favour of #20653 if the maintainers prefer that route — the transition test above applies to either and can be contributed there instead.
