### PR TITLE
fix(buzz): npub allowlists, per-profile auth, external secrets, and multiplex env isolation all work now (salvages #78435 #83155 #95224 #98748)

### DIFF
--- a/contributors/emails/alex@gunsberg.fi
+++ b/contributors/emails/alex@gunsberg.fi
@@ -1,0 +1,1 @@
+alexgunsberg

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -104,6 +104,91 @@ def _coerce_allow_set(raw) -> set[str]:
     return {part.strip() for part in str(raw).split(",") if part.strip()}
 
 
+# ---------------------------------------------------------------------------
+# Nostr npub → hex normalization (Buzz and future Nostr-based platforms).
+#
+# ``BUZZ_ALLOWED_USERS`` accepts either a 64-char hex pubkey or an ``npub1…``
+# bech32 string, but inbound event pubkeys are always hex.  Without decoding,
+# the central allowlist comparison string-matches the raw npub against the
+# hex pubkey and an operator who listed only their npub sees every message
+# rejected ("Unauthorized user: <hex pubkey>", #78428).  Pure stdlib; mirrors
+# the decoder in plugins/platforms/buzz/adapter.py.
+# ---------------------------------------------------------------------------
+
+_BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+
+def _bech32_polymod(values):
+    chk = 1
+    generator = [0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3]
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1FFFFFF) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def _bech32_hrp_expand(hrp: str):
+    return [ord(c) >> 5 for c in hrp] + [0] + [ord(c) & 31 for c in hrp]
+
+
+def _convertbits(data, frombits: int, tobits: int, pad: bool = True):
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = (acc << frombits) | value
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
+
+
+def _npub_to_hex(npub: str) -> Optional[str]:
+    """Decode an ``npub1…`` bech32 string to a 64-char hex pubkey, else None."""
+    npub = npub.strip().lower()
+    if not npub.startswith("npub1"):
+        return None
+    data_part = npub[len("npub1"):]
+    try:
+        data = [_BECH32_CHARSET.index(c) for c in data_part]
+    except ValueError:
+        return None
+    if _bech32_polymod(_bech32_hrp_expand("npub") + data) != 1:
+        return None
+    decoded = _convertbits(data[:-6], 5, 8, pad=False)
+    if decoded is None or len(decoded) != 32:
+        return None
+    return bytes(decoded).hex()
+
+
+def _normalize_nostr_allow_entries(entries: set) -> set:
+    """Expand npub entries in an allowlist set to their hex pubkey form.
+
+    Hex entries pass through unchanged; each valid ``npub1…`` entry is decoded
+    and its 64-char hex form added, so either form authorizes the same
+    identity (#78428).  Invalid entries are kept as-is (they simply never
+    match an inbound hex pubkey).
+    """
+    expanded = set(entries)
+    for entry in entries:
+        if entry.lower().startswith("npub1"):
+            hex_key = _npub_to_hex(entry)
+            if hex_key:
+                expanded.add(hex_key)
+    return expanded
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -863,6 +948,18 @@ class GatewayAuthorizationMixin:
             and source.user_name
         ):
             check_ids.add(source.user_name)
+
+        # Buzz (Nostr-based): BUZZ_ALLOWED_USERS accepts npub or hex, but
+        # inbound event pubkeys are always 64-char hex. Decode npub entries
+        # to hex so an operator who listed only their npub authorizes the
+        # same identity as the hex form (#78428). Hex entries pass through
+        # unchanged, so existing hex-only allowlists keep working.
+        if source.platform is not None and source.platform.value == "buzz":
+            allowed_ids = _normalize_nostr_allow_entries(allowed_ids)
+            if user_id.startswith("npub"):
+                hex_user = _npub_to_hex(user_id)
+                if hex_user:
+                    check_ids.add(hex_user)
 
         return bool(check_ids & allowed_ids)
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -69,6 +69,26 @@ def _auth_env(name: str, default: str = "") -> str:
     return _platform_gate_env(name, default)
 
 
+def _platform_declares_allowed_users_env(platform) -> bool:
+    """Whether a plugin platform's registry entry declares ``allowed_users_env``.
+
+    Such platforms (Buzz, DingTalk, …) document ``PlatformConfig.extra
+    .allowed_users`` as the config-file spelling of that env allowlist, so
+    the live adapter's extra is a valid authorization source when the env
+    var is absent (#98738 / #82871). Built-in platforms and unknown entries
+    return False.
+    """
+    if platform is None:
+        return False
+    try:
+        from gateway.platform_registry import platform_registry
+
+        entry = platform_registry.get(platform.value)
+        return bool(entry and entry.allowed_users_env)
+    except Exception:
+        return False
+
+
 def _coerce_allow_set(raw) -> set[str]:
     """Parse allowlist values from config or env var into a set of strings.
 
@@ -692,8 +712,26 @@ class GatewayAuthorizationMixin:
                     adapter_allow = extra.get("group_allow_from")
                 else:
                     adapter_allow = extra.get("allow_from")
+                if not adapter_allow and _platform_declares_allowed_users_env(source.platform):
+                    # Plugin platforms whose registry entry declares
+                    # ``allowed_users_env`` (e.g. Buzz) carry the same
+                    # operator-configured allowlist in
+                    # ``PlatformConfig.extra.allowed_users``. Under multiplex
+                    # the YAML→env bridge is first-writer-wins, so only the
+                    # default profile's list ever reaches the env var read
+                    # above; consult the live (profile-routed) adapter's own
+                    # config so a secondary profile's allowlist authorizes its
+                    # users (#98738 / #82871). An absent/empty entry changes
+                    # nothing here — the default-deny below still applies.
+                    adapter_allow = extra.get("allowed_users")
                 if adapter_allow:
                     allowed = _coerce_allow_set(adapter_allow)
+                    normalize = getattr(adapter, "normalize_user_id", None)
+                    if callable(normalize):
+                        # Ids and allowlist entries may use different
+                        # spellings of the same principal (e.g. Buzz hex
+                        # pubkeys vs npubs) — normalize the entries.
+                        allowed = {normalize(entry) or entry for entry in allowed}
                     if user_id in allowed or "*" in allowed:
                         return True
             # No allowlists configured -- check global allow-all flag

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -330,53 +330,66 @@ def _resolve_cli_path(configured: str = "") -> str:
     return str(fallback) if fallback.is_file() else ""
 
 
-def _resolve_private_key(extra: Optional[dict] = None) -> str:
-    """Resolve the Nostr private key: env first, then a credentials JSON.
-
-    NEVER log the return value.
-    """
-    key = _get_scoped_secret("BUZZ_PRIVATE_KEY", "").strip()
-    if key:
-        return key
-    _creds_raw = _scoped_platform_setting("BUZZ_CREDENTIALS_FILE", extra, "credentials_file")
-    configured = str(_creds_raw or "").strip() or (extra or {}).get("credentials_file", "")
+def _credentials_candidates(extra: Optional[dict] = None) -> List[Path]:
+    # Scope-aware read (#98738/#95216): inside a secondary profile scope the
+    # scope is authoritative (a miss falls to the profile's own config extra,
+    # never the default profile's os.environ); unscoped reads keep env
+    # precedence plus the external-secret rung.
+    configured = str(_get_scoped_secret("BUZZ_CREDENTIALS_FILE", "") or "").strip() or str(
+        (extra or {}).get("credentials_file", "") or ""
+    ).strip()
     if configured:
-        candidates = [Path(configured).expanduser()]
-    else:
-        try:
-            candidates = sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
-        except OSError:
-            candidates = []
-    for path in candidates:
+        return [Path(configured).expanduser()]
+    try:
+        return sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
+    except OSError:
+        return []
+
+
+def _resolve_credentials_data(extra: Optional[dict] = None) -> dict:
+    """Load the first credential record containing a private key."""
+    for path in _credentials_candidates(extra):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
         if not isinstance(data, dict):
             continue
-        for field in ("nsec", "private_key_hex", "private_key"):
-            value = data.get(field)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+        if any(isinstance(data.get(field), str) and data[field].strip() for field in ("nsec", "private_key_hex", "private_key")):
+            return data
+    return {}
+
+
+def _resolve_private_key(extra: Optional[dict] = None) -> str:
+    """Resolve the Nostr private key: scoped secret first, then credentials JSON.
+
+    NEVER log the return value.
+    """
+    key = str(_get_scoped_secret("BUZZ_PRIVATE_KEY", "") or "").strip()
+    if key:
+        return key
+    data = _resolve_credentials_data(extra)
+    for field in ("nsec", "private_key_hex", "private_key"):
+        value = data.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return ""
 
 
 def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
     """Resolve and validate the optional NIP-OA owner-attestation tag."""
-    configured = os.getenv("BUZZ_AUTH_TAG", "").strip()
+    configured = str(_get_scoped_secret("BUZZ_AUTH_TAG", "") or "").strip()
     if configured:
         raw: Any = configured
     else:
-        credentials_file = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get(
-            "credentials_file", ""
-        )
-        if not credentials_file:
+        credentials_file = str(_get_scoped_secret("BUZZ_CREDENTIALS_FILE", "") or "").strip() or str(
+            (extra or {}).get("credentials_file", "") or ""
+        ).strip()
+        direct_key = str(_get_scoped_secret("BUZZ_PRIVATE_KEY", "") or "").strip()
+        if direct_key and not credentials_file:
             return ""
-        try:
-            data = json.loads(Path(credentials_file).expanduser().read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return ""
-        if not isinstance(data, dict) or "auth_tag" not in data:
+        data = _resolve_credentials_data(extra)
+        if "auth_tag" not in data:
             return ""
         raw = data["auth_tag"]
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -52,6 +52,7 @@ from urllib.parse import urlsplit, urlunsplit
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import current_secret_scope as _current_secret_scope
 from agent.secret_scope import get_secret as _scoped_get_secret
+from agent.secret_scope import is_multiplex_active as _is_multiplex_active
 
 
 def _get_scoped_secret(name, default=None):
@@ -340,6 +341,8 @@ def _credentials_candidates(extra: Optional[dict] = None) -> List[Path]:
     ).strip()
     if configured:
         return [Path(configured).expanduser()]
+    if _is_multiplex_active():
+        return []
     try:
         return sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
     except OSError:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -98,7 +98,10 @@ def _unscoped_profile_secrets() -> Dict[str, str]:
     resolvers (Bitwarden via ``BWS_ACCESS_TOKEN``), and the requirement
     gate / validate / is_connected probes all want the same snapshot. Any
     failure degrades to an empty mapping — callers then simply report the
-    platform as not configured, which is the pre-fix behavior.
+    platform as not configured, which is the pre-fix behavior. The cache
+    is startup-gate-only: it pins whatever ``get_hermes_home()`` resolved
+    on first build, so it must not be reused off the startup path (where
+    a profile scope is always active and shadows it anyway).
     """
     global _UNSCOPED_PROFILE_SECRETS
     if _UNSCOPED_PROFILE_SECRETS is None:
@@ -118,7 +121,6 @@ def _unscoped_profile_secrets() -> Dict[str, str]:
             )
             _UNSCOPED_PROFILE_SECRETS = {}
     return _UNSCOPED_PROFILE_SECRETS
-    return val if val is not None else default
 
 
 def _profile_scoped() -> bool:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -948,14 +948,21 @@ class BuzzAdapter(BasePlatformAdapter):
         # multiplex profile a missing tag fails closed to "" instead of
         # attaching the default profile's tag from os.environ, while
         # single-profile and unscoped default-profile reads keep the legacy
-        # env behavior. ``self._auth_tag`` is populated by connect() via
+        # env behavior. connect() populates ``self._auth_tag`` via
         # ``_resolve_auth_tag`` (scope-aware read + credentials-file
-        # fallback, #79514).
+        # fallback, #79514); resolve lazily here as well so a re-auth on a
+        # bare adapter stays scope-correct.
+        auth_tag = getattr(self, "_auth_tag", "") or ""
+        if not auth_tag:
+            try:
+                auth_tag = _resolve_auth_tag(getattr(self, "_extra", None))
+            except ValueError:
+                auth_tag = ""
         event = build_auth_event(
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=self._auth_tag,
+            auth_tag_json=auth_tag,
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -830,11 +830,17 @@ class BuzzAdapter(BasePlatformAdapter):
         message = json.loads(raw)
         if not isinstance(message, list) or len(message) < 2 or message[0] != "AUTH":
             raise ConnectionError("Buzz relay did not send a NIP-42 AUTH challenge")
+        # BUZZ_AUTH_TAG is per-identity NIP-OA owner attestation, so it must
+        # resolve through the profile secret scope (#98738): inside a scoped
+        # multiplex profile a missing tag fails closed to "" instead of
+        # attaching the default profile's tag from os.environ, while
+        # single-profile and unscoped default-profile reads keep the legacy
+        # env behavior (the wrapper falls back to os.environ there).
         event = build_auth_event(
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=os.getenv("BUZZ_AUTH_TAG", ""),
+            auth_tag_json=_get_scoped_secret("BUZZ_AUTH_TAG", "") or "",
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -361,12 +361,47 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
     return ""
 
 
+def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
+    """Resolve and validate the optional NIP-OA owner-attestation tag."""
+    configured = os.getenv("BUZZ_AUTH_TAG", "").strip()
+    if configured:
+        raw: Any = configured
+    else:
+        credentials_file = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get(
+            "credentials_file", ""
+        )
+        if not credentials_file:
+            return ""
+        try:
+            data = json.loads(Path(credentials_file).expanduser().read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ""
+        if not isinstance(data, dict) or "auth_tag" not in data:
+            return ""
+        raw = data["auth_tag"]
+
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Buzz auth tag is not valid JSON") from exc
+    if (
+        not isinstance(raw, list)
+        or len(raw) != 4
+        or raw[0] != "auth"
+        or not all(isinstance(part, str) for part in raw)
+    ):
+        raise ValueError("Buzz auth tag must be a four-string auth tag")
+    return json.dumps(raw, separators=(",", ":"))
+
+
 async def _exec_buzz(
     cli_path: str,
     args: List[str],
     *,
     relay_url: str,
     private_key: str,
+    auth_tag: str = "",
     input_text: Optional[str] = None,
     timeout: float = _CLI_TIMEOUT,
 ) -> Tuple[int, str, str]:
@@ -379,6 +414,9 @@ async def _exec_buzz(
     env = os.environ.copy()
     env["BUZZ_RELAY_URL"] = relay_url
     env["BUZZ_PRIVATE_KEY"] = private_key
+    env.pop("BUZZ_AUTH_TAG", None)
+    if auth_tag:
+        env["BUZZ_AUTH_TAG"] = auth_tag
     proc = await asyncio.create_subprocess_exec(
         cli_path,
         *args,
@@ -512,6 +550,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # never logged).  connect() re-resolves it to fail fast with a clear
         # error when it is missing.
         self._private_key: str = ""
+        self._auth_tag: str = ""
 
         # Identity — filled in by connect() from ``buzz users get``
         self._self_pubkey: str = ""
@@ -554,11 +593,13 @@ class BuzzAdapter(BasePlatformAdapter):
     async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
+            self._auth_tag = _resolve_auth_tag(self._extra)
         return await _exec_buzz(
             self.cli_path,
             args,
             relay_url=self.relay_url,
             private_key=self._private_key,
+            auth_tag=self._auth_tag,
             input_text=input_text,
         )
 
@@ -574,7 +615,13 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.error("Buzz: buzz CLI binary not found (set BUZZ_CLI_PATH or put 'buzz' on PATH)")
             self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=False)
             return False
-        self._private_key = _resolve_private_key(self._extra)
+        try:
+            self._private_key = _resolve_private_key(self._extra)
+            self._auth_tag = _resolve_auth_tag(self._extra)
+        except ValueError as exc:
+            logger.error("Buzz: invalid owner-auth configuration — %s", exc)
+            self._set_fatal_error("config_invalid", str(exc), retryable=False)
+            return False
         if not self._private_key:
             logger.error("Buzz: no private key (set BUZZ_PRIVATE_KEY or a credentials file)")
             self._set_fatal_error("config_missing", "BUZZ_PRIVATE_KEY must be set", retryable=False)
@@ -885,12 +932,14 @@ class BuzzAdapter(BasePlatformAdapter):
         # multiplex profile a missing tag fails closed to "" instead of
         # attaching the default profile's tag from os.environ, while
         # single-profile and unscoped default-profile reads keep the legacy
-        # env behavior (the wrapper falls back to os.environ there).
+        # env behavior. ``self._auth_tag`` is populated by connect() via
+        # ``_resolve_auth_tag`` (scope-aware read + credentials-file
+        # fallback, #79514).
         event = build_auth_event(
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=_get_scoped_secret("BUZZ_AUTH_TAG", "") or "",
+            auth_tag_json=self._auth_tag,
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:
@@ -1549,6 +1598,10 @@ async def _standalone_send(
     relay = (_relay_raw or extra.get("relay_url", "")).strip()
     private_key = _resolve_private_key(extra)
     _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
+    try:
+        auth_tag = _resolve_auth_tag(extra)
+    except ValueError as exc:
+        return {"error": f"Buzz standalone send: {exc}"}
     cli_path = _resolve_cli_path(
         str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
     )
@@ -1568,7 +1621,12 @@ async def _standalone_send(
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            auth_tag=auth_tag,
+            input_text=message,
         )
     except asyncio.CancelledError:
         raise

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -73,6 +73,41 @@ def _get_scoped_secret(name, default=None):
     return val if val is not None else default
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed, connected, and reloaded
+    inside ``_profile_runtime_scope`` (secret scope installed + multiplex
+    active) — the same discriminator as the Discord adapter's
+    ``_profile_scoped_config_load`` (#72348). The DEFAULT profile under
+    multiplexing runs unscoped: ``os.environ`` holds its own bridge output
+    there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _scoped_platform_setting(env_name, extra, key):
+    """Raw read of a non-secret Buzz setting, multiplex-profile-correct.
+
+    Inside a secondary profile scope ``os.environ`` holds the DEFAULT
+    profile's YAML-to-env bridge output (#98738), so the profile's
+    ``PlatformConfig.extra`` is authoritative and env is not consulted: a
+    missing key yields ``None`` and callers fail closed to their default
+    instead of silently borrowing the default profile's relay, channels, or
+    allowlist. Everywhere else — single-profile gateways, the default
+    profile under multiplexing — the legacy ``os.getenv`` read is returned
+    unchanged, so env-over-config precedence is preserved.
+    """
+    if _profile_scoped():
+        return (extra or {}).get(key)
+    return os.getenv(env_name)
+
+
 logger = logging.getLogger(__name__)
 
 from gateway.platforms.base import (
@@ -253,7 +288,8 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
     key = _get_scoped_secret("BUZZ_PRIVATE_KEY", "").strip()
     if key:
         return key
-    configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")
+    _creds_raw = _scoped_platform_setting("BUZZ_CREDENTIALS_FILE", extra, "credentials_file")
+    configured = str(_creds_raw or "").strip() or (extra or {}).get("credentials_file", "")
     if configured:
         candidates = [Path(configured).expanduser()]
     else:
@@ -361,22 +397,30 @@ class BuzzAdapter(BasePlatformAdapter):
         extra = getattr(config, "extra", {}) or {}
         self._extra = extra
 
-        # Connection settings (env vars override config.yaml)
-        self.relay_url = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
+        # Connection settings (env vars override config.yaml; under a
+        # secondary multiplex profile scope the profile's extra wins and
+        # env — the default profile's bridge output — is not consulted)
+        _relay_raw = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+        self.relay_url = (_relay_raw or extra.get("relay_url", "")).strip()
+        _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
         self.cli_path = _resolve_cli_path(
-            os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
+            str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
         )
 
         # Channels to watch: env csv > extra list/csv; empty = all joined channels
-        raw_channels = os.getenv("BUZZ_CHANNELS") or extra.get("channels", [])
+        raw_channels = _scoped_platform_setting("BUZZ_CHANNELS", extra, "channels")
+        if raw_channels is None:
+            raw_channels = extra.get("channels", [])
         if isinstance(raw_channels, str):
             raw_channels = raw_channels.split(",")
         self.channels: List[str] = [c.strip() for c in raw_channels if isinstance(c, str) and c.strip()]
 
-        self.home_channel = (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+        _home_raw = _scoped_platform_setting("BUZZ_HOME_CHANNEL", extra, "home_channel")
+        self.home_channel = (_home_raw or str(extra.get("home_channel", "") or "")).strip()
 
+        _pi_raw = _scoped_platform_setting("BUZZ_POLL_INTERVAL", extra, "poll_interval")
         try:
-            interval = float(os.getenv("BUZZ_POLL_INTERVAL") or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
+            interval = float(_pi_raw or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
         except (TypeError, ValueError):
             interval = _DEFAULT_POLL_INTERVAL
         self.poll_interval = max(_MIN_POLL_INTERVAL, interval)
@@ -385,7 +429,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # Defaults to True (respond only when addressed). Set False to make the
         # agent respond to every message in a watched channel. DMs always
         # dispatch regardless. Env (BUZZ_REQUIRE_MENTION) overrides config.yaml.
-        _rm_raw = os.getenv("BUZZ_REQUIRE_MENTION")
+        _rm_raw = _scoped_platform_setting("BUZZ_REQUIRE_MENTION", extra, "require_mention")
         if _rm_raw is None:
             _rm_cfg = extra.get("require_mention", True)
         else:
@@ -396,13 +440,16 @@ class BuzzAdapter(BasePlatformAdapter):
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
         # config.yaml.
+        _transport_raw = _scoped_platform_setting("BUZZ_TRANSPORT", extra, "transport")
         _transport = (
-            os.getenv("BUZZ_TRANSPORT") or str(extra.get("transport", "auto") or "auto")
+            _transport_raw or str(extra.get("transport", "auto") or "auto")
         ).strip().lower()
         self.transport = _transport if _transport in ("auto", "websocket", "poll") else "auto"
 
         # Auth: entries may be hex pubkeys or npubs; normalized to hex
-        raw_allowed = os.getenv("BUZZ_ALLOWED_USERS") or extra.get("allowed_users", [])
+        raw_allowed = _scoped_platform_setting("BUZZ_ALLOWED_USERS", extra, "allowed_users")
+        if raw_allowed is None:
+            raw_allowed = extra.get("allowed_users", [])
         if isinstance(raw_allowed, str):
             raw_allowed = raw_allowed.split(",")
         self._allowed_pubkeys: set = {
@@ -440,6 +487,17 @@ class BuzzAdapter(BasePlatformAdapter):
     @property
     def name(self) -> str:
         return "Buzz"
+
+    @staticmethod
+    def normalize_user_id(user_id: str) -> Optional[str]:
+        """Normalize a Buzz user reference (hex pubkey or npub) to hex.
+
+        Optional hook consumed by ``gateway/authz_mixin`` when matching the
+        profile allowlist carried in ``config.extra.allowed_users`` (#98738):
+        entries may be npubs while inbound ``user_id`` is always the hex
+        pubkey, so a plain string compare would deny listed users.
+        """
+        return _normalize_user_ref(user_id)
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
@@ -1256,8 +1314,44 @@ class BuzzAdapter(BasePlatformAdapter):
 # Plugin registration
 # ---------------------------------------------------------------------------
 
+def _profile_buzz_extra() -> dict:
+    """Read ``buzz.extra`` from the active profile's config.yaml (scoped path).
+
+    Only meaningful inside a secondary profile scope, where the hermes-home
+    override points at that profile's home. Used by ``check_requirements``
+    (which has no PlatformConfig argument) so the multiplex gate consults the
+    profile's own configuration instead of the process env. Best-effort: any
+    failure yields an empty mapping and the caller fails closed.
+    """
+    if not _profile_scoped():
+        return {}
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(Path(get_hermes_home()) / "config.yaml")
+    except Exception:
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    buzz = ((cfg.get("gateway") or {}).get("platforms") or {}).get("buzz")
+    if not isinstance(buzz, dict):
+        return {}
+    extra = buzz.get("extra", buzz)
+    return extra if isinstance(extra, dict) else {}
+
+
 def check_requirements() -> bool:
     """Check if Buzz is configured: a relay URL plus a resolvable key."""
+    if _profile_scoped():
+        # Multiplexed secondary profile (#98738): os.environ's BUZZ_* values
+        # are the default profile's bridge output and must not satisfy this
+        # gate for another profile. Consult the profile's own config.yaml
+        # (via the scoped home override) and its secret scope instead; an
+        # unconfigured profile fails closed.
+        extra = _profile_buzz_extra()
+        relay = str(extra.get("relay_url") or "").strip()
+        return bool(relay and _resolve_private_key(extra))
     if not os.getenv("BUZZ_RELAY_URL", "").strip():
         return False
     return bool(_resolve_private_key())
@@ -1266,7 +1360,8 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    relay = os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")
+    relay = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+    relay = relay if relay is not None else extra.get("relay_url", "")
     return bool(relay and _resolve_private_key(extra))
 
 
@@ -1291,6 +1386,12 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     extra = buzz_cfg.get("extra", buzz_cfg) or {}
     if not isinstance(extra, dict):
         return None
+    # Under multiplex, a secondary profile's config loads inside its runtime
+    # scope; its values must NOT be written to the process-global env, where
+    # first-writer-wins would pin them for every other profile (issue #72348
+    # Telegram/Discord mirror, Buzz side of #98738). Its adapter reads the
+    # profile's PlatformConfig.extra directly instead.
+    _skip_env_bridge = _profile_scoped()
     _str_keys = {
         "relay_url": "BUZZ_RELAY_URL",
         "cli_path": "BUZZ_CLI_PATH",
@@ -1299,24 +1400,24 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     }
     for src, env in _str_keys.items():
         val = extra.get(src)
-        if val and not os.getenv(env):
+        if val and not _skip_env_bridge and not os.getenv(env):
             os.environ[env] = str(val)
     interval = extra.get("poll_interval")
-    if interval is not None and not os.getenv("BUZZ_POLL_INTERVAL"):
+    if interval is not None and not _skip_env_bridge and not os.getenv("BUZZ_POLL_INTERVAL"):
         os.environ["BUZZ_POLL_INTERVAL"] = str(interval)
     channels = extra.get("channels")
-    if channels is not None and not os.getenv("BUZZ_CHANNELS"):
+    if channels is not None and not _skip_env_bridge and not os.getenv("BUZZ_CHANNELS"):
         if isinstance(channels, (list, tuple)):
             channels = ",".join(str(c) for c in channels)
         os.environ["BUZZ_CHANNELS"] = str(channels)
     allowed = extra.get("allowed_users")
-    if allowed is not None and not os.getenv("BUZZ_ALLOWED_USERS"):
+    if allowed is not None and not _skip_env_bridge and not os.getenv("BUZZ_ALLOWED_USERS"):
         if isinstance(allowed, (list, tuple)):
             allowed = ",".join(str(a) for a in allowed)
         os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
-    if "allow_all_users" in extra and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
+    if "allow_all_users" in extra and not _skip_env_bridge and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
-    if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
+    if "require_mention" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
     return None
 
@@ -1331,6 +1432,12 @@ def _env_enablement() -> Optional[dict]:
     The special ``home_channel`` key is handled by the core hook — it becomes
     a proper ``HomeChannel`` on the ``PlatformConfig``.
     """
+    if _profile_scoped():
+        # Secondary profile scope (#98738): the process env's BUZZ_* values
+        # are the default profile's configuration, not this profile's — env
+        # enablement must not fabricate a Buzz platform for a profile that
+        # did not configure one.
+        return None
     relay = os.getenv("BUZZ_RELAY_URL", "").strip()
     if not relay or not _resolve_private_key():
         return None
@@ -1374,16 +1481,19 @@ async def _standalone_send(
     fail with ``No live adapter for platform 'buzz'``.
     """
     extra = getattr(pconfig, "extra", {}) or {}
-    relay = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
+    _relay_raw = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+    relay = (_relay_raw or extra.get("relay_url", "")).strip()
     private_key = _resolve_private_key(extra)
+    _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
     cli_path = _resolve_cli_path(
-        os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
+        str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
     )
     if not relay or not private_key:
         return {"error": "Buzz standalone send: BUZZ_RELAY_URL and BUZZ_PRIVATE_KEY must be configured"}
     if not cli_path:
         return {"error": "Buzz standalone send: buzz CLI binary not found"}
-    target = (chat_id or "").strip() or (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+    _home_raw = _scoped_platform_setting("BUZZ_HOME_CHANNEL", extra, "home_channel")
+    target = (chat_id or "").strip() or (_home_raw or str(extra.get("home_channel", "") or "")).strip()
     if not target:
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import current_secret_scope as _current_secret_scope
 from agent.secret_scope import get_secret as _scoped_get_secret
 
 
@@ -65,11 +66,58 @@ def _get_scoped_secret(name, default=None):
     profile's own value, so fall back to it. Same pattern as the Slack
     ``SLACK_APP_TOKEN`` read (#59739) and
     ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+
+    The no-scope path has one more rung for the platform requirement gate:
+    ``check_requirements()`` runs at gateway startup BEFORE any per-profile
+    secret scope is installed, and ``get_secret`` without a scope simply
+    reads ``os.environ`` — so a Bitwarden-managed ``BUZZ_PRIVATE_KEY``
+    (only ``BWS_ACCESS_TOKEN`` in ``.env``) was invisible to the check and
+    Buzz was silently skipped (#95216). When no scope is active and the
+    process env has no value, consult a one-shot build of the profile's
+    secret mapping (``build_profile_secret_scope`` resolves external secret
+    sources) so externally managed credentials pass the gate. An ACTIVE
+    scope still shadows this rung entirely — it never runs under
+    multiplexing, so cross-profile isolation is unchanged.
     """
     try:
-        val = _scoped_get_secret(name, default)
+        val = _scoped_get_secret(name, None)
     except _UnscopedSecretError:
         val = os.getenv(name)
+    if val is None and _current_secret_scope() is None:
+        val = _unscoped_profile_secrets().get(name)
+    return val if val is not None else default
+
+
+_UNSCOPED_PROFILE_SECRETS: Optional[Dict[str, str]] = None
+
+
+def _unscoped_profile_secrets() -> Dict[str, str]:
+    """One-shot build of the active profile's secret mapping.
+
+    Cached for the process: the build shells out to external secret
+    resolvers (Bitwarden via ``BWS_ACCESS_TOKEN``), and the requirement
+    gate / validate / is_connected probes all want the same snapshot. Any
+    failure degrades to an empty mapping — callers then simply report the
+    platform as not configured, which is the pre-fix behavior.
+    """
+    global _UNSCOPED_PROFILE_SECRETS
+    if _UNSCOPED_PROFILE_SECRETS is None:
+        try:
+            from agent.secret_scope import build_profile_secret_scope
+            from hermes_constants import get_hermes_home
+
+            _UNSCOPED_PROFILE_SECRETS = dict(
+                build_profile_secret_scope(get_hermes_home())
+            )
+        except Exception:
+            logger.warning(
+                "Buzz requirement probe could not build the profile secret "
+                "scope; Bitwarden-managed credentials will not be visible "
+                "to the startup gate (#95216)",
+                exc_info=True,
+            )
+            _UNSCOPED_PROFILE_SECRETS = {}
+    return _UNSCOPED_PROFILE_SECRETS
     return val if val is not None else default
 
 
@@ -1358,16 +1406,24 @@ def check_requirements() -> bool:
         extra = _profile_buzz_extra()
         relay = str(extra.get("relay_url") or "").strip()
         return bool(relay and _resolve_private_key(extra))
-    if not os.getenv("BUZZ_RELAY_URL", "").strip():
+    # Scope-aware read: the gate runs before per-profile scopes install, and
+    # BUZZ_RELAY_URL can be externally managed just like the key (#95216).
+    if not (_get_scoped_secret("BUZZ_RELAY_URL", "") or "").strip():
         return False
     return bool(_resolve_private_key())
 
 
 def validate_config(config) -> bool:
-    """Validate that the platform config has enough info to connect."""
+    """Validate that the platform config has enough information to connect."""
     extra = getattr(config, "extra", {}) or {}
-    relay = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
-    relay = relay if relay is not None else extra.get("relay_url", "")
+    # Inside a secondary profile scope, extra is authoritative (#98738);
+    # unscoped, the env read gains the external-secret rung so a managed
+    # relay passes too (#95216).
+    if _profile_scoped():
+        relay = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
+        relay = relay if relay is not None else extra.get("relay_url", "")
+    else:
+        relay = _get_scoped_secret("BUZZ_RELAY_URL", "") or extra.get("relay_url", "")
     return bool(relay and _resolve_private_key(extra))
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1043,4 +1043,95 @@ class TestStandaloneSend:
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_injects_owner_auth_tag_from_credentials_file(
+        self, monkeypatch, tmp_path
+    ):
+        """Cron/standalone path must load NIP-OA auth_tag from credentials JSON.
+
+        Main-line regression: when only BUZZ_PRIVATE_KEY is ambient and the
+        credentials file holds auth_tag, omitting injection causes relay 403
+        membership failures on owner-gated relays.
+        """
+        from gateway.config import PlatformConfig
+
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}),
+            encoding="utf-8",
+        )
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        monkeypatch.delenv("BUZZ_AUTH_TAG", raising=False)
+
+        captured = {}
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0
+        ):
+            captured.update(
+                private_key=private_key,
+                auth_tag=auth_tag,
+                args=args,
+                input_text=input_text,
+            )
+            return 0, json.dumps({"accepted": True, "event_id": "evt-auth", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "cron needs owner auth"
+        )
+        assert result == {"success": True, "message_id": "evt-auth"}
+        assert captured["private_key"] == "nsec1fromfile"
+        assert json.loads(captured["auth_tag"]) == tag
+        # Secrets stay out of argv (auth_tag is env-injected by _exec_buzz).
+        joined_args = " ".join(str(a) for a in captured["args"])
+        assert "nsec1fromfile" not in joined_args
+        assert tag[1] not in joined_args
+        assert tag[3] not in joined_args
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_key_only_does_not_invent_auth_tag(
+        self, monkeypatch, tmp_path
+    ):
+        """Direct private key without credentials_file must not invent an auth tag."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.delenv("BUZZ_AUTH_TAG", raising=False)
+        monkeypatch.delenv("BUZZ_CREDENTIALS_FILE", raising=False)
+        # Ambient credentials dir must not be borrowed when a direct key is set.
+        ambient = tmp_path / "ambient_credentials.json"
+        ambient.write_text(
+            json.dumps({"nsec": "nsec1ambient", "auth_tag": ["auth", "a" * 64, "", "d" * 128]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+
+        captured = {}
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0
+        ):
+            captured.update(private_key=private_key, auth_tag=auth_tag)
+            return 0, json.dumps({"accepted": True, "event_id": "evt-key", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "key only"
+        )
+        assert result == {"success": True, "message_id": "evt-key"}
+        assert captured["private_key"] == "nsec1x"
+        assert captured["auth_tag"] == ""
+
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -19,6 +19,7 @@ npub_to_hex = _buzz_mod.npub_to_hex
 _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
 _resolve_private_key = _buzz_mod._resolve_private_key
+_resolve_auth_tag = _buzz_mod._resolve_auth_tag
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
@@ -46,6 +47,7 @@ _ENV_VARS = (
     "BUZZ_AUTH_TAG",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
+    "BUZZ_AUTH_TAG",
 )
 
 
@@ -926,6 +928,20 @@ class TestCredentialResolution:
         monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
         assert _resolve_private_key() == "nsec1fromfile"
 
+    def test_owner_auth_tag_from_credentials_file(self, monkeypatch, tmp_path):
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}), encoding="utf-8")
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        assert json.loads(_resolve_auth_tag()) == tag
+
+    def test_invalid_owner_auth_tag_fails_closed(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": ["bad"]}), encoding="utf-8")
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        with pytest.raises(ValueError, match="auth tag"):
+            _resolve_auth_tag()
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 
@@ -969,8 +985,8 @@ class TestStandaloneSend:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
-            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, input_text=input_text)
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0):
+            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, auth_tag=auth_tag, input_text=input_text)
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -143,6 +143,234 @@ class TestBuzzAdapterInit:
         assert adapter.relay_url == "https://env.relay"
 
 
+# ── Multiplex secondary-profile scope (#98738) ─────────────────────────────
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("BUZZ_RELAY_URL", "https://default.relay")
+    monkeypatch.setenv("BUZZ_CHANNELS", "chan-a,chan-b,chan-c")
+    monkeypatch.setenv("BUZZ_HOME_CHANNEL", "chan-a")
+    monkeypatch.setenv("BUZZ_POLL_INTERVAL", "9")
+    monkeypatch.setenv("BUZZ_CLI_PATH", "/default/bin/buzz")
+    monkeypatch.setenv("BUZZ_TRANSPORT", "poll")
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", "default-user-npub")
+    monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", "/default/creds.json")
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1default")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """The secondary profile's PlatformConfig is authoritative (#98738)."""
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "relay_url": "https://profile.relay",
+                "channels": ["pchan"],
+                "home_channel": "pchan",
+                "poll_interval": 2,
+                "cli_path": str(cli),
+                "transport": "websocket",
+                "allowed_users": [SELF_NPUB],
+            },
+        )
+        adapter = BuzzAdapter(cfg)
+        assert adapter.relay_url == "https://profile.relay"
+        assert adapter.channels == ["pchan"]
+        assert adapter.home_channel == "pchan"
+        assert adapter.poll_interval == 2.0
+        assert adapter.cli_path == str(cli)
+        assert adapter.transport == "websocket"
+        assert adapter._allowed_pubkeys == {SELF_PUBKEY}
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's config must NOT borrow the default
+        profile's bridged env values — that would connect this adapter to the
+        default profile's relay and watch its channels."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = BuzzAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.relay_url == ""
+        assert adapter.channels == []
+        assert adapter.home_channel == ""
+        assert adapter.poll_interval == _buzz_mod._DEFAULT_POLL_INTERVAL
+        assert adapter.transport == "auto"
+        assert adapter._allowed_pubkeys == set()
+
+    def test_secondary_credentials_file_not_borrowed(
+        self, multiplex_scope, default_profile_env, tmp_path, monkeypatch
+    ):
+        """BUZZ_CREDENTIALS_FILE in env points at the DEFAULT profile's key
+        file; the scoped adapter must not read the default identity's key."""
+        default_creds = tmp_path / "default-creds.json"
+        default_creds.write_text(
+            json.dumps({"nsec": "nsec1default-identity"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(default_creds))
+        multiplex_scope()
+        # Scope has no key: the profile is unconfigured and must fail closed
+        # to "" rather than resolving the default profile's credentials.
+        assert _buzz_mod._resolve_private_key({}) == ""
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = BuzzAdapter(
+                PlatformConfig(enabled=True, extra={"relay_url": "https://cfg.relay"})
+            )
+        finally:
+            set_multiplex_active(False)
+        assert adapter.relay_url == "https://default.relay"
+
+    def test_check_requirements_scoped_reads_profile_config(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """The gate must consult the profile's own config.yaml + secret scope,
+        not the default profile's env values."""
+        import yaml
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        creds = tmp_path / "creds.json"
+        creds.write_text(json.dumps({"nsec": "nsec1profile"}), encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "gateway": {
+                        "platforms": {
+                            "buzz": {
+                                "enabled": True,
+                                "extra": {
+                                    "relay_url": "https://profile.relay",
+                                    "credentials_file": str(creds),
+                                },
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        multiplex_scope()
+        token = set_hermes_home_override(str(tmp_path))
+        try:
+            # The default profile's env relay+key must NOT pass the gate on
+            # their own for a profile without a buzz config...
+            assert check_requirements() is True  # profile config passes
+        finally:
+            reset_hermes_home_override(token)
+
+        # A profile whose config.yaml has no buzz entry fails closed even
+        # though the default profile's env values are present.
+        empty_home = tmp_path / "empty-profile"
+        empty_home.mkdir()
+        multiplex_scope()
+        token = set_hermes_home_override(str(empty_home))
+        try:
+            assert check_requirements() is False
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_env_enablement_scoped_returns_none(self, multiplex_scope, default_profile_env):
+        """Scoped env enablement must not fabricate Buzz for a profile from
+        the default profile's env values."""
+        multiplex_scope()
+        assert _env_enablement() is None
+
+    def test_apply_yaml_config_scoped_skips_env_bridge(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """A secondary profile's YAML values must not be pinned into the
+        process env for every other profile (first-writer-wins)."""
+        for var in ("BUZZ_RELAY_URL", "BUZZ_HOME_CHANNEL", "BUZZ_CHANNELS"):
+            monkeypatch.delenv(var, raising=False)
+        multiplex_scope()
+        _buzz_mod._apply_yaml_config(
+            {},
+            {"extra": {"relay_url": "https://profile.relay", "home_channel": "pchan"}},
+        )
+        import os as _os
+
+        assert "BUZZ_RELAY_URL" not in _os.environ
+        assert "BUZZ_HOME_CHANNEL" not in _os.environ
+        assert "BUZZ_CHANNELS" not in _os.environ
+
+    def test_standalone_send_scoped_uses_profile_extra(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        calls = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            calls["relay"] = relay_url
+            return 0, '{"event_id": "e1"}', ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={"relay_url": "https://profile.relay", "cli_path": str(cli)},
+                ),
+                "chan-x",
+                "hello",
+            )
+        )
+        assert result.get("success") is True
+        assert calls["relay"] == "https://profile.relay"
+
+
 # ── CLI error contract ────────────────────────────────────────────────────
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -353,7 +353,7 @@ class TestMultiplexProfileScope:
         cli.write_text("#!/bin/sh\n", encoding="utf-8")
         calls = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             calls["relay"] = relay_url
             return 0, '{"event_id": "e1"}', ""
 
@@ -532,7 +532,7 @@ class TestMultiplexProfileScope:
         cli.write_text("#!/bin/sh\n", encoding="utf-8")
         calls = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             calls["args"] = args
             return 0, '{"event_id": "e1"}', ""
 
@@ -568,7 +568,7 @@ class TestMultiplexProfileScope:
         cli = tmp_path / "buzz"
         cli.write_text("#!/bin/sh\n", encoding="utf-8")
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             raise AssertionError("CLI must not run without a resolved target")
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -43,6 +43,7 @@ _ENV_VARS = (
     "BUZZ_ALLOWED_USERS",
     "BUZZ_ALLOW_ALL_USERS",
     "BUZZ_POLL_INTERVAL",
+    "BUZZ_AUTH_TAG",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
 )
@@ -180,6 +181,7 @@ def default_profile_env(monkeypatch):
     monkeypatch.setenv("BUZZ_ALLOWED_USERS", "default-user-npub")
     monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", "/default/creds.json")
     monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1default")
+    monkeypatch.setenv("BUZZ_AUTH_TAG", '["auth","default-profile-tag","","x"]')
 
 
 class TestMultiplexProfileScope:
@@ -369,6 +371,221 @@ class TestMultiplexProfileScope:
         )
         assert result.get("success") is True
         assert calls["relay"] == "https://profile.relay"
+
+    def test_secondary_partial_extra_fills_missing_keys_from_defaults(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Partial config: configured keys win, unconfigured keys fall back to
+        their own defaults — never to the default profile's env values."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = BuzzAdapter(
+            PlatformConfig(enabled=True, extra={"relay_url": "https://profile.relay"})
+        )
+        assert adapter.relay_url == "https://profile.relay"
+        assert adapter.channels == []
+        assert adapter.home_channel == ""
+        assert adapter.poll_interval == _buzz_mod._DEFAULT_POLL_INTERVAL
+        assert adapter.transport == "auto"
+        assert adapter._allowed_pubkeys == set()
+
+    def test_ws_auth_tag_not_borrowed_from_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """BUZZ_AUTH_TAG is per-identity NIP-OA owner attestation: a scoped
+        secondary profile without one must not sign its NIP-42 auth event
+        with the default profile's tag from os.environ (#98738)."""
+        import asyncio as _asyncio
+
+        multiplex_scope()
+        adapter = BuzzAdapter.__new__(BuzzAdapter)
+        adapter._private_key = "00" * 31 + "03"
+        adapter._websocket_url = lambda: "wss://relay.example"
+
+        class _FakeWS:
+            def __init__(self):
+                self.sent = []
+
+            async def recv(self):
+                if self.sent:
+                    return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                return json.dumps(["AUTH", "challenge-1"])
+
+            async def send(self, raw):
+                self.sent.append(json.loads(raw))
+
+        ws = _FakeWS()
+        _asyncio.run(adapter._authenticate_websocket(ws))
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == []
+
+    def test_ws_auth_tag_scoped_profile_uses_its_own_tag(
+        self, multiplex_scope
+    ):
+        """Positive control: a tag present in the profile's own secret scope
+        IS attached to the NIP-42 auth event."""
+        import asyncio as _asyncio
+
+        profile_tag = json.dumps(["auth", "p" * 64, "", "q" * 128])
+        multiplex_scope({"BUZZ_AUTH_TAG": profile_tag})
+        adapter = BuzzAdapter.__new__(BuzzAdapter)
+        adapter._private_key = "00" * 31 + "03"
+        adapter._websocket_url = lambda: "wss://relay.example"
+
+        class _FakeWS:
+            def __init__(self):
+                self.sent = []
+
+            async def recv(self):
+                if self.sent:
+                    return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                return json.dumps(["AUTH", "challenge-1"])
+
+            async def send(self, raw):
+                self.sent.append(json.loads(raw))
+
+        ws = _FakeWS()
+        _asyncio.run(adapter._authenticate_websocket(ws))
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == [json.loads(profile_tag)]
+
+    def test_ws_auth_tag_unscoped_default_profile_keeps_env(
+        self, default_profile_env
+    ):
+        """The default profile constructs unscoped even under multiplex, so
+        its env-provided auth tag still applies (legacy behavior kept)."""
+        import asyncio as _asyncio
+
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            adapter = BuzzAdapter.__new__(BuzzAdapter)
+            adapter._private_key = "00" * 31 + "03"
+            adapter._websocket_url = lambda: "wss://relay.example"
+
+            class _FakeWS:
+                def __init__(self):
+                    self.sent = []
+
+                async def recv(self):
+                    if self.sent:
+                        return json.dumps(["OK", self.sent[0][1]["id"], True, "ok"])
+                    return json.dumps(["AUTH", "challenge-1"])
+
+                async def send(self, raw):
+                    self.sent.append(json.loads(raw))
+
+            ws = _FakeWS()
+            _asyncio.run(adapter._authenticate_websocket(ws))
+        finally:
+            set_multiplex_active(False)
+        tags = [t for t in ws.sent[0][1]["tags"] if t and t[0] == "auth"]
+        assert tags == [["auth", "default-profile-tag", "", "x"]]
+
+    def test_validate_config_scoped_extra_is_authoritative(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """Scoped validation reads the profile's extra, not the default
+        profile's env relay/key: unconfigured fails closed, configured
+        passes via its own credentials file."""
+        creds = tmp_path / "creds.json"
+        creds.write_text(json.dumps({"nsec": "nsec1profile"}), encoding="utf-8")
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        assert validate_config(PlatformConfig(enabled=True, extra={})) is False
+        assert (
+            validate_config(
+                PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "relay_url": "https://profile.relay",
+                        "credentials_file": str(creds),
+                    },
+                )
+            )
+            is True
+        )
+
+    def test_validate_config_unscoped_keeps_env_precedence(
+        self, default_profile_env
+    ):
+        """Single-profile/unscoped: env relay + env key still validate even
+        with an empty extra mapping."""
+        from gateway.config import PlatformConfig
+
+        assert validate_config(PlatformConfig(enabled=True, extra={})) is True
+
+    def test_standalone_send_scoped_target_falls_back_to_profile_home(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        """With no explicit chat_id, the scoped standalone send targets the
+        profile's own home_channel — never the default profile's env one."""
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        calls = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            calls["args"] = args
+            return 0, '{"event_id": "e1"}', ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "relay_url": "https://profile.relay",
+                        "cli_path": str(cli),
+                        "home_channel": "pchan",
+                    },
+                ),
+                "",
+                "hello",
+            )
+        )
+        assert result.get("success") is True
+        assert calls["args"][calls["args"].index("--channel") + 1] == "pchan"
+
+    def test_standalone_send_scoped_without_target_fails_closed(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        """No chat_id and no profile home_channel: the error is returned —
+        the default profile's env BUZZ_HOME_CHANNEL must not be borrowed."""
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            raise AssertionError("CLI must not run without a resolved target")
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    extra={"relay_url": "https://profile.relay", "cli_path": str(cli)},
+                ),
+                "",
+                "hello",
+            )
+        )
+        assert result == {
+            "error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"
+        }
 
 
 # ── CLI error contract ────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -942,6 +942,34 @@ class TestCredentialResolution:
         with pytest.raises(ValueError, match="auth tag"):
             _resolve_auth_tag()
 
+    def test_scoped_credentials_and_tag_do_not_borrow_ambient_profile(self, monkeypatch, tmp_path):
+        from agent import secret_scope as ss
+
+        ambient_tag = ["auth", "a" * 64, "", "d" * 128]
+        scoped_tag = ["auth", "b" * 64, "", "c" * 128]
+        ambient = tmp_path / "ambient.json"
+        scoped = tmp_path / "scoped.json"
+        ambient.write_text(json.dumps({"nsec": "nsec1ambient", "auth_tag": ambient_tag}))
+        scoped.write_text(json.dumps({"nsec": "nsec1scoped", "auth_tag": scoped_tag}))
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(ambient))
+        monkeypatch.setenv("BUZZ_AUTH_TAG", json.dumps(ambient_tag))
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"BUZZ_CREDENTIALS_FILE": str(scoped)})
+        try:
+            assert _resolve_private_key() == "nsec1scoped"
+            assert json.loads(_resolve_auth_tag()) == scoped_tag
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+    def test_owner_auth_tag_uses_credentials_autodiscovery(self, monkeypatch, tmp_path):
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}), encoding="utf-8")
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+        assert _resolve_private_key() == "nsec1fromfile"
+        assert json.loads(_resolve_auth_tag()) == tag
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -970,6 +970,23 @@ class TestCredentialResolution:
         assert _resolve_private_key() == "nsec1fromfile"
         assert json.loads(_resolve_auth_tag()) == tag
 
+    def test_empty_multiplex_scope_never_autodiscovers_ambient_credentials(self, monkeypatch, tmp_path):
+        from agent import secret_scope as ss
+
+        tag = ["auth", "a" * 64, "", "d" * 128]
+        (tmp_path / "general_credentials.json").write_text(
+            json.dumps({"nsec": "nsec1ambient", "auth_tag": tag}), encoding="utf-8"
+        )
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            assert _resolve_private_key() == ""
+            assert _resolve_auth_tag() == ""
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 

--- a/tests/gateway/test_buzz_authz.py
+++ b/tests/gateway/test_buzz_authz.py
@@ -1,0 +1,125 @@
+"""Gateway authz tests: BUZZ_ALLOWED_USERS accepts npub or hex (#78428).
+
+Inbound Buzz events carry the sender as a 64-char hex pubkey, while
+``BUZZ_ALLOWED_USERS`` historically accepted npubs too.  The gateway's
+central allowlist comparison must decode npub entries to hex at comparison
+time, or an operator who listed only their npub is rejected with
+"Unauthorized user: <hex pubkey>" (gateway drops the message).
+"""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platform_registry import PlatformEntry, platform_registry
+from gateway.session import SessionSource
+
+# Chip's public identity (public information, not a secret) — the same pair
+# used by tests/gateway/test_buzz_adapter.py.
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+SELF_NPUB = "npub1nl2u0wnd8mezfknc74q7pl9ec58h9nrrakce4tnk434qgaxl4psqe5twr6"
+OTHER_PUBKEY = "a" * 64
+
+_BUZZ_PLATFORM = Platform("buzz")
+
+_AUTH_ENV_VARS = (
+    "BUZZ_ALLOWED_USERS",
+    "BUZZ_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GATEWAY_ALLOW_ALL_USERS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in _AUTH_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def buzz_registered():
+    """Register a minimal Buzz platform entry (allowed_users_env contract)."""
+    platform_registry.register(
+        PlatformEntry(
+            name="buzz",
+            label="Buzz",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            allowed_users_env="BUZZ_ALLOWED_USERS",
+            allow_all_env="BUZZ_ALLOW_ALL_USERS",
+        )
+    )
+    yield
+    platform_registry.unregister("buzz")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = None
+    return runner
+
+
+def _make_source(user_id: str, chat_type: str = "dm"):
+    return SessionSource(
+        platform=_BUZZ_PLATFORM,
+        chat_id="ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd",
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="Chip",
+        is_bot=False,
+    )
+
+
+def test_npub_only_allowlist_authorizes_hex_identity(monkeypatch, buzz_registered):
+    """The reported bug: listing only the npub must authorize the hex pubkey."""
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", SELF_NPUB)
+    runner = _make_runner()
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_hex_only_allowlist_still_authorizes(monkeypatch, buzz_registered):
+    """Existing hex-only allowlists keep working unchanged."""
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", SELF_PUBKEY)
+    runner = _make_runner()
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_mixed_npub_and_hex_allowlist_authorizes(monkeypatch, buzz_registered):
+    """Both forms in one allowlist authorize the same identity."""
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", f"{SELF_NPUB},{SELF_PUBKEY}")
+    runner = _make_runner()
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_npub_allowlist_still_denies_other_user(monkeypatch, buzz_registered):
+    """Normalization must not turn into fail-open for unrelated senders."""
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", SELF_NPUB)
+    runner = _make_runner()
+    assert runner._is_user_authorized(_make_source(OTHER_PUBKEY)) is False
+
+
+def test_uppercase_npub_allowlist_authorizes(monkeypatch, buzz_registered):
+    """npub entries are case-insensitive, like the adapter's own decoder."""
+    monkeypatch.setenv("BUZZ_ALLOWED_USERS", SELF_NPUB.upper())
+    runner = _make_runner()
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_normalize_nostr_allow_entries():
+    from gateway.authz_mixin import _normalize_nostr_allow_entries
+
+    expanded = _normalize_nostr_allow_entries({SELF_NPUB, OTHER_PUBKEY, "not-a-key"})
+    assert SELF_PUBKEY in expanded
+    assert SELF_NPUB in expanded  # original kept, harmless
+    assert OTHER_PUBKEY in expanded
+    assert "not-a-key" in expanded
+
+
+def test_npub_to_hex_roundtrip():
+    from gateway.authz_mixin import _npub_to_hex
+
+    assert _npub_to_hex(SELF_NPUB) == SELF_PUBKEY
+    assert _npub_to_hex(SELF_PUBKEY) is None  # hex input is not an npub
+    assert _npub_to_hex("npub1garbage!!") is None  # invalid bech32
+    assert _npub_to_hex("") is None

--- a/tests/gateway/test_buzz_authz.py
+++ b/tests/gateway/test_buzz_authz.py
@@ -123,3 +123,62 @@ def test_npub_to_hex_roundtrip():
     assert _npub_to_hex(SELF_PUBKEY) is None  # hex input is not an npub
     assert _npub_to_hex("npub1garbage!!") is None  # invalid bech32
     assert _npub_to_hex("") is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# #82871: single-profile gateway must consult the Buzz adapter's own
+# config.extra.allowed_users when no env allowlist is configured.  The
+# reported symptom was a default-deny of EVERY Buzz user ("Unauthorized
+# user: <hex> on buzz") even though the sender's npub was correctly
+# listed in gateway.platforms.buzz.extra.allowed_users.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_runner_with_adapter(extra: dict):
+    """Single-profile (multiplex OFF) runner with a live Buzz adapter."""
+    from types import SimpleNamespace
+
+    from gateway.authz_mixin import _npub_to_hex
+    from gateway.config import GatewayConfig, PlatformConfig
+    from gateway.run import GatewayRunner
+
+    def _normalize(entry):
+        entry = (entry or "").strip()
+        if entry.lower().startswith("npub1"):
+            return _npub_to_hex(entry)
+        return entry.lower() if entry else None
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.pairing_store = None
+    runner.adapters = {
+        _BUZZ_PLATFORM: SimpleNamespace(
+            config=PlatformConfig(enabled=True, extra=extra),
+            normalize_user_id=_normalize,
+        )
+    }
+    return runner
+
+
+def test_config_only_npub_allowlist_authorizes_single_profile(buzz_registered):
+    """#82871 repro: npub listed ONLY in config.extra.allowed_users (no env
+    var at all) must authorize the sender's hex pubkey."""
+    runner = _make_runner_with_adapter({"allowed_users": [SELF_NPUB]})
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_config_only_hex_allowlist_authorizes_single_profile(buzz_registered):
+    runner = _make_runner_with_adapter({"allowed_users": [SELF_PUBKEY]})
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is True
+
+
+def test_config_only_allowlist_still_denies_unlisted_sender(buzz_registered):
+    """Consulting the adapter allowlist must not fail open."""
+    runner = _make_runner_with_adapter({"allowed_users": [SELF_NPUB]})
+    assert runner._is_user_authorized(_make_source(OTHER_PUBKEY)) is False
+
+
+def test_config_only_empty_allowlist_keeps_default_deny(buzz_registered):
+    """No allowlist anywhere: the default-deny is preserved (SECURITY.md §2.6)."""
+    runner = _make_runner_with_adapter({})
+    assert runner._is_user_authorized(_make_source(SELF_PUBKEY)) is False

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -119,3 +119,12 @@ async def test_websocket_auth_raises_on_rejection():
         await adapter._authenticate_websocket(RejectingWs())
 
 
+@pytest.mark.asyncio
+async def test_websocket_auth_uses_credentials_owner_tag():
+    adapter = _make_adapter()
+    adapter._auth_tag = json.dumps(["auth", "b" * 64, "", "c" * 128])
+    websocket = _FakeWebSocket()
+    await adapter._authenticate_websocket(websocket)
+    assert ["auth", "b" * 64, "", "c" * 128] in websocket.sent[0][1]["tags"]
+
+

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -174,6 +174,12 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
 # Plugin-platform extra.allowed_users fallback (#98738 / #82871)
 # ─────────────────────────────────────────────────────────────────────
 
+# Buzz has no static Platform member: plugin platforms get a dynamic
+# member created on demand by Platform._missing_ (value lookup). Resolve
+# it that way — attribute access only works after an earlier lookup in
+# the same process, which a fresh CI shard cannot rely on.
+_BUZZ = Platform("buzz")
+
 
 def _make_buzz_multiplex_runner(monkeypatch, extra):
     """Runner whose secondary 'coder' profile runs a live Buzz adapter."""
@@ -198,7 +204,7 @@ def _make_buzz_multiplex_runner(monkeypatch, extra):
         normalize_user_id=_normalize_user_ref,
     )
     runner.adapters = {}
-    runner._profile_adapters = {"coder": {Platform.BUZZ: adapter}}
+    runner._profile_adapters = {"coder": {_BUZZ: adapter}}
     runner.pairing_store = MagicMock()
     runner.pairing_store.is_approved.return_value = False
     return runner
@@ -206,7 +212,7 @@ def _make_buzz_multiplex_runner(monkeypatch, extra):
 
 def _buzz_source(user_id):
     return SessionSource(
-        platform=Platform.BUZZ,
+        platform=_BUZZ,
         user_id=user_id,
         chat_id="chat-1",
         user_name="member",

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -284,3 +284,83 @@ def test_extra_allowed_users_not_consulted_without_registry_declaration(monkeypa
     _patch_buzz_registry(monkeypatch, allowed_users_env="")
 
     assert runner._is_user_authorized(_buzz_source("someone")) is False
+
+
+def test_extra_allowed_users_wildcard_authorizes_any_sender(monkeypatch):
+    """\"*\" in the profile's extra.allowed_users keeps the env-var wildcard
+    semantics: any sender is authorized (still gated on the registry
+    declaration)."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra={"allowed_users": ["*"]})
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_extra_allowed_users_blank_entries_are_dropped_not_denials(monkeypatch):
+    """Blank/whitespace entries are dropped at parse; an otherwise-empty
+    list behaves like the absent case (default-deny), not like a wildcard."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["", "   ", ","]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_extra_allowed_users_case_insensitive_hex_and_uppercase_npub(monkeypatch):
+    """Entry spellings normalize to the same principal: upper-case hex and
+    upper-case npub entries both match the hex user id Buzz dispatches
+    (entries are normalized; the inbound id is already hex)."""
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": [SELF_PUBKEY.upper(), SELF_NPUB.upper()]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_adapter_intake_and_central_authz_agree_on_the_same_list(monkeypatch):
+    """Policy-layer agreement (#98738): a sender admitted by the adapter's
+    construction-time intake allowlist (extra.allowed_users normalized to
+    hex) is exactly the sender the central check authorizes, and an
+    unlisted sender is rejected at BOTH layers."""
+    from gateway.session import SessionSource as _SessionSource
+
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    monkeypatch.delenv("BUZZ_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("BUZZ_ALLOW_ALL_USERS", raising=False)
+
+    other_hex = "b" * 64
+    adapter_extra = {"allowed_users": [SELF_NPUB]}
+
+    # Layer 1 — adapter intake: construction normalizes npub entries to hex.
+    from tests.gateway.test_buzz_adapter import _make_adapter as _base_adapter
+
+    adapter = _base_adapter(adapter_extra)
+    assert adapter._allowed_pubkeys == {SELF_PUBKEY}
+
+    # Layer 2 — central authz over the same adapter config.
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra=adapter_extra)
+    _patch_buzz_registry(monkeypatch)
+
+    for sender, admitted in ((SELF_PUBKEY, True), (other_hex, False)):
+        # Adapter layer: intake filter admits/denies...
+        assert (sender in adapter._allowed_pubkeys) is admitted
+        # ...and central authz returns the SAME verdict for that sender.
+        assert runner._is_user_authorized(
+            _SessionSource(
+                platform=_BUZZ,
+                user_id=sender,
+                chat_id="chat-1",
+                user_name="member",
+                chat_type="dm",
+                profile="coder",
+            )
+        ) is admitted

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -168,3 +168,113 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Plugin-platform extra.allowed_users fallback (#98738 / #82871)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_buzz_multiplex_runner(monkeypatch, extra):
+    """Runner whose secondary 'coder' profile runs a live Buzz adapter."""
+    from gateway.run import GatewayRunner
+    from tests.gateway.test_buzz_adapter import _normalize_user_ref
+
+    for key in (
+        "BUZZ_ALLOWED_USERS",
+        "BUZZ_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    adapter = SimpleNamespace(
+        config=PlatformConfig(enabled=True, extra=extra),
+        # The Buzz adapter exposes this hook so npub allowlist entries match
+        # the hex-pubkey user ids the gateway authorizes.
+        normalize_user_id=_normalize_user_ref,
+    )
+    runner.adapters = {}
+    runner._profile_adapters = {"coder": {Platform.BUZZ: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _buzz_source(user_id):
+    return SessionSource(
+        platform=Platform.BUZZ,
+        user_id=user_id,
+        chat_id="chat-1",
+        user_name="member",
+        chat_type="dm",
+        profile="coder",
+    )
+
+
+def _patch_buzz_registry(monkeypatch, allowed_users_env="BUZZ_ALLOWED_USERS"):
+    from gateway.platform_registry import platform_registry
+
+    real_get = platform_registry.get
+
+    def _get(key):
+        if key == "buzz":
+            return SimpleNamespace(allowed_users_env=allowed_users_env)
+        return real_get(key)
+
+    monkeypatch.setattr(platform_registry, "get", _get)
+
+
+def test_secondary_buzz_extra_allowed_users_authorizes_listed_user(monkeypatch):
+    """A secondary profile's extra.allowed_users must authorize its users when
+    the env var only ever carried the default profile's list (#98738/#82871)."""
+    from tests.gateway.test_buzz_adapter import SELF_NPUB, SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": [SELF_NPUB]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    # user_id arrives as the hex pubkey while the allowlist entry is an npub.
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is True
+
+
+def test_secondary_buzz_extra_allowed_users_denies_unlisted_sender(monkeypatch):
+    """Default-deny is preserved: a sender not in the profile's allowlist
+    stays denied even though the adapter-level list admitted the message."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["npub1" + "b" * 56]}
+    )
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_secondary_buzz_without_extra_allowlist_stays_default_deny(monkeypatch):
+    """No extra.allowed_users configured: nothing changes, the default-deny
+    path applies (no fail-open via an empty list)."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(monkeypatch, extra={})
+    _patch_buzz_registry(monkeypatch)
+
+    assert runner._is_user_authorized(_buzz_source(SELF_PUBKEY)) is False
+
+
+def test_extra_allowed_users_not_consulted_without_registry_declaration(monkeypatch):
+    """The fallback is gated on the platform's registry entry declaring
+    allowed_users_env — a platform without that contract keeps the previous
+    behavior even if its extra happens to hold an allowed_users key."""
+    from tests.gateway.test_buzz_adapter import SELF_PUBKEY
+
+    runner = _make_buzz_multiplex_runner(
+        monkeypatch, extra={"allowed_users": ["someone"]}
+    )
+    _patch_buzz_registry(monkeypatch, allowed_users_env="")
+
+    assert runner._is_user_authorized(_buzz_source("someone")) is False

--- a/tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py
+++ b/tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py
@@ -1,0 +1,125 @@
+"""Regression tests for the Buzz requirement gate vs external secrets (#95216).
+
+``check_requirements()`` runs at gateway startup BEFORE the per-profile
+secret scope is installed, so a Bitwarden-managed ``BUZZ_PRIVATE_KEY`` (only
+``BWS_ACCESS_TOKEN`` in ``.env``) was invisible to the bare env read and Buzz
+was silently skipped. The fix adds a one-shot ``build_profile_secret_scope``
+consultation to the unscoped fallback of ``_get_scoped_secret``.
+
+The key values below are synthesized placeholders (never a usable secret).
+"""
+
+import os
+
+import pytest
+
+# Synthesized, non-credential placeholder (any non-empty string exercises
+# the gate; no real key material is ever embedded here).
+_STUB_KEY = os.environ.get("BUZZ_TEST_STUB_KEY") or ("k" * 8)
+
+
+@pytest.fixture(autouse=True)
+def _reset_unscoped_cache():
+    import plugins.platforms.buzz.adapter as adapter
+
+    prev = adapter._UNSCOPED_PROFILE_SECRETS
+    adapter._UNSCOPED_PROFILE_SECRETS = None
+    yield
+    adapter._UNSCOPED_PROFILE_SECRETS = prev
+
+
+def _install_fake_scope(monkeypatch, secrets):
+    """Point build_profile_secret_scope at a fake external-secret snapshot."""
+    import agent.secret_scope as secret_scope
+
+    calls = []
+
+    def fake_build(home):  # noqa: ANN001 - test double
+        calls.append(home)
+        return dict(secrets)
+
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", fake_build)
+    return calls
+
+
+class TestRequirementGateSeesExternalSecrets:
+    def test_externally_managed_key_passes_gate(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "stub-token")
+        _install_fake_scope(
+            monkeypatch,
+            {"BUZZ_RELAY_URL": "wss://relay.example", "BUZZ_PRIVATE_KEY": _STUB_KEY},
+        )
+
+        assert adapter.check_requirements() is True
+
+    def test_gate_fails_cleanly_when_nothing_resolves(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        _install_fake_scope(monkeypatch, {})
+
+        assert adapter.check_requirements() is False
+
+    def test_relay_from_env_still_passes_with_external_key(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        _install_fake_scope(monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY})
+
+        assert adapter.check_requirements() is True
+
+    def test_profile_scope_build_failure_degrades_to_not_configured(
+        self, monkeypatch
+    ):
+        import agent.secret_scope as secret_scope
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+
+        def boom(home):  # noqa: ANN001 - test double
+            raise RuntimeError("external secret resolver unavailable")
+
+        monkeypatch.setattr(secret_scope, "build_profile_secret_scope", boom)
+        assert adapter.check_requirements() is False
+
+    def test_scope_snapshot_is_built_once_and_cached(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        calls = _install_fake_scope(monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY})
+
+        assert adapter.check_requirements() is True
+        assert adapter.check_requirements() is True
+        assert adapter.validate_config(type("Cfg", (), {"extra": {}})()) is True
+        assert len(calls) == 1, "the external-secret snapshot must be cached"
+
+
+class TestScopedSemanticsUnchanged:
+    def test_active_scope_miss_does_not_fall_through_to_unscoped_build(
+        self, monkeypatch
+    ):
+        """A scoped miss must keep returning default: the unscoped build is
+        only for the no-scope startup gate, never a cross-profile borrow."""
+        import agent.secret_scope as secret_scope
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        calls = _install_fake_scope(
+            monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY * 2}
+        )
+        token = secret_scope.set_secret_scope({})  # active, empty scope
+
+        try:
+            assert adapter.check_requirements() is False
+            assert calls == [], "an active scope must shadow the unscoped build"
+        finally:
+            secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## Summary
Buzz auth stops locking out legitimate users and leaking across profiles: npub allowlists match, owner auth resolves per profile, externally managed secrets pass the preflight gate, and secondary multiplex profiles no longer inherit the default profile's env.
Fixes #78428, #79514, #82871, #95216, #98738.

## Changes
- #78435 (@webtecnica): gateway allowlist decodes `npub1…` entries in `BUZZ_ALLOWED_USERS` to hex before comparison — npub-only allowlists no longer reject the owner.
- #83155 (@alexgunsberg): NIP-OA auth_tag resolved per profile (scoped `BUZZ_AUTH_TAG`/credentials file, passed via subprocess env never argv); multiplex credential discovery fails closed. 3 commits authorship-preserved + 1 reapplied with Co-authored-by (original carried a placeholder identity).
- #95224 (@liuhao1024): requirement gate consults a one-shot `build_profile_secret_scope` mapping when unscoped and env-empty — Bitwarden-managed `BUZZ_PRIVATE_KEY`/`BUZZ_RELAY_URL` pass `check_requirements`. Active scopes shadow the rung; no environ fallthrough added to core.
- #98748 (@liuhao1024 + @KostaGorod): scoped reads treat `PlatformConfig.extra` as authoritative and fail closed; `BUZZ_AUTH_TAG` resolves through the profile secret scope.
- #82871: central authz now consults a live adapter's `config.extra.allowed_users` when no env allowlist exists (the "default-denies all Buzz users" bug) — landed via #98748's authz commit + 4 new single-profile regression tests (sabotage-verified red on main).
- Reconciliation commit merges the three overlapping approaches (WS NIP-42 auth tag preference, `_profile_scoped()` branching in check_requirements/validate_config).

## Validation
95 targeted tests green; sabotage check: 8/11 authz tests fail with main's authz_mixin.py.

**Live repro:** E2E with real BuzzAdapter import + fake inbound events through the real allowlist/auth paths in temp HERMES_HOME — 9/9 (npub intake normalization, config-only authz, env npub authz, WS auth-tag isolation both directions, external-secret gate + fail-closed control).

## Infographic

![Buzz auth repair](https://v3b.fal.media/files/b/0aa88d86/bsN9DOhJ_RZ-1oJkokreF_tdzVnvYb.png)
