### PR TITLE
Add page2ai to optional MCP catalog (Web to Markdown, MIT, no-auth remote)

### DIFF
--- a/optional-mcps/page2ai/manifest.yaml
+++ b/optional-mcps/page2ai/manifest.yaml
@@ -1,0 +1,34 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: page2ai
+description: Convert web pages or HTML to clean Markdown for LLM context. Preserves code blocks with language tags and reading structure. Zero telemetry.
+source: https://github.com/igorsaevets/page2ai-mcp
+
+# Official author-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). No authentication required (verified live 2026-08-31:
+# initialize succeeds anonymously).
+
+transport:
+  type: http
+  url: https://page2ai-mcp-remote.vercel.app/api/mcp
+
+auth:
+  type: none
+
+# Composer-suggestion triggers.
+suggest:
+  keywords:
+    - page2ai
+    - webpage to markdown
+    - html to markdown
+    - convert page to markdown
+    - web scraping for llm
+  hosts:
+    - page2ai-mcp-remote.vercel.app
+
+post_install: |
+  No account or credentials needed — Page2AI is publicly hosted with no auth.
+  Tools are available as soon as the session restarts. For a local install
+  instead, use the npm package: npx -y @page2ai/mcp (Node 22+ required).


### PR DESCRIPTION
## Adds `optional-mcps/page2ai/`

**Page2AI — Web to Markdown.** Convert web pages or HTML to clean Markdown for LLM context. Preserves code blocks with language hints, tables, and reading structure; strips ads, navigation, and cookie banners. Zero telemetry, no accounts, MIT license.

## What this gives Hermes users

- One-line install of a **generalist docs → Markdown** capability, complementary to `context7` (which is library-docs-only). Where context7 knows library X's canonical docs, page2ai handles any URL a user hands the agent — blog posts, Stack Overflow answers, USCIS pages, product pages, changelogs.
- **Verified live 2026-08-31**: `initialize` (protocol `2025-11-25`) succeeds anonymously against `page2ai-mcp-remote.vercel.app/api/mcp`; `tools/list` returns `page_to_markdown` with a full inputSchema (url, include_images, include_frontmatter, timeout_ms) and read-only / non-destructive annotations. No auth path to trip on.
- Same code also available as `npx -y @page2ai/mcp` (stdio) for users who prefer local — but the URL-only remote entry stays true to the Hermes "no local process for this entry" pattern used by `context7`.

## Files

- `optional-mcps/page2ai/manifest.yaml` — `manifest_version: 1`, HTTP transport, no auth, composer-suggestion keywords + host, post_install note about the npx alternative.

## Provenance

- **Source repository**: `github.com/igorsaevets/page2ai-mcp` (MIT)
- **npm**: `@page2ai/mcp@0.2.5` (OIDC provenance on release)
- **MCP Registry**: `io.github.igorsaevets/page2ai-mcp` at `isLatest: true` (dated 2026-08-29)
- **Security**: GHSA-fx68-fhhj-5874 disclosed and hardened; private ranges / loopback / cloud-metadata endpoints blocked at the fetch layer.

## Testing done

- Anonymous `initialize` + `tools/list` against the hosted endpoint returned the tool and its schema correctly.
- Same tool served via `npx -y @page2ai/mcp` stdio for parity.

Happy to reformat if a specific PR template exists that I missed.
