### PR TITLE
fix(delegation): subagent process notifications stay suppressed when the container key collapses

### DIFF
--- a/tests/tools/test_delegate_control_actions.py
+++ b/tests/tools/test_delegate_control_actions.py
@@ -619,6 +619,105 @@ def test_child_watch_match_suppressed_by_default(monkeypatch):
     assert reg.completion_queue.qsize() == 0
 
 
+def test_child_completion_with_collapsed_container_task_id_suppressed(monkeypatch):
+    """Regression (child-notify leak, Aug 2026): terminal_tool stamps the
+    COLLAPSED container key ("default"/session key) into the event's task_id
+    — _resolve_container_task_id deliberately collapses subagent ids so
+    children share the parent's container. The suppression gate must key on
+    owner_task_id (the raw spawning id), or child events with
+    task_id="default" walk straight past it into the parent chat."""
+    import hermes_cli.config as _cfg
+    from tools.process_registry import ProcessRegistry
+
+    monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
+    reg = ProcessRegistry()
+    evt = _child_completion_evt(task_id="default")
+    evt["owner_task_id"] = "sa-9-supp0005"
+    reg.completion_queue.put(evt)
+    assert reg.drain_notifications() == []
+    assert reg.completion_queue.qsize() == 0
+
+
+def test_spawn_local_stamps_owner_task_id_and_event_carries_it(monkeypatch):
+    """spawn_local(owner_task_id=...) survives to the completion event, so a
+    real subagent-spawned process (collapsed task_id) is suppressed on
+    drain. Exercises the actual spawn -> _move_to_finished -> drain path."""
+    import time as _time
+
+    import hermes_cli.config as _cfg
+    from tools.process_registry import ProcessRegistry
+
+    monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
+    reg = ProcessRegistry()
+    session = reg.spawn_local(
+        command="echo owner-stamp-e2e",
+        task_id="default",
+        owner_task_id="sa-9-supp0006",
+    )
+    session.notify_on_complete = True
+    assert session.owner_task_id == "sa-9-supp0006"
+    deadline = _time.time() + 15
+    while not session.exited and _time.time() < deadline:
+        _time.sleep(0.05)
+    assert session.exited, "test process should exit promptly"
+    _time.sleep(0.3)  # let the reader thread enqueue the completion event
+    assert reg.drain_notifications() == []
+
+
+def test_spawn_local_without_owner_defaults_to_task_id(monkeypatch):
+    """Backward compat: callers that don't pass owner_task_id behave exactly
+    as before (owner falls back to task_id; parent-owned still delivers)."""
+    import time as _time
+
+    import hermes_cli.config as _cfg
+    from tools.process_registry import ProcessRegistry
+
+    monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
+    reg = ProcessRegistry()
+    session = reg.spawn_local(command="echo parent-e2e", task_id="default")
+    session.notify_on_complete = True
+    assert session.owner_task_id == "default"
+    deadline = _time.time() + 15
+    while not session.exited and _time.time() < deadline:
+        _time.sleep(0.05)
+    assert session.exited
+    _time.sleep(0.3)
+    results = reg.drain_notifications()
+    assert len(results) == 1
+    assert "completed normally" in results[0][1]
+
+
+def test_attribution_line_uses_owner_task_id(monkeypatch):
+    """format_process_notification resolves attribution from owner_task_id
+    when task_id is a collapsed container key (surface flag on)."""
+    import hermes_cli.config as _cfg
+    from tools.process_registry import ProcessRegistry, format_process_notification
+
+    monkeypatch.setattr(
+        _cfg,
+        "read_raw_config",
+        lambda *a, **k: {
+            "delegation": {"surface_child_process_notifications": True}
+        },
+    )
+    parent = _StubParentWithSession("sess-attr-owner")
+    child = _StubChild(parent)
+    _register("sa-9-supp0007", child, delegation_id="deleg_attr_owner")
+    try:
+        reg = ProcessRegistry()
+        evt = _child_completion_evt(task_id="default", sid="proc_ownerattr01")
+        evt["owner_task_id"] = "sa-9-supp0007"
+        reg.completion_queue.put(evt)
+        results = reg.drain_notifications()
+        assert len(results) == 1
+        assert "Started by subagent sa-9-supp0007" in results[0][1]
+        # And the standalone formatter agrees.
+        text = format_process_notification(evt)
+        assert "Started by subagent sa-9-supp0007" in text
+    finally:
+        _unregister_subagent("sa-9-supp0007")
+
+
 def test_completion_notification_trims_subagent_output_wall():
     from tools.process_registry import format_process_notification
 

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -167,6 +167,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "command": "sleep 1",
         "cwd": "/workspace/live",
         "task_id": task_id,
