### PR TITLE
fix(transports/codex): resolve codex CLI on Windows when binary lacks extension

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -32,6 +32,32 @@ from tools.environments.local import hermes_subprocess_env
 MIN_CODEX_VERSION = (0, 125, 0)
 
 
+def _resolve_codex_bin(name: str) -> str:
+    """Resolve a usable codex executable path across platforms.
+
+    On Windows, `npm i -g @openai/codex` installs both `codex` (a POSIX shell
+    wrapper without an extension) and `codex.cmd` (the Windows shim). The
+    shell wrapper cannot be invoked by `subprocess.run([...])` because
+    CreateProcessW does not consult PATHEXT, so the wrapper is silently
+    unrunnable from Python on Windows even though `where codex` reports it.
+
+    Fall back to `.cmd` / `.bat` / `.exe` candidates so the binary check and
+    app-server spawn both work on a stock Windows install.
+    """
+    import shutil
+
+    found = shutil.which(name)
+    if found:
+        return found
+    if os.name != "nt":
+        return name
+    for ext in (".cmd", ".bat", ".exe", ".com"):
+        candidate = shutil.which(name + ext)
+        if candidate:
+            return candidate
+    return name
+
+
 @dataclass
 class CodexAppServerError(RuntimeError):
     """Raised on JSON-RPC errors from the app-server."""
@@ -75,7 +101,7 @@ class CodexAppServerClient:
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
     ) -> None:
-        self._codex_bin = codex_bin
+        self._codex_bin = _resolve_codex_bin(codex_bin)
         # codex app-server is a model-driving CLI executor: it runs a
         # model-chosen agentic loop that executes shell commands, so it
         # legitimately needs LLM provider credentials (inherit_credentials=True)
@@ -390,9 +416,10 @@ def check_codex_binary(
     """Verify codex CLI is installed and meets minimum version.
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
+    resolved = _resolve_codex_bin(codex_bin)
     try:
         proc = subprocess.run(
-            [codex_bin, "--version"],
+            [resolved, "--version"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=10,
@@ -400,7 +427,7 @@ def check_codex_binary(
         )
     except FileNotFoundError:
         return False, (
-            f"codex CLI not found at {codex_bin!r}. Install with: "
+            f"codex CLI not found at {codex_bin!r} (resolved: {resolved!r}). Install with: "
             f"npm i -g @openai/codex"
         )
     except subprocess.TimeoutExpired:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -102,6 +102,36 @@ class TestCodexAppServerModule:
         assert ok is False
         assert "not found" in msg.lower() or "no such" in msg.lower()
 
+    def test_resolves_windows_cmd_extension(self, monkeypatch) -> None:
+        """On Windows, `codex` (no extension) is a POSIX shell wrapper that
+        CreateProcessW cannot run. `codex.cmd` is the real shim. The resolver
+        must fall back to it; otherwise the check falsely reports missing."""
+        from agent.transports import codex_app_server as cas
+
+        fake_cmd = (
+            "C:\\Users\\someone\\AppData\\Local\\hermes\\node\\codex.cmd"
+        )
+        monkeypatch.setattr(cas, "_resolve_codex_bin", lambda name: fake_cmd)
+
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            from subprocess import CompletedProcess
+
+            calls.append(cmd)
+            return CompletedProcess(cmd, 0, stdout="codex-cli 0.151.0", stderr="")
+
+        monkeypatch.setattr(cas.subprocess, "run", fake_run)
+
+        ok, msg = cas.check_codex_binary()
+
+        assert ok is True, msg
+        assert msg == "0.151.0"
+        assert len(calls) == 1
+        assert calls[0][0].endswith(".cmd"), (
+            f"expected resolved binary to end with .cmd, got {calls[0][0]!r}"
+        )
+
     def test_codex_error_class_is_runtimeerror(self) -> None:
         from agent.transports.codex_app_server import CodexAppServerError
 


### PR DESCRIPTION
## Bug

On Windows, `npm i -g @openai/codex` installs both `codex` (a POSIX shell wrapper without an extension) and `codex.cmd` (the Windows shim). `check_codex_binary()` and `CodexAppServerClient` invoked the binary via `subprocess.run([codex_bin, ...])`, which uses `CreateProcessW` and does **not** consult `PATHEXT`. The shell wrapper is therefore silently unrunnable from Python on Windows even though `where codex` reports it, so the `/codex-runtime codex_app_server` slash command fails with:

```
Cannot enable codex_app_server runtime: codex CLI not found at 'codex'.
Install with: npm i -g @openai/codex
```

## Repro on Windows 10/11

```
> where codex
C:\Users\someone\AppData\Local\hermes\node\codex
C:\Users\someone\AppData\Local\hermes\node\codex.cmd
> codex.cmd --version
codex-cli 0.151.0
```

Inside Python:
```python
>>> subprocess.run(["codex", "--version"], capture_output=True, text=True)
FileNotFoundError: [WinError 2]
```

In Hermes slash command:
```
/codex-runtime codex_app_server
# Cannot enable codex_app_server runtime: codex CLI not found at 'codex'.
```

## Fix

Add `_resolve_codex_bin()` in `agent/transports/codex_app_server.py` that prefers `shutil.which(name)` and falls back to `name + .cmd` / `.bat` / `.exe` / `.com` candidates on Windows. Apply it in both call sites (`check_codex_binary()` and `CodexAppServerClient.__init__`) so the binary check and the app-server spawn agree on the executable.

The non-Windows path is unchanged — it still returns whatever `shutil.which(name)` found, or the original `name` if nothing matches (preserving the existing `FileNotFoundError` diagnostic).

## Test

Added `test_resolves_windows_cmd_extension` that monkeypatches the resolver to return a `.cmd` path and asserts `check_codex_binary()` invokes a `.cmd`-suffixed binary and parses the version string correctly. All 24 tests in `tests/agent/transports/test_codex_app_server_runtime.py` pass:

```
24 passed in 2.67s
```

## Why a PR and not an upstream Issue

This is a minimal, well-scoped fix with a regression test and no API surface changes. Worth landing directly once reviewed.