### PR TITLE
fix(desktop): refresh multiplexed profile transcripts

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -14,9 +14,11 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionStates,
   $stalledSessionIds,
   $workingSessionIds,
   clearAllSessionStates,
+  publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
@@ -247,9 +249,16 @@ describe('active transcript refresh', () => {
     // Seed a tile so reconcileTileTranscripts has a target.
     setSessions([]) // bot chats are hidden from $sessions — the whole point
 
+    const ownerRoute = {
+      connectionId: 'bot-connection',
+      mode: 'remote' as const,
+      profile: 'bot-route',
+      targetProfile: 'bot-profile'
+    }
+
     await act(async () => {
       await reconcileTileTranscriptsForTest({
-        tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
+        tiles: [{ ownerRoute, storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
         busyRef,
         requestSequenceRef,
         signatureRef,
@@ -259,7 +268,233 @@ describe('active transcript refresh', () => {
 
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID, {
+      connectionId: ownerRoute.connectionId,
+      profile: ownerRoute.targetProfile
+    })
+  })
+
+  it('isolates tile transcript reads by connection and profile while preserving the legacy local path', async () => {
+    vi.mocked(getLatestSessionMessages).mockImplementation(async storedId => transcript(storedId, storedId) as never)
+
+    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
+      (_sessionId, updater) => updater({} as Parameters<typeof updater>[0])
+    )
+
+    await act(async () => {
+      await reconcileTileTranscriptsForTest({
+        tiles: [
+          {
+            ownerRoute: {
+              connectionId: 'connection-a',
+              mode: 'remote',
+              profile: 'shared-profile',
+              targetProfile: 'target-a'
+            },
+            runtimeId: 'runtime-a',
+            storedSessionId: 'stored-a'
+          },
+          {
+            ownerRoute: {
+              connectionId: 'connection-b',
+              mode: 'remote',
+              profile: 'shared-profile'
+            },
+            runtimeId: 'runtime-b',
+            storedSessionId: 'stored-b'
+          },
+          { runtimeId: 'runtime-local', storedSessionId: 'stored-local' }
+        ],
+        busyRef: { current: false },
+        requestSequenceRef: { current: 0 },
+        signatureRef: { current: new Map<string, string>() },
+        updateSessionState
+      })
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-a', {
+      connectionId: 'connection-a',
+      profile: 'target-a'
+    })
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-b', {
+      connectionId: 'connection-b',
+      profile: 'shared-profile'
+    })
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-local', undefined)
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-a', expect.any(Function), 'stored-a')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-b', expect.any(Function), 'stored-b')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-local', expect.any(Function), 'stored-local')
+  })
+
+  it('discards a tile transcript when the tile closes during the read', async () => {
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+    const tiles = [{ runtimeId: 'runtime-closing', storedSessionId: 'stored-closing' }]
+    const signatureRef = { current: new Map<string, string>() }
+    const updateSessionState = vi.fn()
+
+    const pending = reconcileTileTranscriptsForTest({
+      tiles,
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState
+    })
+
+    await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-closing', undefined))
+
+    tiles.length = 0
+    resolve?.(transcript('stale answer', 'stored-closing'))
+    await pending
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(signatureRef.current).toEqual(new Map())
+  })
+
+  it('discards a tile transcript when the owner route changes during the read', async () => {
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const tiles = [
+      {
+        ownerRoute: { connectionId: 'connection-old', mode: 'remote' as const, profile: 'profile-old' },
+        runtimeId: 'runtime-rebound',
+        storedSessionId: 'stored-rebound'
+      }
+    ]
+
+    const signatureRef = { current: new Map<string, string>() }
+    const updateSessionState = vi.fn()
+
+    const pending = reconcileTileTranscriptsForTest({
+      tiles,
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState
+    })
+
+    await waitFor(() =>
+      expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-rebound', {
+        connectionId: 'connection-old',
+        profile: 'profile-old'
+      })
+    )
+
+    tiles[0] = {
+      ...tiles[0],
+      ownerRoute: { connectionId: 'connection-new', mode: 'remote', profile: 'profile-new' }
+    }
+    resolve?.(transcript('stale answer', 'stored-rebound'))
+    await pending
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(signatureRef.current).toEqual(new Map())
+  })
+
+  it('discards a tile transcript when its runtime changes during the read', async () => {
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const tiles = [{ runtimeId: 'runtime-old', storedSessionId: 'stored-rebound-runtime' }]
+    const signatureRef = { current: new Map<string, string>() }
+    const updateSessionState = vi.fn()
+
+    const pending = reconcileTileTranscriptsForTest({
+      tiles,
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState
+    })
+
+    await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-rebound-runtime', undefined))
+
+    tiles[0] = { runtimeId: 'runtime-new', storedSessionId: 'stored-rebound-runtime' }
+    resolve?.(transcript('stale answer', 'stored-rebound-runtime'))
+    await pending
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(signatureRef.current).toEqual(new Map())
+  })
+
+  it('does not fetch a tile transcript while its local submit is busy', async () => {
+    const runtimeId = 'runtime-busy-tile'
+    const storedSessionId = 'stored-busy-tile'
+
+    const optimistic = {
+      ...createClientSessionState(storedSessionId),
+      awaitingResponse: true,
+      busy: true,
+      messages: [{ id: 'optimistic-user', parts: [{ text: 'keep me', type: 'text' as const }], role: 'user' as const }]
+    }
+
+    publishSessionState(runtimeId, optimistic)
+
+    const updateSessionState = vi.fn()
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId }],
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map<string, string>() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect($sessionStates.get()[runtimeId]).toEqual(optimistic)
+  })
+
+  it('does not apply a durable tile snapshot when a local submit starts during the read', async () => {
+    const runtimeId = 'runtime-submitting-tile'
+    const storedSessionId = 'stored-submitting-tile'
+    let resolve: ((value: unknown) => void) | undefined
+
+    publishSessionState(runtimeId, createClientSessionState(storedSessionId))
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const updateSessionState = vi.fn()
+
+    const pending = reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId }],
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map<string, string>() },
+      updateSessionState
+    })
+
+    await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalledWith(storedSessionId, undefined))
+
+    const optimistic = {
+      ...createClientSessionState(storedSessionId),
+      awaitingResponse: true,
+      busy: true,
+      messages: [{ id: 'optimistic-user', parts: [{ text: 'keep me', type: 'text' as const }], role: 'user' as const }]
+    }
+
+    publishSessionState(runtimeId, optimistic)
+    resolve?.(transcript('stale durable answer', storedSessionId))
+    await pending
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect($sessionStates.get()[runtimeId]).toEqual(optimistic)
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
@@ -284,7 +519,10 @@ describe('active transcript refresh', () => {
     // Compute the same signature the reconcile will compute, and pre-seed it.
     const preSignature = sessionMessagesSignature(pre.messages as never)
 
-    signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
+    signatureRef.current.set(
+      `tile:${JSON.stringify([TILE_STORED_ID, TILE_RUNTIME_ID, '', '', '', ''])}`,
+      preSignature
+    )
 
     const updateSessionState = vi.fn()
     const busyRef = { current: false }
@@ -301,6 +539,57 @@ describe('active transcript refresh', () => {
     })
 
     expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('prunes signatures for tiles closed between refresh passes without touching active-pane signatures', async () => {
+    const signatureRef = {
+      current: new Map([
+        [`tile:${JSON.stringify(['stored-closed', 'runtime-closed', '', '', '', ''])}`, 'closed-signature'],
+        ['default:active-pane', 'active-signature']
+      ])
+    }
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [],
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState: vi.fn()
+    })
+
+    expect(signatureRef.current).toEqual(new Map([['default:active-pane', 'active-signature']]))
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+  })
+
+  it('does not reuse a previous runtime signature after a durable tile rebind', async () => {
+    const storedSessionId = 'stored-rebound-runtime'
+    const previous = transcript('same durable tail', storedSessionId)
+    const signature = sessionMessagesSignature(previous.messages as never)
+
+    const signatureRef = {
+      current: new Map([
+        [`tile:${JSON.stringify([storedSessionId, 'runtime-old', '', '', '', ''])}`, signature]
+      ])
+    }
+
+    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
+      (_sessionId, updater) => updater({} as Parameters<typeof updater>[0])
+    )
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(previous as never)
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId: 'runtime-new', storedSessionId }],
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState
+    })
+
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-new', expect.any(Function), storedSessionId)
+    expect(signatureRef.current).toEqual(
+      new Map([[`tile:${JSON.stringify([storedSessionId, 'runtime-new', '', '', '', ''])}`, signature]])
+    )
   })
 
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -66,6 +66,30 @@ export interface ActiveTranscriptRefreshDeps {
   ) => ClientSessionState
 }
 