+        "owner_task_id": task_id,
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -379,6 +379,10 @@ class ProcessSession:
     id: str                                     # Unique session ID ("proc_xxxxxxxxxxxx")
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
+    owner_task_id: str = ""                     # RAW spawning task id (e.g. subagent "sa-...");
+                                                # task_id is the CONTAINER key and may be collapsed
+                                                # to "default"/session key by _resolve_container_task_id,
+                                                # so ownership checks must use this field (#child-notify)
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
@@ -623,6 +627,7 @@ class ProcessRegistry:
                     "session_id": session.id,
                     "session_key": session.session_key,
                     "task_id": session.task_id,
+                    "owner_task_id": session.owner_task_id or session.task_id,
                     "command": session.command,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
@@ -661,6 +666,7 @@ class ProcessRegistry:
             "session_id": session.id,
             "session_key": session.session_key,
             "task_id": session.task_id,
+            "owner_task_id": session.owner_task_id or session.task_id,
             "command": session.command,
             "type": "watch_match",
             "pattern": matched_pattern,
@@ -687,6 +693,7 @@ class ProcessRegistry:
             "session_id": session.id,
             "session_key": session.session_key,
             "task_id": session.task_id,
+            "owner_task_id": session.owner_task_id or session.task_id,
             "command": session.command,
             "type": "watch_disabled",
             "suppressed": 0,
@@ -1038,6 +1045,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        owner_task_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -1062,6 +1070,7 @@ class ProcessRegistry:
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            owner_task_id=owner_task_id or task_id,
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
@@ -1281,6 +1290,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        owner_task_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1297,6 +1307,7 @@ class ProcessRegistry:
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            owner_task_id=owner_task_id or task_id,
             session_key=session_key,
             cwd=cwd,
             started_at=time.time(),
@@ -1640,6 +1651,7 @@ class ProcessRegistry:
                 "session_id": session.id,
                 "session_key": session.session_key,
                 "task_id": session.task_id,
+                "owner_task_id": session.owner_task_id or session.task_id,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,
@@ -1948,14 +1960,20 @@ class ProcessRegistry:
             ):
                 continue
 
-            # Subagent-owned process notifications (task_id "sa-...") are
-            # suppressed from the parent conversation by default — the
-            # child's consolidated delegation result is the deliverable;
-            # "npm ci finished" walls mid-chat are noise. Dropped, NOT
-            # requeued (children never drain notify events, so requeueing
-            # would pin them in the queue forever). Type 'async_delegation'
-            # is the delegation result itself and is NEVER suppressed.
-            _evt_task_id = str(evt.get("task_id") or "")
+            # Subagent-owned process notifications are suppressed from the
+            # parent conversation by default — the child's consolidated
+            # delegation result is the deliverable; "npm ci finished" walls
+            # mid-chat are noise. Ownership is judged on owner_task_id (the
+            # RAW spawning task id): the container key in task_id is
+            # deliberately collapsed to "default"/the session key by
+            # _resolve_container_task_id, which previously let child events
+            # bypass this gate. Dropped, NOT requeued (children never drain
+            # notify events, so requeueing would pin them in the queue
+            # forever). Type 'async_delegation' is the delegation result
+            # itself and is NEVER suppressed.
+            _evt_task_id = str(
+                evt.get("owner_task_id") or evt.get("task_id") or ""
+            )
             if not is_async_delegation and _evt_task_id.startswith("sa-"):
                 if surface_child is None:
                     surface_child = self._surface_child_process_notifications()
