### PR TITLE
fix(agent): honor custom context windows in Desktop

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2788,6 +2788,7 @@ def init_agent(
             base_url=agent.base_url,
             api_key=getattr(agent, "api_key", ""),
             config_context_length=_effective_context_length,
+            custom_providers=_custom_providers,
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2425,6 +2425,7 @@ class ContextCompressor(ContextEngine):
                 api_key=self.api_key,
                 config_context_length=self._config_context_length,
                 provider=self.provider,
+                custom_providers=self._custom_providers,
             )
             # Small-context threshold floor: models under 512K trigger at
             # >=75% so compaction doesn't fire with half the window still
@@ -3312,6 +3313,7 @@ class ContextCompressor(ContextEngine):
         base_url: str = "",
         api_key: str = "",
         config_context_length: int | None = None,
+        custom_providers: Optional[List[Dict[str, Any]]] = None,
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
@@ -3434,6 +3436,7 @@ class ContextCompressor(ContextEngine):
         # so switching small -> large correctly drops back to the configured
         # value.
         self._config_context_length = config_context_length
+        self._custom_providers = custom_providers
         self._configured_threshold_percent = self.threshold_percent
         self._resolved_context_length: int | None = None
         self._threshold_tokens: int | None = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1900,11 +1900,12 @@ def get_custom_provider_context_length(
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
 ) -> Optional[int]:
-    """Look up a per-model ``context_length`` override from ``custom_providers``.
+    """Look up the effective ``context_length`` for a custom-provider model.
 
     Matches any entry whose normalized route identity equals ``base_url`` and
