### PR TITLE
fix(desktop): preserve scroll position on same-session transcript refresh

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -10,6 +10,7 @@ import {
   type MessageGroup,
   resolveThreadScrollTarget,
   shouldClampTranscriptBudget,
+  shouldRePinOnTranscriptReload,
   subscribeToThreadForeground,
   transcriptBackfillFrameCount,
   transcriptPaneBudget
@@ -327,5 +328,25 @@ describe('liveTailStart', () => {
 describe('transcriptBackfillFrameCount', () => {
   it('settles a full pane in at most three prepend commits', () => {
     expect(transcriptBackfillFrameCount()).toBeLessThanOrEqual(3)
+  })
+})
+
+describe('shouldRePinOnTranscriptReload', () => {
+  it('pins on a session switch even before the transcript has settled', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: true, settledNonEmpty: false })).toBe(true)
+  })
+
+  it('pins on a session switch even when the prior session had settled', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: true, settledNonEmpty: true })).toBe(true)
+  })
+
+  it('preserves the reader position on a same-session refresh after settling', () => {
+    // The bug case: a transcript that briefly empties and repopulates under
+    // the SAME sessionKey must NOT re-pin a scrolled-up reader to the bottom.
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: true })).toBe(false)
+  })
+
+  it('pins on a cold-load arrival (same session, never settled non-empty)', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: false })).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -138,6 +138,17 @@ export const resolveThreadScrollTarget: GetTargetScrollTop = (targetScrollTop, {
   return remaining >= 0 && remaining <= SCROLL_TARGET_EPSILON_PX ? currentScrollTop : targetScrollTop
 }
 
+// Returns true when the pin-to-bottom effect should re-arm (pin to bottom),
+// false when it should preserve the reader's position.
+export function shouldRePinOnTranscriptReload(opts: {
+  sessionSwitched: boolean
+  settledNonEmpty: boolean
+}): boolean {
+  if (opts.sessionSwitched) return true
+  if (opts.settledNonEmpty) return false
+  return true
+}
+
 export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
   let frameId: number | null = null
   let framePending = false
@@ -469,6 +480,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // Session the settle loop last armed for, so a re-arm within the same load
   // is distinguishable from a switch to a different transcript.
   const settleKeyRef = useRef(sessionKey)
+  // True once the CURRENT session has settled with a non-empty transcript.
+  // A same-session refresh (transcript briefly cleared and repopulated under
+  // the same key) must preserve the reader's scroll position rather than
+  // re-pin to the bottom; only a session switch or a cold-load arrival re-arms.
+  const settledNonEmptyRef = useRef(false)
 
   // Record where the view should land once a prepend has grown the content,
   // measured from the BOTTOM so the added height doesn't invalidate it. Only a
@@ -646,6 +662,20 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       return
     }
 
+    // A same-session refresh (transcript briefly cleared and repopulated under
+    // the same key) must preserve the reader's position, not re-pin to the
+    // bottom. Only a session switch or a cold-load arrival re-arms. This must
+    // run BEFORE stopScroll / scrollTop / loadSettledRef reset so a refresh
+    // neither yanks the view nor clears the settled flag.
+    if (
+      !shouldRePinOnTranscriptReload({
+        sessionSwitched: settleKeyRef.current !== sessionKey,
+        settledNonEmpty: settledNonEmptyRef.current
+      })
+    ) {
+      return
+    }
+
     stopScroll()
     el.scrollTop = el.scrollHeight
     loadSettledRef.current = false
@@ -680,6 +710,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       // frames to minimize the settle-loop racing markdown paint on every switch.
       if (stableFrames >= 2 || ++frame > 15) {
         void scrollToBottom('instant')
+        settledNonEmptyRef.current = hasGroups
         loadSettledRef.current = true
 
         return


### PR DESCRIPTION
## Summary

Fixes #99338 — the desktop thread view force-scrolls to the bottom on a same-session transcript refresh (context compaction, gateway reconnect re-fetch, or any event that briefly empties and repopulates the message list), yanking a scrolled-up reader back to the latest message.

## Root cause

`apps/desktop/src/components/assistant-ui/thread/list.tsx` — the pin-to-bottom `useLayoutEffect` has `hasGroups` (`groups.length > 0`) in its dependency array. `hasGroups` flips `false -> true` in two situations the effect cannot tell apart:

1. **Cold-load arrival** — a session switch happened while the transcript was still empty; the transcript arrives a moment later (should pin to bottom).
2. **Same-session refresh** — the transcript is briefly cleared and repopulated with the SAME `sessionKey` (compaction / re-fetch). The flip should PRESERVE the user's scroll position, but the effect unconditionally runs `el.scrollTop = el.scrollHeight` + a settle loop that pins to bottom.

## Changes

- Added a pure, exported helper `shouldRePinOnTranscriptReload({ sessionSwitched, settledNonEmpty })` that encodes the decision: session switch → pin; same session + already settled non-empty → preserve; same session + never settled (cold-load arrival) → pin.
- Added a `settledNonEmptyRef` that is set to `hasGroups` in the settle loop, so it only becomes true once the transcript actually rendered content.
- The pin-to-bottom effect now early-returns (before `stopScroll` / `scrollTop` / `loadSettledRef` reset) when the reload is a same-session refresh of an already-settled transcript, preserving the reader's position.

## Tests

- Added 4 unit tests for `shouldRePinOnTranscriptReload` covering the full truth table, including the bug case (same-session refresh after settling must NOT re-pin).
- Scroll mechanics are deliberately not unit-tested in jsdom (see `streaming.test.tsx` — "brittle change-detector tests"), so the decision logic is tested as a pure function.
- `npx vitest run --project ui src/components/assistant-ui/thread/list.test.ts` → 32 passed (28 pre-existing + 4 new).
- `npx tsc --noEmit` → clean.
- Revert-to-buggy proof: with the helper returning `true` unconditionally, the bug-case test fails (`expected true to be false`); restored, all pass.

Closes #99338
