### PR TITLE
fix(agent): qualify unproven completion claims as partial delivery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2040,6 +2040,13 @@ def init_agent(
     # targets.
     agent._task_completion_guidance = bool(_agent_section.get("task_completion_guidance", True))
 
+    # Requirement-to-evidence gate (#99316). Default True. Separate from
+    # task_completion_guidance: that block is advisory prompt text; this
+    # flag also enables the turn-end qualifier that retracts completion
+    # claims that lack a complete delivery receipt.
+    agent._scope_fidelity = bool(_agent_section.get("scope_fidelity", True))
+    agent._scope_fidelity_contract = None
+
     # Universal parallel-tool-call guidance toggle.  Default True.  Separate
     # flag from task_completion_guidance because a user may want one but not
     # the other.  Steers the model to batch independent tool calls into a

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8620,6 +8620,21 @@ def run_conversation(
                     final_response = None
                     continue
 
+                if getattr(agent, "_scope_fidelity", True) and final_response:
+                    try:
+                        from agent.scope_fidelity import apply_scope_fidelity
+
+                        _qualified = apply_scope_fidelity(
+                            final_response, messages, agent=agent
+                        )
+                    except Exception:
+                        logger.debug("scope-fidelity qualifier failed", exc_info=True)
+                        _qualified = final_response
+                    if _qualified != final_response:
+                        final_response = _qualified
+                        if isinstance(final_msg.get("content"), str):
+                            final_msg["content"] = final_response
+
                 append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —
                 # a session torn down before finalize_turn's _persist_session

--- a/agent/scope_fidelity.py
+++ b/agent/scope_fidelity.py
@@ -1,0 +1,322 @@
+"""Requirement-to-evidence gate for completion claims.
+
+Prompt-only "finish the job" guidance is not enough: a model can still
+replace an explicit operational mandate with a narrower substitute and
+describe that substitute as complete. This module is the machine half of
+the fix.
+
+It never calls a model. It:
+- extracts an explicit or implicit requirement contract from the user turn
+- parses an optional ``<delivery_receipt>`` in the assistant reply
+- qualifies completion language when the receipt is missing or incomplete
+
+The contract is stored on the agent so it survives context compaction
+rebuilds in the same session.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+SCOPE_FIDELITY_GUIDANCE = (
+    "# Scope fidelity\n"
+    "When the user states an explicit operational mandate or numbered "
+    "acceptance criteria, that list is the job. Do not silently replace it "
+    "with a smaller, offline, read-only, routing-DISABLED, or demonstration "
+    "substitute and then describe the substitute as finished.\n"
+    "A hard boundary on personally submitting a live order must not block "
+    "permitted work: adapters, live/fresh data, signal engines, authenticated "
+    "reads, operator-controlled order paths, or reconciliation. Say the exact "
+    "blocked action; continue everything else.\n"
+    "Do not attribute a host, VM, desktop, or VNC endpoint to another session "
+    "without independently verified identity.\n"
+    "Before any completion claim (finished / complete / ready / successfully "
+    "built), emit a receipt with every criterion marked PROVEN, MISSING, or "
+    "BLOCKED plus concrete evidence. Completion language is forbidden while "
+    "any criterion is MISSING or BLOCKED. Partial components, tests, or a GUI "
+    "startup are not evidence for a broader deliverable.\n"
+    "<delivery_receipt>\n"
+    "1. <criterion> — PROVEN|MISSING|BLOCKED — <evidence>\n"
+    "</delivery_receipt>"
+)
+
+SCOPE_FIDELITY_FOOTER = (
+    "\n\n---\n"
+    "**Scope-fidelity note (automatic):** Completion language was used, but a "
+    "requirement-to-evidence receipt is missing or incomplete. Treat the work "
+    "above as a **partial delivery**, not a finished operational system.\n"
+    "{status_lines}"
+    "Allowed statuses are PROVEN, MISSING, or BLOCKED with concrete evidence. "
+    "A signal-only, offline, or routing-DISABLED component is not the requested "
+    "operational path."
+)
+
+_COMPLETION_CLAIM_RE = re.compile(
+    r"(?is)(?:"
+    r"\b(?:successfully|now)\s+(?:created|implemented|built|completed)\b|"
+    r"\b(?:setup|system|build|job|task|work|engine|path)\s+"
+    r"(?:has been\s+)?(?:successfully\s+)?(?:created|completed|finished)\b|"
+    r"\b(?:is|are)\s+(?:now\s+)?(?:complete|completed|finished|done)\b|"
+    r"\bcompleted and ready\b|"
+    r"\bready for use\b|"
+    r"\bthe (?:operational\s+)?(?:system|build)\s+is\s+completed\b|"
+    r"\b(?:all (?:acceptance )?criteria (?:are|were) (?:proven|met))\b"
+    r")"
+)
+
+_RECEIPT_RE = re.compile(
+    r"<delivery_receipt>(?P<body>.*?)</delivery_receipt>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_STATUS_LINE_RE = re.compile(
+    r"(?im)^\s*(?:[-*]|\d+[.)])\s+(?P<body>.+)$"
+)
+
+_STATUS_TOKEN_RE = re.compile(r"\b(?P<status>PROVEN|MISSING|BLOCKED)\b")
+
+_CRITERION_LINE_RE = re.compile(
+    r"(?m)^\s*(?:[-*]|\d+[.)])\s+(?P<text>\S.*)$"
+)
+
+_OPERATIONAL_MARKERS = (
+    "operational",
+    "live/fresh",
+    "fresh market",
+    "live market",
+    "order path",
+    "routing",
+    "read-only",
+    "inert",
+    "offline",
+    "do not silently replace",
+    "do not replace",
+    "not a shortcut",
+    "acceptance criteria",
+)
+
+_STATUSES = frozenset({"PROVEN", "MISSING", "BLOCKED"})
+
+
+def _message_text(message: Any) -> str:
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content") or ""
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def latest_user_text(messages: Optional[Iterable[Any]]) -> str:
+    if not messages:
+        return ""
+    for message in reversed(list(messages)):
+        if isinstance(message, dict) and message.get("role") == "user":
+            if message.get("_verification_stop_synthetic") or message.get(
+                "_kanban_stop_synthetic"
+            ):
+                continue
+            return _message_text(message).strip()
+    return ""
+
+
+def extract_criteria(user_text: str) -> list[str]:
+    """Return explicit numbered/bulleted criteria, or implicit operational ones."""
+    text = (user_text or "").strip()
+    if not text:
+        return []
+
+    listed: list[str] = []
+    for match in _CRITERION_LINE_RE.finditer(text):
+        line = match.group("text").strip()
+        if len(line) < 8:
+            continue
+        listed.append(line)
+    if listed:
+        return listed[:12]
+
+    lowered = text.lower()
+    hits = sum(1 for marker in _OPERATIONAL_MARKERS if marker in lowered)
+    if hits >= 2:
+        return [
+            "Live/fresh market data (not an offline mockup)",
+            "Strategy signal wired into the requested operational path",
+            "Operator-controlled order/routing path present and not DISABLED",
+            "No silent substitute presented as the requested deliverable",
+        ]
+    return []
+
+
+def parse_receipt_statuses(assistant_text: str) -> list[tuple[str, str]]:
+    """Return (criterion, status) pairs from a receipt or status-tagged lines."""
+    text = assistant_text or ""
+    receipt = _RECEIPT_RE.search(text)
+    body = receipt.group("body") if receipt else text
+    found: list[tuple[str, str]] = []
+    for match in _STATUS_LINE_RE.finditer(body):
+        line = match.group("body").strip()
+        status_match = _STATUS_TOKEN_RE.search(line)
+        if not status_match:
+            continue
+        status = status_match.group("status").upper()
+        criterion = _STATUS_TOKEN_RE.sub("", line)
+        criterion = re.sub(r"\s+[—-]\s+", " ", criterion)
+        criterion = re.sub(r"\s+", " ", criterion).strip(" :.-")
+        found.append((criterion or "criterion", status))
+    return found
+
+
+def has_completion_claim(assistant_text: str) -> bool:
+    return bool(_COMPLETION_CLAIM_RE.search(assistant_text or ""))
+
+
+def receipt_covers_contract(
+    statuses: list[tuple[str, str]],
+    criteria: list[str],
+) -> bool:
+    if not criteria:
+        return True
+    if len(statuses) < len(criteria):
+        return False
+    return all(status == "PROVEN" for _criterion, status in statuses[: len(criteria)])
+
+
+def format_status_lines(
+    criteria: list[str],
+    statuses: list[tuple[str, str]],
+) -> str:
+    by_index = {i: statuses[i] for i in range(min(len(criteria), len(statuses)))}
+    lines: list[str] = []
+    for i, criterion in enumerate(criteria):
+        if i in by_index:
+            _label, status = by_index[i]
+        else:
+            status = "MISSING"
+        short = criterion if len(criterion) <= 120 else criterion[:117] + "..."
+        lines.append(f"- {short} — {status}\n")
+    return "".join(lines)
+
+
+def render_contract_prompt(criteria: list[str]) -> str:
+    if not criteria:
+        return ""
+    numbered = "\n".join(f"{i}. {item}" for i, item in enumerate(criteria, start=1))
+    return (
+        "# Active requirement contract\n"
+        "These acceptance criteria remain in force across compaction. "
+        "Do not claim completion unless every item is PROVEN.\n"
+        f"{numbered}"
+    )
+
+
+def persist_contract_journal(
+    agent: Any,
+    criteria: list[str],
+    statuses: list[tuple[str, str]],
+    *,
+    qualified_partial: bool,
+) -> Path | None:
+    """Write a redacted local receipt next to the session (no secrets)."""
+    session_id = getattr(agent, "session_id", None)
+    if not agent or not session_id or not criteria:
+        return None
+    try:
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "sessions" / str(session_id) / "scope_fidelity.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "session_id": str(session_id),
+            "criteria": list(criteria),
+            "statuses": [
+                {"criterion": label, "status": status} for label, status in statuses
+            ],
+            "qualified_partial": bool(qualified_partial),
+        }
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return path
+    except Exception:
+        logger.debug("scope-fidelity journal write failed", exc_info=True)
+        return None
+
+
+def apply_scope_fidelity(
+    assistant_text: str,
+    messages: Optional[Iterable[Any]] = None,
+    *,
+    agent: Any = None,
+    enabled: Optional[bool] = None,
+) -> str:
+    """Qualify a completion claim that lacks a complete evidence receipt."""
+    if enabled is None:
+        enabled = True if agent is None else bool(getattr(agent, "_scope_fidelity", True))
+    if not enabled:
+        return assistant_text
+
+    text = assistant_text or ""
+    user_text = latest_user_text(messages)
+    criteria = extract_criteria(user_text)
+    if agent is not None:
+        stored = getattr(agent, "_scope_fidelity_contract", None)
+        if criteria:
+            agent._scope_fidelity_contract = list(criteria)
+        elif stored:
+            criteria = list(stored)
+
+    if not criteria or not has_completion_claim(text):
+        return text
+
+    statuses = parse_receipt_statuses(text)
+    covered = receipt_covers_contract(statuses, criteria)
+    persist_contract_journal(
+        agent, criteria, statuses, qualified_partial=not covered
+    )
+    if covered:
+        return text
+    if SCOPE_FIDELITY_FOOTER.split("{status_lines}", 1)[0].strip() in text:
+        return text
+
+    footer = SCOPE_FIDELITY_FOOTER.format(
+        status_lines=format_status_lines(criteria, statuses)
+    )
+    return text.rstrip() + footer
+
+
+def looks_like_operational_mandate(user_text: str) -> bool:
+    lowered = (user_text or "").lower()
+    return sum(1 for marker in _OPERATIONAL_MARKERS if marker in lowered) >= 2
+
+
+def parse_receipt(assistant_text: str) -> list[tuple[str, str]]:
+    """Alias used by tests: (item, status)."""
+    return parse_receipt_statuses(assistant_text)
+
+
+def qualify_final_response(
+    assistant_text: str,
+    messages: Optional[Iterable[Any]] = None,
+    *,
+    enabled: bool = True,
+    user_text: Optional[str] = None,
+) -> str:
+    """Test-facing wrapper around apply_scope_fidelity."""
+    if user_text is not None:
+        messages = list(messages or []) + [{"role": "user", "content": user_text}]
+    return apply_scope_fidelity(assistant_text, messages, enabled=enabled)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -52,6 +52,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
 )
+from agent.scope_fidelity import SCOPE_FIDELITY_GUIDANCE
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_default_hermes_root, get_hermes_home
 from pathlib import Path
@@ -506,6 +507,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
 
+    # Requirement-to-evidence / no-silent-narrowing. Always-on for tool
+    # sessions (including Telegram): prompt-only completion guidance is not
+    # enough to stop over-broad "finished" claims. Gated by
+    # ``agent.scope_fidelity`` (default True).
+    if getattr(agent, "_scope_fidelity", True) and agent.valid_tool_names:
+        stable_parts.append(SCOPE_FIDELITY_GUIDANCE)
+
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one
     # call per turn — the runtime already runs independent calls concurrently
@@ -951,6 +959,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     volatile_parts.extend(
         _plugin_section_blocks(_frozen_plugin_prompt_sections(agent), "after_memory")
     )
+
+    _scope_contract = getattr(agent, "_scope_fidelity_contract", None)
+    if _scope_contract and getattr(agent, "_scope_fidelity", True):
+        from agent.scope_fidelity import render_contract_prompt
+
+        _contract_block = render_contract_prompt(list(_scope_contract))
+        if _contract_block:
+            volatile_parts.append(_contract_block)
 
     from hermes_time import get_timezone as _hermes_tz, now as _hermes_now
     now = _hermes_now()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -190,6 +190,11 @@ DEFAULT_CONFIG = {
         # plausible-looking output when a real path is blocked.  Costs ~80
         # tokens in the cached system prompt.  Set False to disable globally.
         "task_completion_guidance": True,
+        # Requirement-to-evidence gate for completion claims. When True
+        # (default), the system prompt includes scope-fidelity rules and the
+        # conversation loop qualifies "finished/complete" language that lacks
+        # a PROVEN/MISSING/BLOCKED receipt. Set False to disable globally.
+        "scope_fidelity": True,
         # Universal parallel-tool-call guidance — short prompt block applied to
         # all models that tells the model to batch independent tool calls
         # (reads, searches, web fetches, read-only commands) into one turn

--- a/tests/agent/test_scope_fidelity.py
+++ b/tests/agent/test_scope_fidelity.py
@@ -1,0 +1,169 @@
+"""Tests for the requirement-to-evidence / scope-fidelity gate."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.scope_fidelity import (
+    SCOPE_FIDELITY_GUIDANCE,
+    apply_scope_fidelity,
+    extract_criteria,
+    has_completion_claim,
+    parse_receipt_statuses,
+)
+from agent.system_prompt import build_system_prompt_parts
+
+
+INCIDENT_B_PROMPT = (
+    "I want a real TSMOM setup for BTC/USDC on Coinbase: a functioning "
+    "strategy signal using live/fresh market data, integrated with the "
+    "intended operational setup. I explicitly reject a read-only "
+    "interpretation. Do not silently replace this with a shortcut, "
+    "offline mockup, or inert demonstration component.\n\n"
+    "I am not asking you to independently place a money-moving trade "
+    "right now. I am asking for an operational system build, not an "
+    "offline mockup.\n\n"
+    "When you are done, tell me it is finished."
+)
+
+INCIDENT_B_OVERCLAIM = (
+    "The TSMOM setup for BTC/USDC on Coinbase has been successfully created. "
+    "The operational system build is completed and ready for use."
+)
+
+
+def test_incident_style_prompt_extracts_implicit_criteria():
+    criteria = extract_criteria(INCIDENT_B_PROMPT)
+    assert len(criteria) >= 3
+
+
+def test_overclaim_without_receipt_is_qualified():
+    messages = [{"role": "user", "content": INCIDENT_B_PROMPT}]
+    qualified = apply_scope_fidelity(INCIDENT_B_OVERCLAIM, messages)
+    assert "partial delivery" in qualified.lower()
+    assert "Scope-fidelity note" in qualified
+    assert qualified.startswith(INCIDENT_B_OVERCLAIM)
+
+
+def test_complete_receipt_is_not_qualified():
+    criteria = extract_criteria(INCIDENT_B_PROMPT)
+    rows = "\n".join(f"- {c} — PROVEN — live check" for c in criteria)
+    reply = (
+        "The wiring is finished.\n"
+        f"<delivery_receipt>\n{rows}\n</delivery_receipt>"
+    )
+    messages = [{"role": "user", "content": INCIDENT_B_PROMPT}]
+    assert apply_scope_fidelity(reply, messages) == reply
+
+
+def test_missing_row_in_receipt_is_qualified():
+    reply = (
+        "The operational system build is completed.\n"
+        "<delivery_receipt>\n"
+        "- live data — PROVEN — ticker 200\n"
+        "- signal — MISSING — not wired\n"
+        "</delivery_receipt>"
+    )
+    messages = [{"role": "user", "content": INCIDENT_B_PROMPT}]
+    qualified = apply_scope_fidelity(reply, messages)
+    assert "partial delivery" in qualified.lower()
+
+
+def test_no_completion_claim_is_untouched():
+    reply = (
+        "I have only built an isolated GUI and execution skeleton. "
+        "There is no connected TSMOM signal calculation."
+    )
+    messages = [{"role": "user", "content": INCIDENT_B_PROMPT}]
+    assert apply_scope_fidelity(reply, messages) == reply
+
+
+def test_disabled_gate_is_noop():
+    messages = [{"role": "user", "content": INCIDENT_B_PROMPT}]
+    assert (
+        apply_scope_fidelity(INCIDENT_B_OVERCLAIM, messages, enabled=False)
+        == INCIDENT_B_OVERCLAIM
+    )
+
+
+def test_casual_hello_is_not_a_mandate():
+    messages = [{"role": "user", "content": "Thanks, that is done."}]
+    reply = "Glad it's finished — yell if you need anything else."
+    assert apply_scope_fidelity(reply, messages) == reply
+
+
+def test_parse_receipt_statuses():
+    text = (
+        "<delivery_receipt>\n"
+        "- live ticker — PROVEN — GET 200\n"
+        "2. order path — BLOCKED — no credentials\n"
+        "</delivery_receipt>"
+    )
+    rows = parse_receipt_statuses(text)
+    assert [status for _label, status in rows] == ["PROVEN", "BLOCKED"]
+
+
+def test_has_completion_claim_matches_incident_wording():
+    assert has_completion_claim(INCIDENT_B_OVERCLAIM)
+    assert not has_completion_claim("Still working on the signal daemon.")
+
+
+def test_contract_persists_on_agent_across_turns():
+    agent = SimpleNamespace(_scope_fidelity=True)
+    apply_scope_fidelity(
+        "Still working on the signal daemon.",
+        [{"role": "user", "content": INCIDENT_B_PROMPT}],
+        agent=agent,
+    )
+    assert getattr(agent, "_scope_fidelity_contract", None)
+    later = apply_scope_fidelity(
+        INCIDENT_B_OVERCLAIM,
+        [{"role": "user", "content": "ok continue"}],
+        agent=agent,
+    )
+    assert "partial delivery" in later.lower()
+
+
+def test_journal_written_under_session_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", lambda: tmp_path
+    )
+    agent = SimpleNamespace(_scope_fidelity=True, session_id="sess-99316")
+    apply_scope_fidelity(
+        INCIDENT_B_OVERCLAIM,
+        [{"role": "user", "content": INCIDENT_B_PROMPT}],
+        agent=agent,
+    )
+    journal = tmp_path / "sessions" / "sess-99316" / "scope_fidelity.json"
+    assert journal.is_file()
+    payload = json.loads(journal.read_text())
+    assert payload["qualified_partial"] is True
+    assert payload["criteria"]
+
+
+def test_guidance_injected_when_enabled():
+    agent = SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=["terminal"],
+        _task_completion_guidance=False,
+        _scope_fidelity=True,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+        _emit_status=lambda *_a, **_k: None,
+    )
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+    ):
+        stable = build_system_prompt_parts(agent)["stable"]
+    assert SCOPE_FIDELITY_GUIDANCE in stable

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -15,6 +15,7 @@ def _make_agent(**overrides):
         skip_context_files=False,
         valid_tool_names=[],
         _task_completion_guidance=False,
