### PR TITLE
fix(compression): move parent-context capture outside the worker timeout budget

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1441,7 +1441,6 @@ def run_compress_context_with_progress_timeout(
     ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
     idle = float(idle_timeout_seconds)
     fence = fence if fence is not None else CompressionCommitFence()
-    fence.set_total_ceiling_seconds(ceiling)
     # Sync mirror of gateway session-hygiene's run_in_executor(None, ...) +
     # wait_for loop (gateway/run.py): offload compress_context onto the shared
     # daemon pool, poll with an inactivity budget + total ceiling, then
@@ -1493,16 +1492,24 @@ def run_compress_context_with_progress_timeout(
         return worker(worker_fence)
 
     # Bare pool workers start with an empty ContextVar map; propagate the
-    # parent conversation/approval context into the worker.
+    # parent conversation/approval context into the worker.  Build the wrapper
+    # before arming the timeout: callback capture performs lazy imports on its
+    # first use, and that host-side setup must not consume the worker budget.
+    contextual_worker = propagate_context_to_thread(_fence_gated_worker)
+
+    # Start the timeout budget only after one-time lazy imports and executor
+    # initialization.  Charging that host-side setup can expire tiny budgets
+    # before the submitted worker is even allowed to start (notably on the
+    # first Windows invocation).  Submission/queue time remains inside the
+    # budget so a saturated executor is still bounded.
+    wait_started = time.monotonic()
+    fence.set_total_ceiling_seconds(ceiling)
     try:
-        future = executor.submit(
-            propagate_context_to_thread(_fence_gated_worker), fence
-        )
+        future = executor.submit(contextual_worker, fence)
     except BaseException:
         _release_compression_admission()
         raise
     future.add_done_callback(_release_compression_admission)
-    wait_started = time.monotonic()
     # F2: EVERY host unwind (KeyboardInterrupt, task cancellation, unexpected
     # exception while waiting) must revoke future commit admission before the
     # host resumes, or a detached worker could later commit and mutate durable

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -686,11 +686,13 @@ class CompressionCommitFence:
             self.set_total_ceiling_seconds(total_ceiling_seconds)
 
     def set_total_ceiling_seconds(self, seconds: float) -> None:
-        """Arm the wall-clock deadline shared by the host and worker."""
+        """Arm the wall-clock and no-progress clocks for a new attempt."""
         seconds = float(seconds)
         if seconds <= 0:
             raise ValueError("total compression ceiling must be positive")
-        self._deadline = time.monotonic() + seconds
+        now = time.monotonic()
+        self._last_progress = now
+        self._deadline = now + seconds
 
     def touch_progress(self) -> None:
         """Record forward progress (e.g. a streamed summary token arriving).
@@ -1491,21 +1493,14 @@ def run_compress_context_with_progress_timeout(
             return messages, ""
         return worker(worker_fence)
 
-    # Bare pool workers start with an empty ContextVar map; propagate the
-    # parent conversation/approval context into the worker.  Build the wrapper
-    # before arming the timeout: callback capture performs lazy imports on its
-    # first use, and that host-side setup must not consume the worker budget.
-    contextual_worker = propagate_context_to_thread(_fence_gated_worker)
-
-    # Start the timeout budget only after one-time lazy imports and executor
-    # initialization.  Charging that host-side setup can expire tiny budgets
-    # before the submitted worker is even allowed to start (notably on the
-    # first Windows invocation).  Submission/queue time remains inside the
-    # budget so a saturated executor is still bounded.
-    wait_started = time.monotonic()
-    fence.set_total_ceiling_seconds(ceiling)
+    # Capture the parent context before the attempt clocks start: this helper
+    # can lazily import approval plumbing, which is setup work rather than
+    # summary-model time. Every failure after admission must release the slot.
     try:
-        future = executor.submit(contextual_worker, fence)
+        wrapped_worker = propagate_context_to_thread(_fence_gated_worker)
+        wait_started = time.monotonic()
+        fence.set_total_ceiling_seconds(ceiling)
+        future = executor.submit(wrapped_worker, fence)
     except BaseException:
         _release_compression_admission()
         raise

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -119,6 +119,44 @@ class TestWorkerTeardownOnCeiling:
         # Teardown proved quiescence, so the lease must NOT stay retained.
         assert fence._retain_cancelled_lock_until_worker_done is False
 
+    def test_parent_context_capture_is_outside_worker_budget(self, monkeypatch):
+        """One-time parent-thread setup must not expire the worker deadline."""
+        from tools import thread_context
+
+        original = [{"role": "user", "content": "keep"}]
+        compressed = [{"role": "assistant", "content": "summary"}]
+        worker_started = threading.Event()
+        real_propagate = thread_context.propagate_context_to_thread
+
+        def slow_first_capture(target):
+            # Deterministically model Windows cold-start import/callback capture.
+            time.sleep(0.3)
+            return real_propagate(target)
+
+        monkeypatch.setattr(
+            thread_context,
+            "propagate_context_to_thread",
+            slow_first_capture,
+        )
+
+        def fast_worker(_fence: CompressionCommitFence):
+            worker_started.set()
+            return compressed, "compressed"
+
+        msgs, prompt = run_compress_context_with_progress_timeout(
+            worker=fast_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.1,
+            total_ceiling_seconds=0.2,
+            fence=CompressionCommitFence(),
+            stall_fallback=False,
+        )
+
+        assert worker_started.is_set()
+        assert msgs is compressed
+        assert prompt == "compressed"
+
     def test_uninterruptible_worker_is_orphaned_with_lease_retained(self):
         """A worker stuck in an uninterruptible provider call is orphaned:
         the host returns after the grace, the poison fence discards its late

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -141,6 +141,9 @@ class TestWorkerTeardownOnCeiling:
 
         def fast_worker(_fence: CompressionCommitFence):
             worker_started.set()
+            # Stay inside a freshly armed idle budget, but long enough to prove
+            # the pre-capture timestamp is not still charged to this attempt.
+            time.sleep(0.05)
             return compressed, "compressed"
 
         msgs, prompt = run_compress_context_with_progress_timeout(
@@ -156,6 +159,44 @@ class TestWorkerTeardownOnCeiling:
         assert worker_started.is_set()
         assert msgs is compressed
         assert prompt == "compressed"
+
+    def test_parent_context_capture_failure_releases_admission(self, monkeypatch):
+        """A setup failure before Future creation must release admission."""
+        import agent.conversation_compression as compression
+        from tools import thread_context
+
+        balance = 0
+
+        def admit():
+            nonlocal balance
+            balance += 1
+            return True
+
+        def release():
+            nonlocal balance
+            balance -= 1
+
+        def fail_capture(_target):
+            raise RuntimeError("context capture failed")
+
+        monkeypatch.setattr(compression, "_try_admit_compression_job", admit)
+        monkeypatch.setattr(compression, "_release_compression_admission", release)
+        monkeypatch.setattr(
+            thread_context,
+            "propagate_context_to_thread",
+            fail_capture,
+        )
+
+        with pytest.raises(RuntimeError, match="context capture failed"):
+            run_compress_context_with_progress_timeout(
+                worker=lambda _fence: ([], ""),
+                messages=[],
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=1.0,
+                total_ceiling_seconds=1.0,
+            )
+
+        assert balance == 0
 
     def test_uninterruptible_worker_is_orphaned_with_lease_retained(self):
         """A worker stuck in an uninterruptible provider call is orphaned:


### PR DESCRIPTION
## Summary
- `propagate_context_to_thread` performs lazy imports on first use (`tools.terminal_tool`), and callback capture can take real time on Windows cold start.
- Building the wrapper AFTER arming the ceiling timer meant that host-side setup consumed the worker deadline — potentially expiring tiny budgets before the submitted worker even started.
- Build the contextual wrapper BEFORE setting the ceiling so the budget covers only the actual worker execution.
- Add a regression test that deterministically models slow capture and asserts the fast worker still runs.

## Testing
- [x] `test_compression_attempt_lifecycle.py` — 11 passed
- [x] `test_auxiliary_client.py` — 185 passed
- [x] `test_parent_context_capture_is_outside_worker_budget` — passed (5/5 reruns)