### PR TITLE
feat(skills): add board-gated-execution to optional-skills

### DIFF
--- a/optional-skills/software-development/board-gated-execution/SKILL.md
+++ b/optional-skills/software-development/board-gated-execution/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: board-gated-execution
+description: "Gate agent work on an issue board so tasks cannot drift."
+version: 0.1.0
+author: Nidhal Gharbi (NidhalxMRR), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Workflow, GitHub, Issues, Focus, Project-Management]
+    related_skills: [github, weekly-review-planning, systematic-debugging]
+---
+
+# Board-Gated Execution Skill
+
+Long agent sessions lose work silently. A feature reaches "service running, route
+written, UI missing, nothing committed", attention moves to an adjacent question,
+and the half-built state is invisible until someone asks "did you finish that?".
+This skill makes an issue board the source of truth for what to work on, and
+makes consulting it a gate rather than a habit.
+
+It does not replace the `github` skill (creating, triaging and closing issues,
+and carrying one to a merged PR). It answers the question that comes before all
+of that: *which* issue, and *may I start something new at all*.
+
+## When to Use
+
+- A session spans many turns and several topics, and work risks being left open
+- The user asks "did you finish X?" about something you started earlier
+- You are about to start a new task while another is still incomplete
+- A project's open threads live only in chat history, not in a tracker
+
+Don't use for: single-task sessions, repos where the user tracks work elsewhere
+(Linear, Jira) without a mirror, or one-off questions with no follow-up work.
+
+## Prerequisites
+
+- `gh` authenticated with `repo` scope: `terminal(command="gh auth status")`
+- A GitHub repo with Issues enabled
+- Python 3.9+ for the helper scripts
+
+The GitHub Projects **board view** needs `read:project`, which most tokens lack.
+This skill deliberately uses **Issues plus labels** instead, so it works with the
+default `repo` scope. Do not make Projects a hard dependency.
+
+## Procedure
+
+### 1. Create the label vocabulary
+
+Run `scripts/setup-labels.sh`. It creates `area:*`, `blocked:human`,
+`in-progress`, `needs-tests` and `P0`-`P3`, and is idempotent (create, else
+edit). *Completion criterion:* `terminal(command="gh label list")` shows every
+label the gate depends on — at minimum `in-progress`, `blocked:human`, `P0`-`P3`.
+
+### 2. Seed the board from what exists only in conversation
+
+Enumerate every open thread — half-built features, deferred decisions, missing
+docs, things blocked on the user — and file one issue each. Use
+`scripts/seed-issues.py` as the template: it embeds a `<!-- seed:<key> -->`
+marker in each body and searches for that marker before creating, so re-runs
+create nothing.
+
+Every issue needs **acceptance criteria that can be settled by evidence**, not by
+opinion. "Voice UI done" is not a criterion; "the user can hold a button, speak,
+and hear a reply on the live site" is.
+
+*Completion criterion:* running the seeder twice creates zero issues the second
+time, and no open thread from the conversation is missing from the board.
+
+### 3. Gate every start on the board
+
+Before starting any work:
+
+```
+terminal(command="python3 scripts/next-task.py")
+```
+
+It prints the single issue to work on. Obey it. If what you were about to do is
+not that issue, then either it is not the next thing, or it is not on the board —
+and unboarded work is exactly how drift starts.
+
+Selection order, enforced mechanically:
+
+1. **WIP limit of one.** Two unblocked `in-progress` issues means one is
+   drifting; the script exits 1 and refuses to name new work.
+2. **Finishing beats starting.** An `in-progress` issue wins over a
+   higher-priority fresh one.
+3. **Priority otherwise:** P0 > P1 > P2 > P3.
+
+`blocked:human` issues are **never selected**. They need a decision or a
+credential the agent cannot supply, so "working" them means waiting, and waiting
+is indistinguishable from drift. Report them to the user instead.
+
+*Completion criterion:* the script exits 0 and names exactly one issue, or exits
+1 with a refusal you then resolve.
+
+### 4. Mark and close honestly
+
+- Starting: `terminal(command="gh issue edit <n> --add-label in-progress")`
+- Shipping: reference the issue in the commit body, then
+  `terminal(command="gh issue close <n>")`
+
+An issue left open after the work shipped teaches the board to lie; an issue
+closed before the work is verified teaches it to lie faster. Close on evidence —
+tests green, artifact exercised — never on intent.
+
+*Completion criterion:* `gh issue list --state open` contains nothing already
+delivered.
+
+### 5. Prove the gate refuses
+
+A gate that only ever says "go" is decoration. Run `scripts/gate-check.py`: it
+marks a second issue `in-progress`, asserts the gate exits 1, names both
+offenders and declines to name a task, then restores the label.
+
+*Completion criterion:* all checks pass, and the board is left exactly as found.
+
+## Quick Reference
+
+```bash
+bash scripts/setup-labels.sh                 # one-time label vocabulary
+python3 scripts/seed-issues.py               # idempotent board seeding
+python3 scripts/next-task.py                 # THE GATE — run before starting work
+python3 scripts/gate-check.py                # prove the gate refuses
+gh issue edit <n> --add-label in-progress    # mark started
+gh issue close <n>                           # close on evidence
+```
+
+## Pitfalls
+
+1. **A board you do not consult is just a nicer place to lose work.** The gate is
+   worthless as an intention; run the script.
+2. **Do not let the gate pick a `blocked:human` issue.** Surfacing a blocker to
+   the user is progress; silently waiting on it is not.
+3. **Acceptance criteria that need a judgment call cannot close an issue.** Write
+   criteria a script or a human can settle by looking at evidence.
+4. **Seeding without markers creates duplicates on every re-run.** The marker
+   comment is what makes the seeder idempotent.
+5. **GitHub Projects needs `read:project`.** Use Issues plus labels so the gate
+   works with the `repo` scope alone; ask the user before requesting more.
+6. **Priority labels only sort; they do not decide.** An `in-progress` P3 still
+   outranks a fresh P1, because finishing beats starting.
+7. **Closing an issue because the code exists.** Tests written after the fact
+   encode what the code does, not what it should do — close on verified
+   behaviour.
+
+## Verification
+
+- `python3 scripts/next-task.py` exits 0 and names one issue
+- `python3 scripts/gate-check.py` passes every check and restores the board
+- Running the seeder twice creates zero issues on the second run
+- `gh issue list --state open` matches the work that is genuinely outstanding

