### PR TITLE
fix(windows): protect secrets with ACLs where POSIX modes are inert

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -356,6 +356,21 @@ class TokenMapping:
 # ---------------------------------------------------------------------------
 
 
+def _secure_owner_only(path: Path, mode: int) -> None:
+    """Apply the platform-native owner-only boundary to ``path``.
+
+    POSIX modes do not express a Windows trust boundary: CPython's chmod only
+    toggles the read-only attribute there.  Native Windows therefore uses the
+    same protected-DACL policy as Hermes credentials and restored secrets.
+    """
+    if os.name == "nt":
+        from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+        restrict_path_to_current_user(path)
+    else:
+        os.chmod(path, mode)
+
+
 def _hermes_bin_dir() -> Path:
     from hermes_constants import get_hermes_home
 
@@ -385,13 +400,17 @@ def _proxy_state_dir() -> Path:
     """
     d = _proxy_state_dir_ro()
     d.mkdir(parents=True, exist_ok=True)
-    try:
-        d.chmod(0o700)
-    except OSError:
-        # On Windows the chmod is a no-op for POSIX modes; on shared
-        # filesystems we may not own the dir.  Don't fail here — the
-        # individual files still get explicit perms.
-        pass
+    if os.name == "nt":
+        # The directory holds the CA signing key and management token.  A
+        # failed DACL application is a failed security boundary, not a warning.
+        _secure_owner_only(d, 0o700)
+    else:
+        try:
+            _secure_owner_only(d, 0o700)
+        except OSError:
+            # On shared POSIX filesystems we may not own the directory.  The
+            # individual files below still get explicit permissions.
+            pass
     return d
 
 
@@ -811,6 +830,7 @@ def ensure_ca_cert(*, force: bool = False) -> Tuple[Path, Path]:
                 pass
             raise
         os.replace(key_staged, ca_key)
+        _secure_owner_only(ca_key, 0o600)
 
         # Cert is public — 0o644 is fine and matches typical PEM layout.
         ca_crt.write_bytes(crt_bytes)
@@ -873,6 +893,7 @@ def ensure_management_token(*, force: bool = False) -> str:
         os.write(fd, token.encode("utf-8"))
     finally:
         os.close(fd)
+    _secure_owner_only(p, 0o600)
     return token
 
 
@@ -1345,10 +1366,12 @@ def ensure_audit_log(audit_path: Path) -> None:
         try:
             # Tighten perms even if the file already existed under a
             # slacker umask.
-            os.fchmod(fd, 0o600)
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
         finally:
             os.close(fd)
-    except OSError as exc:
+        _secure_owner_only(audit_path, 0o600)
+    except (OSError, RuntimeError) as exc:
         raise RuntimeError(
             f"Refusing to start: could not pre-create audit log "
             f"{audit_path} with restrictive permissions ({exc}).  "
@@ -1380,7 +1403,7 @@ def write_proxy_config(config: Dict) -> Path:
     # (the config embeds proxy token values).  chmod-after-replace would
     # leave a TOCTOU window; the 0o700 state dir mitigates but same-uid
     # processes could still race.
-    os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+    _secure_owner_only(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
     os.replace(tmp_path, out)
     return out
 
@@ -1414,7 +1437,7 @@ def write_mappings(mappings: List[TokenMapping]) -> Path:
     # chmod before the atomic replace — see write_proxy_config.  The
     # mappings file holds proxy token values, so close the TOCTOU window
     # rather than chmod-ing after the file is already at its final path.
-    os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+    _secure_owner_only(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
     os.replace(tmp_path, out)
     return out
 
@@ -1845,7 +1868,9 @@ def start_proxy(
             "Remove that path manually and retry."
         ) from exc
     try:
-        os.fchmod(log_fd, 0o600)  # tighten if file pre-existed
+        if hasattr(os, "fchmod"):
+            os.fchmod(log_fd, 0o600)  # tighten if file pre-existed
+        _secure_owner_only(log_path, 0o600)
     except OSError:
         pass
     # Verify ownership — same st_uid check the pidfile uses.

--- a/agent/secret_sources/_cache.py
+++ b/agent/secret_sources/_cache.py
@@ -180,7 +180,12 @@ class DiskCache(Generic[K]):
             # mkdir's mode is umask-subject; chmod the dir to 0700 so cache
             # metadata isn't exposed if HERMES_HOME is ever made traversable.
             try:
-                os.chmod(cache_dir, 0o700)
+                if os.name == "nt":
+                    from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+                    restrict_path_to_current_user(cache_dir)
+                else:
+                    os.chmod(cache_dir, 0o700)
             except OSError:
                 pass
             payload = {
@@ -198,6 +203,10 @@ class DiskCache(Generic[K]):
                     json.dump(payload, f)
                 os.chmod(tmp, 0o600)
                 os.replace(tmp, path)
+                if os.name == "nt":
+                    from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+                    restrict_path_to_current_user(path)
             except BaseException:
                 try:
                     os.unlink(tmp)

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -405,7 +405,12 @@ def _write_encrypted_disk_cache(
         cache_dir = path.parent
         cache_dir.mkdir(parents=True, exist_ok=True)
         try:
-            os.chmod(cache_dir, 0o700)
+            if os.name == "nt":
+                from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+                restrict_path_to_current_user(cache_dir)
+            else:
+                os.chmod(cache_dir, 0o700)
         except OSError:
             pass
         salt = os.urandom(16)
@@ -434,6 +439,10 @@ def _write_encrypted_disk_cache(
                 json.dump(payload, f)
             os.chmod(tmp, 0o600)
             os.replace(tmp, path)
+            if os.name == "nt":
+                from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+                restrict_path_to_current_user(path)
             # A successful encrypted write completes migration; remove the
             # legacy plaintext cache so stale secrets cannot remain on disk.
             try:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -672,7 +672,15 @@ def _is_recoverable_error_job(job: Dict[str, Any]) -> bool:
 
 
 def _secure_dir(path: Path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+    """Set directory to owner-only access (0700 or a protected Windows DACL)."""
+    if os.name == "nt":
+        try:
+            from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+            restrict_path_to_current_user(path)
+        except Exception:
+            logger.warning("Failed to restrict Windows ACL on cron directory %s", path)
+        return
     try:
         os.chmod(path, 0o700)
     except (OSError, NotImplementedError):
@@ -680,7 +688,17 @@ def _secure_dir(path: Path):
 
 
 def _secure_file(path: Path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
+    """Set file to owner-only read/write (0600 or a protected Windows DACL)."""
+    if os.name == "nt":
+        if not path.exists():
+            return
+        try:
+            from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+            restrict_path_to_current_user(path)
+        except Exception:
+            logger.warning("Failed to restrict Windows ACL on cron file %s", path)
+        return
     try:
         if path.exists():
             os.chmod(path, 0o600)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -839,7 +839,7 @@ def _chown_to_hermes_uid(path) -> None:
 
 
 def _secure_dir(path):
-    """Set directory to owner-only access (0700 by default). No-op on Windows.
+    """Set directory to owner-only access (0700 or a protected Windows DACL).
 
     Skipped in managed mode — the NixOS module sets group-readable
     permissions (0750) so interactive users in the hermes group can
@@ -857,6 +857,14 @@ def _secure_dir(path):
     subsequent uid-mapped workers).
     """
     if is_managed():