+        _scope_fidelity=False,
         _tool_use_enforcement=False,
         _environment_probe=False,
         _kanban_worker_guidance="",
@@ -718,4 +719,38 @@ class TestConversationStartedTwoLine:
         vol = self._volatile(agent)
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
+
+
+class TestScopeFidelityPrompt:
+    def test_injected_when_enabled(self):
+        agent = _make_agent(
+            valid_tool_names=["terminal"],
+            _scope_fidelity=True,
+            _task_completion_guidance=False,
+            _parallel_tool_call_guidance=False,
+            _execution_guidance=False,
+        )
+        stable = _stable_prompt(agent)
+        assert "Scope fidelity" in stable
+        assert "<delivery_receipt>" in stable
+
+    def test_suppressed_when_disabled(self):
+        agent = _make_agent(
+            valid_tool_names=["terminal"],
+            _scope_fidelity=False,
+            _task_completion_guidance=False,
+            _parallel_tool_call_guidance=False,
+            _execution_guidance=False,
+        )
+        assert "Scope fidelity" not in _stable_prompt(agent)
+
+    def test_contract_in_volatile(self):
+        agent = _make_agent(
+            valid_tool_names=["terminal"],
+            _scope_fidelity=True,
+            _scope_fidelity_contract=["Live data", "Order path"],
+        )
+        parts = _prompt_parts(agent)
+        assert "Active requirement contract" in parts["volatile"]
+        assert "1. Live data" in parts["volatile"]
 


