### PR TITLE
fix(skills): keep Humanizer rewrites source-faithful

### DIFF
--- a/skills/creative/humanizer/SKILL.md
+++ b/skills/creative/humanizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-description: "Humanize text: strip AI-isms and add real voice."
+description: "Humanize text without changing its meaning."
 version: 2.5.1
 author: Siqi Chen (@blader, https://github.com/blader/humanizer), ported by Hermes Agent
 license: MIT
@@ -15,9 +15,9 @@ metadata:
 
 # Humanizer: Remove AI Writing Patterns
 
-Identify and remove signs of AI-generated text to make writing sound natural and human. Based on Wikipedia's "Signs of AI writing" guide (maintained by WikiProject AI Cleanup), derived from observations of thousands of AI-generated text instances.
+Rewrite AI-sounding text so it reads naturally without changing what it says. Humanizer is an editing heuristic, not proof of authorship, factual accuracy, writer identity, or publication readiness.
 
-**Key insight:** LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely completion, which is how the telltale patterns below get baked in.
+The patterns below come from Wikipedia's "Signs of AI writing" guide, maintained by WikiProject AI Cleanup.
 
 ## When to use this skill
 
@@ -37,18 +37,18 @@ The text usually arrives one of three ways:
 2. **File.** The user points at a file. Use `read_file` to load it, then `patch` or `write_file` to apply edits. For a markdown doc in a repo, a targeted `patch` per section is cleaner than rewriting the whole file.
 3. **Voice calibration sample.** The user provides a sample of their own writing (inline or by file path) and asks you to match it. Read the sample first, then rewrite. See the Voice Calibration section below.
 
-Always show the rewrite to the user. For file edits, show a diff or the changed section instead of silently overwriting.
+Use the output mode near the end of this skill. Never silently overwrite a file or expose an intermediate rewrite when another task embeds Humanizer as an editing pass.
 
 ## Your task
 
 When given text to humanize:
 
-1. **Identify AI patterns.** Scan for the 34 patterns listed below.
-2. **Rewrite problematic sections.** Replace AI-isms with natural alternatives.
-3. **Preserve meaning.** Keep the core message intact.
-4. **Maintain voice.** Match the intended tone (formal, casual, technical, and so on). If a voice sample was provided, match it specifically.
-5. **Add soul.** Removing bad patterns is only half the job; the rewrite also needs real personality. See PERSONALITY AND SOUL below.
-6. **Do a final anti-AI pass.** Ask yourself: "What makes the below so obviously AI generated?" Answer briefly with any remaining tells, then revise one more time.
+1. **Identify AI patterns.** Scan for the 34 patterns listed below. Look for patterns in context and in clusters rather than treating one isolated feature as proof.
+2. **Keep every substantive claim.** Preserve the source's facts, names, numbers, dates, quotations, citations, qualifiers, uncertainty, deliberate point of view, technical literals, and material details even when changing its structure. Formulaic greetings, praise, signposting, reassurance, and promotional flourishes may be removed when they add no substantive proposition. If unsure, preserve them.
+3. **Do not invent.** Add no factual detail, anecdote, first-person experience, opinion, emotion, attribution, example, or source unless it comes from the text, the user's instructions, or an authorized writing sample. If a rewrite needs missing information, ask for it or use a simpler sentence. Fiction and explicit ideation are exempt because invention is part of those tasks.
+4. **Rewrite only what needs work.** Replace formulaic language without flattening deliberate roughness, formatting, or voice.
+5. **Match the writer.** Follow the requested tone and any supplied writing sample. The sample takes priority over generic style rules.
+6. **Audit the candidate.** Treat every unsupported addition and every lost or distorted substantive claim as an error. Run the anti-AI pass only after the source-fidelity audit passes.
 
 
 ## Voice Calibration (optional)
@@ -63,9 +63,11 @@ If the user provides a writing sample (their own previous writing), analyze it b
    - Any recurring phrases or verbal tics
    - How they handle transitions (explicit connectors? Just start the next point?)
 
-2. **Match their voice in the rewrite.** Removing AI patterns is only half of it; swap in patterns from the sample as well. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
+2. **Match their voice in the rewrite.** Preserve the sample's habits instead of replacing them with a generic idea of natural prose. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
 
-3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+3. **When no sample is provided,** match the requested context. Keep factual and reference prose neutral; preserve personality already present in expressive writing.
+
+A supplied sample outranks the generic pattern rules. If it deliberately uses em dashes, curly quotation marks, fragments, repeated openings, or another watched feature, keep that feature at roughly the sample's rate.
 
 ### How to provide a sample
 - Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
@@ -74,35 +76,9 @@ If the user provides a writing sample (their own previous writing), analyze it b
 
 ## PERSONALITY AND SOUL
 
-Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+Add personality only when the source, user, or writing sample calls for it. Blog posts, essays, opinions, and personal writing may need a visible point of view. Technical, legal, reference, and factual prose should usually stay neutral.
 
-### Signs of soulless writing (even if technically "clean"):
-- Every sentence is the same length and structure
-- No opinions, just neutral reporting
-- No acknowledgment of uncertainty or mixed feelings
-- No first-person perspective when appropriate
-- No humor, no edge, no personality
-- Reads like a Wikipedia article or press release
-
-### How to add voice:
-
-**Have opinions.** Report the facts, then react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
-
-**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
-
-**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
-
-**Use "I" when it fits.** First person reads as honest and fits most prose. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
-
-**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
-
-**Be specific about feelings.** Instead of "this is concerning," write "there's something unsettling about agents churning away at 3am while nobody's watching."
-
-### Before (clean but soulless):
-> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
-
-### After (has a pulse):
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle, but I keep thinking about those agents working through the night.
+Preserve the writer's existing opinions, uncertainty, mixed feelings, humor, asides, and uneven rhythm. Do not manufacture an opinion, emotion, first-person claim, anecdote, or deliberate mess to make neutral text seem human.
 
 
 ## CONTENT PATTERNS
@@ -117,7 +93,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
 
 **After:**
-> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+> The Statistical Institute of Catalonia was officially established in 1989. It changed how regional statistics were handled in Spain and formed part of the country's effort to decentralize administrative functions and strengthen regional governance.
 
 
 ### 2. Undue Emphasis on Notability and Media Coverage
@@ -130,7 +106,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 **After:**
-> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+> Her views have been cited in The New York Times, the BBC, the Financial Times, and The Hindu. She is active on social media and has more than 500,000 followers.
 
 
 ### 3. Superficial Analyses with -ing Endings
@@ -143,7 +119,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
 
 **After:**
-> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+> The palette's blue, green, and gold represent Texas bluebonnets, the Gulf of Mexico, and other Texan landscapes. Together, the colors reflect the region's natural beauty and the community's connection to the land.
 
 
 ### 4. Promotional and Advertisement-like Language
@@ -156,7 +132,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 **After:**
-> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+> Alamata Raya Kobo is a town in Ethiopia's Gonder region. The source describes its cultural heritage as rich and its natural setting as beautiful.
 
 
 ### 5. Vague Attributions and Weasel Words
@@ -169,7 +145,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
 
 **After:**
-> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+> The Haolai River interests researchers and conservationists because of its unusual characteristics. The source says it is important to the regional ecosystem but does not identify the experts behind that claim.
 
 
 ### 6. Outline-like "Challenges and Future Prospects" Sections
@@ -182,7 +158,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
 
 **After:**
-> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+> Korattur is industrially prosperous but also faces traffic congestion and water scarcity, problems typical of urban areas. Its strategic location and ongoing initiatives help it continue to thrive as an integral part of Chennai's growth.
 
 
 ## LANGUAGE AND GRAMMAR PATTERNS
@@ -199,7 +175,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
 
 **After:**
-> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+> Camel meat is a distinctive part of Somali cuisine. Pasta dishes introduced during Italian colonization remain common in the local diet and reflect that lasting influence.
 
 
 ### 8. Avoidance of "is"/"are" (Copula Avoidance)
@@ -212,7 +188,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 **After:**
-> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four separate spaces and more than 3,000 square feet.
 
 
 ### 9. Negative Parallelisms and Tailing Negations
@@ -223,7 +199,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
 
 **After:**
-> The heavy beat adds to the aggressive tone.
+> The heavy beat contributes to the song's aggression and atmosphere. The song also makes a statement.
 
 **Before (tailing negation):**
 > The options come from the selected item, no guessing.
@@ -240,7 +216,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 **After:**
-> The event includes talks and panels. There's also time for informal networking between sessions.
+> The event has keynote sessions and panel discussions, with time for networking. The program covers innovation and industry insights, and attendees can expect inspiration.
 
 
 ### 11. Elegant Variation (Synonym Cycling)
@@ -262,7 +238,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
 
 **After:**
-> The book covers the Big Bang, star formation, and current theories about dark matter.
+> We explore the Big Bang singularity, the cosmic web, the birth and death of stars, and dark matter.
 
 
 ### 13. Passive Voice and Subjectless Fragments
@@ -273,7 +249,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > No configuration file needed. The results are preserved automatically.
 
 **After:**
-> You do not need a configuration file. The system preserves the results automatically.
+> You do not need a configuration file. The results are preserved automatically.
 
 
 ## STYLE PATTERNS
@@ -297,7 +273,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
 
 **After:**
-> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+> It blends objectives and key results (OKRs), key performance indicators (KPIs), and visual strategy tools such as the Business Model Canvas (BMC) and Balanced Scorecard (BSC).
 
 
 ### 16. Inline-Header Vertical Lists
@@ -310,7 +286,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 **After:**
-> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+> The update substantially improves the interface. Optimized algorithms enhance performance, and end-to-end encryption strengthens security.
 
 
 ### 17. Title Case in Headings
@@ -330,7 +306,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **Before:**
 > 🚀 **Launch Phase:** The product launches in Q3
-> 💡 **Key Insight:** Users prefer simplicity
+> 💡 **Key Insight:** User research showed a preference for simplicity
 > ✅ **Next Steps:** Schedule follow-up meeting
 
 **After:**
@@ -339,10 +315,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 19. Curly Quotation Marks
 
-**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+**Problem:** Some model output uses curly quotes, but word processors and publishing systems also add them automatically. Curly quotes are not a problem by themselves. Change them only when the user, writing sample, or style guide calls for straight quotes.
 
-**Before:**
-> He said "the project is on track" but others disagreed.
+**Before (when straight quotes are required):**
+> He said “the project is on track” but others disagreed.
 
 **After:**
 > He said "the project is on track" but others disagreed.
@@ -357,10 +333,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** Text meant as chatbot correspondence gets pasted as content.
 
 **Before:**
-> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+> Of course! The French Revolution began in 1789. I hope this helps! Let me know if you'd like me to expand on any section.
 
 **After:**
-> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+> The French Revolution began in 1789.
 
 
 ### 21. Knowledge-Cutoff Disclaimers
@@ -373,7 +349,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 **After:**
-> The company was founded in 1994, according to its registration documents.
+> The available sources do not document the exact founding date, but suggest the company was established in the 1990s.
 
 
 ### 22. Sycophantic/Servile Tone
@@ -384,7 +360,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
 
 **After:**
-> The economic factors you mentioned are relevant here.
+> The economic factors you mentioned are relevant to this complex topic.
 
 
 ## FILLER AND HEDGING
@@ -419,20 +395,20 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 **After:**
-> The company plans to open two more locations next year.
+> The passage presents this as a major step and expresses optimism about what comes next.
 
 
 ### 26. Hyphenated Word Pair Overuse
 
 **Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
 
-**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it's inconsistent. Less common or technical compound modifiers are fine to hyphenate.
+**Problem:** AI may hyphenate common word pairs with mechanical consistency, but correct compound modifiers are not errors. Keep hyphens when grammar or established usage calls for them. Predicate phrases are often open compounds.
 
 **Before:**
-> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
 
 **After:**
-> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
 
 
 ### 27. Persuasive Authority Tropes
@@ -445,7 +421,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
 
 **After:**
-> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+> The question is whether teams can adapt. That depends on organizational readiness.
 
 
 ### 28. Signposting and Announcements
@@ -455,10 +431,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
 
 **Before:**
-> Let's dive into how caching works in Next.js. Here's what you need to know.
+> Let's dive into how caching works in Next.js. Here's what you need to know: Next.js caches data at request, data, and router layers.
 
 **After:**
-> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+> Next.js caches data at request, data, and router layers.
 
 
 ### 29. Fragmented Headers
@@ -492,7 +468,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The codebase is a garden we must tend, pruning dead branches and planting seeds of innovation so the whole ecosystem can flourish. In other words, delete unused code and add features.
 
 **After:**
-> Delete unused code and add the features users are asking for.
+> Delete unused code and add new features.
 
 
 ### 31. Dramatic Fragmentation and Punchy Kickers
@@ -505,7 +481,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The catalog, honestly priced. Pay for what it does. Not promises. It just works. Every time.
 
 **After:**
-> The catalog is priced by usage, so you pay for the calls you actually make rather than a flat monthly fee.
+> The catalog is honestly priced: you pay for what it does rather than promises, and it works every time.
 
 
 ### 32. Rhetorical Questions Answered Immediately
@@ -531,7 +507,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > So, the results were mixed. Interestingly, adoption went up. Importantly, churn went up too. I think that means the feature still needs work.
 
 **After:**
-> The results were mixed: adoption rose, but churn rose alongside it, so the feature still needs work.
+> The results were mixed: adoption rose, but churn rose too. I think the feature still needs work.
 
 
 ### 34. Reassurance Kickers
@@ -544,104 +520,43 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > You might not have a testing setup yet. And that's okay. Plenty of teams start without one, and there's nothing wrong with that.
 
 **After:**
-> Many teams start without a testing setup and add one once regressions begin costing real time.
+> Many teams start without a testing setup, and that is not inherently a problem.
 
 ---
 
-## Process
+## Check for false positives
 
-1. Read the input text carefully (use `read_file` if it's a file).
-2. Identify all instances of the patterns above.
-3. Rewrite each problematic section.
-4. Ensure the revised text:
-   - Sounds natural when read aloud
-   - Varies sentence structure naturally
-   - Uses specific details over vague claims
-   - Maintains appropriate tone for context
-   - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version.
-6. Prompt yourself: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any).
-8. Prompt yourself: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit).
-10. If the text came from a file, apply the edit with `patch` (targeted) or `write_file` (full rewrite) and show the user what changed.
+A person may use some of these patterns. Do not treat any single feature as proof of AI writing or as a reason to edit otherwise effective prose.
 
