### PR TITLE
fix(verify): probe the compose-mapped host port instead of defaulting to 8000

### DIFF
--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -439,16 +439,63 @@ _COMPOSE_FILES = (
 )
 
 
+def _compose_host_port(root: Path, compose_file: str) -> int | None:
+    """First host port published by the compose file, or ``None`` if unknowable.
+
+    ``hermes verify`` probes readiness on ``127.0.0.1``, so only a real
+    ``HOST:CONTAINER`` publishing pins a probeable port; a container-only
+    short entry (``"3000"``) leaves the host port to Docker's discretion and
+    must not be guessed.
+    """
+    try:
+        import yaml  # core dependency; guarded so a broken install degrades, not crashes
+
+        doc = yaml.safe_load((root / compose_file).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    services = doc.get("services") if isinstance(doc, dict) else None
+    if not isinstance(services, dict):
+        return None
+    for svc in services.values():
+        ports = svc.get("ports") if isinstance(svc, dict) else None
+        if not isinstance(ports, list):
+            continue
+        for entry in ports:
+            if isinstance(entry, dict):
+                # Long syntax: {"target": ..., "published": HOST} (published
+                # may be a str; a range pins several — take the first).
+                published = entry.get("published")
+                if isinstance(published, str):
+                    published = published.split("-")[0]
+                    published = int(published) if published.isdigit() else None
+                if (
+                    isinstance(published, int)
+                    and not isinstance(published, bool)
+                    and 0 < published < 65536
+                ):
+                    return published
+                continue
+            if not (isinstance(entry, str) and ":" in entry):
+                continue  # container-only entry: host port not pinned
+            host = entry.split(":")[-2]  # "[IP:]HOST:CONTAINER[/proto]"
+            if host.isdigit() and 0 < int(host) < 65536:
+                return int(host)
+    return None
+
+
 def _detect_compose_recipe(root: Path) -> Recipe | None:
     compose_file = next((f for f in _COMPOSE_FILES if (root / f).exists()), None)
     if compose_file is None:
         return None
+    host_port = _compose_host_port(root, compose_file)
     return Recipe(
         name="docker-compose project",
         kind="compose",
         build=["docker compose build"],
         start="docker compose up",
-        evidence=[f"Detected {compose_file}"],
+        port=host_port,
+        evidence=[f"Detected {compose_file}"]
+        + ([f"Probing first published host port: {host_port}"] if host_port else []),
     )
 
 

--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -25,10 +25,13 @@ Layer ownership vs :mod:`agent.coding_context`:
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -452,6 +455,13 @@ def _compose_host_port(root: Path, compose_file: str) -> int | None:
 
         doc = yaml.safe_load((root / compose_file).read_text(encoding="utf-8"))
     except Exception:
+        # An unparseable compose file must stay indistinguishable from an
+        # unpinned one in behavior, but leave a trace for debugging a wrong
+        # probe target.
+        logger.debug(
+            "verify: could not parse %s for a published host port",
+            compose_file, exc_info=True,
+        )
         return None
     services = doc.get("services") if isinstance(doc, dict) else None
     if not isinstance(services, dict):
@@ -478,6 +488,7 @@ def _compose_host_port(root: Path, compose_file: str) -> int | None:
             if not (isinstance(entry, str) and ":" in entry):
                 continue  # container-only entry: host port not pinned
             host = entry.split(":")[-2]  # "[IP:]HOST:CONTAINER[/proto]"
+            host = host.split("-")[0]  # "3000-3005" range pins several — take the first
             if host.isdigit() and 0 < int(host) < 65536:
                 return int(host)
     return None

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -205,6 +205,58 @@ class TestOtherEcosystems:
         assert recipe.kind == "compose"
         assert recipe.start == "docker compose up"
 
+    def test_compose_port_from_short_syntax(self, tmp_path):
+        # "HOST:CONTAINER" and "[IP:]HOST:CONTAINER[/proto]" both pin a
+        # probeable host port (#99391: probe 3002, not the 8000 fallback).
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  app:\n"
+            '    ports: ["127.0.0.1:3002:3002"]\n',
+            encoding="utf-8",
+        )
+        recipe = detect_recipe(tmp_path)
+        assert recipe.kind == "compose"
+        assert recipe.port == 3002
+
+    def test_compose_port_from_long_syntax(self, tmp_path):
+        (tmp_path / "compose.yaml").write_text(
+            "services:\n"
+            "  app:\n"
+            "    ports:\n"
+            "      - target: 80\n"
+            '        published: "3002"\n',
+            encoding="utf-8",
+        )
+        assert detect_recipe(tmp_path).port == 3002
+
+    def test_compose_port_first_mapped_service_wins(self, tmp_path):
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  db:\n"
+            "    image: postgres\n"
+            "  app:\n"
+            '    ports: ["8080:80"]\n',
+            encoding="utf-8",
+        )
+        recipe = detect_recipe(tmp_path)
+        assert recipe.port == 8080
+        assert recipe.evidence[-1] == "Probing first published host port: 8080"
+
+    def test_compose_port_not_guessed_when_unpinned_or_broken(self, tmp_path):
+        # Container-only entries leave the host port to Docker — keep the
+        # 8000 fallback rather than guessing; malformed YAML must not break
+        # detection either.
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  app:\n"
+            '    ports: ["3002"]\n',
+            encoding="utf-8",
+        )
+        assert detect_recipe(tmp_path).port is None
+        (tmp_path / "docker-compose.yml").write_text("services: [broken", encoding="utf-8")
+        recipe = detect_recipe(tmp_path)
+        assert recipe is not None and recipe.port is None
+
     def test_empty_dir_returns_none(self, tmp_path):
         assert detect_recipe(tmp_path) is None
 

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -218,6 +218,17 @@ class TestOtherEcosystems:
         assert recipe.kind == "compose"
         assert recipe.port == 3002
 
