### PR TITLE
fix(buzz): replies join the existing thread, threading is configurable, and streaming edits work (salvages #77080 #79578 #80120 #85613 #86232 #89868)

### DIFF
--- a/contributors/emails/nanakoice@NanakoIces-Mac-mini.local
+++ b/contributors/emails/nanakoice@NanakoIces-Mac-mini.local
@@ -1,0 +1,1 @@
+nanakoice

--- a/contributors/emails/nntruonghan@gmail.com
+++ b/contributors/emails/nntruonghan@gmail.com
@@ -1,0 +1,1 @@
+tieubao

--- a/contributors/emails/tom@clientspike.com
+++ b/contributors/emails/tom@clientspike.com
@@ -1,0 +1,1 @@
+tomwattsca

--- a/contributors/emails/yuvalfis@users.noreply.github.com
+++ b/contributors/emails/yuvalfis@users.noreply.github.com
@@ -1,0 +1,1 @@
+yuvalfis

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -149,6 +149,12 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "mattermost":      _TIER_MEDIUM,
     "matrix":          _TIER_MEDIUM,
     "feishu":          _TIER_MEDIUM,
+    # Buzz (Nostr relay via buzz-cli): messages can be edited in place
+    # (`buzz messages edit`), so grouped/accumulating progress works, but
+    # channels are shared community spaces — keep the medium tier. Without
+    # this entry Buzz inherited the verbose _GLOBAL_DEFAULTS and every
+    # interim update became a separate permanent channel post (#95841).
+    "buzz":            _TIER_MEDIUM,
 
     # Tier 3 — no edit support, progress messages are permanent
     "signal":          _TIER_LOW,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30069,6 +30069,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and source.thread_id
                 and event_message_id
             )
