### PR TITLE
fix(bot-mode): re-route retry_indeterminate() on worker races like cancel()

### DIFF
--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -1349,6 +1349,73 @@ def test_retry_uses_runtime_session_id_returned_by_resume(db: Path):
     assert observed == {"history": runtime_id, "info": runtime_id}
 
 
+def test_retry_indeterminate_reroutes_on_worker_race(db: Path, monkeypatch):
+    """The background reconcile pass can transition the task concurrently
+    with an explicit Retry call. retry_indeterminate() must re-read and
+    re-route on a transient StaleTaskError instead of surfacing it, mirroring
+    cancel()'s established routing-retry contract."""
+    identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=1,
+        clock=clock,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    now[0] = 102.0
+    recovery_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="recovery-process",
+        ttl_seconds=30,
+        clock=clock,
+    )
+    state.recover_room(db, recovery_lease, clock=clock)
+    state.release_lease(db, recovery_lease, clock=clock)
+
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    runtime = _runtime(db, rpc, clock=clock)
+
+    real_requeue = state.requeue_indeterminate_task
+    calls = {"n": 0}
+
+    def flaky_requeue(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Simulate the background reconcile worker winning the race on
+            # this generation between retry_indeterminate()'s read and its
+            # write attempt.
+            raise state.StaleTaskError("worker moved the task first")
+        return real_requeue(*args, **kwargs)
+
+    monkeypatch.setattr(state, "requeue_indeterminate_task", flaky_requeue)
+
+    retried = runtime.retry_indeterminate(identity)
+
+    assert calls["n"] == 2
+    assert retried["status"] == "queued"
+    task = state.get_task(db, identity)
+    assert task["status"] == "queued"
+
+
 def test_retry_reconciles_terminal_remote_cancellation_without_new_generation(
     db: Path,
 ):

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -408,79 +408,112 @@ class HostedRoomRuntime:
         return self._info_acknowledges_peer_cancel(info, task)
 
     def retry_indeterminate(self, identity: state.TaskIdentity) -> dict[str, Any]:
-        """Explicitly retry one uncertain attempt under the current room lease."""
-        task = state.get_task(self.db_path, identity)
-        if task["status"] not in {"indeterminate", "deferred"}:
-            raise state.InvalidTaskTransitionError(
-                f"cannot retry task in state '{task['status']}'"
-            )
+        """Explicitly retry one uncertain attempt under the current room lease.
+
+        The background reconcile pass (``_reconcile_indeterminate``) runs on
+        every poll cycle for any room with an indeterminate task, so it can
+        settle/defer/requeue the same task concurrently with an explicit
+        Retry call. Mirror ``cancel()``'s routing-retry loop: every
+        fast-path failure caused by a concurrent transition re-reads and
+        re-routes instead of surfacing a transient
+        `InvalidTaskTransitionError`/`StaleTaskError` to the caller.
+        """
         binding = self._binding_for_room(identity.room_id)
         if binding is None:
             raise state.RoomUnavailableError("hosted room is unavailable")
         lease = self._ensure_lease(binding)
-        if task["status"] == "deferred":
-            retried = state.requeue_deferred_task(
-                self.db_path,
-                identity,
-                lease,
-                expected_execution_generation=task["execution_generation"],
-                expected_cancel_generation=task["cancel_generation"],
-                clock=self.clock,
-            )
+        for _ in range(_CANCEL_ROUTE_RETRIES):
+            task = state.get_task(self.db_path, identity)
+            if task["status"] not in {"indeterminate", "deferred"}:
+                raise state.InvalidTaskTransitionError(
+                    f"cannot retry task in state '{task['status']}'"
+                )
+            if task["status"] == "deferred":
+                try:
+                    retried = state.requeue_deferred_task(
+                        self.db_path,
+                        identity,
+                        lease,
+                        expected_execution_generation=task["execution_generation"],
+                        expected_cancel_generation=task["cancel_generation"],
+                        clock=self.clock,
+                    )
+                except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                    # Lost the race with the worker; re-read and re-route.
+                    continue
+                with self._status_lock:
+                    self._blocked_rooms.discard(identity.room_id)
+                self.wakeup()
+                return retried
+            # Explicit Retry may resume the exact stored session. Use the
+            # returned runtime id for every subsequent history/info probe; an
+            # automatic abandoned-attempt scan remains non-resuming for local
+            # sessions.
+            inspection = self._inspect_recovery_session(binding, task)
+            if inspection.terminal is not None:
+                try:
+                    resolved = state.resolve_indeterminate_task(
+                        self.db_path,
+                        identity,
+                        lease,
+                        expected_execution_generation=task["execution_generation"],
+                        expected_cancel_generation=task["cancel_generation"],
+                        settlement_id=inspection.terminal.settlement_id,
+                        status=inspection.terminal.status,
+                        result=inspection.terminal.result,
+                        clock=self.clock,
+                    )
+                except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                    continue
+                if self.publish_terminal is not None:
+                    self.publish_terminal(binding, resolved)
+                return resolved
+            if inspection.status == "cancelled":
+                try:
+                    resolved = state.resolve_indeterminate_cancellation(
+                        self.db_path,
+                        identity,
+                        lease,
+                        expected_execution_generation=task["execution_generation"],
+                        expected_cancel_generation=task["cancel_generation"],
+                        cancel_id=f"remote-cancel:{task['execution_generation']}",
+                        clock=self.clock,
+                    )
+                except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                    continue
+                if self.publish_terminal is not None:
+                    self.publish_terminal(binding, resolved)
+                return resolved
+            if inspection.active:
+                with self._status_lock:
+                    self._blocked_rooms.add(identity.room_id)
+                raise state.InvalidTaskTransitionError(
+                    "cannot retry while the original task attempt is still active"
+                )
+            try:
+                retried = state.requeue_indeterminate_task(
+                    self.db_path,
+                    identity,
+                    lease,
+                    expected_execution_generation=task["execution_generation"],
+                    expected_cancel_generation=task["cancel_generation"],
+                    clock=self.clock,
+                )
+            except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                continue
             with self._status_lock:
                 self._blocked_rooms.discard(identity.room_id)
             self.wakeup()
             return retried
-        # Explicit Retry may resume the exact stored session. Use the returned
-        # runtime id for every subsequent history/info probe; an automatic
-        # abandoned-attempt scan remains non-resuming for local sessions.
-        inspection = self._inspect_recovery_session(binding, task)
-        if inspection.terminal is not None:
-            resolved = state.resolve_indeterminate_task(
-                self.db_path,
-                identity,
-                lease,
-                expected_execution_generation=task["execution_generation"],
-                expected_cancel_generation=task["cancel_generation"],
-                settlement_id=inspection.terminal.settlement_id,
-                status=inspection.terminal.status,
-                result=inspection.terminal.result,
-                clock=self.clock,
-            )
-            if self.publish_terminal is not None:
-                self.publish_terminal(binding, resolved)
-            return resolved
-        if inspection.status == "cancelled":
-            resolved = state.resolve_indeterminate_cancellation(
-                self.db_path,
-                identity,
-                lease,
-                expected_execution_generation=task["execution_generation"],
-                expected_cancel_generation=task["cancel_generation"],
-                cancel_id=f"remote-cancel:{task['execution_generation']}",
-                clock=self.clock,
-            )
-            if self.publish_terminal is not None:
-                self.publish_terminal(binding, resolved)
-            return resolved
-        if inspection.active:
-            with self._status_lock:
-                self._blocked_rooms.add(identity.room_id)
-            raise state.InvalidTaskTransitionError(
-                "cannot retry while the original task attempt is still active"
-            )
-        retried = state.requeue_indeterminate_task(
-            self.db_path,
-            identity,
-            lease,
-            expected_execution_generation=task["execution_generation"],
-            expected_cancel_generation=task["cancel_generation"],
-            clock=self.clock,
+        # Exhausted routing retries under sustained contention: surface the
+        # live status honestly rather than a transient transition error.
+        final = state.get_task(self.db_path, identity)
+        if final["status"] not in {"indeterminate", "deferred"}:
+            return final
+        raise state.InvalidTaskTransitionError(
+            f"retry kept losing races with task transitions "
+            f"(last observed state '{final['status']}')"
         )
-        with self._status_lock:
-            self._blocked_rooms.discard(identity.room_id)
-        self.wakeup()
-        return retried
 
     def _interrupt_stopping_task(
         self,


### PR DESCRIPTION
## Summary

`HostedRoomRuntime.cancel()` was rewritten by #97744's follow-up (5a3edc7467, "cancel re-routes on worker races instead of failing disband") to re-read and re-route on every transient `StaleTaskError`/`InvalidTaskTransitionError` caused by the background reconcile worker transitioning a task concurrently with the call.

Its structural sibling, `retry_indeterminate()` (invoked via `groups.retry`), was never given the same treatment. It reads the task once, then makes fenced writes (`requeue_deferred_task`, `resolve_indeterminate_task`, `resolve_indeterminate_cancellation`, `requeue_indeterminate_task`) using generations captured from that single read — with no retry if the row changed underneath it.

The background indeterminate-reconcile pass (`_reconcile_indeterminate`) runs on every poll cycle for any room that has an indeterminate task — i.e. continuously, for the exact duration `groups.retry` is actually callable at all. So this isn't a rare edge case: a user clicking Retry races this worker on every call, and losing the race surfaces a raw `StaleTaskError` to the caller instead of the transparent re-route `cancel()` now provides for the same class of race.

## Fix

Wrapped `retry_indeterminate()` in the same routing-retry loop shape as `cancel()`:
- Re-read task status at the top of each iteration (bounded by the existing `_CANCEL_ROUTE_RETRIES`).
- Attempt the appropriate fenced transition for the current status/inspection result.
- `continue` (re-read, re-route) on `InvalidTaskTransitionError`/`StaleTaskError` from the write itself.
- After exhausting retries under sustained contention, fall back to surfacing the live task status honestly, mirroring `cancel()`'s own fallback.

The "still active" rejection (`cannot retry while the original task attempt is still active`) stays an immediate, hard error exactly as before — that's a genuine business-rule reject, not a race-shaped failure, so it must not be swallowed by the retry loop.

## Test plan

- Added `test_retry_indeterminate_reroutes_on_worker_race` (`tests/tui_gateway/test_hosted_room_driver_runtime.py`): injects one `StaleTaskError` on the first `requeue_indeterminate_task` call and asserts `retry_indeterminate()` re-reads and completes successfully on the retry instead of raising.
- Mutation-verified: stashing the fix reproduces the raw `StaleTaskError` propagating out of `retry_indeterminate()`.
- `tests/tui_gateway/test_hosted_room_driver_runtime.py` (44/44), `test_groups_methods.py`, `test_groups_replication_methods.py`, `test_hosted_room_service.py`, `test_hosted_room_prompt_fence.py` — all green across 3 consecutive combined runs (one earlier combined run had one unrelated flaky failure that reproduced identically with the fix stashed — pre-existing test-order/timing pollution, not caused by this change).
- Confirmed `retry_indeterminate()` has exactly one caller repo-wide (`tui_gateway/hosted_room_service.py`), whose usage of the return value is unaffected — same dict shape returned on every path.