### PR TITLE
fix(plugins): harden Doctor staging

### DIFF
--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -8,17 +8,22 @@ runtime contracts instead of maintaining a parallel scanner.
 
 from __future__ import annotations
 
+import errno
+import fnmatch
 import inspect
 import os
+import signal
 import shutil
 import socket
+import stat
 import sys
 import tempfile
+import threading
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Literal
+from typing import Any, Callable, Literal, cast
 from unittest.mock import patch
 
 from hermes_constants import get_hermes_home
@@ -28,8 +33,244 @@ class _DoctorLoadError(RuntimeError):
     """Raised when the real plugin runtime cannot load the target."""
 
 
+class _DoctorTerminated(SystemExit):
+    """Turn SIGTERM into normal unwinding so temporary files are removed."""
+
+    def __init__(self, signum: int, frame: Any) -> None:
+        super().__init__(128 + signum)
+        self.signum = signum
+        self.frame = frame
+
+
 def _deny_network(*_args: Any, **_kwargs: Any) -> None:
     raise RuntimeError("network access is disabled while Plugin Doctor runs")
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_symlink_target(candidate: Path, raw_target: Path, root: Path) -> None:
+    link_target = raw_target
+    if not raw_target.is_absolute():
+        link_target = Path(os.path.normpath(candidate.parent / raw_target))
+    if raw_target.is_absolute() or not _is_within(link_target, root):
+        raise ValueError(
+            f"Plugin symlink escapes plugin root: {candidate} -> {raw_target}"
+        )
+
+
+def _validate_plugin_symlinks(root: Path) -> None:
+    """Reject absolute or lexically escaping links without resolving targets."""
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        for name in (*directory_names, *file_names):
+            candidate = directory_path / name
+            if not candidate.is_symlink():
+                continue
+            raw_target = Path(os.readlink(candidate))
+            _validate_symlink_target(candidate, raw_target, root)
+
+
+def _validate_plugin_root(path: Path) -> Path:
+    """Require one bounded plugin tree before creating any Doctor temp data."""
+    if path.is_symlink():
+        raise ValueError(f"Plugin target must not be a symlink: {path}")
+
+    resolved = path.resolve()
+    if resolved == Path(resolved.anchor):
+        raise ValueError(f"Plugin Doctor refuses the filesystem root: {resolved}")
+    if resolved == Path.home().resolve():
+        raise ValueError(f"Plugin Doctor refuses the home directory: {resolved}")
+    manifest_names = ("plugin.yaml", "plugin.yml", "plugin.json")
+    manifest_paths = tuple(resolved / name for name in manifest_names)
+    if not any(os.path.lexists(path) for path in manifest_paths):
+        raise ValueError(
+            "Plugin Doctor requires one plugin directory containing plugin.yaml, "
+            "plugin.yml, or plugin.json; "
+            f"refusing broad or non-plugin target: {resolved}"
+        )
+    if not any(
+        stat.S_ISREG(os.stat(path, follow_symlinks=False).st_mode)
+        for path in manifest_paths
+        if os.path.lexists(path)
+    ):
+        raise ValueError(f"Plugin manifest is not a regular file under: {resolved}")
+    return resolved
+
+
+_COPY_IGNORE_PATTERNS = (".git", "__pycache__", ".pytest_cache", "*.pyc")
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_OPEN_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+_SECURE_STAGING_REQUIREMENTS = {
+    "os.open(dir_fd)": os.open in os.supports_dir_fd,
+    "os.stat(dir_fd)": os.stat in os.supports_dir_fd,
+    "os.readlink(dir_fd)": os.readlink in os.supports_dir_fd,
+    "os.scandir(fd)": os.scandir in os.supports_fd,
+}
+_MISSING_SECURE_STAGING_APIS = tuple(
+    name for name, supported in _SECURE_STAGING_REQUIREMENTS.items() if not supported
+)
+
+
+def _require_secure_staging_support() -> None:
+    if _MISSING_SECURE_STAGING_APIS:
+        raise ValueError(
+            "Secure plugin staging is unavailable on this platform; "
+            "refusing an unsafe path-based copy (missing: "
+            + ", ".join(_MISSING_SECURE_STAGING_APIS)
+            + ")"
+        )
+
+
+def _same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _open_verified_entry(
+    name: str, source_fd: int, expected: os.stat_result, flags: int
+) -> int:
+    descriptor = os.open(name, flags, dir_fd=source_fd)
+    try:
+        opened = os.fstat(descriptor)
+        if not _same_identity(expected, opened):
+            raise ValueError(
+                f"Plugin entry changed while Doctor was copying it: {name}"
+            )
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _copy_directory_fd(
+    source_fd: int,
+    logical_source: Path,
+    destination: Path,
+    plugin_root: Path,
+) -> None:
+    with os.scandir(source_fd) as entries:
+        for entry in entries:
+            if any(
+                fnmatch.fnmatch(entry.name, pattern)
+                for pattern in _COPY_IGNORE_PATTERNS
+            ):
+                continue
+
+            expected = entry.stat(follow_symlinks=False)
+            logical_entry = logical_source / entry.name
+            copied_entry = destination / entry.name
+            if stat.S_ISLNK(expected.st_mode):
+                raw_target = Path(os.readlink(entry.name, dir_fd=source_fd))
+                _validate_symlink_target(logical_entry, raw_target, plugin_root)
+                os.symlink(os.fspath(raw_target), copied_entry)
+                continue
+
+            if stat.S_ISDIR(expected.st_mode):
+                child_fd = _open_verified_entry(
+                    entry.name, source_fd, expected, _DIRECTORY_OPEN_FLAGS
+                )
+                try:
+                    copied_entry.mkdir(mode=0o700)
+                    _copy_directory_fd(
+                        child_fd, logical_entry, copied_entry, plugin_root
+                    )
+                    os.chmod(copied_entry, stat.S_IMODE(expected.st_mode))
+                finally:
+                    os.close(child_fd)
+                continue
+
+            if stat.S_ISREG(expected.st_mode):
+                child_fd = _open_verified_entry(
+                    entry.name, source_fd, expected, _FILE_OPEN_FLAGS
+                )
+                with (
+                    os.fdopen(child_fd, "rb") as source_file,
+                    copied_entry.open("xb") as copied_file,
+                ):
+                    shutil.copyfileobj(source_file, copied_file)
+                os.chmod(copied_entry, stat.S_IMODE(expected.st_mode))
+                continue
+
+            raise ValueError(
+                f"Plugin contains unsupported special file: {logical_entry}"
+            )
+
+
+def _copy_plugin_tree(source: Path, destination: Path) -> None:
+    """Copy a plugin through a pinned directory FD without following links."""
+    expected_root = os.stat(source, follow_symlinks=False)
+    if stat.S_ISLNK(expected_root.st_mode):
+        raise ValueError(f"Plugin target must not be a symlink: {source}")
+    try:
+        source_fd = os.open(source, _DIRECTORY_OPEN_FLAGS)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP or source.is_symlink():
+            raise ValueError(
+                f"Plugin target changed or became a symlink before copy: {source}"
+            ) from exc
+        raise
+
+    try:
+        opened_root = os.fstat(source_fd)
+        if not stat.S_ISDIR(opened_root.st_mode) or not _same_identity(
+            expected_root, opened_root
+        ):
+            raise ValueError(f"Plugin target changed while Doctor opened it: {source}")
+
+        manifest_names = ("plugin.yaml", "plugin.yml", "plugin.json")
+        has_manifest = False
+        for name in manifest_names:
+            try:
+                manifest_stat = os.stat(name, dir_fd=source_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if stat.S_ISREG(manifest_stat.st_mode):
+                has_manifest = True
+                break
+        if not has_manifest:
+            raise ValueError(
+                "Plugin Doctor requires one plugin directory containing plugin.yaml, "
+                "plugin.yml, or plugin.json; source changed before copy"
+            )
+
+        destination.mkdir()
+        _copy_directory_fd(source_fd, source, destination, source)
+    finally:
+        os.close(source_fd)
+
+
+@contextmanager
+def _cleanup_on_sigterm():
+    """Let SIGTERM unwind TemporaryDirectory on the Python main thread."""
+    if (
+        not hasattr(signal, "SIGTERM")
+        or threading.current_thread() is not threading.main_thread()
+    ):
+        yield
+        return
+
+    previous_handler = signal.getsignal(signal.SIGTERM)
+
+    def terminate(signum: int, frame: Any) -> None:
+        raise _DoctorTerminated(signum, frame)
+
+    signal.signal(signal.SIGTERM, terminate)
+    try:
+        yield
+    except _DoctorTerminated as exc:
+        if callable(previous_handler):
+            handler = cast(Callable[[int, Any], Any], previous_handler)
+            handler(exc.signum, exc.frame)
+        raise
+    finally:
+        signal.signal(signal.SIGTERM, previous_handler)
 
 
 @contextmanager
@@ -40,97 +281,105 @@ def _doctor_runtime(plugin_path: Path):
     test framework. Registration code executes under a temporary HERMES_HOME
     with outbound socket connects blocked.
     """
-    temporary_home = tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
-    stack = ExitStack()
-    home = Path(temporary_home.name)
-    bundled = home / "bundled-plugins"
-    plugins_root = home / "plugins"
-    bundled.mkdir(parents=True)
-    plugins_root.mkdir(parents=True)
-    copied = plugins_root / plugin_path.name
-    shutil.copytree(
-        plugin_path,
-        copied,
-        ignore=shutil.ignore_patterns(".git", "__pycache__", ".pytest_cache", "*.pyc"),
-    )
-
-    stack.enter_context(
-        patch.dict(
-            os.environ,
-            {
-                "HERMES_HOME": str(home),
-                "HERMES_BUNDLED_PLUGINS": str(bundled),
-                "HERMES_ENABLE_PROJECT_PLUGINS": "0",
-            },
-            clear=False,
-        )
-    )
-    stack.enter_context(patch.object(socket, "create_connection", _deny_network))
-    stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
-    stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
-
-    from hermes_cli.plugins import PluginManager
-    from tools.registry import registry
-
-    entries_before = {entry.name: entry for entry in registry._snapshot_entries()}
-    policy_before = dict(registry._plugin_override_policy)
-    modules_before = {
-        name
-        for name in sys.modules
-        if name == "hermes_plugins" or name.startswith("hermes_plugins.")
-    }
-    manager = PluginManager()
-    try:
-        manifests = manager._scan_directory(plugins_root, source="user")
-        if not manifests:
-            raise _DoctorLoadError(
-                f"Hermes discovery found no valid plugin manifest under {copied}"
+    _require_secure_staging_support()
+    with _cleanup_on_sigterm(), ExitStack() as stack:
+        home = Path(
+            stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
             )
-        if len(manifests) != 1:
-            raise _DoctorLoadError(
-                f"Expected one plugin manifest, discovered {len(manifests)} under {copied}"
-            )
-        manifest = manifests[0]
-        manager._load_plugin(manifest)
-        loaded = manager._plugins.get(manifest.key or manifest.name)
-        if loaded is None:
-            raise _DoctorLoadError("Plugin registration produced no runtime record")
-        if loaded.error:
-            raise _DoctorLoadError(f"Plugin registration failed: {loaded.error}")
-        if not loaded.enabled:
-            raise _DoctorLoadError("Plugin registration did not enable the runtime record")
-        yield SimpleNamespace(
-            manifest=manifest,
-            manager=manager,
-            registered_tools=tuple(sorted(loaded.tools_registered)),
-            registered_hooks=tuple(loaded.hooks_registered),
         )
-    finally:
-        entries_after = {entry.name: entry for entry in registry._snapshot_entries()}
-        changed_names = {
+        if _is_within(home.resolve(), plugin_path.resolve()):
+            raise ValueError(
+                "Plugin Doctor temporary destination is inside the plugin source; "
+                "refusing a recursive copy"
+            )
+
+        bundled = home / "bundled-plugins"
+        plugins_root = home / "plugins"
+        bundled.mkdir(parents=True)
+        plugins_root.mkdir(parents=True)
+        copied = plugins_root / plugin_path.name
+        _copy_plugin_tree(plugin_path, copied)
+        _validate_plugin_symlinks(copied)
+
+        stack.enter_context(
+            patch.dict(
+                os.environ,
+                {
+                    "HERMES_HOME": str(home),
+                    "HERMES_BUNDLED_PLUGINS": str(bundled),
+                    "HERMES_ENABLE_PROJECT_PLUGINS": "0",
+                },
+                clear=False,
+            )
+        )
+        stack.enter_context(patch.object(socket, "create_connection", _deny_network))
+        stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
+        stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
+
+        from hermes_cli.plugins import PluginManager
+        from tools.registry import registry
+
+        entries_before = {entry.name: entry for entry in registry._snapshot_entries()}
+        policy_before = dict(registry._plugin_override_policy)
+        modules_before = {
             name
-            for name in set(entries_before) | set(entries_after)
-            if entries_after.get(name) is not entries_before.get(name)
+            for name in sys.modules
+            if name == "hermes_plugins" or name.startswith("hermes_plugins.")
         }
-        with registry._lock:
-            for name in changed_names:
-                previous = entries_before.get(name)
-                if previous is None:
-                    registry._tools.pop(name, None)
-                else:
-                    registry._tools[name] = previous
-            registry._plugin_override_policy.clear()
-            registry._plugin_override_policy.update(policy_before)
-            if changed_names:
-                registry._generation += 1
-        for name in list(sys.modules):
-            if (
-                name not in modules_before
-                and (name == "hermes_plugins" or name.startswith("hermes_plugins."))
-            ):
-                sys.modules.pop(name, None)
-        stack.close()
-        temporary_home.cleanup()
+        manager = PluginManager()
+        try:
+            manifests = manager._scan_directory(plugins_root, source="user")
+            if not manifests:
+                raise _DoctorLoadError(
+                    f"Hermes discovery found no valid plugin manifest under {copied}"
+                )
+            if len(manifests) != 1:
+                raise _DoctorLoadError(
+                    f"Expected one plugin manifest, discovered {len(manifests)} under {copied}"
+                )
+            manifest = manifests[0]
+            manager._load_plugin(manifest)
+            loaded = manager._plugins.get(manifest.key or manifest.name)
+            if loaded is None:
+                raise _DoctorLoadError("Plugin registration produced no runtime record")
+            if loaded.error:
+                raise _DoctorLoadError(f"Plugin registration failed: {loaded.error}")
+            if not loaded.enabled:
+                raise _DoctorLoadError(
+                    "Plugin registration did not enable the runtime record"
+                )
+            yield SimpleNamespace(
+                manifest=manifest,
+                manager=manager,
+                registered_tools=tuple(sorted(loaded.tools_registered)),
+                registered_hooks=tuple(loaded.hooks_registered),
+            )
+        finally:
+            entries_after = {
+                entry.name: entry for entry in registry._snapshot_entries()
+            }
+            changed_names = {
+                name
+                for name in set(entries_before) | set(entries_after)
+                if entries_after.get(name) is not entries_before.get(name)
+            }
+            with registry._lock:
+                for name in changed_names:
+                    previous = entries_before.get(name)
+                    if previous is None:
+                        registry._tools.pop(name, None)
+                    else:
+                        registry._tools[name] = previous
+                registry._plugin_override_policy.clear()
+                registry._plugin_override_policy.update(policy_before)
+                if changed_names:
+                    registry._generation += 1
+            for name in list(sys.modules):
+                if name not in modules_before and (
+                    name == "hermes_plugins" or name.startswith("hermes_plugins.")
+                ):
+                    sys.modules.pop(name, None)
 
 
 @dataclass(frozen=True)
@@ -180,10 +429,14 @@ class DoctorReport:
 
 def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     """Resolve an explicit path or an installed/bundled plugin id."""
-    raw = os.fspath(target or ".")
+    if target is None:
+        raise ValueError(
+            "Plugin Doctor requires an explicit plugin path or installed plugin id"
+        )
+    raw = os.fspath(target)
     direct = Path(raw).expanduser()
     if direct.is_dir():
-        return direct.resolve()
+        return _validate_plugin_root(direct)
 
     candidates: list[Path] = []
     user_root = get_hermes_home() / "plugins"
@@ -192,19 +445,17 @@ def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
         from hermes_cli.plugins import get_bundled_plugins_dir
 
         bundled = get_bundled_plugins_dir()
-        candidates.extend(
-            [
-                bundled / raw,
-                bundled / "platforms" / raw,
-                bundled / "model-providers" / raw,
-            ]
-        )
+        candidates.extend([
+            bundled / raw,
+            bundled / "platforms" / raw,
+            bundled / "model-providers" / raw,
+        ])
     except Exception:
         pass
     candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
     for candidate in candidates:
         if candidate.is_dir():
-            return candidate.resolve()
+            return _validate_plugin_root(candidate)
     raise FileNotFoundError(
         f"Plugin {raw!r} was not found as a path or installed plugin id"
     )
@@ -215,7 +466,9 @@ def _accepts_var_kwargs(callback: Any) -> bool:
         parameters = inspect.signature(callback).parameters.values()
     except (TypeError, ValueError):
         return False
-    return any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters)
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    )
 
 
 def _check_manifest_v2(report: "DoctorReport", manifest: Any) -> None:
@@ -234,7 +487,9 @@ def _check_manifest_v2(report: "DoctorReport", manifest: Any) -> None:
 
     api_version = getattr(manifest, "api_version", None)
     if api_version is not None and api_version < 1:
-        report.warning(f"api_version {api_version} is not a valid API generation (>= 1)")
+        report.warning(
+            f"api_version {api_version} is not a valid API generation (>= 1)"
+        )
 
     for dep in getattr(manifest, "requires_plugins", []) or []:
         dep_id = dep.get("id") if isinstance(dep, dict) else None
@@ -295,7 +550,7 @@ def doctor_plugin(target: str | os.PathLike[str] | None = None) -> DoctorReport:
     """Validate one plugin through Hermes' real scanner and registration path."""
     try:
         path = resolve_plugin_path(target)
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, ValueError) as exc:
         report = DoctorReport(Path(os.fspath(target or ".")).expanduser())
         report.error(str(exc))
         return report
