### PR TITLE
feat(agent): add fail-closed passive worker contracts

### DIFF
--- a/agent/worker_contract.py
+++ b/agent/worker_contract.py
@@ -1,0 +1,311 @@
+"""Small, JSON-safe contracts for evidence-first worker collaboration.
+
+The contracts are deliberately passive.  They validate worker-produced
+metadata, but do not grant authority, dispatch work, or decide whether a
+task is complete.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class ContractValidationError(ValueError):
+    """Raised when a worker contract is incomplete or internally unsafe."""
+
+
+_CONFIDENCES = {"unknown", "low", "medium", "high"}
+_EVIDENCE_CLASSES = {
+    "unknown",
+    "observation",
+    "research",
+    "diagnostic",
+    "targeted",
+    "governed",
+    "acceptance",
+}
+_CAPABILITY_STATUSES = {"proposed", "tested", "reviewed", "active"}
+_CONSENSUS_STATUSES = {"pending", "partial", "needs_review", "accepted", "rejected"}
+_VERBOSITIES = {"concise", "normal", "detailed"}
+_DIRECTNESS = {"low", "normal", "high"}
+
+
+def _require_text(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ContractValidationError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _validate_texts(name: str, values: Any) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, (str, bytes)):
+        raise ContractValidationError(f"{name} must be a sequence of strings")
+    try:
+        normalized = tuple(_require_text(f"{name}[{index}]", value) for index, value in enumerate(values))
+    except TypeError as exc:
+        raise ContractValidationError(f"{name} must be a sequence of strings") from exc
+    return normalized
+
+
+def _validate_choice(name: str, value: Any, choices: set[str]) -> str:
+    value = _require_text(name, value)
+    if value not in choices:
+        allowed = ", ".join(sorted(choices))
+        raise ContractValidationError(f"{name} must be one of: {allowed}")
+    return value
+
+
+@dataclass(frozen=True)
+class EvidencePacket:
+    """Evidence with observations kept separate from interpretation."""
+
+    observations: tuple[str, ...]
+    sources: tuple[str, ...]
+    hypotheses: tuple[str, ...] = ()
+    conclusions: tuple[str, ...] = ()
+    unknowns: tuple[str, ...] = ()
+    confidence: str = "unknown"
+    evidence_class: str = "unknown"
+    artifacts: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
+
+    def validate(self) -> "EvidencePacket":
+        observations = _validate_texts("observations", self.observations)
+        sources = _validate_texts("sources", self.sources)
+        _validate_texts("hypotheses", self.hypotheses)
+        conclusions = _validate_texts("conclusions", self.conclusions)
+        _validate_texts("unknowns", self.unknowns)
+        _validate_texts("artifacts", self.artifacts)
+        _validate_texts("limitations", self.limitations)
+        _validate_choice("confidence", self.confidence, _CONFIDENCES)
+        _validate_choice("evidence_class", self.evidence_class, _EVIDENCE_CLASSES)
+
+        if conclusions and not observations:
+            raise ContractValidationError("conclusions require observations")
+        if observations and not sources:
+            raise ContractValidationError("observations require sources")
+        if conclusions and not sources:
+            raise ContractValidationError("conclusions require sources")
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "observations": list(self.observations),
+            "sources": list(self.sources),
+            "hypotheses": list(self.hypotheses),
+            "conclusions": list(self.conclusions),
+            "unknowns": list(self.unknowns),
+            "confidence": self.confidence,
+            "evidence_class": self.evidence_class,
+            "artifacts": list(self.artifacts),
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass(frozen=True)
+class ObjectiveStack:
+    """Operator-visible mission and constraints for one worker invocation."""
+
+    profile: str
+    authority: str
+    mission: str
+    constraints: tuple[str, ...] = ()
+    forbidden_actions: tuple[str, ...] = ()
+    hidden_objectives: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+
+    def validate(self) -> "ObjectiveStack":
+        _require_text("profile", self.profile)
+        _require_text("authority", self.authority)
+        _require_text("mission", self.mission)
+        _validate_texts("constraints", self.constraints)
+        _validate_texts("forbidden_actions", self.forbidden_actions)
+        hidden = _validate_texts("hidden_objectives", self.hidden_objectives)
+        conflicts = _validate_texts("conflicts", self.conflicts)
+        if hidden:
+            raise ContractValidationError("hidden objectives are forbidden")
+        if conflicts:
+            raise ContractValidationError("objective conflict requires review")
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "profile": self.profile,
+            "authority": self.authority,
+            "mission": self.mission,
+            "constraints": list(self.constraints),
+            "forbidden_actions": list(self.forbidden_actions),
+            "hidden_objectives": [],
+            "conflicts": [],
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityRecord:
+    """A capability claim tied to a tested source and explicit limitations."""
+
+    name: str
+    owner_profile: str
+    authority: str
+    evidence_class: str = "unknown"
+    status: str = "proposed"
+    tested_at: str | None = None
+    source_sha: str | None = None
+    limitations: tuple[str, ...] = ()
+
+    def validate(self) -> "CapabilityRecord":
+        _require_text("name", self.name)
+        _require_text("owner_profile", self.owner_profile)
+        _require_text("authority", self.authority)
+        _validate_choice("evidence_class", self.evidence_class, _EVIDENCE_CLASSES)
+        status = _validate_choice("status", self.status, _CAPABILITY_STATUSES)
+        _validate_texts("limitations", self.limitations)
+        if status in {"tested", "reviewed", "active"}:
+            _require_text("tested_at", self.tested_at)
+            _require_text("source_sha", self.source_sha)
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "name": self.name,
+            "owner_profile": self.owner_profile,
+            "authority": self.authority,
+            "evidence_class": self.evidence_class,
+            "status": self.status,
+            "tested_at": self.tested_at,
+            "source_sha": self.source_sha,
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass(frozen=True)
+class ConsensusRecord:
+    """Independent worker reports with disagreement retained explicitly."""
+
+    worker_reports: tuple[Mapping[str, Any], ...]
+    agreement: tuple[str, ...] = ()
+    dissent: tuple[str, ...] = ()
+    status: str = "pending"
+
+    def validate(self) -> "ConsensusRecord":
+        if not self.worker_reports:
+            raise ContractValidationError("worker_reports must not be empty")
+        for index, report in enumerate(self.worker_reports):
+            if not isinstance(report, Mapping):
+                raise ContractValidationError(f"worker_reports[{index}] must be an object")
+            _require_text(f"worker_reports[{index}].worker", report.get("worker"))
+        _validate_texts("agreement", self.agreement)
+        _validate_texts("dissent", self.dissent)
+        _validate_choice("status", self.status, _CONSENSUS_STATUSES)
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "worker_reports": [dict(report) for report in self.worker_reports],
+            "agreement": list(self.agreement),
+            "dissent": list(self.dissent),
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class WorkerMode:
+    """Communication settings whose safety requirements cannot be disabled."""
+
+    name: str
+    verbosity: str = "normal"
+    directness: str = "normal"
+    requires_citations: bool = True
+    requires_uncertainty: bool = True
+    humor_enabled: bool = False
+
+    def validate(self) -> "WorkerMode":
+        _require_text("name", self.name)
+        _validate_choice("verbosity", self.verbosity, _VERBOSITIES)
+        _validate_choice("directness", self.directness, _DIRECTNESS)
+        if self.requires_citations is not True:
+            raise ContractValidationError("citations are mandatory")
+        if self.requires_uncertainty is not True:
+            raise ContractValidationError("uncertainty reporting is mandatory")
+        if not isinstance(self.humor_enabled, bool):
+            raise ContractValidationError("humor_enabled must be boolean")
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "name": self.name,
+            "verbosity": self.verbosity,
+            "directness": self.directness,
+            "requires_citations": True,
+            "requires_uncertainty": True,
+            "humor_enabled": self.humor_enabled,
+        }
+
+
+_CONTRACT_FIELDS = {
+    "evidence_packet": {
+        "kind",
+        "observations",
+        "sources",
+        "hypotheses",
+        "conclusions",
+        "unknowns",
+        "confidence",
+        "evidence_class",
+        "artifacts",
+        "limitations",
+    },
+    "objective_stack": {
+        "kind",
+        "profile",
+        "authority",
+        "mission",
+        "constraints",
+        "forbidden_actions",
+        "hidden_objectives",
+        "conflicts",
+    },
+    "capability": {
+        "kind",
+        "name",
+        "owner_profile",
+        "authority",
+        "evidence_class",
+        "status",
+        "tested_at",
+        "source_sha",
+        "limitations",
+    },
+    "consensus": {"kind", "worker_reports", "agreement", "dissent", "status"},
+    "worker_mode": {
+        "kind",
+        "name",
+        "verbosity",
+        "directness",
+        "requires_citations",
+        "requires_uncertainty",
+        "humor_enabled",
+    },
+}
+
+
+def validate_contract_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Reject unknown fields before a serialized contract is interpreted."""
+
+    if not isinstance(value, Mapping):
+        raise ContractValidationError("contract must be an object")
+    kind = value.get("kind")
+    if not isinstance(kind, str) or kind not in _CONTRACT_FIELDS:
+        raise ContractValidationError("kind must identify a known contract")
+    unknown = set(value) - _CONTRACT_FIELDS[kind]
+    if unknown:
+        field_names = ", ".join(sorted(str(field) for field in unknown))
+        raise ContractValidationError(f"unknown field(s): {field_names}")
+    return value

