### PR TITLE
fix(gateway): fire /new memory boundary for idle-evicted sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11826,6 +11826,106 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+    def _commit_memory_for_evicted_session(
+        self, session_key: str, old_entry: Any, source: Any
+    ) -> None:
+        """Fire end-of-session memory for a /new'd session with no cached agent.
+
+        The idle-TTL sweep soft-evicts agents of ``mode="none"`` sessions
+        without firing ``on_session_end`` — correct at eviction time, because
+        eviction is a cache detail and the session itself continues. But
+        ``/new`` is a real session boundary: when the cached agent is gone,
+        the whole memory chain (``_cleanup_agent_resources`` →
+        ``shutdown_memory_provider`` → ``on_session_end``) is skipped, so
+        providers that extract at session end (Cognee ``improve()``,
+        MEMORY.md synthesis, …) silently lose the transcript (#99402).
+
+        Compensation: reload the transcript from the session DB and fire
+        ``on_session_end`` on a throwaway ``MemoryManager`` initialized with
+        the OLD session id and the source-derived scoping kwargs the
+        per-agent manager would have received, then shut it down. Runs on a
+        worker thread with a bounded wait (see _handle_reset_command).
+        Best-effort: any failure is swallowed so /new never breaks on memory.
+        """
+        old_sid = getattr(old_entry, "session_id", None)
+        if not old_sid:
+            return
+        db = getattr(self, "_session_db", None)
+        if db is None:
+            return
+        try:
+            from tools.memory_tool import get_builtin_memory_config
+            provider_name = (get_builtin_memory_config().get("provider") or "").strip()
+        except Exception:
+            provider_name = ""
+        if not provider_name:
+            return  # no external memory provider configured — nothing to fire
+        try:
+            messages = db.get_messages_as_conversation(str(old_sid))
+        except Exception:
+            logger.debug(
+                "Could not reload transcript for /new memory commit (session %s)",
+                old_sid, exc_info=True,
+            )
+            return
+        if not messages:
+            return
+        try:
+            from agent.memory_manager import MemoryManager
+            from plugins.memory import load_memory_provider
+
+            provider = load_memory_provider(provider_name)
+            if provider is None or not provider.is_available():
+                return
+            manager = MemoryManager()
+            manager.add_provider(provider)
+            # Same scoping contract the per-agent manager gets in
+            # agent_init.py; user/chat identity comes from the message source
+            # the session key itself was derived from, so provider-side
+            # keying (per-user memory, chat isolation) matches the turns
+            # that were actually lived.
+            init_kwargs = {
+                "session_id": str(old_sid),
+                "platform": source.platform.value if getattr(source, "platform", None) else "",
+                "agent_context": "primary",
+            }
+            for src_attr, kwarg in (
+                ("user_id", "user_id"),
+                ("chat_id", "chat_id"),
+                ("chat_type", "chat_type"),
+                ("thread_id", "thread_id"),
+            ):
+                _v = getattr(source, src_attr, None)
+                if _v:
+                    init_kwargs[kwarg] = _v
+            if session_key:
+                init_kwargs["gateway_session_key"] = session_key
+            try:
+                _title = db.get_session_title(str(old_sid))
+            except Exception:
+                _title = None
+            if _title:
+                init_kwargs["session_title"] = _title
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                init_kwargs["agent_identity"] = get_active_profile_name()
+                init_kwargs["agent_workspace"] = "hermes"
+            except Exception:
+                pass
+            manager.initialize_all(**init_kwargs)
+            manager.on_session_end(messages)
+            manager.shutdown_all()
+            logger.debug(
+                "Committed /new end-of-session memory for evicted session=%s "
+                "(old sid=%s, %d messages)",
+                session_key, old_sid, len(messages),
+            )
+        except Exception as e:
+            logger.warning(
+                "/new memory commit for evicted session %s failed: %s (#99402)",
+                session_key, e,
+            )
+
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -200,6 +200,36 @@ class GatewaySlashCommandsMixin:
                         "reset: %s (#35994)",
                         session_key, cleanup_exc,
                     )
