### PR TITLE
fix(desktop): respect compositor window controls

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -395,6 +395,13 @@ import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-market
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
+import {
+  DEFAULT_WINDOW_CONTROLS_MODE,
+  isCompositorManagedWaylandSession,
+  nativeWindowControlsEnabled,
+  normalizeWindowControlsMode,
+  type WindowControlsMode
+} from './window-controls'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -451,7 +458,9 @@ const DEV_SERVER = process.env.HERMES_DESKTOP_DEV_SERVER
 const IS_PACKAGED = app.isPackaged || Boolean(process.env.HERMES_DESKTOP_IS_PACKAGED)
 const IS_MAC = process.platform === 'darwin'
 const IS_WINDOWS = process.platform === 'win32'
+const IS_LINUX = process.platform === 'linux'
 const IS_WSL = isWslEnvironment()
+const IS_COMPOSITOR_MANAGED_WAYLAND = IS_LINUX && isCompositorManagedWaylandSession(process.env)
 // Truthful macOS kernel major (Tahoe = 25). Product version lies (16 vs 26) per
 // build SDK, so gate Tahoe workarounds on Darwin instead.
 const DARWIN_MAJOR = IS_MAC ? Number.parseInt(os.release(), 10) || 0 : 0
@@ -955,6 +964,36 @@ function writePersistedThemeSource(mode) {
 
 nativeTheme.themeSource = readPersistedThemeSource()
 
+// Linux desktop environments do not all handle frameless Electron windows the
+// same way. Electron's titleBarOverlay is an in-content control strip, not a
+// compositor server-side decoration, so the system default hides it there
+// and keeps it on desktops where it is the expected fallback. Explicit Native
+// or Hidden choices are available in Appearance.
+const WINDOW_CONTROLS_CONFIG_PATH = path.join(app.getPath('userData'), 'window-controls.json')
+
+function readPersistedWindowControlsMode(): WindowControlsMode {
+  try {
+    return normalizeWindowControlsMode(JSON.parse(fs.readFileSync(WINDOW_CONTROLS_CONFIG_PATH, 'utf8')).mode)
+  } catch {
+    return DEFAULT_WINDOW_CONTROLS_MODE
+  }
+}
+
+let windowControlsMode = readPersistedWindowControlsMode()
+
+function nativeWindowControlsAreEnabled(): boolean {
+  return !IS_LINUX || nativeWindowControlsEnabled(windowControlsMode, IS_COMPOSITOR_MANAGED_WAYLAND)
+}
+
+function writePersistedWindowControlsMode(mode: WindowControlsMode): void {
+  try {
+    fs.mkdirSync(path.dirname(WINDOW_CONTROLS_CONFIG_PATH), { recursive: true })
+    fs.writeFileSync(WINDOW_CONTROLS_CONFIG_PATH, JSON.stringify({ mode }, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[window-controls] write failed: ${error.message}`)
+  }
+}
+
 // Window translucency (see-through window). One lever, 0–100; 0 = off (the
 // default). Two modes share the lever (see electron/translucency.ts and
 // store/translucency): 'clear' maps it to the native window opacity so the
@@ -1131,6 +1170,10 @@ function getWindowBackgroundColor() {
 const TITLEBAR_OVERLAY_COLOR = 'rgba(1, 0, 0, 0)'
 
 function getTitleBarOverlayOptions() {
+  if (!nativeWindowControlsAreEnabled()) {
+    return false
+  }
+
   if (IS_MAC) {
     // Tahoe (Darwin 25+) misplaces the traffic lights when the overlay has a
     // nonzero height (electron#49183); 0 there keeps them at the configured
@@ -1158,9 +1201,9 @@ function getTitleBarOverlayOptions() {
 }
 
 // Push refreshed overlay options to a live window after a theme/appearance
-// change. No-op only on plain (non-WSL) Linux, where getTitleBarOverlayOptions()
-// returns false; the try/catch additionally guards builds where
-// setTitleBarOverlay isn't supported.
+// change. This also switches Linux between Electron's controls and no overlay
+// when the user changes the Appearance setting. The try/catch additionally
+// guards builds where setTitleBarOverlay isn't supported.
 function applyTitleBarOverlay(win) {
   const options = getTitleBarOverlayOptions()
 
@@ -6207,7 +6250,12 @@ function getWindowButtonPosition(win = mainWindow) {
 }
 
 function getNativeOverlayWidth() {
-  return computeNativeOverlayWidth({ isWindows: IS_WINDOWS, isWsl: IS_WSL, isMac: IS_MAC })
+  return computeNativeOverlayWidth({
+    isMac: IS_MAC,
+    isWindows: IS_WINDOWS,
+    isWsl: IS_WSL,
+    nativeWindowControls: nativeWindowControlsAreEnabled()
+  })
 }
 
 function getWindowState(win = mainWindow) {
@@ -16520,6 +16568,34 @@ app.on('will-quit', () => {
 // itself. Registered at module scope, which runs long before any window.
 ipcMain.on('hermes:translucency:support', event => {
   event.returnValue = { glass: GLASS_SUPPORTED, translucency: TRANSLUCENCY_SUPPORTED }
+})
+
+// Window Controls Overlay is a renderer-painted strip, not a Hyprland
+// decoration. Keep its preference in the main process so every window (and a
+// cold launch) uses the same answer. The renderer receives the initial value
+// synchronously through preload, then sends changes here for live application.
+ipcMain.on('hermes:window-controls:get', event => {
+  event.returnValue = {
+    compositorManaged: IS_COMPOSITOR_MANAGED_WAYLAND,
+    mode: windowControlsMode,
+    supported: IS_LINUX
+  }
+})
+
+ipcMain.on('hermes:window-controls:set', (_event, value) => {
+  const next = normalizeWindowControlsMode(value)
+
+  if (next === windowControlsMode) {
+    return
+  }
+
+  windowControlsMode = next
+  writePersistedWindowControlsMode(next)
+
+  for (const win of BrowserWindow.getAllWindows()) {
+    applyTitleBarOverlay(win)
+    win.webContents.send('hermes:window-controls:changed', next)
+  }
 })
 
 ipcMain.on('hermes:translucency', (_event, payload) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -8,12 +8,25 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 // "Desktop IPC bridge is unavailable"). No reply means no glass, which degrades
 // to an ordinary opaque window rather than a page thinned over nothing.
 const translucencySupport = ipcRenderer.sendSync('hermes:translucency:support')
+const windowControls = ipcRenderer.sendSync('hermes:window-controls:get')
 const hudWindowing = ipcRenderer.sendSync('hermes:hud:windowing')
 const hudNativeDrag = hudWindowing?.nativeDrag === true
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   glassSupported: translucencySupport?.glass === true,
   translucencySupported: translucencySupport?.translucency === true,
+  windowControls: {
+    compositorManaged: windowControls?.compositorManaged === true,
+    mode: windowControls?.mode,
+    supported: windowControls?.supported === true,
+    setMode: mode => ipcRenderer.send('hermes:window-controls:set', mode),
+    onChanged: callback => {
+      const listener = (_event, mode) => callback(mode)
+      ipcRenderer.on('hermes:window-controls:changed', listener)
+
+      return () => ipcRenderer.removeListener('hermes:window-controls:changed', listener)
+    }
+  },
   getConnection: profile => ipcRenderer.invoke('hermes:connection', profile),
   // Registry-scoped backend resolution: { connectionId, profile } → descriptor.
   getConnectionFor: payload => ipcRenderer.invoke('hermes:connection:for', payload),

--- a/apps/desktop/electron/titlebar-overlay-width.test.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.test.ts
@@ -37,6 +37,10 @@ test('macOS uses traffic lights, not a WCO overlay, so it reserves nothing', () 
   assert.equal(nativeOverlayWidth({ isMac: true }), 0)
 })
 
+test('hidden native controls reserve no titlebar width', () => {
+  assert.equal(nativeOverlayWidth({ nativeWindowControls: false }), 0)
+})
+
 test('the fallback width is a sane positive pixel value', () => {
   assert.ok(Number.isInteger(OVERLAY_FALLBACK_WIDTH) && OVERLAY_FALLBACK_WIDTH > 0)
 })

--- a/apps/desktop/electron/titlebar-overlay-width.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.ts
@@ -8,14 +8,20 @@ export const OVERLAY_FALLBACK_WIDTH = 144
  * API is unavailable.
  *
  * macOS uses traffic lights positioned via trafficLightPosition, not a WCO
- * overlay, so it reserves nothing here. Every other desktop platform now paints
- * the Electron overlay (Windows, WSLg, and plain Linux KDE/GNOME), so they all
- * reserve the fallback width — the split is simply mac vs. not.
+ * overlay, so it reserves nothing here. Every other desktop platform paints the
+ * Electron overlay when native controls are enabled. Hyprland's system default
+ * disables them because its frameless Wayland windows have no server-side
+ * decoration to replace them with.
  *
- * @param {{ isMac?: boolean }} opts
+ * @param {{ isWindows?: boolean, isWsl?: boolean, isMac?: boolean, nativeWindowControls?: boolean }} opts
  */
-export function nativeOverlayWidth({ isWindows = false, isWsl = false, isMac = false } = {}) {
-  if (isMac) {
+export function nativeOverlayWidth({
+  isWindows = false,
+  isWsl = false,
+  isMac = false,
+  nativeWindowControls = true
+} = {}) {
+  if (isMac || !nativeWindowControls) {
     return 0
   }
 

--- a/apps/desktop/electron/window-controls.test.ts
+++ b/apps/desktop/electron/window-controls.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  DEFAULT_WINDOW_CONTROLS_MODE,
+  isCompositorManagedWaylandSession,
+  nativeWindowControlsEnabled,
+  normalizeWindowControlsMode
+} from './window-controls'
+
+test('invalid window-controls values use the system default', () => {
+  assert.equal(normalizeWindowControlsMode(undefined), DEFAULT_WINDOW_CONTROLS_MODE)
+  assert.equal(normalizeWindowControlsMode('anything'), DEFAULT_WINDOW_CONTROLS_MODE)
+})
+
+test('system mode hides controls on compositor-managed Wayland and shows them elsewhere', () => {
+  assert.equal(nativeWindowControlsEnabled('system', true), false)
+  assert.equal(nativeWindowControlsEnabled('system', false), true)
+})
+
+test('explicit window-controls modes override compositor detection', () => {
+  assert.equal(nativeWindowControlsEnabled('native', true), true)
+  assert.equal(nativeWindowControlsEnabled('hidden', false), false)
+})
+
+test('known tiling Wayland compositors are compositor-managed sessions', () => {
+  for (const desktop of ['Hyprland', 'Sway', 'river', 'niri', 'dwl']) {
+    assert.equal(
+      isCompositorManagedWaylandSession({ XDG_CURRENT_DESKTOP: desktop, XDG_SESSION_TYPE: 'wayland' }),
+      true,
+      desktop
+    )
+  }
+})
+
+test('Hyprland instance signatures identify the session without desktop variables', () => {
+  assert.equal(isCompositorManagedWaylandSession({ HYPRLAND_INSTANCE_SIGNATURE: 'instance' }), true)
+})
+
+test('GNOME and KDE remain native-control defaults', () => {
+  assert.equal(isCompositorManagedWaylandSession({ XDG_CURRENT_DESKTOP: 'GNOME', XDG_SESSION_TYPE: 'wayland' }), false)
+  assert.equal(isCompositorManagedWaylandSession({ XDG_CURRENT_DESKTOP: 'KDE', XDG_SESSION_TYPE: 'wayland' }), false)
+})

--- a/apps/desktop/electron/window-controls.ts
+++ b/apps/desktop/electron/window-controls.ts
@@ -1,0 +1,29 @@
+export type WindowControlsMode = 'hidden' | 'native' | 'system'
+
+export const DEFAULT_WINDOW_CONTROLS_MODE: WindowControlsMode = 'system'
+
+const COMPOSITOR_MANAGED_DESKTOPS = /(?:^|[:;])(hyprland|sway|river|niri|dwl)(?:$|[:;])/i
+
+export function normalizeWindowControlsMode(value: unknown): WindowControlsMode {
+  return value === 'hidden' || value === 'native' || value === 'system' ? value : DEFAULT_WINDOW_CONTROLS_MODE
+}
+
+/**
+ * Known compositor-managed Wayland sessions do not need an in-app titlebar
+ * control strip by default. Desktop environments such as KDE and GNOME keep
+ * the native-control fallback because they are commonly used with decorations.
+ */
+export function isCompositorManagedWaylandSession(env: NodeJS.ProcessEnv): boolean {
+  if (env.HYPRLAND_INSTANCE_SIGNATURE) {
+    return true
+  }
+
+  const wayland = env.XDG_SESSION_TYPE === 'wayland' || Boolean(env.WAYLAND_DISPLAY)
+  const desktops = `${env.XDG_CURRENT_DESKTOP ?? ''};${env.XDG_SESSION_DESKTOP ?? ''}`
+
+  return wayland && COMPOSITOR_MANAGED_DESKTOPS.test(desktops)
+}
+
+export function nativeWindowControlsEnabled(mode: WindowControlsMode, compositorManaged: boolean): boolean {
+  return mode === 'native' || (mode === 'system' && !compositorManaged)
+}

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -47,6 +47,12 @@ import {
   TRANSLUCENCY_SUPPORTED
 } from '@/store/translucency'
 import { $vibeHeartsEnabled, setVibeHeartsEnabled } from '@/store/vibe-hearts-enabled'
+import {
+  $windowControlsMode,
+  setWindowControlsMode,
+  WINDOW_CONTROLS_SUPPORTED,
+  type WindowControlsMode
+} from '@/store/window-controls'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
 import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
@@ -364,6 +370,7 @@ export function AppearanceSettings() {
   const backdrop = useStore($backdrop)
   const introSplash = useStore($introSplash)
   const installs = useStore($marketplaceInstalls)
+  const windowControlsMode = useStore($windowControlsMode)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
@@ -445,6 +452,12 @@ export function AppearanceSettings() {
   ] as const satisfies readonly { id: EmbedMode; label: string }[]
 
   const uiScaleOptions = UI_SCALE_PRESETS.map(preset => ({ id: preset, label: `${preset}%` }))
+
+  const windowControlsOptions = [
+    { id: 'system', label: a.windowControlsSystem },
+    { id: 'native', label: a.windowControlsNative },
+    { id: 'hidden', label: a.windowControlsHidden }
+  ] as const satisfies readonly { id: WindowControlsMode; label: string }[]
 
   const matchedScalePreset = matchUiScalePreset(zoomPercent)
 
@@ -582,6 +595,24 @@ export function AppearanceSettings() {
           />
 
           <TerminalFontSetting />
+
+          {WINDOW_CONTROLS_SUPPORTED && (
+            <ListRow
+              action={
+                <SegmentedControl
+                  onChange={id => {
+                    triggerHaptic('selection')
+                    setWindowControlsMode(id)
+                  }}
+                  options={windowControlsOptions}
+                  value={windowControlsMode}
+                />
+              }
+              description={a.windowControlsDesc}
+              id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.windowControls)}
+              title={a.windowControlsTitle}
+            />
+          )}
 
           <ListRow
             action={

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -18,7 +18,8 @@ export const APPEARANCE_SETTING_IDS = {
   theme: 'appearance.theme',
   toolView: 'appearance.tool-view',
   translucency: 'appearance.translucency',
-  uiScale: 'appearance.ui-scale'
+  uiScale: 'appearance.ui-scale',
+  windowControls: 'appearance.window-controls'
 } as const
 
 export interface SettingsSearchTarget {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -291,6 +291,14 @@ declare global {
       setActiveWork?: (payload: HermesActiveWork) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
+      /** Linux titlebar controls: system hides Electron's overlay on compositor-managed Wayland. */
+      windowControls?: {
+        compositorManaged: boolean
+        mode: 'hidden' | 'native' | 'system'
+        supported: boolean
+        setMode: (mode: 'hidden' | 'native' | 'system') => void
+        onChanged: (callback: (mode: 'hidden' | 'native' | 'system') => void) => () => void
+      }
       /** Main-process fact: this OS can back glass with a native material. */
       glassSupported?: boolean
       /** Main-process fact: this OS can do any translucency at all (not Linux). */

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -444,6 +444,12 @@ export const ar = defineLocale({
       toolViewDesc: 'تحكم في كيفية عرض نشاط الأدوات داخل المحادثة.',
       reasoningCollapsedTitle: 'طي التفكير افتراضيًا',
       reasoningCollapsedDesc: 'أبقِ التفكير المتدفق متاحًا دون توسيعه حتى تفتحه.',
+      windowControlsTitle: 'عناصر التحكم بالنافذة',
+      windowControlsDesc:
+        'اختر ما إذا كان Electron يعرض أزرار التصغير والتكبير والإغلاق. يخفي وضع النظام الأزرار في Hyprland؛ ويعرضها الوضع الأصلي دائمًا؛ ويترك الوضع المخفي إدارة النافذة للمركّب.',
+      windowControlsSystem: 'النظام',
+      windowControlsNative: 'أصلي',
+      windowControlsHidden: 'مخفي',
       translucencyTitle: 'شفافية النافذة',
       translucencyDesc: 'إظهار سطح المكتب من خلال النافذة بالكامل، بما في ذلك النص.',
       translucencyGlassDesc: 'زجاج غير لامع: يظهر سطح المكتب كضبابية ناعمة بينما يبقى النص واضحًا.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -546,6 +546,12 @@ export const en: Translations = {
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,
+      windowControlsTitle: 'Window Controls',
+      windowControlsDesc:
+        'Choose whether Electron shows minimize, maximize, and close controls. System hides them on compositor-managed Wayland sessions such as Hyprland, Sway, river, niri, and dwl; Native always shows them; Hidden leaves window management to your compositor.',
+      windowControlsSystem: 'System',
+      windowControlsNative: 'Native',
+      windowControlsHidden: 'Hidden',
       sessionDensityTitle: 'Session List Density',
       sessionDensityDesc: 'Choose how much context appears beneath session titles in the sidebar.',
       sessionDensityCompact: 'Compact',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -369,6 +369,12 @@ export const ja = defineLocale({
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,
+      windowControlsTitle: 'ウィンドウ操作ボタン',
+      windowControlsDesc:
+        'Electron の最小化・最大化・閉じるボタンを表示するか選びます。「システム」は Hyprland で非表示にし、「ネイティブ」は常に表示し、「非表示」はコンポジターに任せます。',
+      windowControlsSystem: 'システム',
+      windowControlsNative: 'ネイティブ',
+      windowControlsHidden: '非表示',
       sessionDensityTitle: 'セッションリストの密度',
       sessionDensityDesc: 'サイドバーのセッションタイトルの下に表示する情報量を選びます。',
       sessionDensityCompact: 'コンパクト',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -440,6 +440,11 @@ export interface Translations {
       reasoningCollapsedDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
+      windowControlsTitle: string
+      windowControlsDesc: string
+      windowControlsSystem: string
+      windowControlsNative: string
+      windowControlsHidden: string
       sessionDensityTitle: string
       sessionDensityDesc: string
       sessionDensityCompact: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -359,6 +359,12 @@ export const zhHant = defineLocale({
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,
+      windowControlsTitle: '視窗控制',
+      windowControlsDesc:
+        '選擇是否顯示 Electron 的最小化、最大化與關閉按鈕。系統模式會在 Hyprland 上隱藏它們；原生模式一律顯示；隱藏模式交由視窗合成器管理。',
+      windowControlsSystem: '系統',
+      windowControlsNative: '原生',
+      windowControlsHidden: '隱藏',
       sessionDensityTitle: '工作階段列表密度',
       sessionDensityDesc: '選擇側邊欄工作階段標題下方顯示的資訊量。',
       sessionDensityCompact: '緊湊',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -533,6 +533,12 @@ export const zh: Translations = {
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,
+      windowControlsTitle: '窗口控制',
+      windowControlsDesc:
+        '选择是否显示 Electron 的最小化、最大化和关闭按钮。系统模式会在 Hyprland 上隐藏它们；原生模式始终显示；隐藏模式交给窗口合成器管理。',
+      windowControlsSystem: '系统',
+      windowControlsNative: '原生',
+      windowControlsHidden: '隐藏',
       sessionDensityTitle: '会话列表密度',
       sessionDensityDesc: '选择侧边栏会话标题下方显示的信息量。',
       sessionDensityCompact: '紧凑',

--- a/apps/desktop/src/store/window-controls.ts
+++ b/apps/desktop/src/store/window-controls.ts
@@ -1,0 +1,25 @@
+import { atom } from 'nanostores'
+
+export type WindowControlsMode = 'hidden' | 'native' | 'system'
+
+const DEFAULT_WINDOW_CONTROLS_MODE: WindowControlsMode = 'system'
+
+function normalize(value: unknown): WindowControlsMode {
+  return value === 'hidden' || value === 'native' || value === 'system' ? value : DEFAULT_WINDOW_CONTROLS_MODE
+}
+
+const bridge = typeof window !== 'undefined' ? window.hermesDesktop?.windowControls : undefined
+
+/** Main-process preference for Electron's right-side window control overlay. */
+export const $windowControlsMode = atom<WindowControlsMode>(normalize(bridge?.mode))
+
+/** This option only changes a Linux WCO; other platforms keep their native chrome. */
+export const WINDOW_CONTROLS_SUPPORTED = bridge?.supported === true
+
+export function setWindowControlsMode(mode: WindowControlsMode): void {
+  const next = normalize(mode)
+  $windowControlsMode.set(next)
+  bridge?.setMode(next)
+}
+
+bridge?.onChanged(mode => $windowControlsMode.set(normalize(mode)))


### PR DESCRIPTION
## Summary
- Respect compositor-managed Wayland sessions such as Hyprland when deciding whether Electron window controls should be shown.
- Add Appearance controls for `System`, `Native`, and `Hidden` modes.
- Keep titlebar overlay spacing aligned with the selected mode.

## Implementation
- Detect compositor-managed Wayland from the session environment, covering Hyprland, Sway, river, niri, and dwl.
- Persist the window-control preference through the Electron user-data directory.
- Expose the resolved mode and environment capability through the preload bridge.
- Apply mode changes to existing windows and update overlay geometry immediately.
- Add localized Appearance labels and settings search coverage.

## Test plan
- `npm exec -- vitest run --project electron electron/window-controls.test.ts electron/titlebar-overlay-width.test.ts`
- `npm exec -- tsc --build tsconfig.json --pretty false`
- `npm exec -- tsc --build tsconfig.electron.json --pretty false`
- `npm run build`
- `npm exec -- eslint src/ electron/` (0 errors; existing warnings remain)
- `git diff --check`

## Scope and limitations
- `System` uses environment-based compositor detection because Electron does not expose a portable compositor-decoration capability to the renderer.
- Restart Hermes Desktop after installing the build so the updated Electron main process is loaded.