--- a/optional-skills/software-development/board-gated-execution/scripts/gate-check.py
+++ b/optional-skills/software-development/board-gated-execution/scripts/gate-check.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Prove the execution gate refuses.
+
+A gate that only ever says "go" is decoration. The behaviour that matters is the
+refusal: when two issues are in progress, the gate must stop and say so rather
+than helpfully picking one — because helpfully picking one is exactly how a
+half-built feature gets abandoned for a fresher, more interesting task.
+
+This mutates the board (adds `in-progress` to one issue), asserts the gate
+refuses, and restores the label in a `finally` block so the board is left as
+found even if an assertion fails.
+
+    python3 gate-check.py                      # repo inferred, victim auto-picked
+    python3 gate-check.py owner/repo 42        # explicit repo and victim issue
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+GATE = Path(__file__).with_name("next-task.py")
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=180)
+
+
+def detect_repo() -> str:
+    p = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    if p.returncode != 0 or not p.stdout.strip():
+        print("Cannot determine the repository.", file=sys.stderr)
+        sys.exit(2)
+    return p.stdout.strip()
+
+
+def gate(repo: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(GATE), repo],
+                          capture_output=True, text=True, timeout=300)
+
+
+def pick_victim(repo: str) -> str | None:
+    """An open issue that is neither in-progress nor blocked — safe to relabel."""
+    p = run(["gh", "issue", "list", "--repo", repo, "--state", "open",
+             "--limit", "100", "--json", "number,labels"])
+    if p.returncode != 0:
+        return None
+    for issue in json.loads(p.stdout or "[]"):
+        names = {l["name"] for l in issue.get("labels", [])}
+        if "in-progress" not in names and "blocked:human" not in names:
+            return str(issue["number"])
+    return None
+
+
+def main(argv: list[str]) -> int:
+    repo = argv[1] if len(argv) > 1 else detect_repo()
+    victim = argv[2] if len(argv) > 2 else pick_victim(repo)
+    if not victim:
+        print("No safe issue to use for the refusal test. Seed the board first.")
+        return 2
+
+    checks: list[tuple[str, bool]] = []
+
+    before = gate(repo)
+    checks.append(("gate runs cleanly before the mutation", before.returncode == 0))
+    checks.append(("gate names exactly one task or reports none actionable",
+                   "WORK THIS" in before.stdout or "Nothing actionable" in before.stdout))
+    if "BLOCKED ON A HUMAN" in before.stdout:
+        head = before.stdout.split("BLOCKED ON A HUMAN")[0]
+        checks.append(("gate never selects a blocked issue as the task",
+                       "blocked:human" not in head))
+
+    try:
+        run(["gh", "issue", "edit", victim, "--repo", repo, "--add-label", "in-progress"])
+        during = gate(repo)
+        checks.append(("gate REFUSES with two in-progress issues", during.returncode == 1))
+        checks.append(("refusal explains why",
+                       "more than one issue is in progress" in during.stdout))
+        checks.append((f"refusal names the offender #{victim}", f"#{victim}" in during.stdout))
+        checks.append(("refusal declines to name a task",
+                       "WORK THIS" not in during.stdout))
+    finally:
+        run(["gh", "issue", "edit", victim, "--repo", repo, "--remove-label", "in-progress"])
+
+    after = gate(repo)
+    checks.append(("gate recovers once the WIP limit is restored", after.returncode == 0))
+
+    passed = sum(1 for _, ok in checks if ok)
+    for name, ok in checks:
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+    print(f"\n{passed}/{len(checks)} checks passed")
+    return 0 if passed == len(checks) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/optional-skills/software-development/board-gated-execution/scripts/next-task.py
+++ b/optional-skills/software-development/board-gated-execution/scripts/next-task.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+The execution gate: what am I allowed to work on right now?
+
+WHY THIS EXISTS
+
+A board that is not consulted is just a nicer place to lose work. The failure it
+prevents is concrete: a feature reaches "service running, route written, UI
+missing, nothing committed" while attention moves to an adjacent question, and
+the half-built state stays invisible until someone asks "did you finish that?".
+
+So the rule is mechanical rather than a good intention:
+
+    Before starting anything, run this. Work the issue it names. If what you
+    are about to do is not that issue, either it is not the next thing, or it
+    is not on the board — and unboarded work is how drift starts.
+
+SELECTION ORDER
+
+  1. WIP LIMIT FIRST. More than one unblocked `in-progress` issue is itself the
+     defect; the gate refuses to name new work until the count is back to one.
+  2. Anything `in-progress` that is not `blocked:human` — finish before starting.
+  3. Otherwise the highest priority (P0 > P1 > P2 > P3) unblocked issue.
+
+`blocked:human` issues are never selected: they need a decision or a credential
+the agent cannot supply, so "working" them would mean waiting, and waiting looks
+identical to drift. Report them to the user instead.
+
+USAGE
+
+    python3 next-task.py                 # repo inferred from the git remote
+    python3 next-task.py owner/repo      # explicit
+
+EXIT CODES
+  0  an issue was selected, or the board holds no actionable work
+  1  the gate refuses: WIP limit breached, resolve that first
+  2  the board could not be read (auth, network, no remote)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+PRIORITY = ["P0", "P1", "P2", "P3"]
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=180)
+
+
+def detect_repo() -> str:
+    """`owner/repo` from the current checkout, so the script is not repo-specific."""
+    p = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    if p.returncode != 0 or not p.stdout.strip():
+        print("Cannot determine the repository. Pass it explicitly: "
+              "python3 next-task.py owner/repo", file=sys.stderr)
+        sys.exit(2)
+    return p.stdout.strip()
+
+
+def fetch_issues(repo: str) -> list[dict]:
+    p = run(["gh", "issue", "list", "--repo", repo, "--state", "open",
+             "--limit", "100", "--json", "number,title,labels"])
+    if p.returncode != 0:
+        print(f"Could not read the board: {p.stderr.strip()[:200]}", file=sys.stderr)
+        sys.exit(2)
+    return json.loads(p.stdout or "[]")
+
+
+def labels_of(issue: dict) -> set[str]:
+    return {l["name"] for l in issue.get("labels", [])}
+
+
+def rank(issue: dict) -> int:
+    names = labels_of(issue)
+    for i, p in enumerate(PRIORITY):
+        if p in names:
+            return i
+    return len(PRIORITY)  # unprioritised sorts last
+
+
+def describe(issue: dict, indent: str = "") -> str:
+    names = ", ".join(sorted(labels_of(issue)))
+    return f"{indent}#{issue['number']} {issue['title']}\n{indent}  labels: {names}"
+
+
+def main(argv: list[str]) -> int:
+    repo = argv[1] if len(argv) > 1 else detect_repo()
+    issues = fetch_issues(repo)
+    if not issues:
+        print(f"{repo}: the board is empty. Nothing is tracked — that is itself "
+              f"the problem. Seed it before starting work.")
+        return 0
+
+    blocked = [i for i in issues if "blocked:human" in labels_of(i)]
+    active = [i for i in issues
+              if "in-progress" in labels_of(i) and "blocked:human" not in labels_of(i)]
+
+    # 1. WIP limit. Two things in flight means one of them is drifting.
+    if len(active) > 1:
+        print("GATE: REFUSED — more than one issue is in progress.\n")
+        for i in active:
+            print(describe(i, "  "))
+        print("\nFinish or explicitly park one before starting anything new.")
+        return 1
+
+    # 2. Finish what is already started.
+    if active:
+        chosen = active[0]
+        print("WORK THIS (already in progress — finish before starting anything new):\n")
+        print(describe(chosen))
+    else:
+        candidates = [i for i in issues
+                      if "blocked:human" not in labels_of(i)
+                      and "in-progress" not in labels_of(i)]
+        if not candidates:
+            print("Nothing actionable: every open issue is blocked on a human decision.\n")
+            for i in blocked:
+                print(describe(i, "  "))
+            print("\nSay so plainly rather than inventing adjacent work.")
+            return 0
+        candidates.sort(key=lambda i: (rank(i), i["number"]))
+        chosen = candidates[0]
+        print("WORK THIS (highest priority unblocked):\n")
+        print(describe(chosen))
+        print(f"\n  Mark it started:  gh issue edit {chosen['number']} "
+              f"--repo {repo} --add-label in-progress")
+
+    if blocked:
+        print(f"\nBLOCKED ON A HUMAN ({len(blocked)}) — surface these, do not work them:")
+        for i in blocked:
+            print(describe(i, "  "))
+
+    remaining = [i for i in issues
+                 if i["number"] != chosen["number"]
+                 and "blocked:human" not in labels_of(i)]
+    if remaining:
+        remaining.sort(key=lambda i: (rank(i), i["number"]))
+        print(f"\nQUEUED ({len(remaining)}):")
+        for i in remaining[:5]:
+            pri = next((p for p in PRIORITY if p in labels_of(i)), "--")
+            print(f"  {pri:3} #{i['number']} {i['title'][:60]}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/optional-skills/software-development/board-gated-execution/scripts/seed-issues.py
+++ b/optional-skills/software-development/board-gated-execution/scripts/seed-issues.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Seed an issue board from work that currently exists only in conversation.
+
+WHY
+
+A repository with zero issues keeps every open thread in chat history: the
+half-built feature, the deferred decision, the missing doc, the thing waiting on
+a human. Work that is not on a board drifts, and the drift is invisible until
+someone asks about it. An issue is the smallest artifact that survives a context
+window.
+
+HOW TO USE
+
+Edit ISSUES below to describe the real backlog, then run it. This is a template
+on purpose — the value is in writing acceptance criteria that can be *settled by
+evidence*, which no script can do for you. "Feature done" is not a criterion;
+"the user can hold a button, speak, and hear a reply on the live site" is.
+
+IDEMPOTENT
+
+Each issue carries a `<!-- seed:<key> -->` marker in its body. The script reads
+existing issues and skips any key already present, so re-running creates nothing
+and duplicates nothing.
+
+    python3 seed-issues.py                # repo inferred from the git remote
+    python3 seed-issues.py owner/repo     # explicit
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=180)
+
+
+def detect_repo() -> str:
+    p = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    if p.returncode != 0 or not p.stdout.strip():
+        print("Cannot determine the repository. Pass it explicitly: "
+              "python3 seed-issues.py owner/repo", file=sys.stderr)
+        sys.exit(2)
+    return p.stdout.strip()
+
+
+def existing_markers(repo: str) -> set[str]:
+    p = run(["gh", "issue", "list", "--repo", repo, "--state", "all",
+             "--limit", "200", "--json", "body"])
+    if p.returncode != 0:
+        return set()
+    found: set[str] = set()
+    for item in json.loads(p.stdout or "[]"):
+        for line in (item.get("body") or "").splitlines():
+            if line.startswith("<!-- seed:") and line.endswith("-->"):
+                found.add(line[len("<!-- seed:"):-len(" -->")].strip())
+    return found
+
+
+# ---------------------------------------------------------------------------
+# EDIT THIS. Two worked examples showing the shape; replace with the real
+# backlog. Keep acceptance criteria checkable.
+# ---------------------------------------------------------------------------
+ISSUES: list[dict] = [
+    {
+        "key": "example-half-built",
+        "title": "Example: finish the half-built feature",
+        "labels": ["area:backend", "P1", "in-progress"],
+        "body": """Describe the state honestly: what exists, what does not, what is untested.
+
+## Acceptance criteria
+- [ ] A criterion a script or a human can settle by looking at evidence
+- [ ] Tests covering the behaviour, not merely the code paths
+- [ ] Works at the smallest viewport or platform the project actually supports
+""",
+    },
+    {
+        "key": "example-blocked",
+        "title": "Example: something only the human can unblock",
+        "labels": ["area:infra", "blocked:human", "P1"],
+        "body": """State exactly what is needed and why the agent cannot do it — a credential,
+a billing decision, a judgment call.
+
+## Acceptance criteria
+- [ ] The observable result once the human has acted
+""",
+    },
+]
+
+
+def main(argv: list[str]) -> int:
+    repo = argv[1] if len(argv) > 1 else detect_repo()
+    have = existing_markers(repo)
+    print(f"{repo}: {len(have)} seeded issue(s) already present\n")
+
+    created = 0
+    tmp = Path(tempfile.gettempdir())
+    for spec in ISSUES:
+        key = spec["key"]
+        if key in have:
+            print(f"  skip     {key} (already seeded)")
+            continue
+        body_file = tmp / f"seed-issue-{key}.md"
+        body_file.write_text(spec["body"] + f"\n<!-- seed:{key} -->\n")
+        p = run(["gh", "issue", "create", "--repo", repo,
+                 "--title", spec["title"],
+                 "--body-file", str(body_file),
+                 "--label", ",".join(spec["labels"])])
+        if p.returncode != 0:
+            print(f"  FAILED   {key}: {p.stderr.strip()[:160]}")
+            continue
+        num = p.stdout.strip().rstrip("/").split("/")[-1]
+        created += 1
+        print(f"  created  #{num:<4} {spec['title'][:58]}")
+
+    print(f"\n{created} issue(s) created")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/optional-skills/software-development/board-gated-execution/scripts/setup-labels.sh
+++ b/optional-skills/software-development/board-gated-execution/scripts/setup-labels.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Create the label vocabulary the execution gate depends on.
+#
+# The gate reads Issues plus labels rather than a GitHub Project board, because
+# Projects require the `read:project` scope that most tokens lack. Issues work
+# with plain `repo` scope.
+#
+# Idempotent: `gh label create` fails if the label exists, so each call falls
+# back to `edit`. Safe to re-run.
+#
+# Usage:  bash setup-labels.sh [owner/repo]
+set -uo pipefail
+
+REPO="${1:-}"
+REPO_ARG=()
+[ -n "$REPO" ] && REPO_ARG=(--repo "$REPO")
+
+label() {
+  local name="$1" color="$2" desc="$3"
+  if gh label create "$name" "${REPO_ARG[@]}" --color "$color" --description "$desc" >/dev/null 2>&1; then
+    echo "  created  $name"
+  else
+    gh label edit "$name" "${REPO_ARG[@]}" --color "$color" --description "$desc" >/dev/null 2>&1 \
+      && echo "  updated  $name" || echo "  FAILED   $name"
+  fi
+}
+
+# Area labels are examples: rename them to match the project. The gate does not
+# read them — they exist so a human can filter the board.
+echo "area labels (customise per project):"
+label "area:backend"   "0e8a16" "Server, API, data layer"
+label "area:frontend"  "5319e7" "UI and client code"
+label "area:infra"     "fbca04" "Deploys, CI, hosting"
+label "area:docs"      "0075ca" "Documentation"
+
+# State labels ARE read by the gate. Do not rename these without updating
+# next-task.py.
+echo "state labels (required by the gate):"
+label "in-progress"    "fef2c0" "Actively being worked — WIP limit is one"
+label "blocked:human"  "e99695" "Needs a decision or credential only a human can supply"
+label "needs-tests"    "d4c5f9" "Implementation exists, verification does not"
+
+echo "priority labels (required by the gate):"
+label "P0"             "b60205" "Drop everything — broken in production"
+label "P1"             "d93f0b" "Next in line"
+label "P2"             "fbca04" "Planned"
+label "P3"             "c2e0c6" "Someday"
+
+echo "done."

