### PR TITLE
fix(compression): give gateway session hygiene the #97488 bounded-grace lease join

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -51,6 +51,7 @@ thread, not the conversation thread. Extension authors must assume:
 
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures
 import copy
 import inspect
@@ -979,6 +980,41 @@ def _join_cancelled_worker(future: Any, grace_seconds: float) -> bool:
     except concurrent.futures.CancelledError:
         # Never started; nothing can be in flight.
         return True
+    except Exception:
+        # The worker raised — it exited. The exception is intentionally
+        # swallowed here: the host already chose the fallback result, and the
+        # fence prevents the failed attempt from touching session state.
+        logger.debug(
+            "cancelled compression worker exited with an exception",
+            exc_info=True,
+        )
+        return True
+
+
+async def _join_cancelled_worker_async(future: Any, grace_seconds: float) -> bool:
+    """Async-safe counterpart to :func:`_join_cancelled_worker`.
+
+    For a host that drives a fence-cancelled compression worker via
+    ``loop.run_in_executor`` inside a coroutine (e.g. gateway session
+    hygiene) instead of blocking a thread on
+    ``concurrent.futures.Future.result``. Same contract: returns True when
+    the worker future settled within ``grace_seconds``, False if it is still
+    running. Uses ``asyncio.shield`` so a timeout here never cancels the
+    underlying future — a caller that still needs to await/observe it
+    afterward (e.g. deferred cleanup) sees the same object in the same
+    state as if this join had never happened.
+    """
+    try:
+        grace = max(float(grace_seconds), 0.0)
+    except (TypeError, ValueError):
+        grace = 0.0
+    try:
+        await asyncio.wait_for(asyncio.shield(future), timeout=grace)
+        return True
+    except asyncio.TimeoutError:
+        return False
+    except asyncio.CancelledError:
+        raise
     except Exception:
         # The worker raised — it exited. The exception is intentionally
         # swallowed here: the host already chose the fallback result, and the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -49,6 +49,8 @@ from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union,
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
+    _CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS,
+    _join_cancelled_worker_async,
     COMPACTION_DONE_STATUS,
     COMPACTION_STATUS,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
@@ -21131,11 +21133,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
-                                            # Release an inactivity-timed-out
-                                            # worker's holder-qualified lease
-                                            # promptly. Total-ceiling attempts
-                                            # retained it above, so this is a
-                                            # no-op until worker cleanup there.
+                                            # #97488 teardown (total-ceiling path
+                                            # only): mirror the CLI's bounded-grace
+                                            # join (agent.conversation_compression.
+                                            # _join_cancelled_worker) before releasing
+                                            # the lease early. A worker that exits
+                                            # within grace proves no provider call is
+                                            # still in flight, so the lease can be
+                                            # freed immediately instead of staying
+                                            # retained for the rest of the process's
+                                            # lifetime. Inactivity timeouts skip the
+                                            # join and fall straight through to the
+                                            # release below, matching the established
+                                            # behavior for a provider call that may
+                                            # never return.
+                                            if _hyg_total_exhausted:
+                                                _hyg_grace = min(
+                                                    _CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS,
+                                                    _hyg_total_ceiling_seconds,
+                                                )
+                                                _hyg_worker_exited = await _join_cancelled_worker_async(
+                                                    _hyg_future, _hyg_grace
+                                                )
+                                                if _hyg_worker_exited:
+                                                    _hyg_commit_fence.allow_cancelled_lock_release()
+                                                else:
+                                                    logger.warning(
+                                                        "Cancelled session hygiene "
+                                                        "compression worker for session "
+                                                        "%s did not exit within %.1fs "
+                                                        "grace — orphaning it behind the "
+                                                        "poison fence (late result will "
+                                                        "be discarded); retaining the "
+                                                        "session compression lease until "
+                                                        "it exits so no new attempt "
+                                                        "overlaps it",
+                                                        session_entry.session_id,
+                                                        _hyg_grace,
+                                                    )
+                                            # Release an inactivity-timed-out worker's
+                                            # holder-qualified lease promptly. A
+                                            # total-ceiling worker that exited within
+                                            # grace above is released here too; one
+                                            # that didn't stays retained until its own
+                                            # eventual cleanup.
                                             _hyg_commit_fence.release_cancelled_compression_lock()
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -19,6 +19,7 @@ collapsed lean compaction to one auxiliary request per attempt:
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import os
 import threading
