### PR TITLE
fix(tui_gateway): focused-profile config reads and writes no longer land on the launch profile (#95760, salvage #95823)

### DIFF
--- a/tests/tui_gateway/test_config_profile_scope.py
+++ b/tests/tui_gateway/test_config_profile_scope.py
@@ -1,0 +1,113 @@
+"""config.get / config.set must honor params.profile (issue #95760).
+
+A single dashboard backend in desktop app-global remote mode serves every
+profile. projects.* RPCs already bind params.profile via @_profile_scoped;
+config.get / config.set did not, so reads and persistent writes used the
+launch profile's config.yaml for every focused profile.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import tui_gateway.server as server
+
+
+LAUNCH_CWD = "/workspace/default"
+WORKER_CWD = "/workspace/code"
+LAUNCH_ROOTS = ["/workspace/default"]
+WORKER_ROOTS = ["/workspace/code"]
+
+
+def _write_cfg(home: Path, cwd: str, roots: list[str]) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "terminal": {"cwd": cwd},
+                "desktop": {"repo_scan_roots": list(roots)},
+                "display": {"busy_input_mode": "queue"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _homes(tmp_path: Path) -> tuple[Path, Path]:
+    launch = tmp_path / "launch"
+    worker = tmp_path / "profiles" / "code"
+    _write_cfg(launch, LAUNCH_CWD, LAUNCH_ROOTS)
+    _write_cfg(worker, WORKER_CWD, WORKER_ROOTS)
+    return launch, worker
+
+
+def _reset_cfg_cache() -> None:
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+
+def _bind_homes(monkeypatch, launch: Path, worker: Path) -> None:
+    monkeypatch.setattr(server, "_hermes_home", launch)
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda name: worker if (name or "").strip() == "code" else None,
+    )
+    _reset_cfg_cache()
+
+
+def _get(params: dict) -> dict:
+    return server._methods["config.get"]("rid-get", params)
+
+
+def _set(params: dict) -> dict:
+    return server._methods["config.set"]("rid-set", params)
+
+
+def _read_yaml(home: Path) -> dict:
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
+def test_config_get_full_reads_params_profile_yaml_not_launch(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    launch_resp = _get({"key": "full"})
+    assert launch_resp["result"]["config"]["terminal"]["cwd"] == LAUNCH_CWD
+    assert launch_resp["result"]["config"]["desktop"]["repo_scan_roots"] == LAUNCH_ROOTS
+
+    _reset_cfg_cache()
+    worker_resp = _get({"key": "full", "profile": "code"})
+    assert worker_resp["result"]["config"]["terminal"]["cwd"] == WORKER_CWD
+    assert worker_resp["result"]["config"]["desktop"]["repo_scan_roots"] == WORKER_ROOTS
+
+    # Launch file must be untouched by the focused-profile read.
+    assert _read_yaml(launch)["terminal"]["cwd"] == LAUNCH_CWD
+
+
+def test_config_set_persistent_write_lands_on_params_profile_yaml(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    resp = _set({"key": "busy", "value": "steer", "profile": "code"})
+    assert resp["result"]["value"] == "steer"
+
+    worker_cfg = _read_yaml(worker)
+    launch_cfg = _read_yaml(launch)
+    assert worker_cfg["display"]["busy_input_mode"] == "steer"
+    assert launch_cfg["display"]["busy_input_mode"] == "queue"
+    assert launch_cfg["terminal"]["cwd"] == LAUNCH_CWD
+    assert worker_cfg["terminal"]["cwd"] == WORKER_CWD
+
+
+def test_config_set_without_profile_still_writes_launch_home(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    resp = _set({"key": "busy", "value": "interrupt"})
+    assert resp["result"]["value"] == "interrupt"
+    assert _read_yaml(launch)["display"]["busy_input_mode"] == "interrupt"
+    assert _read_yaml(worker)["display"]["busy_input_mode"] == "queue"

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -179,6 +179,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("config.get")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     key = params.get("key", "")
     if key == "provider":

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4430,7 +4430,9 @@ def _save_cfg(cfg: dict):
 
     from utils import atomic_roundtrip_yaml_save
 
-    path = _hermes_home / "config.yaml"
+    override = get_hermes_home_override()
+    home = Path(override) if isinstance(override, str) and override else _hermes_home
+    path = Path(home) / "config.yaml"
     # Comment-, ordering-, and Unicode-preserving full-state write.
     # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
     # `atomic_config_write`, which is not comment-preserving) which clobbered
@@ -13919,6 +13921,7 @@ def _respond(rid, params, key, *, allow_expired=False):
 # opt/model-resolution-core PR touches its body; move it to methods_config.py
 # in a follow-up once that PR lands.
 @method("config.set")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
     session = _sessions.get(params.get("session_id", ""))


### PR DESCRIPTION
## Summary
Desktop/TUI `config.get` / `config.set` RPCs now honor `params.profile`: on a shared app-global remote backend, focused-profile config reads return that profile's `config.yaml` and persistent writes land in it — previously both silently used the launch profile's file (#95760).

Salvage of #95823 by @StanleyStetson (clean cherry-pick, 0 commits behind main at push).

Root cause: `projects.*` RPCs were profile-scoped via `@_profile_scoped`, but `config.get`/`config.set` never got the decorator, and `_save_cfg` hardcoded `_hermes_home / "config.yaml"` — ignoring the contextvar home override the decorator installs.

## Changes
- `tui_gateway/methods_config.py`: `@_profile_scoped` on `config.get`
- `tui_gateway/server.py`: `@_profile_scoped` on `config.set`; `_save_cfg` writes through `get_hermes_home_override()` when active
- `tests/tui_gateway/test_config_profile_scope.py`: profile-scoped read, profile-scoped persistent write, and no-profile launch-home fallback

## Validation
| | Before (origin/main) | After |
|---|---|---|
| `config.get {profile: code}` | launch profile's yaml | focused profile's yaml |
| `config.set {profile: code}` | writes launch `config.yaml` | writes `profiles/code/config.yaml` only |
| `config.set` (no profile) | launch home | launch home (unchanged) |

Sabotage run: both new scoping tests FAIL with the fix reverted, pass with it. Sibling coverage green: 71 config-k tests in `tests/tui_gateway/`, 111 config/profile-k tests in `tests/test_tui_gateway_server.py`.

**Live repro:** real `tui_gateway.server` handlers invoked against two real on-disk `config.yaml` homes — pre-fix both reads and writes hit the launch home (matching #95760's report); post-fix they hit the focused profile's home.

## Infographic

![Profile-scoped config RPC](https://v3b.fal.media/files/b/0aa888d6/Lm8fcrxx3yW_ZGUGqkENx_v1Ag3o21.png)

Fixes #95760

Credit: @StanleyStetson (#95823). Related earlier reports of the same class: #46155, #45899 (session-resume flavor), #85669 (write half), #85676.
