### PR TITLE
fix(profiles): honor tombstones in Group Chat and cron enumeration

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -431,19 +431,25 @@ def profile_matches_home(name: str, home: "Path | None" = None) -> bool:
         return False
 
 
-def list_profile_names() -> List[str]:
+def list_profile_names(*, profiles_root: Path | None = None) -> List[str]:
     """Cheap name-only profile listing: ``default`` plus profile dirs.
 
     Unlike :func:`list_profiles` this reads NO per-profile config/metadata —
     it is a directory scan, safe to call from hot paths (cron delivery-target
-    listings, create-time validation).
+    listings, create-time validation). ``profiles_root`` lets callers scope
+    the scan to the Hermes root they serve.
     """
     names = ["default"]
-    profiles_root = _get_profiles_root()
+    profiles_root = profiles_root or _get_profiles_root()
     try:
         if profiles_root.is_dir():
             for entry in sorted(profiles_root.iterdir()):
-                if entry.is_dir() and entry.name != "default" and _PROFILE_ID_RE.match(entry.name):
+                if (
+                    entry.is_dir()
+                    and entry.name != "default"
+                    and _PROFILE_ID_RE.match(entry.name)
+                    and not named_profile_is_deleted(entry)
+                ):
                     names.append(entry.name)
     except OSError:
         pass

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -18,6 +18,7 @@ from hermes_cli.profiles import (
     backfill_profile_envs,
     create_profile,
     delete_profile,
+    list_profile_names,
     list_profiles,
     profile_exists,
     profiles_to_serve,
@@ -67,7 +68,7 @@ class TestDeletedProfileTombstone:
         monkeypatch.setenv("HERMES_HOME", str(profile_env / ".hermes"))
         assert "worker" not in _named_homes(profile_env)
 
-    def test_empty_shell_after_delete_is_not_listed_or_served(self, profile_env):
+    def test_empty_shell_after_delete_is_not_enumerated_or_served(self, profile_env):
         profile_dir = create_profile("worker", no_alias=True, no_skills=True)
         with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
             "hermes_cli.profiles._stop_profile_backends"
@@ -79,8 +80,14 @@ class TestDeletedProfileTombstone:
         (profile_dir / "state.db").write_bytes(b"")
 
         assert "worker" not in _named_homes(profile_env)
+        assert "worker" not in list_profile_names()
         served = [name for name, _ in profiles_to_serve(True)]
         assert "worker" not in served
+
+        from cron.scheduler import cron_delivery_targets
+
+        target_ids = {target["id"] for target in cron_delivery_targets()}
+        assert "bot-chat:worker" not in target_ids
 
     def test_tombstoned_home_is_not_bootstrapped(self, profile_env, monkeypatch):
         profile_dir = create_profile("worker", no_alias=True, no_skills=True)

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -23,6 +23,7 @@ from gateway.hosted_room_peer import (
     catalog_mapping,
     issue_room_grant,
 )
+from hermes_constants import mark_named_profile_deleted
 from tui_gateway.hosted_room_service import (
     HostedRoomService,
     _RouteStatusPeerClient,
@@ -392,6 +393,31 @@ def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path:
     ]
     assert events[1]["payload"]["text"] == "reply from ops"
     assert service.status("room-1")["working"] is False
+
+
+def test_local_profiles_hide_reserved_and_tombstoned_directories(tmp_path: Path):
+    profiles_dir = tmp_path / "profiles"
+    (profiles_dir / "ops").mkdir(parents=True)
+    worker = profiles_dir / "worker"
+    worker.mkdir()
+    mark_named_profile_deleted(worker)
+    service = HostedRoomService(_server(), db_path=tmp_path / "state.db")
+
+    assert service.local_profiles() == ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Valid room",
+        members=[
+            {
+                "member_id": "default",
+                "profile": "default",
+                "handle": "hermes",
+            },
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+
+    assert room["room_id"] == "room-1"
 
 
 def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -149,13 +149,9 @@ class HostedRoomService:
         return self.db_path.parent
 
     def local_profiles(self) -> tuple[str, ...]:
-        profiles = {"default"}
-        profiles_dir = self.root / "profiles"
-        if profiles_dir.is_dir():
-            profiles.update(
-                path.name for path in profiles_dir.iterdir() if path.is_dir()
-            )
-        return tuple(sorted(profiles))
+        from hermes_cli.profiles import list_profile_names
+
+        return tuple(list_profile_names(profiles_root=self.root / "profiles"))
 
     def bindings(self) -> tuple[HostedRoomBinding, ...]:
         local_gateway_id = hosted_rooms.local_authority_gateway_id()


### PR DESCRIPTION
## Summary

Deleting a named profile left the reserved `.deleted` directory visible to Group Chat roster validation. A stale process could also recreate a tombstoned profile shell, causing it to reappear in Group Chat and cron Bot Chat target enumeration.

## Changes

- Make the lightweight `list_profile_names()` enumerator tombstone-aware and allow callers to scope it to an explicit profiles root.
- Reuse that enumerator from `HostedRoomService.local_profiles()` so Group Chats only advertise valid live profiles from the service's own Hermes root.
- Add regressions covering valid Group Chat creation after deletion, stale directory recreation, and cron Bot Chat target filtering.

## Validation

- Focused tombstone and HostedRoomService regressions: 2 passed.
- Deleted-profile tombstone suite: 16 passed.
- Cron Bot Chat delivery suite: 17 passed.
- Python compilation and `git diff --check` passed.

Fixes #99226
