### PR TITLE
feat(gateway): authorize Discord profile routes

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -38,6 +38,11 @@ profile_routes:
     guild_id: "1234567890"
     chat_id: "9876543210"
     profile: support-profile
+    # Optional: let these Discord principals send conversational messages only
+    # when this route matches. The global bot allowlist still applies elsewhere.
+    authorization:
+      allowed_users: ["184587051943985152"]
+      allowed_roles: ["112233445566778899"]
 
   # Pin a Telegram group to a profile (Telegram has no guild_id — chat_id only).
   - name: tg-group
@@ -65,6 +70,27 @@ profile_routes:
 | `chat_id` | no | Channel/group/DM id. |
 | `thread_id` | no | Thread id within a channel. |
 | `enabled` | no | Default `true`; set `false` to disable a route without removing it. |
+| `authorization` | no | Discord-only route-scoped conversational user/role grants. |
+
+### Route-scoped Discord authorization
+
+An optional `authorization` mapping lets one Discord bot expose a limited
+profile to users or roles only in the guild/channel/thread matched by that
+route. It **replaces** the transport's global user/role allowlist for matching
+conversational messages; it does not widen access elsewhere.
+
+- `allowed_users` and `allowed_roles` must be lists of positive decimal Discord IDs.
+- Role grants require the route to declare `guild_id`; role membership is checked
+  only in the originating guild and never authorizes DMs.
+- Route grants cannot target the privileged `default` profile.
+- Native slash commands and text gateway commands remain behind the transport's
+  global allowlist, so route-granted users cannot invoke `/restart`, `/sethome`,
+  or other gateway control operations.
+- Malformed authorization fails gateway configuration loading instead of silently
+  opening or skipping the route. An explicitly matched route whose target profile
+  is unavailable is still rejected without falling back to the default profile.
+- With no `authorization` field, existing route and global-allowlist behavior is
+  unchanged. With an empty `authorization: {}`, the matching route admits nobody.
 
 ## Matching rules
 
@@ -94,7 +120,8 @@ If no route matches, the message uses the default/active profile.
 
 ## How it works at runtime
 
-1. An inbound message arrives at a platform adapter.
+1. An inbound message arrives at a platform adapter. Discord resolves any route
+   authorization before dispatch; rejected principals never create an agent session.
 2. `BasePlatformAdapter.build_source` builds the `SessionSource` for the message. Every
    adapter carries a back-reference to the running `GatewayRunner`
    (`gateway_runner`, injected in `gateway/run.py`), so it asks the runner to resolve the

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -587,6 +587,17 @@ class GatewayAuthorizationMixin:
         ):
             return True
 
+        # Route-scoped transport authorization is deliberately distinct from
+        # role_authorized: a route may grant either a user ID or a guild role.
+        # The live adapter-reference check in this gate prevents serialized or
+        # forged sources from asserting this in-process admission result.
+        if (
+            allow_adapter_delegation
+            and getattr(source, "_transport_authorized", False) is True
+            and self._registered_transport_adapter(source) is not None
+        ):
+            return True
+
         # Check pairing store. A pairing entry is a first-class authorization
         # grant, created only by a trusted operator approving a pairing code
         # (hermes gateway pairing approve / the authenticated dashboard) — an

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1030,8 +1030,9 @@ class GatewayConfig:
     session_store_max_age_days: int = 90
 
     # Profile-based routing: route specific guilds/channels/threads to
-    # different profiles. See gateway/profile_routing.py. Each entry is a
-    # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
+    # different profiles. See gateway/profile_routing.py. Each entry has name,
+    # platform, profile, optional guild_id/chat_id/thread_id, and an optional
+    # Discord-only route-scoped authorization mapping.
     profile_routes: list = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7327,6 +7327,7 @@ class BasePlatformAdapter(ABC):
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
         role_authorized: bool = False,
+        transport_authorized: bool = False,
         auto_thread_created: bool = False,
         auto_thread_initial_name: Optional[str] = None,
     ) -> SessionSource:
@@ -7373,9 +7374,10 @@ class BasePlatformAdapter(ABC):
                 profile_route_rejected = True
             except Exception:
                 logger.warning(
-                    "Profile resolution failed for %s/%s, defaulting to active profile",
+                    "Profile resolution failed for %s/%s; rejecting ingress",
                     self.platform, chat_id, exc_info=True,
                 )
