### PR TITLE
fix(tui): enable faulthandler so fatal signals leave a stack

### DIFF
--- a/tests/tui_gateway/test_entry_faulthandler.py
+++ b/tests/tui_gateway/test_entry_faulthandler.py
@@ -22,14 +22,28 @@ import textwrap
 import pytest
 
 
-def _run_child(hermes_home, body: str) -> subprocess.CompletedProcess:
-    """Import tui_gateway.entry in a fresh interpreter, then run `body`."""
-    script = textwrap.dedent(
-        """
-        import faulthandler, os, signal, threading, time
-        import tui_gateway.entry as entry
-        """
-    ) + textwrap.dedent(body)
+def _run_child(
+    hermes_home, body: str, preamble: str = ""
+) -> subprocess.CompletedProcess:
+    """Import tui_gateway.entry in a fresh interpreter, then run `body`.
+
+    `preamble` runs *before* the import, for tests that need to break
+    something the module-level _enable_faulthandler() call depends on.
+    """
+    script = (
+        textwrap.dedent(
+            """
+            import faulthandler, os, signal, threading, time
+            """
+        )
+        + textwrap.dedent(preamble)
+        + textwrap.dedent(
+            """
+            import tui_gateway.entry as entry
+            """
+        )
+        + textwrap.dedent(body)
+    )
 
     return subprocess.run(
         [sys.executable, "-c", script],
@@ -71,13 +85,24 @@ def test_fatal_signal_writes_native_stack_to_crash_log(tmp_path):
         """,
     )
 
-    # -11 on POSIX; 139 when a shell layer translates it.
-    assert result.returncode in (-11, 139), (
-        f"expected a fatal SIGSEGV, got {result.returncode}: {result.stderr[-2000:]}"
+    # The child must have died on the fault, whatever the platform calls it:
+    # -11/139 on POSIX, an NTSTATUS like 0xC0000005 on Windows.
+    assert result.returncode != 0, (
+        f"child survived a forced fault: {result.stderr[-2000:]}"
     )
+    if os.name == "posix":
+        assert result.returncode in (-11, 139), (
+            f"expected a fatal SIGSEGV, got {result.returncode}: "
+            f"{result.stderr[-2000:]}"
+        )
 
     text = _crash_log_text(tmp_path)
-    assert "Fatal Python error: Segmentation fault" in text
+    # The header wording is platform-specific — POSIX says "Segmentation
+    # fault", Windows reports an access violation. Only the prefix is a
+    # contract; what matters is that a dump was written at all.
+    assert "Fatal Python error:" in text or "fatal exception:" in text, (
+        f"no fatal-signal dump in the crash log: {text[:500]!r}"
+    )
     assert "Bystander" in text or text.count("Thread 0x") >= 2, (
         "dump does not cover non-faulting threads — all_threads was not set"
     )
@@ -150,3 +175,49 @@ def test_unwritable_crash_log_does_not_break_startup(tmp_path):
         f"import died on an unwritable crash log: {result.stderr[-2000:]}"
     )
     assert _emitted(result, "STARTED")
+
+
+def test_failed_enable_does_not_strand_the_crash_log_fd(tmp_path):
+    """If ``faulthandler.enable()`` rejects the handle, close it.
+
+    The handle is a module global so faulthandler can keep writing to it for
+    the process lifetime — which means nothing will ever collect it if enable()
+    bailed. Holding an fd open for a file nothing writes to is a leak.
+    """
+    result = _run_child(
+        tmp_path,
+        """
+        assert entry._FAULTHANDLER_FILE is None, (
+            "handle retained even though enable() failed"
+        )
+        assert _opened and _opened[0].closed, "crash-log fd was left open"
+        print("OK")
+        """,
+        preamble="""
+        # Fail enable() only for the file-backed call entry.py makes, so the
+        # stderr fallback is exercised too.
+        _opened = []
+        _real_open = open
+
+        def _tracking_open(*a, **k):
+            fh = _real_open(*a, **k)
+            if a and str(a[0]).endswith("tui_gateway_crash.log"):
+                _opened.append(fh)
+            return fh
+
+        import builtins
+        builtins.open = _tracking_open
+
+        _real_enable = faulthandler.enable
+
+        def _boom(*a, **k):
+            if "file" in k:
+                raise OSError("simulated enable() rejection")
+            return _real_enable(*a, **k)
+
+        faulthandler.enable = _boom
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert _emitted(result, "OK")

--- a/tests/tui_gateway/test_entry_faulthandler.py
+++ b/tests/tui_gateway/test_entry_faulthandler.py
@@ -1,0 +1,152 @@
+"""The TUI gateway must leave a native stack behind when it dies on a fatal signal.
+
+``_log_signal`` only covers signals Python hands to a handler (SIGTERM/SIGHUP).
+A *fatal* signal — SIGSEGV from a C extension — kills the interpreter outright,
+so without faulthandler the TUI can only report ``child exit signal=SIGSEGV``
+with nothing to point at. ``gateway/run.py`` has enabled faulthandler since
+#70344; ``tui_gateway/entry.py`` never did, so every crash on the TUI path was
+forensically silent.
+
+The subprocess tests are the ones that matter: they drive real signals through a
+real interpreter and assert the dump lands in the crash log the TUI already
+collects.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_child(hermes_home, body: str) -> subprocess.CompletedProcess:
+    """Import tui_gateway.entry in a fresh interpreter, then run `body`."""
+    script = textwrap.dedent(
+        """
+        import faulthandler, os, signal, threading, time
+        import tui_gateway.entry as entry
+        """
+    ) + textwrap.dedent(body)
+
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env={**os.environ, "HERMES_HOME": str(hermes_home)},
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+def _emitted(result: subprocess.CompletedProcess, marker: str) -> bool:
+    """Did the child reach `marker`?
+
+    entry.py owns stdout for the JSON-RPC channel and redirects ordinary
+    writes to stderr, so a marker can legitimately land on either stream.
+    """
+    return marker in result.stdout or marker in result.stderr
+
+
+def _crash_log_text(hermes_home) -> str:
+    log = hermes_home / "logs" / "tui_gateway_crash.log"
+    assert log.exists(), "no crash log written — faulthandler was not wired up"
+    return log.read_text(encoding="utf-8", errors="replace")
+
+
+def test_fatal_signal_writes_native_stack_to_crash_log(tmp_path):
+    """A SIGSEGV must leave an all-thread dump in tui_gateway_crash.log."""
+    result = _run_child(
+        tmp_path,
+        """
+        # A second thread proves all_threads=True: the dump must show a frame
+        # from a thread other than the one taking the signal, which is what
+        # makes these dumps useful for cross-thread teardown races.
+        threading.Thread(
+            target=lambda: time.sleep(30), daemon=True, name="Bystander"
+        ).start()
+        time.sleep(0.2)
+        faulthandler._sigsegv()
+        """,
+    )
+
+    # -11 on POSIX; 139 when a shell layer translates it.
+    assert result.returncode in (-11, 139), (
+        f"expected a fatal SIGSEGV, got {result.returncode}: {result.stderr[-2000:]}"
+    )
+
+    text = _crash_log_text(tmp_path)
+    assert "Fatal Python error: Segmentation fault" in text
+    assert "Bystander" in text or text.count("Thread 0x") >= 2, (
+        "dump does not cover non-faulting threads — all_threads was not set"
+    )
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGUSR2"), reason="POSIX-only signal")
+def test_sigusr2_dumps_threads_without_killing_the_gateway(tmp_path):
+    """``kill -USR2 <pid>`` must dump and keep serving.
+
+    SIGUSR2's default disposition is "terminate", so registering the dump with
+    ``chain=True`` would make the diagnostic kill the session it was meant to
+    inspect — the same trap #84539 fixes for the messaging gateway.
+    """
+    result = _run_child(
+        tmp_path,
+        """
+        os.kill(os.getpid(), signal.SIGUSR2)
+        time.sleep(0.4)
+        print("SURVIVED")
+        """,
+    )
+
+    assert result.returncode == 0, (
+        f"SIGUSR2 killed the process: rc={result.returncode} {result.stderr[-2000:]}"
+    )
+    assert _emitted(result, "SURVIVED")
+    assert "Current thread" in _crash_log_text(tmp_path)
+
+
+def test_crash_log_handle_is_retained_and_open(tmp_path):
+    """The module-global file handle must outlive ``_enable_faulthandler()``.
+
+    faulthandler keeps writing to this fd for the process lifetime; a local
+    handle would be garbage-collected and the next fatal signal would dump
+    into a closed fd.
+    """
+    result = _run_child(
+        tmp_path,
+        """
+        assert faulthandler.is_enabled(), "faulthandler not enabled on import"
+        handle = entry._FAULTHANDLER_FILE
+        assert handle is not None, "no crash-log handle retained"
+        assert not handle.closed, "crash-log handle was closed"
+        print("OK")
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert _emitted(result, "OK")
+
+
+def test_unwritable_crash_log_does_not_break_startup(tmp_path):
+    """A gateway that cannot open its crash log must still start and serve.
+
+    Forensics are best-effort; losing them must never cost the user a session.
+    """
+    blocked = tmp_path / "logs"
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    result = _run_child(
+        tmp_path,
+        """
+        # Import above already ran _enable_faulthandler() against the blocked
+        # path. Reaching this line at all is the contract.
+        print("STARTED")
+        """,
+    )
+
+    assert result.returncode == 0, (
+        f"import died on an unwritable crash log: {result.stderr[-2000:]}"
+    )
+    assert _emitted(result, "STARTED")

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -274,6 +274,14 @@ def _enable_faulthandler() -> None:
     try:
         faulthandler.enable(file=_FAULTHANDLER_FILE, all_threads=True)
     except (RuntimeError, ValueError, OSError, AttributeError):
+        # enable() rejected the handle — don't strand an fd nothing will ever
+        # write to for the rest of the process lifetime.
+        try:
+            _FAULTHANDLER_FILE.close()
+        except Exception:
+            pass
+        _FAULTHANDLER_FILE = None
+
         return
 
     _sigusr2 = getattr(signal, "SIGUSR2", None)

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -231,6 +231,72 @@ elif hasattr(signal, "SIGBREAK"):
 _install_signal("SIGINT", signal.SIG_IGN)
 
 
+# ── Native-crash forensics ──────────────────────────────────────────────
+# _log_signal above only covers signals Python can hand to a handler
+# (SIGTERM/SIGHUP). A *fatal* signal — SIGSEGV from a C extension, typically
+# an OpenSSL/httpx socket teardown racing another thread — kills the
+# interpreter with no Python-level trace at all, so the TUI could only report
+# "child exit signal=SIGSEGV" with nothing to point at (observed 2026-08-31).
+# faulthandler writes an all-thread native+Python stack into the same crash
+# log the tui-parent appends its lifecycle lines to, so the next occurrence
+# lands next to the exit line instead of vanishing.
+#
+# The file handle is module-global on purpose: faulthandler keeps writing to
+# this fd for the process lifetime, so it must never be garbage-collected.
+_FAULTHANDLER_FILE = None
+
+
+def _enable_faulthandler() -> None:
+    """Route fatal-signal stack dumps into the TUI gateway crash log.
+
+    Best-effort by design: a gateway that cannot open its crash log must
+    still start and serve the session. Also registers SIGUSR2 (POSIX only)
+    as an on-demand "dump every thread" trigger for a wedged gateway —
+    ``kill -USR2 <gateway pid>`` while it looks hung.
+    """
+    global _FAULTHANDLER_FILE
+
+    import faulthandler
+
+    try:
+        os.makedirs(os.path.dirname(_CRASH_LOG), exist_ok=True)
+        _FAULTHANDLER_FILE = open(_CRASH_LOG, "a", encoding="utf-8")
+    except Exception:
+        # No crash log available — fall back to stderr, which the node
+        # parent tees. enable() with no file raises when stderr is None
+        # (detached service), hence the second guard.
+        try:
+            faulthandler.enable(all_threads=True)
+        except (RuntimeError, ValueError, OSError, AttributeError):
+            pass
+        return
+
+    try:
+        faulthandler.enable(file=_FAULTHANDLER_FILE, all_threads=True)
+    except (RuntimeError, ValueError, OSError, AttributeError):
+        return
+
+    _sigusr2 = getattr(signal, "SIGUSR2", None)
+    if _sigusr2 is not None and hasattr(faulthandler, "register"):
+        try:
+            faulthandler.register(
+                _sigusr2,
+                file=_FAULTHANDLER_FILE,
+                all_threads=True,
+                # chain=False on purpose: SIGUSR2's default disposition is
+                # "terminate", so chaining would make the diagnostic dump kill
+                # the very session we wanted to inspect. Dump and keep serving.
+                chain=False,
+            )
+        except (ValueError, OSError, RuntimeError):
+            # register() is main-thread-only, same constraint as
+            # _install_signal — an off-thread import just skips it.
+            pass
+
+
+_enable_faulthandler()
+
+
 def _log_exit(reason: str) -> None:
     """Record why the gateway subprocess is shutting down.
 


### PR DESCRIPTION
## What does this PR do?

`gateway/run.py` has enabled `faulthandler` since #70344. `tui_gateway/entry.py` never did — so when the TUI gateway dies on a **fatal** signal, it leaves no stack at all.

`entry.py` already installs `_log_signal` for SIGTERM/SIGHUP and writes a full all-thread Python dump to `tui_gateway_crash.log`. That covers signals Python can hand to a handler. A SIGSEGV out of a C extension kills the interpreter outright, `_log_signal` never runs, and the only record is the tui-parent's own lifecycle line:

```
[tui-parent] 2026-08-31T12:20:59.247Z [lifecycle] child exit pid=36381 killed=false exitCode=null signal=SIGSEGV
```

That is the entire forensic trail. `gateway_faulthandler.log` stays 0 bytes because only `gateway/run.py` ever opens it.

This wires `faulthandler` into the TUI gateway, dumping into the same `tui_gateway_crash.log` the tui-parent already appends its lifecycle lines to — so the native stack lands directly next to the exit line that reports it.

## Related Issue

Refs #94248 — **this PR does not fix that crash.** It removes the reason TUI-path occurrences of it are undiagnosable.

Every dataset in #94248 (macOS arm64, Debian x86_64, Ubuntu 24.04) comes from the **messaging** gateway or the foreground CLI, which is why all of them have faulthandler dumps to reason about. I hit the same signature on the **TUI** path and could contribute nothing but a timestamp, because of this gap.

For what it is worth, here is the Linux/TUI datapoint, which lines up with the parent-teardown-races-child-worker interleaving @acgh213 captured in [this comment](https://github.com/NousResearch/hermes-agent/issues/94248#issuecomment-5470879474):

```
12:20:58,756  tools.delegate_tool: Subagent 0 timed out after 600.1s
12:20:58,763  run_agent: OpenAI client closed (agent_close, shared=True) thread=ThreadPoolExecutor-239_0
12:20:59,030  tools.delegate_tool: Subagent 1 timed out after 600.3s
12:20:59,041  hermes_cli.mem_trim: memory trim: reason=agent close ... threads=42
12:20:59,047  [child d54af2] Turn ended: reason=interrupted_during_api_call   <-- child still writing
12:20:59,070  [child c80956] Turn ended: reason=interrupted_during_api_call   <-- child still writing
12:20:59,247  [lifecycle] child exit signal=SIGSEGV                           <-- ~180ms later
```

Two children hit `delegation.child_timeout_seconds: 600` in the same second; the parent ran `AIAgent.close()` on the delegate pool worker while both children were still finishing their own turns. `PRAGMA integrity_check` on `state.db` (640 MB, WAL) and every other DB in the profile returned `ok`. Hermes v0.20.6, Ubuntu/Debian x86_64, bundled CPython 3.13.13, `openai-codex` / `gpt-5.6-sol-900k`.

I cannot say which pointer was dereferenced, and that is exactly the point of this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/entry.py` — added `_enable_faulthandler()`, called at module import right after the existing `_install_signal(...)` block so it is armed as early as possible:
  - `faulthandler.enable(file=<tui_gateway_crash.log>, all_threads=True)` — fatal-signal dumps land next to the tui-parent's lifecycle lines.
  - The file handle is kept in a module global (`_FAULTHANDLER_FILE`). faulthandler writes to that fd for the process lifetime, so a local would be GC'd and the next fatal signal would dump into a closed fd.
  - Falls back to stderr (which the node parent tees) when the crash log cannot be opened, and gives up silently if that also fails — a gateway that cannot open its log must still start and serve.
  - `faulthandler.register(SIGUSR2, all_threads=True, chain=False)` — on-demand "dump every thread" for a gateway that looks wedged: `kill -USR2 <gateway pid>`.
- `tests/tui_gateway/test_entry_faulthandler.py` — new.

### On `chain=False`

SIGUSR2's default disposition is *terminate*, so `chain=True` makes the diagnostic dump kill the session it was meant to inspect. I hit this while testing and switched to `chain=False`. This is the same trap #84539 and #75750 fix for `gateway/run.py`; I have deliberately **not** touched `gateway/run.py` here so as not to collide with those PRs, but the two should probably end up consistent.

## How to Test

```
pytest tests/tui_gateway/test_entry_faulthandler.py -q
```

Red-proof against this branch — 3 of the 4 fail on unmodified `main`:

```
$ git checkout -- tui_gateway/entry.py     # back to main's entry.py
$ pytest tests/tui_gateway/test_entry_faulthandler.py -q
FAILED test_fatal_signal_writes_native_stack_to_crash_log
FAILED test_sigusr2_dumps_threads_without_killing_the_gateway
FAILED test_crash_log_handle_is_retained_and_open
3 failed, 1 passed
```

Note the middle one: on `main`, `kill -USR2` on a TUI gateway **kills it** (no handler → default terminate). After this PR it dumps and keeps serving.

Manual end-to-end, simulating the crash this came from:

```
$ HERMES_HOME=/tmp/fh python -c "
import tui_gateway.entry, faulthandler, threading, time
threading.Thread(target=lambda: time.sleep(30), daemon=True).start()
time.sleep(0.2); faulthandler._sigsegv()"
$ echo $?
139
$ head -1 /tmp/fh/logs/tui_gateway_crash.log
Fatal Python error: Segmentation fault
```

All threads are present in the dump, including the ones blocked in `ssl.py:read` — which is the shape #94248 needs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `faulthandler` PRs #84539, #75750, #43264 all target `gateway/run.py` or the oneshot CLI; none touch `tui_gateway/`. `main` has zero `faulthandler` references in `tui_gateway/entry.py`.
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 x86_64, bundled CPython 3.13.13

Note on `pytest tests/ -q`: I ran the suites around the change (`tests/tui_gateway/`, `tests/test_tui_gateway_server.py`, `tests/gateway/test_71671_faulthandler_no_stderr.py`) rather than the full tree. Result: **1527 passed, 3 failed**. All three fail identically on unmodified `main` (verified by reverting `tui_gateway/entry.py` and re-running) and are unrelated to this change:

  - `tests/tui_gateway/test_gui_surface_toolsets.py::test_holds_exactly_the_gui_affordances` — ordering-dependent toolset registry assertion (`apply_layout` leaks in); passes in isolation.
  - `tests/tui_gateway/test_hosted_room_two_gateway_scoped.py::test_in_process_scoped_transport_contract_finishes_headlessly` — fails in isolation on `main`.
  - `tests/test_tui_gateway_server.py::test_model_options_preserves_canonical_custom_row_after_agent_init` — fails in isolation on `main`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new function carries the rationale
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — `SIGUSR2` is guarded with `getattr(signal, "SIGUSR2", None)` and `hasattr(faulthandler, "register")`, so Windows keeps `faulthandler.enable()` fatal-dump coverage and skips the signal registration. `register()` is main-thread-only, so the off-main-thread import path (Desktop `server._build()`, see `_install_signal`) is caught and skipped rather than raising.
- [x] Tool descriptions/schemas — N/A


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
