### PR TITLE
fix(desktop): use ~/.local/bin/hermes wrapper in XDG desktop entry when uv-managed interpreter detected

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,7 +78,18 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            #
+            # Exception: if sys.executable is a uv-managed interpreter
+            # (path contains "uv/python/cpython-"), it lives outside the venv
+            # and also lacks hermes dependencies when launched by a DE (#92923).
+            # In that case look for the shell wrapper in ~/.local/bin first.
+            exe = Path(sys.executable).resolve()
+            if "uv/python/cpython-" in str(exe) or "uv/python/pypy-" in str(exe):
+                # Prefer the user-local shell wrapper which sources the venv
+                local_bin = Path.home() / ".local" / "bin" / "hermes"
+                if local_bin.is_file():
+                    return " ".join(_quote_exec_arg(a) for a in [str(local_bin), "desktop"])
+            argv = [str(exe), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
﻿On uv-managed installs, sys.executable is outside the venv. Prefer ~/.local/bin/hermes wrapper when uv path detected. Fixes #92923.
