### PR TITLE
fix(state): retry bare SQLite NULL SystemError

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5292,8 +5292,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # SQLite build — some surface it as InterfaceError, which lives
         # OUTSIDE DatabaseError and escaped the retry net entirely on
         # attempt 0 — so the check is message-scoped, not class-scoped.
-        def _is_no_more_rows(exc: sqlite3.Error) -> bool:
+        def _is_no_more_rows(exc: BaseException) -> bool:
             return "no more rows available" in str(exc).lower()
+
+        def _is_null_without_exception(exc: BaseException) -> bool:
+            """Recognize SQLite's transient contended-WAL SystemError.
+
+            Some Python/SQLite combinations surface the same driver-level
+            condition covered by ``no more rows available`` as a bare
+            ``SystemError`` instead of a sqlite3.Error.  It is transient under
+            concurrent WAL writers, but the message check must stay narrow so
+            unrelated SystemError instances are never swallowed (#85079).
+            """
+            return (
+                isinstance(exc, SystemError)
+                and "returned null without setting an exception" in str(exc).lower()
+            )
 
         while True:
             try:
@@ -5315,6 +5329,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if self._write_count % self._FTS_MERGE_EVERY_N_WRITES == 0:
                     self._try_incremental_merge_fts()
                 return result
+            except SystemError as exc:
+                # On some Python/SQLite builds, a contended WAL append escapes
+                # as SystemError("returned NULL without setting an exception")
+                # rather than sqlite3.Error.  Treat only this known transient
+                # driver shape as retryable; unrelated SystemError instances
+                # must still propagate unchanged (#85079, #94258).
+                if _is_null_without_exception(exc) and self._sleep_before_write_retry(
+                    deadline, patience_s
+                ):
+                    continue
+                raise
             except SessionCompressionInProgressError:
                 # A live foreign compression lock is transient: the compressor
                 # publishes in a couple of seconds. Without any wait, a steer