+function sameSessionProfileRoute(left?: SessionProfileRoute, right?: SessionProfileRoute): boolean {
+  return (
+    left?.connectionId === right?.connectionId &&
+    left?.mode === right?.mode &&
+    left?.profile === right?.profile &&
+    left?.targetProfile === right?.targetProfile
+  )
+}
+
+function tileTranscriptSignatureKey(tile: {
+  ownerRoute?: SessionProfileRoute
+  storedSessionId: string
+  runtimeId?: string
+}): string {
+  return `tile:${JSON.stringify([
+    tile.storedSessionId,
+    tile.runtimeId ?? '',
+    tile.ownerRoute?.connectionId ?? '',
+    tile.ownerRoute?.profile ?? '',
+    tile.ownerRoute?.targetProfile ?? '',
+    tile.ownerRoute?.mode ?? ''
+  ])}`
+}
+
 /**
  * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
  * slice 1). Bot canonical chats live here — never in $sessions /
@@ -92,7 +116,7 @@ export async function reconcileTileTranscripts({
   busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
-  tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
+  tiles?: Array<{ ownerRoute?: SessionProfileRoute; storedSessionId: string; runtimeId?: string }>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
@@ -100,6 +124,13 @@ export async function reconcileTileTranscripts({
   ) => ClientSessionState
 }): Promise<void> {
   const tiles = tilesOverride ?? $sessionTiles.get()
+  const liveSignatureKeys = new Set(tiles.filter(tile => tile.runtimeId).map(tileTranscriptSignatureKey))
+
+  for (const signatureKey of signatureRef.current.keys()) {
+    if (signatureKey.startsWith('tile:') && !liveSignatureKeys.has(signatureKey)) {
+      signatureRef.current.delete(signatureKey)
+    }
+  }
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
@@ -114,6 +145,14 @@ export async function reconcileTileTranscripts({
       continue
     }
 
+    const tileState = $sessionStates.get()[runtimeSessionId]
+
+    if (tileState?.busy || tileState?.awaitingResponse) {
+      // Tile submits keep their busy state local; never replace an optimistic
+      // prompt with an older durable snapshot while that turn is in flight.
+      continue
+    }
+
     if ($activeSessionId.get() === runtimeSessionId) {
       // The main pane reconcile already owns this surface.
       continue
@@ -121,25 +160,42 @@ export async function reconcileTileTranscripts({
 
     const requestId = ++requestSequenceRef.current
 
-    // With a tiles override (test path), the live $sessionTiles check can't
-    // see the synthetic tile — treat override tiles as present.
-    const stillPresent = tilesOverride
-      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
-      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
-
     try {
-      const latest = await getLatestSessionMessages(storedSessionId)
+      const profileScope: ProfileScope = tile.ownerRoute
+        ? {
+            connectionId: tile.ownerRoute.connectionId,
+            profile: tile.ownerRoute.targetProfile ?? tile.ownerRoute.profile
+          }
+        : undefined
 
-      if (requestId !== requestSequenceRef.current || busyRef.current || !stillPresent) {
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope)
+
+      const currentTiles = tilesOverride ?? $sessionTiles.get()
+      const currentTileState = $sessionStates.get()[runtimeSessionId]
+
+      const stillPresent = currentTiles.some(
+        current =>
+          current.storedSessionId === storedSessionId &&
+          current.runtimeId === runtimeSessionId &&
+          sameSessionProfileRoute(current.ownerRoute, tile.ownerRoute)
+      )
+
+      if (
+        requestId !== requestSequenceRef.current ||
+        busyRef.current ||
+        currentTileState?.busy ||
+        currentTileState?.awaitingResponse ||
+        !stillPresent
+      ) {
         // Tile closed or superseded mid-read — discard AND prune its
         // signature so the map doesn't grow one entry per ever-opened tile
         // for the app's lifetime (#94255 review point 3).
-        signatureRef.current.delete(`tile:${storedSessionId}`)
+        signatureRef.current.delete(tileTranscriptSignatureKey(tile))
 
         continue
       }
 
-      const signatureKey = `tile:${storedSessionId}`
+      const signatureKey = tileTranscriptSignatureKey(tile)
       const signature = sessionMessagesSignature(latest.messages)
 
       if (signatureRef.current.get(signatureKey) === signature) {

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -268,6 +268,30 @@ describe('SessionTile workspace scope', () => {
     ])
   })
 
+  it('keeps one canonical Bot tile when the same durable session opens twice', () => {
+    const firstScope = {
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'connection-a::default'
+    }
+
+    const refreshedScope = {
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'connection-a::default',
+      workspaceTabTitle: 'Bot Chat'
+    }
+
+    openSessionTile('bot-chat', 'right', undefined, undefined, firstScope)
+    openSessionTile('bot-chat', 'right', undefined, undefined, refreshedScope)
+
+    expect($sessionTiles.get()).toHaveLength(1)
+    expect($sessionTiles.get()[0]).toMatchObject({
+      storedSessionId: 'bot-chat',
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'connection-a::default',
+      workspaceTabTitle: 'Bot Chat'
+    })
+  })
+
   it('allows a Bot-scoped tab when the same stored session is hidden in Sessions main', () => {
     const scope = { workspaceMode: 'bots' as const, workspaceOwnerKey: 'connection-a::default' }
 

--- a/tests/desktop/test_multiplex_sessions_change_watcher.py
+++ b/tests/desktop/test_multiplex_sessions_change_watcher.py
@@ -1,0 +1,61 @@
+"""Regression coverage for multiplexed Desktop session change events."""
+
+from __future__ import annotations
+
+import os
+
+from tui_gateway import server
+
+
+def _touch(path, mtime_ns: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+
+
+def test_sessions_signature_moves_when_a_named_profile_changes(monkeypatch, tmp_path):
+    """A Bot Chat write in any named profile must emit sessions.changed."""
+    _touch(tmp_path / "state.db", 100)
+    _touch(tmp_path / "profiles" / "productions" / "state.db", 200)
+    monkeypatch.setattr(server, "_watcher_home", lambda: tmp_path)
+
+    assert server._sessions_sig() == 200
+
+
+def test_sessions_signature_includes_named_profile_wal(monkeypatch, tmp_path):
+    _touch(tmp_path / "state.db", 100)
+    _touch(tmp_path / "profiles" / "editorial" / "state.db-wal", 300)
+    monkeypatch.setattr(server, "_watcher_home", lambda: tmp_path)
+
+    assert server._sessions_sig() == 300
+
+
+def test_sessions_signature_includes_root_home_wal(monkeypatch, tmp_path):
+    _touch(tmp_path / "state.db", 100)
+    _touch(tmp_path / "state.db-wal", 350)
+    _touch(tmp_path / "profiles" / "editorial" / "state.db", 300)
+    monkeypatch.setattr(server, "_watcher_home", lambda: tmp_path)
+
+    assert server._sessions_sig() == 350
+
+
+def test_sessions_signature_finds_siblings_from_a_named_profile_home(monkeypatch, tmp_path):
+    profiles = tmp_path / "profiles"
+    active = profiles / "engineering"
+    _touch(active / "state.db", 100)
+    _touch(profiles / "productions" / "state.db", 400)
+    monkeypatch.setattr(server, "_watcher_home", lambda: active)
+
+    assert server._sessions_sig() == 400
+
+
+def test_sessions_signature_ignores_symlinked_profile_directories(monkeypatch, tmp_path):
+    outside = tmp_path / "outside"
+    profiles = tmp_path / "profiles"
+    _touch(tmp_path / "state.db", 100)
+    _touch(outside / "state.db", 500)
+    profiles.mkdir()
+    (profiles / "linked").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(server, "_watcher_home", lambda: tmp_path)
+
+    assert server._sessions_sig() == 100

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4898,18 +4898,37 @@ def _cron_sig():
 
 
 def _sessions_sig():
-    """Newest mtime across state.db and its WAL — the cross-process change
-    signal. Messaging-gateway turns and cron runs are written by OTHER
-    processes that never touch this gateway's transports; the shared SQLite
-    file is the one thing they all move (#58671)."""
+    """Newest session-store mtime across every multiplexed profile.
+
+    Messaging-gateway turns, cron runs and bot-to-bot deliveries are written
+    by OTHER processes that never touch this gateway's transports. In a
+    multiplexed install each profile owns a separate SQLite store, so watching
+    only the active home leaves every sibling Bot Chat without a
+    ``sessions.changed`` signal.
+    """
     home = _watcher_home()
     sig = None
-    for name in ("state.db", "state.db-wal"):
-        try:
-            mtime = (home / name).stat().st_mtime_ns
-        except OSError:
-            continue
-        sig = mtime if sig is None else max(sig, mtime)
+    profiles_dir = home.parent if home.parent.name == "profiles" else home / "profiles"
+    roots = [home]
+    try:
+        resolved_profiles_dir = profiles_dir.resolve()
+        roots.extend(
+            path
+            for path in profiles_dir.iterdir()
+            if not path.is_symlink()
+            and path.is_dir()
+            and path.resolve().parent == resolved_profiles_dir
+        )
+    except OSError:
+        pass
+
+    for root in roots:
+        for name in ("state.db", "state.db-wal"):
+            try:
+                mtime = (root / name).stat().st_mtime_ns
+            except OSError:
+                continue
+            sig = mtime if sig is None else max(sig, mtime)
     return sig
 
 


### PR DESCRIPTION
# fix(desktop): refresh multiplexed profile transcripts

## Summary

In a multiplexed gateway, each profile writes to its own session database. The Desktop change watcher only inspected the active profile, so turns written to sibling profiles did not emit `sessions.changed`. When another event did trigger tile reconciliation, the transcript read omitted the tile's owner route and could query the wrong profile.

The change signature now resolves the shared profiles directory from both root-home and named-profile launches, includes active and named-profile session stores, and ignores symlinked profile directories. Open-tile transcript reads use the tile's connection and target profile. A tile-local busy or awaiting submit is skipped before the read and rechecked after it, preserving optimistic prompts; a completion is also discarded if the tile closes or changes owner while the read is in flight. Tile transcript signatures are keyed by durable ID, runtime ID and complete owner route, with closed-tile entries pruned on each pass. Existing durable-session rebind and canonical tile identity remain unchanged and are included in the regression suite.

## Relationship to open work

PR #97887 handles visible-session recovery after a stale runtime RPC. This patch does not modify or duplicate those files; it fixes the two producer paths that leave a multiplexed profile's open transcript stale. A local integration branch combining both commits was tested separately.

## Tests

- `scripts/run_tests.sh tests/desktop/test_multiplex_sessions_change_watcher.py`
- `scripts/run_tests.sh tests/desktop/test_bots_chat_live_append.py`
- `npm --workspace apps/desktop run test:ui -- use-background-sync.test.ts session-states.test.ts session-tile-actions.test.ts use-prompt-actions/utils.test.ts enter-submit-dom-race.test.tsx agent-init-error.test.tsx`
- `npm --workspace apps/desktop run test:ui`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop exec eslint -- src/app/contrib/hooks/use-background-sync.ts src/app/contrib/hooks/use-background-sync.test.ts src/store/session-states.test.ts`