@@ -335,22 +590,34 @@ def doctor_plugin(target: str | os.PathLike[str] | None = None) -> DoctorReport:
                             "must accept **kwargs for forward compatibility"
                         )
 
-            declared_hook_names = {name for name in declared_hooks if isinstance(name, str)}
+            declared_hook_names = {
+                name for name in declared_hooks if isinstance(name, str)
+            }
             registered_hook_names = set(host.registered_hooks)
             for name in sorted(declared_hook_names - registered_hook_names):
-                report.warning(f"manifest declares hook {name!r} but registration did not add it")
+                report.warning(
+                    f"manifest declares hook {name!r} but registration did not add it"
+                )
             for name in sorted(registered_hook_names - declared_hook_names):
-                report.warning(f"registration adds hook {name!r} not listed in provides_hooks")
+                report.warning(
+                    f"registration adds hook {name!r} not listed in provides_hooks"
+                )
 
-            declared_tool_names = {name for name in declared_tools if isinstance(name, str)}
+            declared_tool_names = {
+                name for name in declared_tools if isinstance(name, str)
+            }
             registered_tool_names = set(host.registered_tools)
             for name in sorted(declared_tool_names - registered_tool_names):
-                report.warning(f"manifest declares tool {name!r} but registration did not add it")
+                report.warning(
+                    f"manifest declares tool {name!r} but registration did not add it"
+                )
             for name in sorted(registered_tool_names - declared_tool_names):
