### PR TITLE
fix(agent): harvest finish_reason before the SSE guard can continue past it

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4252,6 +4252,24 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 continue
 
             delta = chunk.choices[0].delta
+
+            # Harvest the terminal metadata BEFORE any `continue` in this loop
+            # body.  It used to sit at the very end, which meant the SSE
+            # passthrough guard below (which buffers content that looks like an
+            # SSE frame and `continue`s) swallowed the finish_reason of the very
+            # chunk carrying it.  Providers that merge the marker into the last
+            # content chunk — vLLM does — then reached the end of the stream
+            # with finish_reason=None after delivering text, which
+            # `_text_only_dropped_no_finish` classifies as a mid-stream drop.
+            # The completed turn was retried as if the connection had died.
+            # Neither branch reads finish_reason, so harvesting early is
+            # order-independent.
+            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
+            if chunk_finish_reason:
+                finish_reason = chunk_finish_reason
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage_obj = chunk.usage
+
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
@@ -4389,14 +4407,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # at line ~6107 return `tool_calls=None`, silently
                         # discarding the attempted action.
                         result["partial_tool_names"].append(name)
-
-            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
-            if chunk_finish_reason:
-                finish_reason = chunk_finish_reason
-
-            # Usage in the final chunk
-            if hasattr(chunk, "usage") and chunk.usage:
-                usage_obj = chunk.usage
 
         _close_managed_stream()
 

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -269,6 +269,61 @@ class TestMixedToolCallsOneDroppedOneComplete:
         )
 
 