+            else:
+                # The cached agent is gone — the idle-TTL sweep soft-evicted it
+                # (a mode="none" session never gets an expiry-watcher finalize,
+                # so nothing else will fire the memory chain later). /new is
+                # still a real session boundary: rebuild the transcript from
+                # the session DB and fire on_session_end on a throwaway
+                # manager scoped to the old session id, so end-of-session
+                # extraction does not silently lose the session (#99402).
+                # Same off-loop + bounded-timeout shape as the branch above.
+                try:
+                    await asyncio.wait_for(
+                        self._run_in_executor_with_context(
+                            self._commit_memory_for_evicted_session,
+                            session_key, old_entry, source,
+                        ),
+                        timeout=_RESET_CLEANUP_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Memory commit for evicted session %s exceeded %ss during "
+                        "/new reset; proceeding with reset (the worker thread is "
+                        "left to finish on its own). (#99402)",
+                        session_key, _RESET_CLEANUP_TIMEOUT_S,
+                    )
+                except Exception as mem_exc:
+                    logger.warning(
+                        "Memory commit for evicted session %s failed during /new "
+                        "reset: %s (#99402)",
+                        session_key, mem_exc,
+                    )
         self._evict_cached_agent(session_key)
 
         # Conversation boundary: clear ALL conversation-scoped per-session

--- a/tests/gateway/test_99402_reset_memory_after_idle_evict.py
+++ b/tests/gateway/test_99402_reset_memory_after_idle_evict.py
@@ -1,0 +1,170 @@
+"""Regression test for #99402: /new after an idle-evicted agent loses memory.
+
+A mode="none" gateway session's agent can be soft-evicted by the idle-TTL
+sweep without firing ``on_session_end`` (correct — eviction is a cache
+detail, the session continues). But when the user then runs ``/new``, the
+handler used to skip the whole memory chain because ``_old_agent is None``:
+``_cleanup_agent_resources`` → ``shutdown_memory_provider`` →
+``on_session_end`` never ran, and the old transcript never reached memory
+providers that extract at session end (Cognee ``improve()``, MEMORY.md
+synthesis, …).
+
+The fix compensates on the cache-miss branch: reload the transcript from
+the session DB and fire ``on_session_end`` on a throwaway MemoryManager
+initialized with the OLD session id.
+"""
+import asyncio
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner(cache: dict) -> "GatewayRunner":
+    """Bare GatewayRunner whose agent cache is ``cache`` ({} = idle-evicted)."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key, session_id="sess-old",
+        created_at=datetime.now(), updated_at=datetime.now(),
+        platform=Platform.TELEGRAM, chat_type="dm",
+    )
+    new_entry = SessionEntry(
+        session_key=session_key, session_id="sess-new",
+        created_at=datetime.now(), updated_at=datetime.now(),
+        platform=Platform.TELEGRAM, chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.reset_session.return_value = new_entry
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._format_session_info = lambda: ""
+
+    runner._agent_cache_lock = threading.RLock()
+    runner._agent_cache = cache
+
+    runner._session_db = MagicMock()
+    runner._session_db.get_messages_as_conversation.return_value = [
+        {"role": "user", "content": "hello there"},
+        {"role": "assistant", "content": "hi!"},
+    ]
+    runner._session_db.get_session_title.return_value = None
+    return runner
+
+
+def _fake_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.name = "fakeprov"
+    provider.is_available.return_value = True
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_new_after_idle_evict_fires_on_session_end_from_db():
+    """Cache miss at /new: the old transcript must still reach the memory
+    provider's on_session_end, scoped to the OLD session id."""
+    runner = _make_runner(cache={})  # idle-evicted — no cached agent
+    provider = _fake_provider()
+
+    with patch(
+        "tools.memory_tool.get_builtin_memory_config",
+        return_value={"provider": "fakeprov"},
+    ), patch(
+        "plugins.memory.load_memory_provider", return_value=provider
+    ) as loaded, patch(
+        "hermes_cli.profiles.get_active_profile_name", return_value="default"
+    ):
+        await asyncio.wait_for(
+            runner._handle_reset_command(_make_event("/new")), timeout=5
+        )
+
+    loaded.assert_called_once_with("fakeprov")
+    provider.on_session_end.assert_called_once_with([
+        {"role": "user", "content": "hello there"},
+        {"role": "assistant", "content": "hi!"},
+    ])
+    provider.initialize.assert_called_once()
+    init_kwargs = provider.initialize.call_args.kwargs
+    assert init_kwargs["session_id"] == "sess-old"
+    assert init_kwargs["gateway_session_key"] == build_session_key(_make_source())
+    provider.shutdown.assert_called_once()
+    # The reset itself still rotated the session.
+    runner.session_store.reset_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_new_with_cached_agent_skips_compensation():
+    """Cache hit at /new keeps the established path: the cached agent's own
+    teardown fires on_session_end — the compensation manager must NOT run."""
+    session_key = build_session_key(_make_source())
+    agent = MagicMock()
+    runner = _make_runner(cache={session_key: agent})
+    # Loud failure if the compensation path is reached on a cache hit.
+    runner._commit_memory_for_evicted_session = MagicMock(
+        side_effect=AssertionError("compensation ran with a cached agent")
+    )
+
+    await asyncio.wait_for(
+        runner._handle_reset_command(_make_event("/new")), timeout=5
+    )
+
+    agent.shutdown_memory_provider.assert_called_once()
+    runner.session_store.reset_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_new_after_idle_evict_without_memory_config_is_noop():
+    """No external memory provider configured: /new after eviction must not
+    build anything — the DB transcript read is skipped and reset proceeds."""
+    runner = _make_runner(cache={})
+
+    with patch(
+        "tools.memory_tool.get_builtin_memory_config", return_value={}
+    ), patch(
+        "plugins.memory.load_memory_provider",
+        side_effect=AssertionError("provider loaded with no memory config"),
+    ):
+        await asyncio.wait_for(
+            runner._handle_reset_command(_make_event("/new")), timeout=5
+        )
+
+    runner._session_db.get_messages_as_conversation.assert_not_called()
+    runner.session_store.reset_session.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