-    returns ``custom_providers[i].models.<model>.context_length`` if present and
-    valid.  Returns ``None`` when no override applies.
+    prefers ``custom_providers[i].models.<model>.context_length`` when present
+    and valid. Otherwise the entry-level ``context_length`` is the provider's
+    default for models on that route. Returns ``None`` when no override applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -1935,28 +1936,36 @@ def get_custom_provider_context_length(
     if not target_url:
         return None
 
+    provider_default = None
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
+
+        raw_provider_ctx = entry.get("context_length")
+        if raw_provider_ctx is not None and provider_default is None:
+            try:
+                parsed_provider_ctx = int(raw_provider_ctx)
+            except (TypeError, ValueError):
+                parsed_provider_ctx = 0
+            if parsed_provider_ctx > 0:
+                provider_default = parsed_provider_ctx
+
         models = entry.get("models")
-        if not isinstance(models, dict):
-            continue
-        model_cfg = models.get(model)
-        if not isinstance(model_cfg, dict):
-            continue
-        raw_ctx = model_cfg.get("context_length")
-        if raw_ctx is None:
-            continue
-        try:
-            ctx = int(raw_ctx)
-        except (TypeError, ValueError):
-            continue
-        if ctx > 0:
-            return ctx
-    return None
+        if isinstance(models, dict):
+            model_cfg = models.get(model)
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is not None:
+                    try:
+                        ctx = int(raw_ctx)
+                    except (TypeError, ValueError):
+                        ctx = 0
+                    if ctx > 0:
+                        return ctx
+    return provider_default
 
 
 def get_custom_provider_model_capability(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2424,6 +2424,30 @@ class TestLazyContextResolution:
             result = c.context_length
             assert result == 200_000
 
+    def test_custom_provider_context_reaches_deferred_resolver(self):
+        custom_providers = [
+            {
+                "base_url": "http://127.0.0.1:8081/v1",
+                "models": {"qwen3.8-27b": {"context_length": 262_144}},
+            }
+        ]
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            side_effect=lambda model, **kwargs: (
+                kwargs["custom_providers"][0]["models"][model]["context_length"]
+            ),
+        ) as mock_get:
+            c = ContextCompressor(
+                model="qwen3.8-27b",
+                base_url="http://127.0.0.1:8081/v1",
+                provider="custom",
+                custom_providers=custom_providers,
+                quiet_mode=True,
+            )
+
+            assert c.context_length == 262_144
+            mock_get.assert_called_once()
+
 
 class TestPreflightSentinelGuard:
     """Regression for #36718: the preflight token-display seed in

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -51,6 +51,51 @@ class TestGetCustomProviderContextLength:
         assert get_custom_provider_context_length("m", "http://x", None) is None
         assert get_custom_provider_context_length("m", "http://x", []) is None
 
+    def test_provider_context_length_is_default_for_its_models(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8081/v1",
+                "context_length": 262_144,
+                "models": {"qwen3.8-27b": {}},
+            }
+        ]
+
+        assert get_custom_provider_context_length(
+            "qwen3.8-27b", "http://127.0.0.1:8081/v1", custom
+        ) == 262_144
+        assert get_custom_provider_context_length(
+            "qwen3.8-27b", "http://127.0.0.1:9090/v1", custom
+        ) is None
+
+    def test_per_model_context_length_wins_over_provider_default(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8081/v1",
+                "context_length": 262_144,
+                "models": {"qwen3.8-27b": {"context_length": 524_288}},
+            }
+        ]
+
+        assert get_custom_provider_context_length(
+            "qwen3.8-27b", "http://127.0.0.1:8081/v1", custom
+        ) == 524_288
+
+    def test_per_model_override_wins_across_duplicate_route_entries(self):
+        custom = [
+            {
+                "base_url": "http://127.0.0.1:8081/v1",
+                "context_length": 262_144,
+            },
+            {
+                "base_url": "http://127.0.0.1:8081/v1",
+                "models": {"qwen3.8-27b": {"context_length": 524_288}},
+            },
+        ]
+
+        assert get_custom_provider_context_length(
+            "qwen3.8-27b", "http://127.0.0.1:8081/v1", custom
+        ) == 524_288
+
 
 class TestGetCustomProviderModelCapability:
     def test_matches_exact_model_on_normalized_route(self):


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop and other agent surfaces now keep a custom provider's configured context window instead of dropping to static model metadata. This prevents `/usage` and compression budgets from showing or using 131,072 tokens when the active provider declares 262,144 tokens.

### Symptom

A local OpenAI-compatible provider can declare a 262,144-token context window while Desktop `/usage` and the status bar report 131,072 tokens after metadata probing falls back to the static model catalog.

### Impact

Affected custom-provider sessions display the wrong capacity and may compress against a context budget smaller than the provider actually supports.

### Bug Cause

**Trigger:** `agent/context_compressor.py:2420` in `ContextCompressor._resolve_context_length` and `hermes_cli/config.py:1897` in `get_custom_provider_context_length`.

**Causal chain:**
1. Agent initialization loads the active custom provider and creates the built-in context compressor.
2. The compressor's deferred resolver omits the custom-provider metadata, while the shared custom-provider helper ignores an entry-level `context_length` default.
3. When no per-model value reaches the deferred call, resolution continues to probing or static family metadata and Desktop exposes the smaller fallback.

**Why it is wrong:** A route-scoped provider default and a more-specific per-model override are explicit user configuration and must take precedence over inferred metadata.

**Working sibling / contrast:** Explicit top-level `model.context_length` already reaches the compressor as `config_context_length`; this change gives custom-provider configuration the same resolution authority while preserving top-level precedence.

**Ruled out:** The renderer is not selecting the 131,072-token value. Desktop reads `context_max` from the backend agent's live `ContextCompressor`, so the loss occurs before presentation.

### Fix

The shared resolver now treats provider-level `context_length` as a route-scoped default, while retaining per-model precedence even across compatible duplicate entries. Agent initialization also threads the normalized custom-provider snapshot into `ContextCompressor`, whose deferred metadata call now preserves that configuration.

## Related Issue

Closes #99286

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` - resolve per-model context first, then the route-matched provider default.
- `agent/context_compressor.py` - retain and forward custom-provider metadata during deferred context resolution.
- `agent/agent_init.py` - pass normalized custom providers into the built-in compressor.
- `tests/hermes_cli/test_custom_provider_context_length.py` - cover provider defaults, route isolation, and precedence.
- `tests/agent/test_context_compressor.py` - cover the deferred compressor resolution path.

## How to Test

1. Run the focused context configuration and compressor tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_custom_provider_context_length.py tests/agent/test_context_compressor.py tests/run_agent/test_invalid_context_length_warning.py tests/run_agent/test_switch_model_context.py -q
```

2. Confirm all 174 tests pass.
3. Configure a custom provider with `context_length: 262144` and confirm Desktop `/usage` reports a 262,144-token context maximum.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required; existing configuration keys retain their documented meaning
- [x] `cli-config.yaml.example` update is not required; no config key was added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not required; architecture and workflows are unchanged
- [x] Cross-platform impact was considered; the change is platform-independent Python configuration resolution
- [x] Tool descriptions and schemas are not affected
