### PR TITLE
feat(gateway): browse and resume native Codex tasks

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -714,6 +714,34 @@ def run_codex_app_server_turn(
         _ServerRequestRouting,
     )
 
+    # The native Codex thread is authoritative for context. Hermes persists
+    # only the binding in model_config so a rebuilt AIAgent (gateway restart,
+    # /resume, cache eviction) reconnects with thread/resume instead of
+    # silently creating a new Codex task.
+    requested_thread_id = None
+    strict_thread_resume = False
+    session_db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if session_db is not None and session_id:
+        try:
+            requested_thread_id = session_db.get_session_model_config_value(
+                session_id, "codex_thread_id"
+            )
+            if not isinstance(requested_thread_id, str):
+                requested_thread_id = None
+            strict_thread_resume = (
+                session_db.get_session_model_config_value(
+                    session_id, "codex_thread_resume_strict", False
+                )
+                is True
+            )
+        except Exception:
+            logger.debug(
+                "codex app-server thread binding lookup failed (session=%s)",
+                session_id,
+                exc_info=True,
+            )
+
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
@@ -760,6 +788,8 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            thread_id=requested_thread_id,
+            resume_fallback_to_start=not strict_thread_resume,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
@@ -810,6 +840,23 @@ def run_codex_app_server_turn(
             ),
             "error": str(exc),
         }
+
+    # Persist after every successful handshake, including turns whose
+    # turn/start later failed. The binding is known as soon as run_turn sets
+    # TurnResult.thread_id, and saving it here prevents an orphan native task
+    # from being replaced on the next retry.
+    if session_db is not None and session_id and turn.thread_id:
+        try:
+            if turn.thread_id != requested_thread_id:
+                session_db.patch_session_model_config(
+                    session_id, {"codex_thread_id": turn.thread_id}
+                )
+        except Exception:
+            logger.warning(
+                "codex app-server thread binding persist failed (session=%s)",
+                session_id,
+                exc_info=True,
+            )
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
     # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -8,7 +8,7 @@ into its `messages` list.
 
 Lifecycle:
     session = CodexAppServerSession(cwd="/home/x/proj")
-    session.ensure_started()                              # spawns + handshake + thread/start
+    session.ensure_started()                     # handshake + thread/start or thread/resume
     result = session.run_turn(user_input="hello")         # blocks until turn/completed
     # result.final_text          → assistant text returned to caller
     # result.projected_messages  → list of {role, content, ...} for messages list
@@ -275,6 +275,8 @@ class CodexAppServerSession:
         self,
         *,
         cwd: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        resume_fallback_to_start: bool = True,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
@@ -284,6 +286,8 @@ class CodexAppServerSession:
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
+        self._requested_thread_id = str(thread_id or "").strip() or None
+        self._resume_fallback_to_start = bool(resume_fallback_to_start)
         self._codex_bin = codex_bin
         self._codex_home = codex_home
         self._permission_profile = (
@@ -313,9 +317,11 @@ class CodexAppServerSession:
     # ---------- lifecycle ----------
 
     def ensure_started(self) -> str:
-        """Spawn the subprocess, do the initialize handshake, and start a
-        thread. Returns the codex thread id. Idempotent — repeated calls
-        return the same thread id."""
+        """Spawn, initialize, then start or resume a Codex thread.
+
+        Returns the Codex thread id. Idempotent — repeated calls return the
+        same thread id.
+        """
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
@@ -326,13 +332,14 @@ class CodexAppServerSession:
             client_name="hermes",
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
+            capabilities={
+                "experimentalApi": True,
+                "requestAttestation": False,
+            },
         )
-        # Permission selection is intentionally NOT sent on thread/start.
-        # Two reasons (live-tested against codex 0.130.0):
-        #   1. `thread/start.permissions` is gated behind the experimentalApi
-        #      capability on this codex version — we'd have to opt in during
-        #      initialize and accept the unstable surface.
-        #   2. Even with experimentalApi declared and the correct shape
+        # Permission selection is intentionally NOT sent on thread/start or
+        # thread/resume. Even with experimentalApi declared (required for the
+        # resume path) and the correct shape
         #      (`{"type": "profile", "id": "..."}`, not `{"profileId": ...}`),
         #      codex requires a matching `[permissions]` table in
         #      ~/.codex/config.toml or it fails the request with
@@ -342,8 +349,37 @@ class CodexAppServerSession:
         # codex CLI workflow and avoids fighting codex's own validation.
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
-        params: dict[str, Any] = {"cwd": self._cwd}
-        result = self._client.request("thread/start", params, timeout=15)
+        result: dict[str, Any] = {}
+        method = "thread/start"
+        if self._requested_thread_id:
+            method = "thread/resume"
+            try:
+                result = self._client.request(
+                    method,
+                    {
+                        "cwd": self._cwd,
+                        "threadId": self._requested_thread_id,
+                        # The Hermes SessionDB is a display/search mirror. Codex
+                        # remains authoritative for the native thread transcript,
+                        # so there is no need to hydrate all turns over JSON-RPC.
+                        "excludeTurns": True,
+                    },
+                    timeout=15,
+                )
+            except (CodexAppServerError, TimeoutError) as exc:
+                if not self._resume_fallback_to_start:
+                    raise
+                logger.warning(
+                    "codex thread/resume failed for id=%s (%s) — starting "
+                    "a fresh thread",
+                    self._requested_thread_id[:8],
+                    exc,
+                )
+                method = "thread/start"
+        if method == "thread/start":
+            result = self._client.request(
+                method, {"cwd": self._cwd}, timeout=15
+            )
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
         # tolerance fix so future codex drops/renames don't KeyError us