--- a/agent/worker_contract.py
+++ b/agent/worker_contract.py
@@ -8,6 +8,8 @@ task is complete.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
+import math
 from typing import Any, Mapping
 
 
@@ -41,13 +43,9 @@ def _require_text(name: str, value: Any) -> str:
 def _validate_texts(name: str, values: Any) -> tuple[str, ...]:
     if values is None:
         return ()
-    if isinstance(values, (str, bytes)):
+    if not isinstance(values, (list, tuple)):
         raise ContractValidationError(f"{name} must be a sequence of strings")
-    try:
-        normalized = tuple(_require_text(f"{name}[{index}]", value) for index, value in enumerate(values))
-    except TypeError as exc:
-        raise ContractValidationError(f"{name} must be a sequence of strings") from exc
-    return normalized
+    return tuple(_require_text(f"{name}[{index}]", value) for index, value in enumerate(values))
 
 
 def _validate_choice(name: str, value: Any, choices: set[str]) -> str:
@@ -56,6 +54,37 @@ def _validate_choice(name: str, value: Any, choices: set[str]) -> str:
         allowed = ", ".join(sorted(choices))
         raise ContractValidationError(f"{name} must be one of: {allowed}")
     return value
+
+
+def _validate_timestamp(name: str, value: Any) -> str:
+    timestamp = _require_text(name, value)
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError as exc:
+        raise ContractValidationError(f"{name} must be a timezone-aware ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ContractValidationError(f"{name} must be a timezone-aware ISO-8601 timestamp")
+    return timestamp
+
+
+def _validate_json_value(name: str, value: Any) -> None:
+    if value is None or isinstance(value, (bool, int, str)):
+        return
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return
+        raise ContractValidationError(f"{name} must contain only JSON-compatible values")
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_json_value(f"{name}[{index}]", item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ContractValidationError(f"{name} must contain only JSON-compatible values")
+            _validate_json_value(f"{name}.{key}", item)
+        return
+    raise ContractValidationError(f"{name} must contain only JSON-compatible values")
 
 
 @dataclass(frozen=True)
@@ -92,29 +121,35 @@ class EvidencePacket:
             raise ContractValidationError("observations require sources")
         if conclusions and not sources:
             raise ContractValidationError("conclusions require sources")
-        _require_text("freshness", self.freshness)
+        _validate_timestamp("freshness", self.freshness)
         next_actions = _validate_texts("reversible_next_actions", self.reversible_next_actions)
         if not next_actions:
             raise ContractValidationError("reversible_next_actions must not be empty")
-        _validate_choice("outcome", self.outcome, _OUTCOMES)
+        outcome = _validate_choice("outcome", self.outcome, _OUTCOMES)
+        if outcome == "completed" and not observations:
+            raise ContractValidationError("completed outcome requires source-backed observations")
         return self
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
             "kind": "evidence_packet",
-            "observations": list(self.observations),
-            "sources": list(self.sources),
-            "hypotheses": list(self.hypotheses),
-            "conclusions": list(self.conclusions),
-            "unknowns": list(self.unknowns),
-            "confidence": self.confidence,
-            "evidence_class": self.evidence_class,
-            "artifacts": list(self.artifacts),
-            "limitations": list(self.limitations),
-            "freshness": self.freshness,
-            "reversible_next_actions": list(self.reversible_next_actions),
-            "outcome": self.outcome,
+            "observations": list(_validate_texts("observations", self.observations)),
+            "sources": list(_validate_texts("sources", self.sources)),
+            "hypotheses": list(_validate_texts("hypotheses", self.hypotheses)),
+            "conclusions": list(_validate_texts("conclusions", self.conclusions)),
+            "unknowns": list(_validate_texts("unknowns", self.unknowns)),
+            "confidence": _validate_choice("confidence", self.confidence, _CONFIDENCES),
+            "evidence_class": _validate_choice(
+                "evidence_class", self.evidence_class, _EVIDENCE_CLASSES
+            ),
+            "artifacts": list(_validate_texts("artifacts", self.artifacts)),
+            "limitations": list(_validate_texts("limitations", self.limitations)),
+            "freshness": _validate_timestamp("freshness", self.freshness),
+            "reversible_next_actions": list(
+                _validate_texts("reversible_next_actions", self.reversible_next_actions)
+            ),
+            "outcome": _validate_choice("outcome", self.outcome, _OUTCOMES),
         }
 
 
@@ -154,14 +189,16 @@ class ObjectiveStack:
         self.validate()
         return {
             "kind": "objective_stack",
-            "profile": self.profile,
-            "authority": self.authority,
-            "mission": self.mission,
-            "task_id": self.task_id,
-            "owner_id": self.owner_id,
-            "repository": self.repository,
-            "constraints": list(self.constraints),
-            "forbidden_actions": list(self.forbidden_actions),
+            "profile": _require_text("profile", self.profile),
+            "authority": _require_text("authority", self.authority),
+            "mission": _require_text("mission", self.mission),
+            "task_id": _require_text("task_id", self.task_id),
+            "owner_id": _require_text("owner_id", self.owner_id),
+            "repository": _require_text("repository", self.repository),
+            "constraints": list(_validate_texts("constraints", self.constraints)),
+            "forbidden_actions": list(
+                _validate_texts("forbidden_actions", self.forbidden_actions)
+            ),
             "hidden_objectives": [],
             "conflicts": [],
         }
@@ -196,14 +233,16 @@ class CapabilityRecord:
         self.validate()
         return {
             "kind": "capability",
-            "name": self.name,
-            "owner_profile": self.owner_profile,
-            "authority": self.authority,
-            "evidence_class": self.evidence_class,
-            "status": self.status,
+            "name": _require_text("name", self.name),
+            "owner_profile": _require_text("owner_profile", self.owner_profile),
+            "authority": _require_text("authority", self.authority),
+            "evidence_class": _validate_choice(
+                "evidence_class", self.evidence_class, _EVIDENCE_CLASSES
+            ),
+            "status": _validate_choice("status", self.status, _CAPABILITY_STATUSES),
             "tested_at": self.tested_at,
             "source_sha": self.source_sha,
-            "limitations": list(self.limitations),
+            "limitations": list(_validate_texts("limitations", self.limitations)),
         }
 
 
@@ -217,12 +256,15 @@ class ConsensusRecord:
     status: str = "pending"
 
     def validate(self) -> "ConsensusRecord":
+        if not isinstance(self.worker_reports, (list, tuple)):
+            raise ContractValidationError("worker_reports must be a stable sequence of objects")
         if not self.worker_reports:
             raise ContractValidationError("worker_reports must not be empty")
         workers: set[str] = set()
         for index, report in enumerate(self.worker_reports):
             if not isinstance(report, Mapping):
                 raise ContractValidationError(f"worker_reports[{index}] must be an object")
+            _validate_json_value(f"worker_reports[{index}]", report)
             worker = _require_text(f"worker_reports[{index}].worker", report.get("worker"))
             if worker in workers:
                 raise ContractValidationError("worker_reports must contain independent workers; duplicate worker")
@@ -239,9 +281,9 @@ class ConsensusRecord:
         return {
             "kind": "consensus",
             "worker_reports": [dict(report) for report in self.worker_reports],
-            "agreement": list(self.agreement),
-            "dissent": list(self.dissent),
-            "status": self.status,
+            "agreement": list(_validate_texts("agreement", self.agreement)),
+            "dissent": list(_validate_texts("dissent", self.dissent)),
+            "status": _validate_choice("status", self.status, _CONSENSUS_STATUSES),
         }
 
 
@@ -272,9 +314,9 @@ class WorkerMode:
         self.validate()
         return {
             "kind": "worker_mode",
-            "name": self.name,
-            "verbosity": self.verbosity,
-            "directness": self.directness,
+            "name": _require_text("name", self.name),
+            "verbosity": _validate_choice("verbosity", self.verbosity, _VERBOSITIES),
+            "directness": _validate_choice("directness", self.directness, _DIRECTNESS),
             "requires_citations": True,
             "requires_uncertainty": True,
             "humor_enabled": self.humor_enabled,

--- a/agent/worker_contract.py
+++ b/agent/worker_contract.py
@@ -29,6 +29,7 @@ _CAPABILITY_STATUSES = {"proposed", "tested", "reviewed", "active"}
 _CONSENSUS_STATUSES = {"pending", "partial", "needs_review", "accepted", "rejected"}
 _VERBOSITIES = {"concise", "normal", "detailed"}
 _DIRECTNESS = {"low", "normal", "high"}
+_OUTCOMES = {"completed", "partial", "blocked", "failed"}
 
 
 def _require_text(name: str, value: Any) -> str:
@@ -70,6 +71,9 @@ class EvidencePacket:
     evidence_class: str = "unknown"
     artifacts: tuple[str, ...] = ()
     limitations: tuple[str, ...] = ()
+    freshness: str = ""
+    reversible_next_actions: tuple[str, ...] = ()
+    outcome: str = ""
 
     def validate(self) -> "EvidencePacket":
         observations = _validate_texts("observations", self.observations)
@@ -88,11 +92,17 @@ class EvidencePacket:
             raise ContractValidationError("observations require sources")
         if conclusions and not sources:
             raise ContractValidationError("conclusions require sources")
+        _require_text("freshness", self.freshness)
+        next_actions = _validate_texts("reversible_next_actions", self.reversible_next_actions)
+        if not next_actions:
+            raise ContractValidationError("reversible_next_actions must not be empty")
+        _validate_choice("outcome", self.outcome, _OUTCOMES)
         return self
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
+            "kind": "evidence_packet",
             "observations": list(self.observations),
             "sources": list(self.sources),
             "hypotheses": list(self.hypotheses),
@@ -102,6 +112,9 @@ class EvidencePacket:
             "evidence_class": self.evidence_class,
             "artifacts": list(self.artifacts),
             "limitations": list(self.limitations),
+            "freshness": self.freshness,
+            "reversible_next_actions": list(self.reversible_next_actions),
+            "outcome": self.outcome,
         }
 
 
@@ -112,6 +125,9 @@ class ObjectiveStack:
     profile: str
     authority: str
     mission: str
+    task_id: str = ""
+    owner_id: str = ""
+    repository: str = ""
     constraints: tuple[str, ...] = ()
     forbidden_actions: tuple[str, ...] = ()
     hidden_objectives: tuple[str, ...] = ()
@@ -121,6 +137,9 @@ class ObjectiveStack:
         _require_text("profile", self.profile)
         _require_text("authority", self.authority)
         _require_text("mission", self.mission)
+        _require_text("task_id", self.task_id)
+        _require_text("owner_id", self.owner_id)
+        _require_text("repository", self.repository)
         _validate_texts("constraints", self.constraints)
         _validate_texts("forbidden_actions", self.forbidden_actions)
         hidden = _validate_texts("hidden_objectives", self.hidden_objectives)
@@ -134,9 +153,13 @@ class ObjectiveStack:
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
+            "kind": "objective_stack",
             "profile": self.profile,
             "authority": self.authority,
             "mission": self.mission,
+            "task_id": self.task_id,
+            "owner_id": self.owner_id,
+            "repository": self.repository,
             "constraints": list(self.constraints),
             "forbidden_actions": list(self.forbidden_actions),
             "hidden_objectives": [],
@@ -172,6 +195,7 @@ class CapabilityRecord:
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
+            "kind": "capability",
             "name": self.name,
             "owner_profile": self.owner_profile,
             "authority": self.authority,
@@ -195,18 +219,25 @@ class ConsensusRecord:
     def validate(self) -> "ConsensusRecord":
         if not self.worker_reports:
             raise ContractValidationError("worker_reports must not be empty")
+        workers: set[str] = set()
         for index, report in enumerate(self.worker_reports):
             if not isinstance(report, Mapping):
                 raise ContractValidationError(f"worker_reports[{index}] must be an object")
-            _require_text(f"worker_reports[{index}].worker", report.get("worker"))
+            worker = _require_text(f"worker_reports[{index}].worker", report.get("worker"))
+            if worker in workers:
+                raise ContractValidationError("worker_reports must contain independent workers; duplicate worker")
+            workers.add(worker)
         _validate_texts("agreement", self.agreement)
         _validate_texts("dissent", self.dissent)
-        _validate_choice("status", self.status, _CONSENSUS_STATUSES)
+        status = _validate_choice("status", self.status, _CONSENSUS_STATUSES)
+        if status == "accepted" and len(workers) < 2:
+            raise ContractValidationError("accepted consensus requires independent worker reports")
         return self
 
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
+            "kind": "consensus",
             "worker_reports": [dict(report) for report in self.worker_reports],
             "agreement": list(self.agreement),
             "dissent": list(self.dissent),
@@ -240,6 +271,7 @@ class WorkerMode:
     def to_dict(self) -> dict[str, Any]:
         self.validate()
         return {
+            "kind": "worker_mode",
             "name": self.name,
             "verbosity": self.verbosity,
             "directness": self.directness,
@@ -261,12 +293,18 @@ _CONTRACT_FIELDS = {
         "evidence_class",
         "artifacts",
         "limitations",
+        "freshness",
+        "reversible_next_actions",
+        "outcome",
     },
     "objective_stack": {
         "kind",
         "profile",
         "authority",
         "mission",
+        "task_id",
+        "owner_id",
+        "repository",
         "constraints",
         "forbidden_actions",
         "hidden_objectives",
@@ -297,7 +335,7 @@ _CONTRACT_FIELDS = {
 
 
 def validate_contract_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Reject unknown fields before a serialized contract is interpreted."""
+    """Validate a complete serialized contract before it is interpreted."""
 
     if not isinstance(value, Mapping):
         raise ContractValidationError("contract must be an object")
@@ -308,4 +346,23 @@ def validate_contract_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
     if unknown:
         field_names = ", ".join(sorted(str(field) for field in unknown))
         raise ContractValidationError(f"unknown field(s): {field_names}")
+    missing = _CONTRACT_FIELDS[kind] - set(value)
+    if missing:
+        field_names = ", ".join(sorted(missing))
+        raise ContractValidationError(f"missing field(s): {field_names}")
+    payload = dict(value)
+    payload.pop("kind")
+    constructors = {
+        "evidence_packet": EvidencePacket,
+        "objective_stack": ObjectiveStack,
+        "capability": CapabilityRecord,
+        "consensus": ConsensusRecord,
+        "worker_mode": WorkerMode,
+    }
+    try:
+        constructors[kind](**payload).validate()
+    except ContractValidationError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise ContractValidationError(f"invalid {kind} payload: {exc}") from exc
     return value

--- a/docs/superpowers/plans/2026-08-31-pr-98470-passive-worker-contract.md
+++ b/docs/superpowers/plans/2026-08-31-pr-98470-passive-worker-contract.md
@@ -1,0 +1,111 @@
+# PR 98470 Passive Worker Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce an exact-main, authorship-preserving, two-file replacement for the passive worker-contract claim hidden inside cumulative PR #98470.
+
+**Architecture:** Start from verified upstream `main` commit `1cf36398135f4848a1d04b2167ffb564b7881d35` and cherry-pick the original passive-contract commit `e0b848fed2f0bb446237c066eaa991e454096a43`. Treat the production-file allowlist as fail-closed: any conflict or additional production path stops integration instead of widening scope.
+
+**Tech Stack:** Python 3.13, pytest, Ruff, compileall, Git.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-pr-98470-passive-worker-contract-design.md`
+
+## Global Constraints
+
+- Preserve the original commit author and commit message.
+- Production changes are limited to `agent/worker_contract.py` and `tests/agent/test_worker_contract.py`.
+- Do not include lifecycle integration, model or provider changes, Qwen changes, routing, concurrency, egress, Kanban, PR-feedback, desktop, cron, gateway, packaging, or Python pinning.
+- Do not push, create or close a PR, force-push, delete a branch, or merge.
+- Focused checks are diagnostic evidence, not a full-suite or hosted exact-head CI receipt.
+
+---
+
+### Task 1: Integrate the Passive Worker Contract
+
+**Files:**
+- Create: `agent/worker_contract.py`
+- Create: `tests/agent/test_worker_contract.py`
+- Verify: `docs/superpowers/specs/2026-08-31-pr-98470-passive-worker-contract-design.md`
+
+**Interfaces:**
+- Consumes: original commit `e0b848fed2f0bb446237c066eaa991e454096a43` and upstream base `1cf36398135f4848a1d04b2167ffb564b7881d35`.
+- Produces: the public classes and functions defined by `agent.worker_contract`, with their contract tests preserved byte-for-byte unless current-main compatibility requires a reviewed two-file-only adjustment.
+
+- [ ] **Step 1: Verify the exact clean base and source provenance**
+
+Run:
+
+```bash
+git status --short
+git rev-parse refs/remotes/origin/main
+git merge-base HEAD refs/remotes/origin/main
+git show -s --format='%H%n%an%n%ae%n%s' e0b848fed2f0bb446237c066eaa991e454096a43
+git diff-tree --no-commit-id --name-only -r e0b848fed2f0bb446237c066eaa991e454096a43
+```
+
+Expected: clean tracked state; branch ancestry contains base `1cf36398135f4848a1d04b2167ffb564b7881d35`; source author is preserved; source paths are exactly the two allowlisted files.
+
+- [ ] **Step 2: Apply the original commit without rewriting authorship**
+
+Run:
+
+```bash
+git cherry-pick e0b848fed2f0bb446237c066eaa991e454096a43
+```
+
+Expected: a clean cherry-pick that creates only the two allowlisted production paths. On any conflict, abort with `git cherry-pick --abort` and stop for reassessment.
+
+- [ ] **Step 3: Verify the branch diff is narrowly scoped**
+
+Run:
+
+```bash
+git diff --name-status 1cf36398135f4848a1d04b2167ffb564b7881d35..HEAD
+git diff --stat 1cf36398135f4848a1d04b2167ffb564b7881d35..HEAD
+git diff --check 1cf36398135f4848a1d04b2167ffb564b7881d35..HEAD
+```
+
+Expected: the two contract files plus the approved spec and plan documents; no excluded subsystem paths; no whitespace errors.
+
+- [ ] **Step 4: Run the complete contract test module**
+
+Run:
+
+```bash
+/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_worker_contract.py
+```
+
+Expected: all collected contract tests pass with zero failures.
+
+- [ ] **Step 5: Run focused lint and compilation**
+
+Run:
+
+```bash
+/Users/mikedemott/.hermes/hermes-agent/venv/bin/ruff check agent/worker_contract.py tests/agent/test_worker_contract.py
+/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m compileall -q agent/worker_contract.py tests/agent/test_worker_contract.py
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 6: Run adjacent agent compatibility tests**
+
+Run:
+
+```bash
+/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_subagent_lifecycle.py
+```
+
+Expected: all collected adjacent lifecycle tests pass with zero failures; the passive module remains unwired and introduces no lifecycle regression.
+
+- [ ] **Step 7: Verify final provenance and cleanliness**
+
+Run:
+
+```bash
+git show -s --format='%H%n%P%n%an%n%ae%n%s' HEAD
+git status --short
+git log --oneline --decorate -3
+```
+
+Expected: the integration commit retains Mike DeMott and the original noreply identity; the worktree is clean; the branch contains only the design commit, plan commit, and passive-contract commit above upstream main.

--- a/docs/superpowers/specs/2026-08-31-pr-98470-passive-worker-contract-design.md
+++ b/docs/superpowers/specs/2026-08-31-pr-98470-passive-worker-contract-design.md
@@ -1,0 +1,80 @@
+# PR 98470 Passive Worker Contract Replacement Design
+
+## Objective
+
+Replace the cumulative upstream PR `NousResearch/hermes-agent#98470` with a
+reviewable contribution that contains only the passive, evidence-aware worker
+contract originally introduced by commit
+`e0b848fed2f0bb446237c066eaa991e454096a43`.
+
+The replacement must preserve contributor authorship, start from exact upstream
+`main` commit `1cf36398135f4848a1d04b2167ffb564b7881d35`, and avoid changing the existing
+published PR until the replacement is independently verified.
+
+## Included Scope
+
+The production replacement is restricted to these two files:
+
+- `agent/worker_contract.py`
+- `tests/agent/test_worker_contract.py`
+
+The intended behavior is passive contract construction and validation:
+
+- bind task, owner, profile, repository, and authority identity;
+- distinguish observations, inferences, unknowns, and evidence sources;
+- validate safety, freshness, authorization, and reversible next actions;
+- serialize contract payloads safely; and
+- report partial, blocked, or failed work without inventing completion.
+
+The contract must not grant runtime, dispatch, Kanban, deployment, profile
+mutation, or external-write authority.
+
+## Explicit Exclusions
+
+The replacement must contain none of the cumulative branch's unrelated work:
+
+- model catalog or provider-default changes;
+- Qwen 3.8 Flash changes already present on upstream `main`;
+- Claude-to-Codex retuning;
+- model-performance routing or per-model concurrency controls;
+- egress, Kanban, PR-feedback, desktop, cron, gateway, or packaging changes;
+- lifecycle integration from commits `9af3ec00`, `1c4afcd1`, or `7120646c`;
+- Python runtime pinning; or
+- generated artifacts unrelated to the two-file contract.
+
+## Provenance and Integration Method
+
+Create the replacement by cherry-picking the original contract commit onto the
+verified upstream base. Preserve the original author and commit message. Resolve
+only conflicts within the two-file allowlist. If the cherry-pick requires any
+other tracked file, abort the integration and reassess instead of widening scope.
+
+The later workforce-contract commits are not part of this replacement. They
+overlap and duplicate lifecycle behavior, so any future integration requires a
+separate semantic design and PR after the passive contract is reviewed.
+
+## Verification
+
+Verification is exact-head and must include:
+
+1. clean tracked worktree state before integration;
+2. two-file allowlist audit against upstream `main`;
+3. the complete `tests/agent/test_worker_contract.py` module;
+4. focused Ruff checks for both changed files;
+5. Python bytecode compilation for both changed files;
+6. a relevant adjacent agent test slice if current-main imports require it;
+7. `git diff --check`; and
+8. commit-author and diff-size verification.
+
+Focused checks are not a full-suite receipt. Any unavailable or failing broader
+lane remains explicit in the handoff.
+
+## Publication and Disposition Boundaries
+
+Local branch preparation and verification do not authorize a destination push,
+new upstream PR, force-push, closure of `#98470`, branch deletion, or merge.
+Immediately before publication, re-read upstream `main`, the original PR head,
+and duplicate PR state. Publication should create a new cross-repository PR from
+the user's fork with a body that names the exact base/head and supersedes only
+the passive-contract claim. The user retains final authority over publishing
+the replacement and disposing of `#98470`.

--- a/tests/agent/test_worker_contract.py
+++ b/tests/agent/test_worker_contract.py
@@ -1,3 +1,6 @@
+import json
+import math
+
 import pytest
 
 from agent.worker_contract import (
@@ -132,6 +135,62 @@ def test_evidence_packet_requires_freshness_reversible_actions_and_explicit_outc
         ).validate()
 
 
+@pytest.mark.parametrize(
+    "unstable_values",
+    [
+        {"observation": "source"},
+        {"observation"},
+        (value for value in ("observation",)),
+    ],
+)
+def test_text_sequences_reject_mappings_sets_and_generators(unstable_values):
+    with pytest.raises(ContractValidationError, match="sequence"):
+        EvidencePacket(
+            observations=unstable_values,
+            sources=("source",),
+            freshness="2026-08-30T12:00:00Z",
+            reversible_next_actions=("inspect",),
+            outcome="completed",
+        ).validate()
+
+
+def test_evidence_packet_completed_requires_source_backed_observations():
+    with pytest.raises(ContractValidationError, match="completed.*observations"):
+        EvidencePacket(
+            observations=(),
+            sources=(),
+            freshness="2026-08-30T12:00:00Z",
+            reversible_next_actions=("inspect",),
+            outcome="completed",
+        ).validate()
+
+    assert (
+        EvidencePacket(
+            observations=(),
+            sources=(),
+            freshness="2026-08-30T12:00:00Z",
+            reversible_next_actions=("inspect",),
+            outcome="blocked",
+        ).validate()
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    "freshness",
+    ["not-a-timestamp", "2026-08-30T12:00:00", "2026-08-30"],
+)
+def test_evidence_packet_freshness_requires_timezone_aware_iso_8601(freshness):
+    with pytest.raises(ContractValidationError, match="timezone-aware ISO-8601"):
+        EvidencePacket(
+            observations=("observed",),
+            sources=("source",),
+            freshness=freshness,
+            reversible_next_actions=("inspect",),
+            outcome="completed",
+        ).validate()
+
+
 def test_objective_stack_rejects_hidden_or_conflicting_objectives():
     with pytest.raises(ContractValidationError, match="hidden"):
         ObjectiveStack(
@@ -231,5 +290,38 @@ def test_consensus_record_preserves_dissent_and_requires_worker_identity():
                 {"worker": "a", "conclusion": "pass"},
                 {"worker": "a", "conclusion": "pass"},
             ),
+            status="pending",
+        ).validate()
+
+
+def test_serialized_contracts_are_json_safe():
+    packet = EvidencePacket(
+        observations=(" observed ",),
+        sources=(" source ",),
+        freshness="2026-08-30T12:00:00+00:00",
+        reversible_next_actions=(" inspect ",),
+        outcome="completed",
+    )
+    consensus = ConsensusRecord(
+        worker_reports=(
+            {"worker": "a", "payload": {"ok": True, "items": [None, 1, 1.5, "value"]}},
+        ),
+        status="pending",
+    )
+
+    assert json.loads(json.dumps(packet.to_dict()))["observations"] == ["observed"]
+    assert json.loads(json.dumps(consensus.to_dict()))["worker_reports"][0]["payload"]["ok"]
+
+
+@pytest.mark.parametrize(
+    "unsafe_value",
+    [object(), {1: "non-string key"}, float("nan"), float("inf"), -float("inf")],
+)
+def test_consensus_record_rejects_nested_non_json_safe_values(unsafe_value):
+    if isinstance(unsafe_value, float):
+        assert not math.isfinite(unsafe_value)
+    with pytest.raises(ContractValidationError, match="JSON-compatible"):
+        ConsensusRecord(
+            worker_reports=({"worker": "a", "payload": unsafe_value},),
             status="pending",
         ).validate()

--- a/tests/agent/test_worker_contract.py
+++ b/tests/agent/test_worker_contract.py
@@ -1,0 +1,126 @@
+import pytest
+
+from agent.worker_contract import (
+    ContractValidationError,
+    CapabilityRecord,
+    ConsensusRecord,
+    EvidencePacket,
+    ObjectiveStack,
+    WorkerMode,
+    validate_contract_mapping,
+)
+
+
+def test_evidence_packet_serializes_observations_separately_from_conclusions():
+    packet = EvidencePacket(
+        observations=("pytest exited 0",),
+        sources=("terminal://run-1",),
+        hypotheses=("the focused suite is green",),
+        conclusions=("the focused suite passed",),
+        unknowns=("full-suite status",),
+        confidence="high",
+        evidence_class="targeted",
+    )
+
+    assert packet.to_dict() == {
+        "observations": ["pytest exited 0"],
+        "sources": ["terminal://run-1"],
+        "hypotheses": ["the focused suite is green"],
+        "conclusions": ["the focused suite passed"],
+        "unknowns": ["full-suite status"],
+        "confidence": "high",
+        "evidence_class": "targeted",
+        "artifacts": [],
+        "limitations": [],
+    }
+
+
+def test_evidence_packet_rejects_conclusion_without_observation_or_source():
+    with pytest.raises(ContractValidationError, match="observations"):
+        EvidencePacket(
+            observations=(),
+            sources=(),
+            conclusions=("done",),
+        ).validate()
+
+
+def test_objective_stack_rejects_hidden_or_conflicting_objectives():
+    with pytest.raises(ContractValidationError, match="hidden"):
+        ObjectiveStack(
+            profile="scientist",
+            authority="advisory",
+            mission="research",
+            hidden_objectives=("do not tell the operator",),
+        ).validate()
+
+    with pytest.raises(ContractValidationError, match="conflict"):
+        ObjectiveStack(
+            profile="worker",
+            authority="read_only",
+            mission="publish",
+            constraints=("never publish without approval",),
+            conflicts=("publish automatically",),
+        ).validate()
+
+
+def test_worker_mode_cannot_reduce_truth_or_safety_requirements():
+    with pytest.raises(ContractValidationError, match="citations"):
+        WorkerMode(
+            name="incident",
+            verbosity="concise",
+            directness="high",
+            requires_citations=False,
+            requires_uncertainty=True,
+        ).validate()
+
+
+def test_contract_mapping_rejects_unknown_fields():
+    with pytest.raises(ContractValidationError, match="unknown field"):
+        validate_contract_mapping(
+            {"kind": "evidence_packet", "observations": [], "unexpected": True}
+        )
+
+
+def test_capability_record_requires_test_provenance_before_activation():
+    record = CapabilityRecord(
+        name="exact_head_verification",
+        owner_profile="acceptance-gate-verifier",
+        authority="read_only",
+        evidence_class="governed",
+        status="active",
+        tested_at="2026-08-30T12:00:00Z",
+        source_sha="abc123",
+    )
+
+    assert record.validate() is record
+    assert record.to_dict()["source_sha"] == "abc123"
+
+    with pytest.raises(ContractValidationError, match="source_sha"):
+        CapabilityRecord(
+            name="unsafe_capability",
+            owner_profile="worker",
+            authority="execute",
+            status="active",
+            tested_at="2026-08-30T12:00:00Z",
+        ).validate()
+
+
+def test_consensus_record_preserves_dissent_and_requires_worker_identity():
+    record = ConsensusRecord(
+        worker_reports=(
+            {"worker": "a", "conclusion": "pass"},
+            {"worker": "b", "conclusion": "blocked"},
+        ),
+        agreement=("same source was inspected",),
+        dissent=("worker b found a missing receipt",),
+        status="needs_review",
+    )
+
+    assert record.validate() is record
+    assert record.to_dict()["dissent"] == ["worker b found a missing receipt"]
+
+    with pytest.raises(ContractValidationError, match="worker"):
+        ConsensusRecord(
+            worker_reports=({"conclusion": "pass"},),
+            status="accepted",
+        ).validate()

--- a/tests/agent/test_worker_contract.py
+++ b/tests/agent/test_worker_contract.py
@@ -20,9 +20,13 @@ def test_evidence_packet_serializes_observations_separately_from_conclusions():
         unknowns=("full-suite status",),
         confidence="high",
         evidence_class="targeted",
+        freshness="2026-08-30T12:00:00Z",
+        reversible_next_actions=("rerun the focused test",),
+        outcome="completed",
     )
 
     assert packet.to_dict() == {
+        "kind": "evidence_packet",
         "observations": ["pytest exited 0"],
         "sources": ["terminal://run-1"],
         "hypotheses": ["the focused suite is green"],
@@ -32,6 +36,9 @@ def test_evidence_packet_serializes_observations_separately_from_conclusions():
         "evidence_class": "targeted",
         "artifacts": [],
         "limitations": [],
+        "freshness": "2026-08-30T12:00:00Z",
+        "reversible_next_actions": ["rerun the focused test"],
+        "outcome": "completed",
     }
 
 
@@ -44,12 +51,96 @@ def test_evidence_packet_rejects_conclusion_without_observation_or_source():
         ).validate()
 
 
+def test_contract_mapping_requires_complete_typed_payloads():
+    with pytest.raises(ContractValidationError, match="missing field"):
+        validate_contract_mapping({"kind": "evidence_packet"})
+
+    with pytest.raises(ContractValidationError, match="observations"):
+        validate_contract_mapping(
+            {
+                "kind": "evidence_packet",
+                "observations": "not-a-list",
+                "sources": ["terminal://run-1"],
+                "hypotheses": [],
+                "conclusions": [],
+                "unknowns": [],
+                "confidence": "high",
+                "evidence_class": "targeted",
+                "artifacts": [],
+                "limitations": [],
+                "freshness": "2026-08-30T12:00:00Z",
+                "reversible_next_actions": [],
+                "outcome": "completed",
+            }
+        )
+
+
+def test_contract_serialization_is_composable_with_mapping_validation():
+    packet = EvidencePacket(
+        observations=("observed",),
+        sources=("source",),
+        freshness="2026-08-30T12:00:00Z",
+        reversible_next_actions=("inspect again",),
+        outcome="blocked",
+    )
+    assert validate_contract_mapping(packet.to_dict()) == packet.to_dict()
+
+
+def test_objective_stack_requires_task_owner_and_repository_identity():
+    stack = ObjectiveStack(
+        profile="worker",
+        authority="read_only",
+        mission="research",
+        task_id="task-1",
+        owner_id="operator-1",
+        repository="org/repo",
+    )
+    assert stack.validate() is stack
+    with pytest.raises(ContractValidationError, match="task_id"):
+        ObjectiveStack(
+            profile="worker",
+            authority="read_only",
+            mission="research",
+            owner_id="operator-1",
+            repository="org/repo",
+        ).validate()
+
+
+def test_evidence_packet_requires_freshness_reversible_actions_and_explicit_outcome():
+    with pytest.raises(ContractValidationError, match="freshness"):
+        EvidencePacket(
+            observations=("observed",),
+            sources=("source",),
+            reversible_next_actions=("inspect",),
+            outcome="failed",
+        ).validate()
+
+    with pytest.raises(ContractValidationError, match="reversible"):
+        EvidencePacket(
+            observations=("observed",),
+            sources=("source",),
+            freshness="2026-08-30T12:00:00Z",
+            outcome="blocked",
+        ).validate()
+
+    with pytest.raises(ContractValidationError, match="outcome"):
+        EvidencePacket(
+            observations=("observed",),
+            sources=("source",),
+            freshness="2026-08-30T12:00:00Z",
+            reversible_next_actions=("inspect",),
+        ).validate()
+
+
 def test_objective_stack_rejects_hidden_or_conflicting_objectives():
     with pytest.raises(ContractValidationError, match="hidden"):
         ObjectiveStack(
             profile="scientist",
             authority="advisory",
             mission="research",
+            task_id="task-1",
+            owner_id="operator-1",
+            repository="org/repo",
             hidden_objectives=("do not tell the operator",),
         ).validate()
 
@@ -58,6 +149,9 @@ def test_objective_stack_rejects_hidden_or_conflicting_objectives():
             profile="worker",
             authority="read_only",
             mission="publish",
+            task_id="task-1",
+            owner_id="operator-1",
+            repository="org/repo",
             constraints=("never publish without approval",),
             conflicts=("publish automatically",),
         ).validate()
@@ -123,4 +217,19 @@ def test_consensus_record_preserves_dissent_and_requires_worker_identity():
         ConsensusRecord(
             worker_reports=({"conclusion": "pass"},),
             status="accepted",
+        ).validate()
+
+    with pytest.raises(ContractValidationError, match="independent"):
+        ConsensusRecord(
+            worker_reports=({"worker": "a", "conclusion": "pass"},),
+            status="accepted",
+        ).validate()
+
+    with pytest.raises(ContractValidationError, match="duplicate"):
+        ConsensusRecord(
+            worker_reports=(
+                {"worker": "a", "conclusion": "pass"},
+                {"worker": "a", "conclusion": "pass"},
+            ),
+            status="pending",
         ).validate()


### PR DESCRIPTION
## What does this PR do?

Adds a narrow, passive worker-contract layer for evidence, objectives, capabilities, consensus, and worker mode. This replaces the relevant contract portion of cumulative PR #98470 without carrying its unrelated tuning, model, routing, federation, runtime, or desktop changes.

The contracts fail closed on incomplete identity, unsupported outcomes, stale or malformed evidence, non-reversible next actions, non-JSON report values, and unilateral or duplicate-worker consensus. They do not grant runtime, dispatch, Kanban, deployment, trading, profile-mutation, or external-write authority.

## Related PR

Focused replacement for #98470. This PR does not close or modify that PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `agent/worker_contract.py` with validated `EvidencePacket`, `ObjectiveStack`, `CapabilityRecord`, `ConsensusRecord`, and `WorkerMode` contracts.
- Require task, owner, profile, repository, authority, timezone-aware freshness, source-backed completion evidence, and reversible next actions.
- Recursively reject non-JSON-safe consensus data and require at least two unique workers before consensus can be accepted.
- Add adversarial and round-trip tests in `tests/agent/test_worker_contract.py`.
- Add the focused design and implementation plan under `docs/superpowers/`.

## How to Test

1. `/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_worker_contract.py tests/agent/test_subagent_lifecycle.py`
2. `/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m ruff check agent/worker_contract.py tests/agent/test_worker_contract.py`
3. `/Users/mikedemott/.hermes/hermes-agent/venv/bin/python -m compileall -q agent/worker_contract.py tests/agent/test_worker_contract.py`

Focused exact-head receipt: `28 passed`; Ruff, compileall, and `git diff --check` passed.

Full-suite limitation: a complete `pytest tests/ -q` receipt is **not** claimed. `pytest -q --maxfail=1` stopped after `156 passed, 5 skipped` at the unrelated `tests/agent/lsp/test_client_e2e.py::test_client_lifecycle_clean`, where the Python 3.13 live-system guard blocked `SIGTERM` to an LSP PID reported outside the pytest process subtree.

## Checklist

### Code

- [ ] I've read the full Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs; this is an intentionally decomposed replacement for #98470
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked as documented above
- [x] I've added tests for my changes
- [x] I've tested the focused scope on macOS with Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A
- [x] I've considered cross-platform impact; implementation uses only Python standard-library dataclasses, datetime, math, and typing
- [x] Tool descriptions/schema changes are N/A

## Screenshots / Logs

Not applicable; this PR adds passive Python contracts with test evidence and no user-interface changes.