@@ -32,6 +33,7 @@ from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.conversation_compression import (
     CompressionCommitFence,
     _claim_compressor_attempt,
+    _join_cancelled_worker_async,
     compress_context,
     compression_blocked_transiently,
     run_compress_context_with_progress_timeout,
@@ -168,6 +170,84 @@ class TestWorkerTeardownOnCeiling:
         assert worker_finished.wait(timeout=2)
         # Late result was fence-poisoned, never adopted.
         assert msgs == [{"role": "user", "content": "keep"}]
+
+
+class TestAsyncWorkerTeardownOnCeiling:
+    """Async counterpart of ``TestWorkerTeardownOnCeiling`` above: pins
+    ``_join_cancelled_worker_async``, the bounded-grace join a host running
+    inside a coroutine (gateway session hygiene) uses instead of
+    ``_join_cancelled_worker``'s blocking ``concurrent.futures.Future.result``
+    join — a host that awaited a plain ``loop.run_in_executor`` future was
+    never joined at all on the total-ceiling path, so a genuinely quick
+    worker's lease stayed retained for the rest of the process's lifetime
+    exactly like a permanently stuck one."""
+
+    @pytest.mark.asyncio
+    async def test_cooperative_worker_joined_within_grace(self):
+        worker_done = threading.Event()
+
+        def cooperative_worker():
+            time.sleep(0.05)
+            worker_done.set()
+            return "late"
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, cooperative_worker)
+
+        exited = await _join_cancelled_worker_async(future, grace_seconds=2.0)
+
+        assert exited is True, (
+            "a cooperative worker that exits well within grace must be "
+            "reported as joined so the host can release the lease early"
+        )
+        assert worker_done.is_set()
+        # asyncio.shield must leave the future itself untouched: a caller
+        # (deferred agent cleanup) can still await/observe it afterward.
+        assert await future == "late"
+
+    @pytest.mark.asyncio
+    async def test_uninterruptible_worker_is_not_joined_within_grace(self):
+        release = threading.Event()
+        worker_finished = threading.Event()
+
+        def stuck_worker():
+            release.wait(timeout=5.0)
+            worker_finished.set()
+            return "late"
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, stuck_worker)
+
+        started = time.monotonic()
+        exited = await _join_cancelled_worker_async(future, grace_seconds=0.1)
+        elapsed = time.monotonic() - started
+
+        assert exited is False
+        assert not worker_finished.is_set()
+        # Bounded: must not have waited for the full worker duration.
+        assert elapsed < 1.0, "join did not return within its own grace bound"
+        # asyncio.shield must have kept a timeout from cancelling the
+        # underlying future — it must still be joinable/awaitable later.
+        assert not future.done()
+
+        release.set()
+        assert await future == "late"
+        assert worker_finished.is_set()
+
+    @pytest.mark.asyncio
+    async def test_worker_exception_counts_as_exited(self):
+        def raising_worker():
+            raise RuntimeError("boom")
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, raising_worker)
+
+        exited = await _join_cancelled_worker_async(future, grace_seconds=2.0)
+
+        assert exited is True, (
+            "a worker that raised has provably exited and must count as "
+            "joined, mirroring _join_cancelled_worker's sync contract"
+        )
 
 
 class TestDurableAttemptBackoff:


### PR DESCRIPTION
## Summary

#97488 (892f756b8c) taught the CLI's `compress_context` total-ceiling path to bounded-join a fence-cancelled worker (`_join_cancelled_worker`, grace-capped at `_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS`) before deciding whether to release the durable compression lease early via `fence.allow_cancelled_lock_release()`. A worker that provably exits within grace proves no provider call is still in flight, so the lease no longer needs protecting against an overlapping retry.

Gateway session hygiene's structurally parallel total-ceiling handler (`gateway/run.py`, the async twin of the same cancel/retain/release sequence) retains the lease on total-ceiling exhaustion exactly like the CLI, but never performs the join. It falls straight through to `release_cancelled_compression_lock()`, which is a no-op while `_retain_cancelled_lock_until_worker_done` stays `True` — so a gateway session's compression lease stays retained until the worker *eventually* exits on its own, for up to the full lease TTL, even when the cancelled worker actually exits within milliseconds. This is a gateway-vs-CLI parity regression introduced by #97488: no new compression attempt (automatic or manual) can proceed against that session until the stale lease clears.

## Fix

Added `_join_cancelled_worker_async` to `agent/conversation_compression.py` as the async-safe counterpart of `_join_cancelled_worker`, for a host that drives the worker via `loop.run_in_executor` inside a coroutine instead of blocking a thread on `concurrent.futures.Future.result`. Uses `asyncio.wait_for(asyncio.shield(future), timeout=grace)` so a timeout never cancels the underlying future — a caller that still needs to await it afterward (gateway's deferred agent cleanup) sees the same object in the same state as if the join had never happened.

Wired it into `gateway/run.py`'s total-ceiling branch with the same `min(grace, ceiling)` bound and `allow_cancelled_lock_release()` call the CLI path uses.

## Competitor check

- #97512 ("enforce total ceiling across attempts") introduces `retain_compression_lock_until_worker_done()` as new code in its own diff — its base predates that method's actual introduction on `main` entirely, and it contains no reference to `_join_cancelled_worker`/`allow_cancelled_lock_release` anywhere. Stale relative to current `main`, not a competitor for this gap.
- #71569 ("release hygiene lock after timeout") is the PR whose holder-qualified release-hook design was already transplanted into `main` (see the code's own attribution comment). Its base is from ~5 weeks before the bounded-grace-join mechanism existed; its diff has zero references to it. Not a competitor.

## Test plan

- Added `TestAsyncWorkerTeardownOnCeiling` (`tests/agent/test_compression_attempt_lifecycle.py`), the async counterpart of the existing `TestWorkerTeardownOnCeiling`:
  - A cooperative worker (real `loop.run_in_executor` future) is joined within grace and remains awaitable afterward.
  - An uninterruptible worker is correctly reported as not-joined within a bounded wait, and is left untouched (not cancelled/done) so a caller can still await it later.
  - A worker that raises counts as exited.
- Mutation-verified against the actual join/timeout logic, not just the function's presence: temporarily replacing the body with an unconditional `return True` makes both the cooperative- and uninterruptible-worker tests fail as expected, then reverted.
- `tests/agent/test_compression_attempt_lifecycle.py` (13/13), plus `test_context_compressor.py`, `test_compress_context_progress_timeout.py`, `test_compression_split_failure_cooldown.py`, `test_compression_stall_interrupt_96775.py`, `test_compression_review_76354.py`, `test_compression_concurrent_fork.py` (249/249 combined), `tests/gateway/test_session_hygiene.py` (18/18) — all green.
- `ruff check` clean on all three touched files; `gateway.run` imports cleanly with the new import.

## Scope note

The analogous bounded-grace join was **not** added to the idle-timeout (non-total-ceiling) branch, mirroring the CLI's own design — that path intentionally releases the lease immediately without a join, matching the established "a provider call that may never return" handling.