### PR TITLE
fix(update): skip Task Scheduler service in Windows gateway service discovery

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1084,6 +1084,13 @@ def find_windows_gateway_services(
                 raise RuntimeError("SCM service inspection failed") from exc
             if not service_name:
                 raise RuntimeError("SCM service has an empty name")
+            if service_name.casefold() == "schedule":
+                # Built-in Task Scheduler (svchost -k netsvcs). Scheduled-Task
+                # gateways inherit it as an ancestor process but it is NOT a
+                # gateway owner; treating it as one made the updater call
+                # `sc.exe stop Schedule` (i.e. stop Task Scheduler itself),
+                # which needs admin and aborts every update. Skip it.
+                continue
             if service_status == "stopped":
                 continue
             if service_status != "running":


### PR DESCRIPTION
## Summary

`hermes update` aborts on Windows when gateways run via Scheduled Tasks: `find_windows_gateway_services()` misattributes the built-in **Task Scheduler** service (`Schedule`) as the gateway's supervising service, then tries `sc.exe stop Schedule` — stopping Task Scheduler itself — which fails with `Access denied` on non-elevated shells and aborts the update before the git pull.

## Root cause

- Scheduled-Task gateways (`pythonw -m hermes_cli.main gateway run` launched by a Scheduled Task) have the Task Scheduler service (`Schedule`, a `svchost -k netsvcs` host) in their parent chain.
- `find_windows_gateway_services()` walks each profile gateway's ancestors and treats any ancestor that maps to exactly **one** running SCM service as the gateway's supervising service. Since `Schedule` is a single-service host here, the gateway is falsely claimed as service-supervised.
- `_pause_windows_gateways_for_update()` then calls `_stop_windows_gateway_service("Schedule")` → `[SC] OpenService FAILED 5: Access is denied` (sc.exe requires admin to stop Task Scheduler) → `RuntimeError` → **update aborts before fetching**, every time, on every non-elevated shell.

Repro trace:

```
RuntimeError: Could not stop Windows gateway service Schedule: [SC] OpenService FAILED 5:
Access is denied.
```

## Fix

Skip the built-in `Schedule` (Task Scheduler) service during SCM enumeration in `find_windows_gateway_services()`. A Hermes gateway can never legitimately be supervised by Task Scheduler; the false positive only happens because Scheduled-Task-launched processes inherit it as an ancestor.

The update's existing socket-pause / force-stop / resume machinery then handles the gateways exactly as before — only the bogus service-stop step disappears.

## Verification

On a Windows host with all three gateways (default, crypto, gateway profile) running under Scheduled Tasks:

- Before: `find_windows_gateway_services()` → `[WindowsGatewayService(name='Schedule', ...)]`; `hermes update` aborts with the trace above.
- After: `find_windows_gateway_services()` → `[]`; `hermes update` completes cleanly (gateways paused/resumed, no `sc.exe stop` attempt).

Live-verified on 2026-08-31: first update run aborted (pre-fix), second run completed (post-fix, exit 0).