### PR TITLE
feat(toolsets): add read-only skills-read toolset

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -41,6 +41,20 @@ class TestGetToolset:
         assert "xurl" in description
         assert "authenticated" in description
 
+    def test_skills_read_toolset_has_no_manage_tool(self):
+        ts = get_toolset("skills-read")
+        assert ts is not None
+        assert set(ts["tools"]) == {"skills_list", "skill_view"}
+        assert "skill_manage" not in ts["tools"]
+
+    def test_skills_read_resolves_without_pulling_in_skills_toolset(self):
+        assert set(resolve_toolset("skills-read")) == {"skills_list", "skill_view"}
+
+    def test_existing_skills_toolset_unchanged(self):
+        ts = get_toolset("skills")
+        assert ts is not None
+        assert set(ts["tools"]) == {"skills_list", "skill_view", "skill_manage"}
+
     def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
         reg = ToolRegistry()
         reg.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -178,7 +178,13 @@ TOOLSETS = {
         "tools": ["skills_list", "skill_view", "skill_manage"],
         "includes": []
     },
-    
+
+    "skills-read": {
+        "description": "Read-only skill access: list and view skill documents, no create/edit/delete",
+        "tools": ["skills_list", "skill_view"],
+        "includes": []
+    },
+
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
         "tools": [


### PR DESCRIPTION
Adds a `skills-read` toolset that exposes skill *reading* without the write side.

Motivation: a profile that should consult skills but must never modify them (reviewer/verifier roles) previously had to be granted the full skills toolset. Covered in `tests/test_toolsets.py`.