### PR TITLE
fix: MSAL mit cryptography 50 kompatibel halten

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,6 +409,10 @@ exclude-newer = "14 days"
 # request-smuggling) fix in 4.4.1, published 2026-08-03. Remove after 2026-08-17.
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
+# msal 1.38.0 lifts its cryptography ceiling to include the core 50.x security
+# pin. Older releases leave installed environments formally inconsistent even
+# when uv's cryptography override resolves the graph. Remove the msal exception
+# after 2026-09-07, when 1.38.0 has aged through the normal 14-day window.
 #
 # defusedxml, python-olm, unpaddedbase64: the OPPOSITE shape (#80387, #79434,
 # #78227 family). These are ancient, effectively frozen releases (2021-2023)
@@ -433,7 +437,7 @@ exclude-newer = "14 days"
 # firecrawl-anydoc: same exact-pin shape (==0.2.4, hosted-OCR wiring PR).
 # The pin bump WAS the review; exclude-newer adds zero float protection to
 # an exact pin and would only delay the reviewed version 14 days.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, msal = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -120,6 +120,32 @@ def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
         )
 
 
+def test_locked_msal_supports_pinned_cryptography_50():
+    """MSAL 1.38 lifts the cryptography ceiling to include the core 50.x pin.
+
+    Older MSAL releases declare ``cryptography<49``. uv's deliberate
+    cryptography override can resolve that graph, but the installed environment
+    remains formally inconsistent and ``uv pip check`` fails. Keep the young
+    compatible MSAL release visible through the repository's 14-day cutoff and
+    locked at or above the first compatible version.
+    """
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    exemptions = pyproject["tool"]["uv"].get("exclude-newer-package", {})
+    assert exemptions.get("msal") is False, (
+        "msal must bypass exclude-newer until 1.38.0 ages through the 14-day "
+        "window; otherwise lock regeneration can restore the cryptography<49 conflict"
+    )
+
+    versions = _locked_versions("msal")
+    assert versions, "msal not found in uv.lock"
+    assert all(_version_tuple(version) >= (1, 38, 0) for version in versions), (
+        f"uv.lock resolves incompatible MSAL version(s) {sorted(versions)}; "
+        "MSAL >=1.38.0 is required with cryptography 50.x"
+    )
+
+
 def test_locked_starlette_is_not_vulnerable_to_cve_2026_48710():
     """The committed uv.lock must resolve starlette to a patched version.
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ vercel = false
 pillow = false
 unpaddedbase64 = false
 h2 = false
+msal = false
 defusedxml = false
 aiohttp = false
 cryptography = false
@@ -2612,16 +2613,16 @@ wheels = [
 
 [[package]]
 name = "msal"
-version = "1.36.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/1f/10f9d47a63d3a2e61b2c43e15bee6b95682aab827018f9a1b97a80787e25/msal-1.38.0.tar.gz", hash = "sha256:4f10ff1257bacfd1781f22e85bd2b8d43ad1b490f3b6aafd7906671cadedd464", size = 203411, upload-time = "2026-08-24T10:22:46.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547, upload-time = "2026-04-09T10:20:32.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ca/d768f77a27d81ed0a6884f2458f8613c31c79b2eb95defbeca2273fd0754/msal-1.38.0-py3-none-any.whl", hash = "sha256:765b9b98b6aa380ee8b8f1c75636e08863edaf0a953498955bd668650dde5d49", size = 131057, upload-time = "2026-08-24T10:22:47.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Hermes pinnt `cryptography==50.0.0` wegen behobener Sicherheitslücken. Der bisherige Lockstand mit `msal 1.36.0` deklarierte jedoch `cryptography<49`. Dadurch war die installierte Azure Identity Umgebung formal inkonsistent und `uv pip check` schlug fehl.

## Lösung

1. `msal` wird im Lockfile auf `1.38.0` aktualisiert. Diese Version deklariert `cryptography>=2.5,<51`.
2. MSAL wird bis zum 7. September 2026 gezielt vom relativen 14 Tage Reifefenster ausgenommen. Danach kann die Ausnahme entfernt werden.
3. Ein Regressionstest sichert die Ausnahme und den kompatiblen Mindeststand im Lockfile.

## Prüfung

1. `uv lock --check` erfolgreich.
2. `uv pip check` mit dem Zusatz `azure-identity` erfolgreich.
3. 27 relevante Tests bestanden.
4. Ruff ohne Befund.
5. Hermes Azure Identity Adapter, MSAL Client und Token Cache funktional geprüft.
6. Unabhängiger Review ohne Sicherheits- oder Logikfehler.