### PR TITLE
fix(memory): cap successful writes per turn to stop success-only mutation loops

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -244,6 +244,75 @@ class TestMemoryConsolidationGracefulDegrade:
         assert "continue with your reply" not in r["error"]
 
 
+class TestMemorySuccessfulWriteBudget:
+    """#81120: a loop made entirely of SUCCESSFUL memory mutations bypasses the
+    #42405 failure cap (every success resets it). Successful writes must have
+    their own per-turn budget; beyond it further writes are refused with a
+    terminal result, the store keeps its last known-good state, and unrelated
+    entries survive."""
+
+    def test_alternating_successful_writes_stop_after_cap(self, store):
+        store.add("memory", "unrelated durable fact")
+        # Seed done; a new turn starts with a fresh write budget.
+        store.reset_consolidation_failures()
+
+        cap = store._MAX_SUCCESSFUL_WRITES_PER_TURN
+        # The observed oscillation: add(x) -> remove(x) -> add(x) -> ... Every
+        # call succeeds, so the #42405 failure counter never accumulates.
+        # Each round consumes 2 writes, so cap // 2 rounds stay within budget.
+        for i in range(cap // 2):
+            r = store.add("memory", f"temp note {i}")
+            assert r["success"] is True
+            r = store.remove("memory", f"temp note {i}")
+            assert r["success"] is True
+        assert store._successful_writes == cap
+
+        # Budget exhausted: the next mutation is refused, terminally, and the
+        # store keeps its last known-good state.
+        r = store.add("memory", "another fact")
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "continue with your reply" in r["error"]
+        assert "another fact" not in store.memory_entries
+        assert "unrelated durable fact" in store.memory_entries
+
+    def test_batch_writes_count_toward_budget(self, store):
+        cap = store._MAX_SUCCESSFUL_WRITES_PER_TURN
+        batch = [{"action": "add", "content": "fact A"}]
+        for _ in range(cap):
+            r = store.apply_batch("memory", batch)
+            assert r["success"] is True
+        # The atomic batch path is the primary consolidation route; it must
+        # consume the same budget as single ops (sibling call path).
+        r = store.apply_batch("memory", batch)
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "continue with your reply" in r["error"]
+
+    def test_duplicate_add_counts_toward_budget(self, store):
+        cap = store._MAX_SUCCESSFUL_WRITES_PER_TURN
+        for _ in range(cap):
+            r = store.add("memory", "same fact")
+            assert r["success"] is True  # idempotent no-op after the first
+        # Idempotent successes still consume budget: re-issuing an
+        # already-saved write is the repeat behaviour the budget suppresses.
+        r = store.add("memory", "same fact")
+        assert r["success"] is False
+        assert r["done"] is True
+
+    def test_budget_resets_at_turn_boundary(self, store):
+        cap = store._MAX_SUCCESSFUL_WRITES_PER_TURN
+        for i in range(cap):
+            assert store.add("memory", f"fact {i}")["success"] is True
+        assert store.add("memory", "overflow fact")["success"] is False
+
+        # New user turn -> fresh, legitimate maintenance episode.
+        store.reset_consolidation_failures()
+        r = store.add("memory", "new turn fact")
+        assert r["success"] is True
+        assert "new turn fact" in store.memory_entries
+
+
 class TestMemoryStorePersistence:
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -173,6 +173,15 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
+    # Cap on SUCCESSFUL writes in ONE turn. The failure cap above can't stop a
+    # loop made entirely of successful mutations: every success resets the
+    # failure counter, so a model oscillating add -> remove -> add on the
+    # bounded store can churn it indefinitely, burning the turn's API budget
+    # and destroying unrelated durable facts along the way (issue #81120).
+    # Beyond this cap further writes are refused with a terminal result and
+    # the store keeps its last known-good state; the turn's reply continues.
+    _MAX_SUCCESSFUL_WRITES_PER_TURN = 6
+
     def __init__(
         self,
         memory_char_limit: int = 2200,
@@ -192,14 +201,46 @@ class MemoryStore:
         # Per-turn counter of failed at-capacity consolidation attempts; reset
         # at each turn boundary by reset_consolidation_failures() (#42405).
         self._consolidation_failures = 0
+        # Per-turn counter of successful writes (#81120); same turn-boundary
+        # reset as the failure counter above.
+        self._successful_writes = 0
 
     def target_enabled(self, target: str) -> bool:
         """Return whether this session's selected built-in store is writable."""
         return self.user_profile_enabled if target == "user" else self.memory_enabled
 
     def reset_consolidation_failures(self) -> None:
-        """Reset the per-turn consolidation-failure counter (call at turn start)."""
+        """Reset the per-turn memory guard counters (call at turn start).
+
+        Covers both the consolidation-failure budget (#42405) and the
+        successful-write budget (#81120): a new user turn is a fresh,
+        legitimate maintenance episode.
+        """
         self._consolidation_failures = 0
+        self._successful_writes = 0
+
+    def _write_budget_response(self) -> Optional[Dict[str, Any]]:
+        """Terminal refusal once the per-turn successful-write cap is hit.
+
+        Returns ``None`` while the budget lasts, so mutation entry points can
+        guard with ``budget = self._write_budget_response(); if budget: return budget``.
+        The refusal leaves the store untouched and tells the model to finish
+        its reply — mirroring the degraded terminal shape of
+        ``_consolidation_failure`` (#42405).
+        """
+        if self._successful_writes < self._MAX_SUCCESSFUL_WRITES_PER_TURN:
+            return None
+        return {
+            "success": False,
+            "done": True,
+            "error": (
+                f"Memory write budget for this turn is exhausted "
+                f"({self._MAX_SUCCESSFUL_WRITES_PER_TURN} successful writes). "
+                "Stop making memory calls — leave memory as it is and continue "
+                "with your reply to the user. Further changes can wait for a "
+                "later turn."
+            ),
+        }
 
     def _consolidation_failure(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Count an at-capacity consolidation failure and degrade gracefully.
@@ -423,6 +464,9 @@ class MemoryStore:
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
+            budget = self._write_budget_response()
+            if budget:
+                return budget
             # Re-read from disk under lock to pick up writes from other sessions.
             # For add (append-only), we skip the drift guard — appending never
             # clobbers existing content, so round-trip mismatches from prior
@@ -485,6 +529,9 @@ class MemoryStore:
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
+            budget = self._write_budget_response()
+            if budget:
+                return budget
             bak = self._reload_target(target)
             if bak is _READ_FAILED:
                 return _read_failed_error(self._path_for(target))
@@ -548,6 +595,9 @@ class MemoryStore:
             return {"success": False, "error": "old_text cannot be empty."}
 
         with self._file_lock(self._path_for(target)):
+            budget = self._write_budget_response()
+            if budget:
+                return budget
             bak = self._reload_target(target)
             if bak is _READ_FAILED:
                 return _read_failed_error(self._path_for(target))
@@ -610,6 +660,9 @@ class MemoryStore:
                     return {"success": False, "error": f"Operation {i + 1}: {scan_error}"}
 
         with self._file_lock(self._path_for(target)):
+            budget = self._write_budget_response()
+            if budget:
+                return budget
             bak = self._reload_target(target)
             if bak is _READ_FAILED:
                 return _read_failed_error(self._path_for(target))
@@ -728,6 +781,12 @@ class MemoryStore:
         # per-turn failure budget resets (the cap counts consecutive failures,
         # not lifetime ones within a turn) (#42405).
         self._consolidation_failures = 0
+        # ...but a success still consumes the per-turn successful-write budget:
+        # a loop made entirely of successful mutations is exactly what that
+        # budget exists to bound (#81120). Idempotent no-op successes (duplicate
+        # add) count too — re-issuing an already-saved write is the same
+        # repeat behaviour the budget suppresses.
+        self._successful_writes += 1
         entries = self._entries_for(target)
         current = self._char_count(target)
         limit = self._char_limit(target)


### PR DESCRIPTION
## What does this PR do?

The #42405 graceful-degrade guard only bounds *failed* memory consolidation attempts — `MemoryStore._success_response()` resets the failure counter after every successful write. A loop made entirely of **successful** mutations therefore has no cumulative budget: a model can oscillate `add(x) -> remove(x) -> add(x)` (or churn `replace`/`remove` on unrelated entries) indefinitely, burning the turn's API budget and destroying durable facts, while every response says `done=true` + "Write saved. This update is complete — do not repeat it." (issue #81120: 47 memory ops in one incident, unrelated facts actually removed; the newer duplicate report #99202 measured 82 memory calls ending at 85/85 API calls with no user-facing answer).

This PR adds a per-turn successful-write budget to `MemoryStore`, mirroring the existing #42405 failure-budget pattern: beyond `_MAX_SUCCESSFUL_WRITES_PER_TURN` (6) successful writes in one turn, further mutating calls (`add`/`replace`/`remove`/`apply_batch`) are refused with a terminal `success=false, done=true` result that tells the model to stop making memory calls and continue with its reply to the user. The refusal happens before any state change, so the store keeps its last known-good state and unrelated entries survive. The budget resets at the turn boundary via the existing `reset_consolidation_failures()` hook (called by `agent/turn_context.py` at every turn start), so legitimate maintenance in later turns is unaffected. Idempotent no-op successes (duplicate `add`) also consume budget, since re-issuing an already-saved write is the same repeat behaviour the budget suppresses.

Reads and the staged-write approval replay path are unaffected (both route through the same guarded entry points, so approved writes also respect the budget consistently).

## Related Issue

Fixes #81120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py` — added `_MAX_SUCCESSFUL_WRITES_PER_TURN = 6` and `_successful_writes` per-turn counter; new `_write_budget_response()` helper returning the terminal refusal; budget check inserted as the first step inside the file lock of all four mutation entry points (`add`, `replace`, `remove`, `apply_batch`); `_success_response()` increments the counter; `reset_consolidation_failures()` now resets both per-turn guard counters (docstring updated; call site in `agent/turn_context.py` unchanged).
- `tests/tools/test_memory_tool.py` — new `TestMemorySuccessfulWriteBudget` class: alternating successful add/remove oscillation stops at the cap with last-known-good store preserved; `apply_batch` successes consume the same budget; duplicate-add idempotent successes count; budget resets at the turn boundary.

## How to Test

1. `pytest tests/tools/test_memory_tool.py -q` → **45 passed** (41 existing + 4 new).
2. Regression for the observed oscillation: `TestMemorySuccessfulWriteBudget::test_alternating_successful_writes_stop_after_cap` seeds an unrelated durable fact, performs 3 add/remove rounds (6 successful writes), then asserts the 7th mutation returns `success=false, done=true` with the "continue with your reply" instruction, that the refused entry was never written, and that the unrelated fact survives.
3. Memory-surface verification: all 20 test files that exercise `MemoryStore`/`memory_tool` (memory tool + write approval + memory provider/bridge + learning mutations + turn context + tool guardrails + run_agent + cron scheduler), 490+ tests, all green. Full-suite run on this host has two pre-existing environment-only failure groups unrelated to this change (verified failing identically on a clean checkout of `main`): `tests/hermes_cli/test_cmd_update.py` (real local launchd services interfere; passes 39/39 with the restart path stubbed) and one anthropic interrupt-handler test; `tests/acp*` cannot even collect locally (`No module named 'acp'`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; the budget is a class constant like `_MAX_CONSOLIDATION_FAILURES_PER_TURN`)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python counter logic, no platform-specific behaviour
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool schema unchanged; the refusal is a normal tool-result shape)