-## Output Format
+- Curly quotation marks alone are not a problem. Word processors and publishing systems often add them automatically.
+- An em dash, one short sentence, or one formal transition is not enough. Look for repeated, formulaic use in context.
+- Keep deliberate repetition, useful disclaimers, real alternatives, quotations, titles, proper names, code, URLs, and technical literals.
+- Keep passive voice when the actor is unknown, irrelevant, or deliberately withheld.
+- Keep correct compound modifiers. Mechanical consistency may be worth reviewing, but grammar takes priority.
+- Preserve unusual details, unresolved tension, asides, self-corrections, and other choices that carry the writer's voice.
 
-Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+When unsure, look for several patterns together or a clear editing problem. A valid outcome is to leave the text unchanged.
 
+## Output modes
 
-## Full Example
+- **Pasted text (default).** Return the final rewrite first. Include a brief audit or change summary only when the user asks for it or it materially helps.
+- **File mode.** Use `read_file`, then `patch` or `write_file`, but write only the final prose. Preserve code blocks, frontmatter, data, citations, and link targets. Return a short summary or diff.
+- **Embedded mode.** When another task uses Humanizer as an editing pass, return only the final text to the caller.
 
-**Before (AI-sounding):**
-> Great question! Here is an essay on this topic. I hope this helps!
->
-> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
->
-> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
->
-> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
->
-> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
-> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
-> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
->
-> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
->
-> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you'd like me to expand on any section!
+## Rewrite process
 