+        return
+    if os.name == "nt":
+        try:
+            from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+            restrict_path_to_current_user(path)
+        except Exception:
+            logger.warning("Failed to restrict Windows ACL on directory %s", path)
         return
     try:
         mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
@@ -896,7 +904,7 @@ def _is_container() -> bool:
 
 
 def _secure_file(path):
-    """Set file to owner-only read/write (0600). No-op on Windows.
+    """Set file to owner-only read/write (0600 or a protected Windows DACL).
 
     Skipped in managed mode — the NixOS activation script sets
     group-readable permissions (0640) on config files.
@@ -905,6 +913,16 @@ def _secure_file(path):
     permissions.  Set HERMES_SKIP_CHMOD=1 to force-skip on other systems.
     """
     if is_managed() or _is_container():
+        return
+    if os.name == "nt":
+        if not os.path.exists(str(path)):
+            return
+        try:
+            from hermes_cli.windows_permissions import restrict_path_to_current_user
+
+            restrict_path_to_current_user(path)
+        except Exception:
+            logger.warning("Failed to restrict Windows ACL on file %s", path)
         return
     try:
         if os.path.exists(str(path)):

--- a/hermes_cli/windows_permissions.py
+++ b/hermes_cli/windows_permissions.py
@@ -1,0 +1,121 @@
+"""Owner-only filesystem permissions for native Windows state files.
+
+POSIX ``chmod(0600/0700)`` does not express a Windows trust boundary: CPython
+only toggles the read-only attribute and ``stat().st_mode`` continues to report
+the inherited ACL.  Hermes stores credentials and scheduler state below its
+home, so the Windows equivalent must be an explicit, protected DACL.
+
+The policy intentionally mirrors ``windows_ssh_runtime``: the current user and
+LocalSystem receive full control; inherited and unrelated allow ACEs are
+removed.  Directories propagate the same policy to new children.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _win32_modules():
+    if sys.platform != "win32":
+        raise RuntimeError("Windows permissions are only available on Windows")
+
+    import ntsecuritycon
+    import win32api
+    import win32con
+    import win32security
+
+    return ntsecuritycon, win32api, win32con, win32security
+
+
+def _current_sid():
+    _, win32api, win32con, win32security = _win32_modules()
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    return win32security.GetTokenInformation(token, win32security.TokenUser)[0]
+
+
+def _system_sid():
+    return _win32_modules()[3].ConvertStringSidToSid("S-1-5-18")
+
+
+def restrict_path_to_current_user(path: Path | str) -> None:
+    """Replace ``path``'s DACL with current-user + LocalSystem full control.
+
+    This function is deliberately strict and raises on failure.  Callers that
+    historically treated permission tightening as best-effort may catch and
+    log the error, while tests and security-sensitive creation paths can verify
+    the boundary directly.
+    """
+
+    target = Path(path)
+    ntsecuritycon, _, _, win32security = _win32_modules()
+    owner = _current_sid()
+    acl = win32security.ACL()
+    inheritance = 0
+    if target.is_dir():
+        inheritance = (
+            win32security.OBJECT_INHERIT_ACE
+            | win32security.CONTAINER_INHERIT_ACE
+        )
+    for sid in (owner, _system_sid()):
+        acl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            inheritance,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+
+    security_info = (
+        win32security.DACL_SECURITY_INFORMATION
+        | win32security.PROTECTED_DACL_SECURITY_INFORMATION
+    )
+    win32security.SetNamedSecurityInfo(
+        str(target),
+        win32security.SE_FILE_OBJECT,
+        security_info,
+        None,
+        None,
+        acl,
+        None,
+    )
+
+
+def path_is_restricted_to_current_user(path: Path | str) -> bool:
+    """Return whether ``path`` has the protected Hermes Windows DACL."""
+
+    _, _, _, win32security = _win32_modules()
+    descriptor = win32security.GetNamedSecurityInfo(
+        str(path),
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION,
+    )
+    control, _revision = descriptor.GetSecurityDescriptorControl()
+    if not control & win32security.SE_DACL_PROTECTED:
+        return False
+    dacl = descriptor.GetSecurityDescriptorDacl()
+    if dacl is None:
+        return False
+
+    allowed = {
+        win32security.ConvertSidToStringSid(_current_sid()),
+        win32security.ConvertSidToStringSid(_system_sid()),
+    }
+    allow_types = {
+        win32security.ACCESS_ALLOWED_ACE_TYPE,
+        win32security.ACCESS_ALLOWED_OBJECT_ACE_TYPE,
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_ACE_TYPE", 9),
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE", 11),
+    }
+    observed_allowed: set[str] = set()
+    for index in range(dacl.GetAceCount()):
+        ace = dacl.GetAce(index)
+        ace_type = ace[0][0]
+        mask = ace[1]
+        sid = win32security.ConvertSidToStringSid(ace[-1])
+        if ace_type in allow_types and mask:
+            if sid not in allowed:
+                return False
+            observed_allowed.add(sid)
+    return observed_allowed == allowed

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -20,6 +20,14 @@ class TestCronFilePermissions(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    def assertPrivate(self, path: Path, posix_mode: int):
+        if os.name == "nt":
+            from hermes_cli.windows_permissions import path_is_restricted_to_current_user
+
+            self.assertTrue(path_is_restricted_to_current_user(path))
+        else:
+            self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), posix_mode)
+
     @patch("cron.jobs.CRON_DIR")
     @patch("cron.jobs.OUTPUT_DIR")
     @patch("cron.jobs.JOBS_FILE")
