### PR TITLE
fix(gateway): guard asyncio.start_unix_server behind hasattr on Windows

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -569,9 +569,17 @@ async def loop_heartbeat_forever(
                 logger.debug(
                     "stale loop-tick socket sweep failed", exc_info=True
                 )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+        # windows-footgun: asyncio.start_unix_server is POSIX-only. On
+        # Windows it raises AttributeError which the except below turned into
+        # a warning + traceback spammed into gateway.log on every startup.
+        # Guard with hasattr so POSIX keeps the socket and Windows skips it
+        # cleanly (loop_tick_socket=False payload already documents this).
+        if hasattr(asyncio, "start_unix_server"):
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        else:
+            tick_server = None
     except Exception:
         tick_server = None
         logger.warning(


### PR DESCRIPTION
## Summary
- `asyncio.start_unix_server` does not exist on Windows (no AF_UNIX event-loop support), so `loop_heartbeat_forever()` raised `AttributeError` on every gateway startup
- The surrounding `except` caught it, but logged a full warning + traceback into `gateway.log` on **every** startup, burying real diagnostics (observed 14 entries in one day on a Windows install)
- Guard the call with `hasattr(asyncio, "start_unix_server")`: POSIX keeps the loop-tick socket, Windows skips it cleanly at debug level
- No behaviour change otherwise — the witness stays absent on Windows, exactly as already documented in the payload comment block (`loop_tick_socket=False`, stale-file probes classify UNKNOWN, never WEDGED)

## Test plan
- [x] `python -m py_compile gateway/shutdown_watchdog.py` passes
- [x] Verified on a live Windows install (v0.20.6): traceback gone from gateway.log after restart
- [ ] POSIX regression: loop-tick socket still created on Linux/macOS (code path unchanged when `hasattr` is true)

Observed on Windows 11, v0.20.6 (2026.8.27), gateway running as a Scheduled Task.