@@ -355,17 +391,33 @@ class CodexAppServerSession:
             or result.get("sessionId")
             or result.get("threadId")
         )
+        if not thread_id and method == "thread/resume" and self._resume_fallback_to_start:
+            logger.warning(
+                "codex thread/resume returned no thread id "
+                "(payload keys: %s) — starting a fresh thread",
+                sorted(result.keys()),
+            )
+            method = "thread/start"
+            result = self._client.request(method, {"cwd": self._cwd}, timeout=15)
+            thread_obj = result.get("thread") or {}
+            thread_id = (
+                thread_obj.get("id")
+                or thread_obj.get("sessionId")
+                or result.get("sessionId")
+                or result.get("threadId")
+            )
         if not thread_id:
             raise CodexAppServerError(
                 code=-32603,
                 message=(
-                    "codex thread/start returned no thread id "
+                    f"codex {method} returned no thread id "
                     f"(payload keys: {sorted(result.keys())})"
                 ),
             )
         self._thread_id = thread_id
         logger.info(
-            "codex app-server thread started: id=%s profile=%s cwd=%s",
+            "codex app-server thread %s: id=%s profile=%s cwd=%s",
+            "resumed" if method == "thread/resume" else "started",
             self._thread_id[:8],
             self._permission_profile,
             self._cwd,

--- a/agent/transports/codex_thread_catalog.py
+++ b/agent/transports/codex_thread_catalog.py
@@ -1,0 +1,158 @@
+"""Read the native Codex task catalog through ``codex app-server``.
+
+The Codex CLI, desktop app, and app-server runtime all write to the same
+thread store.  ``thread/list`` is the supported way to enumerate that store;
+reading rollout JSONL directly misses state-db repairs and newer thread
+metadata.  This module deliberately keeps the catalog read-only.  Resuming a
+thread is owned by :class:`CodexAppServerSession`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from agent.transports.codex_app_server import CodexAppServerClient
+
+
+@dataclass(frozen=True)
+class CodexThreadSummary:
+    """Small, display-safe projection of one native Codex thread."""
+
+    thread_id: str
+    cwd: str
+    preview: str
+    name: str = ""
+    source: str = "unknown"
+    status: str = "unknown"
+    updated_at: float = 0.0
+    is_pinned: bool = False
+
+    @property
+    def title(self) -> str:
+        return self.name or self.preview or "(empty task)"
+
+
+def _nonempty_string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _normalize_thread(raw: Any) -> Optional[CodexThreadSummary]:
+    if not isinstance(raw, dict):
+        return None
+    thread_id = _nonempty_string(raw.get("id"))
+    if not thread_id:
+        return None
+    status = raw.get("status")
+    status_name = (
+        _nonempty_string(status.get("type"))
+        if isinstance(status, dict)
+        else _nonempty_string(status)
+    )
+    source = raw.get("source")
+    source_name = _nonempty_string(source)
+    updated_at = raw.get("recencyAt") or raw.get("updatedAt") or 0
+    try:
+        updated_at = float(updated_at)
+    except (TypeError, ValueError):
+        updated_at = 0.0
+    return CodexThreadSummary(
+        thread_id=thread_id,
+        cwd=_nonempty_string(raw.get("cwd")),
+        preview=_nonempty_string(raw.get("preview")),
+        name=_nonempty_string(raw.get("name")),
+        source=source_name or "unknown",
+        status=status_name or "unknown",
+        updated_at=updated_at,
+        is_pinned=raw.get("isPinned") is True,
+    )
+
+
+def list_codex_threads(
+    *,
+    limit: int = 20,
+    search_term: Optional[str] = None,
+    cwd: Optional[str] = None,
+    cursor: Optional[str] = None,
+    codex_bin: str = "codex",
+    codex_home: Optional[str] = None,
+    timeout: float = 15.0,
+    client_factory=CodexAppServerClient,
+) -> tuple[list[CodexThreadSummary], Optional[str]]:
+    """Return native Codex tasks newest-first plus an optional next cursor.
+
+    ``useStateDbOnly=False`` intentionally asks Codex to scan and repair its
+    rollout store.  This is what makes the result match the desktop task list
+    even when a rollout has not reached Codex's state DB yet.
+    """
+    client = client_factory(codex_bin=codex_bin, codex_home=codex_home)
+    try:
+        client.initialize(
+            client_name="hermes",
+            client_title="Hermes Agent",
+            client_version=_get_hermes_version(),
+            capabilities={
+                "experimentalApi": True,
+                "requestAttestation": False,
+            },
+        )
+        params: dict[str, Any] = {
+            "limit": max(1, min(int(limit), 100)),
+            "sortKey": "recency_at",
+            "sortDirection": "desc",
+            "archived": False,
+            "useStateDbOnly": False,
+        }
+        if search_term and search_term.strip():
+            params["searchTerm"] = search_term.strip()
+        if cwd and cwd.strip():
+            params["cwd"] = cwd.strip()
+        if cursor and cursor.strip():
+            params["cursor"] = cursor.strip()
+        result = client.request("thread/list", params, timeout=timeout)
+        raw_data = result.get("data") if isinstance(result, dict) else None
+        if not isinstance(raw_data, list):
+            raise ValueError("codex thread/list returned a malformed response")
+        rows = [row for item in raw_data if (row := _normalize_thread(item))]
+        next_cursor = (
+            _nonempty_string(result.get("nextCursor"))
+            if isinstance(result, dict)
+            else ""
+        )
+        return rows, next_cursor or None
+    finally:
+        client.close()
+
+
+def resolve_codex_thread(
+    rows: list[CodexThreadSummary], target: str
+) -> Optional[CodexThreadSummary]:
+    """Resolve a one-based picker number, exact ID, unique prefix, or name."""
+    cleaned = (target or "").strip()
+    if not cleaned:
+        return None
+    if cleaned.isdigit():
+        index = int(cleaned)
+        if 1 <= index <= len(rows):
+            return rows[index - 1]
+        return None
+
+    exact = [row for row in rows if row.thread_id == cleaned]
+    if len(exact) == 1:
+        return exact[0]
+    prefixed = [row for row in rows if row.thread_id.startswith(cleaned)]
+    if len(prefixed) == 1:
+        return prefixed[0]
+    named = [row for row in rows if row.title.casefold() == cleaned.casefold()]
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def _get_hermes_version() -> str:
+    try:
+        from hermes_cli import __version__
+
+        return str(__version__)
+    except Exception:
+        return "unknown"

--- a/contributors/emails/jiayu.hong@lilith.com
+++ b/contributors/emails/jiayu.hong@lilith.com
@@ -1,0 +1,1 @@
+aredddd

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5167,6 +5167,14 @@ class GatewaySlashCommandsMixin:
             parts = shlex.split(raw_args)
         except ValueError as exc:
             return t("gateway.resume.parse_error", error=exc)
+
+        # Native Codex tasks live outside Hermes' SessionDB. Keep the existing
+        # /resume contract intact and route only the explicit ``codex``
+        # namespace to the app-server-backed picker.
+        if parts and parts[0].lower() == "codex":
+            return await self._handle_codex_resume_command(
+                event, " ".join(parts[1:]).strip()
+            )
         allow_all = "--all" in parts
         allow_cross_room = "--cross-room" in parts
         name = " ".join(p for p in parts if p not in {"--all", "--cross-room"}).strip()
@@ -5334,6 +5342,17 @@ class GatewaySlashCommandsMixin:
 
         raw_args = event.get_command_args().strip()
         try:
+            native_parts = shlex.split(raw_args)
+        except ValueError as exc:
+            return t("gateway.resume.parse_error", error=exc)
+        if native_parts and native_parts[0].lower() == "codex":
+            query_parts = native_parts[1:]
+            if query_parts and query_parts[0].lower() in {"search", "find"}:
+                query_parts = query_parts[1:]
+            return await self._handle_codex_sessions_command(
+                event, " ".join(query_parts).strip()
+            )
+        try:
             include_all, include_unnamed, target, search_query = (
                 parse_session_listing_args(raw_args)
             )
@@ -5389,6 +5408,204 @@ class GatewaySlashCommandsMixin:
             rows,
             include_source=cross_origin,
             title=title,
+        )
+
+    async def _handle_codex_sessions_command(
+        self, event: MessageEvent, search_term: str = ""
+    ) -> str:
+        """List host-native Codex tasks for an explicitly configured admin.
+
+        The catalog contains previews and workspaces from every Codex client on
+        the host, so normal same-chat ownership is not enough: unlike Hermes
+        sessions, these rows have no gateway user identity to authorize
+        against. Requiring an explicit admin keeps a shared bot from becoming
+        a host-wide Codex history oracle.
+        """
+        source = await asyncio.to_thread(
+            self._normalize_source_for_session_key, event.source
+        )
+        if not self._resume_caller_is_admin(source):
+            return (
+                "Native Codex tasks are host-wide and can only be listed by "
+                "an explicitly configured gateway admin."
+            )
+
+        from agent.transports.codex_thread_catalog import list_codex_threads
+
+        try:
+            rows, next_cursor = await asyncio.to_thread(
+                list_codex_threads,
+                limit=10,
+                search_term=search_term or None,
+            )
+        except Exception as exc:
+            from agent.redact import redact_sensitive_text
+
+            safe_error = redact_sensitive_text(str(exc), force=True)
+            return f"❌ Could not list native Codex tasks: {safe_error}"
+
+        if not rows:
+            suffix = f" matching “{search_term}”" if search_term else ""
+            return f"No native Codex tasks found{suffix}."
+
+        title = "Codex Tasks"
+        if search_term:
+            title += f" matching “{search_term}”"
+        lines = [f"🧵 **{title}**", ""]
+        for index, row in enumerate(rows, start=1):
+            display = re.sub(r"\s+", " ", row.title).strip()[:80]
+            workspace = os.path.basename(row.cwd.rstrip(os.sep)) if row.cwd else ""
+            workspace_part = f" · `{workspace}`" if workspace else ""
+            pin = " 📌" if row.is_pinned else ""
+            lines.append(
+                f"{index}. **{display}**{pin}{workspace_part} · "
+                f"`{row.source}` · `{row.thread_id[:12]}`"
+            )
+        lines.extend(
+            [
+                "",
+                "Resume: `/resume codex <number|thread-id|name>`.",
+                "The Codex task remains the source of truth; Hermes stores only its route binding.",
+            ]
+        )
+        if next_cursor:
+            lines.append("More tasks are available; use `/sessions codex search <query>`.")
+        return "\n".join(lines)
+
+    async def _handle_codex_resume_command(
+        self, event: MessageEvent, target: str
+    ) -> str:
+        """Bind this gateway lane to an existing native Codex task."""
+        source = await asyncio.to_thread(
+            self._normalize_source_for_session_key, event.source
+        )
+        if not self._resume_caller_is_admin(source):
+            return (
+                "Native Codex tasks are host-wide and can only be resumed by "
+                "an explicitly configured gateway admin."
+            )
+        if not target:
+            return await self._handle_codex_sessions_command(event)
+
+        from gateway.run import _load_gateway_config
+        from hermes_cli.codex_runtime_switch import get_current_runtime
+
+        try:
+            user_config = await asyncio.to_thread(_load_gateway_config)
+        except Exception:
+            user_config = {}
+        if get_current_runtime(user_config) != "codex_app_server":
+            return (
+                "Enable the native Codex runtime first with "
+                "`/codex-runtime codex_app_server`, then retry."
+            )
+
+        from agent.transports.codex_thread_catalog import (
+            list_codex_threads,
+            resolve_codex_thread,
+        )
+
+        try:
+            rows, _ = await asyncio.to_thread(list_codex_threads, limit=100)
+            selected = resolve_codex_thread(rows, target)
+            if selected is None and not target.isdigit():
+                matches, _ = await asyncio.to_thread(
+                    list_codex_threads, limit=20, search_term=target
+                )
+                selected = resolve_codex_thread(matches, target)
+        except Exception as exc:
+            from agent.redact import redact_sensitive_text
+
+            safe_error = redact_sensitive_text(str(exc), force=True)
+            return f"❌ Could not query native Codex tasks: {safe_error}"
+        if selected is None:
+            return (
+                f"Native Codex task not found or ambiguous: `{target}`. "
+                "Run `/sessions codex` and choose a number."
+            )
+
+        session_key = self._session_key_for_source(source)
+        current_entry = await self.async_session_store.get_or_create_session(source)
+        current_thread_id = await self._session_db.get_session_model_config_value(
+            current_entry.session_id, "codex_thread_id"
+        )
+        if current_thread_id == selected.thread_id:
+            return (
+                f"Already using native Codex task **{selected.title[:100]}** "
+                f"(`{selected.thread_id[:12]}`)."
+            )
+        now = datetime.now()
+        import json as _json
+        import uuid as _uuid
+
+        session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:6]}"
+        origin = current_entry.origin or source
+        try:
+            origin_json = _json.dumps(origin.to_dict())
+        except Exception:
+            origin_json = None
+        model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
+        model = None
+        if isinstance(model_cfg, dict):
+            model = model_cfg.get("default") or model_cfg.get("model")
+        display_name = getattr(current_entry, "display_name", None)
+        if not isinstance(display_name, str):
+            display_name = None
+
+        try:
+            await self._session_db.create_session(
+                session_id=session_id,
+                source=source.platform.value if source.platform else "gateway",
+                model=model,
+                model_config={
+                    "codex_thread_id": selected.thread_id,
+                    # An explicit native-task selection must never degrade to
+                    # a silently duplicated thread when Codex rejects resume
+                    # (for example because Desktop has the active writer).
+                    "codex_thread_resume_strict": True,
+                },
+                cwd=selected.cwd or None,
+                user_id=source.user_id,
+                session_key=session_key,
+                chat_id=source.chat_id,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+                origin_json=origin_json,
+                display_name=display_name,
+            )
+        except Exception as exc:
+            from agent.redact import redact_sensitive_text
+
+            logger.error("Failed to create native Codex route session: %s", exc)
+            safe_error = redact_sensitive_text(str(exc), force=True)
+            return f"❌ Could not create the Hermes route binding: {safe_error}"
+        try:
+            await self._session_db.set_session_title(
+                session_id, f"Codex: {selected.title[:100]}"
+            )
+        except Exception:
+            logger.debug(
+                "Failed to title native Codex route session %s",
+                session_id,
+                exc_info=True,
+            )
+
+        self._release_running_agent_state(session_key)
+        switched = await self.async_session_store.switch_session(
+            session_key, session_id
+        )
+        if not switched:
+            return "❌ Could not switch this chat to the native Codex task."
+        self._clear_conversation_scope(session_key, reason="resume_codex")
+        self._evict_cached_agent(session_key)
+
+        title = re.sub(r"\s+", " ", selected.title).strip()[:100]
+        workspace = selected.cwd or "Codex's stored workspace"
+        return (
+            f"↪ Resumed native Codex task **{title}** (`{selected.thread_id[:12]}`).\n"
+            f"Workspace: `{workspace}`\n"
+            "Your next message continues that Codex task. If Codex Desktop is "
+            "actively writing to it, finish or stop that turn first."
         )
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -366,11 +366,22 @@ def import_foreign_session(source: str, path, db=None) -> str:
                 "foreign_session_id": parsed.get("session_id"),
             }
         }
+        model_config = None
+        if source == "codex" and parsed.get("session_id"):
+            # Keep the existing portable transcript import, but also retain
+            # the native thread identity. When codex_app_server is active,
+            # resuming this Hermes session reconnects to Codex's authoritative
+            # task instead of starting a duplicate thread.
+            model_config = {
+                "codex_thread_id": parsed["session_id"],
+                "codex_thread_resume_strict": True,
+            }
         db.create_session(
             session_id,
             source=_SOURCE_DB_NAMES[source],
             cwd=parsed.get("cwd"),
             origin_json=json.dumps(origin),
+            model_config=model_config,
         )
         for turn in turns:
             db.append_message(session_id, turn["role"], turn["content"])

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -34,6 +34,7 @@ class FakeClient:
         self.responses: list[tuple[Any, dict]] = []
         self.error_responses: list[tuple[Any, int, str]] = []
         self._initialized = False
+        self.initialize_kwargs: dict[str, Any] = {}
         self._closed = False
         self._notifications: list[dict] = []
         self._server_requests: list[dict] = []
@@ -42,6 +43,7 @@ class FakeClient:
     # API matching CodexAppServerClient
     def initialize(self, **kwargs):
         self._initialized = True
+        self.initialize_kwargs = dict(kwargs)
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
 
@@ -52,6 +54,9 @@ class FakeClient:
         # Sensible defaults for protocol methods used by the session
         if method == "thread/start":
             return {"thread": {"id": "thread-fake-001"},
+                    "activePermissionProfile": {"id": "workspace-write"}}
+        if method == "thread/resume":
+            return {"thread": {"id": (params or {}).get("threadId")},
                     "activePermissionProfile": {"id": "workspace-write"}}
         if method == "turn/start":
             return {"turn": {"id": "turn-fake-001"}}
@@ -173,6 +178,67 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+
+    def test_requested_thread_is_resumed_instead_of_started(self):
+        client = FakeClient()
+        s = make_session(client, thread_id="thread-existing-123")
+
+        assert s.ensure_started() == "thread-existing-123"
+        assert ("thread/start", {"cwd": "/tmp"}) not in client.requests
+        assert (
+            "thread/resume",
+            {
+                "cwd": "/tmp",
+                "threadId": "thread-existing-123",
+                "excludeTurns": True,
+            },
+        ) in client.requests
+        assert client.initialize_kwargs["capabilities"] == {
+            "experimentalApi": True,
+            "requestAttestation": False,
+        }
+
+    def test_resume_failure_falls_back_for_automatic_binding(self):
+        client = FakeClient()
+
+        def handle_request(method, params):
+            if method == "thread/resume":
+                raise session_mod.CodexAppServerError(
+                    code=-32600, message="rollout not found"
+                )
+            if method == "thread/start":
+                return {"thread": {"id": "thread-replacement"}}
+            return {}
+
+        client._request_handler = handle_request
+        s = make_session(client, thread_id="thread-deleted")
+
+        assert s.ensure_started() == "thread-replacement"
+        assert [method for method, _ in client.requests] == [
+            "thread/resume",
+            "thread/start",
+        ]
+
+    def test_resume_failure_is_strict_for_explicit_native_task(self):
+        client = FakeClient()
+
+        def handle_request(method, params):
+            if method == "thread/resume":
+                raise session_mod.CodexAppServerError(
+                    code=-32600, message="thread already has an active writer"
+                )
+            raise AssertionError(f"unexpected request: {method}")
+
+        client._request_handler = handle_request
+        s = make_session(
+            client,
+            thread_id="thread-desktop-active",
+            resume_fallback_to_start=False,
+        )
+
+        with pytest.raises(session_mod.CodexAppServerError, match="active writer"):
+            s.ensure_started()
+        assert [method for method, _ in client.requests] == ["thread/resume"]
 
     def test_close_idempotent(self):
         client = FakeClient()
@@ -895,4 +961,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/agent/transports/test_codex_thread_catalog.py
+++ b/tests/agent/transports/test_codex_thread_catalog.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from agent.transports.codex_thread_catalog import (
+    list_codex_threads,
+    resolve_codex_thread,
+)
+
+
+class FakeClient:
+    def __init__(self, *, codex_bin: str = "codex", codex_home=None) -> None:
+        self.initialize_kwargs: dict[str, Any] = {}
+        self.requests: list[tuple[str, dict, float]] = []
+        self.closed = False
+
+    def initialize(self, **kwargs):
+        self.initialize_kwargs = dict(kwargs)
+        return {}
+
+    def request(
+        self, method: str, params: Optional[dict] = None, timeout: float = 30.0
+    ):
+        self.requests.append((method, params or {}, timeout))
+        return {
+            "data": [
+                {
+                    "id": "thread-new",
+                    "cwd": "/repo",
+                    "preview": "new work",
+                    "name": "Named task",
+                    "source": "vscode",
+                    "status": {"type": "notLoaded"},
+                    "recencyAt": 123,
+                    "isPinned": True,
+                },
+                {
+                    "id": "thread-old",
+                    "cwd": "/repo",
+                    "preview": "old work",
+                    "source": "cli",
+                    "updatedAt": 100,
+                },
+                {"cwd": "/repo", "preview": "missing id"},
+            ],
+            "nextCursor": "next-page",
+        }
+
+    def close(self):
+        self.closed = True
+
+
+def test_list_codex_threads_uses_native_catalog_protocol():
+    client = FakeClient()
+    rows, cursor = list_codex_threads(
+        limit=20,
+        search_term="work",
+        client_factory=lambda **kwargs: client,
+    )
+
+    assert [row.thread_id for row in rows] == ["thread-new", "thread-old"]
+    assert rows[0].title == "Named task"
+    assert rows[0].is_pinned is True
+    assert cursor == "next-page"
+    assert client.initialize_kwargs["capabilities"] == {
+        "experimentalApi": True,
+        "requestAttestation": False,
+    }
+    method, params, timeout = client.requests[0]
+    assert method == "thread/list"
+    assert params == {
+        "limit": 20,
+        "sortKey": "recency_at",
+        "sortDirection": "desc",
+        "archived": False,
+        "useStateDbOnly": False,
+        "searchTerm": "work",
+    }
+    assert timeout == 15.0
+    assert client.closed is True
+
+
+def test_resolve_codex_thread_accepts_picker_id_prefix_and_name():
+    rows, _ = list_codex_threads(client_factory=lambda **kwargs: FakeClient())
+
+    assert resolve_codex_thread(rows, "1").thread_id == "thread-new"
+    assert resolve_codex_thread(rows, "thread-old").thread_id == "thread-old"
+    assert resolve_codex_thread(rows, "thread-n").thread_id == "thread-new"
+    assert resolve_codex_thread(rows, "named task").thread_id == "thread-new"
+    assert resolve_codex_thread(rows, "old work").thread_id == "thread-old"
+    assert resolve_codex_thread(rows, "99") is None

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -80,6 +80,125 @@ class TestHandleResumeCommand:
         assert "not available" in result.lower()
 
     @pytest.mark.asyncio
+    async def test_resume_codex_binds_native_thread(self, tmp_path, monkeypatch):
+        import gateway.run as gateway_run
+        from agent.transports.codex_thread_catalog import CodexThreadSummary
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/resume codex 1")
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "current_session_001",
+            "telegram",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="67890",
+        )
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        runner._resume_caller_is_admin = lambda _source: True
+        runner._release_running_agent_state = MagicMock()
+        runner._clear_conversation_scope = MagicMock()
+        runner._evict_cached_agent = MagicMock()
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {
+                "model": {
+                    "default": "openai/gpt-5",
+                    "openai_runtime": "codex_app_server",
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_thread_catalog.list_codex_threads",
+            lambda **kwargs: (
+                [
+                    CodexThreadSummary(
+                        thread_id="native-thread-123",
+                        cwd="/repo/project",
+                        preview="Fix login refresh",
+                        source="vscode",
+                    )
+                ],
+                None,
+            ),
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed native Codex task" in result
+        switched_id = runner.session_store.switch_session.call_args[0][1]
+        assert switched_id != "current_session_001"
+        assert db.get_session_model_config_value(
+            switched_id, "codex_thread_id"
+        ) == "native-thread-123"
+        assert db.get_session_model_config_value(
+            switched_id, "codex_thread_resume_strict"
+        ) is True
+        assert db.get_session(switched_id)["cwd"] == "/repo/project"
+        runner._clear_conversation_scope.assert_called_once_with(
+            lane_key, reason="resume_codex"
+        )
+        runner._evict_cached_agent.assert_called_once_with(lane_key)
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_codex_does_not_duplicate_current_binding(
+        self, tmp_path, monkeypatch
+    ):
+        import gateway.run as gateway_run
+        from agent.transports.codex_thread_catalog import CodexThreadSummary
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/resume codex native-thread-123")
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "current_session_001",
+            "telegram",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="67890",
+            model_config={"codex_thread_id": "native-thread-123"},
+        )
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        runner._resume_caller_is_admin = lambda _source: True
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"model": {"openai_runtime": "codex_app_server"}},
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_thread_catalog.list_codex_threads",
+            lambda **kwargs: (
+                [
+                    CodexThreadSummary(
+                        thread_id="native-thread-123",
+                        cwd="/repo/project",
+                        preview="Fix login refresh",
+                    )
+                ],
+                None,
+            ),
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Already using native Codex task" in result
+        runner.session_store.switch_session.assert_not_called()
+        assert len(db.list_sessions_rich(limit=10)) == 1
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_list_named_sessions_when_no_arg(self, tmp_path):
         """With no argument, lists recently titled sessions."""
         from hermes_state import SessionDB
@@ -374,6 +493,56 @@ class TestHandleResumeCommand:
 
 class TestHandleSessionsCommand:
     """Tests for GatewayRunner._handle_sessions_command."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_codex_lists_native_tasks_for_admin(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.transports.codex_thread_catalog import CodexThreadSummary
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/sessions codex")
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_caller_is_admin = lambda _source: True
+        monkeypatch.setattr(
+            "agent.transports.codex_thread_catalog.list_codex_threads",
+            lambda **kwargs: (
+                [
+                    CodexThreadSummary(
+                        thread_id="native-thread-123",
+                        cwd="/repo/project",
+                        preview="Fix login refresh",
+                        name="Login task",
+                        source="vscode",
+                        is_pinned=True,
+                    )
+                ],
+                None,
+            ),
+        )
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "Codex Tasks" in result
+        assert "Login task" in result
+        assert "native-threa" in result
+        assert "/resume codex" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_sessions_codex_requires_explicit_admin(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/sessions codex")
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_caller_is_admin = lambda _source: False
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "explicitly configured gateway admin" in result
+        db.close()
 
     @pytest.mark.asyncio
     async def test_sessions_full_keeps_legacy_reset_child_after_parent_resume(

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -223,6 +223,12 @@ def test_import_codex_session(tmp_path, session_db):
     assert title.startswith("Imported from Codex CLI: ")
     messages = session_db.get_messages(session_id)
     _assert_alternating(messages)
+    assert session_db.get_session_model_config_value(
+        session_id, "codex_thread_id"
+    ) == "0000-1111"
+    assert session_db.get_session_model_config_value(
+        session_id, "codex_thread_resume_strict"
+    ) is True
     # resumable: resolve_session_id round-trips
     assert session_db.resolve_session_id(session_id) == session_id
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -86,6 +86,93 @@ class TestRunConversationCodexPath:
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
 
+    @pytest.mark.parametrize(
+        ("strict_resume", "expected_fallback"),
+        [(False, True), (True, False)],
+    )
+    def test_resumes_persisted_native_codex_thread(
+        self, tmp_path, monkeypatch, strict_resume, expected_fallback
+    ):
+        from hermes_state import SessionDB
+        import agent.transports.codex_app_server_session as session_mod
+
+        captured = {}
+
+        class CapturingSession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, user_input, **kwargs):
+                return TurnResult(
+                    final_text="resumed",
+                    projected_messages=[
+                        {"role": "assistant", "content": "resumed"}
+                    ],
+                    thread_id="native-thread-existing",
+                    turn_id="turn-resumed",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(session_mod, "CodexAppServerSession", CapturingSession)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = _make_codex_agent()
+        model_config = {"codex_thread_id": "native-thread-existing"}
+        if strict_resume:
+            model_config["codex_thread_resume_strict"] = True
+        db.create_session(
+            agent.session_id,
+            "cli",
+            model_config=model_config,
+        )
+        agent._session_db = db
+        agent._session_db_created = True
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("continue")
+
+        assert result["final_response"] == "resumed"
+        assert captured["thread_id"] == "native-thread-existing"
+        assert captured["resume_fallback_to_start"] is expected_fallback
+        db.close()
+
+    def test_persists_new_native_codex_thread_binding(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+        import agent.transports.codex_app_server_session as session_mod
+
+        class StartingSession:
+            def __init__(self, **kwargs):
+                assert kwargs["thread_id"] is None
+
+            def run_turn(self, user_input, **kwargs):
+                return TurnResult(
+                    final_text="started",
+                    projected_messages=[
+                        {"role": "assistant", "content": "started"}
+                    ],
+                    thread_id="native-thread-new",
+                    turn_id="turn-new",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(session_mod, "CodexAppServerSession", StartingSession)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = _make_codex_agent()
+        db.create_session(agent.session_id, "cli")
+        agent._session_db = db
+        agent._session_db_created = True
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("start")
+
+        assert db.get_session_model_config_value(
+            agent.session_id, "codex_thread_id"
+        ) == "native-thread-new"
+        db.close()
+
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -242,8 +242,8 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/compress [here [N] \| focus topic]` | Manually compress conversation context. `/compress here [N]` keeps the most recent N exchanges (default 2) verbatim and summarizes the rest. A focus topic narrows what a full summary preserves. |
 | `/topic [off\|help\|session-id]` | **Telegram DM only.** Manage user-managed multi-session topic mode. `/topic` enables it or shows status; `/topic off` disables it and clears bindings; `/topic help` shows usage; `/topic <session-id>` inside a topic restores a previous session. See [Multi-session DM mode](/user-guide/messaging/telegram#multi-session-dm-mode-topic). |
 | `/title [name]` | Set or show the session title. |
-| `/resume [name]` | Resume a previously named session. |
-| `/sessions [all] [search <query>]` | List previous sessions for this chat. `/sessions search <query>` filters by title/id match (most recently active first); `/sessions all` lists across origins (admin only). |
+| `/resume [name]` | Resume a previously named session. With the Codex app-server runtime enabled, an explicitly configured admin can use `/resume codex <number\|thread-id\|name>` to continue a native Codex task. |
+| `/sessions [all] [search <query>]` | List previous sessions for this chat. `/sessions search <query>` filters by title/id match (most recently active first); `/sessions all` lists across origins (admin only). With the Codex app-server runtime enabled, an explicitly configured admin can use `/sessions codex [search <query>]` to browse native Codex tasks. |
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
 | `/topup` | Show your Nous balance and manage billing on the portal. |
 | `/whoami` | Show your slash command access level (admin / user). |

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -197,6 +197,42 @@ model:
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
 ```
 
+## Continue an existing Codex task from a gateway
+
+When this runtime is enabled, an explicitly configured gateway admin can
+browse the same native task catalog used by Codex CLI and Codex Desktop:
+
+```
+/sessions codex
+/sessions codex search login refresh
+```
+
+Continue one of the displayed tasks in the current Telegram, Discord,
+Feishu, or other gateway conversation:
+
+```
+/resume codex 2
+/resume codex <thread-id-or-unique-prefix>
+/resume codex "task name"
+```
+
+Hermes creates a lightweight route session and stores the native Codex thread
+ID, then reconnects with `thread/resume` on the next message. Codex remains the
+source of truth for the task's context; the Hermes session transcript is only
+a searchable/display mirror of turns sent through Hermes. A gateway restart,
+agent-cache eviction, or later Hermes `/resume` therefore reconnects to the
+same Codex task instead of creating a duplicate.
+
+Native Codex tasks are host-wide and may contain previews from unrelated
+workspaces, so this picker requires an explicit gateway admin even when slash
+command access control is otherwise disabled. Configure the gateway's admin
+user list before using it from a messenger.
+
+Codex permits only one active writer per task. If Codex Desktop or another
+client is currently running a turn on the selected task, Hermes preserves that
+lock and reports the app-server error; finish or stop the other turn, then
+retry from the gateway.
+
 ## Self-improvement loop (memory + skill nudges)
 
 Hermes' background self-improvement fires on counter thresholds:


### PR DESCRIPTION
## What does this PR do?

This makes a messaging gateway a first-class client for existing native Codex tasks when Hermes is using the `codex_app_server` runtime.

An explicitly configured gateway admin can browse the same task catalog used by Codex CLI/Desktop with `/sessions codex`, then bind the current gateway lane to one of those tasks with `/resume codex <number|thread-id|name>`. The next message reconnects through `thread/resume`, and Hermes persists only the native thread binding in its existing SessionDB model config. Codex remains authoritative for task context.

Explicit picker selections are strict: if Codex Desktop still owns the active writer, Hermes surfaces that error instead of silently creating a duplicate task. Automatically restored Hermes bindings retain a safe fallback to `thread/start` when a stale native thread can no longer be resumed.

## Related Issue

Related to #82160.

This overlaps #99012's agent-rebuild continuity fix, but is a broader gateway/session-management change: it adds native task discovery and explicit routing, uses the existing SessionDB model config instead of a second JSON mapping file, and distinguishes strict user-selected resumes from fallback-safe automatic bindings.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a read-only `thread/list` catalog adapter with number, exact ID, unique-prefix, and exact-name resolution.
- Teach `CodexAppServerSession` to resume an existing native thread and preserve active-writer errors for explicit selections.
- Persist the returned native Codex thread ID in the Hermes session's existing `model_config` so gateway restarts and agent-cache eviction reconnect to the same task.
- Add admin-only `/sessions codex [search <query>]` and `/resume codex <target>` gateway flows.
- Preserve native thread identity when importing Codex JSONL sessions.
- Document gateway usage, trust boundaries, and single-writer behavior.

## How to Test

1. Enable the runtime with `/codex-runtime codex_app_server` and configure a gateway admin.
2. Run `/sessions codex`, choose a native task, and run `/resume codex <number>`.
3. Send a message and verify the same Codex thread ID is resumed; repeat after gateway cache eviction or restart.

Automated verification:

- `scripts/run_tests.sh -q` for the five touched Codex/gateway test files: **111 passed**.
- `pytest -q tests/gateway/test_feishu.py`: **58 passed, 18 skipped**.
- Ruff on all touched Python files: passed.
- Full local suite: **40,700 passed, 399 skipped, 109 failed** across optional-dependency, host-platform, and pre-existing baseline cases. None of the failing files is modified by this PR; three representative deterministic failures reproduce unchanged on `origin/main`.

Live protocol verification on macOS:

- `thread/list` returned the shared Codex CLI/Desktop catalog.
- `thread/resume` reattached to the same thread ID without starting a turn.
- A task with a live Desktop writer returned Codex's active-writer error and did not fall back to a new thread.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full-suite baseline failures are documented above; targeted tests pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific process or path handling added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not included: native task previews and workspace names can contain private repository context. The protocol and gateway behavior are covered by deterministic tests above.