@@ -34,10 +42,8 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import ensure_dirs
             ensure_dirs()
 
-            cron_mode = stat.S_IMODE(os.stat(cron_dir).st_mode)
-            output_mode = stat.S_IMODE(os.stat(output_dir).st_mode)
-            self.assertEqual(cron_mode, 0o700)
-            self.assertEqual(output_mode, 0o700)
+            self.assertPrivate(cron_dir, 0o700)
+            self.assertPrivate(output_dir, 0o700)
 
     @patch("cron.jobs.CRON_DIR")
     @patch("cron.jobs.OUTPUT_DIR")
@@ -53,8 +59,7 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import save_jobs
             save_jobs([{"id": "test", "prompt": "hello"}])
 
-            file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            self.assertPrivate(jobs_file, 0o600)
 
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
@@ -65,13 +70,11 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import save_job_output
             output_file = save_job_output("test-job", "test output content")
 
-            file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            self.assertPrivate(output_file, 0o600)
 
             # Job output dir should also be 0700
             job_dir = output_dir / "test-job"
-            dir_mode = stat.S_IMODE(os.stat(job_dir).st_mode)
-            self.assertEqual(dir_mode, 0o700)
+            self.assertPrivate(job_dir, 0o700)
 
 
 class TestConfigFilePermissions(unittest.TestCase):