-                report.warning(f"registration adds tool {name!r} not listed in provides_tools")
+                report.warning(
+                    f"registration adds tool {name!r} not listed in provides_tools"
+                )
 
             _check_manifest_v2(report, host.manifest)
-    except _DoctorLoadError as exc:
+    except (_DoctorLoadError, ValueError) as exc:
         report.error(str(exc))
     except Exception as exc:
         report.error(f"unexpected validation failure: {type(exc).__name__}: {exc}")

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -3048,7 +3048,7 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     return {"ok": True, "name": name}
 
 
-def cmd_plugin_doctor(target: str = ".", *, ci: bool = False) -> None:
+def cmd_plugin_doctor(target: str | None = None, *, ci: bool = False) -> None:
     """Validate one plugin through runtime discovery and registration."""
     from rich.console import Console
 

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -163,9 +163,7 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     )
     plugins_doctor.add_argument(
         "target",
-        nargs="?",
-        default=".",
-        help="Plugin path or installed plugin id (default: current directory)",
+        help="Plugin path or installed plugin id",
     )
     plugins_doctor.add_argument(
         "--ci",

--- a/tests/hermes_cli/test_plugin_dev.py
+++ b/tests/hermes_cli/test_plugin_dev.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import errno
+import json
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
+
+import pytest
 
 from hermes_cli.subcommands.plugins import build_plugins_parser
 
@@ -23,6 +31,291 @@ def test_plugins_parser_exposes_doctor() -> None:
     )
 
 