+                profile_route_rejected = True
 
         source = SessionSource(
             platform=self.platform,
@@ -7402,6 +7404,7 @@ class BasePlatformAdapter(ABC):
         # SessionSource.to_dict(). The live receiving adapter is authoritative
         # for this turn even when profile_routes selects a different runtime.
         source._transport_adapter_ref = weakref.ref(self)
+        source._transport_authorized = transport_authorized is True
         # Keep this transport-only fail-closed signal out of SessionSource
         # serialization/session identity. The shared gateway handler consumes it
         # before auth, hooks, or session setup, so every adapter drops matched

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -52,6 +52,14 @@ class ProfileRouteRejected(RuntimeError):
 
 
 @dataclass(frozen=True)
+class ProfileRouteAuthorization:
+    """Principals admitted only when their profile route matches."""
+
+    allowed_users: tuple[str, ...] = ()
+    allowed_roles: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
 class ProfileRoute:
     """A single routing rule that maps a platform scope to a profile."""
 
@@ -62,6 +70,7 @@ class ProfileRoute:
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
     enabled: bool = True
+    authorization: Optional[ProfileRouteAuthorization] = None
 
     @property
     def specificity(self) -> int:
@@ -106,6 +115,56 @@ class ProfileRoute:
         return True
 
 
+def _parse_discord_snowflakes(values: Any, *, route_name: str, field_name: str) -> frozenset[str]:
+    """Validate one route-scoped Discord principal list."""
+    if not isinstance(values, (list, tuple)):
+        raise ValueError(
+            f"profile route {route_name!r} authorization.{field_name} must be a list"
+        )
+    normalized = frozenset(str(value).strip() for value in values)
+    if any(not value.isdigit() or int(value) <= 0 for value in normalized):
+        raise ValueError(
+            f"profile route {route_name!r} authorization.{field_name} "
+            "must contain positive decimal Discord IDs"
+        )
+    return normalized
+
+
+def _parse_route_authorization(
+    entry: Dict[str, Any], *, name: str, platform: str
+) -> Optional[ProfileRouteAuthorization]:
+    """Parse an optional fail-closed transport authorization policy."""
+    if "authorization" not in entry:
+        return None
+    raw = entry.get("authorization")
+    if not isinstance(raw, dict):
+        raise ValueError(f"profile route {name!r} authorization must be a mapping")
+    if platform != "discord":
+        raise ValueError(
+            f"profile route {name!r} authorization is currently supported only for discord"
+        )
+    unknown = set(raw) - {"allowed_users", "allowed_roles"}
+    if unknown:
+        raise ValueError(
+            f"profile route {name!r} authorization has unknown field(s): "
+            f"{', '.join(sorted(unknown))}"
+        )
+    users = _parse_discord_snowflakes(
+        raw.get("allowed_users", []), route_name=name, field_name="allowed_users"
+    )
+    roles = _parse_discord_snowflakes(
+        raw.get("allowed_roles", []), route_name=name, field_name="allowed_roles"
+    )
+    if roles and not entry.get("guild_id"):
+        raise ValueError(
+            f"profile route {name!r} authorization.allowed_roles requires guild_id"
+        )
+    return ProfileRouteAuthorization(
+        allowed_users=tuple(sorted(users)),
+        allowed_roles=tuple(sorted(int(role_id) for role_id in roles)),
+    )
+
+
 def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRoute]:
     """Parse profile_routes from config.yaml into ProfileRoute objects.
 
@@ -121,6 +180,11 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
         platform = entry.get("platform", "")
         profile = entry.get("profile", "")
         if not platform or not profile:
+            if "authorization" in entry:
+                raise ValueError(
+                    f"profile route {name or '<unnamed>'!r} with authorization "
+                    "requires platform and profile"
+                )
             logger.warning(
                 "Skipping profile route %s: missing platform or profile",
                 name,
@@ -135,18 +199,52 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
             )
             profile = normalize_profile_name(profile)
             validate_profile_name(profile)
-        except (ValueError, ImportError):
+        except (ValueError, ImportError) as exc:
+            if "authorization" in entry:
+                raise ValueError(
+                    f"profile route {name or '<unnamed>'!r} with authorization "
+                    f"has invalid profile name {profile!r}"
+                ) from exc
             logger.warning("Skipping profile route %s: invalid profile name %r", name, profile)
             continue
+        authorization = _parse_route_authorization(
+            entry, name=name or profile, platform=platform
+        )
+        route_ids = {
+            discriminator: entry.get(discriminator)
+            for discriminator in ("guild_id", "chat_id", "thread_id")
+        }
+        if authorization is not None:
+            if "enabled" in entry and not isinstance(entry["enabled"], bool):
+                raise ValueError(
+                    f"profile route {name or profile!r} authorization requires enabled to be boolean"
+                )
+            for discriminator in ("guild_id", "chat_id", "thread_id"):
+                value = entry.get(discriminator)
+                if value is None:
+                    continue
+                normalized = str(value).strip()
+                if not normalized.isdigit() or int(normalized) <= 0:
+                    raise ValueError(
+                        f"profile route {name or profile!r} {discriminator} must be a "
+                        "positive decimal Discord ID when authorization is configured"
+                    )
+                route_ids[discriminator] = normalized
+        if authorization is not None and profile == "default":
+            raise ValueError(
+                f"profile route {name or profile!r} authorization cannot grant "
+                "access to the privileged default profile"
+            )
         routes.append(
             ProfileRoute(
                 name=name,
                 platform=platform,
                 profile=profile,
-                guild_id=entry.get("guild_id"),
-                chat_id=entry.get("chat_id"),
-                thread_id=entry.get("thread_id"),
+                guild_id=route_ids["guild_id"],
+                chat_id=route_ids["chat_id"],
+                thread_id=route_ids["thread_id"],
                 enabled=entry.get("enabled", True),
+                authorization=authorization,
             )
         )
     # Sort: most specific first so the first match wins.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17987,10 +17987,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _paused_notice is not None:
                 _estop_allow = False
                 _estop_cmd = None
-                try:
-                    _estop_cmd = event.get_command()
-                except Exception:
-                    _estop_cmd = None
+                if event.allow_gateway_control:
+                    try:
+                        _estop_cmd = event.get_command()
+                    except Exception:
+                        _estop_cmd = None
                 if _estop_cmd:
                     try:
                         from hermes_cli.commands import (
@@ -18314,7 +18315,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # resolver _dispatch_busy_slash_command below — no per-command
             # if-chain here.
             from hermes_cli.commands import resolve_command as _resolve_cmd_inner
-            _evt_cmd = event.get_command()
+            _evt_cmd = event.get_command() if allow_gateway_control else None
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
             # /status and /context are intentionally pre-gate so users
@@ -18386,7 +18387,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             running_agent = _ra_state.turn.agent if _ra_state else None
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
-                if event.get_command() == "stop":
+                if _evt_cmd == "stop":
                     # Force-clean the sentinel so the session is unlocked.
                     self._release_running_agent_state(_quick_key)
                     logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key)
@@ -18513,8 +18514,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # which is read by _run_agent. Removed to prevent unbounded growth.
             return None
 
-        # Check for commands
-        command = event.get_command()
+        # Check for commands. Transport-scoped chat grants deliberately cannot
+        # reach gateway control even if an adapter normalized plain language or
+        # forwarded snapshot content into a slash-shaped message.
+        command = event.get_command() if allow_gateway_control else None
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,
@@ -29549,12 +29552,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 thread_id=getattr(source, "thread_id", None),
                 parent_chat_id=getattr(source, "parent_chat_id", None),
             )
-        except Exception:
+        except Exception as exc:
             logger.warning(
-                "Profile route matching failed for %s/%s, falling back to default",
+                "Profile route matching failed for %s/%s; rejecting ingress",
                 source.platform, source.chat_id, exc_info=True,
             )
-            return None
+            raise ProfileRouteRejected("route-matching-error") from exc
         if matched:
             try:
                 served = {name for name, _home in _multiplex_profile_homes(config)}

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -275,7 +275,7 @@ async def _wait_for_ready_or_bot_exit(
 
 def _needs_server_members_intent(
     allowed_user_ids: set[str] | list[str] | None,
-    allowed_role_ids: set[str] | list[str] | None,
+    allowed_role_ids: set[str | int] | list[str | int] | None,
 ) -> bool:
     """Return True when Hermes must request Discord's Server Members intent.
 
