### PR TITLE
fix(kanban): fence stale-claim reclaim so poison cards cannot re-claim immediately

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -386,6 +386,19 @@ DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 # signal lands, and the following tick reclaims cleanly.
 RECLAIM_DEFER_GRACE_SECONDS = 120
 
+# After a TTL reclaim the card is eligible again only after this backoff
+# (#99283). Stops same-tick re-claim of a poison card by the spawn path
+# that just failed. 0 disables backoff (tests). Override with
+# ``HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS``.
+DEFAULT_RECLAIM_BACKOFF_SECONDS = 60
+
+# Auto-block after this many stale-claim reclaims on the same card
+# (#99283). Symmetric with ``DEFAULT_FAILURE_LIMIT``: ``reclaimed`` is
+# not a recorded failure, so without this counter a crash-loop that
+# only ever TTL-reclaims never trips the breaker. Override with
+# ``HERMES_KANBAN_RECLAIM_LIMIT``.
+DEFAULT_RECLAIM_LIMIT = 2
+
 
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
@@ -408,6 +421,40 @@ def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
             return parsed
 
     return DEFAULT_CLAIM_TTL_SECONDS
+
+
+def _resolve_reclaim_backoff_seconds() -> int:
+    """Seconds a reclaimed card must wait before it can be claimed again.
+
+    A non-negative integer from ``HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS``
+    overrides the default. Invalid values fall back silently.
+    """
+    raw = os.environ.get("HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_RECLAIM_BACKOFF_SECONDS
+
+
+def _resolve_reclaim_limit() -> int:
+    """Reclaim count at which a card is auto-blocked.
+
+    A positive integer from ``HERMES_KANBAN_RECLAIM_LIMIT`` overrides
+    the default. Invalid values fall back silently.
+    """
+    raw = os.environ.get("HERMES_KANBAN_RECLAIM_LIMIT", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    return DEFAULT_RECLAIM_LIMIT
 
 
 # Grace period after a task transitions to ``running`` during which
@@ -1141,6 +1188,18 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Monotonic claim generation. Incremented on every successful claim
+    # and on every reclaim (the reclaim bump is the epoch boundary).
+    # Never cleared — a zombie writer compares its run's stored epoch
+    # against this column and is rejected when the card has moved on.
+    claim_epoch: int = 0
+    # Unix timestamp; claim_task refuses until this instant. Set on
+    # reclaim so the card cannot be re-claimed in the same tick.
+    claim_available_at: Optional[int] = None
+    # How many times this card has been stale-reclaimed (or manually
+    # reclaimed) since the last successful completion. Trips the
+    # reclaim-loop breaker at ``DEFAULT_RECLAIM_LIMIT``.
+    reclaim_count: int = 0
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1235,6 +1294,21 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            claim_epoch=(
+                int(row["claim_epoch"])
+                if "claim_epoch" in keys and row["claim_epoch"] is not None
+                else 0
+            ),
+            claim_available_at=(
+                int(row["claim_available_at"])
+                if "claim_available_at" in keys and row["claim_available_at"] is not None
+                else None
+            ),
+            reclaim_count=(
+                int(row["reclaim_count"])
+                if "reclaim_count" in keys and row["reclaim_count"] is not None
+                else 0
+            ),
         )
 
 
@@ -1265,6 +1339,7 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    claim_epoch: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1289,6 +1364,11 @@ class Run:
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
+            claim_epoch=(
+                int(row["claim_epoch"])
+                if "claim_epoch" in set(row.keys()) and row["claim_epoch"] is not None
+                else None
+            ),
         )
 
 
