### PR TITLE
fix(desktop): stop Bot Mode roster WebSocket churn

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -34,6 +34,7 @@ const { hostMock } = vi.hoisted(() => ({
     profileRoutes: undefined as unknown,
     request: vi.fn(),
     requestProfile: vi.fn(),
+    retainProfileSocket: vi.fn(),
     state: { connectionId: { get: vi.fn(() => 'local') }, profile: { get: () => 'default' } }
   }
 }))
@@ -114,6 +115,27 @@ afterEach(() => {
 })
 
 describe('no union roster', () => {
+  it('retains the polled profile socket for the query observer lifetime', async () => {
+    const release = vi.fn()
+    hostMock.retainProfileSocket.mockReturnValueOnce(release)
+    hostMock.request.mockResolvedValue({ profiles: [] })
+    hostMock.agents.mockResolvedValue({ agents: [], sources: [] })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result, unmount } = renderHook(() => useRoster(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toBeTruthy())
+    expect(hostMock.retainProfileSocket).toHaveBeenCalledWith('default')
+
+    unmount()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('leaves the local list exactly as it was', async () => {
     const rows = await mergedRoster(
       { profiles: [{ last_session: { id: 's1', last_active: 1 }, name: 'default' }] },

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -170,6 +170,7 @@ describe('no union roster', () => {
     await waitFor(() => expect(result.current.data).toBeTruthy())
     expect(hostMock.request).toHaveBeenCalledWith('profiles.list', {})
     expect(hostMock.requestProfile).not.toHaveBeenCalled()
+    expect(hostMock.retainProfileSocket).not.toHaveBeenCalled()
 
     unmount()
   })

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -82,7 +82,7 @@ async function mergedRoster(
   liveConnectionId: null | string = 'local'
 ): Promise<RowFixture[]> {
   hostMock.state.connectionId.get.mockReturnValue(liveConnectionId as string)
-  hostMock.request.mockResolvedValue(local)
+  hostMock.requestProfile.mockResolvedValue(local)
 
   if (union) {
     hostMock.agents.mockResolvedValue(union)
@@ -119,6 +119,7 @@ describe('no union roster', () => {
     const release = vi.fn()
     hostMock.retainProfileSocket.mockReturnValueOnce(release)
     hostMock.request.mockResolvedValue({ profiles: [] })
+    hostMock.requestProfile.mockResolvedValue({ profiles: [] })
     hostMock.agents.mockResolvedValue({ agents: [], sources: [] })
 
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -131,6 +132,8 @@ describe('no union roster', () => {
 
     await waitFor(() => expect(result.current.data).toBeTruthy())
     expect(hostMock.retainProfileSocket).toHaveBeenCalledWith('default')
+    expect(hostMock.requestProfile).toHaveBeenCalledWith('default', 'profiles.list', {})
+    expect(hostMock.request).not.toHaveBeenCalled()
 
     unmount()
     expect(release).toHaveBeenCalledOnce()
@@ -603,7 +606,7 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     // Bots sidebar on a spinner with no error card. The 5s refetchInterval and
     // the gateway-open effect already recover drops.
     hostMock.state.connectionId.get.mockReturnValue('local')
-    hostMock.request.mockRejectedValue(new Error('state.db is locked'))
+    hostMock.requestProfile.mockRejectedValue(new Error('state.db is locked'))
 
     const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
 
@@ -616,6 +619,6 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 })
 
     expect(result.current.isLoading).toBe(false)
-    expect(hostMock.request.mock.calls.length).toBeGreaterThan(1)
+    expect(hostMock.requestProfile.mock.calls.length).toBeGreaterThan(1)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -82,7 +82,12 @@ async function mergedRoster(
   liveConnectionId: null | string = 'local'
 ): Promise<RowFixture[]> {
   hostMock.state.connectionId.get.mockReturnValue(liveConnectionId as string)
-  hostMock.requestProfile.mockResolvedValue(local)
+
+  if (liveConnectionId && liveConnectionId !== 'local') {
+    hostMock.requestProfile.mockResolvedValue(local)
+  } else {
+    hostMock.request.mockResolvedValue(local)
+  }
 
   if (union) {
     hostMock.agents.mockResolvedValue(union)
@@ -115,8 +120,9 @@ afterEach(() => {
 })
 
 describe('no union roster', () => {
-  it('retains the polled profile socket for the query observer lifetime', async () => {
+  it('routes remote polls through the exact retained socket for the query observer lifetime', async () => {
     const release = vi.fn()
+    hostMock.state.connectionId.get.mockReturnValue('homelab')
     hostMock.retainProfileSocket.mockReturnValueOnce(release)
     hostMock.request.mockResolvedValue({ profiles: [] })
     hostMock.requestProfile.mockResolvedValue({ profiles: [] })
@@ -131,12 +137,41 @@ describe('no union roster', () => {
     const { result, unmount } = renderHook(() => useRoster(), { wrapper })
 
     await waitFor(() => expect(result.current.data).toBeTruthy())
-    expect(hostMock.retainProfileSocket).toHaveBeenCalledWith('default')
-    expect(hostMock.requestProfile).toHaveBeenCalledWith('default', 'profiles.list', {})
+    const retainedRoute = hostMock.retainProfileSocket.mock.calls[0][0]
+
+    expect(retainedRoute).toEqual({
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'default',
+      targetProfile: 'default'
+    })
+    expect(hostMock.requestProfile.mock.calls[0][0]).toBe(retainedRoute)
+    expect(hostMock.requestProfile).toHaveBeenCalledWith(retainedRoute, 'profiles.list', {})
     expect(hostMock.request).not.toHaveBeenCalled()
 
     unmount()
     expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('keeps local multi-source polling on the ambient compatibility path', async () => {
+    hostMock.state.connectionId.get.mockReturnValue('local')
+    hostMock.request.mockResolvedValue({ profiles: [] })
+    hostMock.requestProfile.mockRejectedValue(new Error('profile-only route is ambiguous'))
+    hostMock.agents.mockResolvedValue({ agents: [], sources: [] })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result, unmount } = renderHook(() => useRoster(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toBeTruthy())
+    expect(hostMock.request).toHaveBeenCalledWith('profiles.list', {})
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+
+    unmount()
   })
 
   it('leaves the local list exactly as it was', async () => {
@@ -606,7 +641,7 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     // Bots sidebar on a spinner with no error card. The 5s refetchInterval and
     // the gateway-open effect already recover drops.
     hostMock.state.connectionId.get.mockReturnValue('local')
-    hostMock.requestProfile.mockRejectedValue(new Error('state.db is locked'))
+    hostMock.request.mockRejectedValue(new Error('state.db is locked'))
 
     const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
 
@@ -619,6 +654,6 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 })
 
     expect(result.current.isLoading).toBe(false)
-    expect(hostMock.requestProfile.mock.calls.length).toBeGreaterThan(1)
+    expect(hostMock.request.mock.calls.length).toBeGreaterThan(1)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -7,6 +7,7 @@
  */
 
 import { atom, host, queryClient, useQuery, useValue } from '@hermes/plugin-sdk'
+import { useEffect } from 'react'
 
 import { displayName } from './labels'
 import {
@@ -633,6 +634,27 @@ interface UnionRoster {
 
 export function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
+  const activeProfile = String(useValue(host.state.profile) || 'default').trim() || 'default'
+
+  // The five-second roster refresh is recurring ownership, not a succession
+  // of unrelated one-shot requests. Keep its profile socket leased for this
+  // query observer's lifetime so a background profile does not dial and tear
+  // down a fresh WebSocket on every tick. Explicit remote sources retain their
+  // composite route; the local/legacy path uses the bare-profile pool.
+  useEffect(() => {
+    if (typeof host.retainProfileSocket !== 'function') {
+      return undefined
+    }
+
+    const connectionId = String(activeConnectionId || '').trim()
+
+    const route: ProfileRoute | string =
+      connectionId && connectionId !== 'local'
+        ? { connectionId, mode: 'remote', profile: activeProfile, targetProfile: activeProfile }
+        : activeProfile
+
+    return host.retainProfileSocket(route)
+  }, [activeConnectionId, activeProfile])
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
@@ -664,9 +686,7 @@ export function useRoster() {
 
       // Owner routing is ambient in the SDK now (post-#92731): requestForBot
       // resolves the active owner itself, no captured route needed here.
-      const activeBot = {
-        name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
-      }
+      const activeBot = { name: activeProfile }
 
       const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
       // Newer backends inject the teammate-messaging protocol into every

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -648,10 +648,11 @@ export function useRoster() {
   // The five-second roster refresh is recurring ownership, not a succession
   // of unrelated one-shot requests. Keep its profile socket leased for this
   // query observer's lifetime so a background profile does not dial and tear
-  // down a fresh WebSocket on every tick. Explicit remote sources retain their
-  // composite route; the local/legacy path uses the bare-profile pool.
+  // down a fresh WebSocket on every tick. Only explicit routes need this:
+  // string routes poll through the ambient active gateway, which is already
+  // held and must not create an unused legacy/profile-keyed secondary.
   useEffect(() => {
-    if (typeof host.retainProfileSocket !== 'function') {
+    if (typeof rosterRoute === 'string' || typeof host.retainProfileSocket !== 'function') {
       return undefined
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -7,7 +7,7 @@
  */
 
 import { atom, host, queryClient, useQuery, useValue } from '@hermes/plugin-sdk'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { displayName } from './labels'
 import {
@@ -635,6 +635,15 @@ interface UnionRoster {
 export function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
   const activeProfile = String(useValue(host.state.profile) || 'default').trim() || 'default'
+  const connectionId = String(activeConnectionId || '').trim()
+
+  const rosterRoute = useMemo<ProfileRoute | string>(
+    () =>
+      connectionId && connectionId !== 'local'
+        ? { connectionId, mode: 'remote', profile: activeProfile, targetProfile: activeProfile }
+        : activeProfile,
+    [connectionId, activeProfile]
+  )
 
   // The five-second roster refresh is recurring ownership, not a succession
   // of unrelated one-shot requests. Keep its profile socket leased for this
@@ -646,18 +655,11 @@ export function useRoster() {
       return undefined
     }
 
-    const connectionId = String(activeConnectionId || '').trim()
-
-    const route: ProfileRoute | string =
-      connectionId && connectionId !== 'local'
-        ? { connectionId, mode: 'remote', profile: activeProfile, targetProfile: activeProfile }
-        : activeProfile
-
-    return host.retainProfileSocket(route)
-  }, [activeConnectionId, activeProfile])
+    return host.retainProfileSocket(rosterRoute)
+  }, [rosterRoute])
 
   return useQuery({
-    queryKey: [...ROSTER_KEY, activeConnectionId],
+    queryKey: [...ROSTER_KEY, activeConnectionId, activeProfile],
     queryFn: async () => {
       // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
       // against each bot's last local meta write, and a fetch issued before
@@ -684,11 +686,16 @@ export function useRoster() {
         }
       }
 
-      // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-      // resolves the active owner itself, no captured route needed here.
-      const activeBot = { name: activeProfile }
+      // Route the recurring request through the exact socket lease held above.
+      // A name-only bot would make requestForBot use the ambient active socket,
+      // leaving the retained secondary unused and allowing the real request path
+      // to keep dialing and disposing between polls.
 
-      const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+      const local =
+        typeof host.requestProfile === 'function'
+          ? await host.requestProfile<RosterSnapshot>(rosterRoute, 'profiles.list', {})
+          : await requestForBot<RosterSnapshot>({ name: activeProfile }, 'profiles.list', {})
+
       // Newer backends inject the teammate-messaging protocol into every
       // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
       // carry a second copy. Older gateways lack the flag: keep appending.

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -659,7 +659,7 @@ export function useRoster() {
   }, [rosterRoute])
 
   return useQuery({
-    queryKey: [...ROSTER_KEY, activeConnectionId, activeProfile],
+    queryKey: [...ROSTER_KEY, activeConnectionId],
     queryFn: async () => {
       // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
       // against each bot's last local meta write, and a fetch issued before
@@ -692,7 +692,7 @@ export function useRoster() {
       // to keep dialing and disposing between polls.
 
       const local =
-        typeof host.requestProfile === 'function'
+        typeof rosterRoute !== 'string' && typeof host.requestProfile === 'function'
           ? await host.requestProfile<RosterSnapshot>(rosterRoute, 'profiles.list', {})
           : await requestForBot<RosterSnapshot>({ name: activeProfile }, 'profiles.list', {})
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1268,15 +1268,18 @@ export const host = {
     timeoutMs?: number
   ): Promise<T> => requestPluginProfile<T>(route, method, params, timeoutMs),
 
-  /** Pin a route's pooled gateway socket open across repeated `requestProfile`
-   *  calls (#93594: the bot-relay drain loop was dialing and tearing down a
+  /** Pin a route's pooled gateway socket open across repeated profile polls
+   *  (#93594: the bot-relay drain loop was dialing and tearing down a
    *  fresh WebSocket per registered connection per tick). Returns a once-only
-   *  release. Local routes are exempt (no-op release) so the idle reaper can
-   *  still reclaim spawned local backends. Feature-detect on older desktops
-   *  (`typeof host.retainProfileSocket === 'function'`). */
+   *  release. The bare-profile overload retains the legacy/local profile pool;
+   *  explicit registry-local routes stay exempt so the idle reaper can still
+   *  reclaim spawned backends. Feature-detect on older desktops. */
   retainProfileSocket: (route: PluginProfileRoute | string): (() => void) => {
-    if (typeof route === 'string' || !route) {
-      // Bare-profile compatibility overload: local/legacy routing — exempt.
+    if (typeof route === 'string') {
+      return retainGatewayForRelay(null, route.trim() || 'default')
+    }
+
+    if (!route) {
       return () => undefined
     }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -117,6 +117,7 @@ vi.mock('@/store/gateway', async () => {
       params,
       profile
     })),
+    retainGatewayForRelay: vi.fn(() => vi.fn()),
     retireLocalProfileGateways: vi.fn()
   }
 })
@@ -132,6 +133,7 @@ const {
   openGatewayForProfile,
   requestGatewayForAgent,
   requestGatewayForProfile,
+  retainGatewayForRelay,
   retireLocalProfileGateways
 } = await import('@/store/gateway')
 
@@ -545,6 +547,14 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).toHaveBeenCalledWith('legacy-worker', 'profiles.list', {
       include_sessions: true
     })
+  })
+
+  it('retains a profile-only socket for recurring plugin polls', () => {
+    const release = vi.fn()
+    vi.mocked(retainGatewayForRelay).mockReturnValueOnce(release)
+
+    expect(host.retainProfileSocket('legacy-worker')).toBe(release)
+    expect(retainGatewayForRelay).toHaveBeenCalledWith(null, 'legacy-worker')
   })
 
   it('rejects a profile-only request when the current registry makes it ambiguous', async () => {

--- a/apps/desktop/src/store/gateway-relay-retention.test.ts
+++ b/apps/desktop/src/store/gateway-relay-retention.test.ts
@@ -152,18 +152,31 @@ describe('bot-relay gateway retention (#93594)', () => {
     expect(gatewayMocks.constructions).toBe(2)
   })
 
-  it('local routes are exempt: retention is a no-op so the idle reaper can reclaim spawned backends', () => {
-    // Pinning a local route would keep the secondaries touch-loop pinging its
-    // Electron-spawned backend forever, defeating the idle reaper
-    // (gateway.ts local-backend lifecycle). Both the null/legacy and explicit
-    // `local` source ids must decline the pin.
-    const releaseNull = retainGatewayForRelay(null, 'research')
+  it('retains a plain profile socket across recurring roster requests', async () => {
+    const release = retainGatewayForRelay(null, 'research')
+
+    for (let tick = 0; tick < 5; tick += 1) {
+      await requestGatewayForAgent(null, 'research', 'profiles.list', {})
+    }
+
+    expect(gatewayMocks.constructions).toBe(1)
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(1)
+
+    release()
+
+    await requestGatewayForAgent(null, 'research', 'profiles.list', {})
+    expect(gatewayMocks.constructions).toBe(2)
+  })
+
+  it('explicit registry-local routes remain exempt so the idle reaper can reclaim spawned backends', () => {
+    // Pinning an explicit local registry route would keep the secondaries
+    // touch-loop pinging its Electron-spawned backend forever, defeating the
+    // idle reaper (gateway.ts local-backend lifecycle).
     const releaseLocal = retainGatewayForRelay('local', 'research')
 
     // No entry was created or pinned — nothing dials, nothing retains.
     expect(gatewayMocks.constructions).toBe(0)
 
-    releaseNull()
     releaseLocal()
   })
 })

--- a/apps/desktop/src/store/gateway-relay-retention.test.ts
+++ b/apps/desktop/src/store/gateway-relay-retention.test.ts
@@ -46,9 +46,11 @@ const {
   closeSecondaryGateways,
   configureGatewayRegistry,
   pruneSecondaryGateways,
+  reconnectSecondaryGateways,
   requestGatewayForAgent,
   retainGatewayForRelay,
-  setPrimaryGateway
+  setPrimaryGateway,
+  setPrimaryGatewayConnectionId
 } = await import('./gateway')
 
 const agentConn = {
@@ -166,6 +168,25 @@ describe('bot-relay gateway retention (#93594)', () => {
 
     await requestGatewayForAgent(null, 'research', 'profiles.list', {})
     expect(gatewayMocks.constructions).toBe(2)
+  })
+
+  it('does not retain an unused secondary for the plain primary profile', () => {
+    const release = retainGatewayForRelay(null, 'default')
+
+    reconnectSecondaryGateways()
+    expect(gatewayMocks.constructions).toBe(0)
+
+    release()
+  })
+
+  it('does not retain an unused secondary for the primary registry route', () => {
+    setPrimaryGatewayConnectionId('homelab')
+    const release = retainGatewayForRelay('homelab', 'default')
+
+    reconnectSecondaryGateways()
+    expect(gatewayMocks.constructions).toBe(0)
+
+    release()
   })
 
   it('explicit registry-local routes remain exempt so the idle reaper can reclaim spawned backends', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -979,25 +979,23 @@ function drainPendingConnectionRedial(entry: Secondary): boolean {
 }
 
 /**
- * Pin the pooled socket for one relay route open across drain ticks. Returns
- * a once-only release. Local routes (null/empty or explicit `local` source)
- * are deliberately EXEMPT and get a no-op release: their Electron-spawned
- * backend answers to the idle reaper, and a relay pin would keep the
- * touch-loop pinging it forever, resurrecting backends the reaper is meant to
- * reclaim (see the retireLocalProfileGateways note). Local relay traffic is
- * either the primary socket (no churn) or a short-lived local dial — never
- * the remote reconnect flood this retention exists to stop.
+ * Pin one pooled socket open across recurring plugin polls. Returns a
+ * once-only release. A null connection id is the legacy/plain-profile pool,
+ * where background Bot roster requests otherwise dial and dispose the same
+ * socket every five seconds. Explicit registry-local routes remain exempt:
+ * their Electron-spawned backend answers to the idle reaper, and a pin would
+ * keep the touch-loop pinging it forever (see retireLocalProfileGateways).
  */
 export function retainGatewayForRelay(connectionId: null | string, profile: string): () => void {
   const key = normKey(profile)
   const connection = String(connectionId ?? '').trim()
 
-  if (!connection || connection === 'local') {
+  if (connection === 'local') {
     return () => undefined
   }
 
   const scope = registryBackendScopeKey(connection, key)
-  const entry = g.secondaries.get(scope) ?? createSecondary(key, connection)
+  const entry = g.secondaries.get(scope) ?? createSecondary(key, connection || null)
 
   if (!Number.isFinite(entry.relayRetainCount)) {
     entry.relayRetainCount = 0

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -990,7 +990,11 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
   const key = normKey(profile)
   const connection = String(connectionId ?? '').trim()
 
-  if (connection === 'local') {
+  if (
+    connection === 'local' ||
+    (!connection && key === g.primaryProfile) ||
+    (Boolean(connection) && isPrimaryRegistryRoute(connection, key))
+  ) {
     return () => undefined
   }
 


### PR DESCRIPTION
## What does this PR do?

Bot Mode no longer opens and closes a fresh WebSocket for each background profile on every five-second roster refresh. The roster hook now holds one profile-scoped socket lease for the query observer lifetime and releases it on unmount, eliminating repeated connection churn while preserving the idle-reaper exemption for explicit registry-local routes.

### Symptom

With Bot Mode mounted on a multi-profile Desktop, background profile gateway logs show a WebSocket accepted, one JSON-RPC request, and a client-side close about every five seconds.

### Impact

Affected multi-profile Desktop sessions generate continuous gateway connection churn and log noise. Each dial also transitions the profile connection state through `connecting`, which can disrupt UI bound to that state.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/data.ts:634` / `useRoster()` with its five-second `refetchInterval`.

**Causal chain:**
1. Bot Mode keeps the roster query mounted and refreshes `profiles.list` every five seconds.
2. A background profile request uses the plain-profile pooled gateway path, whose per-request lease reaches zero after each response.
3. `apps/desktop/src/store/gateway.ts` disposes that unretained secondary, so the next refresh must construct and connect another WebSocket.

**Why it is wrong:** A recurring query is one long-lived consumer, but it was represented as unrelated one-shot socket ownership on every refresh.

**Working sibling / contrast:** The bot relay already uses counted route retention across its recurring drain loop, so repeated requests reuse one pooled socket and release it when the consumer stops.

**Ruled out:** The five-second React Query timer is not itself the defect. Removing or lengthening it would weaken roster freshness while leaving the socket ownership mismatch intact.

### Fix

- Retain the active roster profile socket in `useRoster()` for the React query observer lifetime, with cleanup on unmount and route changes.
- Extend the profile-only `retainProfileSocket` SDK overload to retain the plain-profile pool.
- Keep explicit registry-local routes exempt so Electron's local-backend idle reaper remains authoritative.
- Add behavioral tests that prove five recurring requests construct one socket while retained, cleanup restores disposal, and the roster hook releases its lease.

## Related Issue

Fixes #99336

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/data.ts` - retain the roster socket for the query observer lifetime.
- `apps/desktop/src/sdk/index.ts` - route profile-only retention into the plain-profile gateway pool.
- `apps/desktop/src/store/gateway.ts` - allow counted retention for plain-profile secondaries while preserving the explicit local-source exemption.
- Focused Bot Mode, SDK routing, and gateway retention tests cover acquisition, reuse, release, and unmount cleanup.

## How to Test

1. Automated:

```bash
cd apps/desktop
npx vitest run src/plugins/hermes-bots src/store/gateway-relay-retention.test.ts src/sdk/profile-routing.test.ts
npm run typecheck
```

2. Manual packaged-app verification: open Bot Mode with multiple profiles and inspect a background profile's `gui.log` across several roster intervals. The profile should keep one WebSocket instead of logging a new accept/close pair every five seconds.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated behavior on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the behavior is internal lifecycle management
- [x] Config example update is N/A; no config keys changed
- [x] Architecture guide update is N/A; the existing pooled-socket contract is preserved
- [x] I've considered Windows and macOS lifecycle impact
- [x] Tool schema update is N/A; no model tool behavior changed
