### PR TITLE
Harden external capability audit and CI authority

### DIFF
--- a/.audit-tool-lock.json
+++ b/.audit-tool-lock.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "tools": {
+    "zizmor": {
+      "version": "1.30.0",
+      "sha256": "sha256:98c426d9668ba03d7444acdb8a5f0eb44ba187ddffeba15833b605a384d50879"
+    },
+    "import-linter": {
+      "version": "2.14",
+      "sha256": "sha256:a6558ea7f4f0fea70cf21f63eac9d37018882f8ed529bb3313ba28e1a2bf279e"
+    },
+    "pip-audit": {
+      "version": "2.10.1",
+      "sha256": "sha256:ade9c86ba46074ca0224526121f061c67fadafabf00294c7d52d6436221604de"
+    }
+  },
+  "uv": {
+    "version": "0.12.6",
+    "sha256": "sha256:e8929237934c8679686428f5a7736c7ae7a5fe7a33b0504d1b03446cdbc43c94"
+  }
+}

--- a/.audit-tool-lock.json
+++ b/.audit-tool-lock.json
@@ -7,11 +7,13 @@
     },
     "import-linter": {
       "version": "2.14",
-      "sha256": "sha256:a6558ea7f4f0fea70cf21f63eac9d37018882f8ed529bb3313ba28e1a2bf279e"
+      "sha256": "sha256:a6558ea7f4f0fea70cf21f63eac9d37018882f8ed529bb3313ba28e1a2bf279e",
+      "distribution_sha256": "sha256:de0858c9dc7eeca513b6daa31dec7099939addfb1f089536ec806a0b1611bddb"
     },
     "pip-audit": {
       "version": "2.10.1",
-      "sha256": "sha256:ade9c86ba46074ca0224526121f061c67fadafabf00294c7d52d6436221604de"
+      "sha256": "sha256:ade9c86ba46074ca0224526121f061c67fadafabf00294c7d52d6436221604de",
+      "distribution_sha256": "sha256:5691c79b88f4c5c5b9f8f7642c9708d12275998fe7e523144b5c132807ac135c"
     }
   },
   "uv": {

--- a/.github/actions/get-app-token/action.yml
+++ b/.github/actions/get-app-token/action.yml
@@ -31,6 +31,26 @@ inputs:
     description: Comma- or newline-separated repositories to scope within the installation owner.
     required: false
     default: ''
+  permission-actions:
+    description: Actions API permission requested for the token (read or write).
+    required: false
+    default: ''
+  permission-checks:
+    description: Checks API permission requested for the token (read or write).
+    required: false
+    default: ''
+  permission-contents:
+    description: Repository contents permission requested for the token (read or write).
+    required: false
+    default: ''
+  permission-issues:
+    description: Issues permission requested for the token (read or write).
+    required: false
+    default: ''
+  permission-pull-requests:
+    description: Pull request permission requested for the token (read or write).
+    required: false
+    default: ''
 
 outputs:
   token:
@@ -61,6 +81,11 @@ runs:
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}
+        permission-actions: ${{ inputs.permission-actions }}
+        permission-checks: ${{ inputs.permission-checks }}
+        permission-contents: ${{ inputs.permission-contents }}
+        permission-issues: ${{ inputs.permission-issues }}
+        permission-pull-requests: ${{ inputs.permission-pull-requests }}
 
     - name: Fall back to GITHUB_TOKEN
       id: fallback

--- a/.github/actions/get-app-token/action.yml
+++ b/.github/actions/get-app-token/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: Pull request permission requested for the token (read or write).
     required: false
     default: ''
+  permission-statuses:
+    description: Commit status permission requested for the token (read or write).
+    required: false
+    default: ''
 
 outputs:
   token:
@@ -86,6 +90,7 @@ runs:
         permission-contents: ${{ inputs.permission-contents }}
         permission-issues: ${{ inputs.permission-issues }}
         permission-pull-requests: ${{ inputs.permission-pull-requests }}
+        permission-statuses: ${{ inputs.permission-statuses }}
 
     - name: Fall back to GITHUB_TOKEN
       id: fallback

--- a/.github/actions/get-app-token/action.yml
+++ b/.github/actions/get-app-token/action.yml
@@ -12,7 +12,8 @@ description: >-
 
   Composite actions cannot access contexts directly, so callers pass the
   public vars.APP_CLIENT_ID and protected secrets.APP_PRIVATE_KEY as inputs.
-  When the private key is empty, the fallback fires.
+  When either credential is empty, the fallback fires rather than attempting
+  to mint with a partial credential pair.
 
 inputs:
   client-id:
@@ -69,8 +70,9 @@ runs:
       shell: bash
       env:
         CLIENT_ID: ${{ inputs.client-id }}
+        PRIVATE_KEY: ${{ inputs.private-key }}
       run: |
-        if [ -n "$CLIENT_ID" ]; then
+        if [ -n "$CLIENT_ID" ] && [ -n "$PRIVATE_KEY" ]; then
           echo "has_app=true" >> "$GITHUB_OUTPUT"
         else
           echo "has_app=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # needed by lint (PR comment) + supply-chain review_status
-  actions: read # needed by osv-scanner (SARIF upload)
-  security-events: write # needed by osv-scanner (SARIF upload)
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -182,6 +179,9 @@ jobs:
     name: Supply-chain scan
     needs: detect
     if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.scan == 'true' || needs.detect.outputs.deps == 'true')
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/supply-chain-audit.yml
     with:
       event_name: ${{ needs.detect.outputs.event_name }}
