### PR TITLE
fix(desktop): session archive/delete land in the owning profile; new rows stop getting profile_name=NULL (#96531 #98609 #99222, salvage #97199)

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -10,13 +10,146 @@ vi.mock('./client', () => ({
 }))
 
 const client = await import('./client')
-const { listSidebarSessions } = await import('./sessions')
+
+const { deleteSession, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
+  await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(client.getApiRequestConnection).mockReturnValue('prometheus')
+})
+
+describe('deleteSession profile scoping', () => {
+  it('scopes the DELETE to the owning profile in the URL (object owner)', async () => {
+    // Regression: the sidebar "All Profiles" delete sent the profile only via
+    // request.profile, not in the URL. On a remote gateway with no remoteProfile
+    // alias the main-process path rewrite left the URL unscoped, so the backend
+    // opened its own default state.db, missed the row, and returned
+    // {ok:true, already_absent:true} — the row vanished optimistically but was
+    // never deleted and came back on refresh. The URL must carry ?profile=.
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // Mirrors the real capabilityScoped for an object owner (remote-stamped row).
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy', connectionId: 'hermes-pi' })
+
+    await deleteSession('sess-1', { connectionId: 'hermes-pi', profile: 'tommy' })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-1?profile=tommy',
+      connectionId: 'hermes-pi',
+      profile: 'tommy'
+    })
+  })
+
+  it('scopes the DELETE to the owning profile in the URL (bare string owner)', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // Bare-string owner: capabilityScoped resolves it to a profile scope.
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy' })
+
+    await deleteSession('sess-2', 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-2?profile=tommy'
+    })
+  })
+
+  it('omits the profile query when no owner is known', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await deleteSession('sess-3')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-3'
+    })
+    expect((hermesApi.mock.calls[0][0] as { path: string }).path).not.toContain('profile=')
+  })
+
+  it('keeps an explicit local pin routed to the local pool', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    // capabilityScoped drops a 'local' connection id by design; sessionScoped
+    // must re-add it so the request stays pinned to this device.
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy' })
+
+    await deleteSession('sess-4', { connectionId: 'local', profile: 'tommy' })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      path: '/api/sessions/sess-4?profile=tommy',
+      connectionId: 'local',
+      profile: 'tommy'
+    })
+  })
+})
+
+describe('setSessionArchived profile scoping', () => {
+  it('carries the owning profile in the PATCH body', async () => {
+    // Same class as the unscoped DELETE: the PATCH handler reads its target DB
+    // from body.profile, so archiving a foreign-profile session must send it in
+    // the body, not only as request.profile (Electron routing), or on a remote
+    // gateway the archive lands on the wrong state.db and silently no-ops.
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-a', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-a',
+      profile: 'tommy',
+      body: { archived: true, profile: 'tommy' }
+    })
+  })
+
+  it('omits the profile from the body when none is given', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-b', false)
+
+    const req = hermesApi.mock.calls[0][0] as { body: Record<string, unknown> }
+    expect(req).toMatchObject({ method: 'PATCH', body: { archived: false } })
+    expect(req.body).not.toHaveProperty('profile')
+  })
+})
+
+describe('setSessionPinnedRemote / setSessionUnreadRemote profile scoping', () => {
+  it('carries the owning profile in the pin PATCH body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionPinnedRemote('sess-p', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-p',
+      profile: 'tommy',
+      body: { pinned: true, profile: 'tommy' }
+    })
+  })
+
+  it('carries the owning profile in the unread PATCH body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionUnreadRemote('sess-u', true, 'tommy')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-u',
+      profile: 'tommy',
+      body: { unread: true, profile: 'tommy' }
+    })
+  })
+
+  it('omits the profile from the body when none is given', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionPinnedRemote('sess-p2', false)
+
+    const req = hermesApi.mock.calls[0][0] as { body: Record<string, unknown> }
+    expect(req).toMatchObject({ method: 'PATCH', body: { pinned: false } })
+    expect(req.body).not.toHaveProperty('profile')
+  })
 })
 
 describe('listSidebarSessions remote ownership', () => {

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -298,11 +298,17 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 // Mutations take the owning `profile` so Electron can route them to the correct
 // remote backend or local profile scope. Omit for the current/default profile.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Carry the owning profile IN THE PATCH BODY, mirroring renameSession — the
+  // backend reads its target DB from body.profile (_open_session_db_for_profile).
+  // Passing it only as request.profile (Electron routing) is not enough on a
+  // remote gateway with no remoteProfile alias: the archive lands on the wrong
+  // (default) state.db, no-ops on a missing row, and the archived/unarchived
+  // state silently fails to stick — the same class as the unscoped DELETE.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived }
+    body: { archived, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -311,11 +317,14 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
 // pinned chat. Best-effort: the sidebar stays localStorage-driven for its own
 // display; this only feeds the backend policy.
 export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Owning profile in the PATCH body (see setSessionArchived / renameSession):
+  // the handler reads its target DB from body.profile, so a remote/foreign
+  // profile's pin must travel in the body or it no-ops on the wrong state.db.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { pinned }
+    body: { pinned, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -324,11 +333,15 @@ export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: st
 // routing as the other session mutations: a remote session's row lives only
 // on its remote host, so the owning profile must travel with the request.
 export function setSessionUnreadRemote(id: string, unread: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  // Owning profile in the PATCH body (see setSessionArchived / renameSession):
+  // the handler reads its target DB from body.profile, so a remote/foreign
+  // profile's unread toggle must travel in the body or it no-ops on the wrong
+  // state.db.
   return hermesApi<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { unread }
+    body: { unread, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -526,9 +539,23 @@ export async function getAllSessionMessages(
 }
 
 export function deleteSession(id: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
+  // Scope the DELETE to the owning profile IN THE URL, mirroring getSession /
+  // getSessionMessages. Passing the profile only via request.profile (which the
+  // Electron main process consumes for backend routing) is NOT enough: on a
+  // remote gateway whose connection has no remoteProfile alias, the main-process
+  // path rewrite leaves the URL unscoped, so the backend opens its OWN (default)
+  // state.db, fails to find another profile's session, and returns
+  // {ok:true, already_absent:true}. The row then vanishes optimistically but was
+  // never deleted and reappears on the next sidebar refresh — the "All Profiles
+  // delete doesn't stick" report. The endpoint already honours ?profile=
+  // (get/rename/messages all send it); DELETE was the one mutation that dropped
+  // it after the api/ split. request.profile stays on for per-profile remote
+  // override + global-remote routing (both re-read/re-append the param).
+  const suffix = sessionScopeQuery(profile)
+
   return hermesApi<{ ok: boolean }>({
     ...sessionScoped(profile),
-    path: `/api/sessions/${encodeURIComponent(id)}`,
+    path: `/api/sessions/${encodeURIComponent(id)}${suffix}`,
     method: 'DELETE'
   })
 }

--- a/contributors/emails/info@bergmann89.de
+++ b/contributors/emails/info@bergmann89.de
@@ -1,0 +1,1 @@
+Bergmann89

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5915,6 +5915,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Session lifecycle
     # =========================================================================
 
+    _PROFILE_DIR_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+    def _own_profile_name(self) -> Optional[str]:
+        """The profile that owns THIS store, derived from ``db_path`` alone.
+
+        Every profile-tree ``state.db`` belongs to exactly one profile
+        (``<root>/state.db`` → ``default``,
+        ``<root>/profiles/<name>/state.db`` → ``<name>``), so the derivation
+        is a single match, never a guess — the same contract
+        :meth:`backfill_null_session_profiles` and the web listing's
+        ``row_profile`` stamp rely on. Path-based (not
+        ``get_active_profile_name()``) on purpose: a gateway serving a
+        NON-launch profile opens that profile's store directly, and the row
+        must be stamped with the store's owner, not the serving process's
+        launch profile. Returns ``None`` for stores outside the profile tree
+        (explicit ``db_path`` in tests, ad-hoc copies) — those rows keep the
+        legacy NULL rather than a fabricated owner.
+        """
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            root = get_default_hermes_root().resolve()
+            parent = Path(self.db_path).resolve().parent
+            if parent == root:
+                return "default"
+            if parent.parent == root / "profiles" and self._PROFILE_DIR_RE.match(
+                parent.name
+            ):
+                return parent.name
+        except Exception:
+            logger.debug("own-profile derivation failed", exc_info=True)
+        return None
+
     def _insert_session_row(
         self,
         session_id: str,
@@ -5929,7 +5962,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         thread_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
-        profile_name: str = None,
+        profile_name: Optional[str] = None,
         git_repo_root: str = None,
         origin_json: str = None,
         display_name: str = None,
@@ -5968,7 +6001,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``thread_id``/``display_name``/``origin_json``) are inherited too, so a
         crash before the gateway re-records the peer can't strand the child
         without a recoverable routing mapping (#59527).
+
+        When the caller passes no ``profile_name`` at all, the row is stamped
+        with THIS store's own profile (:meth:`_own_profile_name`) instead of
+        NULL. Every ``state.db`` belongs to exactly one profile — the same
+        single-match contract :meth:`backfill_null_session_profiles` relies
+        on — so the stamp is derivation, not a guess. Rows minted NULL after
+        that one-shot #94724 backfill ran stayed NULL forever, and
+        profile-keyed consumers (desktop sidebar scope matching,
+        ``@session:<profile>/<id>`` deep links, the fail-closed owner ladder)
+        treat NULL as unowned: the session vanishes from the sidebar even
+        though its transcript is intact (#99222). Stores outside the profile
+        tree (explicit ``db_path`` in tests, ad-hoc copies) derive nothing
+        and keep NULL — never guess.
         """
+        if not (profile_name or "").strip():
+            profile_name = self._own_profile_name()
+
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
@@ -6216,9 +6265,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         """INSERT INTO sessions (
                                id, source, user_id, session_key, chat_id,
                                chat_type, thread_id, display_name, origin_json,
-                               started_at
+                               profile_name, started_at
                            )
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                            ON CONFLICT(id) DO UPDATE SET
                                session_key = COALESCE(sessions.session_key, excluded.session_key),
                                chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
@@ -6236,6 +6285,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             thread_id,
                             display_name,
                             origin_json,
+                            # Same ownership stamp as _insert_session_row: a
+                            # self-healed row is a first creation too, and an
+                            # unowned (NULL) row vanishes from profile-keyed
+                            # consumers (#99222).
+                            self._own_profile_name(),
                             time.time(),
                         ),
                     )
@@ -7137,8 +7191,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     # compression-fork backfill (#59527 / cross-profile jump
                     # fix): the child stays on the parent's profile and keeps
                     # the gateway routing/origin columns so peer recovery
-                    # still works after a crash at the boundary.
-                    profile_name or parent["profile_name"],
+                    # still works after a crash at the boundary. When neither
+                    # names an owner (legacy NULL parent), stamp this store's
+                    # own profile so the rotated child doesn't extend the
+                    # unowned lineage (#99222).
+                    profile_name
+                    or parent["profile_name"]
+                    or self._own_profile_name(),
                     parent["user_id"],
                     parent["session_key"],
                     parent["chat_id"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -656,8 +656,13 @@ class AIAgent:
             try:
                 from hermes_cli.profiles import get_active_profile_name
                 _profile_for_session = get_active_profile_name()
-                if _profile_for_session == "default":
-                    _profile_for_session = None
+                # Persist the profile name EXPLICITLY, including "default".
+                # NULL used to stand in for the default profile, but the
+                # #94724 legacy-owner backfill already stamps literal
+                # "default" onto old rows, and profile-keyed consumers
+                # (sidebar scope matching, @session:<profile>/<id> deep
+                # links) treat NULL as unowned — rows minted NULL after the
+                # one-shot backfill vanished from the sidebar (#99222).
             except Exception:
                 _profile_for_session = None
             # Carry the live YOLO bypass into the creation-time model_config so

--- a/tests/test_session_db_profile_stamp.py
+++ b/tests/test_session_db_profile_stamp.py
@@ -1,0 +1,137 @@
+"""SessionDB stamps its own store's profile onto new session rows (#99222).
+
+Every profile-tree ``state.db`` belongs to exactly one profile, so when a
+creation path passes no ``profile_name`` the store derives its own owner
+instead of persisting NULL. NULL rows minted after the one-shot #94724
+legacy-owner backfill stayed NULL forever and vanished from profile-keyed
+consumers (desktop sidebar scope matching, ``@session:<profile>/<id>`` deep
+links). Stores outside the profile tree must NOT guess — they keep NULL.
+"""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def hermes_root(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    (root / "profiles" / "workprof").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # get_default_hermes_root memoizes on (native_home, env) — the env change
+    # invalidates the memo by itself, but re-point DEFAULT_DB_PATH so any
+    # default-constructed SessionDB in the module under test stays sandboxed.
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", root / "state.db")
+    return root
+
+
+def _profile_of(db_path, session_id):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT profile_name FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def test_default_store_stamps_default(hermes_root):
+    db = SessionDB(db_path=hermes_root / "state.db")
+    try:
+        db.create_session("s_default", source="cli")
+    finally:
+        db.close()
+    assert _profile_of(hermes_root / "state.db", "s_default") == "default"
+
+
+def test_named_profile_store_stamps_own_name(hermes_root):
+    db_path = hermes_root / "profiles" / "workprof" / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s_prof", source="desktop")
+    finally:
+        db.close()
+    assert _profile_of(db_path, "s_prof") == "workprof"
+
+
+def test_explicit_profile_name_wins(hermes_root):
+    db = SessionDB(db_path=hermes_root / "state.db")
+    try:
+        db.create_session("s_explicit", source="cli", profile_name="llm-wiki")
+    finally:
+        db.close()
+    assert _profile_of(hermes_root / "state.db", "s_explicit") == "llm-wiki"
+
+
+def test_store_outside_profile_tree_never_guesses(hermes_root, tmp_path):
+    db_path = tmp_path / "elsewhere" / "state.db"
+    db_path.parent.mkdir()
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s_outside", source="cli")
+    finally:
+        db.close()
+    assert _profile_of(db_path, "s_outside") is None
+
+
+def test_compression_child_of_null_parent_is_stamped(hermes_root):
+    db_path = hermes_root / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s_parent", source="cli")
+        # Simulate a legacy pre-ownership parent row.
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "UPDATE sessions SET profile_name = NULL WHERE id = ?", ("s_parent",)
+        )
+        conn.commit()
+        conn.close()
+        db.publish_compression_child(
+            parent_session_id="s_parent",
+            child_session_id="s_child",
+            source="cli",
+            messages=[{"role": "user", "content": "hi"}],
+            require_compression_lease=False,
+        )
+    finally:
+        db.close()
+    assert _profile_of(db_path, "s_child") == "default"
+
+
+def test_peer_self_heal_insert_is_stamped(hermes_root):
+    db_path = hermes_root / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        # No prior row: the #82616 self-heal INSERT creates it.
+        db.record_gateway_session_peer(
+            "s_selfheal",
+            source="telegram",
+            user_id="u1",
+            session_key="k1",
+            chat_id="c1",
+        )
+    finally:
+        db.close()
+    assert _profile_of(db_path, "s_selfheal") == "default"
+
+
+def test_legacy_backfill_still_targets_only_null(hermes_root):
+    """The one-shot #94724 backfill contract is unchanged: explicit owners are
+    never overwritten, and new rows no longer regenerate its input."""
+    db_path = hermes_root / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s_new", source="cli")
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE sessions SET profile_name = NULL WHERE id = 's_new'")
+        conn.commit()
+        conn.close()
+        assert db.backfill_null_session_profiles("workprof") == 1
+        assert db.backfill_null_session_profiles("workprof") == 0
+    finally:
+        db.close()
+    assert _profile_of(db_path, "s_new") == "workprof"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7639,6 +7639,28 @@ def test_ensure_session_db_row_stamps_profile_name(monkeypatch, tmp_path):
     assert created[0]["db_path"] == profile_home / "state.db"
 
 
+def test_ensure_session_db_row_stamps_launch_profile_name(monkeypatch):
+    """A launch-profile session row is stamped with the ACTUAL profile name,
+    never NULL. NULL-as-launch-profile rows vanish from the desktop sidebar
+    (profile-keyed matching) and break @session:<profile>/<id> deep links, and
+    the #94724 one-shot backfill cannot keep repairing rows minted after it
+    ran (#99222)."""
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, **kwargs):
+            created.append({"key": key, "profile_name": kwargs.get("profile_name")})
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+
+    server._ensure_session_db_row({"session_key": "k1"})
+
+    assert created and created[0]["key"] == "k1"
+    assert created[0]["profile_name"] == "default"
+
+
 def test_session_title_clears_pending_after_persist(monkeypatch):
     class _FakeDB:
         def __init__(self):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3218,11 +3218,13 @@ def _(rid, params: dict) -> dict:
                 cwd=_session_cwd(session),
                 # The branch stays on its parent's profile. Explicit stamp (not
                 # just the parent-backfill) so it holds even when the parent row
-                # predates the profile_name column.
+                # predates the profile_name column. Launch-profile branches are
+                # stamped explicitly too — NULL rows drop out of profile-keyed
+                # sidebar matching and deep-link resolution (#99222).
                 profile_name=(
                     Path(session["profile_home"]).name
                     if session.get("profile_home")
-                    else None
+                    else _current_profile_name()
                 ),
             )
             # Copy the whole parent history in bounded-chunk transactions —

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3916,9 +3916,15 @@ def _ensure_session_db_row(session: dict) -> None:
             parent_session_id=parent_session_id,
             cwd=_persisted_session_cwd(session),
             # Self-describing rows: aggregators that merge multiple profile DBs
-            # into one list can't rely on which file a row came from alone. NULL
-            # means the launch/default profile (matches run_agent's convention).
-            profile_name=Path(profile_home).name if profile_home else None,
+            # into one list can't rely on which file a row came from alone.
+            # Stamp the launch profile explicitly instead of leaving NULL —
+            # NULL is exactly what the #94724 legacy-owner backfill exists to
+            # repair, and rows minted AFTER that one-shot backfill ran stayed
+            # NULL forever: profile-keyed matching then drops them from the
+            # sidebar and deep links can't resolve them (#99222).
+            profile_name=(
+                Path(profile_home).name if profile_home else _current_profile_name()
+            ),
         )
         # A session can be born hidden (session.create hidden=true, or a
         # session.set_hidden that arrived before the row existed): apply the


### PR DESCRIPTION
## Summary

Desktop session mutations (archive, pin, unread, delete) now reach the owning profile's state.db, and new session rows are stamped with their real profile name instead of NULL — so archiving/deleting non-default-profile sessions works and sessions created around a profile switch stop vanishing from the sidebar.

Fixes #96531, #98609, #78836 (canonical dup), #99222.

## Changes

- **apps/desktop/src/api/sessions.ts** (@Bergmann89, salvaged from #97199 with authorship): `deleteSession` carries `?profile=`; `setSessionArchived`/`Pinned`/`Unread` carry `body.profile`. `request.profile` only drives Electron routing — the backend selects its target DB from the query/body param, which these four mutations dropped (lost in the src/hermes.ts → src/api/ split; renameSession was already correct). +134 lines of vitest coverage.
- **run_agent.py, tui_gateway/server.py, tui_gateway/methods_session.py** (maintainer): three writers persisted `profile_name=NULL` for launch/default-profile sessions ('default'→None conversion, `_ensure_session_db_row`, `session.branch`). The desktop now keys rows by (profile, id) and resolves deep links by profile match, so NULL matches nothing — and fresh NULL rows recreated exactly the state the #94724 backfill repairs. All three now stamp the real profile name.
- **hermes_state.py** (maintainer): whole-class fix at the SessionDB choke point — `_insert_session_row` derives the store's own profile from its `db_path` when no explicit stamp is given, covering every remaining creation path (`/new`, `--create-if-missing`, foreign import, ACP, gateway branch/title, the #82616 peer self-heal INSERT, compression children of NULL parents). Explicit `profile_name` args always win; stores outside the profile tree keep NULL (fail-closed, never guess). 7 new regression tests in `tests/test_session_db_profile_stamp.py`.

## Validation

| | Before | After |
|---|---|---|
| DELETE non-default session | `{ok, already_absent}` from wrong DB; row reappears | deleted from owning profile's DB |
| Archive non-default session | "Session not found" / no-op | archived in owning DB |
| New session row profile_name | NULL | 'default' / real profile name (sqlite-verified) |
| Unstamped rows via any path (import, ACP, self-heal, compression child) | NULL | derived from the store's own db_path; out-of-tree stores stay NULL |

vitest `src/api/sessions.test.ts` 10/10; new `tests/test_session_db_profile_stamp.py` 7/7; tui_gateway/hermes_state/compression/backfill/delete-isolation suites 244 passed (1 pre-existing failure on main, unrelated: `test_search_projection_skips_context_enrichment_queries`); tsc + ruff clean.

Supersedes #96211 (PATCH-only subset — close with credit once this lands).

## Infographic

![Desktop session mutations now carry their owning profile](https://v3b.fal.media/files/b/0aa88aed/6Ag4NrIb2bLv7tTV07weZ_sd1IPIKb.png)