+def test_plugins_parser_requires_explicit_doctor_target() -> None:
+    with pytest.raises(SystemExit):
+        _parse_plugins_args("doctor")
+
+
+def _minimal_plugin(root: Path, name: str = "minimal") -> Path:
+    plugin = root / name
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text(f"name: {name}\n", encoding="utf-8")
+    (plugin / "__init__.py").write_text(
+        "def register(ctx):\n    pass\n", encoding="utf-8"
+    )
+    return plugin
+
+
+def test_doctor_without_target_rejects_home_before_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    monkeypatch.chdir(Path.home())
+    monkeypatch.setattr(
+        plugin_dev,
+        "_copy_plugin_tree",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Doctor attempted to copy the home directory"
+        ),
+    )
+
+    report = plugin_dev.doctor_plugin(None)
+
+    assert report.ok is False
+    assert "explicit plugin path or installed plugin id" in report.format_text()
+
+
+@pytest.mark.parametrize(
+    ("target", "message"),
+    [(Path.home(), "home directory"), (Path("/"), "filesystem root")],
+)
+def test_doctor_rejects_broad_targets_before_copy(
+    monkeypatch: pytest.MonkeyPatch, target: Path, message: str
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    monkeypatch.setattr(
+        plugin_dev,
+        "_copy_plugin_tree",
+        lambda *_args, **_kwargs: pytest.fail(f"Doctor attempted to copy {target}"),
+    )
+
+    report = plugin_dev.doctor_plugin(target)
+
+    assert report.ok is False
+    assert message in report.format_text()
+
+
+def test_doctor_rejects_non_plugin_before_tree_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    broad_directory = tmp_path / "not-a-plugin"
+    broad_directory.mkdir()
+    (broad_directory / "nested").mkdir()
+    monkeypatch.setattr(
+        plugin_dev,
+        "_validate_plugin_symlinks",
+        lambda _path: pytest.fail("Doctor walked a non-plugin directory tree"),
+    )
+
+    report = plugin_dev.doctor_plugin(broad_directory)
+
+    assert report.ok is False
+    assert "broad or non-plugin target" in report.format_text()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="native Windows symlink creation is optional"
+)
+def test_doctor_rejects_symlink_that_escapes_without_opening_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    plugin = _minimal_plugin(tmp_path)
+    (plugin / "escape").symlink_to(Path("/"), target_is_directory=True)
+    real_open = os.open
+
+    def reject_escape_open(path, flags, *args, **kwargs):
+        if path == "escape" and kwargs.get("dir_fd") is not None:
+            pytest.fail("Doctor dereferenced an escaping plugin symlink")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(plugin_dev.os, "open", reject_escape_open)
+
+    report = plugin_dev.doctor_plugin(plugin)
+
+    assert report.ok is False
+    assert "symlink escapes plugin root" in report.format_text()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="native Windows symlink creation is optional"
+)
+def test_doctor_accepts_relative_symlink_inside_plugin(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = _minimal_plugin(tmp_path)
+    (plugin / "data.txt").write_text("safe", encoding="utf-8")
+    (plugin / "data-link.txt").symlink_to("data.txt")
+
+    report = doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="native Windows symlink creation is optional"
+)
+def test_doctor_rejects_root_symlink_swap_before_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    source = _minimal_plugin(tmp_path / "source", "safe")
+    outside = _minimal_plugin(tmp_path / "outside", "outside")
+    moved = tmp_path / "moved-safe"
+    real_open = os.open
+    swap_attempted = False
+
+    def swap_before_root_open(path, flags, *args, **kwargs):
+        nonlocal swap_attempted
+        if (
+            not swap_attempted
+            and kwargs.get("dir_fd") is None
+            and os.fspath(path) == os.fspath(source)
+        ):
+            source.rename(moved)
+            source.symlink_to(outside, target_is_directory=True)
+            swap_attempted = True
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(plugin_dev.os, "open", swap_before_root_open)
+
+    report = plugin_dev.doctor_plugin(source)
+
+    assert swap_attempted, "Doctor did not pin the validated plugin root before copying"
+    assert report.ok is False
+    assert report.manifest is None or report.manifest.name != "outside"
+    assert "symlink" in report.format_text().lower()
+
+
+def test_doctor_refuses_unsupported_secure_staging_before_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    plugin = _minimal_plugin(tmp_path / "source")
+    doctor_temp = tmp_path / "doctor-temp"
+    doctor_temp.mkdir()
+    monkeypatch.setattr(plugin_dev.tempfile, "tempdir", str(doctor_temp))
+    monkeypatch.setattr(plugin_dev, "_MISSING_SECURE_STAGING_APIS", ("os.scandir(fd)",))
+
+    report = plugin_dev.doctor_plugin(plugin)
+
+    assert report.ok is False
+    assert "secure plugin staging is unavailable" in report.format_text().lower()
+    assert not list(doctor_temp.glob("hermes-plugin-doctor-*"))
+
+
+def test_doctor_blocks_temp_destination_inside_plugin_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    plugin = _minimal_plugin(tmp_path)
+    monkeypatch.setattr(plugin_dev.tempfile, "tempdir", str(plugin))
+    copy_called = False
+
+    def unexpected_copy(*_args, **_kwargs):
+        nonlocal copy_called
+        copy_called = True
+        pytest.fail("Doctor attempted a recursive copy into its own source")
+
+    monkeypatch.setattr(plugin_dev, "_copy_plugin_tree", unexpected_copy)
+
+    report = plugin_dev.doctor_plugin(plugin)
+
+    assert report.ok is False
+    assert "temporary destination is inside the plugin source" in report.format_text()
+    assert copy_called is False
+    assert not list(plugin.glob("hermes-plugin-doctor-*"))
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        OSError(errno.ENOSPC, "No space left on device"),
+        RuntimeError("copy failed"),
+        KeyboardInterrupt(),
+    ],
+    ids=["enospc", "exception", "keyboard-interrupt"],
+)
+def test_doctor_cleans_temp_when_copy_is_interrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: BaseException
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    plugin = _minimal_plugin(tmp_path / "source")
+    doctor_temp = tmp_path / "doctor-temp"
+    doctor_temp.mkdir()
+    monkeypatch.setattr(plugin_dev.tempfile, "tempdir", str(doctor_temp))
+
+    def interrupted_copy(_source: Path, destination: Path, **_kwargs) -> None:
+        destination.mkdir()
+        locked = destination / "locked"
+        locked.mkdir()
+        (locked / "partial").write_text("partial", encoding="utf-8")
+        locked.chmod(0o500)
+        raise failure
+
+    monkeypatch.setattr(plugin_dev, "_copy_plugin_tree", interrupted_copy)
+
+    if isinstance(failure, Exception):
+        report = plugin_dev.doctor_plugin(plugin)
+        assert report.ok is False
+    else:
+        with pytest.raises(type(failure)):
+            plugin_dev.doctor_plugin(plugin)
+
+    assert not list(doctor_temp.glob("hermes-plugin-doctor-*"))
+
+
+def test_doctor_cleans_temp_on_sigterm(tmp_path: Path) -> None:
+    plugin = _minimal_plugin(tmp_path / "source")
+    doctor_temp = tmp_path / "doctor-temp"
+    doctor_temp.mkdir()
+    previous_handler_marker = tmp_path / "previous-handler-ran"
+    script = textwrap.dedent(
+        f"""
+        import os
+        import signal
+        import tempfile
+        from pathlib import Path
+        import hermes_cli.plugin_dev as plugin_dev
+
+        tempfile.tempdir = {str(doctor_temp)!r}
+
+        def previous_handler(_signum, _frame):
+            Path({str(previous_handler_marker)!r}).write_text("ran", encoding="utf-8")
+
+        signal.signal(signal.SIGTERM, previous_handler)
+
+        def terminate(_source, destination, **_kwargs):
+            Path(destination).mkdir()
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        plugin_dev._copy_plugin_tree = terminate
+        plugin_dev.doctor_plugin(Path({str(plugin)!r}))
+        """
+    )
+
+    completed = subprocess.run([sys.executable, "-c", script], check=False, timeout=30)
+
+    assert completed.returncode != 0
+    assert not list(doctor_temp.glob("hermes-plugin-doctor-*"))
+    assert previous_handler_marker.read_text(encoding="utf-8") == "ran"
+
+
+def test_doctor_cleans_temp_after_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
+
+    plugin = _minimal_plugin(tmp_path / "source")
+    doctor_temp = tmp_path / "doctor-temp"
+    doctor_temp.mkdir()
+    monkeypatch.setattr(plugin_dev.tempfile, "tempdir", str(doctor_temp))
+
+    report = plugin_dev.doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
+    assert not list(doctor_temp.glob("hermes-plugin-doctor-*"))
+
+
 def test_doctor_uses_registration_to_reject_bad_hook_and_callback_signature(
     tmp_path: Path,
 ) -> None:
