### PR TITLE
fix(desktop): detect gitfile checkouts in updater

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -372,6 +372,7 @@ import {
   shouldCountCommits
 } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
+import { isGitCheckout } from './update-git-checkout'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
@@ -2822,9 +2823,9 @@ function resolveUpdateRoot() {
     process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT),
     !IS_PACKAGED && isHermesSourceRoot(SOURCE_REPO_ROOT) ? SOURCE_REPO_ROOT : null,
     isHermesSourceRoot(ACTIVE_HERMES_ROOT) ? ACTIVE_HERMES_ROOT : null
-  ].filter(Boolean)
+  ].filter((candidate): candidate is string => Boolean(candidate))
 
-  return candidates.find(c => directoryExists(path.join(c, '.git'))) || candidates[0] || ACTIVE_HERMES_ROOT
+  return candidates.find(c => isGitCheckout(c)) || candidates[0] || ACTIVE_HERMES_ROOT
 }
 
 function runGit(args, options: any = {}): Promise<{ code: number; stdout: string; stderr: string }> {
@@ -2905,9 +2906,8 @@ async function resolveHealedBranch(updateRoot, branch) {
 async function checkUpdates() {
   const updateRoot = resolveUpdateRoot()
   let { branch } = readDesktopUpdateConfig()
-  const gitDir = path.join(updateRoot, '.git')
 
-  if (!directoryExists(gitDir)) {
+  if (!isGitCheckout(updateRoot)) {
     return {
       supported: false,
       reason: 'not-a-git-checkout',
@@ -3992,7 +3992,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
   const updateRoot = resolveUpdateRoot()
   const { branch: configuredBranch } = readDesktopUpdateConfig()
 
-  const branch = directoryExists(path.join(updateRoot, '.git'))
+  const branch = isGitCheckout(updateRoot)
     ? await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
     : configuredBranch || DEFAULT_UPDATE_BRANCH
 

--- a/apps/desktop/electron/update-git-checkout.test.ts
+++ b/apps/desktop/electron/update-git-checkout.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, test } from 'vitest'
+
+import { isGitCheckout } from './update-git-checkout'
+
+const tempDirs: string[] = []
+
+function tempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-update-git-checkout-'))
+  tempDirs.push(root)
+
+  return root
+}
+
+afterEach(() => {
+  for (const root of tempDirs.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('accepts a normal checkout whose .git entry is a directory', () => {
+  const root = tempRoot()
+  fs.mkdirSync(path.join(root, '.git'))
+
+  assert.equal(isGitCheckout(root), true)
+})
+
+test('accepts a linked worktree whose .git entry is a gitfile', () => {
+  const root = tempRoot()
+  fs.writeFileSync(path.join(root, '.git'), 'gitdir: /external/git-metadata/hermes-agent.git\n')
+
+  assert.equal(isGitCheckout(root), true)
+})
+
+test('rejects a directory without a .git entry', () => {
+  assert.equal(isGitCheckout(tempRoot()), false)
+})

--- a/apps/desktop/electron/update-git-checkout.ts
+++ b/apps/desktop/electron/update-git-checkout.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/** Return whether root is a Git checkout the Desktop updater can operate on. */
+export function isGitCheckout(root: string): boolean {
+  try {
+    const stat = fs.statSync(path.join(root, '.git'))
+
+    return stat.isDirectory() || stat.isFile()
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- treat `.git` files used by linked worktrees and externally stored Git metadata as valid Desktop update roots
- route update-root selection, update checks, and Windows recovery through one checkout detector
- add filesystem regression coverage for directory, gitfile, and missing checkout shapes

## Root cause

Desktop only accepted `.git` directories. Git also accepts a `.git` file containing `gitdir: <path>`, so valid managed installs using linked worktrees or external Git metadata were incorrectly shown as “isn't a git checkout” and could not self-update.

The original one-line fix was authored by `ethernet8023` in `b649d600b5`, but that commit was pushed to `ethie/desktop-bundles` after PR #79599 had already been closed and was never associated with another PR. This clean PR preserves the fix and adds regression coverage.

## Verification

- `vitest run --project electron electron/update-git-checkout.test.ts` (3 passed)
- `tsc -p tsconfig.electron.json --noEmit`
- `eslint electron/main.ts electron/update-git-checkout.ts electron/update-git-checkout.test.ts`
- reproduced against a real managed checkout whose `.git` is a gitfile pointing to externally stored metadata