@@ -1422,7 +1502,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Monotonic claim generation. Incremented on claim, never cleared
+    -- on reclaim, so zombie writes can be fenced (#99283).
+    claim_epoch          INTEGER NOT NULL DEFAULT 0,
+    -- Earliest unix time a reclaimed card may be claimed again.
+    claim_available_at   INTEGER,
+    -- Stale-claim reclaim counter. Auto-blocks at DEFAULT_RECLAIM_LIMIT.
+    reclaim_count        INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1474,7 +1561,10 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Claim generation copied from tasks.claim_epoch at insert time so
+    -- a later writer can prove it still owns that epoch (#99283).
+    claim_epoch         INTEGER
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2690,6 +2780,29 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "claim_epoch" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "claim_epoch", "claim_epoch INTEGER NOT NULL DEFAULT 0",
+        )
+    if "claim_available_at" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "claim_available_at", "claim_available_at INTEGER",
+        )
+    if "reclaim_count" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "reclaim_count", "reclaim_count INTEGER NOT NULL DEFAULT 0",
+        )
+
+    runs_present = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_present:
+        run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        if "claim_epoch" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "claim_epoch", "claim_epoch INTEGER",
+            )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2887,7 +3000,7 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, claim_epoch INTEGER)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
@@ -3991,7 +4104,12 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # ---------------------------------------------------------------------------
 
 def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
+    conn: sqlite3.Connection,
+    task_id: str,
+    author: str,
+    body: str,
+    *,
+    expected_run_id: Optional[int] = None,
 ) -> int:
     if not body or not body.strip():
         raise ValueError("comment body is required")
@@ -4005,6 +4123,11 @@ def add_comment(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
+        if _writer_epoch_is_stale(conn, task_id, expected_run_id):
+            raise ValueError(
+                f"stale comment from run {expected_run_id} "
+                f"on task {task_id}: claim epoch has moved on"
+            )
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)",
@@ -4625,6 +4748,108 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+def _reclaim_backoff_blocks_claim(
+    conn: sqlite3.Connection, task_id: str, now: int,
+) -> bool:
+    """Return True when a TTL-reclaim backoff still forbids a new claim."""
+    row = conn.execute(
+        "SELECT claim_available_at FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    keys = set(row.keys())
+    if "claim_available_at" not in keys or row["claim_available_at"] is None:
+        return False
+    return int(row["claim_available_at"]) > now
+
+
+def _next_claim_epoch(conn: sqlite3.Connection, task_id: str) -> int:
+    """Increment and return ``tasks.claim_epoch``; clear reclaim backoff."""
+    conn.execute(
+        "UPDATE tasks SET claim_epoch = COALESCE(claim_epoch, 0) + 1, "
+        "claim_available_at = NULL WHERE id = ?",
+        (task_id,),
+    )
+    row = conn.execute(
+        "SELECT claim_epoch FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    return int(row["claim_epoch"]) if row and row["claim_epoch"] is not None else 1
+
+
+def _apply_stale_reclaim_pacing(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    now: int,
+    retry_status: str,
+) -> tuple[str, int, Optional[int]]:
+    """Bump reclaim_count and decide ready-vs-blocked plus backoff.
+
+    Returns ``(next_status, reclaim_count, claim_available_at)``.
+    Does not write the status flip — caller issues the CAS UPDATE.
+    """
+    row = conn.execute(
+        "SELECT reclaim_count FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    prev = 0
+    if row is not None and "reclaim_count" in set(row.keys()) and row["reclaim_count"] is not None:
+        prev = int(row["reclaim_count"])
+    new_count = prev + 1
+    limit = _resolve_reclaim_limit()
+    backoff = _resolve_reclaim_backoff_seconds()
+    if new_count >= limit:
+        next_status = "blocked"
+        available_at: Optional[int] = None
+        block_kind = "transient"
+    else:
+        next_status = retry_status
+        available_at = (now + backoff) if backoff > 0 else None
+        block_kind = None
+    conn.execute(
+        "UPDATE tasks SET reclaim_count = ?, claim_available_at = ?, "
+        "block_kind = COALESCE(?, block_kind) WHERE id = ?",
+        (new_count, available_at, block_kind, task_id),
+    )
+    return next_status, new_count, available_at
+
+
+def _writer_epoch_is_stale(
+    conn: sqlite3.Connection,
+    task_id: str,
+    expected_run_id: Optional[int],
+) -> bool:
+    """True when ``expected_run_id`` no longer owns this task's claim epoch."""
+    if expected_run_id is None:
+        return False
+    task = conn.execute(
+        "SELECT claim_epoch, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        return True
+    if (
+        task["current_run_id"] is not None
+        and int(task["current_run_id"]) != int(expected_run_id)
+    ):
+        return True
+    run = conn.execute(
+        "SELECT claim_epoch, ended_at FROM task_runs "
+        "WHERE id = ? AND task_id = ?",
+        (int(expected_run_id), task_id),
+    ).fetchone()
+    if run is None:
+        return True
+    if run["ended_at"] is not None:
+        return True
+    keys = set(run.keys())
+    if "claim_epoch" in keys and run["claim_epoch"] is not None:
+        task_epoch = int(task["claim_epoch"] or 0)
+        if task_epoch != int(run["claim_epoch"]):
+            return True
+    return False
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4666,6 +4891,23 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        if _reclaim_backoff_blocks_claim(conn, task_id, now):
+            row = conn.execute(
+                "SELECT claim_available_at FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {
+                    "reason": "reclaim_backoff",
+                    "claim_available_at": (
+                        int(row["claim_available_at"])
+                        if row and row["claim_available_at"] is not None
+                        else None
+                    ),
+                },
+            )
+            return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4701,6 +4943,7 @@ def claim_task(
         )
         if cur.rowcount != 1:
             return None
+        epoch = _next_claim_epoch(conn, task_id)
         # Look up the current task row so we can populate the run with
         # its assignee / step / runtime cap.
         trow = conn.execute(
@@ -4713,8 +4956,8 @@ def claim_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                started_at, claim_epoch
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4724,6 +4967,7 @@ def claim_task(
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
+                epoch,
             ),
         )
         run_id = run_cur.lastrowid
@@ -4733,7 +4977,8 @@ def claim_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id},
+            {"lock": lock, "expires": expires, "run_id": run_id,
+             "claim_epoch": epoch},
             run_id=run_id,
         )
         claimed = get_task(conn, task_id)
@@ -4786,6 +5031,24 @@ def claim_review_task(
                     },
                 )
             return None
