### PR TITLE
fix(cli): restore WSL image paste with stripped Windows PATH

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -15,6 +15,7 @@ Platform support:
 import base64
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -76,7 +77,7 @@ def _write_clipboard_commands() -> list:
         return [(["powershell", "-NoProfile", "-NonInteractive"], False)]
     attempts = []
     if _is_wsl():
-        attempts.append((["powershell.exe", "-NoProfile", "-NonInteractive"], False))
+        attempts.append(([_wsl_powershell_exe(), "-NoProfile", "-NonInteractive"], False))
     if os.environ.get("WAYLAND_DISPLAY"):
         attempts.append((["wl-copy", "--type", "text/plain"], True))
     attempts.append((["xclip", "-selection", "clipboard", "-in"], True))
@@ -390,14 +391,26 @@ def _linux_save(dest: Path) -> bool:
 # ── WSL2 (powershell.exe) ────────────────────────────────────────────────
 # Reuses _PS_CHECK_IMAGE / _PS_EXTRACT_IMAGE defined above.
 
+_WSL_POWERSHELL_FALLBACK = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+
+
+def _wsl_powershell_exe() -> str:
+    """Resolve PowerShell even when WSL omits Windows directories from PATH."""
+    exe = shutil.which("powershell.exe")
+    if exe:
+        return exe
+    if os.path.isfile(_WSL_POWERSHELL_FALLBACK):
+        return _WSL_POWERSHELL_FALLBACK
+    return "powershell.exe"
+
 def _wsl_has_image() -> bool:
     """Check if Windows clipboard has an image (via powershell.exe)."""
-    return _powershell_has_image("powershell.exe", timeout=8, label="WSL")
+    return _powershell_has_image(_wsl_powershell_exe(), timeout=8, label="WSL")
 
 
 def _wsl_save(dest: Path) -> bool:
     """Extract clipboard image via powershell.exe → base64 → decode to PNG."""
-    return _powershell_save_image("powershell.exe", dest, timeout=15, label="WSL")
+    return _powershell_save_image(_wsl_powershell_exe(), dest, timeout=15, label="WSL")
 
 
 # ── Wayland (wl-paste) ──────────────────────────────────────────────────

--- a/tests/hermes_cli/test_clipboard_text_write.py
+++ b/tests/hermes_cli/test_clipboard_text_write.py
@@ -43,6 +43,15 @@ def test_linux_falls_through_backends_until_success():
     assert calls == ["xclip", "xsel"]
 
 
