### PR TITLE
fix(desktop): Bot Mode group members stop ghost-dialing — named profiles reuse the primary WS on shared remotes (#96493, salvage #96537)

### DIFF
--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -635,4 +635,46 @@ describe('attached shared-remote group turns (#96493)', () => {
     expect(secondaryGateways).toHaveLength(1)
     expect(primary.request).not.toHaveBeenCalled()
   })
+
+  it('reuses the primary when the shared-remote probe fails instead of dialing a ghost secondary', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 't' })),
+      getConnectionFor: vi.fn(async () => {
+        throw new Error('Timed out connecting to profile "voter"')
+      }),
+      getGatewayWsUrlFor: vi.fn(async () => ({ ok: true as const, wsUrl: 'ws://homelab/voter' })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    await ensureGatewayForProfile('default')
+
+    await requestGatewayForAgent('homelab', 'voter', 'session.create', { title: 'g' })
+
+    expect(secondaryGateways).toHaveLength(0)
+    expect(primary.request).toHaveBeenCalledOnce()
+  })
+
+  it('openGatewayForAgent and ensureGatewayForAgent do not dial a secondary', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    installAttachedSharedRemote()
+    await ensureGatewayForProfile('default')
+
+    await openGatewayForAgent('homelab', 'voter')
+    expect(await ensureGatewayForAgent('homelab', 'voter')).toBe(true)
+    expect(secondaryGateways).toHaveLength(0)
+  })
+
+  it('ensureGatewayForAgent is false when the attached primary socket is closed', async () => {
+    const primary = { connectionState: 'closed', request: vi.fn() }
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    installAttachedSharedRemote()
+
+    expect(await ensureGatewayForAgent('homelab', 'voter')).toBe(false)
+    expect(secondaryGateways).toHaveLength(0)
+  })
 })

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -564,3 +564,75 @@ describe('retainGatewayForAgent (#93602)', () => {
     expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
   })
 })
+
+describe('attached shared-remote group turns (#96493)', () => {
+  function installAttachedSharedRemote() {
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 't' })),
+      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        connectionId,
+        port: 9119,
+        profile,
+        sharedRemote: true
+      })),
+      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        ok: true as const,
+        wsUrl: `ws://${connectionId}/${profile}`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+  }
+
+  it('reuses the primary socket for a named profile on the attached shared remote', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    installAttachedSharedRemote()
+    await ensureGatewayForProfile('default')
+
+    const release = await retainGatewayForAgent('homelab', 'voter')
+    await requestGatewayForAgent('homelab', 'voter', 'session.create', { title: 'Group: room' })
+    await requestGatewayForAgent('homelab', 'voter', 'prompt.submit', { session_id: 'rt-1', text: 'hi' })
+
+    expect(secondaryGateways).toHaveLength(0)
+    expect(primary.request).toHaveBeenCalledTimes(2)
+    expect(primary.request).toHaveBeenNthCalledWith(1, 'session.create', {
+      title: 'Group: room',
+      profile: 'voter'
+    })
+    expect(primary.request).toHaveBeenNthCalledWith(2, 'prompt.submit', {
+      session_id: 'rt-1',
+      text: 'hi',
+      profile: 'voter'
+    })
+
+    release()
+    expect(secondaryGateways).toHaveLength(0)
+  })
+
+  it('still dials a secondary when the attached source is not a shared remote', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 't' })),
+      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        connectionId,
+        port: 5151,
+        profile,
+        sharedRemote: false
+      })),
+      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        ok: true as const,
+        wsUrl: `ws://${connectionId}/${profile}`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    await ensureGatewayForProfile('default')
+
+    await requestGatewayForAgent('homelab', 'voter', 'session.create', { title: 'g' })
+
+    expect(secondaryGateways).toHaveLength(1)
+    expect(primary.request).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -296,6 +296,60 @@ function isPrimaryRegistryRoute(connectionId: null | string, profile: string): b
   )
 }
 
