### PR TITLE
fix(windows): resolve shell file operations in one path namespace

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -255,16 +255,20 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
+        from tools.environments.local import _find_bash
+
         completed = subprocess.run(
-            command,
-            shell=True,
-            text=True,
+            [_find_bash(), "-c", command],
             capture_output=True,
-            input=kwargs.get("stdin_data"),
+            input=(
+                kwargs["stdin_data"].encode("utf-8")
+                if kwargs.get("stdin_data") is not None
+                else None
+            ),
         )
-        output = completed.stdout
+        output = completed.stdout.decode("utf-8", errors="replace")
         if include_stderr:
-            output += completed.stderr
+            output += completed.stderr.decode("utf-8", errors="replace")
         return {
             "output": output,
             "returncode": completed.returncode,
@@ -586,6 +590,7 @@ class _DeletedTestGitBaselineCheck:
 # Atomic write: umask-default permissions for new files
 # =========================================================================
 
+@pytest.mark.linux_only
 class TestAtomicWriteNewFilePermissions:
     """_atomic_write should apply umask-default perms to new files (not 0600)."""
 

--- a/tests/tools/test_file_ops_cwd_tracking.py
+++ b/tests/tools/test_file_ops_cwd_tracking.py
@@ -45,15 +45,15 @@ class _FakeEnv:
             return {"output": "", "returncode": 0}
         # Actually run the command — handle stdin via subprocess
         stdin_data = kwargs.get("stdin_data")
+        from tools.environments.local import _find_bash
         proc = subprocess.run(
-            ["bash", "-c", command],
+            [_find_bash(), "-c", command],
             cwd=cwd or self.cwd,
-            input=stdin_data,
+            input=stdin_data.encode("utf-8") if stdin_data is not None else None,
             capture_output=True,
-            text=True,
         )
         return {
-            "output": proc.stdout + proc.stderr,
+            "output": (proc.stdout + proc.stderr).decode("utf-8", errors="replace"),
             "returncode": proc.returncode,
         }
 
@@ -96,7 +96,8 @@ class TestShellFileOpsCwdTracking:
         class _NoCwdEnv:
             def execute(self, command, cwd=None, **kwargs):
                 import subprocess
-                proc = subprocess.run(["bash", "-c", command], cwd=cwd,
+                from tools.environments.local import _find_bash
+                proc = subprocess.run([_find_bash(), "-c", command], cwd=cwd,
                                       capture_output=True, text=True)
                 return {"output": proc.stdout, "returncode": proc.returncode}
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,7 +55,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.normpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -145,7 +148,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.normpath("/tmp/f.py"), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -89,6 +89,7 @@ def test_absolute_terminal_cwd_used_verbatim(_isolated_cwd, monkeypatch):
     assert resolved == (workspace / "target.py")
 
 
+@pytest.mark.linux_only
 def test_container_absolute_input_path_does_not_follow_host_symlink(tmp_path, monkeypatch):
     """Docker paths are sandbox-local and must not be host-dereferenced.
 
@@ -118,6 +119,7 @@ def test_container_path_normalization_uses_posix_path_syntax():
     assert str(resolved) == "/workspace/projects/bar"
 
 
+@pytest.mark.linux_only
 def test_container_relative_path_keeps_container_cwd_symlink(tmp_path, monkeypatch):
     """Relative Docker paths should stay under the container cwd textually."""
     host_project = tmp_path / "host-project"

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -100,8 +100,8 @@ class TestLocalEnvironmentExecute:
 
     def test_cat_deterministic_content(self, env, tmp_path):
         f = tmp_path / "det.txt"
-        f.write_text(SIMPLE_CONTENT)
-        result = env.execute(f"cat {f}")
+        f.write_text(SIMPLE_CONTENT, newline="")
+        result = env.execute(f"cat {env._quote_shell_path(str(f))}")
         assert result["returncode"] == 0
         assert result["output"] == SIMPLE_CONTENT
         _assert_clean(result["output"])
@@ -227,8 +227,9 @@ class TestSearch:
 class TestExpandPath:
     def test_tilde_exact(self, ops):
         result = ops._expand_path("~/test.txt")
-        expected = f"{Path.home()}/test.txt"
-        assert result == expected
+        from tools.environments.local import _msys_to_windows_path
+
+        assert Path(_msys_to_windows_path(result)) == Path.home() / "test.txt"
         _assert_clean(result)
 
 
@@ -263,8 +264,8 @@ class TestTerminalOutputCleanliness:
 
     def test_cat(self, env, tmp_path):
         f = tmp_path / "cat_test.txt"
-        f.write_text("CAT_CONTENT_EXACT\n")
-        result = env.execute(f"cat {f}")
+        f.write_text("CAT_CONTENT_EXACT\n", newline="")
+        result = env.execute(f"cat {env._quote_shell_path(str(f))}")
         assert result["output"] == "CAT_CONTENT_EXACT\n"
         _assert_clean(result["output"])
 

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -291,6 +291,7 @@ class TestAtomicWrite:
         assert [p for p in os.listdir(tmp_path) if ".hermes-tmp" in p] == []
 
 
+    @pytest.mark.linux_only
     def test_patch_routes_through_atomic_write(self, ops, tmp_path: Path):
         target = tmp_path / "edit.py"
         target.write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")

--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -15,6 +15,7 @@ import pytest
 from tools.environments.local import _find_bash, _find_shell
 
 
+@pytest.mark.linux_only
 class TestFindShellPrefersUserShell:
     """_find_shell should prefer $SHELL over bash on POSIX."""
 

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import tools.file_operations as file_operations
-from tools.environments.local import LocalEnvironment
+from tools.environments.local import LocalEnvironment, _bash_safe_path
 from tools.file_operations import ShellFileOperations, _macos_protected_search_exclusions
 
 
@@ -128,7 +128,7 @@ def test_grep_fallback_prunes_by_path_not_basename(tmp_path, monkeypatch):
     for dirname in PROTECTED_NAMES:
         # Path-scoped pruning: full protected path present, no basename-wide
         # --exclude-dir for protected names.
-        assert str(home / dirname) in pruned_command
+        assert _bash_safe_path(str(home / dirname)) in pruned_command
         assert f"--exclude-dir={dirname}" not in pruned_command
         assert f"--exclude-dir='{dirname}'" not in pruned_command
 
@@ -188,7 +188,7 @@ def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):
     find_commands = [command for command in env.commands if command.startswith("find ")]
     assert find_commands
     for command in find_commands:
-        assert str(home / "Downloads") in command
+        assert _bash_safe_path(str(home / "Downloads")) in command
         assert "-prune" in command
 
 

--- a/tests/tools/test_read_shell_line_clamp.py
+++ b/tests/tools/test_read_shell_line_clamp.py
@@ -120,7 +120,8 @@ def test_read_file_raw_not_clamped(tmp_path, ops):
     max_len = get_max_line_length()
     p = tmp_path / "long_raw.txt"
     long_line = "z" * (10 * max_len)
-    p.write_text(long_line + "\n")
+    # The assertion targets line clamping, not Windows newline translation.
+    p.write_bytes((long_line + "\n").encode("utf-8"))
     result = ops.read_file_raw(str(p))
     assert result.error is None
     assert result.content == long_line + "\n"

--- a/tests/tools/test_read_special_file_guard.py
+++ b/tests/tools/test_read_special_file_guard.py
@@ -26,11 +26,13 @@ class TestSpecialFileKind:
     def test_missing_path(self, tmp_path):
         assert _special_file_kind(tmp_path / "nope") is None
 
+    @pytest.mark.skipif(os.name == "nt", reason="FIFO stat classes are POSIX-only")
     def test_fifo(self, tmp_path):
         fifo = tmp_path / "p.pipe"
         os.mkfifo(fifo)
         assert "FIFO" in (_special_file_kind(fifo) or "")
 
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-domain socket stat classes are POSIX-only")
     def test_socket(self, tmp_path):
         sock_path = tmp_path / "s.sock"
         s = socket.socket(socket.AF_UNIX)
@@ -40,6 +42,7 @@ class TestSpecialFileKind:
         finally:
             s.close()
 
+    @pytest.mark.skipif(os.name == "nt", reason="FIFO and symlink semantics are POSIX-only")
     def test_symlink_to_fifo_followed(self, tmp_path):
         fifo = tmp_path / "p.pipe"
         os.mkfifo(fifo)
@@ -54,6 +57,7 @@ class TestSpecialFileKind:
 
 
 class TestReadFileToolFifoGuard:
+    @pytest.mark.skipif(os.name == "nt", reason="FIFO reads are POSIX-only")
     def test_fifo_read_returns_note_instantly(self, tmp_path, monkeypatch):
         import time
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1192,6 +1192,16 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    @staticmethod
+    def _escape_shell_literal(arg: str) -> str:
+        r"""Quote a non-path shell argument without Windows path rewriting.
+
+        Regexes legitimately contain backslashes (``\n``, ``\(``, ``\b``).
+        Passing them through ``_escape_shell_arg`` converted those backslashes
+        to path separators on Windows and silently changed the search.
+        """
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Escape a path argument destined for a NATIVE Windows binary.
 
@@ -1427,9 +1437,15 @@ class ShellFileOperations(FileOperations):
         if file_size > self._UTF16_MAX_BYTES:
             return None
 
+        # The path is base64'd, not repr'd. A Windows repr doubles every
+        # separator, and the Git Bash -> native execution layer folds a
+        # doubled separator back to a single one, so the interpreter received
+        # a truncated unicode escape and SyntaxError'd the whole snippet.
+        # Same remedy as ``bot_relay.waiter_command``.
+        encoded_path = base64.b64encode(path.encode("utf-8")).decode("ascii")
         snippet = (
-            "import sys, json, os\n"
-            f"p = {path!r}\n"
+            "import sys, json, os, base64\n"
+            f"p = base64.b64decode({encoded_path!r}).decode('utf-8')\n"
             f"offset = {int(offset)}\n"
             f"limit = {int(limit)}\n"
             f"MAX = {self._UTF16_MAX_BYTES}\n"
@@ -1470,9 +1486,14 @@ class ShellFileOperations(FileOperations):
             "    print('HERMES_UTF16:NO'); sys.exit(0)\n"
         )
 
-        result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
+        # The snippet is Python source, not a path. ``_escape_shell_arg``
+        # runs ``_bash_safe_path`` over its argument, which on Windows
+        # rewrote the snippet's own escape sequences into path separators:
+        # the BOM survived into the output, CRLF was never normalized, and
+        # the line split collapsed every file to total_lines=1.
+        result = self._exec(f"python3 -c {self._escape_shell_literal(snippet)}")
         if result.exit_code != 0 and "python3" in (result.stdout or ""):
-            result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+            result = self._exec(f"python -c {self._escape_shell_literal(snippet)}")
 
         stdout = _strip_terminal_fence_leaks(result.stdout or "")
         marker = stdout.find("HERMES_UTF16:OK")
@@ -2990,7 +3011,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -3007,7 +3028,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -3021,7 +3042,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_literal(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3109,6 +3130,14 @@ class ShellFileOperations(FileOperations):
                 files.append(parts[1])
             else:
                 files.append(line)
+
+        # ``find`` is an MSYS binary on native Windows and reports drive paths
+        # as ``/c/...``.  Return host-native paths just like the ripgrep branch
+        # so callers can feed a result straight back into read/patch, and so the
+        # hidden-descendant filter below compares paths in one namespace.
+        from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
+        if _IS_WINDOWS:
+            files = [_msys_to_windows_path(file_path) for file_path in files]
 
         # For explicit hidden roots, find's path-based filtering excludes every
         # file under the hidden path. Apply descendant filtering after command
@@ -3238,6 +3267,20 @@ class ShellFileOperations(FileOperations):
         multiline = _pattern_has_regex_newline(pattern)
         if multiline:
             cmd_parts.append("--multiline")
+            # Native Windows text files normally contain CRLF. A user-facing
+            # newline regex should match both LF and CRLF, just as Python's text
+            # readers do, instead of silently returning zero matches on Windows.
+            if os.name == "nt" and getattr(self.env, "is_local", False):
+                pattern = _REGEX_NEWLINE_ESCAPE_RE.sub(
+                    lambda match: match.group(0)[:-2] + r"\r?\n",
+                    pattern,
+                ).replace("\n", r"\r?\n")
+        elif os.name == "nt" and getattr(self.env, "is_local", False):
+            # Keep an escaped literal ``\\n`` away from the nested
+            # bash/native-rg boundary: representing the backslash by its hex
+            # code is regex-equivalent and cannot collapse into a newline
+            # escape while the command is forwarded.
+            pattern = pattern.replace(r"\\n", r"\x5cn")
 
         # Add context if requested
         if context > 0:
@@ -3258,7 +3301,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_literal(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3418,7 +3461,7 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_literal(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )
@@ -3467,7 +3510,7 @@ class ShellFileOperations(FileOperations):
             grep_parts.append("-l")
         elif output_mode == "count":
             grep_parts.append("-c")
-        grep_parts.append(self._escape_shell_arg(pattern))
+        grep_parts.append(self._escape_shell_literal(pattern))
 
         prune_terms = " -o ".join(
             f"-path {self._escape_shell_arg(item)}" for item in protected_paths

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -49,7 +49,14 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        if path == "~":
+            return home
+        # A profile home can intentionally describe a POSIX filesystem even
+        # when the gateway itself runs on Windows (Docker/SSH/profile tests).
+        # Do not inject host separators into that foreign path namespace.
+        if home.startswith("/"):
+            return posixpath.join(home, path[2:])
+        return os.path.join(home, path[2:])
     return os.path.expanduser(path)
 
 
@@ -437,9 +444,15 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             resolved.relative_to(root)
             return None  # Inside the workspace — expected.
         except ValueError:
+            # ``repr`` doubles every Windows backslash, making the warning name
+            # a path that cannot be copied or searched.  Preserve the exact path
+            # spelling while still neutralising line-break injection.
+            shown_input = str(filepath).replace("\r", "\\r").replace("\n", "\\n")
+            shown_resolved = str(resolved).replace("\r", "\\r").replace("\n", "\\n")
+            shown_root = str(root).replace("\r", "\\r").replace("\n", "\\n")
             return (
-                f"Relative path {filepath!r} resolved to {str(resolved)!r}, which is "
-                f"OUTSIDE the active workspace ({str(root)!r}). The edit will land in "
+                f"Relative path `{shown_input}` resolved to `{shown_resolved}`, which is "
+                f"OUTSIDE the active workspace (`{shown_root}`). The edit will land in "
                 f"a different directory than the terminal's cwd. If this is not "
                 f"intended (e.g. a git-worktree session writing into the main "
                 f"checkout), pass an absolute path under the workspace instead."
@@ -523,11 +536,16 @@ def _rewrite_v4a_patch_paths_for_host(
 
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd paths that can hang reads."""
-    normalized = os.path.normpath(_expand_tilde(path))
-    if normalized in _BLOCKED_DEVICE_PATHS:
+    expanded = _expand_tilde(path)
+    normalized = os.path.normpath(expanded)
+    # Preserve POSIX semantics lexically even when the gateway runs on Windows
+    # and the target filesystem is a Docker/SSH environment.  ``ntpath`` turns
+    # ``/proc/x`` into ``\\proc\\x`` and previously disabled every guard below.
+    posix_normalized = posixpath.normpath(expanded.replace("\\", "/"))
+    if normalized in _BLOCKED_DEVICE_PATHS or posix_normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
-    if normalized.startswith("/proc/") and normalized.endswith(
+    if posix_normalized.startswith("/proc/") and posix_normalized.endswith(
         ("/fd/0", "/fd/1", "/fd/2")
     ):
         return True
@@ -540,7 +558,7 @@ def _is_blocked_device_path(path: str) -> bool:
     # load addresses — an ASLR oracle on par with maps. /proc/*/pagemap exposes
     # virtual->physical translation. Both are blocked alongside the maps family.
     # endswith matches both /proc/<pid>/X and /proc/<pid>/task/<tid>/X.
-    if normalized.startswith("/proc/") and normalized.endswith(
+    if posix_normalized.startswith("/proc/") and posix_normalized.endswith(
         (
             "/environ",
             "/cmdline",
@@ -565,6 +583,8 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     the final resolved path so aliases to devices cannot bypass the guard.
     """
     expanded = _expand_tilde(filepath)
+    if _is_blocked_device_path(expanded):
+        return True
     if base_dir is not None and not os.path.isabs(expanded):
         expanded = os.path.join(os.fspath(base_dir), expanded)
     normalized = os.path.normpath(expanded)
@@ -688,14 +708,23 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
+    posix_normalized = posixpath.normpath(_expand_tilde(filepath).replace("\\", "/"))
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if (
+            resolved.startswith(prefix)
+            or normalized.startswith(prefix)
+            or posix_normalized.startswith(prefix)
+        ):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if (
+        resolved in _SENSITIVE_EXACT_PATHS
+        or normalized in _SENSITIVE_EXACT_PATHS
+        or posix_normalized in _SENSITIVE_EXACT_PATHS
+    ):
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or


### PR DESCRIPTION
## What does this PR do?

Shell file operations on Windows straddled two path namespaces (Git Bash `/c/...` and native `C:\...`). Three consequences, all fixed here:

**1. `_escape_shell_arg` ran `_bash_safe_path` over every argument.** That is right for a path and wrong for everything else. A search pattern's backslashes became path separators, and the UTF-16 transcode snippet had its own escapes rewritten — so the BOM survived into the output, CRLF was never normalized, and every file reported `total_lines=1`. Non-path arguments now go through `_escape_shell_literal`.

**2. The transcode snippet embedded its target via `repr()`.** A Windows `repr` doubles each separator; the Git Bash → native execution layer folds a doubled separator back to one. The interpreter therefore received a truncated unicode escape and rejected the whole snippet, so some UTF-16 files were reported as `"Binary file"`. The path is now carried as base64 — the same remedy `bot_relay.waiter_command` already uses.

**3. Two guards in `file_tools` were inert on Windows.** `ntpath.normpath` turns `/proc/self/fd/0` into a backslash path, so the device-read and sensitive-path checks never matched. A POSIX view is now normalized alongside the native one, and both are tested.

## Related Issue

No existing issue. Happy to open one first if you would prefer that.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix — points 3: the device-read and sensitive-path guards did not fire on Windows.

## Changes Made

- `tools/file_operations.py` — route non-path arguments through `_escape_shell_literal`; carry the transcode snippet's target as base64.
- `tools/file_tools.py` — normalize a POSIX view alongside the native one so the device-read and sensitive-path guards match on Windows.
- Ten test files updated, including platform exclusions for cases that assume POSIX file types.

## How Has This Been Tested?

Windows 11, CPython 3.11. This branch against its merge base `8fd144c502`, the eight affected test files, same invocation:

| | failed | passed | skipped |
| --- | --- | --- | --- |
| `origin/main` | **32** | 183 | 3 |
| this branch | **0** | 199 | 19 |

**On the sixteen additional skips** — they are not silenced tests. Each carries an explicit platform reason and previously *failed* on Windows because it assumed a POSIX file type:

- `FIFO reads are POSIX-only`, `FIFO stat classes are POSIX-only`
- `Unix-domain socket stat classes are POSIX-only`
- `FIFO and symlink semantics are POSIX-only`
- `no /dev/null`
- `Linux-only test (marked linux_only); host is win32`

**On `scripts/check-windows-footguns.py`** — running it with `--diff origin/main` reports 8 bare `read_text()`/`write_text()` findings in `tests/tools/test_file_operations.py`. These are **pre-existing and untouched**: the same 8 are reported on `origin/main` for the same files, and 0 of the lines this branch adds contain `read_text` or `write_text`. The `--diff` mode scans whole touched files, which is why they surface here. I left them alone to keep this PR to one subject; happy to fix them in a separate PR if you would like.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed.** I have not run the complete suite to completion on this host, so I am not checking this box. The affected files were measured against the base as shown above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, CPython 3.11

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface changes)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the POSIX path is unchanged: `_escape_shell_literal` differs from `_escape_shell_arg` only in that it does not apply path translation, and the added POSIX-view normalization is an additional match, never a replacement.
- [x] Tool descriptions/schemas — N/A
