### PR TITLE
fix(credentials): removed API keys no longer resurrect across .env, auth.json, config.yaml, and the dashboard

### DIFF
--- a/contributors/emails/ryancurrah@gmail.com
+++ b/contributors/emails/ryancurrah@gmail.com
@@ -1,0 +1,1 @@
+TurboAnbeli

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4387,8 +4387,12 @@ def _env_line_defines_key(
     assigned_key, separator, _value = stripped.partition("=")
     if not separator:
         return False
+    # load_env() strips whitespace around the parsed name, so `KEY = value`
+    # IS a live assignment. The writers must match the same shape, or a
+    # hand-edited spaced line is invisible to save (duplicate appended) and
+    # remove (line survives -> value resurrects on next load). #67488.
     return _env_var_policy_name(
-        assigned_key,
+        assigned_key.strip(),
         is_windows=is_windows,
     ) == _env_var_policy_name(key, is_windows=is_windows)
 

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -141,11 +141,18 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
 
     touched: List[str] = []
 
-    def _fix(section: Any, key_path: str) -> None:
+    def _fix(
+        section: Any,
+        key_path: str,
+        fields: tuple[str, ...] = ("api_key", "api"),
+    ) -> None:
         if not isinstance(section, dict):
             return
         # "api" is the legacy alias for model.api_key kept by older configs.
-        for field in ("api_key", "api"):
+        # NOTE: in the keyed ``providers`` schema ``api`` means the base_url,
+        # not a credential (see ``get_compatible_custom_providers``), so that
+        # section passes ``fields=("api_key",)`` to avoid touching a base_url.
+        for field in fields:
             current = section.get(field)
             if isinstance(current, str) and current == old_value:
                 if new_value:
@@ -168,6 +175,18 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
     elif isinstance(custom, dict):
         for name, entry in custom.items():
             _fix(entry, f"custom_providers.{name}")
+
+    # The keyed ``providers`` schema (v12+) is where the dashboard/desktop
+    # write custom-endpoint credentials — ``providers.<id>.api_key``. It is a
+    # real inline secret and higher-precedence than the env var, so a stale
+    # copy left here shadows a rotation (persistent 401 with a key the UI no
+    # longer shows, #62269) and survives a removal that promised to clear the
+    # credential from EVERY store. Scrub only ``api_key``; ``api`` here is the
+    # base_url alias, not a credential.
+    keyed_providers = user_config.get("providers")
+    if isinstance(keyed_providers, dict):
+        for provider_id, entry in keyed_providers.items():
+            _fix(entry, f"providers.{provider_id}", fields=("api_key",))
 
     if touched:
         require_readable_config_before_write(config_path)

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -218,6 +218,15 @@ def save_provider_env_credential(env_var: str, value: str) -> Dict[str, Any]:
     a stale higher-precedence copy cannot shadow the rotation (#62269).
     Suppressed ``env:<VAR>`` pool sources are re-enabled so a deliberate
     re-add through the UI behaves like ``hermes auth add``.
+
+    The save also forces an immediate ``load_pool()`` for every provider
+    registered against this env var so the env-seeded ``credential_pool``
+    entry is materialized to ``auth.json`` right now — the live runtime reads
+    from the pool, and before #96058 the Desktop "Save" action only touched
+    ``.env`` while ``auth.json``'s mtime stayed unchanged, so an OpenCode Go
+    (or any other env-backed provider) request kept 401'ing until the user
+    ran ``hermes auth add <provider> --type api-key`` separately. This makes
+    the Desktop save's effect on disk match what ``hermes auth add`` does.
     """
     from hermes_cli.config import load_env, save_env_value
 
@@ -236,6 +245,19 @@ def save_provider_env_credential(env_var: str, value: str) -> Dict[str, Any]:
 
         for provider in _providers_for_env_var(env_var):
             unsuppress_credential_source(provider, f"env:{env_var}")
+    except Exception:
+        pass
+
+    # Materialize the env-seeded credential_pool entry to auth.json NOW so the
+    # next request authenticates against the just-saved key. ``load_pool`` is
+    # idempotent and additive-only for env sources (#9331), so re-running it
+    # is safe even when the pool already had this entry. Best-effort: a
+    # failure here must not mask the successful .env write above.
+    try:
+        from agent.credential_pool import load_pool
+
+        for provider in _providers_for_env_var(env_var):
+            load_pool(provider)
     except Exception:
         pass
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7747,7 +7747,27 @@ def _apply_model_assignment_sync(
             cfg.get("model", {}), provider, model, base_url, api_key
         )
         if isinstance(provider_entry, dict) and provider_entry.get("api_key"):
-            model_cfg["api_key"] = provider_entry["api_key"]
+            # #88990: provider_entry comes from load_config(), which expands
+            # ${VAR} env refs to plaintext. Copying that resolved value into
+            # model.api_key writes the SECRET into config.yaml (and recreates
+            # it on every re-apply, even after the user deletes it by hand).
+            # Only mirror the key when the on-disk entry holds a literal
+            # value; env-ref and key_env entries already resolve at runtime
+            # via the provider entry itself.
+            _raw_entry = None
+            try:
+                _stored, _raw_entry = find_provider_entry(
+                    read_raw_config().get("providers"), provider
+                )
+            except Exception:
+                _raw_entry = None
+            _raw_key = _raw_entry.get("api_key") if isinstance(_raw_entry, dict) else None
+            _entry_uses_env = bool(
+                (isinstance(_raw_entry, dict) and str(_raw_entry.get("key_env") or "").strip())
+                or (isinstance(_raw_key, str) and re.search(r"\$\{[^}]+\}", _raw_key))
+            )
+            if not _entry_uses_env:
+                model_cfg["api_key"] = provider_entry["api_key"]
         cfg["model"] = model_cfg
 
         # When switching the main provider to Nous, mirror the CLI's

--- a/tests/hermes_cli/test_credential_lifecycle.py
+++ b/tests/hermes_cli/test_credential_lifecycle.py
@@ -146,6 +146,118 @@ def test_update_rotates_config_yaml_model_mirror(hermes_home):
 
 
 # ---------------------------------------------------------------------------
+# Desktop PUT /api/env — #96058: credential_pool must be materialized so the
+# live runtime picks up the new key without waiting for its next background
+# load_pool() or a separate `hermes auth add`.
+# ---------------------------------------------------------------------------
+
+
+# OpenCode Go is a registered api_key provider with api_key_env_vars containing
+# the single env var OPENCODE_GO_API_KEY — exercising the exact reproducer
+# from issue #96058 (Ubuntu 24.04, openai_sdk 2.24.0, provider=opencode-go).
+OPENCODE_KEY_NEW = "ocg-" + "e" * 28
+
+
+def test_put_api_env_materializes_credential_pool_entry(hermes_home):
+    """Desktop Providers → API keys → Save must write a credential_pool entry.
+
+    Pre-fix: save_provider_env_credential only mutated .env. The live pool
+    kept authenticating with a stale higher-precedence config.yaml mirror or
+    the old cached credential until a separate ``hermes auth add opencode-go``
+    ran. auth.json mtime was unchanged before/after Save (#96058).
+
+    Post-fix: the same PUT /api/env call must also materialize an entry under
+    ``credential_pool.<provider>`` in auth.json so the next request
+    authenticates immediately, matching ``hermes auth add <provider> --type
+    api-key`` behavior.
+    """
+    # Start clean: empty auth.json so the only way a pool entry shows up is
+    # via the PUT /api/env handler we're testing.
+    _write_auth(hermes_home, {})
+
+    resp = client.put(
+        "/api/env",
+        json={"key": "OPENCODE_GO_API_KEY", "value": OPENCODE_KEY_NEW},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("ok") is True
+    assert body.get("key") == "OPENCODE_GO_API_KEY"
+
+    # auth.json must now have a credential_pool entry for opencode-go. The
+    # exact source string lives in source="env:OPENCODE_GO_API_KEY" — env
+    # sources are sanitized on disk (the raw token is replaced with a
+    # fingerprint; the canonical secret lives in .env and gets re-hydrated by
+    # load_pool() on each read). The critical observable is: load_pool() on
+    # the next call returns an in-memory entry carrying the just-saved token.
+    auth = _read_auth(hermes_home)
+    pool = auth.get("credential_pool", {})
+    assert "opencode-go" in pool, (
+        "PUT /api/env did not materialize a credential_pool entry for "
+        "opencode-go (#96058)"
+    )
+    entries = pool["opencode-go"]
+    assert isinstance(entries, list) and entries, pool
+    matched_disk = [
+        e for e in entries
+        if isinstance(e.get("source"), str)
+        and e["source"] == "env:OPENCODE_GO_API_KEY"
+    ]
+    assert matched_disk, (
+        f"credential_pool.opencode-go env-seeded reference missing on disk; "
+        f"got {entries!r}"
+    )
+    # And: a fresh load_pool() must surface the just-saved token to the
+    # runtime. This is the actual end-to-end contract — anything weaker
+    # means the OpenAI client will 401 because it never receives the new key.
+    from agent.credential_pool import load_pool
+    pool_obj = load_pool("opencode-go")
+    runtime_entries = pool_obj.entries()
+    matched_runtime = [
+        e for e in runtime_entries
+        if e.access_token == OPENCODE_KEY_NEW
+        and isinstance(e.source, str)
+        and e.source == "env:OPENCODE_GO_API_KEY"
+    ]
+    assert matched_runtime, (
+        "load_pool('opencode-go') did not surface the just-saved token; "
+        "the live runtime will keep 401'ing (#96058). "
+        f"Got sources: {[e.source for e in runtime_entries]!r}"
+    )
+    assert matched_runtime[0].auth_type == "api_key"
+
+
+def test_put_api_env_writes_auth_json_for_provider(hermes_home):
+    """Sentinel for #96058: PUT /api/env must modify auth.json on disk.
+
+    The reported symptom was ``stat -c '%y' ~/.hermes/auth.json`` returning
+    the same value before and after the Desktop Save. After the fix the file's
+    mtime advances because the save materializes the env-seeded pool entry.
+    """
+    _write_auth(hermes_home, {})
+    auth_path = hermes_home / "auth.json"
+    assert auth_path.exists()
+    mtime_before = auth_path.stat().st_mtime_ns
+
+    # Tiny delay so a write is observable even on filesystems with 1s mtime
+    # resolution. Use ns precision so this is reliable on every FS.
+    import time
+    time.sleep(0.05)
+
+    resp = client.put(
+        "/api/env",
+        json={"key": "OPENCODE_GO_API_KEY", "value": OPENCODE_KEY_NEW},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert auth_path.stat().st_mtime_ns > mtime_before, (
+        "auth.json was not modified by the Desktop Save — bug #96058"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Suppression round-trip: delete sticks, re-add lifts it
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_credential_lifecycle.py
+++ b/tests/hermes_cli/test_credential_lifecycle.py
@@ -258,6 +258,80 @@ def test_put_api_env_writes_auth_json_for_provider(hermes_home):
 
 
 # ---------------------------------------------------------------------------
+# Keyed `providers` schema (v12+) — where the dashboard writes custom
+# endpoints. Its inline api_key is a real credential and higher-precedence
+# than the env var, so a stale copy left here shadows a rotation (#62269) and
+# survives a "remove from EVERY store" delete.
+# ---------------------------------------------------------------------------
+
+
+def test_update_rotates_keyed_providers_mirror(hermes_home):
+    old = "sk-kp-" + "n" * 24
+    new = "sk-kp-" + "o" * 24
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        "    base_url: https://llm.example.test/v1\n"
+        f"    api_key: {old}\n",
+    )
+
+    resp = client.put(
+        "/api/env", json={"key": "OPENAI_API_KEY", "value": new}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    assert "providers.myendpoint.api_key" in resp.json().get("config_updates", [])
+
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old not in cfg_text, "stale key in providers.<id> shadows the rotation (#62269)"
+    assert new in cfg_text, "keyed providers mirror not rotated to the new key"
+
+
+def test_delete_scrubs_keyed_providers_mirror(hermes_home):
+    old = "sk-kp-" + "p" * 24
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        "    base_url: https://llm.example.test/v1\n"
+        f"    api_key: {old}\n",
+    )
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "OPENAI_API_KEY"}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    assert "providers.myendpoint.api_key" in resp.json()["config_scrubbed"]
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old not in cfg_text, "delete must clear the credential from EVERY store"
+
+
+def test_scrub_never_touches_providers_base_url_alias(hermes_home):
+    """In the keyed ``providers`` schema ``api`` is the base_url alias, NOT a
+    credential. Even if the .env value coincided with a base_url, the scrub
+    must not rewrite a provider's endpoint URL."""
+    old = "https://llm.example.test/v1"  # a URL that also happens to be the key value
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        f"    api: {old}\n"          # base_url alias — must be preserved
+        "    model: my-model\n",
+    )
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "OPENAI_API_KEY"}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old in cfg_text, "providers.<id>.api is a base_url and must survive"
+    assert "providers.myendpoint.api" not in resp.json().get("config_scrubbed", [])
+
+
+# ---------------------------------------------------------------------------
 # Suppression round-trip: delete sticks, re-add lifts it
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_env_export_line_lifecycle.py
+++ b/tests/hermes_cli/test_env_export_line_lifecycle.py
@@ -55,8 +55,45 @@ def test_classic_pat_save_via_endpoint_succeeds(hermes_home):
     assert load_env()["GITHUB_TOKEN"] == NEW_PAT
 
 
+def test_remove_export_prefixed_token(hermes_home):
+    """DELETE must clear an ``export KEY=...`` line, not 404 on it."""
+    _write_env_raw(hermes_home, f"export GITHUB_TOKEN={OLD_PAT}\n")
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS
+    )
+    assert resp.status_code == 200, (
+        "export-prefixed lines are parsed by load_env (UI shows the token as "
+        "set) so the delete path must recognise them too (#40041)"
+    )
+
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text
+
+    from hermes_cli.config import load_env
+
+    assert "GITHUB_TOKEN" not in load_env()
 
 
+def test_update_export_prefixed_token_does_not_duplicate(hermes_home):
+    """Saving over an ``export KEY=`` line must replace it in place."""
+    _write_env_raw(hermes_home, f"export GITHUB_TOKEN={OLD_PAT}\n")
+
+    resp = client.put(
+        "/api/env", json={"key": "GITHUB_TOKEN", "value": NEW_PAT}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text, "old exported token line must be replaced"
+    assert env_text.count("GITHUB_TOKEN") == 1, (
+        "save must not append a duplicate GITHUB_TOKEN line alongside the "
+        "export-prefixed one"
+    )
+
+    from hermes_cli.config import load_env
+
+    assert load_env()["GITHUB_TOKEN"] == NEW_PAT
 
 
 def test_plain_line_save_and_remove_still_work(hermes_home):
@@ -72,3 +109,88 @@ def test_plain_line_save_and_remove_still_work(hermes_home):
     assert "GITHUB_TOKEN" not in load_env()
 
 
+def test_export_line_with_comment_untouched(hermes_home):
+    """Commented-out export lines are not live assignments — leave them."""
+    _write_env_raw(
+        hermes_home,
+        f"# export GITHUB_TOKEN={OLD_PAT}\nOTHER_KEY=value\n",
+    )
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS
+    )
+    assert resp.status_code == 404
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert "# export GITHUB_TOKEN=" in env_text
+    assert "OTHER_KEY=value" in env_text
+
+
+# -- whitespace around '=' (same resurrection hole, other line form) ----------
+
+
+def test_remove_token_written_with_spaces_around_equals(hermes_home):
+    """DELETE must clear a ``KEY = value`` line, not 404 on it.
+
+    ``load_env()`` splits on the first ``=`` and strips the name, so this is a
+    live assignment and every UI shows the token as set — the writers have to
+    recognise it for the same reason they recognise ``export`` (#40041).
+    """
+    _write_env_raw(hermes_home, f"GITHUB_TOKEN = {OLD_PAT}\n")
+
+    from hermes_cli.config import load_env
+
+    assert load_env()["GITHUB_TOKEN"] == OLD_PAT, "precondition: token is live"
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS
+    )
+    assert resp.status_code == 200, resp.text
+
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text
+    assert "GITHUB_TOKEN" not in load_env()
+
+
+def test_spaced_token_rotate_then_delete_does_not_resurrect(hermes_home):
+    """Rotating over a spaced line must replace it, not shadow it.
+
+    Otherwise the save appends a second line and a later delete removes only
+    that one — silently restoring the key the user rotated away from.
+    """
+    _write_env_raw(hermes_home, f"GITHUB_TOKEN = {OLD_PAT}\n")
+
+    resp = client.put(
+        "/api/env", json={"key": "GITHUB_TOKEN", "value": NEW_PAT}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text, "the rotated-away token must not survive"
+    assert env_text.count("GITHUB_TOKEN") == 1
+
+    from hermes_cli.config import load_env
+
+    assert load_env()["GITHUB_TOKEN"] == NEW_PAT
+
+    client.request("DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS)
+    assert "GITHUB_TOKEN" not in load_env(), "the old token must not resurrect"
+
+
+def test_writer_matches_exactly_what_load_env_accepts(hermes_home):
+    """Parity: the writers must recognise a line iff ``load_env()`` does."""
+    from hermes_cli.config import _env_line_defines_key, load_env
+
+    for line, expected in [
+        (f"GITHUB_TOKEN={OLD_PAT}", True),
+        (f"export GITHUB_TOKEN={OLD_PAT}", True),
+        (f"GITHUB_TOKEN = {OLD_PAT}", True),
+        (f"GITHUB_TOKEN\t=\t{OLD_PAT}", True),
+        (f"export GITHUB_TOKEN = {OLD_PAT}", True),
+        (f"# GITHUB_TOKEN={OLD_PAT}", False),
+        (f"GITHUB_TOKEN_EXTRA={OLD_PAT}", False),
+        (f"MY_GITHUB_TOKEN={OLD_PAT}", False),
+    ]:
+        _write_env_raw(hermes_home, line + "\n")
+        assert _env_line_defines_key(line, "GITHUB_TOKEN") is expected, line
+        assert ("GITHUB_TOKEN" in load_env()) is expected, (
+            f"writer and load_env disagree on: {line!r}"
+        )

--- a/tests/hermes_cli/test_model_assignment_env_key_mirror.py
+++ b/tests/hermes_cli/test_model_assignment_env_key_mirror.py
@@ -1,0 +1,77 @@
+"""#88990: Desktop model assignment must not copy env-backed keys into model.api_key.
+
+``POST /api/model/set`` (``_apply_model_assignment_sync``) mirrors a custom
+provider entry's ``api_key`` into ``model.api_key``. ``load_config()`` expands
+``${VAR}`` env refs to plaintext, so before the fix the RESOLVED secret was
+written into config.yaml — and re-written on every re-apply even after the
+user deleted it by hand. The mirror must be skipped when the on-disk provider
+entry references the environment (``${VAR}`` template or ``key_env``), and
+preserved when the entry holds a literal key.
+"""
+
+import importlib
+import os
+
+import pytest
+import yaml
+
+
+@pytest.fixture()
+def _hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_cli.config as config_mod
+
+    importlib.reload(config_mod)
+    yield home
+    importlib.reload(config_mod)
+
+
+def _write_config(home, providers):
+    cfg = {
+        "model": {"provider": "openrouter", "default": "some/model"},
+        "providers": providers,
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+
+def _apply(provider, model="local/model"):
+    import hermes_cli.web_server as ws
+
+    return ws._apply_model_assignment_sync("main", provider, model, "", "")
+
+
+def _raw_model_cfg(home):
+    return (yaml.safe_load((home / "config.yaml").read_text()) or {}).get("model", {})
+
+
+def test_env_ref_key_not_copied_into_model_api_key(_hermes_home, monkeypatch):
+    monkeypatch.setenv("MY_LOCAL_KEY", "sk-super-secret-value")
+    _write_config(
+        _hermes_home,
+        {"mylocal": {"base_url": "http://localhost:1234/v1", "api_key": "${MY_LOCAL_KEY}"}},
+    )
+    _apply("mylocal")
+    model_cfg = _raw_model_cfg(_hermes_home)
+    assert "sk-super-secret-value" not in yaml.safe_dump(model_cfg)
+    assert not model_cfg.get("api_key")
+
+
+def test_key_env_entry_not_copied(_hermes_home, monkeypatch):
+    monkeypatch.setenv("MYLOCAL_API_KEY", "sk-keyenv-secret")
+    _write_config(
+        _hermes_home,
+        {"mylocal": {"base_url": "http://localhost:1234/v1", "key_env": "MYLOCAL_API_KEY"}},
+    )
+    _apply("mylocal")
+    assert "sk-keyenv-secret" not in (_hermes_home / "config.yaml").read_text()
+
+
+def test_literal_key_still_mirrored(_hermes_home):
+    _write_config(
+        _hermes_home,
+        {"mylocal": {"base_url": "http://localhost:1234/v1", "api_key": "literal-key-abc"}},
+    )
+    _apply("mylocal")
+    assert _raw_model_cfg(_hermes_home).get("api_key") == "literal-key-abc"

--- a/web/src/lib/env-state.test.ts
+++ b/web/src/lib/env-state.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnvVarInfo } from "./api";
+import { removeDeletedEnvVarFromState } from "./env-state";
+
+function envVar(overrides: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    is_set: true,
+    redacted_value: "secr...alue",
+    description: "",
+    url: null,
+    category: "provider",
+    is_password: true,
+    tools: [],
+    advanced: false,
+    ...overrides,
+  };
+}
+
+describe("removeDeletedEnvVarFromState", () => {
+  it("removes a deleted custom key from dashboard state", () => {
+    const vars = {
+      WHATSAPP_DEBUG: envVar({ category: "custom", custom: true }),
+      OPENAI_API_KEY: envVar(),
+    };
+
+    const updated = removeDeletedEnvVarFromState(vars, "WHATSAPP_DEBUG");
+
+    expect(updated).not.toHaveProperty("WHATSAPP_DEBUG");
+    expect(updated?.OPENAI_API_KEY).toBe(vars.OPENAI_API_KEY);
+  });
+
+  it("keeps a catalog key available while marking it unset", () => {
+    const vars = { OPENAI_API_KEY: envVar() };
+
+    const updated = removeDeletedEnvVarFromState(vars, "OPENAI_API_KEY");
+
+    expect(updated?.OPENAI_API_KEY).toEqual({
+      ...vars.OPENAI_API_KEY,
+      is_set: false,
+      redacted_value: null,
+    });
+  });
+});

--- a/web/src/lib/env-state.ts
+++ b/web/src/lib/env-state.ts
@@ -1,0 +1,21 @@
+import type { EnvVarInfo } from "./api";
+
+/** Reconcile a successful DELETE /api/env response with the Keys page state. */
+export function removeDeletedEnvVarFromState(
+  vars: Record<string, EnvVarInfo> | null,
+  key: string,
+): Record<string, EnvVarInfo> | null {
+  const info = vars?.[key];
+  if (!vars || !info) return vars;
+
+  if (info.custom) {
+    const updated = { ...vars };
+    delete updated[key];
+    return updated;
+  }
+
+  return {
+    ...vars,
+    [key]: { ...info, is_set: false, redacted_value: null },
+  };
+}

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type { EnvVarInfo } from "@/lib/api";
+import { removeDeletedEnvVarFromState } from "@/lib/env-state";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
@@ -722,14 +723,7 @@ export default function EnvPage() {
         setSaving(key);
         try {
           await api.deleteEnvVar(key);
-          setVars((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  [key]: { ...prev[key], is_set: false, redacted_value: null },
-                }
-              : prev,
-          );
+          setVars((prev) => removeDeletedEnvVarFromState(prev, key));
           setEdits((prev) => {
             const n = { ...prev };
             delete n[key];


### PR DESCRIPTION
# fix(credentials): removed API keys no longer resurrect — five-gap cluster (.env, auth.json pool, config.yaml, dashboard)

## Summary
Closes the remaining gaps where a saved or removed API key went missing from — or resurrected into — one of Hermes' credential stores. Salvages four contributor PRs onto current main (authorship preserved per-commit) plus one fix of ours.

## Changes
- **`credential_lifecycle.py` — save now materializes the auth.json pool entry** (#96058, salvage of #96142, @Finn763): Desktop Save previously wrote only `.env`; pool-only readers (`/api/credentials/pool`, model setup) didn't see the key until an unrelated `load_pool` ran. Save now calls the canonical seeder — `source="env:<VAR>"` convention kept, no duplicate entries, OAuth untouched.
- **`credential_lifecycle.py` — keyed `providers.<id>.api_key` scrubbed on rotate/remove** (salvage of #68295, @Drexuxux): the v12+ keyed config.yaml schema was skipped by `_scrub_config_yaml_mirrors`, so a plaintext key there survived removal and out-precedenced a rotated key (re-introducing the #62269 persistent-401). Value-matched; auth.json OAuth blocks never touched.
- **`config.py` — `.env` writer matches `KEY = value`** (salvage of #67488, @Frowtek; tests cherry-picked, fix re-derived): `load_env()` accepted spaced assignments but `_env_line_defines_key()` didn't, so save appended duplicates and remove left the line to resurrect. One-word fix (`assigned_key.strip()`) inside the policy-name compare — preserves the Windows case-insensitive matching that landed after the original PR.
- **`web/` — deleted custom env keys leave the dashboard list** (#72552, salvage of #72568, @TurboAnbeli): delete kept the row in local state as `is_set:false` (ghost row until refresh); extracted state helper + tests.
- **`web_server.py` — model assignment no longer copies env-backed keys into `model.api_key`** (#88990, ours): `POST /api/model/set` mirrored the `load_config()`-RESOLVED plaintext of a `${VAR}`/`key_env` provider entry into config.yaml, recreating the secret on every re-apply. The mirror now checks the raw on-disk entry and skips env-referencing entries; literal keys unchanged.

## Validation
| Check | Result |
|---|---|
| Targeted pytest (3 files, incl. new `test_model_assignment_env_key_mirror.py`) | 18/18 pass |
| Sabotage run (fixes reverted to origin/main) | 4 regression tests fail, as required |
| vitest `env-state.test.ts` | 2/2 pass |
| Live E2E, isolated HERMES_HOME: spaced-line remove → save materializes pool → remove prunes pool + scrubs keyed schema | all 4 stages pass |
| Attribution audit | all emails mapped |

**Live repro:** before/after exercised via real `credential_lifecycle` + `_apply_model_assignment_sync` calls against a temp HERMES_HOME (E2E stages above); each contributor gap reproduced on origin/main code before applying the fix.

Salvaged with authorship preserved: @Finn763 (#96142), @Drexuxux (#68295), @Frowtek (#67488), @TurboAnbeli (#72568). Related: supersedes #73226 (partial fix for #72552 — credit @JonthanaHanh for the report-side analysis).

## Infographic

![API key removal cluster infographic](https://v3b.fal.media/files/b/0aa887cd/P1MfC9mJfAlAVOzicqF-Y_MkJ5SbCc.png)