--- a/tests/hermes_state/test_execute_write_null_retry.py
+++ b/tests/hermes_state/test_execute_write_null_retry.py
@@ -1,0 +1,54 @@
+"""Regression tests for transient SQLite WAL append SystemErrors (#85079)."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def test_execute_write_retries_transient_null_without_exception(tmp_path, monkeypatch):
+    """The SQLite driver spelling is retried through the normal write budget."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        attempts = []
+        sleeps = []
+
+        def write(_conn):
+            attempts.append(True)
+            if len(attempts) == 1:
+                raise SystemError("returned NULL without setting an exception")
+            return "committed"
+
+        def fake_sleep(deadline, patience_s):
+            sleeps.append((deadline, patience_s))
+            return True
+
+        monkeypatch.setattr(db, "_sleep_before_write_retry", fake_sleep)
+
+        assert db._execute_write(write, patience_s=1.0) == "committed"
+        assert len(attempts) == 2
+        assert len(sleeps) == 1
+    finally:
+        db.close()
+
+
+def test_execute_write_does_not_swallow_unrelated_system_error(tmp_path, monkeypatch):
+    """Only the known SQLite driver message is eligible for retry."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sleeps = []
+
+        def fail(_conn):
+            raise SystemError("unrelated driver failure")
+
+        monkeypatch.setattr(
+            db,
+            "_sleep_before_write_retry",
+            lambda deadline, patience_s: sleeps.append(True),
+        )
+
+        with pytest.raises(SystemError, match="unrelated driver failure"):
+            db._execute_write(fail, patience_s=1.0)
+
+        assert sleeps == []
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

Adds a narrowly-scoped retry for the bare Python `SystemError` emitted by the
CPython SQLite wrapper during a transient contended WAL write:

```text
<TrackedConnection ...> returned NULL without setting an exception
```

`SessionDB._execute_write()` already retries several `sqlite3.Error` variants,
and PR #85065 covers the same text when it is wrapped as
`sqlite3.InterfaceError`/`sqlite3.DatabaseError`. However, on the affected
runtime the exception is a plain `SystemError`, so it bypasses every existing
SQLite exception handler and terminates the turn as
`session_persistence_failed`.

This PR complements #85065 and addresses the bare-`SystemError` path described
in #94258. The match remains message-scoped and uses the existing bounded write
patience budget; unrelated `SystemError` instances are still re-raised.

## Related Issue

Fixes #94258

Related: #85065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - Recognize `SystemError` with the exact known driver message
    `returned NULL without setting an exception`.
  - Route only that error through `_sleep_before_write_retry()` and the
    existing deadline/patience loop.
  - Preserve immediate propagation for unrelated `SystemError` values.
- `tests/hermes_state/test_execute_write_null_retry.py`
  - Verify the known bare `SystemError` retries and then succeeds.
  - Verify an unrelated `SystemError` is not swallowed or retried.

## Detailed Reproduction Report

### Environment

- Hermes Agent: `0.20.6`
- OS: Linux `6.12.94+deb13-cloud-amd64`
- Python: `3.11.15`
- SQLite: `3.53.1`
- Journal mode: WAL
- Database: approximately 1.9 GB with approximately 118k stored messages
- Free disk at reproduction: approximately 250 GB

### Failure

On 2026-08-31 (China Standard Time), a long Telegram session failed while
processing an uploaded JSON file. The model had returned a reasoning response
and Hermes was preparing to continue the tool-driven turn. The transcript append
then failed with:

```text
Session DB append_message failed:
<TrackedConnection ...> returned NULL without setting an exception

Turn ended: reason=session_persistence_failed
```

The same failure was observed again in a later continuation of the session.
The uploaded file had already been cached; this was a session-persistence
failure, not an upload or application-data failure.

The session was unusually long (roughly 263 historical messages and an
estimated 270k-token context). The database was writable and the host was not
out of disk space. The error did not match the existing `sqlite3.Error` retry
branches, so the turn stopped instead of retrying the append.

### Separate observation

The same local investigation also found:

```text
malformed inverted index for FTS5 table main.messages_fts_trigram
```

That is a separate FTS5-index health issue and is intentionally **not** changed
by this PR. No local database or user transcript is included in this change.

## How to Test

1. Run the focused regression tests:

   ```bash
   /usr/local/lib/hermes-agent/venv/bin/pytest -q \
     tests/hermes_state/test_execute_write_null_retry.py
   ```

   Result: `2 passed`.

2. Run the full state-database test module:

   ```bash
   /usr/local/lib/hermes-agent/venv/bin/pytest -q tests/hermes_state
   ```

   Result: `202 passed`.

3. Revert the `except SystemError` block and rerun the focused tests. The
   transient-error test fails because the known driver error propagates instead
   of reaching the second attempt.

4. The existing full-suite command was also attempted locally, but exceeded
   the available 420-second execution window on this 4-core host; it is not
   claimed as passed here. Syntax compilation and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.com/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite exceeded the local execution window; focused and state tests pass as reported above)
- [x] I've added tests for the bug fix
- [x] I've tested on Linux with Python 3.11 and SQLite 3.53.1

### Documentation & Housekeeping

- [x] Relevant behavior is documented in the code and PR report — N/A for user docs
- [x] No config keys changed
- [x] No architecture/workflow docs changed
- [x] Cross-platform impact considered: the handling is stdlib exception/message
  based and does not use platform-specific APIs
- [x] No tool schemas changed

## Screenshots / Logs

Redacted pre-fix log shape:

```text
WARNING run_agent: Session DB append_message failed:
<TrackedConnection object at 0x...> returned NULL without setting an exception
INFO agent.conversation_loop: Turn ended: reason=session_persistence_failed
```

The proposed path rolls back the failed transaction, waits through the existing
bounded retry policy, and retries the same write. If the patience budget is
exhausted, the original `SystemError` is still raised.
