### PR TITLE
fix(tui): keep sustained rendering from crashing Node

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2518,6 +2518,13 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
     _ensure_tui_node()
 
+    def _production_argv(node: str, entry: Path) -> list[str]:
+        # React's scheduler drives the sustained Ink render loop through
+        # setImmediate. Keep that hot callback path out of V8's concurrent
+        # Maglev tier: native faults there terminate Node before JavaScript can
+        # report or recover, while baseline + TurboFan remain available.
+        return [node, "--no-maglev", "--expose-gc", str(entry)]
+
     def _node_bin(bin: str) -> str:
         if bin == "node":
             env_node = os.environ.get("HERMES_NODE")
@@ -2567,13 +2574,13 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             p = Path(ext_dir)
             if (p / "dist" / "entry.js").is_file():
                 node = _node_bin("node")
-                return [node, "--expose-gc", str(p / "dist" / "entry.js")], p
+                return _production_argv(node, p / "dist" / "entry.js"), p
 
         # 1b. Bundled prebuilt TUI (Docker image, Nix build, or prior npm build)
         bundled = _find_bundled_tui()
         if bundled is not None:
             node = _node_bin("node")
-            return [node, "--expose-gc", str(bundled)], bundled.parent
+            return _production_argv(node, bundled), bundled.parent
 
     # No prebuilt bundle available (or --dev, which never uses one) — we're
     # about to npm install/build from source, so the workspace must exist.
@@ -2727,7 +2734,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             sys.exit(1)
 
     node = _node_bin("node")
-    return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
+    return _production_argv(node, tui_dir / "dist" / "entry.js"), tui_dir
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -320,6 +320,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
     _touch_tui_entry(tmp_path)
+    monkeypatch.setattr("hermes_constants.find_node_executable", lambda name: f"/bin/{name}")
     monkeypatch.setenv("TERMUX_VERSION", "1")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
@@ -332,7 +333,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
 
     argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
-    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert argv == ["/bin/node", "--no-maglev", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
     assert cwd == tmp_path
 
 
@@ -340,6 +341,7 @@ def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
     _touch_tui_entry(tmp_path)
+    monkeypatch.setattr("hermes_constants.find_node_executable", lambda name: f"/bin/{name}")
     monkeypatch.setenv("TERMUX_VERSION", "1")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
@@ -352,7 +354,7 @@ def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
 
     argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
-    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert argv == ["/bin/node", "--no-maglev", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
     assert cwd == tmp_path
 
 
@@ -530,6 +532,7 @@ def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
     bundled_entry.parent.mkdir(parents=True)
     bundled_entry.write_text("// bundled TUI")
     monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
+    monkeypatch.setattr("hermes_constants.find_node_executable", lambda name: f"/usr/bin/{name}")
 
     def which(name: str) -> str | None:
         if name == "node":
@@ -550,7 +553,7 @@ def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
 
     argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=False)
 
-    assert argv == ["/usr/bin/node", "--expose-gc", str(bundled_entry)]
+    assert argv == ["/usr/bin/node", "--no-maglev", "--expose-gc", str(bundled_entry)]
     assert cwd == bundled_entry.parent
 
 

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --max-old-space-size=8192 --expose-gc
+#!/usr/bin/env -S node --max-old-space-size=8192 --no-maglev --expose-gc
 // Must be first import. If the user explicitly opts into truecolor, this
 // nudges chalk / supports-color before either package is initialized.
 import './lib/forceTruecolor.js'


### PR DESCRIPTION
## What does this PR do?

The Ink TUI can terminate with a native Node SIGSEGV or SIGILL during sustained rendering, leaving dashboard chat unusable until it is restarted. This change launches production TUI processes with V8 Maglev disabled so the hot React scheduler callback path cannot enter that concurrent optimizing tier; baseline compilation and TurboFan remain available.

### Symptom

Long-running TUI and dashboard chat sessions can crash inside `node::Environment::CheckImmediate` while dispatching render callbacks. The same workload remains stable in the classic Python CLI, which does not run the Node/React renderer.

### Impact

Affected users lose the active TUI process and must restart Hermes. The reported failures occur repeatedly during long local-model generations.

### Bug Cause

**Trigger:** `hermes_cli/main.py:_make_tui_argv` launches the production Ink renderer with normal V8 tiering while React's scheduler continuously dispatches render work through the immediate queue.

**Causal chain:**
1. Sustained transcript rendering repeatedly heats the React/Ink callback path.
2. V8 may tier those callbacks through concurrent Maglev compilation while Node continues dispatching them from `CheckImmediate`.
3. A native compiler/code-space fault terminates Node before JavaScript error handling can run.

**Why it is wrong:** A native V8 fault is outside Hermes's JavaScript exception boundary, so the renderer cannot log, recover, or preserve the live TUI process after it happens.

**Working sibling / contrast:** `hermes chat --cli` does not start the Node/Ink renderer and therefore does not exercise this callback tiering path.

**Ruled out:** Disabling Hermes response streaming does not remove the failure because the TUI still performs clock-driven and state-driven render cycles.

### Fix

All production TUI launch paths now pass `--no-maglev` directly to Node, including external prebuilt bundles, packaged bundles, and source-checkout builds. Direct source entry execution carries the same flag in its shebang. The narrower flag preserves the rest of V8's JIT pipeline instead of using `--jitless` or disabling all optimization.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - centralize production TUI Node arguments and disable Maglev on every production launch path.
- `ui-tui/src/entry.tsx` - apply the same runtime policy to direct entry execution.
- `tests/hermes_cli/test_tui_npm_install.py` - verify source and bundled launch paths carry the mitigation.

## How to Test

1. Build and type-check the TUI:

```bash
npm run build --workspace ui-tui
npm run typecheck --workspace ui-tui
```

2. Run the launcher regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -q -k 'skips_build_only_on_termux_when_fresh or skips_install_on_termux_when_bundle_fresh or exits_with_recovery_hint_when_workspace_unrecoverable'
```

3. Run a synthetic 5,000-frame Ink render loop under `node --no-maglev --expose-gc`; it completes with a bounded 31.5 MB heap on Node v22.23.1.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry and the targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] Config example update is N/A
- [x] Architecture guide update is N/A
- [x] I've considered cross-platform impact; the runtime flag is supported by the Node engine lines accepted by Hermes
- [x] Tool schema updates are N/A

## Screenshots / Logs

Synthetic sustained-render result:

```json
{"frames":5000,"heapUsed":31535752,"node":"v22.23.1"}
```