### PR DESCRIPTION
## What does this PR do?

Hermes can replace an explicit operational request with a narrower shell (signal-only, offline, routing-DISABLED) and still describe that shell as finished. Prompt-only "finish the job" text does not stop that.

This adds a requirement-to-evidence gate: extract the user's contract, require a `PROVEN` / `MISSING` / `BLOCKED` receipt before completion language, and rewrite unproven "finished/complete/ready" replies as a **partial delivery**. A hard boundary on personally placing a live order does not block building adapters, live data, signals, or operator-controlled paths. Host/VM/VNC identity must not be attributed without verification.

## Related Issue

Fixes #99316

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/scope_fidelity.py` — contract extraction, receipt parsing, completion-claim qualifier, session journal
- `agent/conversation_loop.py` — apply the qualifier on the final no-tool-call turn
- `agent/system_prompt.py` — inject scope-fidelity guidance; keep the active contract in the volatile prompt across compaction
- `hermes_cli/config_defaults.py` / `agent/agent_init.py` — `agent.scope_fidelity` (default `true`)
- `tests/agent/test_scope_fidelity.py` — incident-wording overclaim vs complete receipt
- `tests/agent/test_system_prompt.py` — guidance on/off and contract in volatile

## How to Test

1. Ask Hermes to build an operational TSMOM-style path (live/fresh data, reject read-only, no inert substitute) and to say when it is finished.
2. If the reply uses completion language without a complete `<delivery_receipt>` of `PROVEN` rows, confirm the automatic **Scope-fidelity note** / partial-delivery footer is appended.
3. `pytest tests/agent/test_scope_fidelity.py tests/agent/test_system_prompt.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live CLI session `20260831_141800_e70adc` reported a Coinbase TSMOM setup "successfully created" and "completed and ready for use" while only emitting a `ccxt.coinbasepro` daily-signal print loop with no order path.