### PR TITLE
fix(kanban): make default-board dispatch safe and durable

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,10 +1,10 @@
 """Turn-end guard for kanban workers.
 
-Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
-(especially GLM / Qwen families) sometimes narrate the next step
-("Let me write the report now") and stop with ``finish_reason=stop`` and no
-tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
-``protocol_violation``.
+Kanban workers must end with a terminal board tool that hands the card to
+whoever owns it next. Models (especially GLM / Qwen families) sometimes
+narrate the next step ("Let me write the report now") and stop with
+``finish_reason=stop`` and no tool calls. Hermes treats that as a clean
+exit → ``rc=0`` → dispatcher ``protocol_violation``.
 
 This module is policy-only: when a kanban worker tries to finish without a
 terminal board tool, return a bounded synthetic nudge so the conversation
@@ -17,7 +17,21 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+# Every tool that hands the card off and ends this worker's responsibility
+# for it — not just the two that close it out.  A build worker legitimately
+# finishes with ``kanban_request_review`` (goals.py's continuation and
+# finalize prompts tell it to, for code changes needing same-card review),
+# and a review agent finishes with ``kanban_request_changes`` (the
+# force-loaded sdlc-review skill's decision table tells it to).  Both move
+# the task out of ``running``, so treating them as non-terminal fired this
+# guard at a worker that had already done the right thing — nudging it to
+# call ``kanban_complete`` on a card it must not close.
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    "kanban_request_review",
+    "kanban_request_changes",
+})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2829,6 +2829,10 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Finite runtime backstop for tasks without an explicit
+        # max_runtime_seconds. The effective value is persisted on the task
+        # and run when claimed; a per-task cap always wins. Set 0 to disable.
+        "default_max_runtime": 2 * 60 * 60,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2770,6 +2770,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if getattr(args, "json", False):
         print(json.dumps({
+            "dry_run": bool(args.dry_run),
             "reclaimed": res.reclaimed,
             "crashed": res.crashed,
             "timed_out": res.timed_out,
@@ -2789,21 +2790,30 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
-    print(f"Reclaimed:    {res.reclaimed}")
-    print(f"Crashed:      {len(res.crashed)}")
+    if args.dry_run:
+        print(f"Would reclaim: {res.reclaimed}")
+        print(f"Would mark crashed: {len(res.crashed)}")
+        print(f"Would time out: {len(res.timed_out)}")
+        print(f"Would mark stale: {len(res.stale)}")
+        print(f"Would auto-block: {len(res.auto_blocked)}")
+        print(f"Would promote: {res.promoted}")
+        print(f"Would spawn:   {len(res.spawned)}")
+    else:
+        print(f"Reclaimed:    {res.reclaimed}")
+        print(f"Crashed:      {len(res.crashed)}")
+        print(f"Timed out:    {len(res.timed_out)}")
+        print(f"Stale:        {len(res.stale)}")
+        print(f"Auto-blocked: {len(res.auto_blocked)}")
+        print(f"Promoted:     {res.promoted}")
+        print(f"Spawned:      {len(res.spawned)}")
     if res.crashed:
         print(f"  {', '.join(res.crashed)}")
-    print(f"Timed out:    {len(res.timed_out)}")
     if res.timed_out:
         print(f"  {', '.join(res.timed_out)}")
-    print(f"Stale:        {len(res.stale)}")
     if res.stale:
         print(f"  {', '.join(res.stale)}")
-    print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
-    print(f"Promoted:     {res.promoted}")
-    print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
         tag = " (dry)" if args.dry_run else ""
         print(f"  - {tid}  ->  {who}  @ {ws or '-'}{tag}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10888,13 +10888,12 @@ def _default_spawn(
         "chat",
         "-q", prompt,
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
+    # Every dispatcher-owned worker must take the fully-quiet single-query path.
+    # That branch maps structured agent failures to rc=1 and provider quota /
+    # rate-limit failures to rc=75, allowing the existing reap classifier to
+    # distinguish crashes from temporary provider failures. Goal-mode also
+    # installs its continuation loop in this branch.
+    cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -366,6 +366,10 @@ def _fire_dispatch_tick_hook(
 # long single-call MCP workflows.
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
+# Finite safety backstop for tasks that do not set a per-task runtime cap.
+# Operators can set kanban.default_max_runtime to 0 to disable inheritance.
+DEFAULT_MAX_RUNTIME_SECONDS = 2 * 60 * 60
+
 # If a worker's PID is still alive but its ``last_heartbeat_at`` is
 # older than this when ``release_stale_claims`` runs, treat the worker
 # as wedged and reclaim regardless of PID liveness (#29747 gap 3).
@@ -4640,6 +4644,7 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    default_max_runtime = configured_default_max_runtime()
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
@@ -4692,12 +4697,13 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = COALESCE(started_at, ?),
+                   max_runtime_seconds = COALESCE(max_runtime_seconds, ?)
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, default_max_runtime, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -4768,6 +4774,7 @@ def claim_review_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    default_max_runtime = configured_default_max_runtime()
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
@@ -4792,12 +4799,13 @@ def claim_review_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = COALESCE(started_at, ?),
+                   max_runtime_seconds = COALESCE(max_runtime_seconds, ?)
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, default_max_runtime, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -9705,6 +9713,31 @@ def resolve_max_in_progress(configured: Optional[int]) -> Optional[int]:
     return derive_default_max_in_progress()
 
 
+def configured_default_max_runtime() -> Optional[int]:
+    """Return the effective ``kanban.default_max_runtime`` in seconds.
+
+    The shipped fallback is finite. A configured value of 0 explicitly
+    disables inheritance; malformed values fail safe to the shipped default.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        kanban_cfg = (load_config_readonly() or {}).get("kanban", {})
+        raw = kanban_cfg.get(
+            "default_max_runtime",
+            DEFAULT_MAX_RUNTIME_SECONDS,
+        )
+    except Exception:
+        return DEFAULT_MAX_RUNTIME_SECONDS
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_RUNTIME_SECONDS
+    if parsed == 0:
+        return None
+    return parsed if parsed > 0 else DEFAULT_MAX_RUNTIME_SECONDS
+
+
 def configured_max_in_progress() -> Optional[int]:
     """Read ``kanban.max_in_progress`` from config, or None when unset/invalid.
 
@@ -9816,6 +9849,31 @@ def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
         return "unknown"
 
 
+def _preview_dispatch_once(
+    conn: sqlite3.Connection,
+    **kwargs,
+) -> DispatchResult:
+    """Run a dispatch tick against an in-memory snapshot of ``conn``.
+
+    Dry-run must exercise the same promotion, reclaim, timeout, and candidate
+    selection code as a real tick without writing the source database or
+    signalling worker processes. SQLite's backup API includes committed WAL
+    frames in the snapshot while leaving the source connection untouched.
+    """
+    preview = sqlite3.connect(":memory:", isolation_level=None)
+    preview.row_factory = sqlite3.Row
+    try:
+        conn.backup(preview)
+        return _dispatch_once_locked(
+            preview,
+            dry_run=True,
+            preview=True,
+            **kwargs,
+        )
+    finally:
+        preview.close()
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -9846,50 +9904,43 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    def _run_tick() -> DispatchResult:
+        kwargs = {
+            "spawn_fn": spawn_fn,
+            "ttl_seconds": ttl_seconds,
+            "max_spawn": max_spawn,
+            "max_in_progress": max_in_progress,
+            "failure_limit": failure_limit,
+            "stale_timeout_seconds": stale_timeout_seconds,
+            "board": board,
+            "default_assignee": default_assignee,
+            "max_in_progress_per_profile": max_in_progress_per_profile,
+            "reconcile_orphans": reconcile_orphans,
+        }
+        if dry_run:
+            return _preview_dispatch_once(conn, **kwargs)
+        return _dispatch_once_locked(conn, dry_run=False, **kwargs)
+
     try:
         db_path = kanban_db_path(board=board)
     except Exception:
         # Path resolution should never fail, but if it somehow does we
         # must not lose the tick — fall through to an unguarded dispatch
         # rather than dropping work.
-        result = _dispatch_once_locked(
-            conn,
-            spawn_fn=spawn_fn,
-            ttl_seconds=ttl_seconds,
-            dry_run=dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=failure_limit,
-            stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
-            reconcile_orphans=reconcile_orphans,
-        )
+        result = _run_tick()
         _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
         return result
     with _dispatch_tick_lock(db_path) as held:
         if not held:
             result = DispatchResult(skipped_locked=True)
         else:
-            result = _dispatch_once_locked(
-                conn,
-                spawn_fn=spawn_fn,
-                ttl_seconds=ttl_seconds,
-                dry_run=dry_run,
-                max_spawn=max_spawn,
-                max_in_progress=max_in_progress,
-                failure_limit=failure_limit,
-                stale_timeout_seconds=stale_timeout_seconds,
-                board=board,
-                default_assignee=default_assignee,
-                max_in_progress_per_profile=max_in_progress_per_profile,
-                reconcile_orphans=reconcile_orphans,
-            )
+            result = _run_tick()
             # Still under the dispatch lock: run the periodic PASSIVE WAL
             # checkpoint (see _maybe_checkpoint_wal; the -wal file size is
             # bounded by journal_size_limit on the writer's natural reset).
-            _maybe_checkpoint_wal(conn, db_path)
+            # A dry-run must leave the source SQLite files byte-for-byte alone.
+            if not dry_run:
+                _maybe_checkpoint_wal(conn, db_path)
     # The dispatch lock has been released here. Fire the tick observer
     # strictly OUTSIDE the single-writer critical section (#56066 sweeper
     # finding / #64231 disposition): a slow subscriber must never extend
@@ -9912,6 +9963,7 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    preview: bool = False,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -9949,18 +10001,28 @@ def _dispatch_once_locked(
     board. When omitted, the current-board resolution chain is used.
     """
     # Reap zombie children from previously spawned workers. See