--- a/tests/skills/test_board_gated_execution_skill.py
+++ b/tests/skills/test_board_gated_execution_skill.py
@@ -1,0 +1,212 @@
+"""Tests for the board-gated-execution skill.
+
+Scope: the SKILL.md contract (frontmatter, structure, no machine-local paths)
+and the gate's selection logic, which is the part that must not drift. The gate
+is exercised by monkeypatching the GitHub reads — no live network, per repo
+policy.
+
+The selection tests are written against the *decisions* the gate must make, not
+against its current output strings, so they survive rewording.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "board-gated-execution"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPTS = SKILL_DIR / "scripts"
+
+
+def load_frontmatter() -> dict:
+    content = SKILL_MD.read_text()
+    assert content.startswith("---"), "frontmatter must start at byte 0"
+    match = re.search(r"\n---\s*\n", content[3:])
+    assert match, "frontmatter must close with a --- line"
+    return yaml.safe_load(content[3 : match.start() + 3])
+
+
+# --------------------------------------------------------------------------
+# SKILL.md contract
+# --------------------------------------------------------------------------
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.is_file()
+
+
+def test_frontmatter_has_required_fields():
+    fm = load_frontmatter()
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in fm, f"missing frontmatter field: {field}"
+    assert fm["name"] == "board-gated-execution"
+
+
+def test_description_fits_the_index_window():
+    """The system prompt index truncates at 57 chars; the hardline is 60."""
+    description = load_frontmatter()["description"]
+    assert len(description) <= 60, f"{len(description)} chars"
+    assert description.endswith(".")
+
+
+def test_description_avoids_marketing_words():
+    description = load_frontmatter()["description"].lower()
+    for word in ("powerful", "comprehensive", "seamless", "advanced", "robust"):
+        assert word not in description
+
+
+def test_related_skills_are_declared():
+    related = load_frontmatter()["metadata"]["hermes"]["related_skills"]
+    assert related, "declare at least one related skill"
+    assert "board-gated-execution" not in related, "a skill must not relate to itself"
+
+
+def test_no_machine_local_paths():
+    """A path from the author's machine breaks the skill for everyone else.
+
+    Text files only: compiled artifacts (.pyc) embed absolute build paths and
+    are not part of the contribution.
+    """
+    sources = [SKILL_MD, *(p for p in SCRIPTS.glob("*") if p.suffix in {".py", ".sh"})]
+    for path in sources:
+        text = path.read_text()
+        assert "/home/" not in text, f"machine-local path in {path.name}"
+        assert not re.search(r"\b\d{1,3}(\.\d{1,3}){3}\b", text), f"bare IP in {path.name}"
+
+
+def test_body_has_the_required_sections():
+    body = SKILL_MD.read_text()
+    for heading in ("## When to Use", "## Prerequisites", "## Procedure",
+                    "## Pitfalls", "## Verification"):
+        assert heading in body, f"missing section: {heading}"
+
+
+def test_counter_triggers_present():
+    """`When to Use` must say when NOT to use the skill."""
+    assert "Don't use for:" in SKILL_MD.read_text()
+
+
+def test_scripts_referenced_by_the_skill_exist():
+    body = SKILL_MD.read_text()
+    for name in re.findall(r"scripts/([\w.-]+\.(?:py|sh))", body):
+        assert (SCRIPTS / name).is_file(), f"SKILL.md references missing scripts/{name}"
+
+
+# --------------------------------------------------------------------------
+# Gate selection logic
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gate(monkeypatch):
+    """Load next-task.py with GitHub reads stubbed out."""
+    spec = importlib.util.spec_from_file_location("next_task", SCRIPTS / "next-task.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "detect_repo", lambda: "owner/repo")
+    return module
+
+
+def issue(number: int, title: str, *labels: str) -> dict:
+    return {"number": number, "title": title,
+            "labels": [{"name": name} for name in labels]}
+
+
+def run_gate(gate, monkeypatch, issues, capsys) -> tuple[int, str]:
+    monkeypatch.setattr(gate, "fetch_issues", lambda repo: issues)
+    code = gate.main(["next-task.py", "owner/repo"])
+    return code, capsys.readouterr().out
+
+
+def test_two_in_progress_issues_are_refused(gate, monkeypatch, capsys):
+    """The WIP limit is the whole point: two in flight means one is drifting."""
+    code, out = run_gate(gate, monkeypatch, [
+        issue(1, "First", "in-progress", "P1"),
+        issue(2, "Second", "in-progress", "P2"),
+    ], capsys)
+    assert code == 1
+    assert "REFUSED" in out
+    assert "WORK THIS" not in out, "a refusal must not also name a task"
+
+
+def test_in_progress_beats_a_higher_priority_fresh_issue(gate, monkeypatch, capsys):
+    code, out = run_gate(gate, monkeypatch, [
+        issue(1, "Started", "in-progress", "P3"),
+        issue(2, "Shiny", "P0"),
+    ], capsys)
+    assert code == 0
+    assert "#1 Started" in out
+    assert "WORK THIS" in out
+
+
+def test_blocked_issues_are_never_selected(gate, monkeypatch, capsys):
+    """Working a blocked issue means waiting, which is indistinguishable from drift."""
+    code, out = run_gate(gate, monkeypatch, [
+        issue(1, "Needs a credential", "blocked:human", "P0"),
+        issue(2, "Actionable", "P3"),
+    ], capsys)
+    assert code == 0
+    selected = out.split("BLOCKED ON A HUMAN")[0]
+    assert "#2 Actionable" in selected
+    assert "#1 Needs a credential" not in selected
+
+
+def test_blocked_issues_are_still_surfaced(gate, monkeypatch, capsys):
+    _, out = run_gate(gate, monkeypatch, [
+        issue(1, "Needs a credential", "blocked:human", "P0"),
+        issue(2, "Actionable", "P3"),
+    ], capsys)
+    assert "BLOCKED ON A HUMAN" in out
+    assert "#1 Needs a credential" in out
+
+
+def test_priority_order_is_respected(gate, monkeypatch, capsys):
+    _, out = run_gate(gate, monkeypatch, [
+        issue(3, "Someday", "P3"),
+        issue(1, "Urgent", "P0"),
+        issue(2, "Planned", "P2"),
+    ], capsys)
+    assert "#1 Urgent" in out.split("QUEUED")[0]
+
+
+def test_unprioritised_issues_sort_last(gate, monkeypatch, capsys):
+    _, out = run_gate(gate, monkeypatch, [
+        issue(1, "No priority label"),
+        issue(2, "Someday", "P3"),
+    ], capsys)
+    assert "#2 Someday" in out.split("QUEUED")[0]
+
+
+def test_all_blocked_reports_nothing_actionable(gate, monkeypatch, capsys):
+    """Saying so plainly beats inventing adjacent work."""
+    code, out = run_gate(gate, monkeypatch, [
+        issue(1, "Waiting on a decision", "blocked:human", "P1"),
+    ], capsys)
+    assert code == 0
+    assert "Nothing actionable" in out
+    assert "WORK THIS" not in out
+
+
+def test_empty_board_is_reported_as_the_problem(gate, monkeypatch, capsys):
+    code, out = run_gate(gate, monkeypatch, [], capsys)
+    assert code == 0
+    assert "empty" in out.lower()
+
+
+def test_a_blocked_in_progress_issue_does_not_consume_the_wip_slot(gate, monkeypatch, capsys):
+    """Parked-and-blocked work must not stop other work from starting."""
+    code, out = run_gate(gate, monkeypatch, [
+        issue(1, "Parked", "in-progress", "blocked:human", "P1"),
+        issue(2, "Actionable", "P2"),
+    ], capsys)
+    assert code == 0
+    assert "#2 Actionable" in out.split("BLOCKED ON A HUMAN")[0]

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -253,6 +253,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**ast-grep**](/docs/user-guide/skills/optional/software-development/software-development-ast-grep) | AST-aware structural code search and rewrite via ast-grep. |
+| [**board-gated-execution**](/docs/user-guide/skills/optional/software-development/software-development-board-gated-execution) | Gate agent work on an issue board so tasks cannot drift. |
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
 | [**grill-me**](/docs/user-guide/skills/optional/software-development/software-development-grill-me) | Adversarial plan interview before implementation. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |

--- a/website/docs/user-guide/skills/optional/software-development/software-development-board-gated-execution.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-board-gated-execution.md
@@ -1,0 +1,170 @@
+---
+title: "Board Gated Execution — Gate agent work on an issue board so tasks cannot drift"
+sidebar_label: "Board Gated Execution"
+description: "Gate agent work on an issue board so tasks cannot drift"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Board Gated Execution
+
+Gate agent work on an issue board so tasks cannot drift.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/software-development/board-gated-execution` |
+| Path | `optional-skills/software-development/board-gated-execution` |
+| Version | `0.1.0` |
+| Author | Nidhal Gharbi (NidhalxMRR), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Workflow`, `GitHub`, `Issues`, `Focus`, `Project-Management` |
+| Related skills | [`github`](/docs/user-guide/skills/bundled/software-development/software-development-github), [`weekly-review-planning`](/docs/user-guide/skills/bundled/productivity/productivity-weekly-review-planning), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Board-Gated Execution Skill
+
+Long agent sessions lose work silently. A feature reaches "service running, route
+written, UI missing, nothing committed", attention moves to an adjacent question,
+and the half-built state is invisible until someone asks "did you finish that?".
+This skill makes an issue board the source of truth for what to work on, and
+makes consulting it a gate rather than a habit.
+
+It does not replace the `github` skill (creating, triaging and closing issues,
+and carrying one to a merged PR). It answers the question that comes before all
+of that: *which* issue, and *may I start something new at all*.
+
+## When to Use
+
+- A session spans many turns and several topics, and work risks being left open
+- The user asks "did you finish X?" about something you started earlier
+- You are about to start a new task while another is still incomplete
+- A project's open threads live only in chat history, not in a tracker
+
+Don't use for: single-task sessions, repos where the user tracks work elsewhere
+(Linear, Jira) without a mirror, or one-off questions with no follow-up work.
+
+## Prerequisites
+
+- `gh` authenticated with `repo` scope: `terminal(command="gh auth status")`
+- A GitHub repo with Issues enabled
+- Python 3.9+ for the helper scripts
+
+The GitHub Projects **board view** needs `read:project`, which most tokens lack.
+This skill deliberately uses **Issues plus labels** instead, so it works with the
+default `repo` scope. Do not make Projects a hard dependency.
+
+## Procedure
+
+### 1. Create the label vocabulary
+
+Run `scripts/setup-labels.sh`. It creates `area:*`, `blocked:human`,
+`in-progress`, `needs-tests` and `P0`-`P3`, and is idempotent (create, else
+edit). *Completion criterion:* `terminal(command="gh label list")` shows every
+label the gate depends on — at minimum `in-progress`, `blocked:human`, `P0`-`P3`.
+
+### 2. Seed the board from what exists only in conversation
+
+Enumerate every open thread — half-built features, deferred decisions, missing
+docs, things blocked on the user — and file one issue each. Use
+`scripts/seed-issues.py` as the template: it embeds a `<!-- seed:<key> -->`
+marker in each body and searches for that marker before creating, so re-runs
+create nothing.
+
+Every issue needs **acceptance criteria that can be settled by evidence**, not by
+opinion. "Voice UI done" is not a criterion; "the user can hold a button, speak,
+and hear a reply on the live site" is.
+
+*Completion criterion:* running the seeder twice creates zero issues the second
+time, and no open thread from the conversation is missing from the board.
+
+### 3. Gate every start on the board
+
+Before starting any work:
+
+```
+terminal(command="python3 scripts/next-task.py")
+```
+
+It prints the single issue to work on. Obey it. If what you were about to do is
+not that issue, then either it is not the next thing, or it is not on the board —
+and unboarded work is exactly how drift starts.
+
+Selection order, enforced mechanically:
+
+1. **WIP limit of one.** Two unblocked `in-progress` issues means one is
+   drifting; the script exits 1 and refuses to name new work.
+2. **Finishing beats starting.** An `in-progress` issue wins over a
+   higher-priority fresh one.
+3. **Priority otherwise:** P0 > P1 > P2 > P3.
+
+`blocked:human` issues are **never selected**. They need a decision or a
+credential the agent cannot supply, so "working" them means waiting, and waiting
+is indistinguishable from drift. Report them to the user instead.
+
+*Completion criterion:* the script exits 0 and names exactly one issue, or exits
+1 with a refusal you then resolve.
+
+### 4. Mark and close honestly
+
+- Starting: `terminal(command="gh issue edit <n> --add-label in-progress")`
+- Shipping: reference the issue in the commit body, then
+  `terminal(command="gh issue close <n>")`
+
+An issue left open after the work shipped teaches the board to lie; an issue
+closed before the work is verified teaches it to lie faster. Close on evidence —
+tests green, artifact exercised — never on intent.
+
+*Completion criterion:* `gh issue list --state open` contains nothing already
+delivered.
+
+### 5. Prove the gate refuses
+
+A gate that only ever says "go" is decoration. Run `scripts/gate-check.py`: it
+marks a second issue `in-progress`, asserts the gate exits 1, names both
+offenders and declines to name a task, then restores the label.
+
+*Completion criterion:* all checks pass, and the board is left exactly as found.
+
+## Quick Reference
+
+```bash
+bash scripts/setup-labels.sh                 # one-time label vocabulary
+python3 scripts/seed-issues.py               # idempotent board seeding
+python3 scripts/next-task.py                 # THE GATE — run before starting work
+python3 scripts/gate-check.py                # prove the gate refuses
+gh issue edit <n> --add-label in-progress    # mark started
+gh issue close <n>                           # close on evidence
+```
+
+## Pitfalls
+
+1. **A board you do not consult is just a nicer place to lose work.** The gate is
+   worthless as an intention; run the script.
+2. **Do not let the gate pick a `blocked:human` issue.** Surfacing a blocker to
+   the user is progress; silently waiting on it is not.
+3. **Acceptance criteria that need a judgment call cannot close an issue.** Write
+   criteria a script or a human can settle by looking at evidence.
+4. **Seeding without markers creates duplicates on every re-run.** The marker
+   comment is what makes the seeder idempotent.
+5. **GitHub Projects needs `read:project`.** Use Issues plus labels so the gate
+   works with the `repo` scope alone; ask the user before requesting more.
+6. **Priority labels only sort; they do not decide.** An `in-progress` P3 still
+   outranks a fresh P1, because finishing beats starting.
+7. **Closing an issue because the code exists.** Tests written after the fact
+   encode what the code does, not what it should do — close on verified
+   behaviour.
+
+## Verification
+
+- `python3 scripts/next-task.py` exits 0 and names one issue
+- `python3 scripts/gate-check.py` passes every check and restores the board
+- Running the seeder twice creates zero issues on the second run
+- `gh issue list --state open` matches the work that is genuinely outstanding

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -596,6 +596,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/software-development/software-development-ast-grep',
+                    'user-guide/skills/optional/software-development/software-development-board-gated-execution',
                     'user-guide/skills/optional/software-development/software-development-code-wiki',
                     'user-guide/skills/optional/software-development/software-development-grill-me',
                     'user-guide/skills/optional/software-development/software-development-rest-graphql-debug',


### PR DESCRIPTION
feat(skills): add board-gated-execution to optional-skills

Long agent sessions lose work silently. A feature reaches "service running,
route written, UI missing, nothing committed", attention moves to an adjacent
question, and the half-built state stays invisible until the user asks "did you
finish that?". The board is usually not the missing piece — consulting it is.

This skill makes an issue board the gate rather than the habit. Before starting
anything, scripts/next-task.py names the single issue to work on:

  1. WIP limit of one. More than one unblocked in-progress issue is itself the
     defect, so the gate exits 1 and refuses to name new work until it is
     resolved. Helpfully picking one is exactly how a half-built feature gets
     abandoned for a fresher, more interesting task.
  2. Finishing beats starting. An in-progress issue outranks a higher-priority
     fresh one.
  3. blocked:human issues are never selected. They need a decision or a
     credential the agent cannot supply, so "working" them means waiting, and
     waiting is indistinguishable from drift. They are surfaced, not worked.

It complements the existing github skill rather than overlapping it: that skill
covers creating, triaging and closing issues and carrying one to a merged PR.
This one answers the question that comes first — which issue, and may I start
something new at all.

Uses Issues plus labels rather than GitHub Projects, deliberately: the Projects
API needs read:project, which most tokens lack, while Issues work with plain
repo scope.

Tier: optional-skills. It matters most on long multi-topic sessions, not every
day, and the bundled bar is "loaded in 5+ sessions per month".

Verification
- tests/skills/test_board_gated_execution_skill.py — 18 tests, stdlib +
  pytest + monkeypatched GitHub reads, no live network. Selection tests assert
  the decisions the gate must make, not its current output strings.
- scripts/gate-check.py exercises the refusal against a real board: it marks a
  second issue in-progress, asserts the gate exits 1, names both offenders and
  declines to name a task, then restores the label in a finally block. 8/8
  against a live repository.
- All four scripts were run end to end against a real board before submission,
  in both auto-detected and explicit-repo modes.

Docs regenerated with scope discipline: the generator rewrites all 196 pages, so
everything unrelated was reverted. The diff adds one catalog row, one sidebar
line and one per-skill page, with zero deletions.
