### PR TITLE
fix(delegation): report partial failure in async batch aggregate status

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -843,6 +843,77 @@ def test_single_task_no_banner_when_clean():
     assert "TRUNCATED" not in text
 
 
+def test_batch_status_partial_when_some_children_fail():
+    """A background batch's own aggregate status must distinguish a mixed
+    outcome from a clean one. Before this fix, `_worker()` reported
+    'completed' whenever ANY child succeeded, masking partial failure in a
+    listing like the CLI's /agents command (each child's own per-task status
+    was already correct in the completion message itself — this pins the
+    separate batch-level aggregate field)."""
+    results = [
+        {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        },
+        {
+            "task_index": 1, "status": "failed", "summary": None,
+            "error": "boom", "api_calls": 1, "duration_seconds": 0.1,
+        },
+    ]
+
+    def runner():
+        return {"results": results, "total_duration_seconds": 0.2}
+
+    out = ad.dispatch_async_delegation_batch(
+        goals=["task a", "task b"], context=None, toolsets=None,
+        role="leaf", model="m", session_key="sess", runner=runner,
+    )
+    assert out["status"] == "dispatched"
+
+    evt = _drain_for(out["delegation_id"])
+    assert evt is not None
+    assert evt["is_batch"] is True
+    assert evt["status"] == "partial", (
+        f"expected 'partial' for a mixed-outcome batch, got {evt['status']!r}"
+    )
+
+
+def test_batch_status_completed_when_all_children_succeed():
+    results = [
+        {"task_index": 0, "status": "completed", "summary": "ok"},
+        {"task_index": 1, "status": "success", "summary": "ok too"},
+    ]
+
+    def runner():
+        return {"results": results, "total_duration_seconds": 0.2}
+
+    out = ad.dispatch_async_delegation_batch(
+        goals=["task a", "task b"], context=None, toolsets=None,
+        role="leaf", model="m", session_key="sess", runner=runner,
+    )
+    evt = _drain_for(out["delegation_id"])
+    assert evt is not None
+    assert evt["status"] == "completed"
+
+
+def test_batch_status_error_when_all_children_fail():
+    results = [
+        {"task_index": 0, "status": "failed", "error": "boom1"},
+        {"task_index": 1, "status": "error", "error": "boom2"},
+    ]
+
+    def runner():
+        return {"results": results, "total_duration_seconds": 0.2}
+
+    out = ad.dispatch_async_delegation_batch(
+        goals=["task a", "task b"], context=None, toolsets=None,
+        role="leaf", model="m", session_key="sess", runner=runner,
+    )
+    evt = _drain_for(out["delegation_id"])
+    assert evt is not None
+    assert evt["status"] == "error"
+
+
 def test_batch_truncation_banner_marks_only_truncated_task():
     """In a batch, only the task that hit max_iterations gets the TRUNCATED
     marker; a clean sibling keeps the normal check icon."""

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1112,15 +1112,28 @@ def dispatch_async_delegation_batch(
         status = "error"
         try:
             combined = runner() or {}
-            # Batch status: completed unless every child errored/was interrupted.
+            # Batch status: completed if every child succeeded, error if none
+            # did, partial if some but not all succeeded. Surfaced distinctly
+            # so a listing of this record (e.g. the CLI's /agents command)
+            # doesn't report a flat "completed" for a batch where some
+            # children actually failed — each child's own per-task status is
+            # already reported correctly in the completion message; this is
+            # the aggregate the batch record itself carries.
             child_results = combined.get("results") or []
-            if child_results and all(
-                (r.get("status") not in ("completed", "success"))
-                for r in child_results
-            ):
-                status = "error"
-            else:
+            if not child_results:
                 status = "completed"
+            else:
+                succeeded = sum(
+                    1
+                    for r in child_results
+                    if r.get("status") in ("completed", "success")
+                )
+                if succeeded == 0:
+                    status = "error"
+                elif succeeded == len(child_results):
+                    status = "completed"
+                else:
+                    status = "partial"
         except Exception as exc:  # noqa: BLE001 — must never crash the worker
             logger.exception("Async delegation batch %s crashed", delegation_id)
             combined = {


### PR DESCRIPTION
## Summary

The delegation failure-status saga (5ce8f71553, 1b6ea1a2c2, ec02d5179a, b4d5174385) fixed each child's own per-task status to correctly say "failed" instead of "completed"/"max_iterations" — that per-task detail is already rendered correctly in the completion message that re-enters the conversation.

`dispatch_async_delegation_batch()`'s own **batch-level aggregate** never got the same treatment: its `_worker()` set the whole batch record's `status` to `"completed"` whenever **at least one** child succeeded, only flipping to `"error"` when every single child failed. A batch of 3 background subagents where 1 completes and 2 fail is stamped `"completed"` on the record itself.

This aggregate is what `list_async_delegations()` exposes, which the CLI's `/agents` command renders verbatim as a per-delegation status line — so a partially-failed background batch shows as a flat "completed" there, even though the actual completion message the model reads already carries the correct per-task ✓/✗ breakdown.

## Why this is safe to change

Confirmed the aggregate field has no other consumer that would break by adding a new value:
- `_format_async_delegation`'s batch-rendering branch only ever reads each result's own `r_status`, never the outer `status` — the per-task rendering is unaffected.
- Its non-batch rendering branch (which does read the outer `status`) is unreachable for batch records, guarded by `is_batch`.
- The durable persistence layer (`_persist_completion`) treats any value outside `("running", "finalizing")` as terminal, exactly as before.

## Fix

Changed the aggregate to three states instead of two: `"completed"` only when every child succeeded, `"error"` when none did, and a new `"partial"` when some but not all succeeded. The empty-results edge case keeps its existing `"completed"` behavior — that's a separate question (what a zero-result batch should mean) out of scope for this fix.

## Test plan

- Added `test_batch_status_partial_when_some_children_fail`, `test_batch_status_completed_when_all_children_succeed`, and `test_batch_status_error_when_all_children_fail` (`tests/tools/test_async_delegation.py`), driving `dispatch_async_delegation_batch()` directly with a synchronous runner and draining the real completion event.
- Mutation-verified: stashing the fix makes the partial-failure test fail with the pre-fix `"completed"` value while the other two (whose behavior is unchanged) keep passing.
- `tests/tools/test_async_delegation.py` (32/32), `tests/tools/test_delegate.py` + `test_process_registry.py` (172 passed, 5 pre-existing skips) — all green.
- `ruff check` clean on both touched files.

## Competitor check

- #98729 (open, "close split-brain where live batch is invisible to action=list") edits the same function immediately before `_worker()` (wrapping `_persist_dispatch` in try/except) but never touches `_worker()`'s status computation — textually adjacent, no semantic overlap; should merge cleanly regardless of order.
- #87523 (closed) and #98349 (open) touch per-child status handling in `tools/delegate_tool.py`, not this batch-level aggregate.
- None compete with this change.