### PR TITLE
fix(desktop): don't resolve() sys.executable in Linux .desktop Exec line

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -77,8 +77,14 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly. Do NOT resolve() it: in a
+            # uv-managed venv, venv/bin/python is a symlink to the base
+            # interpreter, and running THROUGH that symlink is what activates
+            # the venv (Python finds pyvenv.cfg next to it). resolve() would
+            # follow the symlink to the bare base interpreter with no venv,
+            # and `import hermes_cli` would fail silently (Terminal=false).
+            # abspath() only normalizes; it never follows the symlink.
+            argv = [os.path.abspath(sys.executable), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
@@ -105,8 +111,11 @@ def _needs_interpreter(bin_path: Path) -> bool:
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    # a system path) would escape the venv when spawned by the DE. Compare
+    # against the UNRESOLVED interpreter dir: a venv console-script's shebang
+    # names the venv symlink path, and resolve() would map it to the base
+    # interpreter's dir and wrongly flag it as escaping.
+    exe_dir = os.path.dirname(os.path.abspath(sys.executable))
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 from pathlib import Path
 
@@ -107,7 +108,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = os.path.abspath(sys.executable)
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +136,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = os.path.abspath(sys.executable)
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))


### PR DESCRIPTION
## Problem

The Linux `hermes.desktop` shortcut silently fails to launch the desktop app. `Terminal=false` hides the error, so the user sees nothing happen and must fall back to launching from a terminal.

## Root cause

`hermes_cli/linux_desktop_entry.py` builds the `Exec=` line with `Path(sys.executable).resolve()`. In a **uv-managed venv**, `venv/bin/python` is a **symlink** to the base interpreter (`uv/.../python3.11`). Running *through* that symlink is what activates the venv — Python finds `pyvenv.cfg` next to it. `.resolve()` follows the symlink to the bare base interpreter, which has **no venv**, so `import hermes_cli` fails with `ModuleNotFoundError` — silently, because `Terminal=false`.

## Fix

Replace `.resolve()` with `os.path.abspath()` in both `resolve_exec_command()` and `_needs_interpreter()`. `abspath()` normalizes the path but **never follows the symlink**, so the venv stays active.

The `_needs_interpreter()` change matters too: a venv console-script's shebang names the *symlink* path, and `resolve()` would map it to the base interpreter's dir and wrongly flag it as escaping the venv.

## Verification

- Reproduced: the base interpreter has `prefix == base_prefix` (no venv); the venv symlink python has `prefix == <venv>`.
- After fix, `resolve_exec_command()` emits the venv symlink path, and `hermes desktop` launches successfully (Electron processes running).
- Tests updated to assert `os.path.abspath(sys.executable)`.