### PR TITLE
fix(cron): support Slack unfurl suppression flags

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3561,6 +3561,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 media_metadata = dict(media_metadata or {})
                 media_metadata.setdefault("scope_id", str(origin["scope_id"]))
 
+            if platform == Platform.SLACK and job.get("suppress_slack_unfurls") is True:
+                route_metadata["unfurl_links"] = False
+                route_metadata["unfurl_media"] = False
+
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
                 # Route through the gateway's DeliveryRouter so the live send
@@ -3870,7 +3874,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            standalone_pconfig = pconfig
+            if platform == Platform.SLACK and job.get("suppress_slack_unfurls") is True:
+                from dataclasses import replace
+
+                standalone_pconfig = replace(
+                    pconfig,
+                    extra={
+                        **(getattr(pconfig, "extra", None) or {}),
+                        "unfurl_links": False,
+                        "unfurl_media": False,
+                    },
+                )
+            coro = _send_to_platform(platform, standalone_pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -3899,7 +3915,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(asyncio.run, _send_to_platform(platform, standalone_pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1846,7 +1846,7 @@ class RelayAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="no transport")
         _sfp_unfurl = self._slack_unfurl_hints(str(platform_value))
         if _sfp_unfurl:
-            _sfp_metadata.update(_sfp_unfurl)
+            _sfp_metadata = {**_sfp_unfurl, **_sfp_metadata}
         result = await self._transport.send_outbound(
             {
                 "op": "send",

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -634,6 +634,8 @@ def cron_edit(args):
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
+        attach_to_session=getattr(args, "attach_to_session", None),
+        suppress_slack_unfurls=getattr(args, "suppress_slack_unfurls", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -214,6 +214,36 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_edit.add_argument(
+        "--attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Attach delivery to its target session.",
+    )
+    cron_edit.add_argument(
+        "--no-attach-to-session",
+        dest="attach_to_session",
+        action="store_const",
+        const=False,
+        help="Do not attach delivery to its target session.",
+    )
+    cron_edit.add_argument(
+        "--suppress-slack-unfurls",
+        dest="suppress_slack_unfurls",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Suppress Slack link and media previews for this job.",
+    )
+    cron_edit.add_argument(
+        "--no-suppress-slack-unfurls",
+        dest="suppress_slack_unfurls",
+        action="store_const",
+        const=False,
+        help="Use normal Slack link and media preview behavior.",
+    )
+    cron_edit.add_argument(
         "--monitor-script",
         dest="monitor_script",
         help=(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3024,13 +3024,21 @@ class SlackAdapter(BasePlatformAdapter):
             # 3000-char limits, so those fall back to plain text. The ``text``
             # field is always kept as the notification/accessibility fallback.
             blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            metadata_unfurls = {
+                key: metadata[key]
+                for key in ("unfurl_links", "unfurl_media")
+                if isinstance((metadata or {}).get(key), bool)
+            }
+            unfurl_kwargs = _slack_unfurl_kwargs(
+                {**(self.config.extra or {}), **metadata_unfurls}
+            )
 
             for i, chunk in enumerate(chunks):
                 kwargs = {
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
-                    **_slack_unfurl_kwargs(self.config.extra),
+                    **unfurl_kwargs,
                 }
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -381,6 +381,52 @@ class TestDeliverResultWrapping:
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
 
+    @pytest.mark.parametrize(
+        "suppress_slack_unfurls",
+        [pytest.param(True, id="suppressed"), pytest.param(None, id="default")],
+    )
+    def test_standalone_slack_unfurls_use_local_config_copy(
+        self, suppress_slack_unfurls
+    ):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        pconfig = PlatformConfig(enabled=True, extra={"existing": "preserved"})
+        config = GatewayConfig(platforms={Platform.SLACK: pconfig})
+        job = {
+            "id": "standalone-slack",
+            "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "C123"},
+        }
+        if suppress_slack_unfurls is not None:
+            job["suppress_slack_unfurls"] = suppress_slack_unfurls
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("gateway.relay.relay_fronted_platforms", return_value=set()),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(job, "scheduled result", adapters={})
+
+        assert result is None
+        standalone_send.assert_awaited_once()
+        sent_pconfig = standalone_send.await_args.args[1]
+        assert standalone_send.await_args.kwargs["thread_id"] is None
+        assert "thread_ts" not in standalone_send.await_args.kwargs
+        if suppress_slack_unfurls is True:
+            assert sent_pconfig is not pconfig
+            assert sent_pconfig.extra == {
+                "existing": "preserved",
+                "unfurl_links": False,
+                "unfurl_media": False,
+            }
+        else:
+            assert sent_pconfig is pconfig
+            assert "unfurl_links" not in sent_pconfig.extra
+            assert "unfurl_media" not in sent_pconfig.extra
+        assert pconfig.extra == {"existing": "preserved"}
+
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):
         """Persisted Slack home survives restart without native Slack config."""
@@ -2367,7 +2413,7 @@ class TestCronContinuableSurfaceInChannel:
         return mock_cfg
 
     def _run_inchannel_delivery(self, extra, adapter, *, mirror_ok=True, origin=None,
-                                attach_to_session=True):
+                                attach_to_session=True, suppress_slack_unfurls=None):
         """Drive _deliver_result down the live-adapter path for a Slack
         channel-origin job with the given ``extra`` config. Returns the
         _open_continuable_cron_thread mock and the mirror_to_session mock."""
@@ -2400,6 +2446,8 @@ class TestCronContinuableSurfaceInChannel:
             # NOT depend on this — see the no-attach regression test).
             "attach_to_session": attach_to_session,
         }
+        if suppress_slack_unfurls is not None:
+            job["suppress_slack_unfurls"] = suppress_slack_unfurls
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
@@ -2602,6 +2650,43 @@ class TestCronContinuableSurfaceInChannel:
                 attach_to_session=False,
             )
         assert "scope_id" not in captured["metadata"]
+
+    @pytest.mark.parametrize(
+        ("suppress_slack_unfurls", "expected"),
+        [(True, False), (None, None)],
+        ids=("suppressed", "default"),
+    )
+    def test_slack_unfurl_metadata_preserves_top_level_routing(
+        self, suppress_slack_unfurls, expected
+    ):
+        captured = {}
+
+        class _SpyRouter:
+            def __init__(self, *a, **k):
+                pass
+
+            async def _deliver_to_platform(self, target, text, metadata):
+                captured["target"] = target
+                captured["metadata"] = metadata
+                return {"success": True, "message_id": "msg_1"}
+
+        adapter = self._slack_adapter(supports_inchannel=True)
+        with patch("gateway.delivery.DeliveryRouter", _SpyRouter):
+            self._run_inchannel_delivery(
+                {},
+                adapter,
+                attach_to_session=False,
+                suppress_slack_unfurls=suppress_slack_unfurls,
+            )
+
+        assert captured["target"].thread_id is None
+        assert "thread_id" not in captured["metadata"]
+        assert "thread_ts" not in captured["metadata"]
+        for key in ("unfurl_links", "unfurl_media"):
+            if expected is None:
+                assert key not in captured["metadata"]
+            else:
+                assert captured["metadata"][key] is expected
 
     def test_native_adapter_scalar_false_fails_safe_to_thread(self):
         """D6 fallback boundary with a REAL (non-mock) adapter shape: a native

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -10,6 +10,8 @@ Contract under test:
 - The scheduled/cron lane (send_for_platform) stamps too.
 """
 
+import asyncio
+
 import pytest
 
 from gateway.config import Platform, PlatformConfig
@@ -217,6 +219,23 @@ class TestSendForPlatformStampsUnfurl:
         await a.send_for_platform(P.SLACK, "C123", "brief")
         assert "unfurl_links" not in a._transport.sent["metadata"]
         assert "unfurl_media" not in a._transport.sent["metadata"]
+
+    def test_cron_lane_job_metadata_overrides_config(self):
+        a = _slack_adapter(
+            {"slack": {"unfurl_links": True, "unfurl_media": True}}
+        )
+
+        asyncio.run(
+            a.send_for_platform(
+                Platform.SLACK,
+                "C123",
+                "brief https://x.dev",
+                metadata={"unfurl_links": False, "unfurl_media": False},
+            )
+        )
+
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+        assert a._transport.sent["metadata"]["unfurl_media"] is False
 
 class TestUnfurlDisablesDraftStreaming:
     def test_explicit_unfurl_disables_slack_draft_stream(self):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1201,8 +1201,30 @@ class TestStandaloneSendUserDmResolution:
         assert result["success"] is True
         payload = session.post.call_args.kwargs["json"]
         assert payload["text"] == "<https://example.com/hermes|Hermes>"
+        assert payload["mrkdwn"] is True
         assert payload["unfurl_links"] is False
         assert payload["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_channel_delivery_preserves_default_unfurls_and_mrkdwn(self):
+        _slack_mod._slack_dm_cache.clear()
+        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
+        session = self._mock_session(post_resp)
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(
+                config,
+                "C123",
+                "[Hermes](https://example.com/hermes)",
+            )
+
+        assert result["success"] is True
+        payload = session.post.call_args.kwargs["json"]
+        assert payload["text"] == "<https://example.com/hermes|Hermes>"
+        assert payload["mrkdwn"] is True
+        assert "unfurl_links" not in payload
+        assert "unfurl_media" not in payload
 
 
     @pytest.mark.asyncio
@@ -3510,12 +3532,31 @@ class TestMessageSplitting:
         assert kwargs["unfurl_media"] is False
 
     @pytest.mark.asyncio
+    async def test_send_metadata_overrides_configured_unfurl_options(self, adapter):
+        adapter.config.extra["unfurl_links"] = True
+        adapter.config.extra["unfurl_media"] = True
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send(
+            "C123",
+            "[Hermes](https://example.com/hermes)",
+            metadata={"unfurl_links": False, "unfurl_media": False},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"] == "<https://example.com/hermes|Hermes>"
+        assert kwargs["mrkdwn"] is True
+        assert kwargs["unfurl_links"] is False
+        assert kwargs["unfurl_media"] is False
+
+    @pytest.mark.asyncio
     async def test_send_preserves_default_unfurl_behavior(self, adapter):
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
 
         await adapter.send("C123", "https://example.com")
 
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["mrkdwn"] is True
         assert "unfurl_links" not in kwargs
         assert "unfurl_media" not in kwargs
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -46,6 +46,53 @@ class TestCronCommandLifecycle:
         assert updated["provider"] == "nous"
         assert "Updated job" in capsys.readouterr().out
 
+    def test_edit_persists_reversible_delivery_flags(self, tmp_cron_dir, capsys):
+        job = create_job(
+            prompt="Daily report",
+            schedule="every 1h",
+            deliver="slack:C123",
+            model="model-before",
+        )
+        unchanged = {
+            key: job[key] for key in ("prompt", "schedule", "deliver", "model")
+        }
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        enabled = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--attach-to-session",
+                "--suppress-slack-unfurls",
+            ]
+        )
+        assert cron_command(enabled) == 0
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["attach_to_session"] is True
+        assert updated["suppress_slack_unfurls"] is True
+        assert {key: updated[key] for key in unchanged} == unchanged
+
+        disabled = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--no-attach-to-session",
+                "--no-suppress-slack-unfurls",
+            ]
+        )
+        assert cron_command(disabled) == 0
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["attach_to_session"] is False
+        assert updated["suppress_slack_unfurls"] is False
+        assert {key: updated[key] for key in unchanged} == unchanged
+        assert "Updated job" in capsys.readouterr().out
+
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(
             prompt="Combine skill outputs",

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,38 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_edit_delivery_flags_are_reversible_tristates():
+    parser = _build()
+
+    omitted = parser.parse_args(["cron", "edit", "j"])
+    assert omitted.attach_to_session is None
+    assert omitted.suppress_slack_unfurls is None
+
+    enabled = parser.parse_args(
+        [
+            "cron",
+            "edit",
+            "j",
+            "--attach-to-session",
+            "--suppress-slack-unfurls",
+        ]
+    )
+    assert enabled.attach_to_session is True
+    assert enabled.suppress_slack_unfurls is True
+
+    disabled = parser.parse_args(
+        [
+            "cron",
+            "edit",
+            "j",
+            "--no-attach-to-session",
+            "--no-suppress-slack-unfurls",
+        ]
+    )
+    assert disabled.attach_to_session is False
+    assert disabled.suppress_slack_unfurls is False
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -573,6 +573,39 @@ class TestRegisteredHandlerForwardsAttachToSession:
         listed = next(j for j in listing["jobs"] if j["job_id"] == created["job_id"])
         assert listed.get("attach_to_session") is False
 
+    def test_update_persists_suppress_slack_unfurls(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "schedule": "1h",
+                    "prompt": "post links without previews",
+                },
+            )
+        )
+        assert created["success"] is True
+        assert "suppress_slack_unfurls" not in (get_job(created["job_id"]) or {})
+
+        for value in (True, False):
+            updated = json.loads(
+                registry.dispatch(
+                    "cronjob",
+                    {
+                        "action": "update",
+                        "job_id": created["job_id"],
+                        "suppress_slack_unfurls": value,
+                    },
+                )
+            )
+            assert updated["success"] is True, updated
+            stored = get_job(created["job_id"])
+            assert stored is not None
+            assert stored["suppress_slack_unfurls"] is value
+
     def test_omitted_create_leaves_field_absent(self):
         from cron.jobs import get_job
         from tools.registry import registry

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -806,6 +806,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["context_from"] = external_refs
     if isinstance(job.get("attach_to_session"), bool):
         result["attach_to_session"] = job["attach_to_session"]