For a gateway messaging session with reset policy `mode: none`, the idle-TTL sweep soft-evicts the cached agent **without** firing `on_session_end` — correct at eviction time, because eviction is a cache detail and the session itself continues. But when the user later runs `/new`, `_handle_reset_command` only ran the memory chain (`_cleanup_agent_resources` → `shutdown_memory_provider` → `on_session_end`) when a cached agent existed. After an idle evict, `_old_agent is None`, the whole chain was skipped, and the old transcript never reached memory providers — end-of-session extraction (Cognee `improve()`, MEMORY.md synthesis, knowledge-graph updates) silently lost the session. The CLI `/new` path fires the boundary unconditionally, so this is a gateway-only gap.

This PR compensates on the cache-miss branch: reload the transcript from the session DB (`get_messages_as_conversation`, the same API the gateway uses to restore history after a soft evict) and fire `on_session_end` on a throwaway `MemoryManager` initialized with the OLD session id and the source-derived scoping kwargs (`user_id`/`chat_id`/`thread_id`/`gateway_session_key`/`session_title`/`agent_identity` — the same contract `agent_init.py` gives the per-agent manager), then shut it down. The call is offloaded to a worker thread with the same bounded timeout as the cached-agent cleanup (#35994 shape), so `/new` never blocks the event loop on the LLM-bound extraction.

## Related Issue

Fixes #99402

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: in `_handle_reset_command`, when no cached agent exists for the session (idle-evicted), fire the new compensation helper off-loop with a bounded timeout instead of silently skipping the memory boundary.
- `gateway/run.py`: add `_commit_memory_for_evicted_session` — resolves the configured external memory provider, reloads the old transcript from the session DB, fires `on_session_end` on a throwaway manager scoped to the old session id, then shuts it down. Best-effort: any failure is swallowed so `/new` never breaks on memory.
- `tests/gateway/test_99402_reset_memory_after_idle_evict.py`: regression tests for the cache-miss fire (old-session-id scoping + DB transcript + shutdown), the cache-hit no-compensation invariant, and the no-provider no-op.

## How to Test

1. `python -m pytest tests/gateway/test_99402_reset_memory_after_idle_evict.py -q` — Observed result: 3 passed.
2. `python -m pytest tests/gateway/ -k "reset or memory or evict" -q` — Observed result: 177 passed, 4 skipped (pre-existing skips), no regressions on the adjacent #35994 reset-cleanup tests.
3. Red-green check: stashing only the two product files makes `test_new_after_idle_evict_fires_on_session_end_from_db` fail (`load_memory_provider` called 0 times); restoring them makes it pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — covered by the deterministic regression tests above.