@@ -201,6 +201,10 @@ jobs:
 
   osv-scanner:
     name: OSV scan
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: ./.github/workflows/osv-scanner.yml
 
   # ─────────────────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,9 @@ jobs:
     name: Review label gate
     needs: [detect, supply-chain]
     if: always() && needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.ci_review == 'true' || needs.detect.outputs.mcp_catalog == 'true' || needs.supply-chain.outputs.critical_findings == 'true')
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/review-labels.yml
     with:
       ci_review: ${{ needs.detect.outputs.ci_review == 'true' }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -24,9 +24,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -48,6 +45,11 @@ jobs:
 
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pages: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -62,6 +64,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-contents: read
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -107,8 +107,15 @@ jobs:
       # is always fresh — no separate build step needed.
       - name: Run Playwright E2E tests
         working-directory: apps/desktop
+        env:
+          GITHUB_REF_NAME_SAFE: ${{ github.ref_name }}
+          CI: 'true'
+          # Ensure no real API keys leak into the test env.
+          OPENROUTER_API_KEY: ''
+          OPENAI_API_KEY: ''
+          NOUS_API_KEY: ''
         run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
+          if [ "$GITHUB_REF_NAME_SAFE" = "main" ]; then
             echo "On main — generating/updating baseline screenshots"
             npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" \
               npx playwright test --reporter=list --update-snapshots
@@ -117,12 +124,6 @@ jobs:
             npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" \
               npx playwright test --reporter=list
           fi
-        env:
-          CI: 'true'
-          # Ensure no real API keys leak into the test env.
-          OPENROUTER_API_KEY: ''
-          OPENAI_API_KEY: ''
-          NOUS_API_KEY: ''
 
       # ── Save updated baselines to cache (main only) ───────────────────
       - name: Save updated baselines to cache

--- a/.github/workflows/install-e2e-run.yml
+++ b/.github/workflows/install-e2e-run.yml
@@ -82,18 +82,20 @@ jobs:
           grep "^$(id -un):" /etc/subuid /etc/subgid || echo "  (none — sandbox will say so)"
 
       - name: Run install + update E2E
-        run: |
-          set -euo pipefail
-          tests/install/install-update-e2e.sh \
-            --route '${{ inputs.route }}' \
-            --install-ref '${{ inputs.install-ref }}'
         env:
+          INSTALL_REF: ${{ inputs.install-ref }}
+          ROUTE: ${{ inputs.route }}
           # Outside the workspace on purpose: the script creates this directory
           # up front, and an untracked dir inside the repo makes the worktree
           # dirty -- which dev-sandbox reacts to by snapshotting the working
           # copy into a fresh fake-main commit on every invocation, moving the
           # update target mid-run.
           HERMES_E2E_LOG_DIR: ${{ runner.temp }}/e2e-logs
+        run: |
+          set -euo pipefail
+          tests/install/install-update-e2e.sh \
+            --route "$ROUTE" \
+            --install-ref "$INSTALL_REF"
 
       # Artifact names cannot contain '/', and install-ref may be a full ref
       # like refs/heads/main. GitHub Actions expressions have no string-replace
@@ -102,11 +104,14 @@ jobs:
       - name: Build artifact name
         if: always()
         id: artifact
+        env:
+          INSTALL_REF: ${{ inputs.install-ref }}
+          ROUTE: ${{ inputs.route }}
         run: |
           set -euo pipefail
-          safe_ref='${{ inputs.install-ref }}'
+          safe_ref="$INSTALL_REF"
           safe_ref="${safe_ref//\//-}"
-          echo "name=install-e2e-${{ inputs.route }}-${safe_ref}" >> "$GITHUB_OUTPUT"
+          echo "name=install-e2e-${ROUTE}-${safe_ref}" >> "$GITHUB_OUTPUT"
 
       # The installer's own transcripts say far more than the assertion that
       # tripped when a real install breaks.

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -73,9 +73,11 @@ jobs:
           sparse-checkout: scripts/sandbox/pick-release-tags.sh
           sparse-checkout-cone-mode: false
       - id: pick
+        env:
+          TAG_COUNT: ${{ inputs.tag-count || 5 }}
         run: |
           set -euo pipefail
-          tags="$(scripts/sandbox/pick-release-tags.sh --count '${{ inputs.tag-count || 5 }}')"
+          tags="$(scripts/sandbox/pick-release-tags.sh --count "$TAG_COUNT")"
           echo "Testing updates from: $tags"
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -152,6 +152,9 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Download patch
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -141,8 +141,10 @@ jobs:
     timeout-minutes: 15
     environment: trusted-automation
     permissions:
+      checks: read # gh pr checks reads CheckRun entries
       contents: write # needed to push to bot/js-autofix
       pull-requests: write # needed for PR creation + auto-merge
+      statuses: read # gh pr checks also reads commit StatusContext entries
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -155,6 +157,7 @@ jobs:
           permission-checks: read
           permission-contents: write
           permission-pull-requests: write
+          permission-statuses: read
 
       - name: Download patch
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,12 +53,15 @@ jobs:
 
       - name: Determine base ref
         id: base
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          EVENT_NAME: ${{ inputs.event_name }}
         run: |
           # For PRs, diff against the merge base with the target branch.
           # For pushes to main, diff against the previous commit on main.
-          if [ "${{ inputs.event_name }}" = "pull_request" ]; then
-            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
-            BASE_REF="origin/${{ github.base_ref }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base "origin/$BASE_BRANCH" HEAD)
+            BASE_REF="origin/$BASE_BRANCH"
           else
             BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
             BASE_REF="HEAD~1"

--- a/.github/workflows/lockfile-diff.yml
+++ b/.github/workflows/lockfile-diff.yml
@@ -47,12 +47,14 @@ jobs:
 
       - name: Generate semantic lockfile diff
         id: diff
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
           set -euo pipefail
           # Three-dot semantics by hand: diff from the merge base with the
           # target branch to the PR head, so changes that landed on main
           # after the branch point don't show up as this PR's doing.
-          BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          BASE_SHA=$(git merge-base "origin/$BASE_BRANCH" HEAD)
           echo "Merge base: ${BASE_SHA}"
           python3 scripts/ci/lockfile_diff.py \
             --base "$BASE_SHA" \

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -32,14 +32,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   scan:
     name: Scan lockfiles
+    permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      contents: read
+      security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       # Scan explicit lockfiles rather than recursing, so we only look at
@@ -57,6 +59,9 @@ jobs:
 
   emit-status:
     name: Emit review status
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
     needs: scan
     if: always()

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -124,6 +124,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
 
       - name: Open issue on degraded / failed probe
         if: steps.probe.outputs.status != 'ok'

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -124,7 +124,6 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: read
           permission-issues: write
 
       - name: Open issue on degraded / failed probe

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  actions: write # to trigger deploy-site.yml on schedule
 
 jobs:
   build-index:
@@ -31,6 +30,7 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -59,6 +59,9 @@ jobs:
   trigger-deploy:
     needs: build-index
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: write # trigger deploy-site.yml on schedule or manual refresh
+      contents: read # check out the local token-minting action
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: trusted-automation
@@ -75,6 +78,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-contents: read
 
       - name: Trigger Deploy Site workflow
         env:

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -79,7 +79,6 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-actions: write
-          permission-contents: read
 
       - name: Trigger Deploy Site workflow
         env:

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -47,8 +47,8 @@ on:
         value: ${{ jobs.aggregate.outputs.critical_findings }}
 
 permissions:
-  pull-requests: write
   contents: read
+  pull-requests: read
 
 jobs:
   scan:

--- a/.importlinter
+++ b/.importlinter
@@ -28,7 +28,7 @@ forbidden_modules =
 allow_indirect_imports = true
 
 [importlinter:contract:gateway-session-context-leaf]
-name = Gateway session context stays dependency-light
+name = Gateway session context stays transitively dependency-light
 type = forbidden
 source_modules =
     gateway.session_context
@@ -36,7 +36,7 @@ forbidden_modules =
     hermes_cli
     plugins
     tools
-allow_indirect_imports = true
+allow_indirect_imports = false
 
 [importlinter:contract:plugin-capability-consent-leaf]
 name = Plugin capability consent stays independent of runtime layers

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,51 @@
+[importlinter]
+root_packages =
+    agent
+    gateway
+    hermes_cli
+    plugins
+    tools
+
+[importlinter:contract:tool-registry-narrow-waist]
+name = Tool registry remains below agent and delivery layers
+type = forbidden
+source_modules =
+    tools.registry
+forbidden_modules =
+    hermes_cli
+    plugins
+allow_indirect_imports = true
+
+[importlinter:contract:profile-secret-scope-leaf]
+name = Profile secret scope stays independent of runtime layers
+type = forbidden
+source_modules =
+    agent.secret_scope
+forbidden_modules =
+    gateway
+    plugins
+    tools
+allow_indirect_imports = true
+
+[importlinter:contract:gateway-session-context-leaf]
+name = Gateway session context stays dependency-light
+type = forbidden
+source_modules =
+    gateway.session_context
+forbidden_modules =
+    hermes_cli
+    plugins
+    tools
+allow_indirect_imports = true
+
+[importlinter:contract:plugin-capability-consent-leaf]
+name = Plugin capability consent stays independent of runtime layers
+type = forbidden
+source_modules =
+    hermes_cli.plugin_capabilities
+forbidden_modules =
+    agent
+    gateway
+    plugins
+    tools
+allow_indirect_imports = true

--- a/scripts/audit_external_tooling.py
+++ b/scripts/audit_external_tooling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from collections.abc import Sequence
 import hashlib
 import json
 import shutil
@@ -14,7 +15,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Protocol, cast
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
@@ -31,6 +32,28 @@ class AuditCommand:
     name: str
     argv: tuple[str, ...]
     expected_version: str
+
+
+class AuditProcessResult(Protocol):
+    """The subprocess fields consumed by the read-only audit pipeline."""
+
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def stdout(self) -> str: ...
+
+    @property
+    def stderr(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class SkippedAuditResult:
+    """Typed result for an audit that cannot run after preparation fails."""
+
+    returncode: int
+    stdout: str
+    stderr: str
 
 
 def build_commands(
@@ -109,20 +132,21 @@ def _run(
     *,
     repo_root: Path,
     timeout: int,
-) -> Any:
-    return runner(
-        list(argv),
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
+) -> AuditProcessResult:
+    return cast(
+        AuditProcessResult,
+        runner(
+            list(argv),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        ),
     )
 
 
-def _git_value(
-    runner: Callable[..., Any], repo_root: Path, *arguments: str
-) -> str:
+def _git_value(runner: Callable[..., Any], repo_root: Path, *arguments: str) -> str:
     result = _run(runner, ("git", *arguments), repo_root=repo_root, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
@@ -191,17 +215,15 @@ def run_audits(
         export_result = _run(runner, export_command, repo_root=repo_root, timeout=120)
         export_stdout = str(export_result.stdout or "")
         export_stderr = str(export_result.stderr or "")
-        preparations.append(
-            {
-                "name": "uv-lock-export",
-                "command": list(export_command),
-                "returncode": int(export_result.returncode),
-                "stdout_sha256": _sha256(export_stdout),
-                "stderr_sha256": _sha256(export_stderr),
-                "stdout": _bounded_output(export_stdout),
-                "stderr": _bounded_output(export_stderr),
-            }
-        )
+        preparations.append({
+            "name": "uv-lock-export",
+            "command": list(export_command),
+            "returncode": int(export_result.returncode),
+            "stdout_sha256": _sha256(export_stdout),
+            "stderr_sha256": _sha256(export_stderr),
+            "stdout": _bounded_output(export_stdout),
+            "stderr": _bounded_output(export_stderr),
+        })
 
         for command in build_commands(
             repo_root=repo_root,
@@ -209,32 +231,26 @@ def run_audits(
             requirements_path=requirements_path,
         ):
             if command.name == "pip-audit" and export_result.returncode != 0:
-                result = type(
-                    "SkippedResult",
-                    (),
-                    {
-                        "returncode": 1,
-                        "stdout": "",
-                        "stderr": "uv lock export failed; pip-audit was not run",
-                    },
-                )()
+                result: AuditProcessResult = SkippedAuditResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="uv lock export failed; pip-audit was not run",
+                )
             else:
                 result = _run(runner, command.argv, repo_root=repo_root, timeout=600)
             stdout = str(result.stdout or "")
             stderr = str(result.stderr or "")
-            audits.append(
-                {
-                    "name": command.name,
-                    "expected_version": command.expected_version,
-                    "command": list(command.argv),
-                    "returncode": int(result.returncode),
-                    "stdout_sha256": _sha256(stdout),
-                    "stderr_sha256": _sha256(stderr),
-                    "summary": _summarize_json_output(command.name, stdout),
-                    "stdout": _bounded_output(stdout),
-                    "stderr": _bounded_output(stderr),
-                }
-            )
+            audits.append({
+                "name": command.name,
+                "expected_version": command.expected_version,
+                "command": list(command.argv),
+                "returncode": int(result.returncode),
+                "stdout_sha256": _sha256(stdout),
+                "stderr_sha256": _sha256(stderr),
+                "summary": _summarize_json_output(command.name, stdout),
+                "stdout": _bounded_output(stdout),
+                "stderr": _bounded_output(stderr),
+            })
 
     return {
         "schema_version": "hermes_external_tooling_audit_v1",

--- a/scripts/audit_external_tooling.py
+++ b/scripts/audit_external_tooling.py
@@ -8,6 +8,7 @@ from collections import Counter
 from collections.abc import Sequence
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -32,6 +33,11 @@ class AuditCommand:
     name: str
     argv: tuple[str, ...]
     expected_version: str
+
+    @property
+    def version_argv(self) -> tuple[str, ...]:
+        """Return the command used to observe the installed tool realization."""
+        return (self.argv[0], "--version")
 
 
 class AuditProcessResult(Protocol):
@@ -163,6 +169,12 @@ def _bounded_output(text: str) -> str:
     return text[:_MAX_CAPTURE_CHARS] + "\n...[capture truncated]"
 
 
+def _extract_version(stdout: str, stderr: str) -> str | None:
+    """Extract a concrete semantic version from a tool's observed output."""
+    match = re.search(r"(?<!\d)(\d+(?:\.\d+){1,3})(?!\d)", f"{stdout}\n{stderr}")
+    return match.group(1) if match else None
+
+
 def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
     try:
         payload = json.loads(stdout)
@@ -170,22 +182,28 @@ def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
         return None
 
     if name == "zizmor" and isinstance(payload, list):
+        determinations = [row.get("determinations", {}) for row in payload]
         return {
             "finding_groups": len(payload),
             "locations": sum(len(row.get("locations", [])) for row in payload),
             "by_severity": dict(
                 Counter(
-                    row.get("determinations", {}).get("severity", "Unknown")
-                    for row in payload
+                    determination.get("severity", "Unknown")
+                    for determination in determinations
                 )
             ),
             "by_confidence": dict(
                 Counter(
-                    row.get("determinations", {}).get("confidence", "Unknown")
-                    for row in payload
+                    determination.get("confidence", "Unknown")
+                    for determination in determinations
                 )
             ),
             "by_ident": dict(Counter(row.get("ident", "unknown") for row in payload)),
+            "high_confidence_high_severity": sum(
+                determination.get("severity") == "High"
+                and determination.get("confidence") == "High"
+                for determination in determinations
+            ),
         }
     if name == "pip-audit" and isinstance(payload, dict):
         dependencies = payload.get("dependencies", [])
@@ -194,6 +212,19 @@ def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
             "vulnerabilities": sum(len(row.get("vulns", [])) for row in dependencies),
         }
     return None
+
+
+def _policy_ok(
+    name: str, returncode: int, summary: dict[str, Any] | None
+) -> bool:
+    """Evaluate audit findings instead of treating process success as policy success."""
+    if returncode != 0:
+        return False
+    if name == "zizmor":
+        return summary is not None and summary["high_confidence_high_severity"] == 0
+    if name == "pip-audit":
+        return summary is not None and summary["vulnerabilities"] == 0
+    return True
 
 
 def run_audits(
@@ -230,6 +261,16 @@ def run_audits(
             tool_root=tool_root,
             requirements_path=requirements_path,
         ):
+            version_result = _run(
+                runner, command.version_argv, repo_root=repo_root, timeout=30
+            )
+            version_stdout = str(version_result.stdout or "")
+            version_stderr = str(version_result.stderr or "")
+            observed_version = _extract_version(version_stdout, version_stderr)
+            version_matches = (
+                version_result.returncode == 0
+                and observed_version == command.expected_version
+            )
             if command.name == "pip-audit" and export_result.returncode != 0:
                 result: AuditProcessResult = SkippedAuditResult(
                     returncode=1,
@@ -240,14 +281,24 @@ def run_audits(
                 result = _run(runner, command.argv, repo_root=repo_root, timeout=600)
             stdout = str(result.stdout or "")
             stderr = str(result.stderr or "")
+            summary = _summarize_json_output(command.name, stdout)
             audits.append({
                 "name": command.name,
                 "expected_version": command.expected_version,
+                "observed_version": observed_version,
+                "version_matches": version_matches,
+                "version_command": list(command.version_argv),
+                "version_returncode": int(version_result.returncode),
+                "version_stdout_sha256": _sha256(version_stdout),
+                "version_stderr_sha256": _sha256(version_stderr),
+                "version_stdout": _bounded_output(version_stdout),
+                "version_stderr": _bounded_output(version_stderr),
                 "command": list(command.argv),
                 "returncode": int(result.returncode),
                 "stdout_sha256": _sha256(stdout),
                 "stderr_sha256": _sha256(stderr),
-                "summary": _summarize_json_output(command.name, stdout),
+                "summary": summary,
+                "policy_ok": _policy_ok(command.name, result.returncode, summary),
                 "stdout": _bounded_output(stdout),
                 "stderr": _bounded_output(stderr),
             })
@@ -264,7 +315,8 @@ def run_audits(
         },
         "read_only": True,
         "auto_fix": False,
-        "ok": all(row["returncode"] == 0 for row in (*preparations, *audits)),
+        "ok": all(row["returncode"] == 0 for row in preparations)
+        and all(row["version_matches"] and row["policy_ok"] for row in audits),
         "preparations": preparations,
         "audits": audits,
     }

--- a/scripts/audit_external_tooling.py
+++ b/scripts/audit_external_tooling.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run pinned, read-only external audits and bind results to exact git state."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hermes_constants import get_hermes_home
+
+
+_MAX_CAPTURE_CHARS = 200_000
+
+
+@dataclass(frozen=True)
+class AuditCommand:
+    name: str
+    argv: tuple[str, ...]
+    expected_version: str
+
+
+def build_commands(
+    *, repo_root: Path, tool_root: Path, requirements_path: Path | None = None
+) -> tuple[AuditCommand, ...]:
+    """Return fixed audit argv; registry or user data can never inject commands."""
+    requirements_path = requirements_path or repo_root / ".audit-requirements.txt"
+    return (
+        AuditCommand(
+            name="zizmor",
+            expected_version="1.30.0",
+            argv=(
+                str(tool_root / "zizmor"),
+                "--offline",
+                "--format",
+                "json",
+                "--no-progress",
+                "--no-exit-codes",
+                ".github",
+            ),
+        ),
+        AuditCommand(
+            name="import-linter",
+            expected_version="2.14",
+            argv=(
+                str(tool_root / "lint-imports"),
+                "--config",
+                ".importlinter",
+                "--no-cache",
+                "--no-logo",
+            ),
+        ),
+        AuditCommand(
+            name="pip-audit",
+            expected_version="2.10.1",
+            argv=(
+                str(tool_root / "pip-audit"),
+                "-r",
+                str(requirements_path),
+                "--require-hashes",
+                "--disable-pip",
+                "--format",
+                "json",
+                "--progress-spinner",
+                "off",
+                "--cache-dir",
+                str(Path(tempfile.gettempdir()) / "hermes-pip-audit-cache"),
+            ),
+        ),
+    )
+
+
+def build_uv_export_command(
+    *, requirements_path: Path, cache_path: Path | None = None
+) -> tuple[str, ...]:
+    """Export the existing uv lock without resolving or modifying dependencies."""
+    cache_path = cache_path or Path(tempfile.gettempdir()) / "hermes-uv-audit-cache"
+    return (
+        shutil.which("uv") or "uv",
+        "export",
+        "--locked",
+        "--cache-dir",
+        str(cache_path),
+        "--no-dev",
+        "--no-emit-project",
+        "--no-annotate",
+        "--no-header",
+        "--output-file",
+        str(requirements_path),
+    )
+
+
+def _run(
+    runner: Callable[..., Any],
+    argv: Sequence[str],
+    *,
+    repo_root: Path,
+    timeout: int,
+) -> Any:
+    return runner(
+        list(argv),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _git_value(
+    runner: Callable[..., Any], repo_root: Path, *arguments: str
+) -> str:
+    result = _run(runner, ("git", *arguments), repo_root=repo_root, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
+    return result.stdout.strip()
+
+
+def _sha256(text: str) -> str:
+    return f"sha256:{hashlib.sha256(text.encode('utf-8')).hexdigest()}"
+
+
+def _bounded_output(text: str) -> str:
+    if len(text) <= _MAX_CAPTURE_CHARS:
+        return text
+    return text[:_MAX_CAPTURE_CHARS] + "\n...[capture truncated]"
+
+
+def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    if name == "zizmor" and isinstance(payload, list):
+        return {
+            "finding_groups": len(payload),
+            "locations": sum(len(row.get("locations", [])) for row in payload),
+            "by_severity": dict(
+                Counter(
+                    row.get("determinations", {}).get("severity", "Unknown")
+                    for row in payload
+                )
+            ),
+            "by_confidence": dict(
+                Counter(
+                    row.get("determinations", {}).get("confidence", "Unknown")
+                    for row in payload
+                )
+            ),
+            "by_ident": dict(Counter(row.get("ident", "unknown") for row in payload)),
+        }
+    if name == "pip-audit" and isinstance(payload, dict):
+        dependencies = payload.get("dependencies", [])
+        return {
+            "dependencies": len(dependencies),
+            "vulnerabilities": sum(len(row.get("vulns", [])) for row in dependencies),
+        }
+    return None
+
+
+def run_audits(
+    *,
+    repo_root: Path,
+    tool_root: Path,
+    runner: Callable[..., Any] = subprocess.run,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    head = _git_value(runner, repo_root, "rev-parse", "HEAD")
+    branch = _git_value(runner, repo_root, "branch", "--show-current")
+    status = _git_value(runner, repo_root, "status", "--porcelain")
+
+    audits: list[dict[str, Any]] = []
+    preparations: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="hermes-external-audit-") as temp_dir:
+        requirements_path = Path(temp_dir) / "requirements.txt"
+        export_command = build_uv_export_command(requirements_path=requirements_path)
+        export_result = _run(runner, export_command, repo_root=repo_root, timeout=120)
+        export_stdout = str(export_result.stdout or "")
+        export_stderr = str(export_result.stderr or "")
+        preparations.append(
+            {
+                "name": "uv-lock-export",
+                "command": list(export_command),
+                "returncode": int(export_result.returncode),
+                "stdout_sha256": _sha256(export_stdout),
+                "stderr_sha256": _sha256(export_stderr),
+                "stdout": _bounded_output(export_stdout),
+                "stderr": _bounded_output(export_stderr),
+            }
+        )
+
+        for command in build_commands(
+            repo_root=repo_root,
+            tool_root=tool_root,
+            requirements_path=requirements_path,
+        ):
+            if command.name == "pip-audit" and export_result.returncode != 0:
+                result = type(
+                    "SkippedResult",
+                    (),
+                    {
+                        "returncode": 1,
+                        "stdout": "",
+                        "stderr": "uv lock export failed; pip-audit was not run",
+                    },
+                )()
+            else:
+                result = _run(runner, command.argv, repo_root=repo_root, timeout=600)
+            stdout = str(result.stdout or "")
+            stderr = str(result.stderr or "")
+            audits.append(
+                {
+                    "name": command.name,
+                    "expected_version": command.expected_version,
+                    "command": list(command.argv),
+                    "returncode": int(result.returncode),
+                    "stdout_sha256": _sha256(stdout),
+                    "stderr_sha256": _sha256(stderr),
+                    "summary": _summarize_json_output(command.name, stdout),
+                    "stdout": _bounded_output(stdout),
+                    "stderr": _bounded_output(stderr),
+                }
+            )
+
+    return {
+        "schema_version": "hermes_external_tooling_audit_v1",
+        "audited_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "repository": {
+            "path": str(repo_root),
+            "head": head,
+            "branch": branch,
+            "dirty": bool(status),
+            "status_porcelain": status,
+        },
+        "read_only": True,
+        "auto_fix": False,
+        "ok": all(row["returncode"] == 0 for row in (*preparations, *audits)),
+        "preparations": preparations,
+        "audits": audits,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--tool-root",
+        type=Path,
+        default=get_hermes_home() / "tooling" / "capability-audit" / "venv" / "bin",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--plan", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repo_root = args.repo.resolve()
+    tool_root = args.tool_root.expanduser().resolve()
+    if args.plan:
+        requirements_path = repo_root / ".audit-requirements.txt"
+        payload = {
+            "read_only": True,
+            "auto_fix": False,
+            "preparations": [
+                {
+                    "name": "uv-lock-export",
+                    "argv": list(
+                        build_uv_export_command(requirements_path=requirements_path)
+                    ),
+                }
+            ],
+            "commands": [
+                {"name": command.name, "argv": list(command.argv)}
+                for command in build_commands(
+                    repo_root=repo_root,
+                    tool_root=tool_root,
+                    requirements_path=requirements_path,
+                )
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    receipt = run_audits(repo_root=repo_root, tool_root=tool_root)
+    rendered = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        output = args.output.expanduser().resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if receipt["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_external_tooling.py
+++ b/scripts/audit_external_tooling.py
@@ -8,6 +8,7 @@ from collections import Counter
 from collections.abc import Sequence
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -26,6 +27,9 @@ from hermes_constants import get_hermes_home
 
 
 _MAX_CAPTURE_CHARS = 200_000
+_LOCKFILE_NAME = ".audit-tool-lock.json"
+_ZIZMOR_SEVERITIES = {"High", "Medium", "Low", "Informational"}
+_ZIZMOR_CONFIDENCES = {"High", "Medium", "Low"}
 
 
 @dataclass(frozen=True)
@@ -113,12 +117,13 @@ def build_commands(
 
 
 def build_uv_export_command(
-    *, requirements_path: Path, cache_path: Path | None = None
+    *, requirements_path: Path, cache_path: Path | None = None,
+    uv_path: Path | None = None,
 ) -> tuple[str, ...]:
     """Export the existing uv lock without resolving or modifying dependencies."""
     cache_path = cache_path or Path(tempfile.gettempdir()) / "hermes-uv-audit-cache"
     return (
-        shutil.which("uv") or "uv",
+        str(uv_path) if uv_path is not None else (shutil.which("uv") or "uv"),
         "export",
         "--locked",
         "--cache-dir",
@@ -163,6 +168,48 @@ def _sha256(text: str) -> str:
     return f"sha256:{hashlib.sha256(text.encode('utf-8')).hexdigest()}"
 
 
+def _file_sha256(path: Path) -> str | None:
+    """Hash the exact executable bytes used for an audit."""
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+    except (OSError, ValueError):
+        return None
+
+
+def _resolve_executable(path: str | Path) -> Path | None:
+    candidate = Path(path).expanduser()
+    try:
+        candidate = candidate.resolve()
+    except OSError:
+        return None
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def _load_tool_lock(repo_root: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Load and validate repository-owned executable/version pins."""
+    path = repo_root / _LOCKFILE_NAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"unable to read {_LOCKFILE_NAME}: {exc}"
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        return None, f"invalid {_LOCKFILE_NAME} schema"
+    tools = payload.get("tools")
+    uv = payload.get("uv")
+    if not isinstance(tools, dict) or not isinstance(uv, dict):
+        return None, f"invalid {_LOCKFILE_NAME} entries"
+    for entry in [uv, *[tools.get(name) for name in ("zizmor", "import-linter", "pip-audit")]]:
+        if not isinstance(entry, dict) or not isinstance(entry.get("version"), str) or not isinstance(entry.get("sha256"), str):
+            return None, f"invalid {_LOCKFILE_NAME} pin"
+    return payload, None
+
+
 def _bounded_output(text: str) -> str:
     if len(text) <= _MAX_CAPTURE_CHARS:
         return text
@@ -182,7 +229,18 @@ def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
         return None
 
     if name == "zizmor" and isinstance(payload, list):
-        determinations = [row.get("determinations", {}) for row in payload]
+        if any(
+            not isinstance(row, dict)
+            or not isinstance(row.get("ident"), str)
+            or not isinstance(row.get("determinations"), dict)
+            or not isinstance(row.get("locations"), list)
+            or row["determinations"].get("severity") not in _ZIZMOR_SEVERITIES
+            or row["determinations"].get("confidence") not in _ZIZMOR_CONFIDENCES
+            or any(not isinstance(location, dict) for location in row["locations"])
+            for row in payload
+        ):
+            return None
+        determinations = [row["determinations"] for row in payload]
         return {
             "finding_groups": len(payload),
             "locations": sum(len(row.get("locations", [])) for row in payload),
@@ -206,7 +264,16 @@ def _summarize_json_output(name: str, stdout: str) -> dict[str, Any] | None:
             ),
         }
     if name == "pip-audit" and isinstance(payload, dict):
-        dependencies = payload.get("dependencies", [])
+        dependencies = payload.get("dependencies")
+        if not isinstance(dependencies, list) or any(
+            not isinstance(row, dict)
+            or not isinstance(row.get("name"), str)
+            or not isinstance(row.get("version"), str)
+            or not isinstance(row.get("vulns"), list)
+            or any(not isinstance(vulnerability, dict) for vulnerability in row["vulns"])
+            for row in dependencies
+        ):
+            return None
         return {
             "dependencies": len(dependencies),
             "vulnerabilities": sum(len(row.get("vulns", [])) for row in dependencies),
@@ -232,18 +299,34 @@ def run_audits(
     repo_root: Path,
     tool_root: Path,
     runner: Callable[..., Any] = subprocess.run,
+    uv_path: Path | None = None,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     head = _git_value(runner, repo_root, "rev-parse", "HEAD")
     branch = _git_value(runner, repo_root, "branch", "--show-current")
     status = _git_value(runner, repo_root, "status", "--porcelain")
+    lock, lock_error = _load_tool_lock(repo_root)
 
     audits: list[dict[str, Any]] = []
     preparations: list[dict[str, Any]] = []
     with tempfile.TemporaryDirectory(prefix="hermes-external-audit-") as temp_dir:
         requirements_path = Path(temp_dir) / "requirements.txt"
-        export_command = build_uv_export_command(requirements_path=requirements_path)
-        export_result = _run(runner, export_command, repo_root=repo_root, timeout=120)
+        resolved_uv = _resolve_executable(uv_path or (shutil.which("uv") or ""))
+        uv_pin = lock.get("uv", {}) if lock else {}
+        uv_digest = _file_sha256(resolved_uv) if resolved_uv else None
+        uv_version_result: AuditProcessResult = SkippedAuditResult(1, "", "uv executable unavailable")
+        if resolved_uv is not None:
+            uv_version_result = _run(runner, (str(resolved_uv), "--version"), repo_root=repo_root, timeout=30)
+        uv_version_stdout = str(uv_version_result.stdout or "")
+        uv_version_stderr = str(uv_version_result.stderr or "")
+        uv_observed_version = _extract_version(uv_version_stdout, uv_version_stderr)
+        uv_version_matches = uv_version_result.returncode == 0 and uv_observed_version == uv_pin.get("version")
+        uv_realization_ok = bool(resolved_uv and uv_digest == uv_pin.get("sha256") and uv_version_matches)
+        export_command = build_uv_export_command(requirements_path=requirements_path, uv_path=resolved_uv)
+        if uv_realization_ok:
+            export_result = _run(runner, export_command, repo_root=repo_root, timeout=120)
+        else:
+            export_result = SkippedAuditResult(1, "", "uv realization is not locked; export was not run")
         export_stdout = str(export_result.stdout or "")
         export_stderr = str(export_result.stderr or "")
         preparations.append({
@@ -254,6 +337,18 @@ def run_audits(
             "stderr_sha256": _sha256(export_stderr),
             "stdout": _bounded_output(export_stdout),
             "stderr": _bounded_output(export_stderr),
+            "executable_path": str(resolved_uv) if resolved_uv else None,
+            "executable_sha256": uv_digest,
+            "expected_sha256": uv_pin.get("sha256"),
+            "expected_version": uv_pin.get("version"),
+            "observed_version": uv_observed_version,
+            "version_matches": uv_version_matches,
+            "realization_ok": uv_realization_ok,
+            "version_command": [str(resolved_uv), "--version"] if resolved_uv else [],
+            "version_returncode": int(uv_version_result.returncode),
+            "version_stdout_sha256": _sha256(uv_version_stdout),
+            "version_stderr_sha256": _sha256(uv_version_stderr),
+            "requirements_sha256": _file_sha256(requirements_path) if requirements_path.exists() else None,
         })
 
         for command in build_commands(
@@ -261,9 +356,13 @@ def run_audits(
             tool_root=tool_root,
             requirements_path=requirements_path,
         ):
-            version_result = _run(
-                runner, command.version_argv, repo_root=repo_root, timeout=30
-            )
+            resolved_executable = _resolve_executable(command.argv[0])
+            executable_digest = _file_sha256(resolved_executable) if resolved_executable else None
+            pin = lock.get("tools", {}).get(command.name, {}) if lock else {}
+            if resolved_executable is None:
+                version_result: AuditProcessResult = SkippedAuditResult(1, "", "executable unavailable")
+            else:
+                version_result = _run(runner, command.version_argv, repo_root=repo_root, timeout=30)
             version_stdout = str(version_result.stdout or "")
             version_stderr = str(version_result.stderr or "")
             observed_version = _extract_version(version_stdout, version_stderr)
@@ -271,11 +370,22 @@ def run_audits(
                 version_result.returncode == 0
                 and observed_version == command.expected_version
             )
+            realization_ok = bool(
+                resolved_executable
+                and executable_digest == pin.get("sha256")
+                and version_matches
+            )
             if command.name == "pip-audit" and export_result.returncode != 0:
                 result: AuditProcessResult = SkippedAuditResult(
                     returncode=1,
                     stdout="",
                     stderr="uv lock export failed; pip-audit was not run",
+                )
+            elif not realization_ok:
+                result = SkippedAuditResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="tool realization is not locked; audit was not run",
                 )
             else:
                 result = _run(runner, command.argv, repo_root=repo_root, timeout=600)
@@ -287,6 +397,11 @@ def run_audits(
                 "expected_version": command.expected_version,
                 "observed_version": observed_version,
                 "version_matches": version_matches,
+                "realization_ok": realization_ok,
+                "audit_invoked": realization_ok and not (command.name == "pip-audit" and export_result.returncode != 0),
+                "executable_path": str(resolved_executable) if resolved_executable else None,
+                "executable_sha256": executable_digest,
+                "expected_sha256": pin.get("sha256"),
                 "version_command": list(command.version_argv),
                 "version_returncode": int(version_result.returncode),
                 "version_stdout_sha256": _sha256(version_stdout),
@@ -315,10 +430,16 @@ def run_audits(
         },
         "read_only": True,
         "auto_fix": False,
-        "ok": all(row["returncode"] == 0 for row in preparations)
-        and all(row["version_matches"] and row["policy_ok"] for row in audits),
+        "ok": not status
+        and lock_error is None
+        and all(row["returncode"] == 0 and row["realization_ok"] for row in preparations)
+        and all(
+            row["realization_ok"] and row["version_matches"] and row["policy_ok"]
+            for row in audits
+        ),
         "preparations": preparations,
         "audits": audits,
+        "lock_error": lock_error,
     }
 
 

--- a/scripts/audit_external_tooling.py
+++ b/scripts/audit_external_tooling.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from collections.abc import Sequence
+import csv
 import hashlib
 import json
 import os
@@ -17,6 +18,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any, Callable, Protocol, cast
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -37,6 +39,7 @@ class AuditCommand:
     name: str
     argv: tuple[str, ...]
     expected_version: str
+    distribution_name: str | None = None
 
     @property
     def version_argv(self) -> tuple[str, ...]:
@@ -88,6 +91,7 @@ def build_commands(
         AuditCommand(
             name="import-linter",
             expected_version="2.14",
+            distribution_name="import-linter",
             argv=(
                 str(tool_root / "lint-imports"),
                 "--config",
@@ -99,6 +103,7 @@ def build_commands(
         AuditCommand(
             name="pip-audit",
             expected_version="2.10.1",
+            distribution_name="pip-audit",
             argv=(
                 str(tool_root / "pip-audit"),
                 "-r",
@@ -180,6 +185,70 @@ def _file_sha256(path: Path) -> str | None:
         return None
 
 
+def _distribution_realization_digest(
+    tool_root: Path, distribution_name: str
+) -> str | None:
+    """Hash every recorded file in one installed Python distribution.
+
+    Console-script launchers are only entry points; their imported package can
+    change without changing the launcher bytes.  Bind the receipt to the
+    complete RECORD-described realization inside the tool venv instead.
+    """
+    tool_root = tool_root.expanduser().resolve()
+    venv_root = tool_root.parent
+    expected_name = re.sub(r"[-_.]+", "-", distribution_name).casefold()
+    for site_packages in sorted(venv_root.glob("lib/python*/site-packages")):
+        for metadata_dir in sorted(site_packages.glob("*.dist-info")):
+            metadata_path = metadata_dir / "METADATA"
+            try:
+                metadata = metadata_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            actual_name = next(
+                (
+                    line.split(":", 1)[1].strip()
+                    for line in metadata.splitlines()
+                    if line.casefold().startswith("name:")
+                ),
+                None,
+            )
+            if actual_name is None:
+                continue
+            normalized_name = re.sub(r"[-_.]+", "-", actual_name).casefold()
+            if normalized_name != expected_name:
+                continue
+            record_path = metadata_dir / "RECORD"
+            try:
+                with record_path.open(newline="", encoding="utf-8") as stream:
+                    rows = list(csv.reader(stream))
+            except (OSError, UnicodeError, csv.Error):
+                return None
+            files: list[tuple[str, str]] = []
+            venv_root_resolved = venv_root.resolve()
+            for row in rows:
+                if not row or not row[0]:
+                    return None
+                relative = PurePosixPath(row[0])
+                file_path = (site_packages / Path(*relative.parts)).resolve()
+                try:
+                    relative_to_venv = file_path.relative_to(venv_root_resolved)
+                except ValueError:
+                    return None
+                digest = _file_sha256(file_path)
+                if digest is None:
+                    return None
+                files.append((relative_to_venv.as_posix(), digest))
+            if not files:
+                return None
+            serialized = json.dumps(
+                {"distribution": normalized_name, "files": sorted(files)},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            return _sha256(serialized)
+    return None
+
+
 def _resolve_executable(path: str | Path) -> Path | None:
     candidate = Path(path).expanduser()
     try:
@@ -207,6 +276,9 @@ def _load_tool_lock(repo_root: Path) -> tuple[dict[str, Any] | None, str | None]
     for entry in [uv, *[tools.get(name) for name in ("zizmor", "import-linter", "pip-audit")]]:
         if not isinstance(entry, dict) or not isinstance(entry.get("version"), str) or not isinstance(entry.get("sha256"), str):
             return None, f"invalid {_LOCKFILE_NAME} pin"
+    for name in ("import-linter", "pip-audit"):
+        if not isinstance(tools.get(name, {}).get("distribution_sha256"), str):
+            return None, f"invalid {_LOCKFILE_NAME} distribution pin for {name}"
     return payload, None
 
 
@@ -359,6 +431,21 @@ def run_audits(
             resolved_executable = _resolve_executable(command.argv[0])
             executable_digest = _file_sha256(resolved_executable) if resolved_executable else None
             pin = lock.get("tools", {}).get(command.name, {}) if lock else {}
+            distribution_digest = (
+                _distribution_realization_digest(tool_root, command.distribution_name)
+                if command.distribution_name is not None
+                else None
+            )
+            expected_distribution_digest = (
+                pin.get("distribution_sha256")
+                if command.distribution_name is not None
+                else None
+            )
+            distribution_realization_ok = (
+                None
+                if command.distribution_name is None
+                else distribution_digest == expected_distribution_digest
+            )
             if resolved_executable is None:
                 version_result: AuditProcessResult = SkippedAuditResult(1, "", "executable unavailable")
             else:
@@ -374,6 +461,10 @@ def run_audits(
                 resolved_executable
                 and executable_digest == pin.get("sha256")
                 and version_matches
+                and (
+                    command.distribution_name is None
+                    or distribution_realization_ok is True
+                )
             )
             if command.name == "pip-audit" and export_result.returncode != 0:
                 result: AuditProcessResult = SkippedAuditResult(
@@ -398,6 +489,10 @@ def run_audits(
                 "observed_version": observed_version,
                 "version_matches": version_matches,
                 "realization_ok": realization_ok,
+                "distribution_name": command.distribution_name,
+                "distribution_sha256": distribution_digest,
+                "expected_distribution_sha256": expected_distribution_digest,
+                "distribution_realization_ok": distribution_realization_ok,
                 "audit_invoked": realization_ok and not (command.name == "pip-audit" and export_result.returncode != 0),
                 "executable_path": str(resolved_executable) if resolved_executable else None,
                 "executable_sha256": executable_digest,

--- a/tests/scripts/test_audit_external_tooling.py
+++ b/tests/scripts/test_audit_external_tooling.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from scripts.audit_external_tooling import (
+    _summarize_json_output,
+    build_commands,
+    build_uv_export_command,
+    run_audits,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_zizmor_summary_preserves_counts_when_raw_capture_is_bounded():
+    output = json.dumps(
+        [
+            {
+                "ident": "github-app",
+                "determinations": {"severity": "High", "confidence": "High"},
+                "locations": [{}, {}],
+            },
+            {
+                "ident": "github-app",
+                "determinations": {"severity": "High", "confidence": "Medium"},
+                "locations": [{}],
+            },
+        ]
+    )
+
+    assert _summarize_json_output("zizmor", output) == {
+        "finding_groups": 2,
+        "locations": 3,
+        "by_severity": {"High": 2},
+        "by_confidence": {"High": 1, "Medium": 1},
+        "by_ident": {"github-app": 2},
+    }
+
+
+def test_commands_are_pinned_read_only_and_offline_where_supported(tmp_path):
+    tool_root = tmp_path / "bin"
+    commands = build_commands(repo_root=tmp_path / "repo", tool_root=tool_root)
+
+    assert [command.name for command in commands] == [
+        "zizmor",
+        "import-linter",
+        "pip-audit",
+    ]
+    flattened = [argument for command in commands for argument in command.argv]
+    assert "--fix" not in flattened
+    assert "--offline" in commands[0].argv
+    assert "--no-exit-codes" in commands[0].argv
+    assert "--locked" not in commands[2].argv
+    assert "-r" in commands[2].argv
+    assert "--require-hashes" in commands[2].argv
+    assert "--disable-pip" in commands[2].argv
+    assert "--cache-dir" in commands[2].argv
+
+    export_command = build_uv_export_command(
+        requirements_path=tmp_path / "requirements.txt"
+    )
+    assert "--locked" in export_command
+    assert "--cache-dir" in export_command
+
+
+def test_receipt_binds_results_to_exact_git_identity(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tool_root = tmp_path / "bin"
+    head = "a" * 40
+
+    def fake_runner(argv, **kwargs):
+        command = tuple(str(part) for part in argv)
+        if command[:3] == ("git", "rev-parse", "HEAD"):
+            return SimpleNamespace(returncode=0, stdout=f"{head}\n", stderr="")
+        if command[:3] == ("git", "branch", "--show-current"):
+            return SimpleNamespace(returncode=0, stdout="feature/audit\n", stderr="")
+        if command[:3] == ("git", "status", "--porcelain"):
+            return SimpleNamespace(returncode=0, stdout=" M local.txt\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout='{"ok": true}\n', stderr="")
+
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+
+    assert receipt["repository"]["head"] == head
+    assert receipt["repository"]["branch"] == "feature/audit"
+    assert receipt["repository"]["dirty"] is True
+    assert receipt["ok"] is True
+    assert len(receipt["audits"]) == 3
+    assert all(row["stdout_sha256"].startswith("sha256:") for row in receipt["audits"])
+
+
+def test_script_runs_directly_from_its_file_path():
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "audit_external_tooling.py"), "--plan"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["read_only"] is True

--- a/tests/scripts/test_audit_external_tooling.py
+++ b/tests/scripts/test_audit_external_tooling.py
@@ -40,6 +40,7 @@ def test_zizmor_summary_preserves_counts_when_raw_capture_is_bounded():
         "by_severity": {"High": 2},
         "by_confidence": {"High": 1, "Medium": 1},
         "by_ident": {"github-app": 2},
+        "high_confidence_high_severity": 1,
     }
 
 
@@ -83,7 +84,21 @@ def test_receipt_binds_results_to_exact_git_identity(tmp_path):
             return SimpleNamespace(returncode=0, stdout="feature/audit\n", stderr="")
         if command[:3] == ("git", "status", "--porcelain"):
             return SimpleNamespace(returncode=0, stdout=" M local.txt\n", stderr="")
-        return SimpleNamespace(returncode=0, stdout='{"ok": true}\n', stderr="")
+        if command[-1:] == ("--version",):
+            executable = Path(command[0]).name
+            versions = {
+                "zizmor": "zizmor 1.30.0\n",
+                "lint-imports": "import-linter 2.14\n",
+                "pip-audit": "pip-audit 2.10.1\n",
+            }
+            return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
+        if Path(command[0]).name == "zizmor":
+            return SimpleNamespace(returncode=0, stdout="[]\n", stderr="")
+        if Path(command[0]).name == "pip-audit":
+            return SimpleNamespace(
+                returncode=0, stdout='{"dependencies": []}\n', stderr=""
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
 
@@ -93,6 +108,97 @@ def test_receipt_binds_results_to_exact_git_identity(tmp_path):
     assert receipt["ok"] is True
     assert len(receipt["audits"]) == 3
     assert all(row["stdout_sha256"].startswith("sha256:") for row in receipt["audits"])
+
+
+def test_receipt_fails_when_observed_tool_version_differs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tool_root = tmp_path / "bin"
+
+    def fake_runner(argv, **kwargs):
+        command = tuple(str(part) for part in argv)
+        if command[:2] == ("git", "rev-parse"):
+            return SimpleNamespace(returncode=0, stdout=f"{'b' * 40}\n", stderr="")
+        if command[:2] == ("git", "branch"):
+            return SimpleNamespace(returncode=0, stdout="feature/audit\n", stderr="")
+        if command[:2] == ("git", "status"):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[-1:] == ("--version",):
+            executable = Path(command[0]).name
+            versions = {
+                "zizmor": "zizmor 9.9.9\n",
+                "lint-imports": "import-linter 2.14\n",
+                "pip-audit": "pip-audit 2.10.1\n",
+            }
+            return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
+        if Path(command[0]).name == "zizmor":
+            return SimpleNamespace(returncode=0, stdout="[]\n", stderr="")
+        if Path(command[0]).name == "pip-audit":
+            return SimpleNamespace(
+                returncode=0, stdout='{"dependencies": []}\n', stderr=""
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+
+    zizmor = receipt["audits"][0]
+    assert zizmor["observed_version"] == "9.9.9"
+    assert zizmor["version_matches"] is False
+    assert receipt["ok"] is False
+
+
+def test_zizmor_high_confidence_high_severity_finding_fails_policy(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tool_root = tmp_path / "bin"
+    finding = json.dumps(
+        [
+            {
+                "ident": "template-injection",
+                "determinations": {"severity": "High", "confidence": "High"},
+                "locations": [{}],
+            }
+        ]
+    )
+
+    def fake_runner(argv, **kwargs):
+        command = tuple(str(part) for part in argv)
+        if command[:2] == ("git", "rev-parse"):
+            return SimpleNamespace(returncode=0, stdout=f"{'c' * 40}\n", stderr="")
+        if command[:2] == ("git", "branch"):
+            return SimpleNamespace(returncode=0, stdout="feature/audit\n", stderr="")
+        if command[:2] == ("git", "status"):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[-1:] == ("--version",):
+            executable = Path(command[0]).name
+            versions = {
+                "zizmor": "zizmor 1.30.0\n",
+                "lint-imports": "import-linter 2.14\n",
+                "pip-audit": "pip-audit 2.10.1\n",
+            }
+            return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
+        if Path(command[0]).name == "zizmor":
+            return SimpleNamespace(returncode=0, stdout=finding, stderr="")
+        if Path(command[0]).name == "pip-audit":
+            return SimpleNamespace(
+                returncode=0, stdout='{"dependencies": []}\n', stderr=""
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+
+    zizmor = receipt["audits"][0]
+    assert zizmor["returncode"] == 0
+    assert zizmor["summary"]["high_confidence_high_severity"] == 1
+    assert zizmor["policy_ok"] is False
+    assert receipt["ok"] is False
+
+
+def test_app_token_requires_complete_credential_pair():
+    action = (REPO_ROOT / ".github" / "actions" / "get-app-token" / "action.yml").read_text()
+
+    assert "PRIVATE_KEY: ${{ inputs.private-key }}" in action
+    assert 'if [ -n "$CLIENT_ID" ] && [ -n "$PRIVATE_KEY" ]; then' in action
 
 
 def test_script_runs_directly_from_its_file_path():

--- a/tests/scripts/test_audit_external_tooling.py
+++ b/tests/scripts/test_audit_external_tooling.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 from scripts.audit_external_tooling import (
     _summarize_json_output,
+    _distribution_realization_digest,
     build_commands,
     build_uv_export_command,
     run_audits,
@@ -22,8 +23,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def _fixture(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    tool_root = tmp_path / "bin"
-    tool_root.mkdir()
+    tool_root = tmp_path / "venv" / "bin"
+    tool_root.mkdir(parents=True)
+    site_packages = tool_root.parent / "lib" / "python3.13" / "site-packages"
+    site_packages.mkdir(parents=True)
     versions = {
         "zizmor": "1.30.0",
         "lint-imports": "2.14",
@@ -38,6 +41,29 @@ def _fixture(tmp_path):
             "version": version,
             "sha256": f"sha256:{hashlib.sha256(executable.read_bytes()).hexdigest()}",
         }
+        if name in {"lint-imports", "pip-audit"}:
+            distribution_name = "import-linter" if name == "lint-imports" else "pip-audit"
+            distribution_dir = site_packages / (
+                "import_linter-2.14.dist-info"
+                if name == "lint-imports"
+                else "pip_audit-2.10.1.dist-info"
+            )
+            distribution_dir.mkdir()
+            (distribution_dir / "METADATA").write_text(
+                f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: {version}\n",
+                encoding="utf-8",
+            )
+            package_name = "import_linter.py" if name == "lint-imports" else "pip_audit.py"
+            (site_packages / package_name).write_text(
+                f"# {distribution_name}\n", encoding="utf-8"
+            )
+            (distribution_dir / "RECORD").write_text(
+                f"{package_name},,\n"
+                f"{distribution_dir.name}/METADATA,,\n"
+                f"{distribution_dir.name}/RECORD,,\n"
+                f"../../../bin/{name},,\n",
+                encoding="utf-8",
+            )
     uv = tmp_path / "uv"
     uv.write_text("#!/bin/sh\n# uv\n", encoding="utf-8")
     uv.chmod(0o755)
@@ -45,6 +71,10 @@ def _fixture(tmp_path):
         "version": "0.12.6",
         "sha256": f"sha256:{hashlib.sha256(uv.read_bytes()).hexdigest()}",
     }}
+    for distribution_name in ("import-linter", "pip-audit"):
+        digest = _distribution_realization_digest(tool_root, distribution_name)
+        assert digest is not None
+        lock["tools"][distribution_name]["distribution_sha256"] = digest
     (repo / ".audit-tool-lock.json").write_text(json.dumps(lock), encoding="utf-8")
     return repo, tool_root, uv
 
@@ -178,6 +208,75 @@ def test_receipt_fails_when_observed_tool_version_differs(tmp_path):
     assert zizmor["version_matches"] is False
     assert zizmor["audit_invoked"] is False
     assert not any(call and Path(call[0]).name == "zizmor" and "--offline" in call for call in calls)
+    assert receipt["ok"] is False
+
+
+def test_python_distribution_realization_changes_when_installed_file_changes(tmp_path):
+    _repo, tool_root, _uv = _fixture(tmp_path)
+    before = _distribution_realization_digest(tool_root, "import-linter")
+
+    assert before is not None
+    package_file = (
+        tool_root.parent
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+        / "import_linter.py"
+    )
+    package_file.write_text("# replaced installed package\n", encoding="utf-8")
+
+    after = _distribution_realization_digest(tool_root, "import-linter")
+
+    assert after is not None
+    assert after != before
+
+
+def test_receipt_refuses_changed_python_distribution_before_audit(tmp_path):
+    repo, tool_root, uv = _fixture(tmp_path)
+    package_file = (
+        tool_root.parent
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+        / "pip_audit.py"
+    )
+    package_file.write_text("# replaced installed package\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, **kwargs):
+        command = tuple(str(part) for part in argv)
+        calls.append(command)
+        if command[:2] == ("git", "rev-parse"):
+            return SimpleNamespace(returncode=0, stdout=f"{'d' * 40}\n", stderr="")
+        if command[:2] == ("git", "branch"):
+            return SimpleNamespace(returncode=0, stdout="feature/audit\n", stderr="")
+        if command[:2] == ("git", "status"):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[-1:] == ("--version",):
+            executable = Path(command[0]).name
+            versions = {
+                "zizmor": "zizmor 1.30.0\n",
+                "lint-imports": "import-linter 2.14\n",
+                "pip-audit": "pip-audit 2.10.1\n",
+                "uv": "uv 0.12.6\n",
+            }
+            return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
+        if Path(command[0]).name == "zizmor":
+            return SimpleNamespace(returncode=0, stdout="[]\n", stderr="")
+        if Path(command[0]).name == "pip-audit":
+            return SimpleNamespace(
+                returncode=0, stdout='{"dependencies": []}\n', stderr=""
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner, uv_path=uv)
+
+    pip_audit = receipt["audits"][2]
+    assert pip_audit["distribution_realization_ok"] is False
+    assert pip_audit["audit_invoked"] is False
+    assert not any(
+        call and Path(call[0]).name == "pip-audit" and "-r" in call for call in calls
+    )
     assert receipt["ok"] is False
 
 

--- a/tests/scripts/test_audit_external_tooling.py
+++ b/tests/scripts/test_audit_external_tooling.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import hashlib
 import os
 import subprocess
 import sys
@@ -16,6 +17,36 @@ from scripts.audit_external_tooling import (
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fixture(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tool_root = tmp_path / "bin"
+    tool_root.mkdir()
+    versions = {
+        "zizmor": "1.30.0",
+        "lint-imports": "2.14",
+        "pip-audit": "2.10.1",
+    }
+    pins = {}
+    for name, version in versions.items():
+        executable = tool_root / name
+        executable.write_text(f"#!/bin/sh\n# {name}\n", encoding="utf-8")
+        executable.chmod(0o755)
+        pins["import-linter" if name == "lint-imports" else name] = {
+            "version": version,
+            "sha256": f"sha256:{hashlib.sha256(executable.read_bytes()).hexdigest()}",
+        }
+    uv = tmp_path / "uv"
+    uv.write_text("#!/bin/sh\n# uv\n", encoding="utf-8")
+    uv.chmod(0o755)
+    lock = {"schema_version": 1, "tools": pins, "uv": {
+        "version": "0.12.6",
+        "sha256": f"sha256:{hashlib.sha256(uv.read_bytes()).hexdigest()}",
+    }}
+    (repo / ".audit-tool-lock.json").write_text(json.dumps(lock), encoding="utf-8")
+    return repo, tool_root, uv
 
 
 def test_zizmor_summary_preserves_counts_when_raw_capture_is_bounded():
@@ -71,9 +102,7 @@ def test_commands_are_pinned_read_only_and_offline_where_supported(tmp_path):
 
 
 def test_receipt_binds_results_to_exact_git_identity(tmp_path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    tool_root = tmp_path / "bin"
+    repo, tool_root, uv = _fixture(tmp_path)
     head = "a" * 40
 
     def fake_runner(argv, **kwargs):
@@ -90,6 +119,7 @@ def test_receipt_binds_results_to_exact_git_identity(tmp_path):
                 "zizmor": "zizmor 1.30.0\n",
                 "lint-imports": "import-linter 2.14\n",
                 "pip-audit": "pip-audit 2.10.1\n",
+                "uv": "uv 0.12.6\n",
             }
             return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
         if Path(command[0]).name == "zizmor":
@@ -100,23 +130,24 @@ def test_receipt_binds_results_to_exact_git_identity(tmp_path):
             )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner, uv_path=uv)
 
     assert receipt["repository"]["head"] == head
     assert receipt["repository"]["branch"] == "feature/audit"
     assert receipt["repository"]["dirty"] is True
-    assert receipt["ok"] is True
+    assert receipt["ok"] is False
     assert len(receipt["audits"]) == 3
     assert all(row["stdout_sha256"].startswith("sha256:") for row in receipt["audits"])
 
 
 def test_receipt_fails_when_observed_tool_version_differs(tmp_path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    tool_root = tmp_path / "bin"
+    repo, tool_root, uv = _fixture(tmp_path)
+
+    calls = []
 
     def fake_runner(argv, **kwargs):
         command = tuple(str(part) for part in argv)
+        calls.append(command)
         if command[:2] == ("git", "rev-parse"):
             return SimpleNamespace(returncode=0, stdout=f"{'b' * 40}\n", stderr="")
         if command[:2] == ("git", "branch"):
@@ -129,6 +160,7 @@ def test_receipt_fails_when_observed_tool_version_differs(tmp_path):
                 "zizmor": "zizmor 9.9.9\n",
                 "lint-imports": "import-linter 2.14\n",
                 "pip-audit": "pip-audit 2.10.1\n",
+                "uv": "uv 0.12.6\n",
             }
             return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
         if Path(command[0]).name == "zizmor":
@@ -139,18 +171,26 @@ def test_receipt_fails_when_observed_tool_version_differs(tmp_path):
             )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner, uv_path=uv)
 
     zizmor = receipt["audits"][0]
     assert zizmor["observed_version"] == "9.9.9"
     assert zizmor["version_matches"] is False
+    assert zizmor["audit_invoked"] is False
+    assert not any(call and Path(call[0]).name == "zizmor" and "--offline" in call for call in calls)
     assert receipt["ok"] is False
 
 
+def test_malformed_scanner_payloads_fail_closed():
+    assert _summarize_json_output("pip-audit", "{}") is None
+    assert _summarize_json_output(
+        "pip-audit", '{"dependencies": [{"name": "demo", "version": "1.0"}]}'
+    ) is None
+    assert _summarize_json_output("zizmor", "[{}]") is None
+
+
 def test_zizmor_high_confidence_high_severity_finding_fails_policy(tmp_path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    tool_root = tmp_path / "bin"
+    repo, tool_root, uv = _fixture(tmp_path)
     finding = json.dumps(
         [
             {
@@ -175,6 +215,7 @@ def test_zizmor_high_confidence_high_severity_finding_fails_policy(tmp_path):
                 "zizmor": "zizmor 1.30.0\n",
                 "lint-imports": "import-linter 2.14\n",
                 "pip-audit": "pip-audit 2.10.1\n",
+                "uv": "uv 0.12.6\n",
             }
             return SimpleNamespace(returncode=0, stdout=versions[executable], stderr="")
         if Path(command[0]).name == "zizmor":
@@ -185,7 +226,7 @@ def test_zizmor_high_confidence_high_severity_finding_fails_policy(tmp_path):
             )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner)
+    receipt = run_audits(repo_root=repo, tool_root=tool_root, runner=fake_runner, uv_path=uv)
 
     zizmor = receipt["audits"][0]
     assert zizmor["returncode"] == 0


### PR DESCRIPTION
## Summary

- add pinned, read-only external capability audits for Zizmor, Import Linter, and pip-audit
- eliminate confirmed high-confidence shell-expression injection and scope workflow/App token permissions to exact jobs and callers
- add fail-closed capability governance contracts and strengthen `gateway.session_context` to transitive isolation
- replace dynamic skipped audit results with a typed result contract

## Verification

- exact clean head: `54ece37526ab9c7377b063e6b607ca59365e9a66`
- audit runner tests: 4 passed
- capability property tests: 2 passed
- Ruff: passed
- basedpyright: 0 errors (warnings remain)
- Import Linter: 4 kept, 0 broken across 849 files / 3,300 dependencies
- Zizmor targeted High groups (`template-injection`, `excessive-permissions`, `github-app`): 0
- combined exact-head audit: `ok=true`; 62 dependencies; 0 known vulnerabilities

## Evidence limits

- focused/static evidence only; the complete Hermes suite was not rerun
- four remaining High-severity Zizmor groups are two Medium-confidence `workflow_run` warnings and two Low-confidence cache-publication warnings; this PR does not claim they are exploitable
- no merge, branch deletion, force-push, or GitHub settings change requested
