### PR TITLE
fix(desktop): model assignment carries the credential pointer, not a resolved key (#88990, salvage #90484)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7746,27 +7746,38 @@ def _apply_model_assignment_sync(
         model_cfg = _apply_main_model_assignment(
             cfg.get("model", {}), provider, model, base_url, api_key
         )
-        if isinstance(provider_entry, dict) and provider_entry.get("api_key"):
+        _raw_assign_entry = None
+        try:
+            _stored, _raw_assign_entry = find_provider_entry(
+                read_raw_config().get("providers"), provider
+            )
+        except Exception:
+            _raw_assign_entry = None
+        _assign_key_env = (
+            str(_raw_assign_entry.get("key_env") or "").strip()
+            if isinstance(_raw_assign_entry, dict)
+            else ""
+        )
+        if _assign_key_env:
+            # #88990: carry the credential POINTER, never a resolved secret.
+            model_cfg["key_env"] = _assign_key_env
+            model_cfg.pop("api_key", None)
+        elif isinstance(provider_entry, dict) and provider_entry.get("api_key"):
             # #88990: provider_entry comes from load_config(), which expands
             # ${VAR} env refs to plaintext. Copying that resolved value into
             # model.api_key writes the SECRET into config.yaml (and recreates
             # it on every re-apply, even after the user deletes it by hand).
-            # Only mirror the key when the on-disk entry holds a literal
-            # value; env-ref and key_env entries already resolve at runtime
-            # via the provider entry itself.
-            _raw_entry = None
-            try:
-                _stored, _raw_entry = find_provider_entry(
-                    read_raw_config().get("providers"), provider
-                )
-            except Exception:
-                _raw_entry = None
-            _raw_key = _raw_entry.get("api_key") if isinstance(_raw_entry, dict) else None
-            _entry_uses_env = bool(
-                (isinstance(_raw_entry, dict) and str(_raw_entry.get("key_env") or "").strip())
-                or (isinstance(_raw_key, str) and re.search(r"\$\{[^}]+\}", _raw_key))
+            # Prefer the raw ${VAR} template; only fall back to the expanded
+            # value when the raw yaml itself stores the key as a literal (no
+            # new exposure in that case).
+            _raw_key = (
+                str(_raw_assign_entry.get("api_key") or "").strip()
+                if isinstance(_raw_assign_entry, dict)
+                else ""
             )
-            if not _entry_uses_env:
+            if _raw_key.startswith("${") and _raw_key.endswith("}"):
+                model_cfg["api_key"] = _raw_key
+            else:
                 model_cfg["api_key"] = provider_entry["api_key"]
         cfg["model"] = model_cfg
 
@@ -8685,7 +8696,25 @@ def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
                 model_cfg["key_env"] = entry["key_env"]
                 model_cfg.pop("api_key", None)
             elif entry.get("api_key"):
-                model_cfg["api_key"] = entry["api_key"]
+                # Same #88990 shape as /api/model/set: `cfg` is env-expanded,
+                # so a raw `${VAR}` api_key would land as plaintext. Copy the
+                # raw template when that's what's on disk.
+                _raw_entry = None
+                try:
+                    _stored_raw, _raw_entry = find_provider_entry(
+                        read_raw_config().get("providers"), provider_key
+                    )
+                except Exception:
+                    _raw_entry = None
+                _raw_key = (
+                    str(_raw_entry.get("api_key") or "").strip()
+                    if isinstance(_raw_entry, dict)
+                    else ""
+                )
+                if _raw_key.startswith("${") and _raw_key.endswith("}"):
+                    model_cfg["api_key"] = _raw_key
+                else:
+                    model_cfg["api_key"] = entry["api_key"]
             cfg["model"] = model_cfg
             save_config(cfg)
         return {"ok": True, "provider": provider_key, "model": model}

--- a/tests/hermes_cli/test_model_assignment_env_key_mirror.py
+++ b/tests/hermes_cli/test_model_assignment_env_key_mirror.py
@@ -46,7 +46,7 @@ def _raw_model_cfg(home):
     return (yaml.safe_load((home / "config.yaml").read_text()) or {}).get("model", {})
 
 
-def test_env_ref_key_not_copied_into_model_api_key(_hermes_home, monkeypatch):
+def test_env_ref_key_carries_template_not_plaintext(_hermes_home, monkeypatch):
     monkeypatch.setenv("MY_LOCAL_KEY", "sk-super-secret-value")
     _write_config(
         _hermes_home,
@@ -55,17 +55,21 @@ def test_env_ref_key_not_copied_into_model_api_key(_hermes_home, monkeypatch):
     _apply("mylocal")
     model_cfg = _raw_model_cfg(_hermes_home)
     assert "sk-super-secret-value" not in yaml.safe_dump(model_cfg)
-    assert not model_cfg.get("api_key")
+    # Pointer-carry: the raw ${VAR} template rides along so the model
+    # config still resolves the credential at runtime.
+    assert model_cfg.get("api_key") == "${MY_LOCAL_KEY}"
 
 
-def test_key_env_entry_not_copied(_hermes_home, monkeypatch):
+def test_key_env_entry_carries_pointer(_hermes_home, monkeypatch):
     monkeypatch.setenv("MYLOCAL_API_KEY", "sk-keyenv-secret")
     _write_config(
         _hermes_home,
         {"mylocal": {"base_url": "http://localhost:1234/v1", "key_env": "MYLOCAL_API_KEY"}},
     )
     _apply("mylocal")
-    assert "sk-keyenv-secret" not in (_hermes_home / "config.yaml").read_text()
+    raw = (_hermes_home / "config.yaml").read_text()
+    assert "sk-keyenv-secret" not in raw
+    assert _raw_model_cfg(_hermes_home).get("key_env") == "MYLOCAL_API_KEY"
 
 
 def test_literal_key_still_mirrored(_hermes_home):

--- a/tests/hermes_cli/test_model_set_secret_copy.py
+++ b/tests/hermes_cli/test_model_set_secret_copy.py
@@ -1,0 +1,94 @@
+"""POST /api/model/set must never copy an env-expanded secret into config.yaml.
+
+Regression for #88990: ``_apply_model_assignment_sync`` ran on the
+env-EXPANDED config, so a provider entry whose raw yaml held
+``api_key: ${MY_KEY}`` (or a ``key_env`` pointer) got its RESOLVED plaintext
+key copied under ``model.api_key`` and persisted. ``_preserve_env_ref_templates``
+cannot rescue it — no template ever lived at ``model.api_key``.
+
+The fix prefers the credential pointer: ``key_env`` when the raw entry has
+one, else the raw ``${VAR}`` template, and only falls back to the expanded
+value when the key is stored as a literal on disk (no new exposure).
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+SECRET = "sk-SUPERSECRET-e2e-12345"
+
+
+@pytest.fixture()
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("MY_SECRET_KEY", SECRET)
+    # Config caches are keyed per-path, but reload the config module state so
+    # nothing from a previous test's HERMES_HOME bleeds in.
+    for mod in ("hermes_cli.config",):
+        if mod in sys.modules:
+            importlib.reload(sys.modules[mod])
+    return home
+
+
+def _write_config(home, body: str) -> None:
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _apply(provider="myprov", model="test-model"):
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    return _apply_model_assignment_sync("main", provider, model, "", "")
+
+
+def _model_block(home) -> str:
+    text = (home / "config.yaml").read_text(encoding="utf-8")
+    return text.split("providers:")[0]
+
+
+class TestModelSetSecretHandling:
+    def test_env_template_key_is_copied_as_template_not_plaintext(self, isolated_home):
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    api_key: ${MY_SECRET_KEY}\n    model: test-model\n",
+        )
+
+        _apply()
+
+        text = (isolated_home / "config.yaml").read_text(encoding="utf-8")
+        assert SECRET not in text
+        assert "api_key: ${MY_SECRET_KEY}" in _model_block(isolated_home)
+
+    def test_key_env_pointer_is_preferred_over_api_key(self, isolated_home, monkeypatch):
+        monkeypatch.setenv("MYPROV_KEY", SECRET)
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    key_env: MYPROV_KEY\n    api_key: ${MYPROV_KEY}\n    model: test-model\n",
+        )
+
+        _apply()
+
+        text = (isolated_home / "config.yaml").read_text(encoding="utf-8")
+        block = _model_block(isolated_home)
+        assert SECRET not in text
+        assert "key_env: MYPROV_KEY" in block
+        assert "api_key" not in block
+
+    def test_literal_on_disk_key_keeps_legacy_copy_behavior(self, isolated_home):
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    api_key: sk-literal-on-disk\n    model: test-model\n",
+        )
+
+        _apply()
+
+        assert "api_key: sk-literal-on-disk" in _model_block(isolated_home)


### PR DESCRIPTION
# fix(desktop): model assignment carries the credential pointer, not a resolved key (#88990, salvage of #90484)

## Summary
Upgrades the #88990 fix that shipped in #99310: model assignment and custom-endpoint activation now carry the credential POINTER (`key_env` or the raw `${VAR}` template) into `model` config, instead of skipping the copy entirely — the model entry keeps resolving its credential at runtime while config.yaml stays plaintext-free. Salvages the earlier PR #90484, which had the better design but predated newer `web_server.py` changes.

## Changes
- `web_server.py` `_apply_model_assignment_sync`: key_env carried independently of the expanded api_key guard (a key_env-only entry now gets its pointer too); raw `${VAR}` templates preserved verbatim; literal keys unchanged.
- `web_server.py` `activate_custom_endpoint`: same pointer-carry applied to the sibling site.
- Tests: `test_model_assignment_env_key_mirror.py` updated to pin pointer-carry (not just secret-absence); `test_model_set_secret_copy.py` (from #90484) added.

## Validation
| Check | Result |
|---|---|
| Targeted pytest (3 files) | 8/8 pass |
| Secret-absence + pointer-presence asserted for env-ref, key_env, literal cases | pass |
| Base current with origin/main | rev-list count 0 |

**Live repro:** the intermediate behavior (skip-copy, pointer dropped) demonstrated by the pre-fix test failure `test_key_env_entry_carries_pointer` (model_cfg lost its credential reference); passes with the carry.

Note: a straight cherry-pick of #90484 was aborted — its branch predates recent `web_server.py` refactors and `checkout --theirs` would have reverted ~1,169 newer lines. Hunks were re-applied surgically onto current main instead.

## Infographic

![pointer-carry infographic](https://v3b.fal.media/files/b/0aa88928/t3acf-okOyyd0SSGCMNs5_vEgOhWmW.png)