+            or (
+                # Buzz has no native thread_id; threading is always via reply-to
+                # the triggering event id (channel clutter otherwise).
+                str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz"
+                and event_message_id
+            )
             or _relay_prospective_thread_id
             else None
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1180,7 +1180,7 @@ def _resolve_progress_thread_id(
         return str(source_thread_id) if source_thread_id else None
     if source_thread_id:
         return str(source_thread_id)
-    if platform_key in {"slack", "mattermost"} and event_message_id:
+    if platform_key in {"slack", "mattermost", "buzz"} and event_message_id:
         return str(event_message_id)
     return None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30016,6 +30016,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 except Exception:
                     _progress_reply_in_thread = True
+        elif str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz":
+            # Buzz honours the same opt-out (reply_to_mode: off /
+            # extra.reply_in_thread: false). When the user asked for flat
+            # channel replies, progress must not synthesise a thread either.
+            _buzz_adapter_for_progress = self._adapter_for_source(source)
+            if _buzz_adapter_for_progress is not None:
+                try:
+                    _progress_reply_in_thread = (
+                        getattr(_buzz_adapter_for_progress, "_reply_to_mode", "first")
+                        != "off"
+                    )
+                except Exception:
+                    _progress_reply_in_thread = True
         _progress_thread_id = _resolve_progress_thread_id(
             source.platform, source.thread_id, event_message_id,
             reply_in_thread=_progress_reply_in_thread,
@@ -30071,9 +30084,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             or (
                 # Buzz has no native thread_id; threading is always via reply-to
-                # the triggering event id (channel clutter otherwise).
+                # the triggering event id (channel clutter otherwise). Skipped
+                # when the user opted out of threaded replies.
                 str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz"
                 and event_message_id
+                and _progress_reply_in_thread
             )
             or _relay_prospective_thread_id
             else None

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2712,11 +2712,12 @@ class GatewayStreamConsumer:
             # draft(final=true) — that would seal the live stream with
             # interim text and orphan the true final into a plain-send
             # duplicate (live finding, 2026-08-16 canary).
-            _md = dict(self.metadata) if self.metadata else {}
+            _md = self._metadata_for_send(final=False) or {}
             _md["_interim_send"] = True
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self._initial_reply_to_id,
                 metadata=_md,
             )
             # Note: do NOT set _already_sent = True here.

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -611,7 +611,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = (metadata or {}).get("thread_id") or reply_to
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -758,8 +758,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = (metadata or {}).get("thread_id") or reply_to
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1124,6 +1125,23 @@ class BuzzAdapter(BasePlatformAdapter):
         # open with "@Chip" even though no mention is required there, so the
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
+        tags = event.get("tags")
+        thread_id = (
+            next(
+                (
+                    str(tag[1])
+                    for tag in tags
+                    if isinstance(tag, (list, tuple))
+                    and len(tag) > 3
+                    and tag[0] == "e"
+                    and tag[1]
+                    and tag[3] == "root"
+                ),
+                None,
+            )
+            if isinstance(tags, list)
+            else None
+        )
 
         await self._dispatch_message(
             text=dispatch_text,
@@ -1133,6 +1151,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=thread_id,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1296,6 +1315,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1307,6 +1327,7 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -666,6 +666,81 @@ class BuzzAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Edit a previously sent message.
+
+        Implementing this is what lets the gateway stream a reply on Buzz: the
+        stream consumer sends a first partial message and then re-edits that one
+        message as tokens arrive.  Without it the adapter inherits the base
+        stub, which returns ``success=False``, and the whole answer is delivered
+        in one block when the turn finishes.
+
+        ``buzz-cli`` reports a NEW event id for the edit itself, but the edit
+        TARGET stays the original id, and the stream consumer holds a single
+        ``message_id`` across the whole stream.  So this returns the id it was
+        given, not the one the CLI reports; returning the CLI's id would make
+        every edit after the first address a message that was never sent.
+
+        ``finalize`` is a no-op here.  Buzz edits carry no lifecycle state, the
+        same as Telegram, Slack and Discord.
+        """
+        if not message_id:
+            return SendResult(success=False, error="Buzz edit needs a message id")
+        if not content:
+            return SendResult(success=False, error="Empty message")
+        args = ["messages", "edit", "--event", str(message_id), "--content", "-"]
+        code, out, err = await self._run_cli(args, input_text=content)
+        if code != 0:
+            return SendResult(
+                success=False,
+                error=_cli_error_message(err, code),
+                retryable=code == 2,
+            )
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            data = {}
+        edit_event_id = data.get("event_id")
+        if edit_event_id:
+            # The edit is itself an event on the relay and comes back on our own
+            # subscription; mark it seen so the de-dupe does not treat our own
+            # edit as inbound traffic.
+            self._mark_seen(str(chat_id), str(edit_event_id))
+        return SendResult(
+            success=bool(data.get("accepted", True)),
+            message_id=str(message_id),
+            raw_response=data,
+        )
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent message.
+
+        Used by the stream consumer's fresh-final cleanup path, which replaces a
+        long-lived preview with a completed reply rather than editing in place.
+        """
+        if not message_id:
+            return False
+        code, out, _err = await self._run_cli(
+            ["messages", "delete", "--event", str(message_id)]
+        )
+        if code != 0:
+            return False
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            return True
+        event_id = data.get("event_id")
+        if event_id:
+            self._mark_seen(str(chat_id), str(event_id))
+        return bool(data.get("accepted", True))
+
     async def send_image(
         self,
         chat_id: str,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -624,8 +624,13 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
+        # Prefer the stable thread anchor from metadata.thread_id (Slack-style),
+        # then metadata.reply_to_message_id (gateway stream consumer /
+        # progress sends), then the explicit reply_to argument.  Without
+        # reply_to_message_id, interim commentary posts flat in the channel.
+        meta = metadata or {}
         reply_target = self._resolve_reply_anchor(
-            (metadata or {}).get("thread_id") or reply_to
+            meta.get("thread_id") or meta.get("reply_to_message_id") or reply_to
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -392,6 +392,15 @@ class BuzzAdapter(BasePlatformAdapter):
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
 
+        # Reply anchoring: "first"/"all" thread the reply onto the parent event
+        # id, "off" posts every reply as a normal top-level channel message.
+        # Mirrors the Discord/Telegram adapters, which already honor this
+        # PlatformConfig field; without it Buzz threaded unconditionally.
+        # Env (BUZZ_REPLY_TO_MODE) overrides config.yaml.
+        _rtm = (os.getenv("BUZZ_REPLY_TO_MODE") or getattr(config, "reply_to_mode", "first")
+                or "first")
+        self._reply_to_mode: str = str(_rtm).strip().lower()
+
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
@@ -612,7 +621,7 @@ class BuzzAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = (metadata or {}).get("thread_id") or reply_to
-        if reply_target:
+        if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
@@ -759,7 +768,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--content", "-",
             ]
             reply_target = (metadata or {}).get("thread_id") or reply_to
-            if reply_target:
+            if reply_target and self._reply_to_mode != "off":
                 args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
@@ -1484,7 +1493,11 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
-    if thread_id:
+    # Same reply_to_mode gate as the live adapter, so out-of-process cron
+    # delivery (deliver=buzz) doesn't thread when the operator asked for flat.
+    _rtm = (os.getenv("BUZZ_REPLY_TO_MODE")
+            or getattr(pconfig, "reply_to_mode", "first") or "first")
+    if thread_id and str(_rtm).strip().lower() != "off":
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
         args += ["--file", str(path)]

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -445,6 +445,10 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
         self._poll_count = 0
+        # inbound event_id -> thread root event id, or None when that message
+        # was itself top-level.  Lets send() mirror the user's own threading
+        # instead of opening a new thread under every reply (see _thread_root).
+        self._thread_roots: "OrderedDict[str, Optional[str]]" = OrderedDict()
 
     @property
     def name(self) -> str:
@@ -620,7 +624,9 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = (metadata or {}).get("thread_id") or reply_to
+        reply_target = self._resolve_reply_anchor(
+            (metadata or {}).get("thread_id") or reply_to
+        )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -767,7 +773,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            reply_target = (metadata or {}).get("thread_id") or reply_to
+            reply_target = self._resolve_reply_anchor(
+                (metadata or {}).get("thread_id") or reply_to
+            )
             if reply_target and self._reply_to_mode != "off":
                 args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
@@ -1152,6 +1160,10 @@ class BuzzAdapter(BasePlatformAdapter):
             else None
         )
 
+        # Remember where this message sits in the thread graph so our reply
+        # can join the SAME thread rather than nesting a new one under it.
+        self._record_thread_root(event_id, event)
+
         await self._dispatch_message(
             text=dispatch_text,
             chat_id=channel_id,
@@ -1314,6 +1326,76 @@ class BuzzAdapter(BasePlatformAdapter):
         if state is not None:
             state["seen"][event_id] = None
             self._trim_seen(state)
+
+    # ── Thread anchoring ──────────────────────────────────────────────────
+    #
+    # NIP-10 marked ``e`` tags: a reply carries ["e", <root>, "", "root"] plus
+    # ["e", <parent>, "", "reply"]; a message that STARTS a thread carries a
+    # single ["e", <parent>, "", "reply"] and no root marker.
+    #
+    # The gateway hands adapters the triggering message's own id as the reply
+    # anchor.  Anchoring to that id is correct for a top-level message (it
+    # opens the thread the user expects), but inside an existing thread it
+    # nests a fresh sub-thread under every single answer.  Buzz renders that
+    # as an endless ladder of one-message threads.
+    #
+    # Fix: remember each inbound message's thread ROOT.  When the trigger was
+    # already inside a thread, reply against that root so our answer lands in
+    # the same thread the user is typing in.  When it was top-level, keep the
+    # existing behaviour and anchor to the message itself.
+
+    _THREAD_ROOT_CACHE = 512
+
+    @staticmethod
+    def _extract_thread_root(event: dict) -> Optional[str]:
+        """Return the NIP-10 thread root of ``event``, or None if top-level."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return None
+        root = None
+        reply = None
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 2:
+                continue
+            if str(tag[0]) != "e":
+                continue
+            marker = str(tag[3]).lower() if len(tag) > 3 else ""
+            if marker == "root":
+                root = str(tag[1])
+            elif marker == "reply":
+                reply = str(tag[1])
+            elif not marker and reply is None:
+                # Unmarked (deprecated positional) e-tag: treat as the parent.
+                reply = str(tag[1])
+        if root:
+            return root
+        # A lone "reply" e-tag means this message started a thread hanging off
+        # <reply>; that parent IS the thread root for anything that follows.
+        return reply
+
+    def _record_thread_root(self, event_id: str, event: dict) -> None:
+        """Cache the thread root for an inbound message id."""
+        if not event_id:
+            return
+        roots = getattr(self, "_thread_roots", None)
+        if roots is None:
+            roots = self._thread_roots = OrderedDict()
+        roots[event_id] = self._extract_thread_root(event)
+        roots.move_to_end(event_id)
+        while len(roots) > self._THREAD_ROOT_CACHE:
+            roots.popitem(last=False)
+
+    def _resolve_reply_anchor(self, anchor: Optional[str]) -> Optional[str]:
+        """Map a gateway reply anchor onto the right Buzz thread anchor.
+
+        Returns the thread root when the triggering message was already inside
+        a thread (so the reply joins it), otherwise the anchor unchanged (so a
+        reply to a top-level message opens one thread, as before).
+        """
+        if not anchor:
+            return anchor
+        roots = getattr(self, "_thread_roots", None) or {}
+        return roots.get(str(anchor)) or anchor
 
     async def _dispatch_message(
         self,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,11 +25,12 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+            reply_in_thread: true      # false = post replies flat to the channel timeline
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS
+    BUZZ_ALLOW_ALL_USERS, BUZZ_REPLY_IN_THREAD, BUZZ_REPLY_TO_MODE
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
 ``~/.hermes/.env``.  It is passed to the CLI via the subprocess
@@ -400,6 +401,14 @@ class BuzzAdapter(BasePlatformAdapter):
         _rtm = (os.getenv("BUZZ_REPLY_TO_MODE") or getattr(config, "reply_to_mode", "first")
                 or "first")
         self._reply_to_mode: str = str(_rtm).strip().lower()
+        # Slack-convention alias: platforms.buzz.extra.reply_in_thread: false
+        # (the key users already know from Slack) opts out of threading the
+        # same way reply_to_mode: off does. Env (BUZZ_REPLY_IN_THREAD)
+        # overrides config.yaml. See #95842 / #75082.
+        _rit_raw = os.getenv("BUZZ_REPLY_IN_THREAD")
+        _rit = extra.get("reply_in_thread") if _rit_raw is None else _rit_raw
+        if _rit is not None and str(_rit).strip().lower() in ("false", "0", "no", "off"):
+            self._reply_to_mode = "off"
 
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
@@ -1147,23 +1156,10 @@ class BuzzAdapter(BasePlatformAdapter):
         # open with "@Chip" even though no mention is required there, so the
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
-        tags = event.get("tags")
-        thread_id = (
-            next(
-                (
-                    str(tag[1])
-                    for tag in tags
-                    if isinstance(tag, (list, tuple))
-                    and len(tag) > 3
-                    and tag[0] == "e"
-                    and tag[1]
-                    and tag[3] == "root"
-                ),
-                None,
-            )
-            if isinstance(tags, list)
-            else None
-        )
+        # NIP-10 thread root for session scoping: replies inside a thread all
+        # share the root as their thread_id, so the gateway groups them into
+        # one thread session (marked "root" tag preferred, legacy fallback).
+        thread_id = self._extract_thread_root(event)
 
         # Remember where this message sits in the thread graph so our reply
         # can join the SAME thread rather than nesting a new one under it.
@@ -1510,6 +1506,10 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
+    if "reply_in_thread" in extra and not os.getenv("BUZZ_REPLY_IN_THREAD"):
+        os.environ["BUZZ_REPLY_IN_THREAD"] = str(extra["reply_in_thread"]).lower()
+    if "reply_to_mode" in extra and not os.getenv("BUZZ_REPLY_TO_MODE"):
+        os.environ["BUZZ_REPLY_TO_MODE"] = str(extra["reply_to_mode"]).lower()
     return None
 
 
@@ -1580,11 +1580,18 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
-    # Same reply_to_mode gate as the live adapter, so out-of-process cron
-    # delivery (deliver=buzz) doesn't thread when the operator asked for flat.
+    # Same reply_to_mode / reply_in_thread gate as the live adapter, so
+    # out-of-process cron delivery (deliver=buzz) doesn't thread when the
+    # operator asked for flat channel replies.
     _rtm = (os.getenv("BUZZ_REPLY_TO_MODE")
             or getattr(pconfig, "reply_to_mode", "first") or "first")
-    if thread_id and str(_rtm).strip().lower() != "off":
+    _rtm = str(_rtm).strip().lower()
+    _rit = os.getenv("BUZZ_REPLY_IN_THREAD")
+    if _rit is None:
+        _rit = extra.get("reply_in_thread")
+    if _rit is not None and str(_rit).strip().lower() in ("false", "0", "no", "off"):
+        _rtm = "off"
+    if thread_id and _rtm != "off":
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
         args += ["--file", str(path)]

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -57,3 +57,7 @@ optional_env:
     description: "JSON credentials file holding the nsec (fallback when BUZZ_PRIVATE_KEY is unset)"
     prompt: "Credentials file path (or empty)"
     password: false
+  - name: BUZZ_REPLY_IN_THREAD
+    description: "Thread replies under the triggering message (true/false, default: true); false posts flat to the channel timeline"
+    prompt: "Reply in thread? (true/false)"
+    password: false

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -538,3 +538,131 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+# ── Editing and deleting (streaming) ──────────────────────────────────
+
+
+class TestBuzzAdapterEdit:
+
+    @pytest.mark.asyncio
+    async def test_edit_targets_the_original_event_and_uses_stdin(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "partial answer")
+        assert result.success is True
+
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "edit"]
+        assert args[args.index("--event") + 1] == "orig1"
+        # Content travels via stdin (--content -), never argv, same as send
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "partial answer"
+
+    @pytest.mark.asyncio
+    async def test_edit_returns_the_original_id_not_the_cli_event_id(self):
+        """The stream consumer re-edits ONE message id for the whole stream.
+
+        buzz-cli reports a fresh event id for each edit; returning that would
+        make the second edit address a message that was never sent.
+        """
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert result.message_id == "orig1"
+
+    @pytest.mark.asyncio
+    async def test_edit_marks_its_own_event_seen(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert "edit1" in adapter._channel_state[CHANNEL]["seen"]
+
+    @pytest.mark.asyncio
+    async def test_edit_accepts_finalize_without_changing_behaviour(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "text", finalize=True)
+        assert result.success is True
+        assert len(cli.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_edit_without_a_message_id_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "", "text")
+        assert result.success is False
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_edit_with_empty_content_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "")
+        assert result.success is False
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_edit_relay_error_is_retryable_but_bad_input_is_not(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", "", code=2, stderr="relay unreachable")
+        adapter._run_cli = cli
+        relay_failure = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert relay_failure.success is False
+        assert relay_failure.retryable is True
+
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", "", code=1, stderr="bad input")
+        adapter._run_cli = cli
+        input_failure = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert input_failure.success is False
+        assert input_failure.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_delete_targets_the_event(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "delete", {"accepted": True, "event_id": "del1"})
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "orig1") is True
+        assert cli.calls[0][0] == ["messages", "delete", "--event", "orig1"]
+
+    @pytest.mark.asyncio
+    async def test_delete_failure_returns_false(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "delete", "", code=2, stderr="relay unreachable")
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "orig1") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_without_a_message_id_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "") is False
+        assert cli.calls == []

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,22 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_uses_reply_to_flag(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "working",
+            metadata={"thread_id": "buzz-event-123"},
+        )
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "buzz-event-123"
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -398,6 +398,8 @@ class TestThreadRoots:
 
         adapter._message_handler = AsyncMock()
         adapter.handle_message = capture
+        adapter._run_cli = _ScriptedCli()
+        adapter.send_reaction = AsyncMock(return_value=True)
         event = _tagged_event("latest-child", CHANNEL, content="@Chip follow-up")
         event["tags"] += [
             ["e", "stable-root", "", "root"],

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -381,6 +381,34 @@ class TestDmClassification:
         assert a._may_reclassify_as_dm(CHANNEL) is False
 
 
+class TestThreadRoots:
+
+    @pytest.mark.asyncio
+    async def test_inbound_root_e_tag_propagates_to_session_source(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = capture
+        event = _tagged_event("latest-child", CHANNEL, content="@Chip follow-up")
+        event["tags"] += [
+            ["e", "stable-root", "", "root"],
+            ["e", "latest-parent", "", "reply"],
+        ]
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        assert dispatched[0].source.thread_id == "stable-root"
+
+
 # ── Sending ───────────────────────────────────────────────────────────────
 
 
@@ -425,6 +453,24 @@ class TestBuzzAdapterSend:
         assert args[args.index("--reply-to") + 1] == "buzz-event-123"
 
     @pytest.mark.asyncio
+    async def test_send_prefers_stable_thread_root_over_latest_reply(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124"})
+        adapter._run_cli = cli
+
+        await adapter.send(
+            CHANNEL,
+            "threaded reply",
+            reply_to="latest-child",
+            metadata={"thread_id": "stable-root"},
+        )
+
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "stable-root"
+
+
+    @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
         img = tmp_path / "shot.png"
         img.write_bytes(b"\x89PNG fake")
@@ -436,6 +482,25 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_local_file_prefers_stable_thread_root(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127"})
+        adapter._run_cli = cli
+
+        await adapter.send_image(
+            CHANNEL,
+            str(img),
+            reply_to="latest-child",
+            metadata={"thread_id": "stable-root"},
+        )
+
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "stable-root"
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -503,6 +503,81 @@ class TestBuzzAdapterSend:
         assert args[args.index("--reply-to") + 1] == "stable-root"
 
 
+# ── Thread anchoring ──────────────────────────────────────────────────────
+
+
+class TestThreadAnchoring:
+    """A reply must JOIN the thread it was triggered from, not nest a new one.
+
+    The gateway hands adapters the triggering message's own id as the reply
+    anchor. For a top-level message that correctly opens a thread; for a
+    message already inside a thread it used to nest a fresh sub-thread under
+    every answer (an endless ladder of one-message threads in Buzz).
+    """
+
+    @staticmethod
+    def _event(eid, *e_tags):
+        return {"id": eid, "tags": [["h", CHANNEL], *e_tags]}
+
+    def test_top_level_message_has_no_root(self):
+        a = _make_adapter()
+        assert a._extract_thread_root(self._event("m1")) is None
+
+    def test_thread_opener_roots_at_its_parent(self):
+        a = _make_adapter()
+        ev = self._event("m2", ["e", "root1", "", "reply"])
+        assert a._extract_thread_root(ev) == "root1"
+
+    def test_in_thread_message_uses_root_marker_not_parent(self):
+        a = _make_adapter()
+        ev = self._event("m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"])
+        assert a._extract_thread_root(ev) == "root1"
+
+    def test_legacy_unmarked_etag_treated_as_parent(self):
+        a = _make_adapter()
+        assert a._extract_thread_root(self._event("m4", ["e", "root1"])) == "root1"
+
+    def test_reply_to_top_level_still_opens_a_thread(self):
+        """Regression guard: the original (correct) behaviour must survive."""
+        a = _make_adapter()
+        a._record_thread_root("m1", self._event("m1"))
+        assert a._resolve_reply_anchor("m1") == "m1"
+
+    def test_reply_inside_thread_joins_that_thread(self):
+        a = _make_adapter()
+        a._record_thread_root("m3", self._event(
+            "m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"]))
+        assert a._resolve_reply_anchor("m3") == "root1"
+
+    def test_unknown_and_empty_anchors_pass_through(self):
+        a = _make_adapter()
+        assert a._resolve_reply_anchor("never-seen") == "never-seen"
+        assert a._resolve_reply_anchor(None) is None
+
+    def test_root_cache_is_bounded_and_evicts_oldest(self):
+        a = _make_adapter()
+        for i in range(a._THREAD_ROOT_CACHE + 50):
+            a._record_thread_root(f"id{i}", self._event(f"id{i}"))
+        assert len(a._thread_roots) == a._THREAD_ROOT_CACHE
+        assert "id0" not in a._thread_roots
+        assert f"id{a._THREAD_ROOT_CACHE + 49}" in a._thread_roots
+
+    @pytest.mark.asyncio
+    async def test_send_anchors_to_root_not_trigger(self):
+        """End-to-end through send(): argv must carry the thread root."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        adapter._record_thread_root("m3", self._event(
+            "m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"]))
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "e9", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(CHANNEL, "in-thread answer", reply_to="m3")
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "root1"
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -453,6 +453,29 @@ class TestBuzzAdapterSend:
         assert args[args.index("--reply-to") + 1] == "buzz-event-123"
 
     @pytest.mark.asyncio