@@ -299,8 +299,8 @@ def _format_privileged_intents_guidance(*, needs_members: bool) -> str:
     ]
     if needs_members:
         lines.append(
-            "  - Server Members Intent (required for username allowlists "
-            "and/or DISCORD_ALLOWED_ROLES)"
+            "  - Server Members Intent (required for username allowlists, "
+            "DISCORD_ALLOWED_ROLES, and/or profile route roles)"
         )
     lines.extend(
         [
@@ -1348,7 +1348,7 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.guild_messages = True
             intents.members = _needs_server_members_intent(
                 self._allowed_user_ids,
-                self._allowed_role_ids,
+                set(self._allowed_role_ids) | self._profile_route_role_ids(),
             )
             intents.voice_states = True
 
@@ -1550,42 +1550,124 @@ class DiscordAdapter(BasePlatformAdapter):
             guidance = _format_privileged_intents_guidance(
                 needs_members=_needs_server_members_intent(
                     getattr(self, "_allowed_user_ids", None),
-                    getattr(self, "_allowed_role_ids", None),
+                    set(getattr(self, "_allowed_role_ids", None) or set())
+                    | self._profile_route_role_ids(),
                 )
             )
             return ("discord_intents_required", guidance, False)
         return ("discord_connect_error", f"Discord startup failed: {error}", True)
+
+    def _matched_profile_route(self, *, guild: Any, channel: Any):
+        """Return the multiplex route for a Discord channel, if one matches."""
+        runner = getattr(self, "gateway_runner", None)
+        config = getattr(runner, "config", None)
+        if not getattr(config, "multiplex_profiles", False):
+            return None
+        routes = getattr(config, "profile_routes", None)
+        if not routes or channel is None:
+            return None
+
+        from gateway.profile_routing import match_profile_route
+
+        is_thread = isinstance(channel, discord.Thread)
+        chat_id = getattr(channel, "id", None)
+        parent_chat_id = self._get_parent_channel_id(channel) if is_thread else None
+        guild_id = getattr(guild, "id", None)
+        return match_profile_route(
+            routes,
+            platform="discord",
+            guild_id=str(guild_id) if guild_id is not None else None,
+            chat_id=str(chat_id) if chat_id is not None else None,
+            thread_id=str(chat_id) if is_thread and chat_id is not None else None,
+            parent_chat_id=str(parent_chat_id) if parent_chat_id is not None else None,
+        )
+
+    def _route_authorizes_discord_user(
+        self, route: Any, *, user_id: str, author: Any, guild: Any
+    ) -> tuple[bool, bool]:
+        """Return ``(authorized, via_role)`` for a matched route policy."""
+        policy = getattr(route, "authorization", None)
+        if policy is None:
+            return False, False
+        if user_id in policy.allowed_users:
+            return True, False
+        if guild is None or not policy.allowed_roles:
+            return False, False
+
+        roles = getattr(author, "roles", None) or []
+        author_guild = getattr(author, "guild", None)
+        if getattr(author_guild, "id", None) == getattr(guild, "id", None):
+            if any(getattr(role, "id", None) in policy.allowed_roles for role in roles):
+                return True, True
+
+        try:
+            member = guild.get_member(int(user_id))
+        except (AttributeError, TypeError, ValueError):
+            member = None
+        member_guild = getattr(member, "guild", None)
+        if getattr(member_guild, "id", None) != getattr(guild, "id", None):
+            return False, False
+        member_roles = getattr(member, "roles", None) or []
+        if any(getattr(role, "id", None) in policy.allowed_roles for role in member_roles):
+            return True, True
+        return False, False
+
+    def _profile_route_role_ids(self) -> set[int]:
+        """Collect Discord route roles so connect requests Members Intent."""
+        runner = getattr(self, "gateway_runner", None)
+        config = getattr(runner, "config", None)
+        if not getattr(config, "multiplex_profiles", False):
+            return set()
+        roles: set[int] = set()
+        for route in getattr(config, "profile_routes", None) or []:
+            if not getattr(route, "enabled", True):
+                continue
+            if getattr(route, "platform", "") != "discord":
+                continue
+            policy = getattr(route, "authorization", None)
+            if policy is not None:
+                roles.update(policy.allowed_roles)
+        return roles
 
     def _discord_message_admission(
         self,
         message: Any,
         *,
         claim: bool,
-    ) -> tuple[bool, bool]:
-        """Return ``(admitted, role_authorized)`` for one Discord event."""
+    ) -> tuple[bool, bool, bool]:
+        """Return ``(admitted, role_authorized, route_authorized)``."""
         message_id = str(getattr(message, "id", ""))
         if claim:
             if self._dedup.is_duplicate(message_id):
-                return False, False
+                return False, False, False
         elif self._dedup.contains(message_id):
-            return False, False
+            return False, False, False
         if message.author == self._client.user:
-            return False, False
+            return False, False, False
         if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
-            return False, False
+            return False, False, False
 
         role_authorized = False
+        route_authorized = False
+        route_policy = None
         if getattr(message.author, "bot", False):
+            # Route-scoped grants are human principal lists. Do not let a
+            # transport-wide bot allowance bypass a limited route's policy.
+            bot_route = self._matched_profile_route(
+                guild=getattr(message, "guild", None), channel=message.channel
+            )
+            if getattr(bot_route, "authorization", None) is not None:
+                return False, False, False
             allow_bots = self._get_allow_bots()
             if allow_bots == "none":
-                return False, False
+                return False, False, False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
-                return False, False
+                return False, False, False
             if (
                 self._discord_bots_require_inline_mention()
                 and not self._self_is_raw_mentioned(message)
             ):
-                return False, False
+                return False, False, False
         else:
             msg_guild = getattr(message, "guild", None)
             is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
@@ -1595,16 +1677,50 @@ class DiscordAdapter(BasePlatformAdapter):
                 parent_id = self._get_parent_channel_id(message.channel)
                 if parent_id:
                     msg_channel_ids.add(parent_id)
-            if not self._is_allowed_user(
-                str(message.author.id),
-                message.author,
-                guild=msg_guild,
-                is_dm=is_dm,
-                channel_ids=msg_channel_ids,
-            ):
-                self._warn_if_fail_closed_default()
-                return False, False
-            role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
+            route = self._matched_profile_route(guild=msg_guild, channel=message.channel)
+            route_policy = getattr(route, "authorization", None)
+            if route_policy is not None:
+                admitted, _via_role = self._route_authorizes_discord_user(
+                    route,
+                    user_id=str(message.author.id),
+                    author=message.author,
+                    guild=msg_guild,
+                )
+                if not admitted:
+                    return False, False, False
+                globally_authorized = self._is_allowed_user(
+                    str(message.author.id),
+                    message.author,
+                    guild=msg_guild,
+                    is_dm=is_dm,
+                    channel_ids=msg_channel_ids,
+                )
+                route_authorized = not globally_authorized
+                if globally_authorized:
+                    role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
+                route_text = str(getattr(message, "content", "") or "")
+                client_user = getattr(getattr(self, "_client", None), "user", None)
+                client_user_id = getattr(client_user, "id", None)
+                if client_user_id is not None:
+                    route_text = route_text.replace(f"<@{client_user_id}>", "")
+                    route_text = route_text.replace(f"<@!{client_user_id}>", "")
+                if route_text.strip().startswith("/") and not globally_authorized:
+                    # Route grants are conversational only. Gateway control
+                    # commands remain exclusive to the global transport policy.
+                    return False, False, False
+                # Keep route-local transport provenance separate from the
+                # legacy global-role grant carried by role_authorized.
+            else:
+                if not self._is_allowed_user(
+                    str(message.author.id),
+                    message.author,
+                    guild=msg_guild,
+                    is_dm=is_dm,
+                    channel_ids=msg_channel_ids,
+                ):
+                    self._warn_if_fail_closed_default()
+                    return False, False, False
+                role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
 
         raw_self_mention = self._self_is_explicitly_mentioned(message)
         if not isinstance(message.channel, discord.DMChannel) and (
@@ -1615,7 +1731,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 for mentioned in message.mentions
             )
             if other_bots_mentioned and not raw_self_mention:
-                return False, False
+                return False, False, False
             ignore_no_mention = os.getenv(
                 "DISCORD_IGNORE_NO_MENTION", "true"
             ).lower() in {"true", "1", "yes"}
@@ -1626,9 +1742,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 free_channels = self._discord_free_response_channels()
                 channel_keys = self._discord_channel_keys(message, parent_id)
                 if "*" not in free_channels and not (channel_keys & free_channels):
-                    return False, False
+                    return False, False, False
 
-        return True, role_authorized
+        return True, role_authorized, route_authorized
 
     async def _dispatch_discord_message(self, message: Any) -> bool:
         """Apply Discord ingress policy and dispatch one live event."""
@@ -1637,14 +1753,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
             except asyncio.TimeoutError:
                 pass
-        admitted, role_authorized = self._discord_message_admission(
+        admitted, role_authorized, route_authorized = self._discord_message_admission(
             message, claim=True,
         )
         if not admitted:
             return False
-        return await self._handle_message(
-            message, role_authorized=role_authorized,
-        )
+        kwargs = {"role_authorized": role_authorized}
+        if route_authorized:
+            kwargs["route_authorized"] = True
+        return await self._handle_message(message, **kwargs)
 
     # ------------------------------------------------------------------
     # gateway_platform_event fire-sites (#64176)
@@ -2702,16 +2819,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not self._self_is_explicitly_mentioned(message)
             ):
                 return False
-        admitted, role_authorized = self._discord_message_admission(
+        admitted, role_authorized, route_authorized = self._discord_message_admission(
             message, claim=False,
         )
         if not admitted:
             return False
-        return await self._handle_message(
-            message,
-            role_authorized=role_authorized,
-            recovered=True,
-        )
+        kwargs = {
+            "role_authorized": role_authorized,
+            "recovered": True,
+        }
+        if route_authorized:
+            kwargs["route_authorized"] = True
+        return await self._handle_message(message, **kwargs)
 
     async def _iter_missed_message_backfill_candidates(self, channel_ids: set[str]):
         if not self._client:
@@ -5245,7 +5364,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return (False, "missing interaction.user")
 
         user_id = str(user.id)
-        # Pass guild + is_dm so role check is scoped to the originating
+        # Slash commands remain behind the transport's global allowlist. Route-
+        # scoped principals may converse with their limited profile, but cannot
+        # invoke gateway control-plane commands such as /restart or /sethome.
+        # Pass guild + is_dm so role checks are scoped to the originating
         # guild and cross-guild DM bypass (#12136) can't land via the
         # slash surface either.
         interaction_guild = getattr(interaction, "guild", None)
@@ -6422,6 +6544,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # For forum threads, inherit the parent forum's topic.
         chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
+        parent_id = self._get_parent_channel_id(interaction.channel) if is_thread else None
+        guild_id = getattr(getattr(interaction, "guild", None), "id", None)
         source = self.build_source(
             chat_id=str(interaction.channel_id),
             chat_name=chat_name,
@@ -6430,11 +6554,13 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=str(guild_id) if guild_id is not None else None,
+            parent_chat_id=parent_id or None,
+            role_authorized=False,
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         return MessageEvent(
             text=text,
             message_type=msg_type,
@@ -8078,6 +8204,7 @@ class DiscordAdapter(BasePlatformAdapter):
         message: DiscordMessage,
         role_authorized: bool = False,
         *,
+        route_authorized: bool = False,
         recovered: bool = False,
     ) -> bool:
         """Handle one Discord message and report whether it reached dispatch."""
@@ -8293,12 +8420,33 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_chat_id=parent_channel_id,
             message_id=str(message.id),
             role_authorized=role_authorized,
+            transport_authorized=route_authorized,
             auto_thread_created=auto_threaded_channel is not None,
             auto_thread_initial_name=(
                 getattr(auto_threaded_channel, "_hermes_auto_thread_initial_name", None)
                 or self._derive_auto_thread_name(message.content or "")
             ) if auto_threaded_channel is not None else None,
         )
+
+        if route_authorized:
+            # Authorization and routing must agree on the same winning route.
+            # A mismatch or second-pass matcher failure is denied before the
+            # event reaches gateway hooks, session lookup, or an agent run.
+            matched_route = self._matched_profile_route(
+                guild=guild,
+                channel=message.channel,
+            )
+            if (
+                getattr(matched_route, "authorization", None) is None
+                or getattr(source, "profile", None) != getattr(matched_route, "profile", None)
+                or getattr(source, "profile_route_rejected", False)
+            ):
+                logger.warning(
+                    "[%s] Rejecting Discord route authorization/profile mismatch for %s",
+                    self.name,
+                    getattr(message, "id", "unknown"),
+                )
+                return False
 
         # Build media URLs -- download image attachments to local cache so the
         # vision tool can access them reliably (Discord CDN URLs can expire).
@@ -8545,6 +8693,7 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            allow_gateway_control=not route_authorized,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/tests/gateway/test_discord_profile_route_authorization.py
+++ b/tests/gateway/test_discord_profile_route_authorization.py
@@ -1,0 +1,271 @@
+"""Security contracts for Discord route-scoped profile authorization."""
+
+import asyncio
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from gateway.profile_routing import ProfileRoute, ProfileRouteAuthorization
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _Thread:
+    def __init__(self, thread_id: int, parent_id: int, guild):
+        self.id = thread_id
+        self.parent_id = parent_id
+        self.guild = guild
+
+
+def _adapter(monkeypatch, *, global_users=("1",), routes=()):
+    # Some availability tests intentionally reload the adapter with Discord
+    # absent. Rebind the defining module globals for the already-imported class.
+    monkeypatch.setitem(
+        DiscordAdapter._matched_profile_route.__globals__, "discord", discord
+    )
+    monkeypatch.setattr(discord, "Thread", _Thread)
+    adapter = object.__new__(DiscordAdapter)
+    adapter._allowed_user_ids = set(global_users)
+    adapter._allowed_role_ids = set()
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._dedup = SimpleNamespace(
+        is_duplicate=lambda _message_id: False,
+        contains=lambda _message_id: False,
+    )
+    adapter.gateway_runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True, profile_routes=list(routes))
+    )
+    adapter._self_is_explicitly_mentioned = lambda _message: False
+    adapter._self_is_raw_mentioned = lambda _message: False
+    adapter._get_allow_bots = lambda: "none"
+    return adapter
+
+
+def _route(*, users=(), roles=(555,), enabled=True):
+    return ProfileRoute(
+        name="event-pet-forum",
+        platform="discord",
+        profile="event-pet-helper",
+        guild_id="111",
+        chat_id="222",
+        enabled=enabled,
+        authorization=ProfileRouteAuthorization(
+            allowed_users=tuple(users),
+            allowed_roles=tuple(roles),
+        ),
+    )
+
+
+def _message(*, user_id=42, roles=(555,), content="revise the alias"):
+    guild = SimpleNamespace(id=111)
+    author = SimpleNamespace(
+        id=user_id,
+        bot=False,
+        guild=guild,
+        roles=[SimpleNamespace(id=role_id) for role_id in roles],
+    )
+    guild.get_member = lambda candidate: author if candidate == user_id else None
+    return SimpleNamespace(
+        id=1234,
+        author=author,
+        guild=guild,
+        channel=_Thread(333, 222, guild),
+        type=discord.MessageType.default,
+        content=content,
+        mentions=[],
+    )
+
+
+def test_matching_forum_route_admits_role_without_global_grant(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+
+    assert adapter._discord_message_admission(_message(), claim=True) == (
+        True,
+        False,
+        True,
+    )
+
+
+def test_same_role_outside_route_does_not_widen_global_access(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    message = _message()
+    message.channel = _Thread(333, 999, message.guild)
+
+    assert adapter._discord_message_admission(message, claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+def test_route_policy_replaces_global_allowlist_inside_route(monkeypatch):
+    adapter = _adapter(
+        monkeypatch, global_users=("42",), routes=[_route(users=(), roles=())]
+    )
+
+    assert adapter._discord_message_admission(_message(), claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+def test_route_without_authorization_keeps_global_policy(monkeypatch):
+    route = ProfileRoute(
+        name="legacy",
+        platform="discord",
+        profile="limited",
+        guild_id="111",
+        chat_id="222",
+    )
+    adapter = _adapter(monkeypatch, global_users=("42",), routes=[route])
+
+    assert adapter._discord_message_admission(_message(), claim=True) == (
+        True,
+        False,
+        False,
+    )
+
+
+def test_route_user_id_grant_is_scoped_to_matching_forum(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route(users=("42",), roles=())])
+
+    assert adapter._discord_message_admission(_message(roles=()), claim=True) == (
+        True,
+        False,
+        True,
+    )
+
+
+def test_route_role_from_different_guild_is_rejected(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    message = _message()
+    foreign_guild = SimpleNamespace(id=999)
+    message.author.guild = foreign_guild
+    message.guild.get_member = lambda _candidate: None
+
+    assert adapter._discord_message_admission(message, claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+def test_route_role_member_cache_is_scoped_to_origin_guild(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    message = _message()
+    message.author.guild = None
+    message.guild.get_member = lambda _candidate: SimpleNamespace(
+        guild=message.guild,
+        roles=[SimpleNamespace(id=555)],
+    )
+
+    assert adapter._discord_message_admission(message, claim=True) == (
+        True,
+        False,
+        True,
+    )
+
+
+def test_route_role_foreign_cached_member_is_rejected(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    message = _message()
+    message.author.guild = None
+    message.guild.get_member = lambda _candidate: SimpleNamespace(
+        guild=SimpleNamespace(id=999),
+        roles=[SimpleNamespace(id=555)],
+    )
+
+    assert adapter._discord_message_admission(message, claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+def test_route_grant_cannot_invoke_text_gateway_command(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+
+    assert adapter._discord_message_admission(
+        _message(content="<@999> /restart"), claim=True
+    ) == (False, False, False)
+
+
+def test_global_user_retains_gateway_commands_when_route_also_allows_them(monkeypatch):
+    adapter = _adapter(
+        monkeypatch,
+        global_users=("42",),
+        routes=[_route(users=("42",), roles=())],
+    )
+
+    assert adapter._discord_message_admission(
+        _message(roles=(), content="<@999> /restart"), claim=True
+    ) == (True, False, False)
+
+
+def test_route_roles_enable_server_members_intent(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+
+    assert adapter._profile_route_role_ids() == {555}
+
+
+def test_disabled_route_does_not_enable_server_members_intent(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route(enabled=False)])
+
+    assert adapter._profile_route_role_ids() == set()
+
+
+def test_route_role_is_named_in_privileged_intent_diagnostics(monkeypatch):
+    class PrivilegedIntentsRequired(Exception):
+        pass
+
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    code, guidance, retryable = adapter._classify_connect_exception(
+        PrivilegedIntentsRequired()
+    )
+
+    assert code == "discord_intents_required"
+    assert "Server Members Intent" in guidance
+    assert retryable is False
+
+
+def test_transport_bot_allowance_cannot_bypass_route_policy(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    adapter._get_allow_bots = lambda: "all"
+    message = _message()
+    message.author.bot = True
+
+    assert adapter._discord_message_admission(message, claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+def test_authorization_is_inert_when_multiplexing_is_off(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    adapter.gateway_runner.config.multiplex_profiles = False
+
+    assert adapter._discord_message_admission(_message(), claim=True) == (
+        False,
+        False,
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_preserves_route_authorization_provenance(monkeypatch):
+    adapter = _adapter(monkeypatch, routes=[_route()])
+    adapter._ready_event = asyncio.Event()
+    adapter._ready_event.set()
+    adapter._handle_message = AsyncMock(return_value=True)
+    message = _message()
+
+    assert await adapter._dispatch_discord_message(message) is True
+    adapter._handle_message.assert_awaited_once_with(
+        message,
+        role_authorized=False,
+        route_authorized=True,
+    )

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -244,6 +244,39 @@ class TestReplyToText:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
 
+    @pytest.mark.asyncio
+    async def test_route_authorization_disables_gateway_control(
+        self, reply_text_adapter
+    ):
+        message = _make_message(content="forwarded conversational content")
+        route = SimpleNamespace(authorization=object(), profile="limited")
+        reply_text_adapter.gateway_runner = SimpleNamespace(
+            _profile_name_for_source=lambda _source: "limited"
+        )
+        reply_text_adapter._matched_profile_route = lambda **_kwargs: route
+
+        await reply_text_adapter._handle_message(message, route_authorized=True)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.allow_gateway_control is False
+
+    @pytest.mark.asyncio
+    async def test_route_authorization_profile_mismatch_is_rejected(
+        self, reply_text_adapter
+    ):
+        message = _make_message(content="forwarded conversational content")
+        route = SimpleNamespace(authorization=object(), profile="other-profile")
+        reply_text_adapter.gateway_runner = SimpleNamespace(
+            _profile_name_for_source=lambda _source: "limited"
+        )
+        reply_text_adapter._matched_profile_route = lambda **_kwargs: route
+
+        assert (
+            await reply_text_adapter._handle_message(message, route_authorized=True)
+            is False
+        )
+        reply_text_adapter.handle_message.assert_not_awaited()
+
 
     @pytest.mark.asyncio
     async def test_reference_with_empty_resolved_content(self, reply_text_adapter):

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -383,9 +383,11 @@ async def test_dispatch_thread_session_builds_thread_event(adapter):
 
 
 def test_build_slash_event_preserves_thread_context(adapter):
+    channel = _FakeThreadChannel(channel_id=555, name="Planning")
     interaction = SimpleNamespace(
-        channel=_FakeThreadChannel(channel_id=555, name="Planning"),
+        channel=channel,
         channel_id=555,
+        guild=channel.guild,
         user=SimpleNamespace(display_name="Jezza", id=42),
     )
 
@@ -395,6 +397,8 @@ def test_build_slash_event_preserves_thread_context(adapter):
     assert event.source.chat_id == "555"
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "555"
+    assert event.source.guild_id == "1"
+    assert event.source.parent_chat_id == "100"
     assert "TestGuild" in event.source.chat_name
 
 

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -98,7 +98,9 @@ def _make_runner():
     runner._should_send_telegram_lobby_reminder = lambda _source: False
     runner._check_slash_access = lambda _source, _command: None
     runner._begin_session_run_generation = lambda _key: 1
-    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    runner._release_running_agent_state = lambda key: runner._running_agents.pop(
+        key, None
+    )
     return runner, adapter
 
 
@@ -127,3 +129,29 @@ async def test_idle_queue_sends_payload_as_next_turn(command_text):
     assert captured["key"] == build_session_key(_make_source())
     assert captured["generation"] == 1
     assert runner._running_agents == {}
+
+
+@pytest.mark.asyncio
+async def test_non_control_event_cannot_execute_forwarded_gateway_command():
+    runner, _adapter = _make_runner()
+    captured = {}
+
+    async def fake_handle_message_with_agent(event, source, key, generation):
+        captured["text"] = event.text
+        return {"final_response": "agent handled it", "messages": []}
+
+    runner._handle_message_with_agent = fake_handle_message_with_agent
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m-route",
+        internal=True,
+        allow_gateway_control=False,
+    )
+    assert event.text == "/restart"
+
+    result = await runner._handle_message(event)
+
+    assert result == {"final_response": "agent handled it", "messages": []}
+    assert captured["text"] == "/restart"

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -1,6 +1,7 @@
 """Tests for GatewayRunner._resolve_profile_home_for_source — profile resolution logic."""
 
 import logging
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -234,6 +235,25 @@ class TestNonDiscordProfileRouting:
         source = adapter.build_source(chat_id="route-chat", chat_type="group")
         assert source.profile is None
 
+    def test_route_matching_error_rejects_instead_of_defaulting(
+        self, mock_runner, telegram_source
+    ):
+        mock_runner.config.profile_routes = [
+            ProfileRoute(
+                name="worker-route",
+                platform="telegram",
+                profile="worker",
+                chat_id="route-chat",
+            )
+        ]
+
+        with patch(
+            "gateway.profile_routing.match_profile_route",
+            side_effect=RuntimeError("matcher failed"),
+        ):
+            with pytest.raises(ProfileRouteRejected, match="route-matching-error"):
+                mock_runner._profile_name_for_source(telegram_source)
+
 
 class TestGatewayRunnerInjection:
     """``BasePlatformAdapter`` declares ``gateway_runner`` so the gateway's
@@ -266,6 +286,33 @@ def _stub_adapter(platform: Platform, runner) -> "_StubAdapter":
     a.platform = platform
     a.gateway_runner = runner
     return a
+
+
+def test_transport_authorization_requires_live_registered_adapter():
+    adapter = _stub_adapter(Platform.DISCORD, None)
+    source = adapter.build_source(
+        chat_id="222",
+        chat_type="thread",
+        user_id="42",
+        transport_authorized=True,
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+    runner.pairing_store = None
+
+    with patch.dict(
+        os.environ,
+        {
+            "DISCORD_ALLOWED_USERS": "",
+            "DISCORD_ALLOW_ALL_USERS": "false",
+            "GATEWAY_ALLOW_ALL_USERS": "false",
+        },
+        clear=False,
+    ):
+        assert runner._is_user_authorized(source) is True
+        restored = SessionSource.from_dict(source.to_dict())
+        assert runner._is_user_authorized(restored) is False
 
 
 class TestAdapterToSessionKeyIntegration:

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -3,6 +3,7 @@
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
+    ProfileRouteAuthorization,
     parse_profile_routes,
     match_profile_route,
 )
@@ -49,6 +50,138 @@ class TestParseProfileRoutes:
     def test_empty(self):
         assert parse_profile_routes(None) == []
         assert parse_profile_routes([]) == []
+
+    def test_discord_route_authorization_is_normalized(self):
+        routes = parse_profile_routes([{
+            "name": "forum",
+            "platform": "discord",
+            "profile": "limited",
+            "guild_id": "111",
+            "chat_id": "222",
+            "authorization": {
+                "allowed_users": ["42", 42],
+                "allowed_roles": ["555"],
+            },
+        }])
+
+        assert routes[0].authorization == ProfileRouteAuthorization(
+            allowed_users=("42",),
+            allowed_roles=(555,),
+        )
+
+    @pytest.mark.parametrize(
+        "authorization",
+        [
+            "open",
+            {"allowed_users": "42"},
+            {"allowed_users": None},
+            {"allowed_roles": None},
+            {"allowed_roles": ["not-a-snowflake"]},
+            {"unknown": []},
+        ],
+    )
+    def test_malformed_authorization_fails_closed(self, authorization):
+        with pytest.raises(ValueError):
+            parse_profile_routes([{
+                "name": "forum",
+                "platform": "discord",
+                "profile": "limited",
+                "guild_id": "111",
+                "authorization": authorization,
+            }])
+
+    def test_role_authorization_requires_guild_scope(self):
+        with pytest.raises(ValueError, match="requires guild_id"):
+            parse_profile_routes([{
+                "name": "forum",
+                "platform": "discord",
+                "profile": "limited",
+                "chat_id": "222",
+                "authorization": {"allowed_roles": ["555"]},
+            }])
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("enabled", "false"),
+            ("guild_id", "not-an-id"),
+            ("chat_id", 0),
+            ("thread_id", -1),
+        ],
+    )
+    def test_authorized_route_discriminators_are_strict(self, field, value):
+        route = {
+            "name": "forum",
+            "platform": "discord",
+            "profile": "limited",
+            "guild_id": "111",
+            "chat_id": "222",
+            "authorization": {"allowed_users": ["42"]},
+        }
+        route[field] = value
+
+        with pytest.raises(ValueError):
+            parse_profile_routes([route])
+
+    def test_authorization_on_unsupported_platform_fails_closed(self):
+        with pytest.raises(ValueError, match="only for discord"):
+            parse_profile_routes([{
+                "name": "chat",
+                "platform": "telegram",
+                "profile": "limited",
+                "chat_id": "222",
+                "authorization": {"allowed_users": ["42"]},
+            }])
+
+    def test_authorization_cannot_target_default_profile(self):
+        with pytest.raises(ValueError, match="privileged default profile"):
+            parse_profile_routes([{
+                "name": "unsafe",
+                "platform": "discord",
+                "profile": "default",
+                "guild_id": "111",
+                "authorization": {"allowed_users": ["42"]},
+            }])
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            {
+                "name": "missing-profile",
+                "platform": "discord",
+                "authorization": {},
+            },
+            {
+                "name": "invalid-profile",
+                "platform": "discord",
+                "profile": "../default",
+                "authorization": {},
+            },
+        ],
+    )
+    def test_authorized_route_never_skips_invalid_target(self, route):
+        with pytest.raises(ValueError):
+            parse_profile_routes([route])
+
+    def test_gateway_config_round_trip_preserves_authorization(self):
+        from gateway.config import GatewayConfig
+
+        config = GatewayConfig.from_dict({
+            "multiplex_profiles": True,
+            "profile_routes": [{
+                "name": "forum",
+                "platform": "discord",
+                "profile": "limited",
+                "guild_id": "111",
+                "authorization": {
+                    "allowed_users": ["42"],
+                    "allowed_roles": ["555"],
+                },
+            }],
+        })
+
+        restored = GatewayConfig.from_dict(config.to_dict())
+        assert restored.profile_routes == config.profile_routes
 
 
 class TestMatchProfileRoute:

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -266,6 +266,9 @@ gateway:
       guild_id: "1234567890"
       chat_id: "9876543210"
       profile: acme-support
+      authorization:
+        allowed_users: ["184587051943985152"]
+        allowed_roles: ["112233445566778899"]
 
     # A Telegram group (no guild concept — chat_id only)
     - name: tg-group
@@ -287,6 +290,15 @@ target profile is not installed or is outside `multiplex_profile_allowlist`,
 the gateway rejects that ingress and logs the route and target. It does not run
 the default profile. Traffic that matches no route keeps the historical
 default-profile behavior.
+
+Discord routes may optionally include `authorization.allowed_users` and
+`authorization.allowed_roles` lists. These positive decimal Discord IDs grant
+access only to conversational messages for the matched route, replacing the
+bot's global allowlist there without widening it anywhere else. Role grants
+require `guild_id` and are checked only in the originating guild; they never
+authorize DMs. Route grants cannot target `default`, and slash/text gateway
+commands remain restricted to the bot's global allowlist. Invalid route
+authorization fails configuration loading rather than silently opening access.
 
 ## Start, stop, or restart all gateways at once
 


### PR DESCRIPTION
## Reported issue

Discord admission is currently global to one gateway transport. A role added for a limited routed profile can therefore reach the privileged default profile outside that route.

## Implemented

- Added Discord-only `profile_routes.authorization` user and role policies.
- Made a matching route policy replace the global allowlist for conversational messages.
- Scoped role checks to the originating guild and included enabled route roles in Discord intent setup and diagnostics.
- Kept slash commands, components, and gateway control behind the existing global authorization boundary.
- Added non-serialized, live-adapter-bound authorization provenance.
- Rejected malformed policies, route/profile mismatches, unavailable targets, and route-matcher failures without falling back to the default profile.
- Preserved all legacy behavior when a route has no `authorization` block or multiplexing is disabled.

## Code explanation

The Discord adapter resolves the winning route before dispatch and applies that route's local principal policy. Successful route admission is carried only in-process and is accepted by the gateway when the source still references the registered transport adapter. The adapter resolves the profile again while building the source and rejects any authorization/profile disagreement before hooks, session lookup, or agent execution.

Route-scoped events explicitly disable gateway control. This prevents literal commands, normalized plain-language restart requests, forwarded-message command content, and busy-session approval responses from crossing the conversational authorization boundary.

## Verification

- `311 passed` across profile routing, profile resolution, multiplex isolation, Discord admission/roles/slash/backfill/reply paths, config compatibility, command dispatch, plugin injection, busy-session commands, and approval commands.
- `ruff check` passed for every changed Python file.
- `compileall` passed for changed production modules.
- `git diff --check` passed.
- Independent security review findings were addressed and re-reviewed before publication.
