### PR TITLE
feat(models): alphabetize live-only model picker entries; fully sort HuggingFace

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -35,6 +35,7 @@ from hermes_cli.models_catalog_static import (
     _AZURE_FOUNDRY_RESPONSES_PREFIXES,
     _BORROWED_MODEL_PROVIDERS,
     _COPILOT_MODEL_ALIASES,
+    _FULLY_ALPHABETIZE_PICKER_PROVIDERS,
     _KEYLESS_STABLE_CACHE_PROVIDERS,
     _LIVE_FIRST_PICKER_PROVIDERS,
     _MODELS_DEV_PREFERRED,
@@ -1252,7 +1253,10 @@ _PROVIDER_CATALOG_FETCHERS: dict[str, Any] = {
     # DeepInfra's generic /models mixes chat, image, video, speech and embedding models; the tagged
     # catalog helper is the only safe source for the chat picker, including its empty/failure result.
     "deepinfra": lambda normalized, force_refresh: _fetch_deepinfra_models(force_refresh=force_refresh) or [],
-    "ollama-cloud": lambda normalized, force_refresh: fetch_ollama_cloud_models(force_refresh=force_refresh) or None,
+    # Ollama Cloud has no curated _PROVIDER_MODELS entry — same alphabetize-when-no-hand-picked-order
+    # rule as every other live-only catalog (see _merge_picker_models) instead of raw API order.
+    "ollama-cloud": lambda normalized, force_refresh: _merge_picker_models(
+        normalized, [], fetch_ollama_cloud_models(force_refresh=force_refresh) or []) or None,
     "openai": _openai_catalog,
     "openai-api": _openai_catalog,
     "custom": _custom_catalog,
@@ -1279,10 +1283,34 @@ def _profile_live_catalog(normalized: str) -> Optional[list[str]]:
     if not live:
         return list(profile.fallback_models) if profile.fallback_models else None
     curated = list(_PROVIDER_MODELS.get(normalized, [])) or list(profile.fallback_models or ())
+    return _merge_picker_models(normalized, curated, live)
+
+
+def _merge_picker_models(normalized: str, curated: list[str], live: list[str]) -> list[str]:
+    """Merge a provider's curated and live-fetched model lists into picker order.
+
+    ``curated`` keeps its hand-picked order and leads (``_LIVE_FIRST_PICKER_PROVIDERS`` lead with
+    ``live`` instead). Whatever the live endpoint returns BEYOND that list has no ordering signal —
+    it is raw ``/v1/models`` order, which for a large catalog (HuggingFace's ~130-model tail) reads
+    as shuffled and makes a specific model hard to find — so that tail is alphabetized. With no
+    curated list at all the live catalog is the whole picker and is alphabetized outright.
+    ``_FULLY_ALPHABETIZE_PICKER_PROVIDERS`` sort the entire result, curated head included, because
+    their curated entry is a membership filter rather than a ranking.
+    """
+    if not live:
+        return list(curated)
     if not curated:
-        return live
-    primary, secondary = (live, curated) if normalized in _LIVE_FIRST_PICKER_PROVIDERS else (curated, live)
-    return _merge_unique(primary, secondary, key=_model_dedup_key)
+        return sorted(live, key=str.lower)
+    live_first = normalized in _LIVE_FIRST_PICKER_PROVIDERS
+    primary, secondary = (live, curated) if live_first else (curated, live)
+    seen = {_model_dedup_key(m) for m in primary}
+    extra = _merge_unique([], [m for m in secondary if _model_dedup_key(m) not in seen], key=_model_dedup_key)
+    if not live_first:
+        extra.sort(key=str.lower)
+    merged = list(primary) + extra
+    if normalized in _FULLY_ALPHABETIZE_PICKER_PROVIDERS:
+        merged.sort(key=str.lower)
+    return merged
 
 
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -523,6 +523,14 @@ _BORROWED_MODEL_PROVIDERS: frozenset[str] = frozenset()
 # and rotate them often, so their stale curated entries must not pollute the top.
 _LIVE_FIRST_PICKER_PROVIDERS: frozenset[str] = frozenset({"opencode-zen", "opencode-go", "meta-ai"})
 
+# Providers whose curated _PROVIDER_MODELS entry is a hand-picked MEMBERSHIP filter (which models
+# to allow) rather than a deliberate ORDER. Contrast zai/kimi-coding/minimax/vertex/bedrock, whose
+# curated lists are visibly version-descending (newest first) — reordering those would destroy
+# real signal. HuggingFace's curated list has no such structure (it reads as models added over
+# time, not ranked), so the picker sorts its ENTIRE merged result, curated head included, instead
+# of only the live-only tail appended after the curated head (the rule for everyone else).
+_FULLY_ALPHABETIZE_PICKER_PROVIDERS: frozenset[str] = frozenset({"huggingface"})
+
 
 # Models supporting OpenAI Priority Processing (service_tier="priority"; see
 # openai.com/api-priority-processing). Pattern-based: any OpenAI flagship (gpt-*, o1*, o3*, o4*).

--- a/tests/hermes_cli/test_model_picker_sort.py
+++ b/tests/hermes_cli/test_model_picker_sort.py
@@ -1,0 +1,55 @@
+"""Picker ordering: curated head keeps its hand-picked order, live-only tail is alphabetized,
+and providers whose curated list is a membership filter (HuggingFace) sort in full."""
+from types import SimpleNamespace
+
+from hermes_cli.models import _merge_picker_models, _profile_live_catalog
+from hermes_cli.models_catalog_static import (
+    _FULLY_ALPHABETIZE_PICKER_PROVIDERS,
+    _LIVE_FIRST_PICKER_PROVIDERS,
+)
+
+
+def test_curated_head_kept_live_tail_alphabetized():
+    curated = ["z-newest", "m-older"]  # deliberate newest-first order
+    live = ["m-older", "delta", "Alpha", "charlie"]
+    assert _merge_picker_models("zai", curated, live) == ["z-newest", "m-older", "Alpha", "charlie", "delta"]
+
+
+def test_no_curated_list_is_alphabetized_outright():
+    assert _merge_picker_models("ollama-cloud", [], ["qwen", "Gemma", "llama"]) == ["Gemma", "llama", "qwen"]
+
+
+def test_no_live_returns_curated_verbatim():
+    assert _merge_picker_models("zai", ["b", "a"], []) == ["b", "a"]
+
+
+def test_live_first_provider_keeps_raw_live_order():
+    provider = next(iter(_LIVE_FIRST_PICKER_PROVIDERS))
+    live = ["zeta", "alpha", "mid"]
+    curated = ["stale-curated", "alpha"]
+    # live leads verbatim, curated-only entries append in their own order, nothing sorted
+    assert _merge_picker_models(provider, curated, live) == ["zeta", "alpha", "mid", "stale-curated"]
+
+
+def test_fully_alphabetized_provider_sorts_curated_head_too():
+    assert "huggingface" in _FULLY_ALPHABETIZE_PICKER_PROVIDERS
+    curated = ["zephyr", "mistral"]
+    live = ["qwen", "aya", "mistral"]
+    assert _merge_picker_models("huggingface", curated, live) == ["aya", "mistral", "qwen", "zephyr"]
+
+
+def test_dedup_is_case_insensitive_and_keeps_curated_spelling():
+    assert _merge_picker_models("zai", ["GLM-5"], ["glm-5", "b-model"]) == ["GLM-5", "b-model"]
+
+
+def test_profile_live_catalog_routes_through_merge(monkeypatch):
+    profile = SimpleNamespace(
+        auth_type="api_key",
+        base_url="https://example.invalid/v1",
+        fallback_models=["curated-two", "curated-one"],
+        fetch_models=lambda api_key, base_url: ["zulu", "curated-one", "alpha"],
+    )
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr("hermes_cli.models._api_key_credentials", lambda name: ("key", None))
+    monkeypatch.setattr("hermes_cli.models._PROVIDER_MODELS", {})
+    assert _profile_live_catalog("some-plugin-provider") == ["curated-two", "curated-one", "alpha", "zulu"]


### PR DESCRIPTION
## What does this PR do?

Makes a specific model easier to find in the model picker. Providers are already listed alphabetically, but each provider's own models appear in raw `/v1/models` fetch order beyond its curated head. For a large catalog (HuggingFace's ~130-model tail) that order reads as shuffled.

Rebased onto current `main` after the `hermes_cli/models.py` split (`0cb996d97`); the earlier three-commit version of this branch no longer applied.

- Curated `_PROVIDER_MODELS` order is hand-picked and **stays put**. Live-only extras appended after it are alphabetized. A provider with no curated list is alphabetized outright.
- `_LIVE_FIRST_PICKER_PROVIDERS` (OpenCode Zen/Go, meta-ai) are untouched — their live order is authoritative.
- New `_FULLY_ALPHABETIZE_PICKER_PROVIDERS` = `{"huggingface"}`: its curated entry is a membership filter, not a ranking, so the whole merged list is sorted. Providers whose curated lists are version-descending (zai, kimi-coding, minimax, vertex, bedrock, …) are unchanged.
- `ollama-cloud` (no curated list) goes through the same rule. Local `ollama` `/api/tags` order is deliberately **not** changed (its order carries recency signal and an existing test asserts it).

## Related Issue

None filed — small UX change.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/models.py` — new `_merge_picker_models()`; `_profile_live_catalog()` and the `ollama-cloud` fetcher route through it.
- `hermes_cli/models_catalog_static.py` — `_FULLY_ALPHABETIZE_PICKER_PROVIDERS`.
- `tests/hermes_cli/test_model_picker_sort.py` — 7 tests: curated head preserved, tail sorted, no-curated sorted, live-first untouched, HuggingFace fully sorted, case-insensitive dedup keeps curated spelling, `_profile_live_catalog` integration.

## How to Test

1. `pytest tests/hermes_cli/test_model_picker_sort.py tests/hermes_cli/test_models.py tests/hermes_cli/test_provider_parity.py -q`
2. With a HuggingFace key configured, open the model picker → HuggingFace section is alphabetical.
3. Open zai / kimi-coding → curated head order unchanged, only the live-only tail is sorted.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs — this supersedes the earlier revision of the same PR
- [x] Only related changes
- [x] `pytest tests/hermes_cli/ -k "model or ollama or picker or catalog or provider"` — all pass except pre-existing failures that fail identically on clean `main` in this environment (`test_user_providers_model_switch.py` ×2, and web-server 401s from local config)
- [x] Tests added
- [x] Tested on macOS 26 (Darwin 25.6), Python 3.11

### Documentation & Housekeeping

- [x] Docstrings updated — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — pure list ordering, N/A