+    async def test_send_uses_metadata_reply_to_message_id(self):
+        """Gateway stream/progress pass reply anchors via metadata.
+
+        Without honoring reply_to_message_id, mid-turn commentary posts as
+        new top-level channel messages instead of thread replies.
+        """
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-reply", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "threaded reply",
+            metadata={"reply_to_message_id": "root-event-abc"},
+        )
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" in args
+        assert args[args.index("--reply-to") + 1] == "root-event-abc"
+
+    @pytest.mark.asyncio
     async def test_send_prefers_stable_thread_root_over_latest_reply(self):
         adapter = _make_adapter()
         cli = _ScriptedCli()
@@ -468,6 +491,7 @@ class TestBuzzAdapterSend:
 
         args, _stdin = cli.calls[0]
         assert args[args.index("--reply-to") + 1] == "stable-root"
+
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_buzz_progress_thread_routing.py
+++ b/tests/gateway/test_buzz_progress_thread_routing.py
@@ -1,0 +1,15 @@
+"""Buzz progress/status thread-routing regressions."""
+
+from gateway.run import _resolve_progress_thread_id
+
+
+def test_buzz_progress_without_source_thread_uses_triggering_event():
+    """Progress for a Buzz reply must inherit the triggering event anchor."""
+    assert (
+        _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id=None,
+            event_message_id="buzz-event-123",
+        )
+        == "buzz-event-123"
+    )