-**Draft rewrite:**
-> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
->
-> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
->
-> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
->
-> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
->
-> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
-
-**What makes the below so obviously AI generated?**
-- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
-- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
-- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
-
-**Now make it not obviously AI generated.**
-> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
->
-> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
->
-> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
->
-> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
-
-**Changes made:**
-- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
-- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
-- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
-- Removed vague attributions ("Industry observers")
-- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
-- Removed negative parallelism ("It's not just X; it's Y")
-- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
-- Removed false ranges ("from X to Y, from A to B")
-- Removed em dashes, emojis, boldface headers, and curly quotes
-- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
-- Removed formulaic challenges section ("Despite challenges... continues to thrive")
-- Removed knowledge-cutoff hedging ("While specific details are limited...")
-- Removed excessive hedging ("could potentially be argued that... might have some")
-- Removed filler phrases and persuasive framing ("In order to", "At its core")
-- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
-- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
+1. Read the source and note its claims, qualifiers, citations, technical literals, and deliberate voice choices.
+2. Identify repeated patterns that create a real writing problem. Leave isolated or intentional features alone.
+3. Rewrite the smallest sections that need work. Read the candidate aloud and check its rhythm and tone.
+4. Ask: "Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, qualifier, or other claim?"
+5. Fix every unsupported addition and every lost or distorted substantive claim. Then run the final anti-AI pass.
+6. Return or write the result required by the selected output mode. Do not expose an intermediate draft in file or embedded mode.
 
 
 ## Attribution
 