@@ -31,16 +324,14 @@ def test_doctor_uses_registration_to_reject_bad_hook_and_callback_signature(
     plugin = tmp_path / "bad-plugin"
     plugin.mkdir()
     (plugin / "plugin.yaml").write_text(
-        "\n".join(
-            [
-                "name: bad-plugin",
-                "version: 0.1.0",
-                "description: broken contract",
-                "provides_hooks:",
-                "  - typo_hook",
-                "  - pre_tool_call",
-            ]
-        )
+        "\n".join([
+            "name: bad-plugin",
+            "version: 0.1.0",
+            "description: broken contract",
+            "provides_hooks:",
+            "  - typo_hook",
+            "  - pre_tool_call",
+        ])
         + "\n",
         encoding="utf-8",
     )
@@ -74,6 +365,37 @@ def test_doctor_accepts_manifest_defaults_from_runtime_parser(tmp_path: Path) ->
     assert report.ok, report.format_text()
     assert report.manifest is not None
     assert report.manifest.kind == "standalone"
+
+
+def test_doctor_accepts_plugin_yml_manifest(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = tmp_path / "yml-plugin"
+    plugin.mkdir()
+    (plugin / "plugin.yml").write_text("name: yml-plugin\n", encoding="utf-8")
+    (plugin / "__init__.py").write_text(
+        "def register(ctx):\n    pass\n", encoding="utf-8"
+    )
+
+    report = doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
+
+
+def test_doctor_accepts_portable_plugin_json(tmp_path: Path) -> None:
+    from hermes_cli.agent_plugins import PLUGIN_SCHEMA_V1
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = tmp_path / "portable-plugin"
+    plugin.mkdir()
+    (plugin / "plugin.json").write_text(
+        json.dumps({"$schema": PLUGIN_SCHEMA_V1, "name": "portable.test"}),
+        encoding="utf-8",
+    )
+
+    report = doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
 
 
 def test_doctor_restores_global_tool_policy_and_module_state(tmp_path: Path) -> None:
@@ -118,8 +440,10 @@ def test_doctor_restores_global_tool_policy_and_module_state(tmp_path: Path) -> 
     assert after_modules == before_modules
 
 
-def test_doctor_blocks_live_network(tmp_path: Path) -> None:
-    from hermes_cli.plugin_dev import doctor_plugin
+def test_doctor_blocks_live_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_dev as plugin_dev
 
     plugin = tmp_path / "network-plugin"
     plugin.mkdir()
@@ -130,7 +454,12 @@ def test_doctor_blocks_live_network(tmp_path: Path) -> None:
         "    socket.create_connection(('example.com', 443))\n",
         encoding="utf-8",
     )
+    doctor_temp = tmp_path / "doctor-temp"
+    doctor_temp.mkdir()
+    monkeypatch.setattr(plugin_dev.tempfile, "tempdir", str(doctor_temp))
 
-    report = doctor_plugin(plugin)
+    report = plugin_dev.doctor_plugin(plugin)
+
     assert report.ok is False
     assert "network access is disabled while Plugin Doctor runs" in report.format_text()
+    assert not list(doctor_temp.glob("hermes-plugin-doctor-*"))

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -181,7 +181,7 @@ cd ~/.hermes/plugins/calculator
 
 ### Validate with Plugin Doctor
 
-`hermes plugins doctor [path-or-id]` runs the same directory discovery,
+`hermes plugins doctor <path-or-id>` runs the same directory discovery,
 manifest parser, namespaced import, `register(ctx)`, hook registry, and tool
 registry used by Hermes itself. It reports invalid hook names, callbacks that do
 not accept `**kwargs`, registration failures, and drift between declared and
@@ -190,6 +190,14 @@ registered tools/hooks. Pass `--ci` to exit non-zero on an error:
 ```bash
 hermes plugins doctor . --ci
 ```
+
+The target is required and must be one plugin directory containing a native
+`plugin.yaml` / `plugin.yml` manifest or portable `plugin.json`; Doctor refuses
+the filesystem root, the user's home directory, and other broad or non-plugin
+directories. Symlinks that are absolute or escape the plugin root are rejected
+and are never dereferenced during staging. Platforms without the directory-FD
+APIs required for secure staging are refused instead of falling back to an
+unsafe path-based copy.
 
 Doctor uses a temporary `HERMES_HOME`, restores plugin registration state after
 the check, and blocks direct Python socket connections to catch accidental


### PR DESCRIPTION
> **Historical status:** Closed unmerged as superseded by #99464, which salvaged the earlier #90859 fix for #90858. The temporary-directory lifetime analysis in this PR informed the follow-up and was credited there. Its FD-pinned staging engine was not adopted because native Windows lacks the required `dir_fd` support and the maintainers judged that TOCTOU defense outside this local developer tool's threat model.

## What does this PR do?

Historically proposed hardening for `hermes plugins doctor` after the command could default to a broad current working directory and copy that target into a temporary `HERMES_HOME` during runtime validation.

A broad target, or a target containing an escaping symlink, could produce an unbounded copy, exhaust disk space, and leave a large `hermes-plugin-doctor-*` directory after interruption or copy failure. The proposal required an explicit plugin target, gated staging on a regular plugin manifest, tightened symlink/special-file handling, and expanded cleanup coverage.

The accepted successor #99464 used the narrower manifest gate and cleanup-lifetime fix. It deliberately did not take this PR's larger FD-pinned staging design for compatibility and scope reasons.

## Related Issue

Addresses #90858. Superseded by #99464, which salvaged the earliest submitted fix #90859 by the incident reporter and incorporated the temporary-directory cleanup insight from this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins_cmd.py` and `hermes_cli/subcommands/plugins.py`
  - require an explicit plugin path or installed plugin ID.
- `hermes_cli/plugin_dev.py`
  - reject filesystem root, the home directory, symlink roots, and directories without a regular plugin manifest;
  - stage through pinned directory descriptors with identity checks and no-follow behavior;
  - preserve only lexically in-tree relative symlinks, reject special files and recursive temporary destinations;
  - enter temporary-directory cleanup before copy and cover success, exceptions, ENOSPC, `KeyboardInterrupt`, and main-thread `SIGTERM`;
  - fail closed on platforms without the required secure FD APIs.
- `tests/hermes_cli/test_plugin_dev.py`
  - add regression coverage for target validation, root swaps, symlinks, cleanup paths, signals, manifests, and unsupported platforms.
- `website/docs/developer-guide/plugins/index.md`
  - document explicit-target and staging behavior.

These are the changes in this closed historical branch, not a description of the narrower implementation ultimately merged through #99464.

## How to Test

1. Run `uv run pytest -q tests/hermes_cli/test_plugin_dev.py`.
2. Run `uv run pytest -q tests/hermes_cli/test_*plugin*.py`.
3. Verify `hermes plugins doctor` without a target is rejected and a normal single-plugin directory still validates.
4. Exercise success and injected ENOSPC/exception/interrupt/SIGTERM paths and verify no `hermes-plugin-doctor-*` directory remains.
5. Verify escaping symlinks, root swaps, special files, and recursive temporary destinations fail before unsafe traversal.

Verified on the historical branch:

- 22 focused Doctor tests passed.
- 573 plugin CLI tests passed.
- Ruff passed on changed Python files.
- `ty` passed for the changed Doctor and parser modules.
- No Doctor temporary directories remained after the tests.
- Tested on macOS; the proposed implementation intentionally failed closed where secure FD APIs were unavailable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I found no overlapping work — #90859 was the earlier submitted fix, and #99464 later superseded this PR
- [x] My PR contains **only** Doctor target/staging/cleanup hardening, its tests, and documentation
- [ ] I've run `pytest tests/ -q` and all tests pass — only the focused Doctor and plugin CLI suites above are claimed green
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/plugins/index.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the historical fail-closed Windows limitation is explicit and was a reason the larger staging design was not adopted
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed

## Screenshots / Logs

N/A — this was a CLI/runtime-staging fix. The test evidence and the accepted successor's design decision are recorded above.
