### PR TITLE
fix(desktop): present queue action during compaction

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -155,6 +155,19 @@ describe('ComposerControls shortcut tooltips', () => {
 
     await expectShortcutTooltip('Queue message', 'Ctrl+↵')
   })
+
+  // Compaction forces busyAction to 'queue' even with an empty composer (see
+  // index.tsx), so the primary control — not just the secondary ghost button,
+  // which only renders when there's a payload — must present as Queue too.
+  it('presents the primary control as Queue (not Stop) with an empty composer while busyAction is queue', async () => {
+    renderControls({ busy: true, busyAction: 'queue', hasComposerPayload: false })
+
+    expect(screen.queryByLabelText('Stop')).toBeNull()
+    const primary = screen.getByLabelText('Queue message')
+    expect((primary as HTMLButtonElement).type).toBe('submit')
+
+    await expectShortcutTooltip('Queue message', 'Ctrl+↵')
+  })
 })
 
 describe('wake-word ear visibility', () => {

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -74,8 +74,11 @@ export function ComposerControls({
 
   const showVoicePrimary = !busy && !hasComposerPayload
   // Steer is just send: a payload keeps the Send affordance mid-turn. Stop
-  // only when the composer is empty and a turn is running.
-  const showStop = busy && !hasComposerPayload
+  // only when the composer is empty and a turn is running for a stoppable
+  // action; queue (e.g. forced by compaction) presents as Queue instead, even
+  // with an empty composer.
+  const showStop = busy && !hasComposerPayload && busyAction === 'stop'
+  const showQueuePrimary = busy && !hasComposerPayload && busyAction === 'queue'
   const showQueueButton = busyAction !== 'stop' && hasComposerPayload
   // The HUD is a Spotlight bar a few hundred pixels wide, so the four separate
   // voice toggles fold into one menu there and leave the row to the input. A
@@ -147,19 +150,23 @@ export function ComposerControls({
           label={
             showStop ? (
               <TipKeybindLabel actionId="composer.send" text={c.stop} />
+            ) : showQueuePrimary ? (
+              <TipKeybindLabel actionId="composer.queue" text={c.queueMessage} />
             ) : (
               <TipKeybindLabel actionId="composer.send" text={c.send} />
             )
           }
         >
           <Button
-            aria-label={showStop ? c.stop : c.send}
+            aria-label={showStop ? c.stop : showQueuePrimary ? c.queueMessage : c.send}
             className={PRIMARY_ICON_BTN}
             disabled={disabled || !canSubmit}
             type="submit"
           >
             {showStop ? (
               <span className="block size-2.5 rounded-[0.1875rem] bg-current" />
+            ) : showQueuePrimary ? (
+              <Layers3 className={iconSize.sm} />
             ) : (
               <Codicon name="arrow-up" size="0.875rem" />
             )}


### PR DESCRIPTION
## Summary
- present the primary composer action as **Queue message** when `busyAction` is `queue`, including during active compaction with an empty composer
- derive the primary label, tooltip, and icon from the existing busy action instead of displaying **Stop** for every busy empty composer
- add focused regression coverage while preserving the existing submit/queue behavior

## Problem
During active context compaction, submission is intentionally forced to the queue path. The primary composer control nevertheless displayed **Stop** because its presentation depended only on `busy && !hasComposerPayload`. The existing compression E2E expected **Queue message** and failed before it could verify that the draft was queued.

## Scope
This is a UI-presentation fix only. It does not change:
- message submission or queue semantics
- compaction lifecycle or event handling
- per-session compaction state
- shortcuts or unrelated composer controls

## Validation
- `npm run test:ui -- src/app/chat/composer/controls.test.tsx` — 16 passed
- `XDG_RUNTIME_DIR=<temp> xvfb-run -a npx playwright test e2e/session-compression-and-queue-stop.spec.ts --reporter=list` — 2 passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 124 pre-existing warnings and no errors
- `git diff --check` — passed

The focused test was observed red on current upstream before the production change: expected **Queue message**, received **Stop**.
