### PR TITLE
fix(desktop): /btw answers never appear after the started ack

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { handleStatusEvent } from './status'
+import type { GatewayEventContext } from './types'
+
+function btwCompleteEvent({
+  sessionId,
+  question,
+  text
+}: {
+  sessionId: string
+  question: string
+  text: string
+}): { ctx: GatewayEventContext; state: { current: ClientSessionState } } {
+  const state = { current: createClientSessionState('stored-1') }
+
+  const ctx = {
+    deps: {
+      activeGatewayProfile: 'default',
+      activeSessionIdRef: { current: sessionId },
+      compactedTurnRef: { current: new Set<string>() },
+      failAssistantMessage: vi.fn(),
+      flushQueuedDeltas: vi.fn(),
+      hydrateFromStoredSession: vi.fn(),
+      lastCwdInfoSessionRef: { current: null },
+      queryClient: { invalidateQueries: vi.fn() },
+      refreshHermesConfig: vi.fn(),
+      scheduleSessionsRefresh: vi.fn(),
+      sessionInterrupted: () => false,
+      sessionStateByRuntimeIdRef: { current: new Map() },
+      updateSessionState: vi.fn((_id: string, updater: (s: ClientSessionState) => ClientSessionState) => {
+        state.current = updater(state.current)
+
+        return state.current
+      }),
+      upsertToolCall: vi.fn()
+    },
+    event: { profile: 'default', session_id: sessionId, type: 'btw.complete' },
+    explicitSid: sessionId,
+    fromActiveSource: () => true,
+    isActiveEvent: true,
+    occurredAt: 1_700_000_000,
+    payload: { question, text },
+    scheduleConfigRefresh: vi.fn(),
+    sessionId
+  } as unknown as GatewayEventContext
+
+  return { ctx, state }
+}
+
+describe('handleStatusEvent btw.complete', () => {
+  it('appends the side-question answer onto the originating session', () => {
+    const { ctx, state } = btwCompleteEvent({
+      question: 'hello',
+      sessionId: 'runtime-1',
+      text: 'It was in foo.py'
+    })
+
+    expect(handleStatusEvent(ctx)).toBe(true)
+    expect(ctx.deps.flushQueuedDeltas).toHaveBeenCalledWith('runtime-1')
+
+    const last = state.current.messages.at(-1)
+    const body = last?.parts?.map(part => ('text' in part ? part.text : '')).join('') ?? ''
+
+    expect(last?.role).toBe('system')
+    expect(body).toContain('slash:/btw')
+    expect(body).toContain('/btw: "hello"')
+    expect(body).toContain('It was in foo.py')
+  })
+
+  it('surfaces a worker failure instead of looking like /btw hung', () => {
+    const { ctx, state } = btwCompleteEvent({
+      question: 'hello',
+      sessionId: 'runtime-1',
+      text: 'error: no provider credentials'
+    })
+
+    expect(handleStatusEvent(ctx)).toBe(true)
+
+    const body =
+      state.current.messages
+        .at(-1)
+        ?.parts?.map(part => ('text' in part ? part.text : ''))
+        .join('') ?? ''
+
+    expect(body).toContain('/btw failed: "hello"')
+    expect(body).toContain('no provider credentials')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -1,3 +1,4 @@
+import { formatBtwCompleteNotice, slashStatusText } from '@/app/session/hooks/use-prompt-actions/utils'
 import { translateNow } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
 import { coerceGatewayText } from '@/lib/chat-runtime'
@@ -69,6 +70,35 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
             id: `review-summary-${Date.now()}`,
             role: 'system',
             parts: [textPart(`review:${text}`, occurredAt)],
+            timestamp: occurredAt
+          }
+        ]
+      }))
+    }
+
+    return true
+  }
+
+  if (event.type === 'btw.complete') {
+    // prompt.btw answers on a background thread and emits btw.complete with
+    // the originating session_id. The TUI renders that as a system line;
+    // without this handler Desktop showed the "started" ack from /btw and
+    // then went silent. Append onto the event's session so a chat switch
+    // before the answer arrives still lands it on the right transcript.
+    const question = coerceGatewayText(payload?.question)
+    const answer = coerceGatewayText(payload?.text)
+    const notice = formatBtwCompleteNotice(question, answer)
+
+    if (notice.trim() && sessionId) {
+      flushQueuedDeltas(sessionId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `btw-complete-${Date.now()}`,
+            role: 'system',
+            parts: [textPart(slashStatusText('/btw', notice), occurredAt)],
             timestamp: occurredAt
           }
         ]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1002,6 +1002,105 @@ describe('usePromptActions /compress', () => {
   })
 })
 
