### PR TITLE
fix(tbs): require workbook QA evidence before completion

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8146,6 +8146,53 @@ def run_conversation(
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
+                # ── TBS artifact-QA continuation guard ─────────────────
+                # TBS client/CFO finance XLSX outputs must not be called
+                # complete unless a mechanical workbook validator pass is
+                # visible in the turn context. The byte-level workbook check
+                # stays in the external validator; this finalization seam only
+                # guards completion claims that lack validator evidence.
+                try:
+                    from agent.tbs_artifact_qa_guard import (
+                        SYNTHETIC_FLAG as _TBS_ARTIFACT_QA_GUARD_FLAG,
+                        build_artifact_qa_nudge as _build_tbs_artifact_qa_nudge,
+                    )
+
+                    _tbs_artifact_qa_nudge = _build_tbs_artifact_qa_nudge(
+                        final_response,
+                        user_message=original_user_message,
+                        recent_messages=messages,
+                    )
+                except Exception:
+                    logger.debug("TBS artifact-QA guard check failed", exc_info=True)
+                    _tbs_artifact_qa_nudge = None
+                    _TBS_ARTIFACT_QA_GUARD_FLAG = "_tbs_artifact_qa_guard_synthetic"
+
+                if _tbs_artifact_qa_nudge:
+                    final_msg["finish_reason"] = "tbs_artifact_qa_continuation_required"
+                    final_msg[_TBS_ARTIFACT_QA_GUARD_FLAG] = True
+                    append_message(messages, final_msg)
+                    append_message(messages, {
+                        "role": "user",
+                        "content": _tbs_artifact_qa_nudge,
+                        _TBS_ARTIFACT_QA_GUARD_FLAG: True,
+                    })
+                    agent._session_messages = messages
+                    logger.info(
+                        "TBS artifact-QA guard issued continuation nudge "
+                        "(session=%s)",
+                        getattr(agent, "session_id", None) or "none",
+                    )
+                    agent._emit_status(
+                        "↻ TBS workbook completion needs validator evidence — continuing QA"
+                    )
+                    _pending_verification_response = final_response
+                    _pending_verification_response_previewed = (
+                        agent._interim_content_was_streamed(final_response or "")
+                    )
+                    final_response = None
+                    continue
+
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
                 # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"

--- a/agent/tbs_artifact_qa_guard.py
+++ b/agent/tbs_artifact_qa_guard.py
@@ -1,0 +1,125 @@
+"""TBS artifact QA finalization guard.
+
+This guard is deliberately text-only at the finalization seam.  It does not open
+files or inspect workbook bytes inside the generic conversation loop; instead it
+requires evidence that the separate workbook validator already ran before a TBS
+client/CFO XLSX workbook can be called complete.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+SYNTHETIC_FLAG = "_tbs_artifact_qa_guard_synthetic"
+
+_XLSX_RE = re.compile(r"\b\S+\.xlsx\b|\b(workbook|spreadsheet|Excel|XLSX)\b", re.IGNORECASE)
+_FINANCE_FORECAST_RE = re.compile(
+    r"\b(CFO|client[-\s]?facing|finance|financial|cash[-\s]?flow|cash\s+forecast|forecast|projection|13[-\s]?week|reconciliation|workpaper)\b",
+    re.IGNORECASE,
+)
+_COMPLETE_CLAIM_RE = re.compile(
+    r"\b(done|complete(?:d)?|ready|client[-\s]?ready|CEO[-\s]?ready|CFO[-\s]?ready|final(?:ized)?|built|created|generated|delivered|attached|handoff)\b",
+    re.IGNORECASE,
+)
+_NOT_READY_RE = re.compile(
+    r"\b(NOT\s+CLIENT[-\s]?READY|NOT\s+CEO[-\s]?READY|MODEL\s+INCOMPLETE|FORMULAS\s+FLATTENED|not\s+ready|blocked|approval\s+(?:needed|required))\b",
+    re.IGNORECASE,
+)
+_VALIDATOR_EVIDENCE_RE = re.compile(
+    r"tbs_workbook_qa_validator\.py|mechanical\s+workbook\s+QA\s+validator|workbook\s+QA\s+validator",
+    re.IGNORECASE,
+)
+_VALIDATOR_PASS_RE = re.compile(
+    r"\b(status['\"]?\s*[:=]\s*['\"]?PASS['\"]?|validator\s+(?:self-test\s+)?passed|workbook\s+QA\s+validator\s+passed|\bok['\"]?\s*[:=]\s*(?:true|True))\b",
+    re.IGNORECASE,
+)
+_TBS_CONTEXT_RE = re.compile(r"\b(TBS|tbs-|Dave|client[-\s]?facing|CEO[-\s]?ready|CFO[-\s]?ready)\b", re.IGNORECASE)
+
+_CONTINUATION_NUDGE = """[SYSTEM CONTINUATION GUARD — TBS artifact QA]
+Your last response appears to call a TBS client/CFO finance Excel workbook complete, but the session/final response does not show a passing `tbs_workbook_qa_validator.py` result.
+Do not present the workbook as complete yet. Continue the safe next step now: run the workbook QA validator against the `.xlsx` artifact, revise/rebuild if it fails, or relabel the artifact `NOT CLIENT-READY / MODEL INCOMPLETE` or `NOT CEO-READY / FORMULAS FLATTENED` with the exact blocker.
+Stop only when the final answer includes validator pass evidence, or when it explicitly labels the workbook not ready with the failed check/source blocker."""
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return str(value)
+
+
+def _recent_messages_text(messages: Any, *, max_messages: int = 32) -> str:
+    if not isinstance(messages, list):
+        return _as_text(messages)
+    parts: list[str] = []
+    for msg in messages[-max_messages:]:
+        if not isinstance(msg, dict):
+            parts.append(_as_text(msg))
+            continue
+        if msg.get("role") == "system":
+            continue
+        parts.append(_as_text(msg.get("content")))
+    return "\n".join(p for p in parts if p)
+
+
+def has_passing_workbook_validator_evidence(*texts: Any) -> bool:
+    """Return True when the context includes the validator and a pass marker."""
+    context = "\n".join(_as_text(t) for t in texts if t is not None)
+    return bool(_VALIDATOR_EVIDENCE_RE.search(context) and _VALIDATOR_PASS_RE.search(context))
+
+
+def response_needs_artifact_qa(
+    response_text: Any,
+    *,
+    user_message: Any = None,
+    recent_messages: Any = None,
+) -> bool:
+    """Whether a final response should be held for workbook QA evidence.
+
+    This intentionally guards only the high-risk class Dave named: TBS/client/CFO
+    finance forecast XLSX completion claims. It does not block generic scratch
+    spreadsheets, drafts already labeled not-ready, or responses that show the
+    separate validator passed.
+    """
+    response = _as_text(response_text).strip()
+    if not response:
+        return False
+    user = _as_text(user_message)
+    recent = _recent_messages_text(recent_messages)
+    context = "\n".join([response, user, recent])
+
+    if _NOT_READY_RE.search(response):
+        return False
+    if not _TBS_CONTEXT_RE.search(context):
+        return False
+    if not (_XLSX_RE.search(response) or re.search(r"\.xlsx\b", context, re.IGNORECASE)):
+        return False
+    if not _FINANCE_FORECAST_RE.search(context):
+        return False
+    if not _COMPLETE_CLAIM_RE.search(response):
+        return False
+    if has_passing_workbook_validator_evidence(response, recent):
+        return False
+    return True
+
+
+def build_artifact_qa_nudge(
+    response_text: Any,
+    *,
+    user_message: Any = None,
+    recent_messages: Any = None,
+) -> str | None:
+    if not response_needs_artifact_qa(response_text, user_message=user_message, recent_messages=recent_messages):
+        return None
+    return _CONTINUATION_NUDGE

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -54,6 +54,7 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_tbs_artifact_qa_guard_synthetic",
 )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -244,6 +244,10 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     # persisted and emitted as an interim message (#65919).
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    # TBS artifact QA continuation guard: client/CFO workbook completion claims
+    # need mechanical validator evidence before they become durable transcript
+    # content.
+    "_tbs_artifact_qa_guard_synthetic",
     # kanban worker stop-guard: narrated exit without kanban_complete/block
     "_kanban_stop_synthetic",
     # dropped tool-call re-prompt pair (finish_reason=tool_calls with an

--- a/tests/run_agent/test_tbs_artifact_qa_guard.py
+++ b/tests/run_agent/test_tbs_artifact_qa_guard.py
@@ -1,0 +1,48 @@
+import pytest
+
+from agent.tbs_artifact_qa_guard import (
+    SYNTHETIC_FLAG,
+    build_artifact_qa_nudge,
+    has_passing_workbook_validator_evidence,
+    response_needs_artifact_qa,
+)
+from agent.turn_finalizer import _drop_verification_continuation_scaffolding
+
+
+def test_tbs_cfo_xlsx_completion_without_validator_continues():
+    response = "Done — CFO cash-flow forecast workbook created: C:/work/forecast.xlsx"
+    assert response_needs_artifact_qa(response, user_message="TBS client-facing finance forecast") is True
+    assert build_artifact_qa_nudge(response, user_message="TBS client-facing finance forecast")
+
+
+def test_tbs_cfo_xlsx_completion_with_validator_pass_can_finalize():
+    response = "Done — CFO cash-flow forecast workbook created: C:/work/forecast.xlsx"
+    recent = "python tbs_workbook_qa_validator.py C:/work/forecast.xlsx --project-forecast returned status: PASS"
+    assert has_passing_workbook_validator_evidence(recent) is True
+    assert response_needs_artifact_qa(response, user_message="TBS client-facing finance forecast", recent_messages=[{"role": "tool", "content": recent}]) is False
+
+
+def test_not_ready_workbook_label_can_finalize():
+    response = "C:/work/forecast.xlsx is NOT CLIENT-READY / MODEL INCOMPLETE because project rows are missing."
+    assert response_needs_artifact_qa(response, user_message="TBS CFO forecast") is False
+
+
+def test_generic_spreadsheet_is_not_blocked():
+    response = "Done — created the grocery spreadsheet: C:/work/list.xlsx"
+    assert response_needs_artifact_qa(response, user_message="personal spreadsheet") is False
+
+
+def test_tbs_artifact_qa_scaffolding_is_dropped_from_live_history():
+    messages = [
+        {"role": "user", "content": "Build TBS CFO workbook"},
+        {"role": "assistant", "content": "interim", SYNTHETIC_FLAG: True},
+        {"role": "user", "content": "run validator", SYNTHETIC_FLAG: True},
+        {"role": "assistant", "content": "final validator passed"},
+    ]
+
+    _drop_verification_continuation_scaffolding(messages)
+
+    assert messages == [
+        {"role": "user", "content": "Build TBS CFO workbook"},
+        {"role": "assistant", "content": "final validator passed"},
+    ]


### PR DESCRIPTION
Adds a text-only TBS artifact QA finalization guard for client/CFO finance XLSX completion claims. The guard requires evidence that the separate workbook QA validator passed before the assistant can call a workbook complete; otherwise it injects a continuation nudge to run validation or relabel the workbook not-ready.\n\nValidation:\n- python -m pytest tests/run_agent/test_tbs_artifact_qa_guard.py\n- python -m py_compile agent/tbs_artifact_qa_guard.py agent/conversation_loop.py agent/turn_finalizer.py run_agent.py\n- git diff --check\n\nNotes:\n- Byte-level XLSX inspection remains outside the generic finalizer; this guard only checks final-answer completion claims for validator evidence.\n- Branch is based on the current fork main because this token lacks workflow scope to sync upstream workflow commits.