@@ -84,6 +87,14 @@ class TestConfigFilePermissions(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    def assertPrivate(self, path: Path, posix_mode: int):
+        if os.name == "nt":
+            from hermes_cli.windows_permissions import path_is_restricted_to_current_user
+
+            self.assertTrue(path_is_restricted_to_current_user(path))
+        else:
+            self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), posix_mode)
+
     def test_save_config_sets_0600(self):
         config_path = Path(self.tmpdir) / "config.yaml"
         with patch("hermes_cli.config.get_config_path", return_value=config_path), \
@@ -91,8 +102,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import save_config
             save_config({"model": "test/model"})
 
-            file_mode = stat.S_IMODE(os.stat(config_path).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            self.assertPrivate(config_path, 0o600)
 
     def test_save_env_value_sets_0600(self):
         env_path = Path(self.tmpdir) / ".env"
@@ -101,8 +111,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import save_env_value
             save_env_value("TEST_KEY", "test_value")
 
-            file_mode = stat.S_IMODE(os.stat(env_path).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            self.assertPrivate(env_path, 0o600)
 
     def test_ensure_hermes_home_sets_0700(self):
         home = Path(self.tmpdir) / ".hermes"
@@ -110,12 +119,10 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import ensure_hermes_home
             ensure_hermes_home()
 
-            home_mode = stat.S_IMODE(os.stat(home).st_mode)
-            self.assertEqual(home_mode, 0o700)
+            self.assertPrivate(home, 0o700)
 
             for subdir in ("cron", "sessions", "logs", "memories"):
-                subdir_mode = stat.S_IMODE(os.stat(home / subdir).st_mode)
-                self.assertEqual(subdir_mode, 0o700, f"{subdir} should be 0700")
+                self.assertPrivate(home / subdir, 0o700)
 
 
 class TestSecureHelpers(unittest.TestCase):

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -94,7 +94,7 @@ def test_platform_asset_name(system, machine, libc_text, expected):
 def _make_fake_zip(binary_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("bws", binary_bytes)
+        zf.writestr(bw._platform_binary_name(), binary_bytes)
     return buf.getvalue()
 
 
@@ -370,8 +370,13 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
     assert not bw._disk_cache_path(home).exists()
     cache_path = bw._encrypted_disk_cache_path(home)
     assert cache_path.exists()
-    mode = stat.S_IMODE(os.stat(cache_path).st_mode)
-    assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+    if os.name == "nt":
+        from hermes_cli.windows_permissions import path_is_restricted_to_current_user
+
+        assert path_is_restricted_to_current_user(cache_path)
+    else:
+        mode = stat.S_IMODE(os.stat(cache_path).st_mode)
+        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
     text = cache_path.read_text()
     assert "secret-value" not in text
     assert "0.t" not in text
@@ -517,7 +522,6 @@ def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
             access_token="0.t", project_id="proj-1", binary=fake_binary,
             cache_ttl_seconds=300, home_path=home,
         )
-
 
 
 

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -44,6 +44,15 @@ def hermes_home(tmp_path, monkeypatch):
     return home
 
 
+def _assert_owner_only(path: Path, posix_mode: int) -> None:
+    if sys.platform == "win32":
+        from hermes_cli.windows_permissions import path_is_restricted_to_current_user
+
+        assert path_is_restricted_to_current_user(path)
+    else:
+        assert (path.stat().st_mode & 0o777) == posix_mode
+
+
 # ---------------------------------------------------------------------------
 # Token mint + mapping discovery
 # ---------------------------------------------------------------------------
@@ -367,8 +376,7 @@ def test_ca_key_created_with_0o600(hermes_home, monkeypatch):
 
     ca_crt, ca_key = ip.ensure_ca_cert()
     assert ca_key.exists()
-    mode = ca_key.stat().st_mode & 0o777
-    assert mode == 0o600, f"CA key has perms {oct(mode)}, expected 0o600"
+    _assert_owner_only(ca_key, 0o600)
 
 
 # ---------------------------------------------------------------------------
@@ -380,8 +388,7 @@ def test_ensure_audit_log_creates_with_0o600(hermes_home, tmp_path):
     audit = tmp_path / "audit.log"
     ip.ensure_audit_log(audit)
     assert audit.exists()
-    mode = audit.stat().st_mode & 0o777
-    assert mode == 0o600
+    _assert_owner_only(audit, 0o600)
 
 
 def test_ensure_audit_log_tightens_existing_perms(hermes_home, tmp_path):
@@ -389,8 +396,7 @@ def test_ensure_audit_log_tightens_existing_perms(hermes_home, tmp_path):
     audit.write_text("preexisting content\n")
     os.chmod(audit, 0o644)
     ip.ensure_audit_log(audit)
-    mode = audit.stat().st_mode & 0o777
-    assert mode == 0o600
+    _assert_owner_only(audit, 0o600)
 
 
 # ---------------------------------------------------------------------------
@@ -400,8 +406,7 @@ def test_ensure_audit_log_tightens_existing_perms(hermes_home, tmp_path):
 
 def test_proxy_state_dir_is_0o700(hermes_home):
     state = ip._proxy_state_dir()
-    mode = state.stat().st_mode & 0o777
-    assert mode == 0o700
+    _assert_owner_only(state, 0o700)
 
 
 
@@ -492,7 +497,7 @@ def test_ensure_management_token_persists_and_is_stable(hermes_home):
     assert t1.startswith("hermes-mgmt-")
     p = ip._proxy_state_dir() / "management.token"
     assert p.exists()
-    assert (p.stat().st_mode & 0o777) == 0o600
+    _assert_owner_only(p, 0o600)
 
 
 
@@ -812,5 +817,4 @@ def test_bitwarden_importerror_raise_without_fallback(
         ip._build_proxy_subprocess_env(
             refresh_from_bitwarden=True, bitwarden_config=bw_cfg,
         )
-
 

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -20,7 +20,11 @@ from tools import bot_mode_dm, bot_mode_probe
 
 
 @pytest.fixture(autouse=True)
-def _fresh_probe_cache():
+def _fresh_probe_cache(tmp_path, monkeypatch):
+    # Never touch the live per-user DM cache from a unit test. On Windows its
+    # owner-only DACL can belong to a differently scoped process token and a
+    # security repair attempt is both slow and irrelevant to these fixtures.
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
     bot_mode_probe._reset_cache_for_tests()
     yield
     bot_mode_probe._reset_cache_for_tests()
@@ -666,6 +670,7 @@ def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
     assert unrelated.exists()
 
 
+@pytest.mark.linux_only
 def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
 
@@ -678,6 +683,7 @@ def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
     assert dm_dir.stat().st_mode & 0o777 == 0o700
 
 
+@pytest.mark.linux_only
 def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
     uid = os.getuid() if hasattr(os, "getuid") else None

--- a/tests/tools/test_stage2_hook_api_server_keygen.py
+++ b/tests/tools/test_stage2_hook_api_server_keygen.py
@@ -10,12 +10,22 @@ fleet with no api_server and every scheduled cron fire silently lost.
 """
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+
+# ``docker/stage2-hook.sh`` boots a Linux container.  Its permission
+# contract is only observable on a POSIX filesystem: under Git Bash on
+# NTFS a ``chmod 600`` reports back as ``0o666`` and a ``chmod 444`` does
+# not stop the owner writing, so these two cases would assert nothing.
+POSIX_FILE_MODES = pytest.mark.skipif(
+    os.name == "nt",
+    reason="container .env permission contract needs POSIX file modes",
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
@@ -83,6 +93,16 @@ def test_keygen_creates_env_when_missing(stage2_text: str, tmp_path: Path) -> No
     env_path = home / ".env"
     assert env_path.is_file(), "keygen must create .env when it is missing"
     assert KEY_LINE_RE.search(env_path.read_text()), "generated key missing/malformed"
+
+
+@POSIX_FILE_MODES
+def test_keygen_creates_env_owner_only(stage2_text: str, tmp_path: Path) -> None:
+    """The .env the keygen creates carries the API key — it must be 0600."""
+    home = tmp_path / "home"
+    home.mkdir()
+    result = _run_keygen(stage2_text, home)
+    assert result.returncode == 0, result.stderr
+    env_path = home / ".env"
     mode = env_path.stat().st_mode & 0o777
     assert mode == 0o600, f".env must be owner-only, got {oct(mode)}"
 
@@ -198,6 +218,7 @@ def _sed_is_gnu() -> bool:
     return probe.returncode == 0 and "GNU sed" in probe.stdout
 
 
+@POSIX_FILE_MODES
 def test_keygen_readonly_env_degrades_to_warning_not_boot_abort(
     stage2_text: str, tmp_path: Path
 ) -> None:
@@ -207,8 +228,6 @@ def test_keygen_readonly_env_degrades_to_warning_not_boot_abort(
     whole cont-init phase and the container boot. It must instead warn that
     the api_server will be unavailable and exit 0.
     """
-    import os
-
     if os.geteuid() == 0:
         pytest.skip("running as root — file write perms are not enforced")
     home = tmp_path / "home"

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -459,7 +459,14 @@ def _dm_dir() -> Path:
         raise PermissionError(f"DM temp path is not a directory: {path}")
     if uid is not None and info.st_uid != uid:
         raise PermissionError(f"DM temp directory is owned by another user: {path}")
-    if stat.S_IMODE(info.st_mode) != 0o700:
+    if os.name == "nt":
+        # chmod has no owner-only directory semantics on Windows and may raise
+        # WinError 5 for a temp directory. Use the same DACL implementation as
+        # every other Hermes secret directory.
+        from hermes_cli.config import _secure_dir
+
+        _secure_dir(path)
+    elif stat.S_IMODE(info.st_mode) != 0o700:
         path.chmod(0o700)
     return path
 

--- a/tools/spill_safety.py
+++ b/tools/spill_safety.py
@@ -48,6 +48,48 @@ __all__ = [
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
+def _open_exclusive_fd(path: Path, mode: int) -> int:
+    """Create ``path`` atomically without following a Windows reparse point."""
+    if os.name != "nt":
+        return os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW, mode)
+
+    # Windows' os.open(O_EXCL) can follow a dangling symlink and create its
+    # target. CreateFileW + FILE_FLAG_OPEN_REPARSE_POINT applies CREATE_NEW to
+    # the link itself, preserving the same no-follow guarantee as O_NOFOLLOW.
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        0x40000000,  # GENERIC_WRITE
+        0,
+        None,
+        1,  # CREATE_NEW
+        0x00000080 | 0x00200000,  # FILE_ATTRIBUTE_NORMAL | OPEN_REPARSE_POINT
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle == invalid_handle:
+        raise ctypes.WinError()
+    try:
+        return msvcrt.open_osfhandle(handle, os.O_WRONLY)
+    except Exception:
+        ctypes.windll.kernel32.CloseHandle(handle)
+        raise
+
+
 def ensure_spill_dir(path: Path, *, private: bool = True) -> Path:
     """Create ``path`` (and parents) as a directory, refusing symlinks.
 
@@ -94,7 +136,7 @@ def open_exclusive(
                 raise OSError(f"refusing to overwrite a directory: {path}")
             os.unlink(path)
     mode = 0o600 if private else 0o666  # non-private honors umask
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW, mode)
+    fd = _open_exclusive_fd(path, mode)
     try:
         return os.fdopen(fd, "w", encoding=encoding, errors=errors)
     except Exception:


### PR DESCRIPTION
## What does this PR do?

On Windows, CPython's `chmod` only toggles the read-only attribute. Every `chmod(0o600)` Hermes applies to a secret therefore expressed **no trust boundary at all** — the file stayed readable by every account on the machine. This PR replaces those inert calls with real ACLs, and closes a symlink hole in `open_exclusive` found while doing it.

**1. A shared helper, `hermes_cli/windows_permissions.py`.** Applies the same protected-DACL policy Hermes already uses for credentials, and treats a failed application as a **failed boundary** rather than a warning.

**2. The secrets that were unprotected.** The iron-proxy CA signing key, the management token, the audit log, the proxy state directory, the DM spool, and the Bitwarden encrypted disk cache. Each had a `chmod` that did nothing on Windows.

**3. A real hole in `open_exclusive`.** On Windows `os.open(..., O_EXCL)` can **follow a dangling symlink and create its target**, and `O_NOFOLLOW` does not exist there — so the exclusivity guarantee did not hold. Creation now goes through `CreateFileW` with `CREATE_NEW | FILE_FLAG_OPEN_REPARSE_POINT`, so exclusivity applies to the link itself.

**4. Scoping the stage2 keygen permission cases.** That suite drives a Linux container's boot hook; its permission assertions are only observable on a POSIX filesystem. Under Git Bash on NTFS a `chmod 600` reads back as `0666` and a `chmod 444` does not stop the owner writing. Those cases are split out and scoped rather than left failing.

## Related Issue

No existing issue. Happy to open one first if you would prefer that.

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/windows_permissions.py` — new; protected-DACL helper, fail-closed.
- `agent/proxy_sources/iron_proxy.py` — CA key, audit log, state directory, management token.
- `agent/secret_sources/_cache.py`, `agent/secret_sources/bitwarden.py` — encrypted disk cache.
- `tools/bot_mode_dm.py` — DM spool.
- `tools/spill_safety.py` — `open_exclusive` via `CreateFileW` + `CREATE_NEW | FILE_FLAG_OPEN_REPARSE_POINT`.
- Five test files updated, including POSIX-scoped exclusions for contracts that cannot be observed on NTFS.

## How Has This Been Tested?

Windows 11, CPython 3.11. This branch against its merge base `64b96bb5d2`, the five affected test files, same invocation:

| | failed | passed | skipped |
| --- | --- | --- | --- |
| `64b96bb5d2` | **25** | 76 | 1 |
| this branch | **7** | 91 | 5 |

**No new failures.** The 7 that remain are a strict subset of the 25 already failing on the base; I verified that by diffing the two failure sets, not by comparing counts.

**On the four additional skips** — they are not silenced tests. Each carries an explicit platform reason and previously *failed* on Windows because it asserted a POSIX contract:

- `POSIX ownership contract`
- `container .env permission contract needs POSIX file modes` (×2)
- `Linux-only test (marked linux_only); host is win32` (×2)

`scripts/check-windows-footguns.py` on the changed source files → 0 findings, on the base and on this branch alike.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed.** I have not run the complete suite to completion on this host, so I am not checking this box. The affected files were measured against the base as shown above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, CPython 3.11

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface changes)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the ACL helper is a no-op outside Windows; the POSIX `chmod` paths are untouched, and `open_exclusive` keeps its existing implementation on POSIX where `O_EXCL | O_NOFOLLOW` already holds.
- [x] Tool descriptions/schemas — N/A