+# ── Merged finish_reason vs. the SSE passthrough guard (#94614) ────────────
+
+class TestMergedFinishReasonSurvivesSSEGuard:
+    """A provider may deliver ``finish_reason`` on the SAME chunk that carries
+    the last content, instead of in a separate ``"delta":{}`` marker chunk.
+    vLLM does this for most responses.
+
+    If that chunk also starts with ``:`` inside the final line — ordinary
+    prose such as ``"... In short: it turns raw logs into data"`` — the SSE
+    passthrough guard buffers it and ``continue``s, and the guard stays
+    engaged because the closing newline never arrives.  The harvest of
+    ``finish_reason`` must therefore not sit behind that ``continue``:
+    otherwise a COMPLETE turn ends with ``finish_reason=None`` and
+    ``_text_only_dropped_no_finish`` misclassifies it as a mid-stream drop.
+    The resulting continuation asks the model to finish an already-finished
+    text, so it restates its closing line and the answer ships duplicated.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_merged_finish_reason_is_not_swallowed_by_sse_guard(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _stream():
+            yield _make_stream_chunk(content="A log parser reads log files.")
+            yield _make_stream_chunk(content=" In short")
+            # ':' opens what the guard reads as an SSE comment. No newline
+            # follows, so the guard stays engaged until the stream ends.
+            yield _make_stream_chunk(content=": it")
+            yield _make_stream_chunk(
+                content=" turns raw logs into usable data.",
+                finish_reason="stop",
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID, (
+            "A stream that DID deliver finish_reason must not be classified "
+            "as a mid-stream drop merely because the SSE guard buffered the "
+            "chunk carrying it (#94614)."
+        )
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == (
+            "A log parser reads log files. In short"
+            ": it turns raw logs into usable data."
+        )
+        assert response.choices[0].message.tool_calls is None
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:


### PR DESCRIPTION
## What does this PR do?

Fixes a false mid-stream drop: a **completed** streaming turn is classified as a
dropped connection and retried. Because the model is then asked to "continue" a
text that is already finished, the only sensible continuation is to restate the
ending - so the delivered answer contains its closing line twice. With several
retries in a row the whole answer is repeated verbatim (we measured 4x in a
single message).

The terminal metadata is harvested at the **end** of the per-chunk loop body in
`interruptible_streaming_api_call`:

```python
chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
if chunk_finish_reason:
    finish_reason = chunk_finish_reason
```

The SSE passthrough guard sits in the middle of the same body and continues
twice when it buffers content that looks like an SSE frame:

if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
    pending_text_parts.append(delta.content)
    pending_text = "".join(pending_text_parts)
    if _provider_stream_text_may_be_sse(pending_text):
        continue          # <-- skips the harvest
    _flush_pending_stream_text()
    continue              # <-- skips the harvest

Two conditions have to meet:

1. The provider merges finish_reason into the same chunk that carries content,
   instead of sending a separate "delta":{} marker chunk. vLLM does this in
   9 of 10 responses on our box.
2. A chunk in the last line starts with :. _provider_stream_text_may_be_sse
   treats a leading : as an SSE comment, and that state only clears at a newline -
   which never arrives at the end of the text.

Condition 2 is ordinary prose, not an edge case: ": it", ": ready", ": ...".
Any answer ending in "In short: ...", "Status: ready" or "Verified with: ..."
can hit it. That is exactly the shape of an agent's closing report, which is why
this bites hardest at the end of a task.

The stream then ends with finish_reason=None while content_parts is non-empty,
which _text_only_dropped_no_finish classifies as a mid-stream drop - correct
logic, wrong input.

Why this fix is the right one: the harvest is a plain assignment and nothing
inside the loop body reads finish_reason, so moving it above the guard is
order-independent. chunk.choices is guaranteed non-empty at the new position -
the empty-choices case is handled and continued further up, and that branch keeps
its own usage harvest. There are exactly two continue statements between
delta = chunk.choices[0].delta and the old harvest site, both belonging to the
SSE guard.

Related Issue

Fixes #94614

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made

- agent/chat_completion_helpers.py: move the finish_reason / usage harvest
  from the end of the chunk loop to directly after delta = chunk.choices[0].delta,
  above every continue in the body.
- tests/run_agent/test_partial_stream_finish_reason.py: add
  TestMergedFinishReasonSurvivesSSEGuard, which replays the exact chunk sequence.

How to Test

1. Point Hermes at a vLLM endpoint (api_mode: chat_completions) and ask for an
   answer that forces a : into the last line:
   hermes -z "Answer in one sentence: what does a log parser do? End with: In short: ..."
2. Measured on this box, same prompt, same code path - CLI:

   | | responses with a duplicated closing line |
   |---|---|
   | before | 6 / 20 (30%) |
   | after  | 0 / 30 |

   Fisher exact, one-sided: p = 0.0024.

   And on a live Telegram gateway, where the bug was originally found
   (vLLM 0.27.2rc1, Qwen3.8-27B):

   | | before | after |
   |---|---|---|
   | turns | 5 | 6 |
   | `treating as a mid-stream drop` | 7 | 0 |
   | `api_calls` per turn | 1, 4, 3, 2, 2 | 1, 1, 1, 1, 1, 1 |
   | delivered chars | 252, 942, 293, 293, 293 | 233 x 6 |
   | `finish_reason` in the transcript | `length` | `stop` |
   | response time | 8.7-27.9s | 4.7-6.3s |

   Note the second column of the "before" row: with four false drops in a row the
   *entire answer* was delivered four times inside one message. Also note that the
   misdiagnosis itself is gone - the turn is now recorded as `stop`, not `length` -
   and that each false drop cost one to three extra billed API calls.
3. Unit test: pytest tests/run_agent/test_partial_stream_finish_reason.py -q.
   Without the fix the new test fails and logs the exact warning from the report:
   Stream ended with no finish_reason after delivering text with no tool calls; treating as a mid-stream drop.

Full suite via `scripts/run_tests.sh` on a clone of current `main`, in the CI
environment (`uv sync --locked --extra all --extra dev --extra anthropic ...`,
exactly as `.github/workflows/tests.yml` does it):

| | files with failures | tests failed |
|---|---|---|
| without this patch | 12 | 20 |
| with this patch | 11 | 19 |

The single difference is `tests/run_agent/test_partial_stream_finish_reason.py`:
the new test fails without the fix and passes with it. The remaining 19 failures
are identical in both arms and pre-existing on this machine (`test_cmd_update`,
`test_update_*`, `auth_commands`, `doctor`, `browser_real_profile`,
`termux_api_detection`, `hermes_state`, `tui_gateway_server`) - none of them
touch the streaming path.

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (aarch64, NVIDIA DGX Spark GB10), Python 3.11

Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A (internal streaming path, no user-facing config)
- [x] I've updated cli-config.yaml.example - N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md - N/A
- [x] I've considered cross-platform impact - N/A (pure control-flow move, no I/O or platform APIs)
- [x] I've updated tool descriptions/schemas - N/A