+        if _reclaim_backoff_blocks_claim(conn, task_id, now):
+            row_av = conn.execute(
+                "SELECT claim_available_at FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {
+                    "reason": "reclaim_backoff",
+                    "available_at": (
+                        int(row_av["claim_available_at"])
+                        if row_av and row_av["claim_available_at"] is not None
+                        else None
+                    ),
+                    "source_status": "review",
+                },
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4801,6 +5064,7 @@ def claim_review_task(
         )
         if cur.rowcount != 1:
             return None
+        epoch = _next_claim_epoch(conn, task_id)
         trow = conn.execute(
             "SELECT assignee, max_runtime_seconds, current_step_key "
             "FROM tasks WHERE id = ?",
@@ -4811,8 +5075,8 @@ def claim_review_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                started_at, claim_epoch
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4822,6 +5086,7 @@ def claim_review_task(
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
+                epoch,
             ),
         )
         run_id = run_cur.lastrowid
@@ -4930,20 +5195,28 @@ def heartbeat_claim(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
 ) -> bool:
     """Extend a running claim.  Returns True if we still own it.
 
     Workers that know they'll exceed 15 minutes should call this every
     few minutes to keep ownership.
+
+    ``expected_run_id``, when set, fences the heartbeat to that run so a
+    zombie worker cannot extend a successor's claim (#99283).
     """
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
     with write_txn(conn):
