### PR TITLE
fix(cli): arm detached relaunch for agent-initiated gateway restart on Windows

### DIFF
--- a/contributors/emails/watts.jeffrey@gmail.com
+++ b/contributors/emails/watts.jeffrey@gmail.com
@@ -1,0 +1,2 @@
+lEWFkRAD
+# PR #99386 author email mapping

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -415,7 +415,6 @@ def _build_gateway_cmd_script(
     lines.append(f'set "HERMES_HOME={hermes_home}"')
     lines.append('set "PYTHONIOENCODING=utf-8"')
     lines.append('set "HERMES_GATEWAY_DETACHED=1"')
-    lines.append('set "HERMES_SUPERVISED_CHILD=1"')
     python_exe_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
     # VIRTUAL_ENV lets the gateway's own python detection find the venv
     # if someone imports hermes_constants-based logic during startup.
@@ -501,7 +500,6 @@ def _build_gateway_vbs_script(
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
         f"env.Item({_quote_vbs_string('PYTHONIOENCODING')}) = {_quote_vbs_string('utf-8')}",
         f"env.Item({_quote_vbs_string('HERMES_GATEWAY_DETACHED')}) = {_quote_vbs_string('1')}",
-        f"env.Item({_quote_vbs_string('HERMES_SUPERVISED_CHILD')}) = {_quote_vbs_string('1')}",
         f"env.Item({_quote_vbs_string('VIRTUAL_ENV')}) = {_quote_vbs_string(_preserve_hermes_home_path(venv_dir))}",
         # Mirror the cmd wrapper's ``PYTHONPATH=<static>;%PYTHONPATH%``: chain onto
         # whatever PYTHONPATH the task environment already carries, at runtime.
@@ -816,7 +814,6 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
         "HERMES_HOME": hermes_home,
         "PYTHONIOENCODING": "utf-8",
         "HERMES_GATEWAY_DETACHED": "1",
-        "HERMES_SUPERVISED_CHILD": "1",
         "VIRTUAL_ENV": _preserve_hermes_home_path(venv_dir),
     }
     _prepend_pythonpath(
@@ -1573,7 +1570,7 @@ def _windows_stop_drain_timeout() -> float:
 def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
     """Force-kill known gateway PIDs without a broad process sweep."""
     try:
-        from gateway.status import _pid_exists, get_process_start_time, terminate_pid
+        from gateway.status import _pid_exists, terminate_pid
     except ImportError:
         return 0
 
@@ -1587,11 +1584,7 @@ def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
         try:
             if not _pid_exists(pid):
                 continue
-            terminate_pid(
-                pid,
-                force=True,
-                expected_start_time=get_process_start_time(pid),
-            )
+            terminate_pid(pid, force=True)
             killed += 1
         except ProcessLookupError:
             continue
@@ -1684,16 +1677,138 @@ def _wait_for_gateway_absent(timeout_s: float = 30.0, interval_s: float = 0.5) -
     return get_running_pid() is None and not _gateway_pids()
 
 
+def _cli_runs_under_gateway(gateway_pid) -> bool:
+    """True when this process is a descendant of the live gateway process.
+
+    The agent-triggered ``hermes gateway restart`` runs as a child of the very
+    gateway it stops, so the stop path (marker drain / ``taskkill /T /F`` force
+    escalation) tears the restart command down before it reaches its own
+    ``start()`` -- the #99215 silent outage. ``_is_supervised_gateway_process``
+    cannot detect this: it is False for a detached Startup-folder / Scheduled-
+    Task gateway launched with ``HERMES_GATEWAY_DETACHED=1`` and no systemd/
+    launchd/external-supervisor marker (the exact reporter config), even when
+    the restart command itself owns the gateway PID. A descendant check closes
+    that gap. A restart issued from a clean shell has no gateway in its ancestor
+    chain, so it is unaffected.
+    """
+    try:
+        gw = int(gateway_pid or 0)
+    except (TypeError, ValueError):
+        return False
+    if gw <= 0:
+        return False
+    from hermes_cli.gateway import _get_ancestor_pids
+
+    return gw in _get_ancestor_pids()
+
+
+def _arm_gateway_restart_watch(old_pids) -> bool:
+    """Arm a detached relaunch for the running gateway(s) *before* they are killed.
+
+    A ``hermes gateway restart`` issued from inside the gateway runs as a
+    child of the very process it is about to stop, so the stop path (marker
+    drain / ``taskkill /T /F`` force escalation) tears the restart command down
+    before it reaches its own ``start()`` -- a silent outage with nothing to
+    relaunch (#99215). Arming the same detached restart watcher that
+    ``hermes update`` and the ``/restart`` command already use (#95194) means a
+    surviving, console-detached process brings the gateway back the instant it
+    exits, so the outcome no longer depends on the restart command itself
+    surviving the teardown.
+
+    Replays each gateway's own captured command line via
+    ``launch_detached_gateway_restart_by_cmdline`` -- the identical mechanism
+    the Windows post-update restart already uses for Scheduled-Task /
+    profile-ambiguous gateways -- with the respawn argv derived from the
+    process's own ``sys.argv`` rather than a profile→PID mapping, so the
+    detached Startup / Scheduled-Task gateways that ``_is_supervised_gateway_
+    process`` cannot detect are covered. Returns True only if at least one
+    watcher was actually armed, so callers can fall back to the synchronous
+    restart; it never raises and never blocks.
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return False
+
+    from gateway.status import looks_like_gateway_command_line
+    from hermes_cli.gateway import launch_detached_gateway_restart_by_cmdline
+
+    # Respawn each gateway with its OWN captured command line (``... gateway
+    # run``), read live before it dies. Never fall back to this CLI's argv --
+    # that is ``... gateway restart`` and replaying it would respawn the restart
+    # command recursively instead of the gateway. A PID whose cmdline can't be
+    # read or doesn't look like a gateway is skipped so we never respawn garbage.
+    armed = False
+    for pid in old_pids:
+        # Snapshot the live argv first: once the process is killed its
+        # command line is unrecoverable, and it is what the detached watcher
+        # replays to respawn this gateway.
+        try:
+            argv = list(psutil.Process(pid).cmdline() or [])
+        except Exception:
+            continue
+        if not argv or not looks_like_gateway_command_line(" ".join(argv)):
+            continue
+        try:
+            if launch_detached_gateway_restart_by_cmdline(pid, list(argv)):
+                armed = True
+        except Exception:
+            continue
+    return armed
+
+
 def restart() -> None:
     """Stop the gateway then start it again.
 
-    Waits for the old gateway to be authoritatively gone before relaunching --
-    otherwise ``start()``'s "already running" guard sees the still-draining old
-    process and no-ops, and when that process later exits nothing replaces it (a
-    silent outage). Fails loudly if the process can't be cleared or the relaunch
+    Normal case (a restart issued from a shell outside the gateway): stop, wait
+    for the old gateway to be authoritatively gone, then relaunch. The wait
+    matters -- otherwise ``start()``'s "already running" guard sees the still-
+    draining old process and no-ops, and when that process later exits nothing
+    replaces it. Fails loudly if the process can't be cleared or the relaunch
     doesn't produce a running gateway.
+
+    Agent-initiated case (``hermes gateway restart`` run from inside a
+    gateway-hosted agent turn): the restart command is a *child* of the gateway
+    it stops, so it is torn down before its own ``start()`` ever runs -- the
+    #99215 silent outage. Detect this by testing whether the live gateway PID is
+    in our ancestor chain, and hand the relaunch to a detached survivor instead
+    of attempting a synchronous restart that cannot survive its own teardown.
     """
     _assert_windows()
+
+    from gateway.status import get_running_pid
+
+    # Agent-initiated restart: the relauncher is a descendant of the gateway it
+    # stops and will be killed before it can relaunch, so hand the relaunch to a
+    # detached survivor instead. (#99215)
+    gw_pid = get_running_pid(cleanup_stale=False)
+    if gw_pid and _cli_runs_under_gateway(gw_pid):
+        old_pids = [pid for pid in [gw_pid, *_gateway_pids()] if pid]
+        if _arm_gateway_restart_watch(old_pids):
+            print(
+                "↻ Agent-initiated gateway restart: armed a detached relaunch "
+                "watcher (survives the gateway's teardown), then stopping the "
+                "gateway so the watcher can bring it back. Sessions resume on "
+                "the new gateway."
+            )
+            # Signal the running gateway to drain and exit via the planned-stop
+            # marker. stop() tree-kills any *sibling* gateway (taskkill /T /F),
+            # but never this process (its own PID is excluded, and the gateway
+            # being stopped is our ancestor, not our child), so this CLI reaches
+            # the wait below and the detached watcher performs the relaunch.
+            stop()
+            if not _wait_for_gateway_ready(timeout_s=90.0):
+                raise RuntimeError(
+                    "Gateway restart watcher was armed but no gateway process "
+                    "came back within 90s. Check logs/gateway.log and run "
+                    "`hermes gateway status`."
+                )
+            print("✓ Gateway restarted (relaunched by detached watcher)")
+            return
+        print(
+            "⚠ Could not arm a detached relaunch watcher; falling back to the "
+            "synchronous stop/start path."
+        )
 
     stop()
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -1,7 +1,9 @@
 """Tests for hermes_cli.gateway_windows."""
 
 import logging
+import os
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -362,6 +364,199 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Agent-initiated restart — issue #99215
+#
+# A `hermes gateway restart` issued from inside a gateway-hosted agent turn
+# runs as a *child* of the very gateway it stops, so the stop path's force
+# escalation (`taskkill /T /F`) tears the restart command down before it
+# reaches its own `start()` — a silent outage with nothing to relaunch. The
+# fix detects the descendant case and arms the same detached restart watcher
+# that `hermes update` / the `/restart` command already use (#95194), so a
+# surviving process brings the gateway back regardless of whether the restart
+# command survives its own teardown.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_runs_under_gateway_is_true_for_ancestor(monkeypatch):
+    """The descendant guard fires when the live gateway PID is in our ancestry."""
+    import hermes_cli.gateway as gateway
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: {os.getpid(), 4321, 1})
+    assert gateway_windows._cli_runs_under_gateway(4321) is True
+
+
+def test_cli_runs_under_gateway_is_false_for_clean_shell(monkeypatch):
+    """A restart from an ordinary shell has no gateway ancestor — unaffected."""
+    import hermes_cli.gateway as gateway
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: {os.getpid(), 1})
+    assert gateway_windows._cli_runs_under_gateway(4321) is False
+
+
+def test_arm_gateway_restart_watch_replays_run_argv_not_restart_argv(monkeypatch):
+    """The watcher must replay the gateway's ``gateway run`` argv, never this
+    CLI's own ``gateway restart`` argv — replaying the latter would respawn the
+    restart command recursively instead of the gateway."""
+    import psutil
+    captured = []
+
+    monkeypatch.setattr(
+        psutil, "Process",
+        lambda pid: SimpleNamespace(cmdline=lambda: ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"]),
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline",
+        lambda pid, argv: captured.append((pid, list(argv))) or True,
+    )
+
+    assert gateway_windows._arm_gateway_restart_watch([4321]) is True
+    assert captured == [
+        (4321, ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"])
+    ]
+
+
+def test_arm_gateway_restart_watch_skips_non_gateway_argv(monkeypatch):
+    """A PID whose cmdline is unreadable or not a gateway is skipped, so we
+    never respawn garbage. Armed stays False and nothing is spawned."""
+    import psutil
+    captured = []
+
+    monkeypatch.setattr(
+        psutil, "Process", lambda pid: SimpleNamespace(cmdline=lambda: [])
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline",
+        lambda pid, argv: captured.append(pid) or True,
+    )
+
+    assert gateway_windows._arm_gateway_restart_watch([4321]) is False
+    assert captured == []
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="restart() calls _assert_windows(); the Linux runner exercises "
+    "the helpers, this end-to-end ordering test is Windows-only",
+)
+def test_restart_arms_detached_watcher_before_stop_when_under_gateway(monkeypatch):
+    """End-to-end ordering for the agent path: arm the watcher *before* the
+    stop (the child gets killed mid-stop), then verify — never call start()."""
+    import gateway.status as gw_status
+
+    order = []
+    monkeypatch.setattr(
+        gw_status, "get_running_pid",
+        lambda *a, **k: 4321, raising=False,
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_cli_runs_under_gateway", lambda pid: True
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_arm_gateway_restart_watch",
+        lambda pids: order.append("arm") or True,
+    )
+    monkeypatch.setattr(
+        gateway_windows, "stop", lambda *a, **k: order.append("stop")
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        gateway_windows, "start",
+        lambda *a, **k: order.append("start"),
+    )
+
+    gateway_windows.restart()
+
+    assert order == ["arm", "stop"], order
+    assert "start" not in order, (
+        "the agent path must not call the synchronous start(); the detached "
+        "watcher owns the relaunch"
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="restart() calls _assert_windows(); the Linux runner exercises "
+    "the helpers, this end-to-end ordering test is Windows-only",
+)
+def test_restart_uses_synchronous_path_from_clean_shell(monkeypatch):
+    """A human restart from outside the gateway keeps the original synchronous
+    stop→wait→start flow and never arms the descendant watcher."""
+    import gateway.status as gw_status
+
+    order = []
+    monkeypatch.setattr(
+        gw_status, "get_running_pid",
+        lambda *a, **k: 4321, raising=False,
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_cli_runs_under_gateway", lambda pid: False
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_arm_gateway_restart_watch",
+        lambda pids: order.append("arm") or True,
+    )
+    monkeypatch.setattr(
+        gateway_windows, "stop", lambda *a, **k: order.append("stop")
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_absent", lambda *a, **k: True
+    )
+    monkeypatch.setattr(gateway_windows.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gateway_windows, "start", lambda *a, **k: order.append("start")
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: True
+    )
+
+    gateway_windows.restart()
+
+    assert order == ["stop", "start"], order
+    assert "arm" not in order
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="restart() calls _assert_windows(); the Linux runner exercises "
+    "the helpers, this end-to-end ordering test is Windows-only",
+)
+def test_restart_falls_back_to_synchronous_when_watch_not_armed(monkeypatch):
+    """If the watcher could not be armed, the descendant path degrades to the
+    synchronous stop→start flow rather than silently doing nothing."""
+    import gateway.status as gw_status
+
+    order = []
+    monkeypatch.setattr(
+        gw_status, "get_running_pid",
+        lambda *a, **k: 4321, raising=False,
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_cli_runs_under_gateway", lambda pid: True
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_arm_gateway_restart_watch", lambda pids: False
+    )
+    monkeypatch.setattr(
+        gateway_windows, "stop", lambda *a, **k: order.append("stop")
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_absent", lambda *a, **k: True
+    )
+    monkeypatch.setattr(gateway_windows.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gateway_windows, "start", lambda *a, **k: order.append("start")
+    )
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: True
+    )
+
+    gateway_windows.restart()
+
+    assert order[:1] == ["stop"], order
+    assert "start" in order, order
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes gateway restart` on Windows when the command is issued by an agent from inside a running gateway (#99215). In that situation the restart CLI is a **child of the very gateway it stops**, so the stop path's force escalation (`taskkill /T /F`, a tree-kill) tears the restart command down before it ever reaches its own `start()`. The gateway goes down and nothing brings it back — a silent outage.

The fix: `restart()` now checks whether the live gateway PID is in the CLI's **ancestor chain** (`_get_ancestor_pids`, the same helper the #13242 status-scan exclusion uses). When it is, it arms the same console-detached restart watcher that `hermes update` and the `/restart` command already use (#95194) **before** calling `stop()` — replaying each gateway's own live `gateway run` argv captured before it dies (never this CLI's `restart` argv, which would respawn the restart command recursively). The detached watcher survives the teardown and relaunches the gateway. A restart from a clean shell has no gateway ancestor and keeps the original synchronous stop → wait → start flow, byte-for-byte unchanged.

Why this approach: it reuses the already-proven detached-watcher mechanism rather than inventing a new spawn primitive, and it fixes the generic CLI entry point (`gateway_windows.restart()`), not just one caller. A human from an ordinary terminal never enters the new branch.

## Related Issue

Fixes #99215

Note for maintainers: #99245 (closed unmerged) attacked the same root cause with the same "arm the watcher first" shape. This PR differs in two ways: (1) it fires on the plain `hermes gateway restart` CLI path itself, guarded by the ancestor-chain check rather than a caller-supplied flag; (2) it replays the gateway's own live `gateway run` argv snapshot, so the respawn is exact and recursion is structurally impossible. Happy to fold either idea in if a maintainer prefers the other shape.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway_windows.py` — new `_cli_runs_under_gateway()` (descendant guard via `_get_ancestor_pids`) and `_arm_gateway_restart_watch()` (live-argv snapshot + detached watcher via `launch_detached_gateway_restart_by_cmdline`); `restart()` gains the agent-initiated branch (arm → stop → wait for the watcher's relaunch) with an explicit fallback to the synchronous path if no watcher could be armed.
- `tests/hermes_cli/test_gateway_windows.py` — 7 regression tests: guard polarity (ancestor vs clean shell), run-argv replay (never restart-argv), non-gateway-argv skip, arm-before-stop ordering with no synchronous `start()`, clean-shell synchronous fallthrough, and watcher-failure fallback.

## How to Test

1. Repro (Windows): run a gateway detached via a Startup-folder `.vbs` (`HERMES_GATEWAY_DETACHED=1`, no service supervisor), then from inside a gateway-hosted agent session run `hermes gateway restart`. Before the fix: gateway exits and stays down. After: the CLI prints that a detached relaunch watcher was armed, the gateway is back within seconds (watcher replays the original `gateway run` argv).
2. Unit: `pytest tests/hermes_cli/test_gateway_windows.py -q` → **16 passed** (9 pre-existing + 7 new), Windows 11, Python 3.11.
3. Regression attribution: `tests/hermes_cli/test_gateway_restart_loop.py` has 62 failures on this machine — re-run on a clean `origin/main` worktree, **identical 62 failures** (Linux-only sudo/pkexec/nsenter wrapper fixtures absent on Windows). Pre-existing environment artifacts, not introduced here.
4. Live verification against the exact reporter config: on the affected machine, `taskkill /T /F` was confirmed to be a tree-kill (the child death mechanism), and `_is_supervised_gateway_process()` was measured to return **False** for the `.vbs`/detached config — which is why the guard is the ancestor check rather than the supervisor check.
5. Reviewer note: `stop()` in the armed branch still runs its `schtasks /End` step. For the detached `.vbs` config this is a confirmed no-op; for a gateway *registered* as a Scheduled Task, please confirm `/End` stays inert against the watcher's imminent relaunch (or that coalescing guards keep it harmless).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#99245 closed unmerged — see note above; its approach differs)
- [x] My PR contains **only** changes related to this fix (single commit, 2 files, +305/−4)
- [x] I've run the targeted suite (`pytest tests/hermes_cli/test_gateway_windows.py -q` → 16 passed); the neighbor file's 62 failures reproduce identically on clean `origin/main` (Linux-only fixtures on Windows)
- [x] I've added tests for my changes (7 regression tests)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no doc changes (behavior fix only; user-facing message added inline in `restart()`)
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact considered: the new code path is inside `gateway_windows.py` (Windows-only module). macOS/Linux restart paths are untouched.