+    if isinstance(job.get("suppress_slack_unfurls"), bool):
+        result["suppress_slack_unfurls"] = job["suppress_slack_unfurls"]
     return result
 
 
@@ -1479,6 +1481,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    suppress_slack_unfurls: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
@@ -1898,6 +1901,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if suppress_slack_unfurls is not None:
+                updates["suppress_slack_unfurls"] = bool(suppress_slack_unfurls)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -2029,6 +2034,10 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "boolean",
                 "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts. Scope: the job's own conversation only — the origin chat, the home-channel fallback when deliver='origin' captured no origin (script-created jobs), or the job's single explicit platform:chat target (this flag is the only way to attach an explicit target). Broadcast targets are never attached; no effect when deliver='local'."
             },
+            "suppress_slack_unfurls": {
+                "type": "boolean",
+                "description": "On update, true suppresses Slack link and media previews for this job; false restores normal Slack behavior."
+            },
         },
         "required": ["action"]
     }
@@ -2095,6 +2104,7 @@ def _cronjob_handler(args, **kw):
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
         attach_to_session=args.get("attach_to_session"),
+        suppress_slack_unfurls=args.get("suppress_slack_unfurls"),
         monitor_script=_mon_script,
         monitor_url=_mon_url,
         task_id=kw.get("task_id"),


### PR DESCRIPTION
Adds reversible job-level `attach_to_session` and `suppress_slack_unfurls` flags, preserving existing defaults while allowing per-job Slack unfurl suppression.

Focused verification: `scripts/run_tests.sh` across the six affected test files with 12 targeted cases; 12 passed.