+    def test_compose_port_from_short_range_syntax(self, tmp_path):
+        # "FIRST-LAST:CONTAINER" pins a range — probe its first port, the
+        # same tie-break the long syntax applies to a str "published".
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  app:\n"
+            '    ports: ["3000-3005:3000"]\n',
+            encoding="utf-8",
+        )
+        assert detect_recipe(tmp_path).port == 3000
+
     def test_compose_port_from_long_syntax(self, tmp_path):
         (tmp_path / "compose.yaml").write_text(
             "services:\n"


### PR DESCRIPTION
## What does this PR do?

`hermes verify` on a docker-compose project always probed the hardcoded fallback port 8000 because the compose recipe carried no `port`, so healthy stacks mapping e.g. `3002:3002` were reported as "Connection refused". Detection now reads the first pinned host port from the compose `ports:` mapping and puts it on the recipe, which `_run_start_phase` already prefers over the 8000 fallback (and `--save` persists). Container-only short entries ("`3002`" — host port left to Docker) and malformed YAML keep the old fallback instead of guessing.

## Related Issue

Fixes #99391

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verify/recipes.py` — new `_compose_host_port()` parses the compose file and returns the first pinned host port (short "[IP:]HOST:CONTAINER[/proto]" and long-syntax `published`, str or int, range start); tolerant of missing PyYAML/garbage YAML (returns `None`, detection unaffected). `_detect_compose_recipe()` sets `Recipe.port` from it and records the source in `evidence`.
- `tests/verify/test_recipes.py` — regression tests: short syntax with IP prefix, long syntax with string `published`, first-mapped-service wins, container-only entry / broken YAML keep `port=None`.

## How to Test

1. Create a project with a `docker-compose.yml` mapping `3002:3002` and run `hermes verify --json`: observed result — the readiness URL is now `http://127.0.0.1:3002/` (previously `http://127.0.0.1:8000/` → `ok: false`, statusCode null); the stack reports ready against the healthy app.
2. Container-only entry (`ports: ["3002"]`) or unparseable YAML: recipe still detects with `port=None`, behavior unchanged (8000 fallback, no crash).
3. `pytest tests/verify/test_recipes.py -q` — 39 passed (5 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] N/A — docstring on the new helper covers the pinning rule; no config keys, architecture, or tool-behavior changes.

## Screenshots / Logs

```
$ pytest tests/verify/test_recipes.py -q
39 passed in 0.49s
```