### PR TITLE
fix(dashboard): route session deletes at the row's owning profile

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1948,6 +1948,9 @@ export interface SessionInfo {
   output_tokens: number;
   preview: string | null;
   parent_session_id?: string | null;
+  /** Owning profile stamped by the list/detail endpoints (the store the row
+   * was read from). Absent on search-endpoint rows, which carry no stamp. */
+  profile?: string;
 }
 
 export interface SessionLatestDescendantResponse {

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -75,7 +75,9 @@ async function loadPageProviders() {
         <MemoryRouter>
           <SystemActionsProvider>
             <ProfileProvider>
-              <PageHeaderProvider>{children}</PageHeaderProvider>
+              <PageHeaderProvider pluginTabs={[]}>
+                {children}
+              </PageHeaderProvider>
             </ProfileProvider>
           </SystemActionsProvider>
         </MemoryRouter>

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getSessions: vi.fn(),
+  getSessionMessages: vi.fn(),
+  getEmptySessionsCount: vi.fn(),
+  getStatus: vi.fn(),
+  searchSessions: vi.fn(),
+  importSessions: vi.fn(),
+  exportSessionUrl: vi.fn(),
+  renameSession: vi.fn(),
+  pruneSessions: vi.fn(),
+  deleteSession: vi.fn(),
+  deleteEmptySessions: vi.fn(),
+  bulkDeleteSessions: vi.fn(),
+  getProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
+  getSessionStats: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMocks,
+  // ProfileProvider mirrors its selection into the api module; the mock
+  // keeps that import resolvable.
+  setManagementProfile: vi.fn(),
+  getManagementProfile: vi.fn(() => ""),
+}));
+vi.mock("@/components/PlatformsCard", () => ({
+  PlatformsCard: () => null,
+}));
+vi.mock("@/components/Markdown", () => ({
+  Markdown: () => null,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+// Route React updates through act() without warnings (same flag ChatPage's
+// test sets).
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+async function render(ui: ReactNode) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(ui));
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor: condition never became true");
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+}
+
+async function loadPageProviders() {
+  const { I18nProvider } = await import("@/i18n");
+  const { SystemActionsProvider } = await import("@/contexts/SystemActions");
+  const { ProfileProvider } = await import("@/contexts/ProfileProvider");
+  const { PageHeaderProvider } = await import("@/contexts/PageHeaderProvider");
+  // Mirrors the provider nesting App uses around the routed pages.
+  return function PageProviders({ children }: { children: ReactNode }) {
+    return (
+      <I18nProvider>
+        <MemoryRouter>
+          <SystemActionsProvider>
+            <ProfileProvider>
+              <PageHeaderProvider>{children}</PageHeaderProvider>
+            </ProfileProvider>
+          </SystemActionsProvider>
+        </MemoryRouter>
+      </I18nProvider>
+    );
+  };
+}
+
+function clickButton(el: Element) {
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+}
+
+function findRowDeleteButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    'button[aria-label="Delete session"]',
+  );
+  if (!button) throw new Error("row delete button not rendered");
+  return button;
+}
+
+function findConfirmButton(): HTMLButtonElement {
+  const dialog = document.querySelector('[role="alertdialog"]');
+  if (!dialog) throw new Error("confirm dialog not open");
+  const buttons = Array.from(
+    dialog.querySelectorAll<HTMLButtonElement>("button"),
+  );
+  const confirm = buttons.find(
+    (b) => b.textContent?.trim() === "Delete",
+  );
+  if (!confirm) throw new Error("confirm button not found");
+  return confirm;
+}
+
+function mockSessionsPage(rows: Record<string, unknown>[]) {
+  // Page list uses limit 20; the overview tab's recent-cards fetch uses 50.
+  // Keep the overview empty so the list view (with row delete buttons)
+  // renders by default.
+  apiMocks.getSessions.mockImplementation(async (limit: number) => ({
+    sessions: limit >= 50 ? [] : rows,
+    total: limit >= 50 ? 0 : rows.length,
+    limit,
+    offset: 0,
+  }));
+}
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sid-1",
+    source: "cli",
+    model: null,
+    title: "Managed session",
+    started_at: Math.floor(Date.now() / 1000) - 60,
+    ended_at: null,
+    last_active: Math.floor(Date.now() / 1000),
+    is_active: false,
+    message_count: 2,
+    tool_call_count: 0,
+    input_tokens: 10,
+    output_tokens: 10,
+    preview: "hello",
+    parent_session_id: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  apiMocks.getSessions.mockReset();
+  apiMocks.getSessions.mockResolvedValue({
+    sessions: [],
+    total: 0,
+    limit: 20,
+    offset: 0,
+  });
+  apiMocks.getStatus.mockReset();
+  apiMocks.getStatus.mockResolvedValue({});
+  apiMocks.getEmptySessionsCount.mockReset();
+  apiMocks.getEmptySessionsCount.mockResolvedValue({ count: 0 });
+  apiMocks.deleteSession.mockReset();
+  apiMocks.deleteSession.mockResolvedValue({ ok: true });
+  apiMocks.bulkDeleteSessions.mockReset();
+  apiMocks.bulkDeleteSessions.mockResolvedValue({ ok: true, deleted: 0 });
+  apiMocks.getProfiles.mockReset();
+  apiMocks.getProfiles.mockResolvedValue({ profiles: [] });
+  apiMocks.getActiveProfile.mockReset();
+  // active === current keeps the management profile empty (""), which is
+  // exactly the issue's precondition for the misdirected delete.
+  apiMocks.getActiveProfile.mockResolvedValue({
+    current: "default",
+    active: "default",
+  });
+  apiMocks.getSessionStats.mockReset();
+  apiMocks.getSessionStats.mockResolvedValue({ by_source: {} });
+
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    },
+  );
+  // gsap drives its ticker through rAF; invoking the callback synchronously
+  // makes its tick loop recurse to death, so schedule it as a macrotask.
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(0), 0) as unknown as number;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    clearTimeout(id);
+  });
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener() {},
+    matches: false,
+    media: "",
+    removeEventListener() {},
+  }));
+  sessionStorage.clear();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("SessionsPage session deletion routing", () => {
+  it("deletes a cross-profile row against its owning profile, not the management default", async () => {
+    mockSessionsPage([makeSession({ id: "sid-guanli", profile: "guanli" })]);
+
+    const [{ default: SessionsPage }, Providers] = await Promise.all([
+      import("./SessionsPage"),
+      loadPageProviders(),
+    ]);
+    await render(
+      <Providers>
+        <SessionsPage />
+      </Providers>,
+    );
+
+    await waitFor(() => Boolean(findRowDeleteButton()));
+    await act(async () => {
+      clickButton(findRowDeleteButton());
+    });
+    await waitFor(() => Boolean(document.querySelector('[role="alertdialog"]')));
+    await act(async () => {
+      clickButton(findConfirmButton());
+    });
+
+    expect(apiMocks.deleteSession).toHaveBeenCalledWith(
+      "sid-guanli",
+      "guanli",
+    );
+  });
+
+  it("falls back to the management profile when the row carries no profile stamp", async () => {
+    mockSessionsPage([makeSession({ id: "sid-unstamped" })]);
+
+    const [{ default: SessionsPage }, Providers] = await Promise.all([
+      import("./SessionsPage"),
+      loadPageProviders(),
+    ]);
+    await render(
+      <Providers>
+        <SessionsPage />
+      </Providers>,
+    );
+
+    await waitFor(() => Boolean(findRowDeleteButton()));
+    await act(async () => {
+      clickButton(findRowDeleteButton());
+    });
+    await waitFor(() => Boolean(document.querySelector('[role="alertdialog"]')));
+    await act(async () => {
+      clickButton(findConfirmButton());
+    });
+
+    expect(apiMocks.deleteSession).toHaveBeenCalledWith(
+      "sid-unstamped",
+      undefined,
+    );
+  });
+});

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1278,7 +1278,17 @@ export default function SessionsPage() {
     onDelete: useCallback(
       async (id: string) => {
         try {
-          await api.deleteSession(id);
+          // Route the delete at the row's owning profile — the list stamp
+          // is the store the row was actually read from, and the global
+          // management profile can lag it (it stays "" when the sticky
+          // active profile equals the dashboard process's own, so the
+          // request would hit the process store and get a false
+          // already_absent success). Search rows carry no stamp; passing
+          // undefined falls back to the management profile like before.
+          const rowProfile = (searchResults ?? sessions).find(
+            (s) => s.id === id,
+          )?.profile;
+          await api.deleteSession(id, rowProfile);
           setSessions((prev) => prev.filter((s) => s.id !== id));
           setTotal((prev) => prev - 1);
           if (expandedId === id) setExpandedId(null);
@@ -1304,6 +1314,8 @@ export default function SessionsPage() {
       [
         expandedId,
         refreshEmptyCount,
+        searchResults,
+        sessions,
         showToast,
         loadStats,
         t.sessions.sessionDeleted,
@@ -1373,7 +1385,21 @@ export default function SessionsPage() {
     }
     setDeletingSelected(true);
     try {
-      const resp = await api.bulkDeleteSessions(ids);
+      // Same per-row ownership routing as the single delete: the selection
+      // comes from one visible list, so its rows share one stamped profile.
+      // Mixed or unstamped (search) selections fall back to the management
+      // profile, matching the pre-fix behavior.
+      const selectionProfiles = new Set(
+        (searchResults ?? sessions)
+          .filter((s) => selectedIds.has(s.id))
+          .map((s) => s.profile)
+          .filter((p): p is string => Boolean(p)),
+      );
+      const selectionProfile =
+        selectionProfiles.size === 1
+          ? [...selectionProfiles][0]
+          : undefined;
+      const resp = await api.bulkDeleteSessions(ids, selectionProfile);
       showToast(
         t.sessions.selectedSessionsDeleted.replace(
           "{count}",
@@ -1404,7 +1430,9 @@ export default function SessionsPage() {
     loadSessions,
     page,
     refreshEmptyCount,
+    searchResults,
     selectedIds,
+    sessions,
     showToast,
     t.sessions.failedToDeleteSelected,
     t.sessions.selectedSessionsDeleted,


### PR DESCRIPTION
## What does this PR do?

Fixes a silent cross-profile delete failure on the dashboard Sessions page: deleting a session that belongs to a named profile showed "session deleted" but the row reappeared on refresh, because the DELETE request never reached the profile that owns the row.

`api.deleteSession(id)` was called with no profile, so it fell back to the global management profile. That scope stays `""` when the sticky active profile equals the dashboard process's own profile (`ProfileProvider` only calls `setManagementProfile` when `active !== current`), so `appendProfileParam` emitted no `?profile=` and the backend opened the process's own `state.db`. `resolve_session_id` missed there and the endpoint returned `{"ok": true, "already_absent": true}` — an idempotent-looking success while the real row survived in the owning profile's store.

The fix routes the delete at the row's owning profile instead of the ambient scope: the list/detail endpoints already stamp every outgoing row with its serving profile, and the DELETE endpoint already accepts `?profile=` to open that profile's store directly, so this is pure wiring of an existing ownership contract. The single delete resolves the stamped profile of the row being deleted; the bulk delete resolves the shared stamped profile of the selection. Unstamped rows (search results, which carry no stamp) pass `undefined` and fall back to the management profile exactly like before, so no existing behavior changes for single-scope setups.

The backend is deliberately untouched: the `already_absent` idempotent-success contract is load-bearing for the desktop's optimistic-remove flow, and fanning out a delete across every profile on a miss would widen the write semantics rather than fix the routing.

## Related Issue

Fixes #99379

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/api.ts` — declare `profile?: string` on `SessionInfo`; the list/detail endpoints already return it, the type just didn't say so.
- `web/src/pages/SessionsPage.tsx` — single-session delete resolves the row's stamped profile from the visible list (`searchResults ?? sessions`) and passes it to `api.deleteSession`; bulk delete resolves the selection's shared stamped profile and passes it to `api.bulkDeleteSessions`. Mixed or unstamped selections fall back to the management profile (previous behavior).
- `web/src/pages/SessionsPage.test.tsx` — new component-level regression tests covering both routing paths.

## How to Test

1. `cd web && npm run typecheck && npx vitest run src/pages/SessionsPage.test.tsx` — Observed result: 2 passed.
2. Red/green check: reverting only the `SessionsPage.tsx`/`api.ts` changes makes both tests fail (`deleteSession` called without the row profile), confirming the tests pin the fix.
3. `npx vitest run src/lib/api.test.ts src/pages/ChatPage.test.tsx` — Observed result: 14 passed (no regressions in adjacent coverage).
4. `npx eslint src/pages/SessionsPage.tsx src/pages/SessionsPage.test.tsx src/lib/api.ts` — no findings.
5. Manual (multi-profile setup): create a named profile, open the dashboard with the sticky active profile equal to the dashboard process's own, delete a session owned by the named profile — should pass: the DELETE carries `?profile=<owner>` and the row stays gone after refresh.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: frontend-only change (no Python touched); `npm run typecheck` + vitest suites pass instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Node from repo lockfile

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: pure client-side routing fix, no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill change.

## Screenshots / Logs

```
$ npx vitest run src/pages/SessionsPage.test.tsx
 ✓ src/pages/SessionsPage.test.tsx (2 tests) 754ms
 Test Files  1 passed (1)
    Tests  2 passed (2)
```