--- a/tests/gateway/test_buzz_progress_thread_routing.py
+++ b/tests/gateway/test_buzz_progress_thread_routing.py
@@ -13,3 +13,14 @@ def test_buzz_progress_without_source_thread_uses_triggering_event():
         )
         == "buzz-event-123"
     )
+
+
+def test_buzz_progress_preserves_explicit_source_thread():
+    assert (
+        _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id="explicit-thread-root",
+            event_message_id="buzz-event-123",
+        )
+        == "explicit-thread-root"
+    )

--- a/tests/gateway/test_buzz_thread_topology.py
+++ b/tests/gateway/test_buzz_thread_topology.py
@@ -1,0 +1,347 @@
+"""E2E regression tests for the Buzz thread-topology salvage cluster.
+
+Covers the composed behavior of PRs #77080 / #79578 / #80120 / #85613 /
+#86232 / #89868 (+ issues #75082, #95841, #95842):
+
+1. NIP-10 thread-root anchoring — replies join the EXISTING thread root
+   instead of nesting a new sub-thread per turn, across send(),
+   send_image(), and inbound session thread_id.
+2. reply_in_thread / reply_to_mode config honoring — the opt-out posts
+   flat on every send path, including progress routing and the
+   out-of-process cron sender.
+3. _PLATFORM_DEFAULTS coverage — buzz no longer inherits the verbose
+   _GLOBAL_DEFAULTS (#95841).
+
+Uses the real adapter module (no gateway process) with synthetic NIP-10
+events shaped like live relay traffic.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from unittest.mock import AsyncMock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_buzz_module():
+    path = REPO_ROOT / "plugins" / "platforms" / "buzz" / "adapter.py"
+    spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_threads", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_buzz_mod = _load_buzz_module()
+BuzzAdapter = _buzz_mod.BuzzAdapter
+
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+OTHER_PUBKEY = "b" * 64
+ROOT_EVT = "a" * 64
+MID_EVT = "c" * 64
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_env(monkeypatch, tmp_path):
+    for var in (
+        "BUZZ_RELAY_URL", "BUZZ_CHANNELS", "BUZZ_HOME_CHANNEL",
+        "BUZZ_POLL_INTERVAL", "BUZZ_CLI_PATH", "BUZZ_CREDENTIALS_FILE",
+        "BUZZ_ALLOWED_USERS", "BUZZ_ALLOW_ALL_USERS", "BUZZ_PRIVATE_KEY",
+        "BUZZ_REQUIRE_MENTION", "BUZZ_REPLY_IN_THREAD", "BUZZ_REPLY_TO_MODE",
+        "BUZZ_TRANSPORT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path / "no-creds")
+    yield
+
+
+def _make_adapter(extra=None, **cfg_kwargs):
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"relay_url": "https://test.relay", **(extra or {})},
+        **cfg_kwargs,
+    )
+    adapter = BuzzAdapter(cfg)
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._self_npub = _buzz_mod.hex_to_npub(SELF_PUBKEY)
+    adapter._display_name = "Chip"
+    adapter._private_key = "nsec1test"
+    return adapter
+
+
+class _CapturingCli:
+    def __init__(self, payload=None):
+        self.calls = []
+        self.payload = payload or {"accepted": True, "event_id": "evt-out"}
+
+    async def __call__(self, args, *, input_text=None):
+        self.calls.append((list(args), input_text))
+        return 0, json.dumps(self.payload), ""
+
+
+def _nip10_reply_event(event_id, *, root, parent, content="in thread", pubkey=OTHER_PUBKEY):
+    """A kind-9 event shaped like a live relay in-thread reply."""
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "content": content,
+        "created_at": 1000,
+        "kind": 9,
+        "tags": [
+            ["h", CHANNEL],
+            ["e", root, "", "root"],
+            ["e", parent, "", "reply"],
+        ],
+    }
+
+
+def _top_level_event(event_id, content="@Chip hello", pubkey=OTHER_PUBKEY):
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "content": content,
+        "created_at": 1000,
+        "kind": 9,
+        "tags": [["h", CHANNEL]],
+    }
+
+
+
+async def _stub_cli(args, *, input_text=None):
+    return 0, "[]", ""
+
+# ── 1. Thread-root anchoring ──────────────────────────────────────────────
+
+
+class TestThreadRootAnchoring:
+
+    @pytest.mark.asyncio
+    async def test_reply_to_in_thread_trigger_anchors_to_root(self):
+        """E2E: inbound NIP-10 reply -> send(reply_to=<trigger>) -> --reply-to <root>."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = _stub_cli
+
+        event = _nip10_reply_event("trigger-evt", root=ROOT_EVT, parent=MID_EVT,
+                                   content="@Chip what next?")
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "the answer", reply_to="trigger-evt")
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == ROOT_EVT
+
+    @pytest.mark.asyncio
+    async def test_reply_to_top_level_trigger_opens_one_thread(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = _stub_cli
+
+        await adapter._handle_event(
+            CHANNEL, adapter._channel_state[CHANNEL], _top_level_event("root-msg")
+        )
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "answer", reply_to="root-msg")
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "root-msg"
+
+    @pytest.mark.asyncio
+    async def test_inbound_thread_id_is_nip10_root(self):
+        """Session scoping: dispatched source.thread_id is the stable root."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = capture
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = _stub_cli
+
+        event = _nip10_reply_event("child-evt", root=ROOT_EVT, parent=MID_EVT,
+                                   content="@Chip follow-up")
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+        assert dispatched and dispatched[0].source.thread_id == ROOT_EVT
+
+    @pytest.mark.asyncio
+    async def test_send_image_anchors_to_root_too(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        adapter._record_thread_root(
+            "trigger-evt", _nip10_reply_event("trigger-evt", root=ROOT_EVT, parent=MID_EVT)
+        )
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send_image(CHANNEL, str(img), caption="pic", reply_to="trigger-evt")
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == ROOT_EVT
+
+
+# ── 2. Config honoring: reply_in_thread / reply_to_mode ─────────────────
+
+
+class TestReplyThreadingConfig:
+
+    @pytest.mark.asyncio
+    async def test_default_threads_replies(self):
+        adapter = _make_adapter()
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "hi", reply_to="evt-1")
+        assert "--reply-to" in cli.calls[0][0]
+
+    @pytest.mark.asyncio
+    async def test_reply_in_thread_false_posts_flat(self):
+        adapter = _make_adapter(extra={"reply_in_thread": False})
+        assert adapter._reply_to_mode == "off"
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "hi", reply_to="evt-1",
+                           metadata={"thread_id": "evt-1", "reply_to_message_id": "evt-1"})
+        assert "--reply-to" not in cli.calls[0][0]
+
+    @pytest.mark.asyncio
+    async def test_reply_to_mode_off_posts_flat(self):
+        adapter = _make_adapter(reply_to_mode="off")
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "hi", reply_to="evt-1")
+        assert "--reply-to" not in cli.calls[0][0]
+
+    @pytest.mark.asyncio
+    async def test_env_reply_in_thread_false_wins(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_REPLY_IN_THREAD", "false")
+        adapter = _make_adapter()
+        assert adapter._reply_to_mode == "off"
+
+    @pytest.mark.asyncio
+    async def test_reply_in_thread_true_keeps_threading(self):
+        adapter = _make_adapter(extra={"reply_in_thread": True})
+        assert adapter._reply_to_mode != "off"
+
+    @pytest.mark.asyncio
+    async def test_send_image_honors_opt_out(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter(extra={"reply_in_thread": False})
+        cli = _CapturingCli()
+        adapter._run_cli = cli
+        await adapter.send_image(CHANNEL, str(img), caption="pic", reply_to="evt-1")
+        assert "--reply-to" not in cli.calls[0][0]
+
+    def test_apply_yaml_config_bridges_keys(self, monkeypatch):
+        monkeypatch.delenv("BUZZ_REPLY_IN_THREAD", raising=False)
+        monkeypatch.delenv("BUZZ_REPLY_TO_MODE", raising=False)
+        _buzz_mod._apply_yaml_config(
+            {}, {"extra": {"reply_in_thread": False, "reply_to_mode": "off"}}
+        )
+        import os
+        assert os.environ["BUZZ_REPLY_IN_THREAD"] == "false"
+        assert os.environ["BUZZ_REPLY_TO_MODE"] == "off"
+        monkeypatch.delenv("BUZZ_REPLY_IN_THREAD", raising=False)
+        monkeypatch.delenv("BUZZ_REPLY_TO_MODE", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_honors_opt_out(self, monkeypatch, tmp_path):
+        """Out-of-process cron delivery must not thread when opted out."""
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n")
+        fake_cli.chmod(0o755)
+        monkeypatch.setenv("BUZZ_REPLY_IN_THREAD", "false")
+
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            captured["args"] = args
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        class _PC:
+            extra = {"relay_url": "https://test.relay", "cli_path": str(fake_cli)}
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1test")
+        result = await _buzz_mod._standalone_send(_PC(), CHANNEL, "cron msg", thread_id="evt-1")
+        assert result.get("success") is True
+        assert "--reply-to" not in captured["args"]
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_threads_by_default(self, monkeypatch, tmp_path):
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n")
+        fake_cli.chmod(0o755)
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+            captured["args"] = args
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        class _PC:
+            extra = {"relay_url": "https://test.relay", "cli_path": str(fake_cli)}
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1test")
+        result = await _buzz_mod._standalone_send(_PC(), CHANNEL, "cron msg", thread_id="evt-1")
+        assert result.get("success") is True
+        assert "--reply-to" in captured["args"]
+        assert captured["args"][captured["args"].index("--reply-to") + 1] == "evt-1"
+
+
+# ── 3. Progress routing honors the opt-out ───────────────────────────────
+
+
+class TestProgressRouting:
+
+    def test_buzz_progress_threads_by_default(self):
+        from gateway.run import _resolve_progress_thread_id
+
+        assert _resolve_progress_thread_id(
+            "buzz", source_thread_id=None, event_message_id="evt-1",
+            reply_in_thread=True,
+        ) == "evt-1"
+
+    def test_buzz_progress_flat_when_opted_out(self):
+        from gateway.run import _resolve_progress_thread_id
+
+        assert _resolve_progress_thread_id(
+            "buzz", source_thread_id=None, event_message_id="evt-1",
+            reply_in_thread=False,
+        ) is None
+
+
+# ── 4. Display defaults (#95841) ─────────────────────────────────────────
+
+
+class TestDisplayDefaults:
+
+    def test_buzz_has_platform_defaults_entry(self):
+        from gateway.display_config import _PLATFORM_DEFAULTS
+
+        assert "buzz" in _PLATFORM_DEFAULTS
+
+    def test_buzz_does_not_inherit_verbose_global_tool_progress(self):
+        from gateway.display_config import resolve_display_setting
+
+        # No user config: must come from the buzz platform tier, not the
+        # verbose _GLOBAL_DEFAULTS ("all").
+        assert resolve_display_setting({}, "buzz", "tool_progress") != "all"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1925,3 +1925,14 @@ class TestSlackReplyInThreadProgressRouting:
             event_message_id="1700000000.000100",
             reply_in_thread=False,
         ) is None
+
+    def test_buzz_uses_event_message_id_as_progress_thread(self):
+        """Buzz has no native thread_id; progress must reply-to the trigger."""
+        from gateway.run import _resolve_progress_thread_id
+
+        assert _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id=None,
+            event_message_id="evt-trigger-001",
+            reply_in_thread=True,
+        ) == "evt-trigger-001"

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -101,6 +101,23 @@ gateway:
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 
+## Reply threading
+
+Replies are threaded by default: the agent's answer (and any enabled progress/status messages) is anchored to the message that triggered it. Anchoring is NIP-10 aware — when the triggering message was already **inside** a thread, the agent replies to that thread's *root*, so the answer joins the existing thread instead of nesting a new one-message sub-thread under every turn.
+
+To post replies flat at the channel level instead, set either of these (they are equivalent; `reply_in_thread` matches the key Slack uses):
+
+```yaml
+gateway:
+  platforms:
+    buzz:
+      reply_to_mode: off          # PlatformConfig-level, like Discord/Telegram
+      extra:
+        reply_in_thread: false    # Slack-style key; env: BUZZ_REPLY_IN_THREAD
+```
+
+The opt-out applies to **all** send paths — final answers, streamed updates, interim commentary, tool-progress bubbles, and out-of-process cron delivery (`deliver=buzz`).
+
 ## Access control
 
 By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -2,7 +2,7 @@
 
 The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) community — Block's open-source human+agent collaboration platform built on the Nostr protocol — and relays messages between Buzz channels (or DMs) and the agent. Outbound traffic shells out to the `buzz` CLI binary ("JSON in, JSON out"); inbound uses a native Nostr WebSocket subscription (via the already-bundled `websockets` package) with CLI polling as fallback. **No extra Python packages are required** — just the `buzz` binary.
 
-Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
+Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id. When progress or status messages are enabled, they inherit the triggering Buzz event as their reply anchor instead of appearing as unrelated top-level channel posts.
 
 Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 


### PR DESCRIPTION
## Summary
Buzz replies anchor to the existing NIP-10 thread root instead of nesting a new sub-thread per turn, threading becomes a per-deployment choice, and streamed replies edit in place. Consolidates the 12-PR threading dupe swarm.
Fixes #75082, #95842, #95841.

## Changes
- NIP-10 root anchoring (#89868 @tomwattsca, #80120 @yuvalfis): bounded LRU of inbound roots, marked + legacy positional e-tags; replies to in-thread triggers join the EXISTING root; `source.thread_id` = stable root so thread turns share a session.
- Configurable threading (#85613 @al9000-max + Slack-convention alias): `reply_to_mode: off` / `extra.reply_in_thread: false` posts replies flat at channel level — honored by send(), send_image(), commentary, tool-progress bubbles, and cron `_standalone_send`.
- Progress/commentary in-thread (#77080 @reinhold-ph, #86232 @nanakoice): buzz added to `_resolve_progress_thread_id` fallback; `metadata.reply_to_message_id` honored; `_interim_send` stream-sealing guard preserved.
- Streaming (#79578 @tieubao): `edit_message`/`delete_message` via buzz-cli, original-id contract, own-edit echo suppression.
- display_config: buzz added to `_PLATFORM_DEFAULTS` at TIER_MEDIUM (fixes #95841's verbose-default inheritance).
- Superseded by composition: #84492 (same author's earlier version), #85973, #90555, #97608 (unconditional --broadcast). Mention-gating halves of #79458/#91567 handled in the dispatch-cluster PR.

## Validation
121 targeted tests green incl. 17 new E2E regressions (real adapter import + synthetic NIP-10 relay events); sabotage-verified: 10/13 anchoring+config tests fail on main's adapter.py. ruff clean.

**Live repro:** synthetic NIP-10 relay events through the real adapter — root anchoring, opt-out on all send paths incl. cron, progress routing, display tier.

## Infographic

![Reply thread topology](https://v3b.fal.media/files/b/0aa88d80/cj83TtVJ9_zPI8IZkdUAd_yLXoAXFt.png)