+@pytest.mark.linux_only
+def test_wsl_text_write_uses_resolved_powershell():
+    with patch.object(clip, "_is_wsl", return_value=True), \
+         patch.object(clip, "_wsl_powershell_exe", return_value="/wsl/powershell.exe"), \
+         patch.object(clip.subprocess, "run", return_value=_completed()) as run:
+        assert clip.write_clipboard_text("hello") is True
+    assert run.call_args[0][0][0] == "/wsl/powershell.exe"
+
+
 
 
 

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -29,6 +29,7 @@ from hermes_cli.clipboard import (
     _xclip_has_image,
     _wsl_save,
     _wsl_has_image,
+    _wsl_powershell_exe,
     _wayland_save,
     _wayland_has_image,
     _windows_save,
@@ -155,15 +156,34 @@ class TestIsWsl:
 
 # ── WSL (powershell.exe) ────────────────────────────────────────────────
 
+class TestWslPowershellExe:
+    def test_prefers_path_candidate(self):
+        with patch("hermes_cli.clipboard.shutil.which", return_value="/opt/windows/powershell.exe"):
+            assert _wsl_powershell_exe() == "/opt/windows/powershell.exe"
+
+    def test_uses_standard_interop_path_when_path_is_stripped(self):
+        fallback = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        with patch("hermes_cli.clipboard.shutil.which", return_value=None), \
+             patch("hermes_cli.clipboard.os.path.isfile", return_value=True) as isfile:
+            assert _wsl_powershell_exe() == fallback
+        isfile.assert_called_once_with(fallback)
+
+    def test_preserves_graceful_failure_when_no_candidate_exists(self):
+        with patch("hermes_cli.clipboard.shutil.which", return_value=None), \
+             patch("hermes_cli.clipboard.os.path.isfile", return_value=False):
+            assert _wsl_powershell_exe() == "powershell.exe"
+
 class TestWslHasImage:
     @pytest.mark.parametrize("stdout, expected", [
         ("True\n", True),
         ("False\n", False),
     ])
     def test_clipboard_image_probe(self, stdout, expected):
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._wsl_powershell_exe", return_value="/wsl/powershell.exe"), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout=stdout, returncode=0)
             assert _wsl_has_image() is expected
+        assert mock_run.call_args[0][0][0] == "/wsl/powershell.exe"
 
     def test_falls_back_to_get_clipboard_image(self):
         with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
@@ -179,9 +199,11 @@ class TestWslSave:
     def test_successful_extraction(self, tmp_path):
         dest = tmp_path / "out.png"
         b64_png = base64.b64encode(FAKE_PNG).decode()
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._wsl_powershell_exe", return_value="/wsl/powershell.exe"), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout=b64_png + "\n", returncode=0)
             assert _wsl_save(dest) is True
+        assert mock_run.call_args[0][0][0] == "/wsl/powershell.exe"
         assert dest.read_bytes() == FAKE_PNG
 
 


### PR DESCRIPTION
## What does this PR do?

Restores CLI and TUI clipboard image attachment in WSL when `appendWindowsPath=false` removes Windows executables from `PATH`. Hermes now keeps the PATH-resolved PowerShell candidate as the first choice and falls back to the standard WSL interop path, so `/paste` and image-only Ctrl+V can reach the Windows clipboard without weakening the existing fallback behavior.

### Symptom

In hardened WSL setups, `/paste` reports `No image found in clipboard` and image-only Ctrl+V does nothing even though the Windows clipboard contains an image.

### Impact

Users who disable Windows PATH injection cannot attach Windows clipboard images from the CLI or TUI. Normal terminal text paste is unaffected.

### Bug Cause

**Trigger:** `hermes_cli/clipboard.py:393` / `_wsl_has_image()` and `hermes_cli/clipboard.py:398` / `_wsl_save()` when WSL has `appendWindowsPath=false`.

**Causal chain:**
1. WSL starts Hermes without Windows directories in `PATH`.
2. The shared image probe and extraction paths launch the bare `powershell.exe` name.
3. `subprocess.run` raises `FileNotFoundError`; the existing handlers return `False`, so both CLI entry points treat the clipboard as image-free.

**Why it is wrong:** WSL interop remains available through the standard mounted Windows path even when Windows PATH injection is intentionally disabled.

**Working sibling / contrast:** Native Windows already discovers an available PowerShell executable. The same WSL resolver is now shared by image reads and clipboard text writes so sibling WSL PowerShell paths cannot drift.

**Ruled out:** The failure is not in bracketed-paste routing or image decoding. Both `/paste` and Ctrl+V converge on the same WSL clipboard backend before those paths diverge.

### Fix

Add a WSL PowerShell resolver that prefers `shutil.which("powershell.exe")`, falls back to `/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe` when present, and preserves the bare-name fallback when neither candidate can be resolved. Route WSL clipboard probe, extraction, and text-write commands through that resolver.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/clipboard.py` - resolve PowerShell for WSL clipboard operations when Windows PATH injection is disabled.
- `tests/tools/test_clipboard.py` - cover PATH preference, the standard interop fallback, graceful failure, and resolved image command routing.
- `tests/hermes_cli/test_clipboard_text_write.py` - cover the sibling WSL clipboard text-write command path.

## How to Test

1. In WSL2, set `[interop] appendWindowsPath=false` in `/etc/wsl.conf` and restart WSL.
2. Put an image on the Windows clipboard, run Hermes, and verify both `/paste` and image-only Ctrl+V attach it.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/tools/test_clipboard.py tests/hermes_cli/test_clipboard_text_write.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test wrapper on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated suite on Windows 11; WSL interop verification is assigned to the review phase

### Documentation & Housekeeping

- [x] Documentation update is N/A; no user-facing interface changed
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; non-WSL platform dispatch is unchanged
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

Focused automated suite: 44 passed, 5 platform-marked tests skipped on the Windows host.