@@ -2806,6 +2824,7 @@ class ProcessRegistry:
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
+                            "owner_task_id": s.owner_task_id or s.task_id,
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
@@ -2896,6 +2915,7 @@ class ProcessRegistry:
                 id=entry["session_id"],
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
+                owner_task_id=entry.get("owner_task_id", "") or entry.get("task_id", ""),
                 session_key=entry.get("session_key", ""),
                 pid=pid,
                 host_start_time=recorded_start,
@@ -3229,7 +3249,7 @@ def _delegation_attribution_line(evt: dict) -> "str | None":
     the task_id against the live + recently-finished subagent registry and
     return a short provenance line, or None for parent-owned processes.
     """
-    task_id = str(evt.get("task_id") or "")
+    task_id = str(evt.get("owner_task_id") or evt.get("task_id") or "")
     if not task_id.startswith("sa-"):
         return None
     try:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3310,6 +3310,7 @@ def terminal_tool(
                         command=command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
+                        owner_task_id=task_id or effective_task_id,
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
@@ -3320,6 +3321,7 @@ def terminal_tool(
                         command=command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
+                        owner_task_id=task_id or effective_task_id,
                         session_key=session_key,
                     )
 


### PR DESCRIPTION
## Summary
Subagent-spawned background-process notifications no longer leak into the parent chat: the suppression gate now keys on the process's real owner instead of the collapsed container key.

Root cause: the suppression shipped in `afee35700e` checks `evt["task_id"].startswith("sa-")`, but `terminal_tool` stamps `ProcessSession.task_id` with the **collapsed container key** from `_resolve_container_task_id()` — subagent ids deliberately collapse to `"default"`/the session key so children share the parent's container. Real child-spawned processes therefore carried `task_id="default"` and their completion/watch notification walls sailed past the gate into the parent conversation (observed live, Aug 31: `gh pr view` batch loops from a triage subagent notifying the parent CLI chat).

## Changes
- `tools/process_registry.py`: `ProcessSession.owner_task_id` (raw spawning task id) — stamped by `spawn_local`/`spawn_via_env`, carried on all queued events (completion, watch_match, watch_disabled, overflow), round-tripped through the crash checkpoint; drain suppression gate and the delegation-attribution formatter now read `owner_task_id` with `task_id` as fallback (synthetic/legacy events unaffected).
- `tools/terminal_tool.py`: both background spawn call sites pass `owner_task_id=task_id` (raw, pre-collapse).
- `tests/tools/test_delegate_control_actions.py`: 4 regression tests — collapsed-key suppression, real spawn→drain path, backward-compat default, attribution via owner id. All 4 fail on origin/main (sabotage-verified), pass here.

## Validation
| | Before (origin/main) | After |
|---|---|---|
| Child event, collapsed `task_id="default"` | delivered to parent (leak) | suppressed |
| Parent-owned event | delivered | delivered |
| `surface_child_process_notifications: true` | delivered | delivered + attribution |
| Targeted suites | — | 162 passed, 5 skipped (1 pre-existing red on main: checkpoint secret-redaction test, unrelated) |

**Live repro:** simulated the exact leaked event shape through the real `_resolve_container_task_id` → `drain_notifications()` path on origin/main (leak fires) and on this branch (suppressed); plus real `spawn_local` → completion → drain E2E in a temp `HERMES_HOME` for all three cases.

## Infographic

![Silent Children — delegation notification ownership fix](https://v3b.fal.media/files/b/0aa88d02/exR-toXGd5MKZCF-74pp2_dJM975RG.png)
