### PR TITLE
fix(models): preserve any :suffix SKU on custom providers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3451,6 +3451,24 @@ def _openrouter_variant_base(model_id: str) -> Optional[str]:
         return base
     return None
 
+
+def _model_sku_base(model_id: str) -> Optional[str]:
+    """Return the base id when ``model_id`` carries a ``:suffix`` (any
+    non-empty tail after the last colon), else ``None``.
+
+    Used to validate SKU-style ids like ``deepseek/deepseek-v4-flash-0731:free``
+    or ``...:cxbc`` against provider listings that expose only the base id.
+    Both sides of the ``base:suffix`` boundary must be non-empty, so bare
+    names and vendor-prefixed ids (``custom:foo``) are left untouched; the
+    suffix itself is not inspected, so a suffix that is itself a real catalog
+    entry (e.g. ``:cxbc`` on aggregators) is never stripped by accident.
+    """
+    base, sep, tail = (model_id or "").rpartition(":")
+    if not sep or not base or not tail:
+        return None
+    return base
+
+
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models
 # would be listed here (tried only as a last resort for bare short-alias
 # resolution, after every native-vendor catalog, so they never hijack an alias
@@ -6744,6 +6762,23 @@ def validate_requested_model(
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+
+            # SKU-style suffixes (":free", ":batch", ":thinking",
+            # ":extended", and aggregator-specific ones like ":cxbc",
+            # ":network", ":cxo", ":cxa"): distinct SKUs that MAY appear in
+            # /models when the provider lists them, but many custom
+            # aggregators expose only the base id.  If the base id is
+            # present, accept and PRESERVE the suffixed id — it routes the
+            # exact SKU on the upstream gateway and must not be stripped by
+            # fuzzy auto-correction (which would silently route the paid base).
+            sku_base = _model_sku_base(requested_for_lookup)
+            if sku_base and sku_base in set(api_models):
                 return {
                     "accepted": True,
                     "persist": True,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -660,6 +660,85 @@ class TestValidateOpenRouterVariantSuffixes:
         )
         assert result.get("corrected_model") != "x-ai/grok-4.6:nitro"
 
+
+class TestValidateCustomProviderSkuSuffixes:
+    """Custom aggregators (e.g. PlusVibeAPI, RouterAI) expose suffixed SKUs as
+    first-class /v1/models entries, but many list only the base id (e.g.
+    `deepseek/deepseek-v4-flash-0731` without the `:cxbc` / `:free` twins).
+    When the base id is listed, ANY `base:suffix` request must be accepted
+    and the suffixed id PRESERVED — the suffix selects the specific SKU
+    upstream and must not be stripped by fuzzy auto-correction."""
+
+    _LISTING = [
+        "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-flash-0731:cxbc",
+    ]
+
+    def _validate_custom(self, model, listing=None):
+        return _validate(
+            model,
+            "custom",
+            api_models=list(self._LISTING if listing is None else listing),
+            base_url="https://plusvibeapi.ru/v1",
+        )
+
+    def test_free_sku_base_listed_accepted_unmodified(self):
+        result = self._validate_custom("deepseek/deepseek-v4-flash-0731:free")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result.get("corrected_model") is None
+        assert result["message"] is None
+
+    def test_free_sku_not_fuzzy_corrected_to_base(self):
+        """The old failure mode: get_close_matches would 'fix'
+        model:free to the bare base id and silently route the PAID SKU."""
+        result = self._validate_custom("deepseek/deepseek-v4-flash-0731:free")
+        assert result["accepted"] is True
+        assert result.get("corrected_model") is None
+
+    def test_other_real_suffix_unaffected(self):
+        """A suffix that IS a real catalog entry (:cxbc) keeps its existing
+        direct-membership behavior — the base-strip path must not hijack it."""
+        result = self._validate_custom("deepseek/deepseek-v4-flash-0731:cxbc")
+        assert result["accepted"] is True
+        assert result.get("corrected_model") is None
+
+    @pytest.mark.parametrize(
+        "suffix",
+        ["cxbc", "network", "cxo", "cxa", "free", "Free", "batch", "thinking", "extended"],
+    )
+    def test_any_suffix_on_listed_base_preserved(self, suffix):
+        """Aggregator-specific SKU suffixes (:cxbc, :network, :cxo, :cxa,
+        ...) whose base is listed are accepted with the suffixed id PRESERVED
+        — never fuzzy-corrected to the (paid) base."""
+        result = self._validate_custom(f"deepseek/deepseek-v4-flash-0731:{suffix}")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result.get("corrected_model") is None
+        assert result["message"] is None
+
+    def test_unknown_model_still_auto_corrected(self):
+        """Auto-correction still works for genuine typos with no :free suffix."""
+        result = self._validate_custom("deepseek/deepseek-v4-flash-0732")
+        assert result["accepted"] is True
+        assert result.get("corrected_model") == "deepseek/deepseek-v4-flash-0731"
+
+    def test_free_sku_on_unknown_base_still_rejected(self):
+        """A :free SKU whose base id is NOT in the listing falls through to
+        the custom-provider soft-accept path (accepted with a warning, no
+        auto-correction) — never silently corrected to a paid base."""
+        result = self._validate_custom("deepseek/deepseek-v4-flash-9999:free")
+        assert result["accepted"] is True
+        assert result["recognized"] is False
+        assert result.get("corrected_model") is None
+
+    def test_bare_free_suffix_no_crash(self):
+        """A bare name like `my-model:free` (no vendor) must not crash the
+        base-strip helper."""
+        result = self._validate_custom("my-model:free")
+        assert result["accepted"] is True
+        assert result.get("corrected_model") is None
+
     def test_static_catalog_fallback_accepts_variant(self):
         """Gateway path: /models unreachable → static catalog validates the
         base id and preserves the suffix."""


### PR DESCRIPTION
## Problem

Custom aggregators (PlusVibeAPI, RouterAI, and similar [OI]-compatible gateways) expose suffixed SKUs as distinct upstream models — `:cxbc`, `:free`, `:network`, `:cxo`, `:cxa`, `:batch`, `:thinking`, `:extended`, etc. — but many list only the base id in `/v1/models`.

When a user runs `/model deepseek/deepseek-v4-flash-0731:free`, the custom-provider validation path in `validate_requested_model` does not find the suffixed id in the listing and falls through to fuzzy auto-correction (`get_close_matches`, cutoff 0.9). Because `base:suffix` vs `base` sits above the 0.9 cutoff for short suffixes, the suffix is silently stripped and the request is rewritten to the bare base id — routing the PAID SKU instead of the free/variant one the user asked for.

This was already special-cased for `:free` at one point, but the general bug class (any suffix) remained.

## Fix

Add `_model_sku_base()`: return the base id when `model_id` carries a `:suffix` (any non-empty tail after the last colon), else `None`. In the custom-provider branch, between the exact-match check and fuzzy auto-correction: if the base id IS listed, accept and PRESERVE the suffixed id (`recognized: True`, no `corrected_model`).

- The suffix itself is never inspected, so any suffix works and case is irrelevant (the suffix is not compared, only the base).
- `foo:` / `:foo` / `custom:foo` (no vendor colon) return `None` and are left untouched — bare names and vendor-prefixed ids keep their existing behavior.
- Genuine typos in the BASE still get auto-corrected (step 3).
- The OpenRouter path is untouched — its variant-suffix handling (`:nitro/:floor/:exacto/:online`) is a separate, strict mechanism.

## Tests

New `TestValidateCustomProviderSkuSuffixes` (9 parametrized suffix cases + regressions):

- any suffix on a listed base → accepted + preserved (never fuzzy-corrected to the paid base)
- a suffix that IS a real catalog entry (`:cxbc`) keeps direct-membership behavior
- typo in base still auto-corrected
- `:free` on an unknown base → soft-accept, no silent paid-base substitution
- bare `my-model:free` → no crash

`venv/bin/python -m pytest tests/hermes_cli/test_model_validation.py -q` → 67 passed.