-This skill is ported from [blader/humanizer](https://github.com/blader/humanizer) (MIT licensed), which is itself based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+This skill is ported from [blader/humanizer](https://github.com/blader/humanizer) (MIT licensed), which is itself based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of AI-generated text on Wikipedia.
 
-Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer (version 2.5.1). Ported to Hermes Agent with Hermes-native tool references (`read_file`, `patch`, `write_file`) and guidance for when to load the skill. The original 29 patterns come from the source, and the before/after examples (including the full worked example) are kept as demonstrations. Patterns 30-34 and the "marketing and blog clichés" list added to pattern 7 are Hermes additions and are not part of the upstream source. The skill's own instructional prose has also been lightly edited to follow its own guidance (for example, removing em dashes and negative parallelism from the narration) so the skill models the writing it asks for. Original MIT license preserved in the `LICENSE` file alongside this `SKILL.md`.
+Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer. Hermes originally ported version 2.5.1 with Hermes-native tool references (`read_file`, `patch`, `write_file`) and added patterns 30-34 plus the "marketing and blog clichés" list in pattern 7. This revision keeps Hermes's 34-pattern catalog while adapting later upstream guidance on source fidelity, writing-sample precedence, false positives, and output modes. The examples were adjusted so the skill does not model unsupported additions. The original MIT license is preserved in the `LICENSE` file alongside this `SKILL.md`.
 
 Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/tests/skills/test_humanizer_skill.py
+++ b/tests/skills/test_humanizer_skill.py
@@ -1,0 +1,167 @@
+"""Contract tests for the bundled Humanizer skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+from agent.skill_utils import parse_frontmatter
+
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "skills" / "creative" / "humanizer"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+GENERATED_PAGE = (
+    REPO
+    / "website"
+    / "docs"
+    / "user-guide"
+    / "skills"
+    / "bundled"
+    / "creative"
+    / "creative-humanizer.md"
+)
+GENERATOR = REPO / "website" / "scripts" / "generate-skill-docs.py"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def generator_module():
+    spec = importlib.util.spec_from_file_location("generate_skill_docs", GENERATOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_source_fidelity_contract_precedes_pattern_catalog(skill_text):
+    catalog_start = skill_text.index("## CONTENT PATTERNS")
+    safeguards = (
+        "Keep every substantive claim",
+        "Do not invent",
+        "The sample takes priority",
+        "add no substantive proposition",
+        "unsupported addition",
+        "lost or distorted substantive claim",
+    )
+
+    for safeguard in safeguards:
+        assert 0 <= skill_text.index(safeguard) < catalog_start
+
+
+def test_evidence_boundary_and_modes_are_explicit(skill_text):
+    for expected in (
+        "not proof of authorship",
+        "A valid outcome is to leave the text unchanged",
+        "Pasted text (default)",
+        "File mode",
+        "Embedded mode",
+        "Do not expose an intermediate draft",
+    ):
+        assert expected in skill_text
+
+
+def test_pattern_catalog_stays_at_34_entries(skill_text):
+    numbers = [
+        int(number)
+        for number in re.findall(r"^### (\d+)\.", skill_text, flags=re.MULTILINE)
+    ]
+    assert numbers == list(range(1, 35))
+
+
+def test_unsafe_legacy_guidance_does_not_return(skill_text):
+    forbidden = (
+        "Add soul.",
+        "Report the facts, then react to them",
+        'Use "I" when it fits',
+        "default behavior (natural, varied, opinionated voice",
+        "ChatGPT uses curly quotes",
+    )
+
+    for phrase in forbidden:
+        assert phrase.casefold() not in skill_text.casefold()
+
+
+def test_fabricated_worked_example_is_removed(skill_text):
+    assert "## Full Example" not in skill_text
+    for artifact in (
+        "a 2024 study by Google",
+        "55% faster",
+        "Mira, an engineer",
+        "Jake, a senior dev",
+        "The 2024 Uplevel study",
+    ):
+        assert artifact not in skill_text
+
+
+def test_known_catalog_fabrications_do_not_return(skill_text):
+    for artifact in (
+        "collect and publish regional statistics independently",
+        "In a 2024 New York Times interview",
+        "The architect said",
+        "weekly market and 18th-century church",
+        "Chinese Academy of Sciences",
+        "three new IT parks",
+        "rooms totaling 3,000 square feet",
+        "considered a delicacy",
+        "speeds up load times",
+        "founded in 1994",
+        "two more locations next year",
+        "including request memoization",
+        "features users are asking for",
+        "flat monthly fee",
+        "regressions begin costing real time",
+    ):
+        assert artifact not in skill_text
+
+
+def test_skill_remains_a_loadable_instruction_only_package(skill_text):
+    frontmatter, body = parse_frontmatter(skill_text)
+    assert frontmatter["name"] == "humanizer"
+    assert frontmatter["description"] == "Humanize text without changing its meaning."
+    assert body.startswith("# Humanizer:")
+
+    executable_suffixes = {
+        ".bash",
+        ".cjs",
+        ".js",
+        ".mjs",
+        ".py",
+        ".sh",
+        ".ts",
+    }
+    runtime_files = [
+        path.relative_to(SKILL_DIR)
+        for path in SKILL_DIR.rglob("*")
+        if path.is_file() and path.suffix in executable_suffixes
+    ]
+    assert runtime_files == []
+
+
+def test_generated_humanizer_page_matches_skill_source(generator_module):
+    entries = generator_module.discover_skills()
+    skill_index = {}
+    target = None
+    for meta, parsed in entries:
+        name = parsed["frontmatter"].get("name", meta["slug"])
+        if name not in skill_index or meta["source_kind"] == "bundled":
+            skill_index[name] = meta
+        if meta["source_kind"] == "bundled" and name == "humanizer":
+            target = (meta, parsed)
+
+    assert target is not None
+    meta, parsed = target
+    rendered = generator_module.render_skill_page(
+        meta,
+        parsed["frontmatter"],
+        parsed["body"],
+        skill_index=skill_index,
+    )
+    assert GENERATED_PAGE.read_text(encoding="utf-8") == rendered

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -41,7 +41,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic) | Infographics: 21 layouts x 21 styles (信息图, 可视化). | `creative\baoyu-infographic` |
 | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design) | Design one-off HTML artifacts (landing, deck, prototype). | `creative\claude-design` |
 | [`design-md`](/docs/user-guide/skills/bundled/creative/creative-design-md) | Author/validate/export Google's DESIGN.md token spec files. | `creative\design-md` |
-| [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative\humanizer` |
+| [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text without changing its meaning. | `creative\humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative\manim-video` |
 | [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js) | p5.js sketches: gen art, shaders, interactive, 3D. | `creative\p5js` |
 | [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative\popular-web-designs` |

--- a/website/docs/user-guide/skills/bundled/creative/creative-humanizer.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-humanizer.md
@@ -1,21 +1,21 @@
 ---
-title: "Humanizer — Humanize text: strip AI-isms and add real voice"
+title: "Humanizer — Humanize text without changing its meaning"
 sidebar_label: "Humanizer"
-description: "Humanize text: strip AI-isms and add real voice"
+description: "Humanize text without changing its meaning"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Humanizer
 
-Humanize text: strip AI-isms and add real voice.
+Humanize text without changing its meaning.
 
 ## Skill metadata
 
 | | |
 |---|---|
 | Source | Bundled (installed by default) |
-| Path | `skills/creative\humanizer` |
+| Path | `skills/creative/humanizer` |
 | Version | `2.5.1` |
 | Author | Siqi Chen (@blader, https://github.com/blader/humanizer), ported by Hermes Agent |
 | License | MIT |
@@ -31,9 +31,9 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # Humanizer: Remove AI Writing Patterns
 
-Identify and remove signs of AI-generated text to make writing sound natural and human. Based on Wikipedia's "Signs of AI writing" guide (maintained by WikiProject AI Cleanup), derived from observations of thousands of AI-generated text instances.
+Rewrite AI-sounding text so it reads naturally without changing what it says. Humanizer is an editing heuristic, not proof of authorship, factual accuracy, writer identity, or publication readiness.
 
-**Key insight:** LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely completion, which is how the telltale patterns below get baked in.
+The patterns below come from Wikipedia's "Signs of AI writing" guide, maintained by WikiProject AI Cleanup.
 
 ## When to use this skill
 
@@ -53,18 +53,18 @@ The text usually arrives one of three ways:
 2. **File.** The user points at a file. Use `read_file` to load it, then `patch` or `write_file` to apply edits. For a markdown doc in a repo, a targeted `patch` per section is cleaner than rewriting the whole file.
 3. **Voice calibration sample.** The user provides a sample of their own writing (inline or by file path) and asks you to match it. Read the sample first, then rewrite. See the Voice Calibration section below.
 
-Always show the rewrite to the user. For file edits, show a diff or the changed section instead of silently overwriting.
+Use the output mode near the end of this skill. Never silently overwrite a file or expose an intermediate rewrite when another task embeds Humanizer as an editing pass.
 
 ## Your task
 
 When given text to humanize:
 
-1. **Identify AI patterns.** Scan for the 34 patterns listed below.
-2. **Rewrite problematic sections.** Replace AI-isms with natural alternatives.
-3. **Preserve meaning.** Keep the core message intact.
-4. **Maintain voice.** Match the intended tone (formal, casual, technical, and so on). If a voice sample was provided, match it specifically.
-5. **Add soul.** Removing bad patterns is only half the job; the rewrite also needs real personality. See PERSONALITY AND SOUL below.
-6. **Do a final anti-AI pass.** Ask yourself: "What makes the below so obviously AI generated?" Answer briefly with any remaining tells, then revise one more time.
+1. **Identify AI patterns.** Scan for the 34 patterns listed below. Look for patterns in context and in clusters rather than treating one isolated feature as proof.
+2. **Keep every substantive claim.** Preserve the source's facts, names, numbers, dates, quotations, citations, qualifiers, uncertainty, deliberate point of view, technical literals, and material details even when changing its structure. Formulaic greetings, praise, signposting, reassurance, and promotional flourishes may be removed when they add no substantive proposition. If unsure, preserve them.
+3. **Do not invent.** Add no factual detail, anecdote, first-person experience, opinion, emotion, attribution, example, or source unless it comes from the text, the user's instructions, or an authorized writing sample. If a rewrite needs missing information, ask for it or use a simpler sentence. Fiction and explicit ideation are exempt because invention is part of those tasks.
+4. **Rewrite only what needs work.** Replace formulaic language without flattening deliberate roughness, formatting, or voice.
+5. **Match the writer.** Follow the requested tone and any supplied writing sample. The sample takes priority over generic style rules.
+6. **Audit the candidate.** Treat every unsupported addition and every lost or distorted substantive claim as an error. Run the anti-AI pass only after the source-fidelity audit passes.
 
 
 ## Voice Calibration (optional)
@@ -79,9 +79,11 @@ If the user provides a writing sample (their own previous writing), analyze it b
    - Any recurring phrases or verbal tics
    - How they handle transitions (explicit connectors? Just start the next point?)
 
-2. **Match their voice in the rewrite.** Removing AI patterns is only half of it; swap in patterns from the sample as well. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
+2. **Match their voice in the rewrite.** Preserve the sample's habits instead of replacing them with a generic idea of natural prose. If they write short sentences, do not produce long ones. If they use "stuff" and "things," do not upgrade to "elements" and "components."
 
-3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+3. **When no sample is provided,** match the requested context. Keep factual and reference prose neutral; preserve personality already present in expressive writing.
+
+A supplied sample outranks the generic pattern rules. If it deliberately uses em dashes, curly quotation marks, fragments, repeated openings, or another watched feature, keep that feature at roughly the sample's rate.
 
 ### How to provide a sample
 - Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
@@ -90,35 +92,9 @@ If the user provides a writing sample (their own previous writing), analyze it b
 
 ## PERSONALITY AND SOUL
 
-Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+Add personality only when the source, user, or writing sample calls for it. Blog posts, essays, opinions, and personal writing may need a visible point of view. Technical, legal, reference, and factual prose should usually stay neutral.
 
-### Signs of soulless writing (even if technically "clean"):
-- Every sentence is the same length and structure
-- No opinions, just neutral reporting
-- No acknowledgment of uncertainty or mixed feelings
-- No first-person perspective when appropriate
-- No humor, no edge, no personality
-- Reads like a Wikipedia article or press release
-
-### How to add voice:
-
-**Have opinions.** Report the facts, then react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
-
-**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
-
-**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
-
-**Use "I" when it fits.** First person reads as honest and fits most prose. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
-
-**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
-
-**Be specific about feelings.** Instead of "this is concerning," write "there's something unsettling about agents churning away at 3am while nobody's watching."
-
-### Before (clean but soulless):
-> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
-
-### After (has a pulse):
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle, but I keep thinking about those agents working through the night.
+Preserve the writer's existing opinions, uncertainty, mixed feelings, humor, asides, and uneven rhythm. Do not manufacture an opinion, emotion, first-person claim, anecdote, or deliberate mess to make neutral text seem human.
 
 
 ## CONTENT PATTERNS
@@ -133,7 +109,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
 
 **After:**
-> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+> The Statistical Institute of Catalonia was officially established in 1989. It changed how regional statistics were handled in Spain and formed part of the country's effort to decentralize administrative functions and strengthen regional governance.
 
 
 ### 2. Undue Emphasis on Notability and Media Coverage
@@ -146,7 +122,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 **After:**
-> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+> Her views have been cited in The New York Times, the BBC, the Financial Times, and The Hindu. She is active on social media and has more than 500,000 followers.
 
 
 ### 3. Superficial Analyses with -ing Endings
@@ -159,7 +135,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
 
 **After:**
-> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+> The palette's blue, green, and gold represent Texas bluebonnets, the Gulf of Mexico, and other Texan landscapes. Together, the colors reflect the region's natural beauty and the community's connection to the land.
 
 
 ### 4. Promotional and Advertisement-like Language
@@ -172,7 +148,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 **After:**
-> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+> Alamata Raya Kobo is a town in Ethiopia's Gonder region. The source describes its cultural heritage as rich and its natural setting as beautiful.
 
 
 ### 5. Vague Attributions and Weasel Words
@@ -185,7 +161,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
 
 **After:**
-> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+> The Haolai River interests researchers and conservationists because of its unusual characteristics. The source says it is important to the regional ecosystem but does not identify the experts behind that claim.
 
 
 ### 6. Outline-like "Challenges and Future Prospects" Sections
@@ -198,7 +174,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
 
 **After:**
-> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+> Korattur is industrially prosperous but also faces traffic congestion and water scarcity, problems typical of urban areas. Its strategic location and ongoing initiatives help it continue to thrive as an integral part of Chennai's growth.
 
 
 ## LANGUAGE AND GRAMMAR PATTERNS
@@ -215,7 +191,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
 
 **After:**
-> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+> Camel meat is a distinctive part of Somali cuisine. Pasta dishes introduced during Italian colonization remain common in the local diet and reflect that lasting influence.
 
 
 ### 8. Avoidance of "is"/"are" (Copula Avoidance)
@@ -228,7 +204,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 **After:**
-> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four separate spaces and more than 3,000 square feet.
 
 
 ### 9. Negative Parallelisms and Tailing Negations
@@ -239,7 +215,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
 
 **After:**
-> The heavy beat adds to the aggressive tone.
+> The heavy beat contributes to the song's aggression and atmosphere. The song also makes a statement.
 
 **Before (tailing negation):**
 > The options come from the selected item, no guessing.
@@ -256,7 +232,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 **After:**
-> The event includes talks and panels. There's also time for informal networking between sessions.
+> The event has keynote sessions and panel discussions, with time for networking. The program covers innovation and industry insights, and attendees can expect inspiration.
 
 
 ### 11. Elegant Variation (Synonym Cycling)
@@ -278,7 +254,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
 
 **After:**
-> The book covers the Big Bang, star formation, and current theories about dark matter.
+> We explore the Big Bang singularity, the cosmic web, the birth and death of stars, and dark matter.
 
 
 ### 13. Passive Voice and Subjectless Fragments
@@ -289,7 +265,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > No configuration file needed. The results are preserved automatically.
 
 **After:**
-> You do not need a configuration file. The system preserves the results automatically.
+> You do not need a configuration file. The results are preserved automatically.
 
 
 ## STYLE PATTERNS
@@ -313,7 +289,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
 
 **After:**
-> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+> It blends objectives and key results (OKRs), key performance indicators (KPIs), and visual strategy tools such as the Business Model Canvas (BMC) and Balanced Scorecard (BSC).
 
 
 ### 16. Inline-Header Vertical Lists
@@ -326,7 +302,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 **After:**
-> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+> The update substantially improves the interface. Optimized algorithms enhance performance, and end-to-end encryption strengthens security.
 
 
 ### 17. Title Case in Headings
@@ -346,7 +322,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **Before:**
 > 🚀 **Launch Phase:** The product launches in Q3
-> 💡 **Key Insight:** Users prefer simplicity
+> 💡 **Key Insight:** User research showed a preference for simplicity
 > ✅ **Next Steps:** Schedule follow-up meeting
 
 **After:**
@@ -355,10 +331,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 19. Curly Quotation Marks
 
-**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+**Problem:** Some model output uses curly quotes, but word processors and publishing systems also add them automatically. Curly quotes are not a problem by themselves. Change them only when the user, writing sample, or style guide calls for straight quotes.
 
-**Before:**
-> He said "the project is on track" but others disagreed.
+**Before (when straight quotes are required):**
+> He said “the project is on track” but others disagreed.
 
 **After:**
 > He said "the project is on track" but others disagreed.
@@ -373,10 +349,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** Text meant as chatbot correspondence gets pasted as content.
 
 **Before:**
-> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+> Of course! The French Revolution began in 1789. I hope this helps! Let me know if you'd like me to expand on any section.
 
 **After:**
-> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+> The French Revolution began in 1789.
 
 
 ### 21. Knowledge-Cutoff Disclaimers
@@ -389,7 +365,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 **After:**
-> The company was founded in 1994, according to its registration documents.
+> The available sources do not document the exact founding date, but suggest the company was established in the 1990s.
 
 
 ### 22. Sycophantic/Servile Tone
@@ -400,7 +376,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
 
 **After:**
-> The economic factors you mentioned are relevant here.
+> The economic factors you mentioned are relevant to this complex topic.
 
 
 ## FILLER AND HEDGING
@@ -435,20 +411,20 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 **After:**
-> The company plans to open two more locations next year.
+> The passage presents this as a major step and expresses optimism about what comes next.
 
 
 ### 26. Hyphenated Word Pair Overuse
 
 **Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
 
-**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it's inconsistent. Less common or technical compound modifiers are fine to hyphenate.
+**Problem:** AI may hyphenate common word pairs with mechanical consistency, but correct compound modifiers are not errors. Keep hyphens when grammar or established usage calls for them. Predicate phrases are often open compounds.
 
 **Before:**
-> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
 
 **After:**
-> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
 
 
 ### 27. Persuasive Authority Tropes
@@ -461,7 +437,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
 
 **After:**
-> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+> The question is whether teams can adapt. That depends on organizational readiness.
 
 
 ### 28. Signposting and Announcements
@@ -471,10 +447,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
 
 **Before:**
-> Let's dive into how caching works in Next.js. Here's what you need to know.
+> Let's dive into how caching works in Next.js. Here's what you need to know: Next.js caches data at request, data, and router layers.
 
 **After:**
-> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+> Next.js caches data at request, data, and router layers.
 
 
 ### 29. Fragmented Headers
@@ -508,7 +484,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The codebase is a garden we must tend, pruning dead branches and planting seeds of innovation so the whole ecosystem can flourish. In other words, delete unused code and add features.
 
 **After:**
-> Delete unused code and add the features users are asking for.
+> Delete unused code and add new features.
 
 
 ### 31. Dramatic Fragmentation and Punchy Kickers
@@ -521,7 +497,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > The catalog, honestly priced. Pay for what it does. Not promises. It just works. Every time.
 
 **After:**
-> The catalog is priced by usage, so you pay for the calls you actually make rather than a flat monthly fee.
+> The catalog is honestly priced: you pay for what it does rather than promises, and it works every time.
 
 
 ### 32. Rhetorical Questions Answered Immediately
@@ -547,7 +523,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > So, the results were mixed. Interestingly, adoption went up. Importantly, churn went up too. I think that means the feature still needs work.
 
 **After:**
-> The results were mixed: adoption rose, but churn rose alongside it, so the feature still needs work.
+> The results were mixed: adoption rose, but churn rose too. I think the feature still needs work.
 
 
 ### 34. Reassurance Kickers
@@ -560,104 +536,43 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > You might not have a testing setup yet. And that's okay. Plenty of teams start without one, and there's nothing wrong with that.
 
 **After:**
-> Many teams start without a testing setup and add one once regressions begin costing real time.
+> Many teams start without a testing setup, and that is not inherently a problem.
 
 ---
 
-## Process
+## Check for false positives
 
-1. Read the input text carefully (use `read_file` if it's a file).
-2. Identify all instances of the patterns above.
-3. Rewrite each problematic section.
-4. Ensure the revised text:
-   - Sounds natural when read aloud
-   - Varies sentence structure naturally
-   - Uses specific details over vague claims
-   - Maintains appropriate tone for context
-   - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version.
-6. Prompt yourself: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any).
-8. Prompt yourself: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit).
-10. If the text came from a file, apply the edit with `patch` (targeted) or `write_file` (full rewrite) and show the user what changed.
+A person may use some of these patterns. Do not treat any single feature as proof of AI writing or as a reason to edit otherwise effective prose.
 
-## Output Format
+- Curly quotation marks alone are not a problem. Word processors and publishing systems often add them automatically.
+- An em dash, one short sentence, or one formal transition is not enough. Look for repeated, formulaic use in context.
+- Keep deliberate repetition, useful disclaimers, real alternatives, quotations, titles, proper names, code, URLs, and technical literals.
+- Keep passive voice when the actor is unknown, irrelevant, or deliberately withheld.
+- Keep correct compound modifiers. Mechanical consistency may be worth reviewing, but grammar takes priority.
+- Preserve unusual details, unresolved tension, asides, self-corrections, and other choices that carry the writer's voice.
 
-Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+When unsure, look for several patterns together or a clear editing problem. A valid outcome is to leave the text unchanged.
 
+## Output modes
 
-## Full Example
+- **Pasted text (default).** Return the final rewrite first. Include a brief audit or change summary only when the user asks for it or it materially helps.
+- **File mode.** Use `read_file`, then `patch` or `write_file`, but write only the final prose. Preserve code blocks, frontmatter, data, citations, and link targets. Return a short summary or diff.
+- **Embedded mode.** When another task uses Humanizer as an editing pass, return only the final text to the caller.
 
-**Before (AI-sounding):**
-> Great question! Here is an essay on this topic. I hope this helps!
->
-> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
->
-> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
->
-> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
->
-> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
-> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
-> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
->
-> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
->
-> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you'd like me to expand on any section!
+## Rewrite process
 
-**Draft rewrite:**
-> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
->
-> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
->
-> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
->
-> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
->
-> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
-
-**What makes the below so obviously AI generated?**
-- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
-- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
-- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
-
-**Now make it not obviously AI generated.**
-> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
->
-> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
->
-> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
->
-> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
-
-**Changes made:**
-- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
-- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
-- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
-- Removed vague attributions ("Industry observers")
-- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
-- Removed negative parallelism ("It's not just X; it's Y")
-- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
-- Removed false ranges ("from X to Y, from A to B")
-- Removed em dashes, emojis, boldface headers, and curly quotes
-- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
-- Removed formulaic challenges section ("Despite challenges... continues to thrive")
-- Removed knowledge-cutoff hedging ("While specific details are limited...")
-- Removed excessive hedging ("could potentially be argued that... might have some")
-- Removed filler phrases and persuasive framing ("In order to", "At its core")
-- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
-- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
+1. Read the source and note its claims, qualifiers, citations, technical literals, and deliberate voice choices.
+2. Identify repeated patterns that create a real writing problem. Leave isolated or intentional features alone.
+3. Rewrite the smallest sections that need work. Read the candidate aloud and check its rhythm and tone.
+4. Ask: "Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, qualifier, or other claim?"
+5. Fix every unsupported addition and every lost or distorted substantive claim. Then run the final anti-AI pass.
+6. Return or write the result required by the selected output mode. Do not expose an intermediate draft in file or embedded mode.
 
 
 ## Attribution
 
-This skill is ported from [blader/humanizer](https://github.com/blader/humanizer) (MIT licensed), which is itself based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+This skill is ported from [blader/humanizer](https://github.com/blader/humanizer) (MIT licensed), which is itself based on [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of AI-generated text on Wikipedia.
 
-Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer (version 2.5.1). Ported to Hermes Agent with Hermes-native tool references (`read_file`, `patch`, `write_file`) and guidance for when to load the skill. The original 29 patterns come from the source, and the before/after examples (including the full worked example) are kept as demonstrations. Patterns 30-34 and the "marketing and blog clichés" list added to pattern 7 are Hermes additions and are not part of the upstream source. The skill's own instructional prose has also been lightly edited to follow its own guidance (for example, removing em dashes and negative parallelism from the narration) so the skill models the writing it asks for. Original MIT license preserved in the `LICENSE` file alongside this `SKILL.md`.
+Original author: Siqi Chen ([@blader](https://github.com/blader)). Original repo: https://github.com/blader/humanizer. Hermes originally ported version 2.5.1 with Hermes-native tool references (`read_file`, `patch`, `write_file`) and added patterns 30-34 plus the "marketing and blog clichés" list in pattern 7. This revision keeps Hermes's 34-pattern catalog while adapting later upstream guidance on source fidelity, writing-sample precedence, false positives, and output modes. The examples were adjusted so the skill does not model unsupported additions. The original MIT license is preserved in the `LICENSE` file alongside this `SKILL.md`.
 
 Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."


### PR DESCRIPTION
## What does this PR do?

The bundled Humanizer says to preserve meaning, but parts of its instruction set taught the opposite behavior. The personality guidance encouraged the agent to add opinions, emotions, first-person experience, anecdotes, and deliberate mess. Several before-and-after examples replaced source text with unsupported facts. The full worked example also introduced a study, a performance metric, named interviewees, quotations, and attribution that did not exist in its input.

This PR makes source fidelity the skill's primary contract. A Humanizer rewrite must preserve substantive claims and may not invent factual or personal material. It also makes the skill less aggressive by requiring patterns to be judged in context, respecting an authorized writing sample, and allowing the correct result to be no edit.

The root cause was a mismatch between three parts of the skill: the high-level preserve-meaning instruction, examples that modeled unsupported replacement content, and output guidance that always exposed draft and self-critique stages. The skill had no focused contract tests to keep those parts aligned.

## Related work

Related to #72921, which restores the missing smart-quote characters in pattern 19's demonstration. This branch includes the same demonstration correction, then adds the behavioral boundary that curly quotes alone are not evidence of AI writing and should change only when the user, writing sample, or style guide requires straight quotes.

The overlap is limited to pattern 19. This PR's broader source-fidelity contract, example repairs, false-positive guidance, output modes, tests, and generated documentation remain independent of that correction.

## Type of change

- [x] Bug fix
- [x] Documentation update
- [x] Tests
- [ ] New skill
- [ ] Runtime feature or dependency

## Changes made

### Humanizer contract and examples

- Defines source fidelity before the pattern catalog.
- Requires rewrites to preserve facts, names, numbers, dates, quotations, citations, qualifiers, uncertainty, technical literals, and deliberate point of view.
- Prohibits unsupported facts, anecdotes, first-person experience, opinions, emotions, attributions, examples, and sources. Fiction and explicit ideation remain exempt.
- Makes an authorized writing sample take priority over generic pattern rules.
- Replaces the broad "add soul" instruction with context-aware voice guidance.
- Repairs catalog examples that invented details or dropped source claims.
- Removes the fabricated full worked example and the duplicate draft/final workflow.
- Adds false-positive guidance for isolated punctuation, short sentences, passive voice, compound modifiers, quotations, technical literals, and deliberate repetition.
- Adds pasted-text, file, and embedded output modes so a nested editing pass does not leak an intermediate draft.
- Keeps Hermes's existing 34-pattern catalog.

### Regression coverage

Adds eight contract tests covering:

- source-fidelity safeguards and their placement before the pattern catalog;
- the authorship and evidence boundary;
- the exact 1-through-34 pattern sequence;
- removal of unsafe opinion and first-person guidance;
- removal of the fabricated worked example and known catalog fabrications;
- loadability through Hermes's real frontmatter parser;
- instruction-only packaging with no executable files; and
- exact generated-page parity with the skill source.

### Generated documentation

- Regenerates the public Humanizer page from the revised skill.
- Updates the skill catalog description to "Humanize text without changing its meaning."

## Behavioral boundaries

- This remains a prompt-based editing skill. It does not prove human authorship, factual accuracy, writer identity, or publication readiness.
- This PR does not add a detector, hidden-Unicode scanner, fact checker, MCP integration, runtime code, or external dependency.
- This is a selective adaptation, not a full sync with current upstream Humanizer. It retains Hermes's 34-pattern catalog and Hermes-native file tools.
- Source-fidelity, writing-sample, false-positive, and output-mode guidance is adapted from later [blader/humanizer](https://github.com/blader/humanizer) work. The attribution section records that provenance without claiming version parity.

## How to test

Run the focused skill, authoring-standard, and generated-doc tests:

```bash
scripts/run_tests.sh \
  tests/skills/test_humanizer_skill.py \
  tests/skills/test_authoring_standards.py \
  tests/website/test_generate_skill_docs.py \
  -q
```

Result at commit `2c2dc5d2e0`:

```text
3 files, 1,187 tests passed, 0 failed
```

Additional checks:

```bash
./.venv/bin/ruff check tests/skills/test_humanizer_skill.py
./.venv/bin/ruff format --check tests/skills/test_humanizer_skill.py
git diff --check origin/main...HEAD
```

All three checks pass.

## Review evidence

- The branch contains one conventional commit and four changed files relative to the live `origin/main` used for the final rebase.
- Clean Simplify found no justified follow-up edit. The skill already removes 170 net lines, and abstracting the eight explicit contract checks would reduce failure clarity.
- The generated Humanizer page matches the source renderer exactly through `test_generated_humanizer_page_matches_skill_source`.
- The pattern-heading contract confirms the catalog remains exactly 1 through 34.
- The regression contracts reject the removed fabrication examples and the former opinion or first-person guidance.
- An independent Clean Review covered all four changed files at `2c2dc5d2e0` and returned no findings.
- `git diff --check` and Ruff pass.

## Known gaps

- The complete repository test suite was not run locally. The focused suite above passed, and CI remains the full-suite authority.
- Deterministic tests can catch known regressions and generated-document drift, but they cannot prove semantic fidelity for every future prose example.
- The repository has no `.clean-code` policy file, so no policy-backed `clean-code verify` run was available. Focused repository tests and independent review provide the local evidence for this change.
- Pattern 19 overlaps the two-line demonstration correction in #72921. Merge order may require a small conflict resolution in that section.

## Checklist

- [x] Conventional commit used.
- [x] Branch contains only Humanizer source, tests, and generated documentation.
- [x] Focused tests pass: 1,187 passed and 0 failed.
- [x] Ruff and patch checks pass.
- [x] Tests cover the changed contract.
- [x] Generated skill documentation and catalog are updated.
- [x] No configuration keys, tool schemas, runtime behavior, or dependencies changed.
- [ ] Complete repository test suite run locally.