-    # reap_worker_zombies() for the full rationale.
-    reap_worker_zombies()
+    # reap_worker_zombies() for the full rationale. Preview runs against an
+    # in-memory snapshot and must not mutate process-lifecycle state.
+    if not preview:
+        reap_worker_zombies()
 
+    def _preview_signal(*_args) -> None:
+        # Simulate an already-gone worker so reclaim/timeout classification is
+        # accurate without signalling or waiting on a real process.
+        raise ProcessLookupError
+
+    signal_fn = _preview_signal if preview else None
     result = DispatchResult()
-    result.reclaimed = release_stale_claims(conn)
+    result.reclaimed = release_stale_claims(conn, signal_fn=signal_fn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
         # bookkeeping is broken (no valid claim, dead/gone worker) that the
         # TTL/crash/stale paths can never see. See reconcile_orphaned_running.
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(
-        conn, stale_timeout_seconds=stale_timeout_seconds,
+        conn,
+        stale_timeout_seconds=stale_timeout_seconds,
+        signal_fn=signal_fn,
     )
     result.crashed = detect_crashed_workers(conn)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
@@ -9979,7 +10041,7 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
-    result.timed_out = enforce_max_runtime(conn)
+    result.timed_out = enforce_max_runtime(conn, signal_fn=signal_fn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -2,7 +2,7 @@
 
 This user service keeps the Hermes **default** Kanban board moving when no long-lived default-profile gateway process owns the embedded dispatcher. It intentionally uses the repository virtual environment and does not set `HERMES_PROFILE`, so Hermes resolves the normal default home (`~/.hermes`).
 
-The daemon runs in standalone `--force` mode because `kanban.dispatch_in_gateway` defaults to enabled. The same daemon singleton lock used by embedded dispatch still prevents two dispatch loops from owning the board at once.
+The daemon runs in standalone `--force` mode because `kanban.dispatch_in_gateway` defaults to enabled. That legacy command does **not** acquire the embedded gateway lock itself, so the unit wraps it with `/usr/bin/flock --no-fork --nonblock /home/anombyte/.hermes/kanban/.dispatcher.lock`. This is the exact lock path used by the gateway and it is **machine-global across profiles**, not per database. A gateway with embedded dispatch accidentally re-enabled therefore contends instead of racing this service; conversely, an embedded dispatcher for any other profile also contends, so keep gateway dispatch disabled when this unit owns the machine-global lock.
 
 ## Install
 
@@ -29,6 +29,9 @@ systemctl --user enable --now hermes-kanban-daemon.service
 systemctl --user status hermes-kanban-daemon.service
 journalctl --user -u hermes-kanban-daemon.service -f
 hermes kanban --board default list --json
+# While the service is active this must exit non-zero: the shared lock is held.
+/usr/bin/flock --no-fork --nonblock \
+  /home/anombyte/.hermes/kanban/.dispatcher.lock /usr/bin/true
 ```
 
 A normal verbose tick reports promoted, spawned, skipped and running counts. A zero-spawn tick is not evidence by itself that the daemon is healthy; prove it with a reversible default-board task and read back the corresponding task/run records.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -2,7 +2,7 @@
 
 This user service keeps the Hermes **default** Kanban board moving when no long-lived default-profile gateway process owns the embedded dispatcher. It intentionally uses the repository virtual environment and does not set `HERMES_PROFILE`, so Hermes resolves the normal default home (`~/.hermes`).
 
-The daemon runs in standalone `--force` mode because `kanban.dispatch_in_gateway` defaults to enabled. That legacy command does **not** acquire the embedded gateway lock itself, so the unit wraps it with `/usr/bin/flock --no-fork --nonblock /home/anombyte/.hermes/kanban/.dispatcher.lock`. This is the exact lock path used by the gateway and it is **machine-global across profiles**, not per database. A gateway with embedded dispatch accidentally re-enabled therefore contends instead of racing this service; conversely, an embedded dispatcher for any other profile also contends, so keep gateway dispatch disabled when this unit owns the machine-global lock.
+The daemon runs in standalone `--force` mode because `kanban.dispatch_in_gateway` defaults to enabled. That legacy command does **not** acquire the embedded gateway lock itself, so the unit wraps it with `/usr/bin/flock --no-fork --nonblock $HOME/.hermes/kanban/.dispatcher.lock`. This is the exact lock path used by the gateway and it is **machine-global across profiles**, not per database. A gateway with embedded dispatch accidentally re-enabled therefore contends instead of racing this service; conversely, an embedded dispatcher for any other profile also contends, so keep gateway dispatch disabled when this unit owns the machine-global lock.
 
 ## Install
 
@@ -31,7 +31,7 @@ journalctl --user -u hermes-kanban-daemon.service -f
 hermes kanban --board default list --json
 # While the service is active this must exit non-zero: the shared lock is held.
 /usr/bin/flock --no-fork --nonblock \
-  /home/anombyte/.hermes/kanban/.dispatcher.lock /usr/bin/true
+  $HOME/.hermes/kanban/.dispatcher.lock /usr/bin/true
 ```
 
 A normal verbose tick reports promoted, spawned, skipped and running counts. A zero-spawn tick is not evidence by itself that the daemon is healthy; prove it with a reversible default-board task and read back the corresponding task/run records.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -1,0 +1,47 @@
+# Default-board Kanban daemon
+
+This user service keeps the Hermes **default** Kanban board moving when no long-lived default-profile gateway process owns the embedded dispatcher. It intentionally uses the repository virtual environment and does not set `HERMES_PROFILE`, so Hermes resolves the normal default home (`~/.hermes`).
+
+The daemon runs in standalone `--force` mode because `kanban.dispatch_in_gateway` defaults to enabled. The same daemon singleton lock used by embedded dispatch still prevents two dispatch loops from owning the board at once.
+
+## Install
+
+Record the current embedded-dispatch setting so rollback can restore the operator's prior choice:
+
+```bash
+PREVIOUS_DISPATCH_IN_GATEWAY="$(hermes config get kanban.dispatch_in_gateway)"
+printf 'Previous kanban.dispatch_in_gateway=%s\n' "$PREVIOUS_DISPATCH_IN_GATEWAY"
+```
+
+When this service is the sole dispatcher, disable embedded gateway dispatch in the default home before enabling it:
+
+```bash
+hermes config set kanban.dispatch_in_gateway false
+install -Dm644 ops/systemd/hermes-kanban-daemon.service \
+  ~/.config/systemd/user/hermes-kanban-daemon.service
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-kanban-daemon.service
+```
+
+## Observe
+
+```bash
+systemctl --user status hermes-kanban-daemon.service
+journalctl --user -u hermes-kanban-daemon.service -f
+hermes kanban --board default list --json
+```
+
+A normal verbose tick reports promoted, spawned, skipped and running counts. A zero-spawn tick is not evidence by itself that the daemon is healthy; prove it with a reversible default-board task and read back the corresponding task/run records.
+
+## Roll back
+
+Stop and remove only this unit, then restore the `kanban.dispatch_in_gateway` value captured before installation:
+
+```bash
+systemctl --user disable --now hermes-kanban-daemon.service
+rm -f ~/.config/systemd/user/hermes-kanban-daemon.service
+systemctl --user daemon-reload
+hermes config set kanban.dispatch_in_gateway "$PREVIOUS_DISPATCH_IN_GATEWAY"
+```
+
+Rollback does not delete the Kanban database, tasks, runs, logs, or worker worktrees.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -36,6 +36,19 @@ hermes kanban --board default list --json
 
 A normal verbose tick reports promoted, spawned, skipped and running counts. A zero-spawn tick is not evidence by itself that the daemon is healthy; prove it with a reversible default-board task and read back the corresponding task/run records.
 
+## Maintenance safety
+
+**Do not stop or restart this unit while it owns active workers.** A live acceptance run showed that stopping the service can terminate a worker it spawned, which the next dispatcher tick correctly records as a crash and may turn into a retry or circuit-breaker block.
+
+There is not yet a first-class drain command. Before planned maintenance, check both running and ready work and wait for the board to quiesce:
+
+```bash
+hermes kanban --board default list --status running --json
+hermes kanban --board default list --status ready --json
+```
+
+If either list is non-empty, do not stop or restart the service. Merely seeing no running cards is not a durable drain barrier: another ready card can be claimed on the next tick.
+
 ## Roll back
 
 Stop and remove only this unit, then restore the `kanban.dispatch_in_gateway` value captured before installation:

--- a/ops/systemd/hermes-kanban-daemon.service
+++ b/ops/systemd/hermes-kanban-daemon.service
@@ -8,7 +8,8 @@ After=network-online.target
 Type=simple
 WorkingDirectory=/home/anombyte/.hermes/hermes-agent
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/anombyte/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main kanban --board default daemon --force --interval 30 --verbose --pidfile %t/hermes-kanban-default.pid
+ExecStartPre=/usr/bin/mkdir -p /home/anombyte/.hermes/kanban
+ExecStart=/usr/bin/flock --no-fork --nonblock /home/anombyte/.hermes/kanban/.dispatcher.lock /home/anombyte/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main kanban --board default daemon --force --interval 30 --verbose --pidfile %t/hermes-kanban-default.pid
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGINT

--- a/ops/systemd/hermes-kanban-daemon.service
+++ b/ops/systemd/hermes-kanban-daemon.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Hermes Kanban daemon (default board)
+Documentation=https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/anombyte/.hermes/hermes-agent
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/anombyte/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main kanban --board default daemon --force --interval 30 --verbose --pidfile %t/hermes-kanban-default.pid
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/ops/systemd/hermes-kanban-daemon.service
+++ b/ops/systemd/hermes-kanban-daemon.service
@@ -6,10 +6,10 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/anombyte/.hermes/hermes-agent
+WorkingDirectory=%h/.hermes/hermes-agent
 Environment=PYTHONUNBUFFERED=1
-ExecStartPre=/usr/bin/mkdir -p /home/anombyte/.hermes/kanban
-ExecStart=/usr/bin/flock --no-fork --nonblock /home/anombyte/.hermes/kanban/.dispatcher.lock /home/anombyte/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main kanban --board default daemon --force --interval 30 --verbose --pidfile %t/hermes-kanban-default.pid
+ExecStartPre=/usr/bin/mkdir -p %h/.hermes/kanban
+ExecStart=/usr/bin/flock --no-fork --nonblock %h/.hermes/kanban/.dispatcher.lock %h/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main kanban --board default daemon --force --interval 30 --verbose --pidfile %t/hermes-kanban-default.pid
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGINT

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -88,3 +88,59 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 
 
 
+
+
+@pytest.mark.parametrize(
+    "tool_name,who",
+    [
+        ("kanban_request_review", "build worker handing off for same-card review"),
+        ("kanban_request_changes", "review agent sending the card back"),
+    ],
+)
+def test_no_nudge_after_handoff_tool(clear_kanban_env, tool_name, who):
+    """Handoff tools end the worker's turn just like complete/block.
+
+    Both move the card out of ``running``, and the worker is told to call
+    them — goals.py's continuation/finalize prompts name
+    ``kanban_request_review``; the force-loaded sdlc-review skill names
+    ``kanban_request_changes``. Nudging afterwards asks a worker that did
+    the right thing to close a card it must not close.
+    """
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_handoff")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool_name, "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True, who
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_nudge_still_fires_for_non_terminal_kanban_tool(clear_kanban_env):
+    """Widening the set must not swallow the case the guard exists for."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Let me open the review next.",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "kanban_comment", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": "kanban_comment", "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is False
+    assert build_kanban_stop_nudge(messages=messages) is not None

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -152,6 +152,21 @@ class TestReconcileOrphanedRunning:
 
 class TestDispatchOnceReconciles:
     def test_dispatch_once_reconciles_orphans(self, conn):
+        """Non-dry-run tick: orphans are durably requeued to ready."""
+        tid = kb.create_task(conn, title="zombie", assignee="w")
+        _orphan_running(conn, tid)
+
+        result = kb.dispatch_once(conn, spawn_fn=lambda *a, **k: (True, ""))
+
+        assert tid in result.reconciled_orphans
+        assert conn.execute(
+            "SELECT status FROM tasks WHERE id=?", (tid,)
+        ).fetchone()["status"] == "ready"
+
+    def test_dispatch_once_dry_run_previews_orphan_reconcile_without_writes(self, conn):
+        """dry_run: the reconciliation is REPORTED (preview) but the source
+        row and the durable event log are left untouched — the same no-write
+        preview contract as every other dispatch_once side effect."""
         tid = kb.create_task(conn, title="zombie", assignee="w")
         _orphan_running(conn, tid)
 
@@ -159,9 +174,13 @@ class TestDispatchOnceReconciles:
                                   dry_run=True)
 
         assert tid in result.reconciled_orphans
+        # Source row untouched: still running, not requeued.
         assert conn.execute(
             "SELECT status FROM tasks WHERE id=?", (tid,)
-        ).fetchone()["status"] == "ready"
+        ).fetchone()["status"] == "running"
+        # No durable `reconciled` event was logged for a preview.
+        assert [e for e in kb.list_events(conn, tid)
+                if e.kind == "reconciled"] == []
 
     def test_dispatch_once_reconcile_can_be_disabled(self, conn):
         """kanban.reconcile_orphans=false plumbs through as

--- a/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
+++ b/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UNIT_PATH = REPO_ROOT / "ops/systemd/hermes-kanban-daemon.service"
+OPS_NOTE_PATH = REPO_ROOT / "ops/systemd/README.md"
+
+
+def _unit_text() -> str:
+    return UNIT_PATH.read_text(encoding="utf-8")
+
+
+def test_default_board_daemon_unit_uses_repo_runtime_and_default_board():
+    text = _unit_text()
+
+    assert "WorkingDirectory=/home/anombyte/.hermes/hermes-agent" in text
+    assert (
+        "ExecStart=/home/anombyte/.hermes/hermes-agent/venv/bin/python "
+        "-m hermes_cli.main kanban --board default daemon"
+    ) in text
+    assert "Environment=HERMES_PROFILE=" not in text
+
+
+def test_default_board_daemon_unit_has_standalone_singleton_runtime_controls():
+    text = _unit_text()
+
+    assert "--force" in text
+    assert "--interval 30" in text
+    assert "--verbose" in text
+    assert "--pidfile %t/hermes-kanban-default.pid" in text
+    assert "Restart=on-failure" in text
+    assert "RestartSec=5" in text
+    assert "KillSignal=SIGINT" in text
+    assert "TimeoutStopSec=30" in text
+
+
+def test_ops_note_documents_install_observe_and_reversible_rollback():
+    text = OPS_NOTE_PATH.read_text(encoding="utf-8")
+
+    for required in (
+        "systemctl --user daemon-reload",
+        "systemctl --user enable --now hermes-kanban-daemon.service",
+        "systemctl --user status hermes-kanban-daemon.service",
+        "journalctl --user -u hermes-kanban-daemon.service",
+        "systemctl --user disable --now hermes-kanban-daemon.service",
+        "kanban.dispatch_in_gateway",
+        "restore",
+    ):
+        assert required in text

--- a/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
+++ b/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
@@ -13,22 +13,23 @@ def _unit_text() -> str:
 def test_default_board_daemon_unit_uses_repo_runtime_and_default_board():
     text = _unit_text()
 
-    assert "WorkingDirectory=/home/anombyte/.hermes/hermes-agent" in text
+    assert "WorkingDirectory=%h/.hermes/hermes-agent" in text
     assert (
         "ExecStart=/usr/bin/flock --no-fork --nonblock "
-        "/home/anombyte/.hermes/kanban/.dispatcher.lock "
-        "/home/anombyte/.hermes/hermes-agent/venv/bin/python "
+        "%h/.hermes/kanban/.dispatcher.lock "
+        "%h/.hermes/hermes-agent/venv/bin/python "
         "-m hermes_cli.main kanban --board default daemon"
     ) in text
+    assert "/home/anombyte" not in text
     assert "Environment=HERMES_PROFILE=" not in text
 
 
 def test_default_board_daemon_unit_has_standalone_singleton_runtime_controls():
     text = _unit_text()
 
-    assert "ExecStartPre=/usr/bin/mkdir -p /home/anombyte/.hermes/kanban" in text
+    assert "ExecStartPre=/usr/bin/mkdir -p %h/.hermes/kanban" in text
     assert "/usr/bin/flock --no-fork --nonblock" in text
-    assert "/home/anombyte/.hermes/kanban/.dispatcher.lock" in text
+    assert "%h/.hermes/kanban/.dispatcher.lock" in text
     assert "--force" in text
     assert "--interval 30" in text
     assert "--verbose" in text
@@ -50,7 +51,7 @@ def test_ops_note_documents_install_observe_and_reversible_rollback():
         "systemctl --user disable --now hermes-kanban-daemon.service",
         "kanban.dispatch_in_gateway",
         "machine-global",
-        "/home/anombyte/.hermes/kanban/.dispatcher.lock",
+        "$HOME/.hermes/kanban/.dispatcher.lock",
         "Do not stop or restart",
         "active workers",
         "hermes kanban --board default list --status running --json",

--- a/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
+++ b/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
@@ -15,7 +15,9 @@ def test_default_board_daemon_unit_uses_repo_runtime_and_default_board():
 
     assert "WorkingDirectory=/home/anombyte/.hermes/hermes-agent" in text
     assert (
-        "ExecStart=/home/anombyte/.hermes/hermes-agent/venv/bin/python "
+        "ExecStart=/usr/bin/flock --no-fork --nonblock "
+        "/home/anombyte/.hermes/kanban/.dispatcher.lock "
+        "/home/anombyte/.hermes/hermes-agent/venv/bin/python "
         "-m hermes_cli.main kanban --board default daemon"
     ) in text
     assert "Environment=HERMES_PROFILE=" not in text
@@ -24,6 +26,9 @@ def test_default_board_daemon_unit_uses_repo_runtime_and_default_board():
 def test_default_board_daemon_unit_has_standalone_singleton_runtime_controls():
     text = _unit_text()
 
+    assert "ExecStartPre=/usr/bin/mkdir -p /home/anombyte/.hermes/kanban" in text
+    assert "/usr/bin/flock --no-fork --nonblock" in text
+    assert "/home/anombyte/.hermes/kanban/.dispatcher.lock" in text
     assert "--force" in text
     assert "--interval 30" in text
     assert "--verbose" in text
@@ -44,6 +49,8 @@ def test_ops_note_documents_install_observe_and_reversible_rollback():
         "journalctl --user -u hermes-kanban-daemon.service",
         "systemctl --user disable --now hermes-kanban-daemon.service",
         "kanban.dispatch_in_gateway",
+        "machine-global",
+        "/home/anombyte/.hermes/kanban/.dispatcher.lock",
         "restore",
     ):
         assert required in text

--- a/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
+++ b/tests/hermes_cli/test_kanban_daemon_systemd_unit.py
@@ -51,6 +51,9 @@ def test_ops_note_documents_install_observe_and_reversible_rollback():
         "kanban.dispatch_in_gateway",
         "machine-global",
         "/home/anombyte/.hermes/kanban/.dispatcher.lock",
+        "Do not stop or restart",
+        "active workers",
+        "hermes kanban --board default list --status running --json",
         "restore",
     ):
         assert required in text

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -213,11 +213,14 @@ def test_dispatch_tick_runs_wal_checkpoint_at_interval(tmp_path, monkeypatch):
     conn = kb.connect(db_path=db_path)
     proxy = _ConnProxy(conn, executed)
     try:
-        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        # dry_run=False: a dry-run tick must NOT checkpoint the source DB
+        # (it runs against an in-memory snapshot), so the cadence contract
+        # under test is the real tick's.
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None)
         assert len(executed) == 1, "first tick should checkpoint"
 
-        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
-        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None)
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None)
         assert len(executed) == 1, "ticks inside the interval must not checkpoint"
 
         # Age the per-path timestamp past the interval → next tick fires.
@@ -225,7 +228,7 @@ def test_dispatch_tick_runs_wal_checkpoint_at_interval(tmp_path, monkeypatch):
         kb._LAST_WAL_CHECKPOINT[key] -= (
             kb._WAL_CHECKPOINT_INTERVAL_SECONDS + 1.0
         )
-        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None)
         assert len(executed) == 2, "tick after the interval should checkpoint"
         # PASSIVE, not TRUNCATE: CLI kanban commands in other processes write
         # to the same board without holding the dispatch flock, so a TRUNCATE

--- a/tests/hermes_cli/test_kanban_dispatch_safety.py
+++ b/tests/hermes_cli/test_kanban_dispatch_safety.py
@@ -1,0 +1,247 @@
+"""Dispatcher safety backstops: honest preview and bounded workers."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    db_path = home / "kanban.db"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db(db_path=db_path)
+    return home
+
+
+def test_dispatch_dry_run_previews_promotion_and_spawn_without_writes(
+    kanban_home: Path,
+    all_assignees_spawnable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = kanban_home / "kanban.db"
+    spawn_calls: list[str] = []
+    monkeypatch.setattr(
+        kb,
+        "reap_worker_zombies",
+        lambda: pytest.fail("dry-run must not reap process state"),
+    )
+
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="eligible preview",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        before_task = dict(conn.execute(
+            "SELECT * FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone())
+        before_events = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+        )]
+        before_backup = kanban_home / "before.db"
+        shutil.copy2(db_path, before_backup)
+
+        def forbidden_spawn(task, workspace, board=None):
+            spawn_calls.append(task.id)
+            return 42
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=forbidden_spawn,
+            dry_run=True,
+            max_spawn=1,
+            reconcile_orphans=False,
+        )
+
+        after_backup = kanban_home / "after.db"
+        shutil.copy2(db_path, after_backup)
+        after_task = dict(conn.execute(
+            "SELECT * FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone())
+        after_events = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+        )]
+
+    assert result.promoted == 1
+    assert result.spawned == [(task_id, "alice", "")]
+    assert spawn_calls == []
+    assert after_task == before_task
+    assert after_events == before_events
+    assert after_backup.read_bytes() == before_backup.read_bytes()
+
+
+def test_claim_inherits_configured_default_runtime_and_explicit_override_wins(
+    kanban_home: Path,
+    all_assignees_spawnable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"kanban": {"default_max_runtime": 7200}},
+    )
+    db_path = kanban_home / "kanban.db"
+
+    with kb.connect(db_path=db_path) as conn:
+        inherited_id = kb.create_task(
+            conn,
+            title="inherits default",
+            assignee="alice",
+        )
+        explicit_id = kb.create_task(
+            conn,
+            title="keeps explicit cap",
+            assignee="alice",
+            max_runtime_seconds=90,
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 42,
+            max_spawn=2,
+            reconcile_orphans=False,
+        )
+        inherited = kb.get_task(conn, inherited_id)
+        explicit = kb.get_task(conn, explicit_id)
+        inherited_run = conn.execute(
+            "SELECT max_runtime_seconds FROM task_runs WHERE task_id = ?",
+            (inherited_id,),
+        ).fetchone()
+        explicit_run = conn.execute(
+            "SELECT max_runtime_seconds FROM task_runs WHERE task_id = ?",
+            (explicit_id,),
+        ).fetchone()
+
+    assert {task_id for task_id, _, _ in result.spawned} == {
+        inherited_id,
+        explicit_id,
+    }
+    assert inherited is not None
+    assert inherited.max_runtime_seconds == 7200
+    assert inherited_run["max_runtime_seconds"] == 7200
+    assert explicit is not None
+    assert explicit.max_runtime_seconds == 90
+    assert explicit_run["max_runtime_seconds"] == 90
+
+
+def test_shipped_default_runtime_and_disable_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hermes_cli import config as config_module
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["kanban"]["default_max_runtime"] == 7200
+
+    cases = [
+        ({"kanban": {"default_max_runtime": 1800}}, 1800),
+        ({"kanban": {"default_max_runtime": "900"}}, 900),
+        ({"kanban": {"default_max_runtime": 0}}, None),
+        ({"kanban": {"default_max_runtime": "invalid"}}, 7200),
+        ({"kanban": {}}, 7200),
+    ]
+    for config, expected in cases:
+        monkeypatch.setattr(
+            config_module,
+            "load_config_readonly",
+            lambda value=config: value,
+        )
+        assert kb.configured_default_max_runtime() == expected
+
+
+def test_inherited_runtime_is_enforced(
+    kanban_home: Path,
+    all_assignees_spawnable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"kanban": {"default_max_runtime": 1}},
+    )
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    db_path = kanban_home / "kanban.db"
+    signals: list[tuple[int, int]] = []
+
+    with kb.connect(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="times out", assignee="alice")
+        kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 999_998,
+            max_spawn=1,
+            reconcile_orphans=False,
+        )
+        conn.execute(
+            "UPDATE task_runs SET started_at = 0 WHERE task_id = ?",
+            (task_id,),
+        )
+        timed_out = kb.enforce_max_runtime(
+            conn,
+            signal_fn=lambda pid, sig: signals.append((pid, sig)),
+        )
+        task = kb.get_task(conn, task_id)
+        run = conn.execute(
+            "SELECT max_runtime_seconds, outcome FROM task_runs WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'timed_out' ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+
+    assert timed_out == [task_id]
+    assert signals
+    assert task is not None
+    assert task.status == "ready"
+    assert task.max_runtime_seconds == 1
+    assert run["max_runtime_seconds"] == 1
+    assert run["outcome"] == "timed_out"
+    assert '"limit_seconds": 1' in event["payload"]
+
+
+def test_fixture_pins_scratch_database(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inherited live-board override must never escape the test fixture."""
+    db_path = kanban_home / "kanban.db"
+
+    assert kb.kanban_db_path() == db_path
+    assert kb.get_current_board() == "default"
+
+
+def test_cli_dry_run_labels_preview_honestly(
+    kanban_home: Path,
+    all_assignees_spawnable,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from hermes_cli import kanban as kanban_cli
+
+    with kb.connect(db_path=kanban_home / "kanban.db") as conn:
+        kb.create_task(
+            conn,
+            title="CLI preview",
+            assignee="alice",
+            initial_status="blocked",
+        )
+
+    args = argparse.Namespace(dry_run=True, max=1, failure_limit=2, json=False)
+    assert kanban_cli._cmd_dispatch(args) == 0
+    output = capsys.readouterr().out
+
+    assert "Would promote: 1" in output
+    assert "Would spawn:   1" in output

--- a/tests/hermes_cli/test_kanban_worker_terminal_failure_exit.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_failure_exit.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def _make_task(kb):
+    return kb.Task(
+        id="t_terminal_failure",
+        title="terminal failure exits",
+        body=None,
+        assignee="worker",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=1,
+        goal_mode=False,
+    )
+
+
+def test_normal_kanban_worker_uses_fully_quiet_failure_propagation(monkeypatch, tmp_path):
+    """A non-goal worker must propagate structured terminal failures to its exit code."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kb._default_spawn(_make_task(kb), str(workspace))
+
+    chat_index = captured["cmd"].index("chat")
+    assert captured["cmd"][chat_index:] == [
+        "chat",
+        "-q",
+        "work kanban task t_terminal_failure",
+        "-Q",
+    ]

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -787,18 +787,26 @@ All commands are also available as a slash command in the interactive CLI and in
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
+`hermes kanban dispatch --dry-run` runs the normal dependency-promotion,
+recovery, timeout, and candidate-selection logic against an in-memory SQLite
+snapshot. It reports what would be promoted or spawned but does not update task
+rows, append events, claim work, signal workers, call the spawn function, or
+checkpoint the source database. JSON output includes `"dry_run": true`.
+
 ### Concurrency, scheduling, and child promotion config
 
 | Config key | Default | What it does |
 |------------|---------|--------------|
 | `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
+| `kanban.default_max_runtime` | `7200` (2 hours) | Finite backstop for tasks created without `--max-runtime`. The effective value is written to both the task and its run when claimed, so timeout evidence is explicit. A task's own `--max-runtime` always wins. Set `0` to disable default inheritance. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
 ```yaml
 kanban:
   max_in_progress: 2
+  default_max_runtime: 7200
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```


### PR DESCRIPTION
## Summary

- make `kanban dispatch --dry-run` a true no-write preview by running the tick against an in-memory SQLite snapshot while preserving honest would-promote/would-spawn output
- send dispatcher-owned workers through the existing `chat -Q` exit-status path so structured terminal/provider failures become non-zero process exits, and persist a finite 7200-second default runtime backstop
- treat review-handoff tools as terminal in the Kanban stop guard (preserving the contributor authorship from #97753)
- add a portable default-board user systemd service that owns the same machine-global dispatcher lock as embedded gateway dispatch, plus install/rollback and active-worker maintenance guidance

Closes #94916.
Supersedes #97753 while preserving its contributor-authored patch as commit `7ebb7c957`.

## Why

The previous dry-run mutated readiness/events before claiming it was only previewing work. Dispatcher workers used ordinary `chat -q`, where a structured `failed=True` response could still print and exit zero. There was also no dedicated, singleton-safe default-board service or finite runtime backstop.

The standalone `kanban daemon --force` path deliberately bypasses the gateway singleton, so the service must take that exact lock externally. This branch uses portable systemd `%h` paths and documents that stopping the service while it owns workers can terminate those workers; operators must wait for both running and ready queues to quiesce.

## Verification

- post-rebase focused/adjacent gate on base `64b96bb5d`: `145 passed, 1 skipped`
- daemon unit/docs gate after the maintenance and portability corrections: `3 passed`
- Ruff on every changed Python/test path: PASS
- `git diff --check`: PASS
- `systemd-analyze verify` on the portable unit: PASS
- full union on the immediately preceding base `fa2dd2802`: `571 passed, 13 skipped, 18 failed — exact established baseline set; all 18 pass when isolated`; the three later upstream commits touched none of this PR's paths, and the post-rebase focused gate is green
- independent verifier refused two earlier candidates (missing singleton lock; stale dry-run mutation test) before returning PASS

## Live acceptance on Linux user systemd

- installed unit active+enabled; embedded gateway dispatch disabled
- active service rejected a competing lock attempt (`rc=1`); stopped service released it (`rc=0`)
- automatic default-board card: daemon claimed without manual dispatch, persisted omitted runtime as 7200 seconds, spawned, heartbeated, and completed
- SIGKILL probe: run 1 crashed and automatically retried; run 2 crashed and tripped the per-task circuit breaker
- isolated closed-endpoint profile: three connection retries, wrapper exit `1`, daemon recorded `nonzero_exit`, card blocked, no lingering process
- transactionally consistent live-board snapshot: dry-run previewed one spawn while physical DB and logical dump hashes remained identical; source task remained ready with zero runs; mutated comparator control returned `1`

## Operational note

There is not yet a first-class drain barrier. During acceptance, stopping the service while it owned a foreign worker caused that worker to exit and its card to auto-block. The same card was documented and restored without duplication. The README now explicitly requires checking both running and ready work before stop/restart and warns that an empty running list is not itself a durable drain.

## Scope

13 product/test/doc paths plus the portable-service and maintenance-warning follow-up commits. No credentials, profile state, acceptance cards, local paths, or operator RFC files are included.
