### PR TITLE
fix(sessions): serialize SessionDB reads during close

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8138,11 +8138,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -8213,14 +8214,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return
         from agent.session_activity import ActivityProvenance
 
-        # No-op fast path: skip the transaction when there is nothing to
-        # clear. Read-only, no write lock.
+        # No-op fast path: skip the transaction when there is nothing to clear.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -15181,12 +15182,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
             if not row:
                 return None
             return {
@@ -15203,15 +15204,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            with self._read_ctx() as conn:
+                rows = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                ).fetchall()
+            return [self._session_row_dict(r) for r in rows]
         except Exception:
             return []
 

--- a/tests/state/test_sessiondb_managed_reads.py
+++ b/tests/state/test_sessiondb_managed_reads.py
@@ -1,0 +1,98 @@
+"""Regression coverage for SessionDB reads racing connection shutdown."""
+
+from contextlib import contextmanager
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self._rows = [_Row(row) for row in rows]
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _Row(dict):
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return tuple(self.values())[key]
+        return super().__getitem__(key)
+
+
+class _ManagedConnection:
+    def __init__(self, rows):
+        self._rows = rows
+        self.executed = False
+
+    def execute(self, _sql, _params=()):
+        self.executed = True
+        return _Cursor(self._rows)
+
+
+class _UnsafeWriterConnection:
+    def execute(self, *_args, **_kwargs):
+        raise AssertionError("read bypassed SessionDB._read_ctx()")
+
+
+@pytest.mark.parametrize(
+    ("rows", "invoke", "expected"),
+    [
+        (
+            [{"holder": "compressor"}],
+            lambda db: db.get_compression_lock_holder("session-1"),
+            "compressor",
+        ),
+        (
+            [
+                {
+                    "last_activity_description": "",
+                    "last_activity_provenance": "unknown",
+                }
+            ],
+            lambda db: db.clear_session_activity_labels("session-1"),
+            None,
+        ),
+        (
+            [
+                {
+                    "handoff_state": "pending",
+                    "handoff_platform": "telegram",
+                    "handoff_error": None,
+                }
+            ],
+            lambda db: db.get_handoff_state("session-1"),
+            {"state": "pending", "platform": "telegram", "error": None},
+        ),
+        (
+            [{"id": "session-1", "_system_prompt_resolved": "prompt"}],
+            lambda db: db.list_pending_handoffs(),
+            [{"id": "session-1"}],
+        ),
+    ],
+    ids=[
+        "compression-lock-holder",
+        "activity-label-fast-path",
+        "handoff-state",
+        "pending-handoffs",
+    ],
+)
+def test_shutdown_sensitive_reads_use_managed_connection(rows, invoke, expected):
+    """Reads must not touch the writer connection outside its close lock."""
+    db = object.__new__(SessionDB)
+    db._conn = _UnsafeWriterConnection()
+    managed = _ManagedConnection(rows)
+
+    @contextmanager
+    def managed_read():
+        yield managed
+
+    db._read_ctx = managed_read
+
+    assert invoke(db) == expected
+    assert managed.executed is True


### PR DESCRIPTION
## Summary

- route shutdown-sensitive SessionDB reads through the managed read context
- keep WAL reads on exclusively checked-out pooled connections and non-WAL reads under the writer lock
- cover all four affected read paths with connection-routing regression tests

## Testing

- `scripts/run_tests.sh tests/state/test_sessiondb_managed_reads.py tests/test_hermes_state_compression_locks.py -q`
- `scripts/run_tests.sh tests/test_hermes_state.py -k activity`
- `scripts/run_tests.sh tests/gateway/test_watchdog_review_76354.py tests/test_session_system_prompt_dedup.py tests/hermes_cli/test_session_handoff.py -q`

## Related Issue

Closes #99349