### PR TITLE
fix(models): let config pin built-in picker catalogs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2936,15 +2936,24 @@ def list_authenticated_providers(
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
-        # A providers.<built-in>.models block extends the provider's discovered
-        # catalog. Section 3 cannot emit it later because this built-in row owns
-        # the slug, so merge declarations here before applying max_models.
+        # A providers.<built-in>.models block normally extends the provider's
+        # discovered catalog. When discovery is explicitly disabled, treat the
+        # declared list as the picker allowlist, matching user-defined endpoint
+        # semantics. Section 3 cannot emit it later because this built-in row
+        # owns the slug.
         configured_models: list[str] = []
+        discover_models = True
         if isinstance(user_providers, dict):
             configured = user_providers.get(hermes_id)
             if isinstance(configured, dict):
                 configured_models = _declared_model_ids(configured.get("models"))
-        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
+                discover_models = configured.get("discover_models", True)
+        if isinstance(discover_models, str):
+            discover_models = discover_models.lower() not in {"false", "no", "0"}
+        if not discover_models:
+            model_ids = configured_models
+        else:
+            model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
         total = len(model_ids)
         if hermes_id in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models

--- a/tests/hermes_cli/test_configured_builtin_models.py
+++ b/tests/hermes_cli/test_configured_builtin_models.py
@@ -1,11 +1,11 @@
-"""Configured models extend built-in picker rows."""
+"""Configured models extend or explicitly pin built-in picker rows."""
 
 from unittest.mock import patch
 
 from hermes_cli.model_switch import list_authenticated_providers
 
 
-def _provider_row(configured_models, *, max_models=None):
+def _provider_row(configured_models, *, discover_models=True, max_models=None):
     with (
         patch(
             "agent.models_dev.fetch_models_dev",
@@ -24,7 +24,12 @@ def _provider_row(configured_models, *, max_models=None):
     ):
         rows = list_authenticated_providers(
             current_provider="deepseek",
-            user_providers={"deepseek": {"models": configured_models}},
+            user_providers={
+                "deepseek": {
+                    "discover_models": discover_models,
+                    "models": configured_models,
+                }
+            },
             max_models=max_models,
         )
     return next(row for row in rows if row["slug"] == "deepseek")
@@ -37,3 +42,12 @@ def test_configured_models_precede_and_deduplicate_discovered_models():
     assert row["total_models"] == 3
 
 
+def test_discover_models_false_pins_builtin_picker_to_configured_models():
+    row = _provider_row(
+        ["glm-5.3-flash", "glm-5.3"],
+        discover_models=False,
+    )
+
+    assert row["models"] == ["glm-5.3-flash", "glm-5.3"]
+    assert row["total_models"] == 2
+    assert "live-a" not in row["models"]


### PR DESCRIPTION
## Summary
- make `discover_models: false` honor a configured model allowlist for built-in provider picker rows
- preserve existing extend-and-deduplicate behavior when discovery remains enabled
- let operators remove a retired provider model from terminal, messaging, API, and desktop generated options without changing runtime manual selection

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_provider_live_curated_merge.py` (4/4)
- `ruff check hermes_cli/model_switch.py tests/hermes_cli/test_configured_builtin_models.py`
- `git diff --check`

This replaces the broader provider-exclusion proposal with the existing `providers.<name>.discover_models/models` configuration seam.