-        cur = conn.execute(
+        sql = (
             "UPDATE tasks SET claim_expires = ? "
-            "WHERE id = ? AND status = 'running' AND claim_lock = ?",
-            (expires, task_id, lock),
+            "WHERE id = ? AND status = 'running' AND claim_lock = ?"
         )
+        params: list[Any] = [expires, task_id, lock]
+        if expected_run_id is not None:
+            sql += " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(sql, params)
         if cur.rowcount == 1:
             run_id = _current_run_id(conn, task_id)
             if run_id is not None:
@@ -5072,6 +5345,14 @@ def release_stale_claims(
             )
             if cur.rowcount != 1:
                 continue
+            next_status, reclaim_count, available_at = _apply_stale_reclaim_pacing(
+                conn, row["id"], now=now, retry_status=retry_status,
+            )
+            if next_status != retry_status:
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (next_status, row["id"]),
+                )
             run_id = _end_run(
                 conn, row["id"],
                 outcome="reclaimed", status="reclaimed",
@@ -5092,7 +5373,9 @@ def release_stale_claims(
                 "now": now,
                 "host_local": host_local,
                 "heartbeat_stale": bool(heartbeat_stale),
-                "retry_status": retry_status,
+                "retry_status": next_status,
+                "reclaim_count": reclaim_count,
+                "claim_available_at": available_at,
             }
             payload.update(termination)
             _append_event(
@@ -5117,7 +5400,7 @@ def release_stale_claims(
                     if row["worker_pid"] is not None else None
                 ),
                 heartbeat_stale=bool(heartbeat_stale),
-                retry_status=retry_status,
+                retry_status=next_status,
             )
     return reclaimed
 
@@ -5164,6 +5447,15 @@ def reclaim_task(
         )
         if cur.rowcount != 1:
             return False
+        now = int(time.time())
+        next_status, reclaim_count, available_at = _apply_stale_reclaim_pacing(
+            conn, task_id, now=now, retry_status=retry_status,
+        )
+        if next_status != retry_status:
+            conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?",
+                (next_status, task_id),
+            )
         run_id = _end_run(
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
@@ -5177,7 +5469,9 @@ def reclaim_task(
             "manual": True,
             "reason": reason,
             "prev_lock": prev_lock,
-            "retry_status": retry_status,
+            "retry_status": next_status,
+            "reclaim_count": reclaim_count,
+            "claim_available_at": available_at,
         }
         payload.update(termination)
         _append_event(
@@ -5445,11 +5739,27 @@ def complete_task(
         # ``review`` or ``running``.
         if not _parents_satisfied(conn, task_id):
             return False
+        if _writer_epoch_is_stale(conn, task_id, expected_run_id):
+            return False
         prior = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        if expected_run_id is not None:
+            fence = conn.execute(
+                "SELECT t.claim_epoch AS task_epoch, r.claim_epoch AS run_epoch "
+                "FROM tasks t LEFT JOIN task_runs r ON r.id = ? AND r.task_id = t.id "
+                "WHERE t.id = ?",
+                (int(expected_run_id), task_id),
+            ).fetchone()
+            if (
+                fence is not None
+                and fence["task_epoch"] is not None
+                and fence["run_epoch"] is not None
+                and int(fence["task_epoch"]) != int(fence["run_epoch"])
+            ):
+                return False
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -5461,7 +5771,9 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       reclaim_count = 0,
+                       claim_available_at = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
                 """,
@@ -5478,7 +5790,9 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       reclaim_count = 0,
+                       claim_available_at = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
                    AND current_run_id = ?
@@ -6537,6 +6851,8 @@ def request_review(
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
+        if _writer_epoch_is_stale(conn, task_id, expected_run_id):
+            return _ret(False, "expected_run_id is stale after reclaim")
         trow = conn.execute(
             "SELECT assignee, status, claim_lock, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
@@ -6597,6 +6913,23 @@ def request_review(
                     )
                 reviewer = prior_reviewer
         reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
+        if expected_run_id is not None:
+            fence = conn.execute(
+                "SELECT t.claim_epoch AS task_epoch, r.claim_epoch AS run_epoch "
+                "FROM tasks t LEFT JOIN task_runs r ON r.id = ? AND r.task_id = t.id "
+                "WHERE t.id = ?",
+                (int(expected_run_id), task_id),
+            ).fetchone()
+            if (
+                fence is not None
+                and fence["task_epoch"] is not None
+                and fence["run_epoch"] is not None
+                and int(fence["task_epoch"]) != int(fence["run_epoch"])
+            ):
+                return _ret(
+                    False,
+                    "expected_run_id does not match the current claim epoch",
+                )
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         params: tuple[Any, ...]
         if expected_run_id is None:
@@ -6942,7 +7275,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "consecutive_failures = 0, last_failure_error = NULL "
+            "consecutive_failures = 0, last_failure_error = NULL, "
+            "reclaim_count = 0, claim_available_at = NULL "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
         )
@@ -10044,10 +10378,13 @@ def _dispatch_once_locked(
             )
             spawn_budget = 1
 
+    _now = int(time.time())
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (claim_available_at IS NULL OR claim_available_at <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (_now,),
     ).fetchall()
     # Review rows are enumerated up front (not after the ready loop) so the
     # budget split below can see whether review work exists at all.
@@ -10056,7 +10393,9 @@ def _dispatch_once_locked(
         review_rows = conn.execute(
             "SELECT id, assignee FROM tasks "
             "WHERE status = 'review' AND claim_lock IS NULL "
-            "ORDER BY priority DESC, created_at ASC"
+            "AND (claim_available_at IS NULL OR claim_available_at <= ?) "
+            "ORDER BY priority DESC, created_at ASC",
+            (_now,),
         ).fetchall()
     # Review-lane reservation (OOF-30 review finding): the ready loop runs
     # first and used to consume the ENTIRE shared budget, so a sustained

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -245,9 +245,6 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
 
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Rate-limit requeue: a worker that bails on a provider quota wall must be
 # released back to ``ready`` WITHOUT counting a failure, so a long (e.g.
@@ -1647,3 +1644,108 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# --------------------------------------------------------------------------------------
+# Stale-claim fencing (#99283)
+# --------------------------------------------------------------------------------------
+
+
+def _expire_and_reclaim(conn, tid, monkeypatch, *, pid=424242):
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    host = _kb._claimer_id().split(":", 1)[0]
+    claimed = kb.claim_task(conn, tid, ttl_seconds=120, claimer=f"{host}:worker")
+    assert claimed is not None
+    run_id = claimed.current_run_id
+    kb._set_worker_pid(conn, tid, pid)
+    conn.execute(
+        "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+        (int(time.time()) - 5, tid),
+    )
+    conn.commit()
+    n = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+    assert n == 1
+    return run_id
+
+
+def test_stale_reclaim_keeps_claim_epoch_and_blocks_instant_reclaim(
+    kanban_home, monkeypatch,
+):
+    """TTL reclaim must not erase the claim epoch or allow same-tick re-claim."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fence", assignee="scout")
+        run1 = _expire_and_reclaim(conn, tid, monkeypatch)
+        after = kb.get_task(conn, tid)
+        assert after.status == "ready"
+        assert after.claim_lock is None
+        assert after.current_run_id is None
+        assert after.claim_epoch == 1
+        assert after.reclaim_count == 1
+        assert after.claim_available_at is not None
+        assert after.claim_available_at > int(time.time())
+        assert after.consecutive_failures == 0
+
+        host = kb._claimer_id().split(":", 1)[0]
+        again = kb.claim_task(conn, tid, claimer=f"{host}:worker2")
+        assert again is None
+        events = [
+            e for e in kb.list_events(conn, tid) if e.kind == "claim_rejected"
+        ]
+        assert events and events[-1].payload.get("reason") == "reclaim_backoff"
+
+        zombie = kb.complete_task(
+            conn, tid, result="zombie", expected_run_id=run1,
+        )
+        assert zombie is False
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_stale_run_comment_and_complete_rejected_after_successor_claim(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS", "0")
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="zombie writes", assignee="scout")
+        run1 = _expire_and_reclaim(conn, tid, monkeypatch)
+        host = kb._claimer_id().split(":", 1)[0]
+        successor = kb.claim_task(conn, tid, claimer=f"{host}:next")
+        assert successor is not None
+        assert successor.claim_epoch == 2
+        assert successor.current_run_id != run1
+
+        with pytest.raises(ValueError, match="stale comment"):
+            kb.add_comment(
+                conn, tid, author="zombie", body="late note",
+                expected_run_id=run1,
+            )
+        assert kb.complete_task(
+            conn, tid, result="zombie done", expected_run_id=run1,
+        ) is False
+        assert kb.heartbeat_claim(
+            conn, tid, claimer=f"{host}:worker", expected_run_id=run1,
+        ) is False
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_reclaim_limit_auto_blocks_poison_card(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS", "0")
+    monkeypatch.setenv("HERMES_KANBAN_RECLAIM_LIMIT", "2")
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="poison", assignee="scout")
+        _expire_and_reclaim(conn, tid, monkeypatch, pid=111)
+        first = kb.get_task(conn, tid)
+        assert first.status == "ready"
+        assert first.reclaim_count == 1
+
+        _expire_and_reclaim(conn, tid, monkeypatch, pid=222)
+        parked = kb.get_task(conn, tid)
+        assert parked.status == "blocked"
+        assert parked.reclaim_count == 2
+        payload = [
+            e.payload for e in kb.list_events(conn, tid)
+            if e.kind == "reclaimed"
+        ][-1]
+        assert payload["retry_status"] == "blocked"
+        assert payload["reclaim_count"] == 2

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -333,7 +333,10 @@ def heartbeat_current_worker_from_env() -> bool:
         try:
             claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
             try:
-                kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+                kb.heartbeat_claim(
+                    conn, tid, claimer=claim_lock,
+                    expected_run_id=_worker_run_id(tid),
+                )
             except Exception:
                 logger.debug("auto-heartbeat: heartbeat_claim failed", exc_info=True)
             run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
@@ -1104,7 +1107,10 @@ def _handle_comment(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+            cid = kb.add_comment(
+                conn, tid, author=author, body=str(body),
+                expected_run_id=_worker_run_id(tid),
+            )
             return _ok(task_id=tid, comment_id=cid)
         finally:
             conn.close()


### PR DESCRIPTION
## What does this PR do?

`release_stale_claims` used to return a TTL-expired card to `ready` with the claim columns cleared and `current_run_id` nulled. The next dispatcher tick could claim it immediately — including the same spawn path that just died — and a late worker write that omitted a run id could still complete or comment on the card.

This stamps a monotonic `claim_epoch` on each successful claim (copied onto the run row, not cleared on reclaim), rejects worker writes whose `expected_run_id` no longer matches that epoch, holds reclaimed cards behind `claim_available_at` (60s by default), and auto-blocks a card after two TTL reclaims (`block_kind=transient`) so a poison loop cannot bypass `consecutive_failures`.

## Related Issue

Fixes #99283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: add `claim_epoch`, `claim_available_at`, and `reclaim_count`; increment epoch on `claim_task` / `claim_review_task`; pace and optionally block in `release_stale_claims`; `_writer_epoch_is_stale` on `complete_task`, `add_comment`, and `request_review`; dispatch ready/review queries skip cards still in backoff
- `tools/kanban_tools.py`: pass the worker run id into `kanban_comment` (complete / heartbeat / review already did)
- `tests/hermes_cli/test_kanban_db.py`: same-tick re-claim fence, stale complete/comment/heartbeat after a successor claim, auto-block at reclaim limit

## How to Test

1. Seed a ready task, `claim_task` it, force `claim_expires` into the past, stub `_pid_alive` false, call `release_stale_claims`.
2. Confirm the card is `ready` with `claim_epoch` still set, `claim_available_at` in the future, and a follow-up `claim_task` returns `None` with a `claim_rejected` / `reclaim_backoff` event.
3. Confirm `complete_task(..., expected_run_id=<dead run>)` is `False` and `add_comment(..., expected_run_id=<dead run>)` raises. After backoff (or `HERMES_KANBAN_RECLAIM_BACKOFF_SECONDS=0`), a second TTL reclaim with `HERMES_KANBAN_RECLAIM_LIMIT=2` parks the card `blocked`.
4. `pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
AFTER {'status': 'ready', 'epoch': 1, 'reclaim_count': 1, 'available_at': 1788176148, 'current_run_id': None}
INSTANT_RECLAIM False
ZOMBIE_COMPLETE False
ZOMBIE_COMMENT False
FIXED True
```

61 passed, 1 skipped (`test_kanban_db.py` + review lifecycle + worker lifecycle hooks)
55 passed, 1 skipped (`test_kanban_core_functionality.py` + `test_kanban_tools.py`)
