### PR TITLE
docs(whatsapp): explain filtered chats and Communities

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -313,7 +313,7 @@ Message-template support (the workaround for outside-window sends) is not yet im
 
 ### Group chats
 
-The Cloud API has limited group support (capability-tier gated by Meta).  Hermes's `whatsapp_cloud` adapter currently handles **direct messages only** in v1.  If you need group chats, use the Baileys bridge.
+The Cloud API has limited group support (capability-tier gated by Meta).  Hermes's `whatsapp_cloud` adapter currently handles **direct messages only** in v1.  If you need group chats, use the Baileys bridge and review its [group, Community, and filtered-traffic behavior](./whatsapp.md#groups-communities-and-filtered-traffic).
 
 ### Outbound rate limit
 
@@ -398,7 +398,7 @@ This uses your Nous Portal access token instead of needing a separate OpenAI key
 | Account ban risk | Yes (unofficial API) | No (officially supported) |
 | Inbound | Polling Node bridge | Webhook POST from Meta |
 | Outbound | Local bridge → Baileys | HTTPS to graph.facebook.com |
-| Groups | Full support | DMs only (v1) |
+| Groups | Full support ([groups and Communities](./whatsapp.md#groups-communities-and-filtered-traffic)) | DMs only (v1) |
 | 24h window | No restriction | Hard rule — templates required after |
 | Voice notes (out) | Native | Native with ffmpeg, MP3 fallback otherwise |
 | Read receipts | No | Yes (blue double-checkmarks) |

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -167,6 +167,19 @@ with reconnection logic.
 
 ---
 
+## Groups, Communities, and filtered traffic
+
+The Baileys bridge handles chats ending in `@g.us` as groups. This includes ordinary WhatsApp groups and Community subgroups. When Baileys reports a Community Announcements chat with an `@g.us` ID, that chat follows the same group access and mention rules. Classification uses the chat ID suffix: only `@newsletter` IDs are treated as Channels.
+
+Hermes ignores these inbound pseudo-chats before applying DM or group access rules:
+
+- Status updates and broadcast lists with IDs ending in `@broadcast`.
+- WhatsApp Channels, which Baileys identifies with IDs ending in `@newsletter`.
+
+Changing an allowlist or access policy does not enable these filtered chats. If you need group support through Hermes, use a regular group or Community subgroup. The [WhatsApp Cloud API adapter](./whatsapp-cloud.md#group-chats) currently handles direct messages only.
+
+---
+
 ## Voice Messages
 
 Hermes supports voice on WhatsApp:
@@ -252,6 +265,7 @@ Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables
 | **Bot stops working after WhatsApp update** | Update Hermes to get the latest bridge version, then re-pair. |
 | **macOS: "Node.js not installed" but node works in terminal** | launchd services don't inherit your shell PATH. Run `hermes gateway install` to re-snapshot your current PATH into the plist, then `hermes gateway start`. See the [Gateway Service docs](./index.md#macos-launchd) for details. |
 | **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's number (with country code, no `+` or spaces), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. |
+| **Status, Channel, or broadcast-list posts do not trigger the agent** | This is expected. The Baileys adapter filters `@broadcast` and `@newsletter` chats before access checks. Community chats reported as `@g.us` use the normal group path instead, so check their group access and mention settings. |
 | **Bot replies to strangers with a pairing code** | Set `whatsapp.unauthorized_dm_behavior: ignore` in `~/.hermes/config.yaml` if you want unauthorized DMs to be silently ignored instead. |
 
 ---


### PR DESCRIPTION
## What does this PR do?

Documents which WhatsApp chats the Baileys bridge handles and which it filters before dispatch.

The issue says a Community announcement channel is dropped. Current code does not support that claim: Baileys marks `@g.us` chats as groups, while Hermes filters `@broadcast` and `@newsletter` IDs. This PR documents the current suffix-based behavior instead of repeating the inaccurate premise.

It also keeps the Cloud API's direct-message-only limitation visible and links the two guides.

## Related Issue

Addresses #80087

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Security fix
- [x] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Document Status, broadcast-list, and Channel filtering in the Baileys guide.
- Explain how ordinary groups and Community chats reported as `@g.us` enter the normal group path.
- Add troubleshooting guidance for filtered chats.
- Cross-link the Baileys behavior from the Cloud API guide and comparison table.

Dropped-event counters remain outside this documentation-only change.

## How to Test

1. Run `python -m pytest tests/gateway/test_whatsapp_group_gating.py -q`.
2. Run `cd website && npm run build:fast`.
3. Check both new cross-links in the generated documentation.

## Verification

- Targeted gateway tests: `10 passed`.
- Docusaurus production build: passed.
- The build reported two existing `/docs/` warnings for `/docs/llms.txt` and `/docs/llms-full.txt`; neither link is touched by this PR.

## Assistance

GPT assisted with the documentation and pull-request draft. Claude independently reviewed the factual claims and issue coverage. Rook checked the source, ran the reported commands, resolved the review findings, and submitted the change.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed PRs for #80087 and related WhatsApp filtering terms.
- [x] This PR contains only changes related to #80087.
- [ ] I ran the full test suite. This documentation-only change used the targeted gateway tests above.
- [x] Tests already cover the behavior being documented; no runtime behavior changed.
- [x] Tested on macOS.

### Documentation and housekeeping

- [x] Relevant user documentation is updated.
- [x] `cli-config.yaml.example`: N/A, no configuration changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md`: N/A, no workflow or architecture changed.
- [x] Cross-platform impact: N/A, documentation only.
- [x] Tool descriptions and schemas: N/A, no tool behavior changed.