### PR TITLE
fix(cli): resolve powershell.exe path for WSL clipboard paste

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -15,6 +15,7 @@ Platform support:
 import base64
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -390,14 +391,28 @@ def _linux_save(dest: Path) -> bool:
 # ── WSL2 (powershell.exe) ────────────────────────────────────────────────
 # Reuses _PS_CHECK_IMAGE / _PS_EXTRACT_IMAGE defined above.
 
+def _wsl_powershell_exe() -> str:
+    """Resolve powershell.exe for WSL clipboard reads.
+
+    WSL processes may inherit a PATH without Windows dirs (wsl.conf
+    ``appendWindowsPath=false``), which makes the bare ``powershell.exe``
+    unresolvable — fall back to the standard WSL-interop install path.
+    """
+    exe = shutil.which("powershell.exe")
+    if exe:
+        return exe
+    fallback = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+    return fallback if os.path.isfile(fallback) else "powershell.exe"
+
+
 def _wsl_has_image() -> bool:
     """Check if Windows clipboard has an image (via powershell.exe)."""
-    return _powershell_has_image("powershell.exe", timeout=8, label="WSL")
+    return _powershell_has_image(_wsl_powershell_exe(), timeout=8, label="WSL")
 
 
 def _wsl_save(dest: Path) -> bool:
     """Extract clipboard image via powershell.exe → base64 → decode to PNG."""
-    return _powershell_save_image("powershell.exe", dest, timeout=15, label="WSL")
+    return _powershell_save_image(_wsl_powershell_exe(), dest, timeout=15, label="WSL")
 
 
 # ── Wayland (wl-paste) ──────────────────────────────────────────────────

--- a/tests/hermes_cli/test_clipboard_wsl_powershell_path.py
+++ b/tests/hermes_cli/test_clipboard_wsl_powershell_path.py
@@ -1,0 +1,52 @@
+"""Regression tests for WSL2 clipboard image paste path resolution.
+
+When wsl.conf sets ``appendWindowsPath=false``, WSL processes inherit a
+PATH with no Windows directories, so the bare ``powershell.exe`` is
+unresolvable and clipboard image paste fails with FileNotFoundError.
+``_wsl_powershell_exe()`` resolves powershell.exe via PATH first and
+falls back to the standard WSL-interop install path.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import clipboard as clip
+
+_FALLBACK = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+
+
+def test_wsl_powershell_exe_returns_path_resolved_exe():
+    with patch.object(clip.shutil, "which", return_value="/usr/bin/powershell.exe"):
+        assert clip._wsl_powershell_exe() == "/usr/bin/powershell.exe"
+
+
+def test_wsl_powershell_exe_returns_mntc_fallback_when_which_none():
+    with patch.object(clip.shutil, "which", return_value=None), \
+         patch.object(clip.os.path, "isfile", return_value=True):
+        assert clip._wsl_powershell_exe() == _FALLBACK
+
+
+def test_wsl_powershell_exe_returns_bare_name_when_nothing_resolves():
+    with patch.object(clip.shutil, "which", return_value=None), \
+         patch.object(clip.os.path, "isfile", return_value=False):
+        assert clip._wsl_powershell_exe() == "powershell.exe"
+
+
+def test_wsl_has_image_passes_resolved_exe():
+    with patch.object(clip.shutil, "which", return_value="/usr/bin/powershell.exe"), \
+         patch.object(clip, "_powershell_has_image", return_value=True) as has_image:
+        assert clip._wsl_has_image() is True
+    exe = has_image.call_args[0][0]
+    assert exe == "/usr/bin/powershell.exe"
+    assert exe != "powershell.exe"
+
+
+def test_wsl_save_passes_resolved_exe(tmp_path):
+    dest = tmp_path / "clip.png"
+    with patch.object(clip.shutil, "which", return_value="/usr/bin/powershell.exe"), \
+         patch.object(clip, "_powershell_save_image", return_value=True) as save_image:
+        assert clip._wsl_save(dest) is True
+    exe = save_image.call_args[0][0]
+    assert exe == "/usr/bin/powershell.exe"
+    assert exe != "powershell.exe"


### PR DESCRIPTION
## Summary

Fixes WSL2 clipboard image paste (`/paste` and Ctrl+V) failing when `wsl.conf` sets `appendWindowsPath = false`. In that configuration WSL processes inherit a PATH with no Windows directories, so the bare `powershell.exe` command in the WSL clipboard branch is unresolvable — `subprocess.run` raises `FileNotFoundError`, `_powershell_save_image` returns `False`, and the TUI reports "No image found in clipboard" even though the image is present.

## Changes

- `hermes_cli/clipboard.py`: add `_wsl_powershell_exe()` which resolves `powershell.exe` via PATH first, then falls back to the standard WSL-interop install path (`/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`), and finally to the bare name so existing `FileNotFoundError` handling stays intact. Both WSL call sites (`_wsl_has_image`, `_wsl_save`) now use it.
- `tests/hermes_cli/test_clipboard_wsl_powershell_path.py`: regression tests covering all three resolution branches plus both call sites.

## Tests

- New regression suite: `5 passed` (verified the two call-site tests fail when the fix is reverted to the bare `powershell.exe`).
- Existing `tests/hermes_cli/test_clipboard_text_write.py`: `2 passed, 1 skipped` — no regression.

Closes #99304
