### PR TITLE
fix(desktop): re-engage stopped groups on actionable @all

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -287,7 +287,13 @@ export function findElectron(): string {
   // In dev mode, we use the `electron` binary directly (not the packaged app).
   // The dev:electron script in package.json does exactly this: `electron .`
   // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
+  const localElectron = path.join(
+    REPO_ROOT,
+    'node_modules',
+    'electron',
+    'dist',
+    process.platform === 'win32' ? 'electron.exe' : 'electron',
+  )
 
   if (fs.existsSync(localElectron)) {
     return localElectron

--- a/apps/desktop/e2e/group-stop-reengagement.spec.ts
+++ b/apps/desktop/e2e/group-stop-reengagement.spec.ts
@@ -1,0 +1,89 @@
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+const HELD_TASK = 'E2E_GROUP_STOP_HELD_TASK'
+
+let fixture: MockBackendFixture | null = null
+
+async function openBots(page: MockBackendFixture['page']): Promise<void> {
+  const tab = page
+    .getByRole('button', { name: 'Bots', exact: true })
+    .or(page.getByRole('tab', { name: 'Bots', exact: true }))
+    .first()
+
+  await tab.click()
+  await expect(page.getByRole('button', { name: 'New bot or group chat' })).toBeVisible()
+}
+
+async function createAgent(page: MockBackendFixture['page'], name: string, title: string): Promise<void> {
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Bot' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'New Bot' })
+
+  await dialog.getByPlaceholder('inbox-triage').fill(name)
+  await dialog.getByPlaceholder('Inbox Triage').fill(title)
+  await dialog.getByRole('button', { name: 'Create Bot' }).click()
+  await expect(dialog).toBeHidden({ timeout: 30_000 })
+  await expect(page.getByRole('button', { name: new RegExp(`^${title}\\b`) }).first()).toBeVisible({ timeout: 30_000 })
+}
+
+async function sendRoomMessage(page: MockBackendFixture['page'], room: string, text: string): Promise<void> {
+  const composer = page.getByRole('textbox', { name: `Message ${room}` }).filter({ visible: true })
+
+  await composer.click()
+  await composer.pressSequentially(text)
+  await page.keyboard.press('Enter')
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend({
+    mockServer: { holdFirstCompletionContaining: HELD_TASK },
+  })
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  fixture?.mock.releaseHeldStream()
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('an actionable @all task re-engages every bot after Stop', async () => {
+  test.setTimeout(180_000)
+  const page = fixture!.page
+  const room = 'Architect, Auditor'
+
+  await openBots(page)
+  await createAgent(page, 'architect', 'Architect')
+  await createAgent(page, 'auditor', 'Auditor')
+
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Group Chat' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'New Group Chat' })
+
+  for (const title of ['Architect', 'Auditor']) {
+    await dialog.getByText(title, { exact: true }).locator('xpath=ancestor::label').getByRole('checkbox').click()
+  }
+
+  await dialog.getByRole('textbox', { name: 'Group name' }).fill(room)
+  await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
+  await expect(page.getByRole('textbox', { name: `Message ${room}` }).filter({ visible: true })).toBeVisible({ timeout: 20_000 })
+
+  await sendRoomMessage(page, room, HELD_TASK)
+  await fixture!.mock.waitForHeldCompletion()
+  await page.getByRole('button', { name: 'Stop', exact: true }).first().click()
+
+  const holdStatus = page.locator('[data-slot="group-hold-status"]')
+
+  await expect(holdStatus).toBeVisible()
+  await expect(holdStatus).toContainText(/paused/i)
+
+  await sendRoomMessage(page, room, '@all review the stopped task')
+
+  await expect(holdStatus).toBeHidden({ timeout: 20_000 })
+  const botReplies = page.getByText('Hello from the mock inference server!', { exact: false })
+
+  await expect(botReplies).toHaveCount(2, { timeout: 60_000 })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -651,7 +651,8 @@ describe('member holds (#93129)', () => {
         { docs: { at: 2 }, impl: { at: 1 } },
         { everyone: true, mentioned: [] },
         '@all resume',
-        {}
+        {},
+        ['impl', 'docs']
       )
     ).toEqual({})
 
@@ -663,6 +664,113 @@ describe('member holds (#93129)', () => {
     expect(held.impl).toBeTruthy()
     expect(held.docs).toBeTruthy()
     expect(held.impl.at).toBe(5)
+  })
+
+  it.each(['@all', '@all!', '@all...'])(
+    'keeps sticky holds for a non-actionable room mention: %s',
+    async text => {
+      const { rounds } = await loadRoom()
+      const held = { impl: { at: 1 } }
+
+      expect(rounds.applyGroupHoldDirective(held, { everyone: true, mentioned: [] }, text, {}, ['impl'])).toBe(held)
+    }
+  )
+
+  it('releases current roster holds but preserves unavailable durable holds for @all task', async () => {
+    const { rounds } = await loadRoom()
+
+    expect(
+      rounds.applyGroupHoldDirective(
+        { 'laptop::builder': { at: 1 }, 'offline::reviewer': { at: 2 } },
+        { everyone: true, mentioned: [] },
+        '@all review this task',
+        {},
+        ['laptop::builder']
+      )
+    ).toEqual({ 'offline::reviewer': { at: 2 } })
+  })
+
+  it('keeps @all plus a direct mention scoped when there is no independent task payload', async () => {
+    const { rounds } = await loadRoom()
+
+    expect(
+      rounds.applyGroupHoldDirective(
+        { docs: { at: 2 }, impl: { at: 1 } },
+        { everyone: true, mentioned: ['impl'] },
+        '@all @impl!',
+        {},
+        ['impl', 'docs']
+      )
+    ).toEqual({ docs: { at: 2 } })
+  })
+
+  it.each(['@all 分析这个故障', '@everyone 复核 42'])('accepts Unicode task payload: %s', async text => {
+    const { rounds } = await loadRoom()
+
+    expect(
+      rounds.applyGroupHoldDirective(
+        { impl: { at: 1 } },
+        { everyone: true, mentioned: [] },
+        text,
+        {},
+        ['impl']
+      )
+    ).toEqual({})
+  })
+
+  it('treats @all plus an attachment as actionable room engagement', async () => {
+    const { rounds } = await loadRoom()
+
+    expect(
+      rounds.applyGroupHoldDirective(
+        { impl: { at: 1 } },
+        { everyone: true, mentioned: [] },
+        '@all',
+        {},
+        ['impl'],
+        true
+      )
+    ).toEqual({})
+  })
+
+  it('keeps stop precedence when @all stop also contains task text', async () => {
+    const { rounds } = await loadRoom()
+
+    const held = rounds.applyGroupHoldDirective({}, { everyone: true, mentioned: [] }, '@all stop then review', {}, [
+      'impl',
+      'docs'
+    ])
+
+    expect(Object.keys(held).sort()).toEqual(['docs', 'impl'])
+  })
+
+  it('re-engages a stopped room when @all carries a task without a resume token (#97740)', async () => {
+    const room = await loadRoom()
+
+    const members: GroupMember[] = [
+      { name: 'research', title: '' },
+      { name: 'builder', title: '' }
+    ]
+
+    room.chat.$groupChats.set({
+      Room: {
+        epoch: 3,
+        holds: {},
+        log: [],
+        members,
+        running: true,
+        sessions: {},
+        turn: null,
+        watermarks: {}
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    await room.rounds.stopGroupThread('Room', 'stopped-thread', members)
+    room.rounds.sendToGroupChat('Room', members, '@all review this task')
+    await settle(room, 'Room')
+
+    expect(room.gateway.calls.map(call => call.profile)).toEqual(expect.arrayContaining(['research', 'builder']))
+    expect(room.chat.$groupChats.get().Room.holds).toEqual({})
   })
 
   it('leaves holds untouched on an unrelated room message', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -690,16 +690,34 @@ describe('member holds (#93129)', () => {
     ).toEqual({ 'offline::reviewer': { at: 2 } })
   })
 
-  it('keeps @all plus a direct mention scoped when there is no independent task payload', async () => {
+  it.each([
+    {
+      member: { name: 'ops', title: 'The Ops' },
+      text: '@all @theops!',
+      heldKey: 'ops'
+    },
+    {
+      member: {
+        connectionId: 'default',
+        handle: 'default-vera',
+        name: 'vera',
+        remoteSource: true,
+        title: ''
+      },
+      text: '@all @default-vera!',
+      heldKey: 'default::vera'
+    }
+  ])('keeps room engagement scoped to a directly mentioned alias: $text', async ({ member, text, heldKey }) => {
     const { rounds } = await loadRoom()
+    const mentions = rounds.parseGroupChatMentions(text, [member as GroupMember])
 
     expect(
       rounds.applyGroupHoldDirective(
-        { docs: { at: 2 }, impl: { at: 1 } },
-        { everyone: true, mentioned: ['impl'] },
-        '@all @impl!',
+        { docs: { at: 2 }, [heldKey]: { at: 1 } },
+        mentions,
+        text,
         {},
-        ['impl', 'docs']
+        [heldKey, 'docs']
       )
     ).toEqual({ docs: { at: 2 } })
   })

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -45,6 +45,7 @@ import type { Attachment, GroupMember, GroupMessage } from './types'
 export function parseGroupChatMentions(text: unknown, members: GroupMember[]) {
   const source = String(text || '')
   const mentioned = new Set<string>()
+  const mentionedTokens = new Set<string>()
   let everyone = false
   const handles = new Map<string, string>()
 
@@ -97,12 +98,14 @@ export function parseGroupChatMentions(text: unknown, members: GroupMember[]) {
 
     if (resolved) {
       mentioned.add(resolved)
+      mentionedTokens.add(handle)
     }
   }
 
   return {
     everyone,
-    mentioned
+    mentioned,
+    mentionedTokens
   }
 }
 
@@ -245,7 +248,8 @@ export type GroupHoldIntent =
 export function hasActionableGroupPayload(
   text: string,
   mentionedKeys: Iterable<string> | null | undefined = [],
-  hasAttachments = false
+  hasAttachments = false,
+  mentionedTokens: Iterable<string> | null | undefined = []
 ) {
   if (hasAttachments) {
     return true
@@ -253,6 +257,15 @@ export function hasActionableGroupPayload(
 
   let residual = String(text || '').replace(/@(all|everyone)\b/gi, ' ')
 
+  for (const token of mentionedTokens || []) {
+    const escaped = String(token || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+    if (escaped) {
+      residual = residual.replace(new RegExp(`@${escaped}\\b`, 'gi'), ' ')
+    }
+  }
+
+  // Compatibility fallback for callers that only have canonical member keys.
   for (const memberKey of mentionedKeys || []) {
     const bareName = String(memberKey || '').split('::').pop() || ''
 
@@ -274,7 +287,8 @@ export function classifyGroupHoldIntent(
   mentionedKeys: Iterable<string> | null | undefined,
   everyone: boolean,
   allMemberKeys: readonly string[] = [],
-  hasAttachments = false
+  hasAttachments = false,
+  mentionedTokens: Iterable<string> | null | undefined = []
 ): GroupHoldIntent {
   const value = String(text || '')
   const mentioned = [...(mentionedKeys || [])]
@@ -289,7 +303,7 @@ export function classifyGroupHoldIntent(
     return everyone ? { kind: 'release-all-explicit' } : { kind: 'release-members', memberKeys: mentioned }
   }
 
-  if (everyone && hasActionableGroupPayload(value, mentioned, hasAttachments)) {
+  if (everyone && hasActionableGroupPayload(value, mentioned, hasAttachments, mentionedTokens)) {
     return { kind: 'engage-room', memberKeys: [...allMemberKeys] }
   }
 
@@ -323,6 +337,7 @@ export function classifyGroupHoldDirective(
 interface GroupMentionParse {
   everyone?: boolean
   mentioned?: Iterable<string>
+  mentionedTokens?: Iterable<string>
 }
 
 /** #93129: next holds map after one user message. Holds are keyed by
@@ -345,7 +360,8 @@ export function applyGroupHoldDirective(
     mentions?.mentioned || [],
     Boolean(mentions?.everyone),
     allMemberKeys,
-    hasAttachments
+    hasAttachments,
+    mentions?.mentionedTokens || []
   )
 
   if (intent.kind === 'release-all-explicit') {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -230,40 +230,92 @@ export function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLine
  *  one keeps doing work it was told to stop). A non-stop direct mention
  *  releases the mentioned members — the user addressing a bot directly
  *  overrides its hold. */
-export function classifyGroupHoldDirective(
+export type GroupHoldIntent =
+  | { kind: 'hold-all' }
+  | { kind: 'hold-members'; memberKeys: readonly string[] }
+  | { kind: 'release-all-explicit' }
+  | { kind: 'engage-room'; memberKeys: readonly string[] }
+  | { kind: 'release-members'; memberKeys: readonly string[] }
+  | { kind: 'none' }
+
+/** Whether a room-wide mention carries work rather than being a bare signal.
+ * This is intentionally mechanical, not an NLP classifier: after removing
+ * @all/@everyone, text needs a Unicode letter/number, or the send needs an
+ * attachment. Punctuation-only mentions must not wake every held member. */
+export function hasActionableGroupPayload(
+  text: string,
+  mentionedKeys: Iterable<string> | null | undefined = [],
+  hasAttachments = false
+) {
+  if (hasAttachments) {
+    return true
+  }
+
+  let residual = String(text || '').replace(/@(all|everyone)\b/gi, ' ')
+
+  for (const memberKey of mentionedKeys || []) {
+    const bareName = String(memberKey || '').split('::').pop() || ''
+
+    if (bareName) {
+      const escaped = bareName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      residual = residual.replace(new RegExp(`@${escaped}\\b`, 'gi'), ' ')
+    }
+  }
+
+  return /[\p{L}\p{N}]/u.test(residual)
+}
+
+/** Classify one USER send into a typed room-hold transition. Stop has highest
+ * priority; explicit resume preserves the historical full-clear contract;
+ * implicit room engagement is roster-scoped so a stale roster cannot erase a
+ * durable hold for an unavailable remote member. */
+export function classifyGroupHoldIntent(
   text: string,
   mentionedKeys: Iterable<string> | null | undefined,
-  everyone: boolean
-) {
+  everyone: boolean,
+  allMemberKeys: readonly string[] = [],
+  hasAttachments = false
+): GroupHoldIntent {
   const value = String(text || '')
   const mentioned = [...(mentionedKeys || [])]
   const stop = /\b(stop|halt|pause)\b/i.test(value)
   const resume = /\b(resume|continue|go|proceed)\b/i.test(value)
 
   if (stop) {
-    // "@all stop" holds every member — symmetric with "@all resume".
-    return {
-      hold: mentioned,
-      holdAll: Boolean(everyone),
-      release: [],
-      releaseAll: false
-    }
+    return everyone ? { kind: 'hold-all' } : { kind: 'hold-members', memberKeys: mentioned }
   }
 
   if (resume) {
-    return {
-      hold: [],
-      holdAll: false,
-      release: mentioned,
-      releaseAll: Boolean(everyone)
-    }
+    return everyone ? { kind: 'release-all-explicit' } : { kind: 'release-members', memberKeys: mentioned }
   }
 
+  if (everyone && hasActionableGroupPayload(value, mentioned, hasAttachments)) {
+    return { kind: 'engage-room', memberKeys: [...allMemberKeys] }
+  }
+
+  if (mentioned.length) {
+    return { kind: 'release-members', memberKeys: mentioned }
+  }
+
+  return { kind: 'none' }
+}
+
+/** Compatibility projection for tests and callers that inspect the original
+ * transition shape. Durable mutation below consumes the typed intent directly. */
+export function classifyGroupHoldDirective(
+  text: string,
+  mentionedKeys: Iterable<string> | null | undefined,
+  everyone: boolean,
+  allMemberKeys: readonly string[] = [],
+  hasAttachments = false
+) {
+  const intent = classifyGroupHoldIntent(text, mentionedKeys, everyone, allMemberKeys, hasAttachments)
+
   return {
-    hold: [],
-    holdAll: false,
-    release: mentioned,
-    releaseAll: false
+    hold: intent.kind === 'hold-members' ? intent.memberKeys : [],
+    holdAll: intent.kind === 'hold-all',
+    release: intent.kind === 'release-members' || intent.kind === 'engage-room' ? intent.memberKeys : [],
+    releaseAll: intent.kind === 'release-all-explicit'
   }
 }
 
@@ -283,17 +335,28 @@ export function applyGroupHoldDirective(
   mentions: GroupMentionParse | null | undefined,
   text: string,
   stamp: GroupHoldStamp | null | undefined,
-  allMemberKeys: string[] = []
+  allMemberKeys: string[] = [],
+  hasAttachments = false
 ): Record<string, GroupHoldStamp> {
   const prior: Record<string, GroupHoldStamp> = holds && typeof holds === 'object' ? holds : {}
-  const action = classifyGroupHoldDirective(text, mentions?.mentioned || [], Boolean(mentions?.everyone))
 
-  if (action.releaseAll) {
+  const intent = classifyGroupHoldIntent(
+    text,
+    mentions?.mentioned || [],
+    Boolean(mentions?.everyone),
+    allMemberKeys,
+    hasAttachments
+  )
+
+  if (intent.kind === 'release-all-explicit') {
     return Object.keys(prior).length ? {} : prior
   }
 
-  // "@all stop": expand to every member key the caller knows about.
-  const toHold = action.holdAll ? [...allMemberKeys] : action.hold
+  const toHold = intent.kind === 'hold-all' ? [...allMemberKeys] : intent.kind === 'hold-members' ? intent.memberKeys : []
+
+  const toRelease =
+    intent.kind === 'release-members' || intent.kind === 'engage-room' ? intent.memberKeys : []
+
   let next = prior
 
   for (const key of toHold) {
@@ -310,7 +373,7 @@ export function applyGroupHoldDirective(
     }
   }
 
-  for (const key of action.release) {
+  for (const key of toRelease) {
     if (Object.prototype.hasOwnProperty.call(next, key)) {
       if (next === prior) {
         next = {
@@ -1015,7 +1078,8 @@ export function sendToGroupChat(
         byMessageId: sent?.id,
         thread: target
       },
-      members.map((member: GroupMember) => groupMemberKey(member))
+      members.map((member: GroupMember) => groupMemberKey(member)),
+      attached.length > 0
     )
 
     return room


### PR DESCRIPTION
## Problem

After a user stops a Desktop-driven Bot Mode Group Chat, the canonical room-level holds remain sticky. Directly addressing a member and `@all resume` already release those holds, but a normal room-wide task such as `@all review this` selects every responder without releasing them. The round then skips every held Bot and the room stays silent.

The persistent visibility half of #97740 is already on `main` via #99094. This PR implements only the remaining release-semantics half.

## Approach

- model hold transitions as typed intents so explicit all-member resume and task-driven room engagement cannot collapse into the same state operation;
- treat an actionable `@all` / `@everyone` task as room engagement and release the room's seated, source-qualified member keys before the existing round driver runs;
- preserve the existing full-clear behavior of explicit `@all resume`;
- keep Stop precedence, direct-member release, epoch fencing, watermarks, room persistence, and hosted-room authority unchanged;
- distinguish a real task from bare or punctuation-only room mentions, while accepting Unicode text and attachment-only tasks;
- retain the exact mention token recognized by the existing parser so title, friendly-name, and remote-handle mentions do not accidentally turn `@all @member` into a room-wide task.

The long-standing ambiguity where a Bot alias itself is a control word such as `@go` or `@stop` is unchanged and outside this PR's narrow contract.

## Validation

- current-main regression before implementation: Stop → `@all <task>` produced no Bot calls;
- sabotage: disabling the new room-engagement intent makes the regression fail again;
- `npm --prefix apps/desktop run test:ui -- --run src/plugins/hermes-bots` — **575 passed**;
- focused round and hold-status tests — **60 passed**;
- `npm --prefix apps/desktop run typecheck`;
- focused ESLint for changed production, unit, and E2E files;
- `npm --prefix apps/desktop run build`;
- real Electron E2E with the mock backend — **1 passed**: creates two Bots and a Group Chat, starts work, clicks Stop, observes the durable hold status, sends an actionable `@all` task, observes the status clear, and receives both Bot replies;
- `git diff --check`.

## Scope

The implementation does not change hosted Group Chat continuity, messaging control, member persistence, Stop cancellation fencing, round limits, or the durable hold schema. Open #97846/#98307 touch the same file for broader hosted continuity but retain the old release classifier and do not implement this behavior.

Closes #97740