+/** True when `connectionId` is the window's already-attached source AND that
+ *  source is a one-host-many-profiles remote (`sharedRemote`). Named member
+ *  profiles on that host must reuse the primary socket — a registry secondary
+ *  dials a second WebSocket at the same Tailscale URL, which accept/closes in
+ *  ~30ms (`messages=1`) and never runs `session.create` (#96493). Isolated
+ *  SSH/pooled backends (`sharedRemote: false`) still get their own secondary. */
+async function isAttachedSharedRemote(connectionId: null | string, profile: string): Promise<boolean> {
+  const id = String(connectionId ?? '').trim()
+  const key = normKey(profile)
+
+  if (!id || !g.primaryConnectionId || id !== g.primaryConnectionId) {
+    return false
+  }
+
+  if (isPrimaryRegistryRoute(id, key)) {
+    return false
+  }
+
+  const desktop = window.hermesDesktop
+
+  if (!desktop?.getConnectionFor) {
+    return false
+  }
+
+  try {
+    const conn = await withTimeout(
+      desktop.getConnectionFor({ connectionId: id, profile: key }),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out resolving shared-remote route for "${key}"`
+    )
+
+    return Boolean(conn && typeof conn === 'object' && (conn as { sharedRemote?: boolean }).sharedRemote === true)
+  } catch {
+    return false
+  }
+}
+
+async function requestOnPrimaryGateway<T>(
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<T> {
+  const gateway = g.primaryGateway
+
+  if (!gateway) {
+    throw new Error('Hermes gateway unavailable')
+  }
+
+  return timeoutMs === undefined && signal === undefined
+    ? gateway.request<T>(method, params)
+    : gateway.request<T>(method, params, timeoutMs, signal)
+}
+
 export function isActivePrimary(): boolean {
   return g.activeKey === g.primaryProfile
 }
@@ -870,6 +924,10 @@ export async function requestGatewayForAgent<T>(
     return requestGatewayForProfile<T>(key, method, params, timeoutMs, signal)
   }
 
+  if (await isAttachedSharedRemote(connectionId, key)) {
+    return requestOnPrimaryGateway<T>(method, { ...params, profile: key }, timeoutMs, signal)
+  }
+
   if (!window.hermesDesktop?.getConnectionFor) {
     throw new Error('This Desktop build cannot dial registry connections. Update Hermes Desktop.')
   }
@@ -1052,6 +1110,11 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     const route = await gatewayForProfile(key, true)
 
     return route.release
+  }
+
+  if (isPrimaryRegistryRoute(connectionId, key) || (await isAttachedSharedRemote(connectionId, key))) {
+    // Primary socket stays open for the window lifetime — no secondary to hold.
+    return () => undefined
   }
 
   if (!window.hermesDesktop?.getConnectionFor) {
@@ -1268,6 +1331,10 @@ export async function openGatewayForAgent(
     return openGatewayForProfile(profile)
   }
 
+  if (await isAttachedSharedRemote(connectionId, profile)) {
+    return
+  }
+
   if (!window.hermesDesktop?.getConnectionFor) {
     throw new Error('This Desktop build cannot dial registry connections. Update Hermes Desktop.')
   }
@@ -1311,6 +1378,10 @@ export async function ensureGatewayForAgent(
 
     await ensureGatewayForProfile(profile)
 
+    return !signal?.aborted
+  }
+
+  if (await isAttachedSharedRemote(connectionId, profile)) {
     return !signal?.aborted
   }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -329,7 +329,11 @@ async function isAttachedSharedRemote(connectionId: null | string, profile: stri
 
     return Boolean(conn && typeof conn === 'object' && (conn as { sharedRemote?: boolean }).sharedRemote === true)
   } catch {
-    return false
+    // Probe failed. A secondary at this already-attached source is the #96493
+    // ghost WebSocket (accept/close, messages=1). Prefer the primary until a
+    // later probe can prove isolation (`sharedRemote: false`). Isolated SSH
+    // still dials its own socket when getConnectionFor succeeds.
+    return true
   }
 }
 
@@ -341,7 +345,7 @@ async function requestOnPrimaryGateway<T>(
 ): Promise<T> {
   const gateway = g.primaryGateway
 
-  if (!gateway) {
+  if (!gateway || !isOpen(gateway)) {
     throw new Error('Hermes gateway unavailable')
   }
 
@@ -1332,6 +1336,10 @@ export async function openGatewayForAgent(
   }
 
   if (await isAttachedSharedRemote(connectionId, profile)) {
+    if (!isOpen(g.primaryGateway)) {
+      throw new Error('Hermes gateway unavailable')
+    }
+
     return
   }
 
@@ -1382,7 +1390,7 @@ export async function ensureGatewayForAgent(
   }
 
   if (await isAttachedSharedRemote(connectionId, profile)) {
-    return !signal?.aborted
+    return Boolean(isOpen(g.primaryGateway) && !signal?.aborted)
   }
 
   if (!window.hermesDesktop?.getConnectionFor) {

--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor


### PR DESCRIPTION
## Summary

Bot Mode group members on named profiles now reuse the window's primary WebSocket when the target is the already-attached shared remote, scoping RPCs with `profile=` — instead of dialing a ghost per-profile secondary WS that accept/closes in ~30ms and silently drops `session.create`/`prompt.submit`.

Fixes #96493 (group rooms silent on Desktop → remote shared gateway).

## Changes

Salvage of #96537 (@smfworks, both commits cherry-picked with authorship):

- **apps/desktop/src/store/gateway.ts**: new `isAttachedSharedRemote()` probe (via `getConnectionFor` → `sharedRemote` flag, fail-open to primary on probe error) + `requestOnPrimaryGateway()`, wired into `requestGatewayForAgent` / `retainGatewayForAgent` / `openGatewayForAgent` / `ensureGatewayForAgent`. Isolated SSH/pooled backends (`sharedRemote: false`) keep their own secondaries (#93594/#93602 behavior preserved).
- **gateway-profile-request.test.ts**: 5 new cases for the #96493 path.

Complements #98169 (merged): that fix stamps `sharedRemote: true` on the registry-primary reuse descriptor — which is exactly the signal `isAttachedSharedRemote()` probes. Server side: tui_gateway session/prompt RPCs are `_profile_scoped` and honor `params.profile`.

## Validation

| | Before | After |
|---|---|---|
| Named-profile member RPC on attached shared remote | fresh secondary WS, accept/close ~30ms, messages=1, prompt never runs | primary WS reused, RPC scoped with `profile=` |

Targeted vitest: 48/48 across 4 gateway store files + 8/8 electron siblings (registry-primary-profile-scope, remote-ws-headers). `audit_pr_attribution.py --fix` green.

## Infographic

![One socket, many profiles — reuse primary WS](https://v3b.fal.media/files/b/0aa88aed/R4hcfKmicvUEu_k3uhYrg_vzC6gROc.png)
