### PR TITLE
fix(dashboard): delete sessions from their owning profile

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -265,6 +265,7 @@ async def search_sessions(
     if not q or not q.strip():
         return {"results": []}
     with http_failure("GET /api/sessions/search failed", 500, detail="Search failed"):
+        row_profile = _serving_profile(profile)
         db = _open_session_db_for_profile(profile, read_only=True)
         try:
             safe_limit = max(1, min(int(limit or 20), 100))
@@ -326,6 +327,8 @@ async def search_sessions(
                 sid = lineage_tip(root)
                 payload["session_id"] = sid
                 payload["lineage_root"] = root
+                payload["profile"] = row_profile
+                payload["is_default_profile"] = row_profile == "default"
                 try:
                     row = db.get_session_rich_row(sid)
                 except Exception:

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -121,6 +121,8 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         "results": [
             {
                 "id": "20260603_090200_exact",
+                "profile": "default",
+                "is_default_profile": True,
                 "session_id": "20260603_090200_exact",
                 "lineage_root": "20260603_090200_exact",
                 "snippet": "ID match preview",
@@ -131,6 +133,8 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
             {
                 "id": "content_session",
+                "profile": "default",
+                "is_default_profile": True,
                 "session_id": "content_session",
                 "lineage_root": "content_session",
                 "snippet": "content hit",
@@ -142,3 +146,23 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         ]
     }
     assert _FakeSessionDB.opened_read_only is True
+
+
+def test_desktop_session_search_stamps_the_requested_profile(monkeypatch):
+    monkeypatch.setattr(
+        _rt_sessions, "_cron_profile_home", lambda profile: (profile, None)
+    )
+    monkeypatch.setattr(
+        _rt_sessions,
+        "_open_session_db_for_profile",
+        lambda profile, *, read_only: _FakeSessionDB(read_only=read_only),
+    )
+
+    response = asyncio.run(
+        _rt_sessions.search_sessions(q="20260603", limit=2, profile="worker")
+    )
+
+    assert {
+        (row["profile"], row["is_default_profile"])
+        for row in response["results"]
+    } == {("worker", False)}

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -151,4 +151,37 @@ describe("SessionsPage per-row profile routing (#99387)", () => {
     await act(async () => click(confirm ?? null));
     expect(apiMocks.deleteSession).toHaveBeenCalledWith("sid-guanli", "guanli");
   });
+
+  it("routes a search result through the profile stamped on that result", async () => {
+    apiMocks.searchSessions.mockResolvedValue({
+      results: [
+        { id: "sid-worker", session_id: "sid-worker", profile: "worker", source: "cli", model: null,
+          title: "Search hit", started_at: 1, ended_at: null, last_active: 1, is_active: false,
+          message_count: 2, tool_call_count: 0, input_tokens: 1, output_tokens: 1, preview: "found",
+          snippet: "found", role: "user", session_started: 1 },
+      ],
+    });
+    await renderSessionsPage([
+      { id: "sid-default", profile: "default", source: "cli", model: null, title: "Listed", started_at: 1,
+        ended_at: null, last_active: 1, is_active: false, message_count: 2, tool_call_count: 0,
+        input_tokens: 1, output_tokens: 1, preview: "listed" },
+    ]);
+
+    const search = document.querySelector<HTMLInputElement>('input[placeholder]');
+    if (!search) throw new Error("search input not rendered");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(search, "found");
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await waitFor(() => document.body.textContent?.includes("Search hit") === true);
+
+    await act(async () => click(button("Delete session")));
+    await waitFor(() => Boolean(document.querySelector('[role="alertdialog"]')));
+    const confirm = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
+      (b) => b.textContent?.trim() === "Delete",
+    );
+    await act(async () => click(confirm ?? null));
+
+    expect(apiMocks.deleteSession).toHaveBeenCalledWith("sid-worker", "worker");
+  });
 });

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1279,10 +1279,11 @@ export default function SessionsPage() {
   // the global management profile, which lags the row (it stays "" while the
   // sticky active profile equals the dashboard process's own, so the request
   // hits the process store — a delete then "succeeds" as already_absent).
-  // Search rows carry no stamp: undefined falls back to the management profile.
+  // Current search rows carry the same stamp; an unstamped row from an older
+  // backend still falls back to the management profile.
   const rowProfile = useCallback(
-    (id: string) => sessions.find((s) => s.id === id)?.profile,
-    [sessions],
+    (id: string) => (searchResults ?? sessions).find((s) => s.id === id)?.profile,
+    [searchResults, sessions],
   );
 
   const sessionDelete = useConfirmDelete({


### PR DESCRIPTION
## Summary

- carry each session row owner through the delete-confirmation flow and send it as the DELETE profile
- expose the already-stamped owner on SessionInfo and stamp search results too, so deletes from filtered search stay scoped
- keep the backend conservative: the client names the owner instead of an unscoped server fan-out guessing across profile databases

Closes #99379.

## Validation

- web Vitest suite: 38 files, 283 tests passed
- web TypeScript typecheck passed
- focused session-search pytest passed
- changed-file ESLint and Ruff passed
- git diff --check passed