+describe('usePromptActions /btw', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('starts a side question via prompt.btw and does not use slash.exec', async () => {
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        return { task_id: 'btw_abc123' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw hello')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.btw', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'hello'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    const texts = renderedSeedTexts(seeds)
+    expect(texts.some(text => text.includes('Side question: "hello"'))).toBe(true)
+    expect(texts.some(text => text.includes('Answering from a snapshot of this conversation'))).toBe(true)
+  })
+
+  it('prints usage when /btw has no question', async () => {
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw')
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(renderedSeedTexts(seeds).some(text => text.includes('Usage: /btw <question>'))).toBe(true)
+  })
+
+  it('falls back to slash.exec when an older gateway lacks prompt.btw', async () => {
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        throw new Error('method not found: prompt.btw')
+      }
+
+      if (method === 'slash.exec') {
+        return {
+          output:
+            'Side question: "hello"\nAnswering from a snapshot of this conversation — the current work continues.'
+        } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw hello')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.btw', expect.objectContaining({ text: 'hello' }))
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'btw hello' }))
+    expect(renderedSeedTexts(seeds).some(text => text.includes('Side question: "hello"'))).toBe(true)
+  })
+})
+
 describe('usePromptActions exec fallback error reporting', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -63,6 +63,8 @@ import type {
 
 import { resolveTargetSessionId } from './resolve-target-session'
 import {
+  BTW_USAGE,
+  formatBtwStartedNotice,
   type GatewayRequest,
   isSessionIdCandidate,
   isTargetSessionBusy,
@@ -661,6 +663,49 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           } finally {
             compressInFlightRef.current.delete(sessionId)
+          }
+        },
+        // /btw must use prompt.btw (the TUI path). slash.exec runs the CLI
+        // handler, which prints a "started" ack and answers on a daemon
+        // thread — the worker returns before that answer exists, so Desktop
+        // showed only the ack and then went silent.
+        btw: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+          const question = ctx.arg.trim()
+
+          if (!question) {
+            renderSlashOutput(BTW_USAGE)
+
+            return
+          }
+
+          try {
+            const result = await requestGateway<{ task_id?: string }>('prompt.btw', {
+              session_id: sessionId,
+              text: question
+            })
+
+            if (!result?.task_id) {
+              renderSlashOutput('/btw: no output')
+
+              return
+            }
+
+            renderSlashOutput(formatBtwStartedNotice(question))
+          } catch (err) {
+            if (isMissingRpcMethod(err)) {
+              await runExec(ctx)
+
+              return
+            }
+
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -7,8 +7,11 @@ import {
   acquireSubmitInFlight,
   appendText,
   base64FromDataUrl,
+  BTW_USAGE,
   clearSessionRecentlyInterrupted,
   clearSubmitInFlight,
+  formatBtwCompleteNotice,
+  formatBtwStartedNotice,
   friendlyRemoteAttachError,
   type GatewayRequest,
   imageFilenameFromPath,
@@ -414,6 +417,21 @@ describe('slashStatusText', () => {
 
   it('omits empty output', () => {
     expect(slashStatusText('/clear', '   ')).toBe('slash:/clear')
+  })
+})
+
+describe('btw notice helpers', () => {
+  it('formats the started ack with a truncated preview', () => {
+    expect(formatBtwStartedNotice('hello')).toBe(
+      'Side question: "hello"\nAnswering from a snapshot of this conversation — the current work continues.'
+    )
+    expect(formatBtwStartedNotice('x'.repeat(61))).toContain('..."')
+    expect(BTW_USAGE).toContain('Usage: /btw <question>')
+  })
+
+  it('formats a successful answer and a worker error', () => {
+    expect(formatBtwCompleteNotice('hello', 'It was in foo.py')).toBe('/btw: "hello"\n\nIt was in foo.py')
+    expect(formatBtwCompleteNotice('hello', 'error: boom')).toBe('/btw failed: "hello"\nboom')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -499,6 +499,36 @@ export function slashStatusText(command: string, output: string): string {
   return [`slash:${command}`, output.trim()].filter(Boolean).join('\n')
 }
 
+export const BTW_USAGE =
+  'Usage: /btw <question>\nExample: /btw which file was that error in?\n\nAnswers a quick side question about this conversation without interrupting it. For an independent background task, use /bg <prompt>.'
+
+function btwPreview(question: string): string {
+  const trimmed = question.trim()
+
+  return trimmed.length > 60 ? `${trimmed.slice(0, 60)}...` : trimmed
+}
+
+/** Immediate /btw ack — the answer arrives later as a `btw.complete` event. */
+export function formatBtwStartedNotice(question: string): string {
+  return `Side question: "${btwPreview(question)}"\nAnswering from a snapshot of this conversation — the current work continues.`
+}
+
+/** Final /btw answer (or failure) painted as a system line. */
+export function formatBtwCompleteNotice(question: string, answer: string): string {
+  const trimmedQuestion = question.trim()
+  const trimmedAnswer = answer.trim()
+  const preview = btwPreview(trimmedQuestion)
+  const failed = /^error:\s*/i.test(trimmedAnswer)
+
+  if (failed) {
+    const detail = trimmedAnswer.replace(/^error:\s*/i, '')
+
+    return trimmedQuestion ? `/btw failed: "${preview}"\n${detail}` : `/btw failed\n${detail}`
+  }
+
+  return trimmedQuestion ? `/btw: "${preview}"\n\n${trimmedAnswer}` : `/btw\n\n${trimmedAnswer}`
+}
+
 /**
  * Format the JSON reply from a gateway RPC surfaced as `kind: 'rpc'` in
  * desktop-slash-commands.ts. Kept here (instead of slash.ts) so it has no

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -190,7 +190,7 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashCommandArgumentMode('/browser')).toBe('options')
   })
 
-  it('routes /compress through the session-compression action', () => {
+    it('routes /compress through the session-compression action', () => {
     // /compress must be an action (session.compress RPC), not exec: the slash
     // worker route times out on large sessions (#44456).
     expect(resolveDesktopCommand('/compress')?.surface).toEqual({ kind: 'action', action: 'compress' })
@@ -202,6 +202,17 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/compact')?.surface).toEqual({ kind: 'action', action: 'compress' })
     expect(isDesktopSlashCommand('/compact')).toBe(true)
     expect(isDesktopSlashSuggestion('/compact')).toBe(false)
+  })
+
+  it('routes /btw through prompt.btw instead of the slash worker', () => {
+    // slash.exec only captures the CLI "started" line; the answer runs on a
+    // daemon thread and never reaches Desktop. prompt.btw + btw.complete is
+    // the TUI path.
+    expect(resolveDesktopCommand('/btw')?.surface).toEqual({ kind: 'action', action: 'btw' })
+    expect(desktopSlashCommandArgumentMode('/btw')).toBe('text')
+    expect(isDesktopSlashCommand('/btw')).toBe(true)
+    expect(isDesktopSlashSuggestion('/btw')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/btw')).toBeNull()
   })
 
   it('routes only stateless session commands through dedicated gateway RPCs', () => {
@@ -234,7 +245,6 @@ describe('desktop slash command curation', () => {
   it('still routes commands without dedicated RPCs through exec()', () => {
     const execNames = [
       '/bg',
-      '/btw',
       '/debug',
       '/goal',
       '/personality',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -55,6 +55,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'btw'
   | 'compress'
   | 'handoff'
   | 'hatch'
@@ -238,6 +239,16 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Compress this conversation context',
     aliases: ['/compact'],
     surface: action('compress'),
+    argumentMode: 'text'
+  },
+  // /btw must be an action (prompt.btw RPC), not exec. The slash-worker CLI
+  // handler prints a "started" line and answers on a daemon thread; slash.exec
+  // returns after that line, so Desktop never sees the answer, and switching
+  // sessions drops the ephemeral slash output.
+  {
+    name: '/btw',
+    description: 'Ask a side question about this conversation without interrupting it',
+    surface: action('btw'),
     argumentMode: 'text'
   },
   {


### PR DESCRIPTION
## Summary
- Desktop `/btw` was going through `slash.exec`, which only captured the CLI "started" line. The real answer ran on a daemon thread and never reached the UI, so the chat showed `Side question: "…"` / `Answering from a snapshot…` and then did nothing. Switching sessions dropped that ephemeral slash output.
- `/btw` now uses the same `prompt.btw` RPC as the TUI. The started ack still prints immediately; `btw.complete` appends the answer onto the originating session so a chat switch does not lose it.
- Older gateways that lack `prompt.btw` still fall back to the slash worker.

## Test plan
- [ ] In Desktop, `/btw hello` in a chat with history shows the started ack, then the answer in that same chat.
- [ ] Switch to another session and back — the answer is still on the original chat.
- [ ] Bare `/btw` prints usage and does not call the model.
- [ ] From `apps/desktop`: `npm test -- src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions/utils.test.ts src/app/session/hooks/use-message-stream/gateway-event/status.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx`