### PR TITLE
fix(kanban): enforce attachment integrity

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4127,10 +4127,16 @@ def store_attachment_bytes(
 ) -> int:
     """Validate, size-check, persist a blob, and record its metadata row.
 
-    This is the single write path shared by the dashboard endpoint, the
-    agent toolset (``kanban_attach`` / ``kanban_attach_url``), and the CLI
-    (``hermes kanban attach``) so name-sanitisation, the size cap, and the
-    collision-resolution all behave identically everywhere.
+    This is the write path shared by the agent toolset (``kanban_attach`` /
+    ``kanban_attach_url``) and the CLI (``hermes kanban attach``) so
+    name-sanitisation, the size cap, and the collision-resolution behave
+    identically across both. The dashboard upload endpoint
+    (``plugins/kanban/dashboard/plugin_api.py::upload_task_attachment``) does
+    **not** route through here — it streams the upload to disk with its own
+    cap and then calls :func:`add_attachment` directly, reusing
+    :func:`_safe_attachment_name` and :func:`_collision_free_path` but not
+    this function. Keep the two in step by hand; a change here does not
+    reach the dashboard.
 
     Steps: enforce ``max_bytes``, sanitise ``filename`` to a safe basename,
     write the bytes under :func:`task_attachments_dir` with a

--- a/tests/tools/test_kanban_attach.py
+++ b/tests/tools/test_kanban_attach.py
@@ -1,0 +1,607 @@
+"""F-17 / F-18 — attachment integrity for the ``kanban_attach`` tool surface.
+
+F-17: base64 is prefix-decodable, so a payload truncated by the model's
+output cap still decodes cleanly and used to be stored silently. Attachments
+are the only durable output path a completed worker has (scratch workspaces
+are deleted on completion), so a silent short write is data loss.
+
+F-18: ``base64.b64decode(..., validate=True)`` rejects whitespace, so ordinary
+line-wrapped (MIME) base64 failed outright.
+
+The fix has two halves:
+
+* ``content_base64`` now requires ``expected_bytes`` **and**
+  ``expected_sha256``, both verified *before* anything reaches
+  ``store_attachment_bytes``;
+* a ``path`` branch reads the bytes off disk inside the task's own resolved
+  workspace, so they never travel through the model at all.
+
+Case ids (U1-U13, P1-P14) match the test plan in
+``F17-ATTACHMENT-INTEGRITY-DESIGN.md`` plus the fail-closed
+``workspace_path IS NULL`` case decided in HERMES-NL-05B.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import stat
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _isolate_home(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return kb
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    """Worker whose task has NO resolved workspace (``workspace_path`` NULL).
+
+    This is the state ``create_task`` leaves a scratch task in until the
+    dispatcher calls ``resolve_workspace``. Inline attaches must still work
+    here; ``path=`` must fail closed (P14).
+    """
+    kb = _isolate_home(monkeypatch, tmp_path)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
+        kb.claim_task(conn, tid)
+        assert kb.get_task(conn, tid).workspace_path is None
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+@pytest.fixture
+def worker_ws(monkeypatch, tmp_path):
+    """Worker whose task HAS a resolved workspace, as after a real dispatch.
+
+    Returns ``(task_id, workspace_dir)``.
+    """
+    kb = _isolate_home(monkeypatch, tmp_path)
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker-ws", assignee="test-worker")
+        kb.claim_task(conn, tid)
+        # Mirror what resolve_workspace() persists at dispatch time.
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?", (str(ws), tid)
+        )
+        conn.commit()
+        assert kb.get_task(conn, tid).workspace_path == str(ws)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid, ws
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _call(args):
+    from tools import kanban_tools as kt
+
+    return json.loads(kt._handle_attach(args))
+
+
+def _attachments(tid):
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        return kb.list_attachments(conn, tid)
+    finally:
+        conn.close()
+
+
+def _assert_refused(out, tid, *, contains=None):
+    assert "error" in out, f"expected refusal, got {out}"
+    if contains:
+        assert contains.lower() in out["error"].lower(), out["error"]
+    assert _attachments(tid) == [], "nothing may be stored on a refusal"
+
+
+def _inline(payload: bytes, **over):
+    args = {
+        "filename": "d.txt",
+        "content_base64": base64.b64encode(payload).decode(),
+        "expected_bytes": len(payload),
+        "expected_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+    args.update(over)
+    return args
+
+
+PAYLOAD = b"hermes attachment integrity payload " * 8
+
+
+# ---------------------------------------------------------------------------
+# U1-U13 — inline content_base64
+# ---------------------------------------------------------------------------
+
+
+def test_U1_inline_without_expected_is_refused(worker_env):
+    """Clean base64 with no declared expectation must be refused outright."""
+    args = _inline(PAYLOAD)
+    args.pop("expected_bytes")
+    args.pop("expected_sha256")
+    _assert_refused(_call(args), worker_env, contains="expected_bytes")
+
+
+def test_U2_line_wrapped_base64_is_accepted(worker_env):
+    """F-18: 76-char MIME wrapping with a trailing newline must decode."""
+    wrapped = textwrap.fill(base64.b64encode(PAYLOAD).decode(), 76) + "\n"
+    out = _call(_inline(PAYLOAD, content_base64=wrapped))
+    assert out.get("ok") is True, out
+    assert out["size"] == len(PAYLOAD)
+    assert len(_attachments(worker_env)) == 1
+
+
+def test_U3_whitespace_variants_are_accepted(worker_env):
+    """Spaces, tabs and CRLF are transport artefacts, not content."""
+    b64 = base64.b64encode(PAYLOAD).decode()
+    noisy = " " + b64[:10] + "\t" + b64[10:30] + "\r\n" + b64[30:] + "  \n"
+    out = _call(_inline(PAYLOAD, content_base64=noisy))
+    assert out.get("ok") is True, out
+    assert out["size"] == len(PAYLOAD)
+
+
+def test_U4_truncated_base64_is_refused(worker_env):
+    """F-17: a prefix-truncated payload still decodes — the length must catch it."""
+    b64 = base64.b64encode(PAYLOAD).decode()
+    truncated = b64[: (len(b64) // 2) // 4 * 4]  # keep a valid 4-char boundary
+    out = _call(_inline(PAYLOAD, content_base64=truncated))
+    _assert_refused(out, worker_env, contains="truncated")
+    assert str(len(PAYLOAD)) in out["error"], "the error must name the declared size"
+
+
+def test_U5_expected_sha256_alone_missing_is_refused(worker_env):
+    args = _inline(PAYLOAD)
+    args.pop("expected_sha256")
+    _assert_refused(_call(args), worker_env, contains="expected_sha256")
+
+
+def test_U6_wrong_expected_sha256_is_refused(worker_env):
+    args = _inline(PAYLOAD, expected_sha256="0" * 64)
+    _assert_refused(_call(args), worker_env, contains="hash")
+
+
+def test_U7_correct_expectations_store_and_echo(worker_env):
+    out = _call(_inline(PAYLOAD))
+    assert out.get("ok") is True, out
+    assert out["size"] == len(PAYLOAD)
+    assert out["sha256"] == hashlib.sha256(PAYLOAD).hexdigest()
+    stored = _attachments(worker_env)
+    assert len(stored) == 1
+    assert Path(stored[0].stored_path).read_bytes() == PAYLOAD
+
+
+def test_U8_non_base64_characters_are_refused(worker_env):
+    _assert_refused(
+        _call(_inline(PAYLOAD, content_base64="!!!not base64!!!")),
+        worker_env,
+        contains="base64",
+    )
+
+
+def test_U9_both_path_and_inline_is_refused(worker_ws):
+    tid, ws = worker_ws
+    src = ws / "f.txt"
+    src.write_bytes(PAYLOAD)
+    args = _inline(PAYLOAD, path=str(src))
+    _assert_refused(_call(args), tid, contains="exactly one")
+
+
+def test_U10_neither_path_nor_inline_is_refused(worker_env):
+    _assert_refused(_call({"filename": "d.txt"}), worker_env, contains="one of")
+
+
+def test_U11_data_uri_prefix_is_refused_by_name(worker_env):
+    """A data: URI must be named, not silently rejected as 'bad base64'."""
+    data_uri = "data:text/plain;base64," + base64.b64encode(PAYLOAD).decode()
+    out = _call(_inline(PAYLOAD, content_base64=data_uri))
+    _assert_refused(out, worker_env, contains="data:")
+
+
+def test_U12_oversize_inline_payload_is_refused(worker_env, monkeypatch):
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 32)
+    _assert_refused(_call(_inline(PAYLOAD)), worker_env, contains="limit")
+
+
+def test_U13_right_length_wrong_bytes_is_refused_by_hash(worker_env):
+    """Proves the two guards are not redundant: length passes, hash must fail."""
+    corrupted = bytearray(PAYLOAD)
+    corrupted[0] ^= 0xFF
+    args = _inline(PAYLOAD, content_base64=base64.b64encode(bytes(corrupted)).decode())
+    out = _call(args)
+    assert "error" in out and "hash" in out["error"].lower(), out
+    assert _attachments(worker_env) == []
+
+
+# ---------------------------------------------------------------------------
+# P1-P14 — path branch
+# ---------------------------------------------------------------------------
+
+
+def test_P1_file_inside_workspace_is_stored(worker_ws):
+    tid, ws = worker_ws
+    src = ws / "report.md"
+    src.write_bytes(PAYLOAD)
+    out = _call({"path": str(src)})
+    assert out.get("ok") is True, out
+    assert out["size"] == len(PAYLOAD)
+    assert out["sha256"] == hashlib.sha256(PAYLOAD).hexdigest()
+    stored = _attachments(tid)
+    assert len(stored) == 1
+    assert stored[0].filename == "report.md", "filename defaults to the basename"
+    assert Path(stored[0].stored_path).read_bytes() == PAYLOAD
+
+
+def test_P2_traversal_out_of_workspace_is_refused(worker_ws, tmp_path):
+    tid, ws = worker_ws
+    secret = tmp_path / ".hermes" / ".env"
+    secret.write_text("TOKEN=redacted\n")
+    _assert_refused(
+        _call({"path": str(ws / ".." / ".hermes" / ".env")}), tid, contains="workspace"
+    )
+
+
+def test_P3_absolute_path_outside_workspace_is_refused(worker_ws, tmp_path):
+    tid, _ws = worker_ws
+    outside = tmp_path / "outside.txt"
+    outside.write_bytes(PAYLOAD)
+    _assert_refused(_call({"path": str(outside)}), tid, contains="workspace")
+
+
+def test_P4_symlink_escaping_workspace_is_refused(worker_ws, tmp_path):
+    tid, ws = worker_ws
+    secret = tmp_path / "auth.json"
+    secret.write_text('{"token": "redacted"}')
+    link = ws / "looks-harmless.json"
+    link.symlink_to(secret)
+    _assert_refused(_call({"path": str(link)}), tid, contains="workspace")
+
+
+def test_P5_symlink_inside_workspace_is_allowed(worker_ws):
+    tid, ws = worker_ws
+    real = ws / "real.txt"
+    real.write_bytes(PAYLOAD)
+    link = ws / "link.txt"
+    link.symlink_to(real)
+    out = _call({"path": str(link)})
+    assert out.get("ok") is True, out
+    assert out["size"] == len(PAYLOAD)
+
+
+def test_P6_directory_is_refused(worker_ws):
+    tid, ws = worker_ws
+    d = ws / "subdir"
+    d.mkdir()
+    _assert_refused(_call({"path": str(d)}), tid, contains="regular file")
+
+
+def test_P7_fifo_is_refused(worker_ws):
+    tid, ws = worker_ws
+    fifo = ws / "pipe"
+    os.mkfifo(fifo)
+    _assert_refused(_call({"path": str(fifo)}), tid, contains="regular file")
+
+
+def test_P8_oversize_file_is_refused_without_reading(worker_ws, monkeypatch):
+    """The cap is enforced from fstat, before a single byte is read."""
+    from hermes_cli import kanban_db as kb
+
+    tid, ws = worker_ws
+    big = ws / "big.bin"
+    big.write_bytes(b"x" * 4096)
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 1024)
+
+    reads = []
+    real_read = os.read
+
+    def counting_read(fd, n):
+        reads.append(fd)
+        return real_read(fd, n)
+
+    monkeypatch.setattr(os, "read", counting_read)
+    _assert_refused(_call({"path": str(big)}), tid, contains="limit")
+    assert reads == [], "an oversize file must not be read at all"
+
+
+def test_P9_missing_file_is_a_clean_error(worker_ws):
+    tid, ws = worker_ws
+    _assert_refused(_call({"path": str(ws / "nope.txt")}), tid, contains="no such file")
+
+
+def test_P10_traversal_in_explicit_filename_is_sanitised(worker_ws):
+    tid, ws = worker_ws
+    src = ws / "ok.txt"
+    src.write_bytes(PAYLOAD)
+    out = _call({"path": str(src), "filename": "../../escape.txt"})
+    assert out.get("ok") is True, out
+    stored = _attachments(tid)
+    assert stored[0].filename == "escape.txt"
+    assert "/" not in stored[0].filename
+
+
+def test_P11_same_name_twice_gets_collision_suffix(worker_ws):
+    tid, ws = worker_ws
+    src = ws / "dup.txt"
+    src.write_bytes(PAYLOAD)
+    assert _call({"path": str(src)}).get("ok") is True
+    assert _call({"path": str(src)}).get("ok") is True
+    names = sorted(a.filename for a in _attachments(tid))
+    assert names == ["dup (1).txt", "dup.txt"], names
+
+
+def test_P12_file_grown_between_fstat_and_read_is_refused(worker_ws, monkeypatch):
+    """TOCTOU: the bytes read must match the size the fd was measured at."""
+    tid, ws = worker_ws
+    src = ws / "racy.txt"
+    src.write_bytes(PAYLOAD)
+
+    real_fstat = os.fstat
+
+    class _Shrunk:
+        def __init__(self, st):
+            self.st_mode = st.st_mode
+            self.st_size = st.st_size - 5  # pretend the file was smaller
+
+    monkeypatch.setattr(os, "fstat", lambda fd: _Shrunk(real_fstat(fd)))
+    _assert_refused(_call({"path": str(src)}), tid, contains="changed")
+
+
+def test_P13_path_outside_workspace_without_extra_roots_is_refused(
+    worker_ws, tmp_path
+):
+    """No attach_extra_roots exists in NL-05B: the workspace is the only root."""
+    tid, _ws = worker_ws
+    projects = tmp_path / "Projects" / "thing"
+    projects.mkdir(parents=True)
+    src = projects / "note.md"
+    src.write_bytes(PAYLOAD)
+    _assert_refused(_call({"path": str(src)}), tid, contains="workspace")
+
+
+def test_P14_null_workspace_path_fails_closed(worker_env, tmp_path):
+    """A-2 (Thomas): no resolved workspace → path= is refused, never guessed."""
+    src = tmp_path / "anywhere.txt"
+    src.write_bytes(PAYLOAD)
+    out = _call({"path": str(src)})
+    _assert_refused(out, worker_env, contains="workspace")
+    # The refusal must point at the usable alternative.
+    assert "content_base64" in out["error"], out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — the property that makes "nothing was stored" true
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["no_expectation", "truncated", "wrong_hash", "data_uri", "bad_base64"],
+)
+def test_verification_failure_never_reaches_storage(worker_env, monkeypatch, case):
+    """No refused inline payload may call store_attachment_bytes."""
+    from hermes_cli import kanban_db as kb
+
+    calls = []
+    real = kb.store_attachment_bytes
+    monkeypatch.setattr(
+        kb,
+        "store_attachment_bytes",
+        lambda *a, **k: (calls.append(1), real(*a, **k))[1],
+    )
+
+    args = _inline(PAYLOAD)
+    if case == "no_expectation":
+        args.pop("expected_bytes")
+        args.pop("expected_sha256")
+    elif case == "truncated":
+        b64 = args["content_base64"]
+        args["content_base64"] = b64[: (len(b64) // 2) // 4 * 4]
+    elif case == "wrong_hash":
+        args["expected_sha256"] = "1" * 64
+    elif case == "data_uri":
+        args["content_base64"] = "data:text/plain;base64," + args["content_base64"]
+    elif case == "bad_base64":
+        args["content_base64"] = "###"
+
+    assert "error" in _call(args)
+    assert calls == [], f"{case}: storage was reached despite a failed verification"
+
+
+def test_path_verification_failure_never_reaches_storage(worker_ws, monkeypatch):
+    from hermes_cli import kanban_db as kb
+
+    tid, ws = worker_ws
+    calls = []
+    real = kb.store_attachment_bytes
+    monkeypatch.setattr(
+        kb,
+        "store_attachment_bytes",
+        lambda *a, **k: (calls.append(1), real(*a, **k))[1],
+    )
+    assert "error" in _call({"path": str(ws / "missing.txt")})
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Schema — the description is what steers the model away from the bad path
+# ---------------------------------------------------------------------------
+
+
+def test_schema_exposes_path_and_expectations():
+    from tools.kanban_tools import KANBAN_ATTACH_SCHEMA
+
+    props = KANBAN_ATTACH_SCHEMA["parameters"]["properties"]
+    for key in ("path", "content_base64", "expected_bytes", "expected_sha256"):
+        assert key in props, f"{key} missing from kanban_attach schema"
+    assert props["expected_bytes"]["type"] == "integer"
+    # Nothing is schema-required: filename defaults to the basename on the path
+    # branch, and the either-or contract cannot be expressed in JSON Schema —
+    # it is enforced in the handler instead (see the two tests below).
+    assert KANBAN_ATTACH_SCHEMA["parameters"]["required"] == []
+    desc = KANBAN_ATTACH_SCHEMA["description"].lower()
+    assert "path" in desc and "expected_bytes" in desc
+
+
+def test_contract_is_enforced_in_code_not_by_schema_required(worker_ws):
+    """`required: []` is safe only because the handler enforces the contract."""
+    tid, ws = worker_ws
+    src = ws / "only-path.txt"
+    src.write_bytes(PAYLOAD)
+    # path alone is a complete, valid call
+    assert _call({"path": str(src)}).get("ok") is True
+    # inline alone is complete only with filename + both expectations
+    assert _call(_inline(PAYLOAD, filename="only-inline.txt")).get("ok") is True
+    # ...and inline without a filename is refused by the handler, not the schema
+    args = _inline(PAYLOAD)
+    args.pop("filename")
+    out = _call(args)
+    assert "error" in out and "filename" in out["error"].lower(), out
+
+
+# ---------------------------------------------------------------------------
+# Hardening added after adversarial review
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_expected_sha256_is_a_contract_error(worker_env):
+    """A typo'd digest must say so, not masquerade as a content mismatch."""
+    out = _call(_inline(PAYLOAD, expected_sha256="not-a-digest"))
+    _assert_refused(out, worker_env, contains="64 hex")
+    assert "mismatch" not in out["error"].lower()
+
+
+def test_non_string_content_base64_is_refused(worker_env):
+    _assert_refused(
+        _call(_inline(PAYLOAD, content_base64=12345)), worker_env, contains="string"
+    )
+
+
+def test_parent_directory_swapped_after_check_is_refused(worker_ws, monkeypatch):
+    """The resolve()/open() window: a parent that becomes a symlink is refused.
+
+    O_NOFOLLOW alone only guards the leaf, so the descent walks from an fd on
+    the workspace root with O_NOFOLLOW on every hop. Simulated by swapping the
+    parent directory for a symlink right after the containment check.
+    """
+    import tools.kanban_tools as kt
+
+    tid, ws = worker_ws
+    sub = ws / "sub"
+    sub.mkdir()
+    src = sub / "f.txt"
+    src.write_bytes(PAYLOAD)
+
+    outside = ws.parent / "elsewhere"
+    outside.mkdir()
+    (outside / "f.txt").write_bytes(b"attacker-controlled")
+
+    real_relative_to = Path.relative_to
+    swapped = {"done": False}
+
+    def racing_relative_to(self, other):
+        # Fires once, between the containment check and the descent.
+        if not swapped["done"]:
+            swapped["done"] = True
+            import shutil
+
+            shutil.rmtree(sub)
+            (ws / "sub").symlink_to(outside)
+        return real_relative_to(self, other)
+
+    monkeypatch.setattr(Path, "relative_to", racing_relative_to)
+    out = _call({"path": str(src)})
+    assert "error" in out, out
+    assert _attachments(tid) == []
+
+
+def test_path_refused_without_dir_fd_support(worker_ws, monkeypatch):
+    """No dir_fd → the workspace boundary is unenforceable → path= fails closed."""
+    tid, ws = worker_ws
+    src = ws / "f.txt"
+    src.write_bytes(PAYLOAD)
+    monkeypatch.setattr(os, "supports_dir_fd", set())
+    out = _call({"path": str(src)})
+    _assert_refused(out, tid, contains="unavailable on this platform")
+    assert "content_base64" in out["error"], "must point at the safe alternative"
+
+
+def test_descent_does_not_leak_file_descriptors(worker_ws):
+    """Repeated refusals must not orphan directory fds."""
+    import resource
+
+    tid, ws = worker_ws
+    deep = ws / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    (deep / "f.txt").write_bytes(PAYLOAD)
+    missing = deep / "gone.txt"
+
+    def open_fd_count():
+        n = 0
+        soft = min(resource.getrlimit(resource.RLIMIT_NOFILE)[0], 4096)
+        for fd in range(3, soft):
+            try:
+                os.fstat(fd)
+                n += 1
+            except OSError:
+                pass
+        return n
+
+    _call({"path": str(missing)})  # warm any lazy imports/connections
+    before = open_fd_count()
+    for _ in range(25):
+        assert "error" in _call({"path": str(missing)})
+        assert _call({"path": str(deep / "f.txt")}).get("ok") is True
+    after = open_fd_count()
+    assert after <= before + 2, f"fd leak: {before} → {after}"
+
+
+def test_fifo_open_does_not_block(worker_ws):
+    """O_NONBLOCK on the open: a writer-less FIFO must not park the worker."""
+    import threading
+
+    tid, ws = worker_ws
+    fifo = ws / "blocking-pipe"
+    os.mkfifo(fifo)
+
+    result = {}
+
+    def run():
+        result["out"] = _call({"path": str(fifo)})
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), "opening a FIFO blocked the worker"
+    assert "error" in result["out"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1115,14 +1115,296 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
-def _handle_attach(args: dict, **kw) -> str:
-    """Attach an inline (base64) file to a task.
+def _decode_inline_attachment(content_b64: Any, expected_bytes: Any,
+                              expected_sha256: Any):
+    """Decode ``content_base64`` and verify it against the caller's declaration.
 
-    Mirrors the dashboard's upload endpoint for the agent surface: decode
-    the payload, enforce the shared size cap, write it under the per-task
-    attachments dir, and record the metadata row — all via
-    ``kanban_db.store_attachment_bytes`` so the three surfaces stay in lockstep.
+    Returns ``(data, None)`` on success or ``(None, tool_error_str)``.
+
+    Two defects live on this path and both are closed here:
+
+    * **F-18** — ``b64decode(validate=True)`` rejects whitespace, so ordinary
+      line-wrapped (MIME) base64 failed outright. All whitespace is stripped
+      first; wrapping is a transport artefact, not content.
+    * **F-17** — base64 is *prefix-decodable*: a payload cut off by the
+      model's output cap still decodes cleanly, so a short write used to be
+      stored silently. ``validate=True`` cannot see incompleteness — only a
+      declared expectation can. ``expected_bytes`` and ``expected_sha256``
+      are therefore both mandatory, and both are checked *before* the caller
+      returns, so nothing reaches storage on a mismatch.
+
+    The length check alone is not enough: a corruption that preserves length
+    passes it. The hash alone would do, but the length check produces the far
+    more actionable error for the common truncation case.
     """
+    import base64
+    import binascii
+    import hashlib
+    import re
+
+    from hermes_cli import kanban_db as kb
+
+    if not isinstance(content_b64, str):
+        return None, tool_error(
+            f"content_base64 must be a string, got {type(content_b64).__name__}. "
+            "Nothing was stored."
+        )
+    raw = "".join(content_b64.split())  # F-18
+    if raw.startswith("data:"):
+        return None, tool_error(
+            "content_base64 must be raw base64, not a 'data:' URI. Strip the "
+            "'data:<mime>;base64,' prefix and pass only the payload. "
+            "Nothing was stored."
+        )
+    if expected_bytes is None or expected_sha256 is None or not str(expected_sha256).strip():
+        return None, tool_error(
+            "content_base64 requires expected_bytes and expected_sha256 — "
+            "base64 truncated mid-stream still decodes cleanly, so without a "
+            "declared size and digest a short write cannot be detected. "
+            "Compute both over the exact bytes you are sending, or use path= "
+            "to attach from disk instead. Nothing was stored."
+        )
+    try:
+        expected_len = int(expected_bytes)
+    except (TypeError, ValueError):
+        return None, tool_error(
+            f"expected_bytes must be an integer, got {expected_bytes!r}. "
+            "Nothing was stored."
+        )
+    # A malformed digest is a caller contract error, not a content mismatch —
+    # saying so plainly beats reporting "hash mismatch" for a typo.
+    expected_digest = str(expected_sha256).strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+        return None, tool_error(
+            f"expected_sha256 must be 64 hex characters, got {expected_sha256!r}. "
+            "Nothing was stored."
+        )
+    try:
+        data = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as e:
+        return None, tool_error(f"content_base64 is not valid base64: {e}")
+
+    if len(data) != expected_len:
+        return None, tool_error(
+            f"attachment truncated or corrupted: decoded {len(data)} bytes, "
+            f"caller declared {expected_len}. Nothing was stored."
+        )
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != expected_digest:
+        return None, tool_error(
+            "attachment content hash mismatch: decoded bytes hash to "
+            f"{digest}, caller declared {expected_digest}. Nothing was stored."
+        )
+    if len(data) > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+        return None, tool_error(
+            f"attachment exceeds the "
+            f"{kb.KANBAN_ATTACHMENT_MAX_BYTES // (1024 * 1024)} MB limit "
+            f"({len(data)} bytes). Nothing was stored."
+        )
+    return data, None
+
+
+def _read_attachment_from_path(tid: str, raw_path: str, *, board=None):
+    """Read attachment bytes off disk, confined to the task's own workspace.
+
+    Returns ``(data, resolved_path, None)`` or ``(None, None, tool_error_str)``.
+
+    This is the branch that *removes* the F-17 failure class rather than
+    detecting it: the bytes never enter the model's output stream, so there
+    is no cap to truncate them and no incentive to shrink a deliverable to
+    fit one.
+
+    Containment: the path is resolved (which also collapses symlinks) and
+    must land inside ``tasks.workspace_path``. A task with no resolved
+    workspace fails closed — guessing a root would be how a
+    ``../../.hermes/.env`` becomes an attachment.
+
+    Reading is fd-based on purpose. ``stat()`` then ``open()`` is TOCTOU-
+    exposed: the file can be swapped in between, so the bytes stored would
+    not be the bytes measured. Here the fd is opened once, ``fstat``-ed, read
+    from, and the byte count is re-checked against that same measurement.
+    """
+    import stat as _stat
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+
+    try:
+        _, conn = _connect(board=board)
+        try:
+            task = kb.get_task(conn, tid)
+        finally:
+            conn.close()
+    except Exception as e:  # pragma: no cover - connection failures
+        logger.exception("kanban_attach: task lookup failed")
+        return None, None, tool_error(f"kanban_attach: {e}")
+    if task is None:
+        return None, None, tool_error(f"kanban_attach: unknown task {tid}")
+
+    if not task.workspace_path:
+        return None, None, tool_error(
+            "kanban_attach: path= needs a resolved task workspace and this "
+            "task has none yet (workspace_path is unset — the dispatcher "
+            "assigns it when it spawns the worker). Use content_base64 with "
+            "expected_bytes and expected_sha256 instead. Nothing was stored."
+        )
+    try:
+        ws_root = Path(task.workspace_path).expanduser().resolve()
+        target = Path(str(raw_path)).expanduser().resolve()
+    except (OSError, RuntimeError) as e:
+        return None, None, tool_error(f"kanban_attach: cannot resolve path: {e}")
+
+    if target != ws_root and ws_root not in target.parents:
+        return None, None, tool_error(
+            f"kanban_attach: refused — {target} is outside this task's "
+            f"workspace ({ws_root}). Only files inside the task workspace can "
+            "be attached by path. Nothing was stored."
+        )
+
+    # ``resolve()`` proved containment for the path *as it was a moment ago*.
+    # Opening ``target`` directly would trust that snapshot: O_NOFOLLOW only
+    # guards the final component, so swapping a parent directory for a symlink
+    # in between would still escape the workspace. Instead, walk down from an
+    # fd on the workspace root, one component at a time, with O_NOFOLLOW on
+    # every hop. ``resolve()`` already collapsed every legitimate symlink, so
+    # anything that is a symlink *now* appeared after the check — which is
+    # exactly the race we refuse.
+    #
+    # O_NONBLOCK is on the open so a FIFO cannot park the worker until some
+    # writer turns up; it is cleared again below once the file is known to be
+    # regular, so the read path is plain blocking I/O.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        rel_parts = target.relative_to(ws_root).parts
+    except ValueError:  # pragma: no cover - containment checked above
+        return None, None, tool_error(
+            f"kanban_attach: refused — {target} is outside this task's "
+            f"workspace ({ws_root}). Nothing was stored."
+        )
+    if not rel_parts:
+        return None, None, tool_error(
+            f"kanban_attach: {target} is not a regular file. Nothing was stored."
+        )
+
+    if os.open not in getattr(os, "supports_dir_fd", set()):
+        # Without dir_fd there is no way to pin the descent to the workspace:
+        # resolve() plus O_NOFOLLOW guards only the leaf, so a swapped parent
+        # directory would still escape. Rather than ship containment we cannot
+        # actually enforce, path= is refused here — content_base64 with
+        # expected_bytes and expected_sha256 is fully safe on every platform.
+        return None, None, tool_error(
+            "kanban_attach: path= is unavailable on this platform (no "
+            "directory-fd support), because the workspace boundary cannot be "
+            "enforced against a concurrently swapped parent directory. Use "
+            "content_base64 with expected_bytes and expected_sha256 instead. "
+            "Nothing was stored."
+        )
+
+    fd = None
+    dir_fd = None
+    try:
+        dir_fd = os.open(str(ws_root), dir_flags)
+        for part in rel_parts[:-1]:
+            nxt = os.open(part, dir_flags, dir_fd=dir_fd)
+            # Reassign unconditionally: if the close of the previous fd were
+            # allowed to fail here, ``nxt`` would be orphaned for the life of
+            # the process. A failing close means the fd is already gone.
+            try:
+                os.close(dir_fd)
+            except OSError:  # pragma: no cover - EBADF only
+                pass
+            dir_fd = nxt
+        fd = os.open(rel_parts[-1], flags, dir_fd=dir_fd)
+    except FileNotFoundError:
+        return None, None, tool_error(f"kanban_attach: no such file: {target}")
+    except OSError as e:
+        return None, None, tool_error(
+            f"kanban_attach: cannot open {target} inside the task "
+            f"workspace: {e}. A component that became a symlink after the "
+            "path was checked is refused. Nothing was stored."
+        )
+    finally:
+        if dir_fd is not None:
+            try:
+                os.close(dir_fd)
+            except OSError:  # pragma: no cover - EBADF only
+                pass
+
+    max_bytes = kb.KANBAN_ATTACHMENT_MAX_BYTES
+    try:
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode):
+            return None, None, tool_error(
+                f"kanban_attach: {target} is not a regular file. "
+                "Nothing was stored."
+            )
+        # Regular file confirmed — drop O_NONBLOCK so the reads below are
+        # ordinary blocking reads and cannot come back short with EAGAIN.
+        try:
+            import fcntl
+
+            cur = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, cur & ~os.O_NONBLOCK)
+        except (ImportError, AttributeError):  # pragma: no cover - non-POSIX
+            pass
+        except OSError as e:  # pragma: no cover - would be surprising on a live fd
+            # Not fatal: the reads below still work, they just stay
+            # non-blocking. But it should not vanish silently either.
+            logger.debug("kanban_attach: could not clear O_NONBLOCK on %s: %s",
+                         target, e)
+        if st.st_size > max_bytes:
+            return None, None, tool_error(
+                f"kanban_attach: {target} is {st.st_size} bytes and exceeds "
+                f"the {max_bytes // (1024 * 1024)} MB limit. Nothing was "
+                "stored and nothing was read."
+            )
+        chunks = []
+        total = 0
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                return None, None, tool_error(
+                    f"kanban_attach: {target} grew past the "
+                    f"{max_bytes // (1024 * 1024)} MB limit while being read. "
+                    "Nothing was stored."
+                )
+            chunks.append(chunk)
+    except OSError as e:
+        return None, None, tool_error(f"kanban_attach: cannot read {target}: {e}")
+    finally:
+        os.close(fd)
+
+    data = b"".join(chunks)
+    if len(data) != st.st_size:
+        # Either direction is a change under our feet: grown, shrunk, or
+        # rewritten. What was measured is not what was read, so it is refused.
+        return None, None, tool_error(
+            f"kanban_attach: {target} changed while it was being read "
+            f"(measured {st.st_size} bytes at open, read {len(data)}). "
+            "Nothing was stored."
+        )
+    return data, target, None
+
+
+def _handle_attach(args: dict, **kw) -> str:
+    """Attach a file to a task, from disk (``path``) or inline (base64).
+
+    ``path`` is the safe branch and the preferred one: the bytes are read
+    inside the task's own workspace and never travel through the model.
+    ``content_base64`` stays available for content the model generated in
+    this turn, but only with a declared ``expected_bytes`` and
+    ``expected_sha256`` that this handler verifies first — see F-17/F-18 in
+    :func:`_decode_inline_attachment`.
+
+    Every verification runs *before* ``kanban_db.store_attachment_bytes``, so
+    a refusal leaves no blob, no metadata row and no ``attached`` event.
+    """
+    import hashlib
+
     from hermes_cli import kanban_db as kb
 
     delegated_err = _reject_delegated_child_mutation("kanban_attach")
@@ -1136,20 +1418,48 @@ def _handle_attach(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
-    filename = args.get("filename")
-    if not filename or not str(filename).strip():
-        return tool_error("filename is required")
-    content_b64 = args.get("content_base64")
-    if not content_b64 or not str(content_b64).strip():
-        return tool_error("content_base64 is required")
-    import base64
-    import binascii
-    try:
-        data = base64.b64decode(str(content_b64), validate=True)
-    except (binascii.Error, ValueError) as e:
-        return tool_error(f"content_base64 is not valid base64: {e}")
-    content_type = args.get("content_type")
+
     board = args.get("board")
+    filename = args.get("filename")
+    content_type = args.get("content_type")
+
+    raw_path = args.get("path")
+    content_b64 = args.get("content_base64")
+    has_path = bool(raw_path and str(raw_path).strip())
+    has_inline = bool(content_b64 and str(content_b64).strip())
+
+    if has_path and has_inline:
+        return tool_error(
+            "kanban_attach: pass exactly one of path or content_base64, not "
+            "both. Nothing was stored."
+        )
+    if not has_path and not has_inline:
+        return tool_error(
+            "kanban_attach: one of path or content_base64 is required. Prefer "
+            "path — the file is read from disk and never passes through your "
+            "output, so it cannot be truncated."
+        )
+
+    if has_path:
+        data, resolved, err = _read_attachment_from_path(
+            tid, str(raw_path), board=board
+        )
+        if err:
+            return err
+        if not filename or not str(filename).strip():
+            filename = resolved.name
+        if not content_type:
+            import mimetypes
+            content_type = mimetypes.guess_type(str(filename))[0]
+    else:
+        if not filename or not str(filename).strip():
+            return tool_error("filename is required")
+        data, err = _decode_inline_attachment(
+            content_b64, args.get("expected_bytes"), args.get("expected_sha256")
+        )
+        if err:
+            return err
+
     try:
         _, conn = _connect(board=board)
         try:
@@ -1162,7 +1472,12 @@ def _handle_attach(args: dict, **kw) -> str:
                 uploaded_by="agent",
                 board=board,
             )
-            return _ok(task_id=tid, attachment_id=att_id, size=len(data))
+            return _ok(
+                task_id=tid,
+                attachment_id=att_id,
+                size=len(data),
+                sha256=hashlib.sha256(data).hexdigest(),
+            )
         finally:
             conn.close()
     except kb.AttachmentTooLarge as e:
@@ -2036,11 +2351,20 @@ KANBAN_COMMENT_SCHEMA = {
 KANBAN_ATTACH_SCHEMA = {
     "name": "kanban_attach",
     "description": (
-        "Attach a file to a task by passing its bytes inline (base64). "
-        "Use for genuine file artifacts the next worker or a human should "
-        "be able to download — generated reports, images, exports. The "
-        "file is stored as a real attachment (not a comment link) under "
-        "the task's attachments dir, capped at 25 MB. Prefer "
+        "Attach a file to a task. Use for genuine file artifacts the next "
+        "worker or a human should be able to download — generated reports, "
+        "images, exports. Stored as a real attachment (not a comment link) "
+        "under the task's attachments dir, capped at 25 MB.\n"
+        "PREFER path: write the file into your task workspace first, then "
+        "pass path. The bytes are read from disk and never pass through "
+        "your output, so they cannot be truncated — and you never need to "
+        "shrink a deliverable to fit an output budget.\n"
+        "Use content_base64 only for content you generated in this turn and "
+        "did not write to disk. It then REQUIRES expected_bytes and "
+        "expected_sha256 of the exact bytes you are sending: truncated "
+        "base64 still decodes cleanly, so without them a short write is "
+        "undetectable. Whitespace and line wrapping in the base64 are fine.\n"
+        "Pass exactly one of path or content_base64. Prefer "
         "kanban_attach_url when you only have a URL."
     ),
     "parameters": {
@@ -2050,24 +2374,57 @@ KANBAN_ATTACH_SCHEMA = {
                 "type": "string",
                 "description": _DESC_TASK_ID_DEFAULT,
             },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Absolute path to a file inside this task's own "
+                    "workspace. Paths outside it are refused, and so is a "
+                    "symlink pointing out of it. Available only once the "
+                    "task has a resolved workspace."
+                ),
+            },
             "filename": {
                 "type": "string",
                 "description": (
                     "File name to store it under (e.g. 'report.pdf'). "
-                    "Directory components are stripped; only the leaf is kept."
+                    "Directory components are stripped; only the leaf is "
+                    "kept. Optional with path (defaults to the source "
+                    "file's name); required with content_base64."
                 ),
             },
             "content_base64": {
                 "type": "string",
-                "description": "The file contents, base64-encoded. Max 25 MB decoded.",
+                "description": (
+                    "The file contents, base64-encoded. Max 25 MB decoded. "
+                    "Requires expected_bytes and expected_sha256."
+                ),
+            },
+            "expected_bytes": {
+                "type": "integer",
+                "description": (
+                    "Decoded size in bytes of the content you are sending. "
+                    "Required with content_base64; a mismatch is refused and "
+                    "nothing is stored."
+                ),
+            },
+            "expected_sha256": {
+                "type": "string",
+                "description": (
+                    "Hex SHA-256 of the decoded content. Required with "
+                    "content_base64; a mismatch is refused and nothing is "
+                    "stored."
+                ),
             },
             "content_type": {
                 "type": "string",
-                "description": "Optional MIME type (e.g. 'application/pdf').",
+                "description": (
+                    "Optional MIME type (e.g. 'application/pdf'). Guessed "
+                    "from the filename when omitted."
+                ),
             },
             "board": _board_schema_prop(),
         },
-        "required": ["filename", "content_base64"],
+        "required": [],
     },
 }
 


### PR DESCRIPTION
Hardens kanban attachment handling against inconsistent state between `kanban_db` and the attachment files on disk.

Touches `hermes_cli/kanban_db.py` and `tools/kanban_tools.py`; `tests/tools/test_kanban_attach.py` covers the cases (607 lines).