### PR TITLE
fix(install): restore Intel macOS cryptography wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,14 @@ dependencies = [
   #
   # A pin here is not sufficient on its own. alibabacloud-tea-openapi caps
   # cryptography<49, so [tool.uv] also holds an override. Read that comment
-  # before you move this version.
-  "cryptography==50.0.0",  # CVE-2026-69247, GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww, CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf
+  # before you move this version. cryptography stopped publishing Intel macOS
+  # wheels in 49.0.0; keep the last wheel-backed release on that platform so
+  # installs without a Rust/OpenSSL toolchain remain possible. This is a
+  # temporary compatibility exception: 48.0.1 lacks the PKCS#7 oracle fix in
+  # 50.0.0. Remove it when upstream restores Intel wheels or Hermes ships a
+  # trusted x86_64 wheel.
+  "cryptography==50.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",  # CVE-2026-69247, GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww, CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf
+  "cryptography==48.0.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",  # Last release with Intel macOS wheels
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package
@@ -401,8 +407,10 @@ override-dependencies = [
   # and its three advisories (see the cryptography pin in
   # [project].dependencies). The package uses cryptography only to sign
   # requests with RSA and AES, and that API did not break in 49 or 50.
-  # Remove this line when alibabacloud-tea-openapi lifts the cap.
-  "cryptography>=50,<51",
+  # Remove this override when alibabacloud-tea-openapi lifts the cap. Keep the
+  # Intel macOS marker aligned with the direct dependency above.
+  "cryptography>=50,<51; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+  "cryptography==48.0.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 exclude-newer = "14 days"
 # h2: temporary exclude-newer exception for the CVE-2026-71554 (GHSA-6hr6-w5qg-qmwg,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,9 +407,9 @@ override-dependencies = [
   # and its three advisories (see the cryptography pin in
   # [project].dependencies). The package uses cryptography only to sign
   # requests with RSA and AES, and that API did not break in 49 or 50.
-  # Remove this override when alibabacloud-tea-openapi lifts the cap. Keep the
-  # Intel macOS marker aligned with the direct dependency above.
-  "cryptography>=50,<51; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+  # Remove this override when alibabacloud-tea-openapi lifts the cap. Keep both
+  # exact versions and their markers aligned with the direct dependencies above.
+  "cryptography==50.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "cryptography==48.0.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 exclude-newer = "14 days"

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -4,6 +4,9 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -72,6 +75,8 @@ _UPDATE_DOWNGRADE_GUARD_FLOORS = {
     "starlette": (1, 3, 1),
     "python-multipart": (0, 0, 32),
 }
+_CRYPTOGRAPHY_INTEL_MACOS_PIN = Version("48.0.1")
+_CRYPTOGRAPHY_DEFAULT_PIN = Version("50.0.0")
 
 
 def _version_tuple(spec: str) -> tuple[int, ...]:
@@ -192,6 +197,60 @@ def _pins_from_specs(specs):
     return pins
 
 
+def _supported_marker_environments():
+    """Representative PEP 508 environments supported by Hermes.
+
+    Marker evaluation is pure input/output here: it checks declaration
+    compatibility without pretending the test process is running on another
+    host. Keep Python versions aligned with ``project.requires-python`` and
+    platform spellings aligned with the markers used in this pyproject.
+    """
+    base = default_environment()
+    platforms = (
+        ("linux", "Linux", "posix", "x86_64"),
+        ("linux", "Linux", "posix", "aarch64"),
+        ("darwin", "Darwin", "posix", "x86_64"),
+        ("darwin", "Darwin", "posix", "arm64"),
+        ("win32", "Windows", "nt", "AMD64"),
+        ("win32", "Windows", "nt", "ARM64"),
+    )
+    for python_version in ("3.11", "3.12", "3.13"):
+        for sys_platform, platform_system, os_name, platform_machine in platforms:
+            yield {
+                **base,
+                "python_version": python_version,
+                "python_full_version": f"{python_version}.0",
+                "sys_platform": sys_platform,
+                "platform_system": platform_system,
+                "os_name": os_name,
+                "platform_machine": platform_machine,
+                "platform_release": "0",
+                "platform_version": "0",
+            }
+
+
+def _pin_conflicts_by_environment(specs):
+    """Return exact-pin conflicts that can coexist in a supported environment."""
+    requirements = []
+    for spec in specs:
+        match = _PIN_RE.match(spec)
+        if match:
+            requirements.append(
+                (_canonical(match.group(1)), match.group(2), Requirement(spec).marker)
+            )
+
+    conflicts: dict[str, set[str]] = {}
+    for environment in _supported_marker_environments():
+        active: dict[str, set[str]] = {}
+        for name, version, marker in requirements:
+            if marker is None or marker.evaluate(environment):
+                active.setdefault(name, set()).add(version)
+        for name, versions in active.items():
+            if len(versions) > 1:
+                conflicts.setdefault(name, set()).update(versions)
+    return {name: sorted(versions) for name, versions in conflicts.items()}
+
+
 def _locked_versions(package: str) -> set[str]:
     lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
     return {
@@ -235,17 +294,87 @@ def _lazy_deps_pinned_specs():
 
 
 def test_pyproject_pins_are_internally_consistent():
-    """No package may be exact-pinned to two different versions in pyproject.
+    """No environment may receive two exact versions of one package.
 
     A package legitimately appearing in several extras (e.g. aiohttp in
-    messaging/slack/homeassistant/sms) must use the SAME version everywhere.
+    messaging/slack/homeassistant/sms) must use the SAME version wherever its
+    markers overlap. Mutually exclusive platform pins may differ.
     """
-    pins = _pins_from_specs(_pyproject_pinned_specs())
-    conflicts = {name: sorted(v) for name, v in pins.items() if len(v) > 1}
+    conflicts = _pin_conflicts_by_environment(_pyproject_pinned_specs())
     assert not conflicts, (
         "pyproject.toml exact-pins the same package to different versions "
-        "across [project.dependencies] / extras: " + str(conflicts)
+        "in at least one supported environment across [project.dependencies] "
+        "/ extras: " + str(conflicts)
     )
+
+
+@pytest.mark.parametrize(
+    ("specs", "expected"),
+    [
+        (["demo==1.0", "demo==2.0"], {"demo": ["1.0", "2.0"]}),
+        (
+            [
+                "demo==1.0; sys_platform == 'darwin'",
+                "demo==2.0; sys_platform == 'linux'",
+            ],
+            {},
+        ),
+        (
+            [
+                "demo==1.0; sys_platform != 'win32'",
+                "demo==2.0; sys_platform == 'linux'",
+            ],
+            {"demo": ["1.0", "2.0"]},
+        ),
+        (
+            [
+                "demo==1.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+                "demo==2.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+            ],
+            {},
+        ),
+    ],
+)
+def test_pin_conflicts_respect_environment_markers(specs, expected):
+    assert _pin_conflicts_by_environment(specs) == expected
+
+
+def test_cryptography_platform_pins_are_complete_and_security_scoped():
+    """Every supported environment gets exactly its intended cryptography pin.
+
+    Intel macOS is a deliberate compatibility exception: 49+ has no x86_64
+    macOS wheel, while 48.0.1 is the last universal2 release. All other
+    environments must stay at the reviewed 50.0.0 security pin.
+    """
+    requirements = [
+        Requirement(spec)
+        for spec in _pyproject_pinned_specs()
+        if _canonical(_distribution_name(spec)) == "cryptography"
+        and _PIN_RE.match(spec)
+    ]
+
+    for environment in _supported_marker_environments():
+        active_versions = {
+            Version(_PIN_RE.match(str(requirement)).group(2))
+            for requirement in requirements
+            if requirement.marker is None or requirement.marker.evaluate(environment)
+        }
+        is_intel_macos = (
+            environment["sys_platform"] == "darwin"
+            and environment["platform_machine"] == "x86_64"
+        )
+        expected = (
+            {_CRYPTOGRAPHY_INTEL_MACOS_PIN}
+            if is_intel_macos
+            else {_CRYPTOGRAPHY_DEFAULT_PIN}
+        )
+        assert active_versions == expected, (
+            "cryptography pins do not provide exactly the intended version for "
+            f"{environment['sys_platform']}/{environment['platform_machine']}/"
+            f"Python {environment['python_version']}: "
+            f"got {sorted(map(str, active_versions))}, "
+            f"expected {sorted(map(str, expected))}"
+        )
 
 
 def test_build_system_requires_exempt_from_exclude_newer():

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 
 [options]
@@ -28,7 +31,8 @@ nemo-relay = false
 
 [manifest]
 overrides = [
-    { name = "cryptography", specifier = ">=50,<51" },
+    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=50,<51" },
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==48.0.1" },
     { name = "pynacl", specifier = ">=1.6,<1.7" },
 ]
 
@@ -273,7 +277,8 @@ version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alibabacloud-tea-util" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/51/be5802851a4ed20ac2c6db50ac8354a6e431e93db6e714ca39b50983626f/alibabacloud_openapi_util-0.2.4.tar.gz", hash = "sha256:87022b9dcb7593a601f7a40ca698227ac3ccb776b58cb7b06b8dc7f510995c34", size = 7981, upload-time = "2026-01-15T08:05:03.947Z" }
 wheels = [
@@ -298,7 +303,8 @@ dependencies = [
     { name = "alibabacloud-credentials" },
     { name = "alibabacloud-gateway-spi" },
     { name = "alibabacloud-tea-util" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "darabonba-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/73/fb0c4d44759791ecdf269fc715c1e810fa1aba3981bfaaf8a01f61899296/alibabacloud_tea_openapi-0.4.5.tar.gz", hash = "sha256:75fa1f4360a46e41f5bf5f8d4917e52efb6f64885839bc1328c35590670c97b9", size = 26616, upload-time = "2026-07-14T13:15:39.364Z" }
@@ -496,7 +502,8 @@ version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "msal" },
     { name = "msal-extensions" },
     { name = "typing-extensions" },
@@ -775,8 +782,31 @@ wheels = [
 
 [[package]]
 name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+]
+
+[[package]]
+name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+]
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -1429,7 +1459,8 @@ name = "google-auth"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
@@ -1591,7 +1622,8 @@ dependencies = [
     { name = "certifi" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'" },
     { name = "croniter" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "fastapi" },
     { name = "fire" },
     { name = "firecrawl-anydoc" },
@@ -1847,7 +1879,8 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.5.20" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
-    { name = "cryptography", specifier = "==50.0.0" },
+    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = "==50.0.0" },
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==48.0.1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -2529,7 +2562,8 @@ name = "microsoft-teams-apps"
 version = "2.0.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "dependency-injector" },
     { name = "fastapi" },
     { name = "microsoft-teams-api" },
@@ -2615,7 +2649,8 @@ name = "msal"
 version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
@@ -3543,7 +3578,8 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -4067,7 +4103,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12'",
+    "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy" },
@@ -4121,8 +4158,10 @@ name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "(python_full_version >= '3.13' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and sys_platform != 'darwin')",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ nemo-relay = false
 
 [manifest]
 overrides = [
-    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=50,<51" },
+    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = "==50.0.0" },
     { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==48.0.1" },
     { name = "pynacl", specifier = ">=1.6,<1.7" },
 ]


### PR DESCRIPTION
Closes #84127.

## What changed

- Pin `cryptography==48.0.1` only when both `sys_platform == "darwin"` and `platform_machine == "x86_64"`.
- Keep every other supported platform on the reviewed exact `cryptography==50.0.0` pin.
- Apply the same mutually exclusive markers to uv overrides and regenerate the universal lockfile.
- Make the existing exact-pin consistency check marker-aware, while retaining rejection of overlapping conflicting pins.
- Add a platform matrix contract covering Python 3.11–3.13 across Linux, macOS, and Windows architectures.

`cryptography` 49.0.0 removed Intel macOS wheels. The previous unconditional 50.0.0 pin therefore forced an sdist build on Intel Macs and failed on machines without a Rust/OpenSSL build toolchain.

## Security trade-off

This is an explicit, temporary compatibility exception, not a security-equivalent version.

`cryptography==48.0.1` does not contain the PKCS#7 Bleichenbacher-oracle fix added in 50.0.0 (CVE-2026-69247). The downgrade is restricted to Intel macOS, where 48.0.1 is the last release with a universal2 wheel. The exception should be removed when upstream restores x86_64 wheels or Hermes ships a trusted wheel.

The two advisories patched in 49.0.0 list affected versions through 48.0.0, so 48.0.1 is outside their affected ranges:

- https://github.com/pyca/cryptography/security/advisories/GHSA-m2h6-j472-rp4c
- https://github.com/pyca/cryptography/security/advisories/GHSA-jwv3-5hgf-82ww

## Verification

- Before the change, `uv pip compile ... --python-platform x86_64-apple-darwin --only-binary cryptography` failed because `cryptography>=50.0.0` had no usable wheel.
- After the change, the same Intel macOS target resolves the full `[all]+[dev]` graph with `cryptography==48.0.1`.
- Apple Silicon macOS and Linux x86_64 target resolution both remain on `cryptography==50.0.0`.
- `scripts/run_tests.sh tests/test_project_metadata.py tests/test_packaging_metadata.py`: 19 passed.
- `uv lock --check`: passed.
- `uv sync --locked --dry-run --extra all --extra dev`: passed.
- `uv run ruff check tests/test_packaging_metadata.py`: passed.
- `scripts/check-windows-footguns.py --diff origin/main`: passed.

## Validation boundary

I do not have an Intel Mac, so I am not claiming local native installation coverage. The issue contains successful native reproduction and validation from two Intel Mac users. My local evidence is uv cross-platform target resolution with binary-only `cryptography`, plus native Apple Silicon locked-resolution checks.

The separate `.update-incomplete` three-attempt recovery deadlock reported in the issue is intentionally out of scope.