### PR TITLE
fix(buzz): forum channels dispatch, /approve replies wake the agent, and bare names don't (salvages #90314 #75953 #92781 #89751 #82646 #83414)

### DIFF
--- a/contributors/emails/elmar@conradie.co.za
+++ b/contributors/emails/elmar@conradie.co.za
@@ -1,0 +1,1 @@
+conrelma

--- a/contributors/emails/mattlutz4@gmail.com
+++ b/contributors/emails/mattlutz4@gmail.com
@@ -1,0 +1,1 @@
+mattlutzz

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1409,9 +1409,14 @@ class BuzzAdapter(BasePlatformAdapter):
         # A NIP-10 thread reply whose direct parent is one of our messages is
         # treated as addressed (parity with Signal/WhatsApp; fixes #75826 —
         # e.g. Desktop "/approve session" replies that never type @name).
-        # DMs always dispatch. p-tag semantics stay untouched (#68871).
-        mentioned = self._is_mentioned(content)
-        if not is_dm and self.require_mention and not mentioned and not reply_to_is_own:
+        # Explicit addressing is a text @mention OR a signed recipient p-tag
+        # (#92781). DMs always dispatch.
+        if (
+            not is_dm
+            and self.require_mention
+            and not self._is_addressed(event)
+            and not reply_to_is_own
+        ):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1452,43 +1457,42 @@ class BuzzAdapter(BasePlatformAdapter):
     # ── DM classification (issue #68871) ──────────────────────────────────
     #
     # ``buzz dms list`` returns [] on some hosted relays even when DM
-    # conversations exist, so DMs leak in via ``channels list`` and get
-    # watched as chat_type="group" — which wrongly puts them behind the
-    # channel mention gate.  Classification therefore keys off the Nostr
-    # tags of the messages themselves.  Observed on a live hosted relay:
-    #
-    #   * every message another user sends IN A DM carries a structural
-    #     ["p", <our pubkey>] tag, even when the text never mentions us
-    #     (recipient addressing);
-    #   * in a real channel, a ["p", <our pubkey>] tag appears only when the
-    #     text visibly @mentions us (typed mention, with or without a reply
-    #     ["e", ...] tag) — never on plain broadcasts.
-    #
-    # So "p-tagged to self WITHOUT a visible mention in the content" is the
-    # DM discriminator: in a channel that combination does not occur, and a
-    # channel reply/mention that p-tags us is excluded because the mention
-    # is right there in the text.  As a second, independent guard, a
-    # conversation whose ``channels list`` metadata looks like a real
-    # community channel (real name / non-empty description) is never
-    # reclassified at all, whereas relay-materialized DMs are always named
-    # "DM" with an empty description.  Nothing is lost while unlatched: a
-    # DM message that DOES mention us dispatches through the mention gate
-    # anyway, so the latch flips exactly on the first message that needs it.
+    # conversations exist, so DMs can leak in through ``channels list`` as
+    # chat_type="group".  Relay-materialized DMs are named "DM" with an empty
+    # description, and their messages carry a structural p-tag to us.  Only
+    # that explicit metadata shape may latch to DM; named channels and missing
+    # metadata fail closed.  In normal channels the same p-tag is an addressing
+    # signal and must wake the agent without changing the conversation type.
 
     def _may_reclassify_as_dm(self, channel_id: str) -> bool:
         """True when the conversation's metadata does not rule out a DM.
 
         Known real community channels (real name or non-empty description in
         ``channels list``) must never turn into DMs just because a message
-        p-tags us.  A conversation with no metadata at all is trusted only
-        when the user did not explicitly configure it as a watched channel.
+        p-tags us.  Missing metadata fails closed rather than allowing a named
+        channel to latch as a DM before its metadata arrives.
         """
         meta = self._channel_meta.get(channel_id)
         if meta is None:
-            return channel_id not in self.channels
+            return False
         name = str(meta.get("name") or "").strip()
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description
+
+    def _p_tagged_to_self(self, event: dict) -> bool:
+        """True when the signed event addresses this identity by pubkey."""
+        if not self._self_pubkey:
+            return False
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return False
+        return any(
+            isinstance(tag, (list, tuple))
+            and len(tag) > 1
+            and tag[0] == "p"
+            and str(tag[1]).lower() == self._self_pubkey
+            for tag in tags
+        )
 
     def _is_direct_message_event(self, channel_id: str, event: dict) -> bool:
         """True when ``event`` is shaped like a direct message to us: a chat
@@ -1502,17 +1506,7 @@ class BuzzAdapter(BasePlatformAdapter):
         pubkey = str(event.get("pubkey") or "").lower()
         if not pubkey or pubkey == self._self_pubkey:
             return False
-        tags = event.get("tags")
-        if not isinstance(tags, list):
-            return False
-        p_tagged_to_self = any(
-            isinstance(tag, (list, tuple))
-            and len(tag) > 1
-            and tag[0] == "p"
-            and str(tag[1]).lower() == self._self_pubkey
-            for tag in tags
-        )
-        if not p_tagged_to_self:
+        if not self._p_tagged_to_self(event):
             return False
         content = event.get("content")
         return isinstance(content, str) and not self._is_mentioned(content)
@@ -1528,17 +1522,32 @@ class BuzzAdapter(BasePlatformAdapter):
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
     def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+        """True when text explicitly addresses this agent (npub, hex, or @name)."""
         lowered = content.lower()
-        if self._self_pubkey and self._self_pubkey in lowered:
-            return True
-        if self._self_npub and self._self_npub in lowered:
-            return True
+        if self._self_pubkey and re.fullmatch(r"[0-9a-f]{64}", self._self_pubkey):
+            pattern = rf"(?<![0-9a-f]){re.escape(self._self_pubkey)}(?![0-9a-f])"
+            if re.search(pattern, lowered):
+                return True
+        if self._self_npub:
+            pattern = rf"(?<![a-z0-9]){re.escape(self._self_npub.lower())}(?![a-z0-9])"
+            if re.search(pattern, lowered):
+                return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = (
+                rf"(?<![\w@])@{re.escape(self._display_name.lower())}"
+                r"(?=$|[\s,;.!?:)\]}])"
+            )
             if re.search(pattern, lowered):
                 return True
         return False
+
+    def _is_addressed(self, event: dict) -> bool:
+        """True when a group event carries an explicit text or p-tag address."""
+        content = event.get("content")
+        return (
+            isinstance(content, str)
+            and (self._is_mentioned(content) or self._p_tagged_to_self(event))
+        )
 
     def _strip_mention(self, content: str) -> str:
         """Remove a leading @mention of this agent so the remaining text can be
@@ -1554,16 +1563,18 @@ class BuzzAdapter(BasePlatformAdapter):
         text = content.strip()
         candidates = []
         if self._display_name:
-            candidates.append(re.escape(self._display_name))
+            candidates.append(
+                rf"@{re.escape(self._display_name)}" + r"(?=$|[\s,;.!?:)\]}])"
+            )
         if self._self_npub:
-            candidates.append(re.escape(self._self_npub))
+            candidates.append(rf"@?{re.escape(self._self_npub)}(?![a-z0-9])")
         if self._self_pubkey:
-            candidates.append(re.escape(self._self_pubkey))
+            candidates.append(rf"@?{re.escape(self._self_pubkey)}(?![0-9a-f])")
         if not candidates:
             return text
-        # Optional leading '@', one of the identity forms, optional trailing
-        # ':' or ',' and surrounding whitespace.
-        pattern = rf"^@?(?:{'|'.join(candidates)})[\s:,]*"
+        # Display names require '@'; npub and hex identities are already
+        # unambiguous and may optionally include it.
+        pattern = rf"^(?:{'|'.join(candidates)})[\s:,]*"
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -26,11 +26,13 @@ Configuration in config.yaml::
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
             reply_in_thread: true      # false = post replies flat to the channel timeline
+            reaction_only_users: []    # acknowledge explicit tags without dispatching; allowed_users wins on overlap
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS, BUZZ_REPLY_IN_THREAD, BUZZ_REPLY_TO_MODE
+    BUZZ_REACTION_ONLY_USERS, BUZZ_ALLOW_ALL_USERS, BUZZ_REPLY_IN_THREAD,
+    BUZZ_REPLY_TO_MODE
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
 ``~/.hermes/.env``.  It is passed to the CLI via the subprocess

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -494,6 +494,38 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _event_reply_parent_id(event: dict) -> Optional[str]:
+    """Resolve a chat event's direct parent event id (NIP-10 ``e`` tags).
+
+    Prefer a ``reply``-marked tag, then a ``root``-marked tag, else the last
+    positional ``e`` tag. Buzz Desktop thread replies typically carry both
+    root and reply markers; the reply marker is the direct parent.
+    """
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return None
+    reply_id: Optional[str] = None
+    root_id: Optional[str] = None
+    last_e: Optional[str] = None
+    for tag in tags:
+        if not isinstance(tag, (list, tuple)) or len(tag) < 2 or tag[0] != "e":
+            continue
+        target = str(tag[1] or "").strip()
+        if not target:
+            continue
+        marker = str(tag[3] or "") if len(tag) > 3 else ""
+        last_e = target
+        if marker == "reply":
+            reply_id = target
+        elif marker == "root":
+            root_id = target
+    return reply_id or root_id or last_e
+
+
+# Cap stored parent content snippets (gateway reply injection also clips).
+_EVENT_META_CONTENT_CAP = 500
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -607,7 +639,13 @@ class BuzzAdapter(BasePlatformAdapter):
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
         self._lock_key: Optional[str] = None
-        # channel_id -> {"chat_type", "last_ts", "seen": OrderedDict[event_id, None]}
+        # channel_id -> {
+        #   "chat_type", "last_ts",
+        #   "seen": OrderedDict[event_id, None],
+        #   "event_meta": OrderedDict[event_id, (author_pubkey, content_snippet)],
+        # }
+        # event_meta backs NIP-10 reply-parent resolution for require_mention
+        # (thread replies to our own messages count as addressed — #75826).
         self._channel_state: Dict[str, dict] = {}
         self._channel_names: Dict[str, str] = {}
         # channel_id -> raw ``channels list`` entry; drives DM-vs-channel
@@ -838,7 +876,12 @@ class BuzzAdapter(BasePlatformAdapter):
         if event_id:
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
+            # Also record event_meta so a thread reply to this send matches
+            # even if the WS/poll echo never arrives (#75826).
             self._mark_seen(str(chat_id), str(event_id))
+            self._remember_event_meta(
+                str(chat_id), str(event_id), self._self_pubkey, content
+            )
         return SendResult(
             success=bool(data.get("accepted", True)),
             message_id=str(event_id) if event_id else None,
@@ -982,6 +1025,12 @@ class BuzzAdapter(BasePlatformAdapter):
             event_id = data.get("event_id")
             if event_id:
                 self._mark_seen(str(chat_id), str(event_id))
+                self._remember_event_meta(
+                    str(chat_id),
+                    str(event_id),
+                    self._self_pubkey,
+                    caption or "",
+                )
             return SendResult(
                 success=bool(data.get("accepted", True)),
                 message_id=str(event_id) if event_id else None,
@@ -1222,9 +1271,17 @@ class BuzzAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
 
+    def _new_channel_state(self, chat_type: str) -> dict:
+        return {
+            "chat_type": chat_type,
+            "last_ts": 0,
+            "seen": OrderedDict(),
+            "event_meta": OrderedDict(),
+        }
+
     async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
         """Initialize a channel's high-water mark from its newest events."""
-        state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict()}
+        state = self._new_channel_state(chat_type)
         self._channel_state[channel_id] = state
         code, out, err = await self._run_cli(
             ["messages", "get", "--channel", channel_id, "--limit", str(_FETCH_LIMIT)]
@@ -1243,6 +1300,10 @@ class BuzzAdapter(BasePlatformAdapter):
             if event_id:
                 state["seen"][str(event_id)] = None
             state["last_ts"] = max(state["last_ts"], created_at)
+            # History is never dispatched, but it still classifies and feeds
+            # the event_meta cache so post-restart thread replies to messages
+            # we sent before the gateway came up still match (#75826).
+            self._remember_event(state, event)
             # History is never dispatched, but it still classifies: a DM that
             # leaked in via ``channels list`` latches to chat_type="dm" here,
             # so it bypasses the mention gate from the very first poll.
@@ -1271,7 +1332,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 if seed:
                     await self._seed_channel(dm_id, chat_type="dm")
                 else:
-                    self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
+                    self._channel_state[dm_id] = self._new_channel_state("dm")
                 self._channel_names.setdefault(dm_id, "DM")
 
         code, out, _err = await self._run_cli(["channels", "list"])
@@ -1288,7 +1349,7 @@ class BuzzAdapter(BasePlatformAdapter):
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")
             else:
-                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+                self._channel_state[ch_id] = self._new_channel_state("group")
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1325,6 +1386,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not pubkey or not isinstance(content, str) or not content.strip():
             return
 
+        # Feed the per-channel event cache before any early return so self-echo
+        # and concurrent-author traffic can still be reply parents (#75826).
+        self._remember_event(state, event)
+
         # Suppress self-echo: never dispatch our own messages back to the agent.
         if pubkey == self._self_pubkey:
             return
@@ -1334,10 +1399,19 @@ class BuzzAdapter(BasePlatformAdapter):
         self._maybe_latch_dm(channel_id, state, event)
 
         is_dm = state["chat_type"] == "dm"
+        reply_parent_id = _event_reply_parent_id(event)
+        reply_meta = self._lookup_event_meta(state, reply_parent_id) if reply_parent_id else None
+        reply_to_is_own = bool(
+            reply_meta is not None and reply_meta[0] == self._self_pubkey
+        )
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        # A NIP-10 thread reply whose direct parent is one of our messages is
+        # treated as addressed (parity with Signal/WhatsApp; fixes #75826 —
+        # e.g. Desktop "/approve session" replies that never type @name).
+        # DMs always dispatch. p-tag semantics stay untouched (#68871).
+        mentioned = self._is_mentioned(content)
+        if not is_dm and self.require_mention and not mentioned and not reply_to_is_own:
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1369,6 +1443,10 @@ class BuzzAdapter(BasePlatformAdapter):
             message_id=event_id,
             created_at=created_at,
             thread_id=thread_id,
+            reply_to_message_id=reply_parent_id,
+            reply_to_text=reply_meta[1] if reply_meta else None,
+            reply_to_author_id=reply_meta[0] if reply_meta else None,
+            reply_to_is_own_message=reply_to_is_own,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1516,6 +1594,10 @@ class BuzzAdapter(BasePlatformAdapter):
         seen = state["seen"]
         while len(seen) > _SEEN_CAP:
             seen.popitem(last=False)
+        meta = state.get("event_meta")
+        if isinstance(meta, OrderedDict):
+            while len(meta) > _SEEN_CAP:
+                meta.popitem(last=False)
 
     def _mark_seen(self, channel_id: str, event_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1592,6 +1674,54 @@ class BuzzAdapter(BasePlatformAdapter):
             return anchor
         roots = getattr(self, "_thread_roots", None) or {}
         return roots.get(str(anchor)) or anchor
+    def _remember_event(self, state: dict, event: dict) -> None:
+        """Record author + content snippet for later NIP-10 parent lookup."""
+        event_id = str(event.get("id") or "")
+        if not event_id:
+            return
+        pubkey = str(event.get("pubkey") or "").lower()
+        content = event.get("content")
+        snippet = content[:_EVENT_META_CONTENT_CAP] if isinstance(content, str) else ""
+        self._store_event_meta(state, event_id, pubkey, snippet)
+
+    def _remember_event_meta(
+        self,
+        channel_id: str,
+        event_id: str,
+        pubkey: str,
+        content: str,
+    ) -> None:
+        state = self._channel_state.get(channel_id)
+        if state is None or not event_id:
+            return
+        snippet = (content or "")[:_EVENT_META_CONTENT_CAP]
+        self._store_event_meta(state, event_id, (pubkey or "").lower(), snippet)
+
+    @staticmethod
+    def _store_event_meta(
+        state: dict,
+        event_id: str,
+        pubkey: str,
+        snippet: str,
+    ) -> None:
+        cache = state.setdefault("event_meta", OrderedDict())
+        if not isinstance(cache, OrderedDict):
+            cache = OrderedDict(cache)
+            state["event_meta"] = cache
+        cache[event_id] = (pubkey, snippet)
+        cache.move_to_end(event_id)
+        while len(cache) > _SEEN_CAP:
+            cache.popitem(last=False)
+
+    @staticmethod
+    def _lookup_event_meta(state: dict, event_id: Optional[str]) -> Optional[Tuple[str, str]]:
+        if not event_id:
+            return None
+        cache = state.get("event_meta") or {}
+        entry = cache.get(event_id)
+        if not entry or not isinstance(entry, tuple) or len(entry) < 2:
+            return None
+        return str(entry[0] or ""), str(entry[1] or "")
 
     async def _dispatch_message(
         self,
@@ -1603,6 +1733,10 @@ class BuzzAdapter(BasePlatformAdapter):
         message_id: str,
         created_at: int,
         thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
+        reply_to_author_id: Optional[str] = None,
+        reply_to_is_own_message: bool = False,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1623,10 +1757,14 @@ class BuzzAdapter(BasePlatformAdapter):
             source=source,
             message_id=message_id,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_author_id=reply_to_author_id,
+            reply_to_is_own_message=reply_to_is_own_message,
         )
 
         await self.handle_message(event)
-        
+
         # Add a "seen" reaction after dispatching — signals to the user that
         # their message was received and is being processed.
         try:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -232,6 +232,12 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
+# Mention-resolution caches: member lists are cheap to refetch but hit on
+# every publish containing "@", so a short TTL amortizes the CLI round-trip;
+# display names change rarely, but must not survive a rename forever.
+_MEMBER_CACHE_TTL = 60.0
+_PROFILE_NAME_TTL = 300.0
+
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
@@ -894,18 +900,213 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
-    async def _run_message_send(self, args: List[str], content: str):
-        """Run one send with a single unresolved-mention preflight retry."""
-        code, out, err = await self._run_cli(args, input_text=content)
+    async def _channel_member_pubkeys(self, chat_id: str) -> List[str]:
+        """Candidate pubkeys for mention resolution, membership-accurate.
+
+        Primary source is ``channels members`` — the relay's membership
+        contract — because a ``--mention`` for a non-member makes the CLI
+        reject the whole publish.  CLIs without that subcommand fall back
+        to harvesting recent channel traffic (authors plus prior mention
+        tags), which can over-approximate; ``send()`` recovers from any
+        resulting non-member mention by retrying without mention flags.
+
+        The member list is cached per channel for ``_MEMBER_CACHE_TTL``
+        seconds so a chatty agent doesn't pay a CLI round-trip on every
+        publish; membership drift inside the TTL window is covered by the
+        same ``send()`` recovery retry.
+        """
+        cache: Dict[str, Tuple[float, List[str]]] = getattr(
+            self, "_member_cache", {}
+        )
+        self._member_cache = cache
+        cached = cache.get(str(chat_id))
+        if cached is not None and (time.monotonic() - cached[0]) < _MEMBER_CACHE_TTL:
+            return list(cached[1])
+        code, out, _err = await self._run_cli(
+            ["channels", "members", "--channel", str(chat_id)]
+        )
+        if code == 0:
+            pks: List[str] = []
+            try:
+                rows = json.loads(out or "[]")
+            except ValueError:
+                rows = []
+            for row in rows:
+                pk = row.get("pubkey") if isinstance(row, dict) else row
+                pk = str(pk or "").lower()
+                if pk and pk not in pks:
+                    pks.append(pk)
+            if pks:
+                cache[str(chat_id)] = (time.monotonic(), list(pks))
+                return pks
+        candidates: List[str] = []
+        code, out, _err = await self._run_cli(
+            ["messages", "get", "--channel", str(chat_id), "--limit", "50"]
+        )
+        if code == 0:
+            try:
+                for msg in json.loads(out or "[]"):
+                    pk = str(msg.get("pubkey") or "").lower()
+                    if pk and pk not in candidates:
+                        candidates.append(pk)
+                    for t in msg.get("tags") or []:
+                        if isinstance(t, list) and len(t) > 1 and t[0] == "p":
+                            tpk = str(t[1]).lower()
+                            if tpk and tpk not in candidates:
+                                candidates.append(tpk)
+            except ValueError:
+                pass
+        if candidates:
+            cache[str(chat_id)] = (time.monotonic(), list(candidates))
+        return candidates
+
+    async def _profile_display_name(self, pubkey: str) -> str:
+        """Display name for *pubkey* via ``users get --pubkey``, cached.
+
+        Bare ``users get`` may return only our own profile
+        (relay-dependent), so lookups are per-pubkey.  Entries expire after
+        ``_PROFILE_NAME_TTL`` seconds so a renamed member resolves under
+        their new display name without a process restart.
+        """
+        cache: Dict[str, Tuple[float, str]] = getattr(
+            self, "_profile_name_cache", {}
+        )
+        self._profile_name_cache = cache
+        cached = cache.get(pubkey)
+        if cached is not None and (time.monotonic() - cached[0]) < _PROFILE_NAME_TTL:
+            return cached[1]
+        name = ""
+        code, out, _err = await self._run_cli(["users", "get", "--pubkey", pubkey])
+        if code == 0:
+            try:
+                profiles = json.loads(out or "[]")
+            except ValueError:
+                profiles = []
+            if profiles and isinstance(profiles[0], dict):
+                p0 = profiles[0]
+                name = str(p0.get("display_name") or p0.get("name") or "").strip()
+                if not name and p0.get("content"):
+                    try:
+                        prof = json.loads(p0["content"])
+                        name = str(
+                            prof.get("display_name") or prof.get("name") or ""
+                        ).strip()
+                    except ValueError:
+                        pass
+        cache[pubkey] = (time.monotonic(), name)
+        return name
+
+    async def _mention_pubkeys_for(self, chat_id: str, content: str) -> List[str]:
+        """Resolve ``@Name`` references in *content* to member pubkeys.
+
+        The CLI hard-fails a publish when any @token fails to resolve to a
+        current member, and LLM prose is full of @-shaped tokens — including
+        real mentions with trailing punctuation ("@Riley!!") the CLI's own
+        parser rejects.  Passing explicit ``--mention`` pubkeys for every
+        member name we find keeps genuine mentions notifying (p-tags intact)
+        while downgrading everything unresolvable to presentation-only text.
+
+        Matching is mention-token semantics, not substring, bounded on both
+        sides with Unicode-aware word classes: the ``@`` must start a token
+        ("email@Fizz", "x@Fizz", "@@Fizz", and "山田@Fizz" do NOT wake
+        Fizz) and the name must be followed by a non-word character or
+        end-of-text ("@Riley!!" tags Riley; "@FizzBuzz" does NOT tag a
+        member named Fizz).  Longer names match first and consume their
+        span, so "@Hermes Matt" prefers the member "Hermes Matt" over a
+        member "Hermes".
+
+        Duplicate display names are ambiguous: the span is consumed but no
+        one is tagged (presentation-only), mirroring how Buzz treats
+        ambiguous names — never pick an arbitrary member.
+        """
+        if "@" not in content:
+            return []
+        by_name: Dict[str, List[str]] = {}
+        display: Dict[str, str] = {}
+        self_pk = getattr(self, "_self_pubkey", None)
+        for pk in await self._channel_member_pubkeys(chat_id):
+            if pk == self_pk:
+                continue
+            name = await self._profile_display_name(pk)
+            if not name:
+                continue
+            key = name.lower()
+            by_name.setdefault(key, [])
+            if pk not in by_name[key]:
+                by_name[key].append(pk)
+            display.setdefault(key, name)
+        found: List[str] = []
+        text = content
+        for key in sorted(by_name, key=len, reverse=True):
+            pattern = re.compile(
+                r"(?<![\w@])@" + re.escape(display[key]) + r"(?!\w)",
+                re.IGNORECASE,
+            )
+            if pattern.search(text):
+                pks = by_name[key]
+                if len(pks) == 1 and pks[0] not in found:
+                    found.append(pks[0])
+                # Consume the span either way: a shorter member name that is
+                # a prefix of this one must not double-match, and an
+                # ambiguous name must stay presentation-only rather than
+                # falling through to a partial match.
+                text = pattern.sub("\x00", text)
+        return found
+
+    async def _run_message_send(
+        self,
+        args: List[str],
+        content: str,
+        mention_pubkeys: Optional[List[str]] = None,
+    ):
+        """Run one send with bounded mention-failure recovery.
+
+        Ladder (each rung fires at most once):
+
+        1. publish with explicit ``--mention`` pubkeys resolved from the
+           content (#83414) so genuine member mentions carry p-tags and
+           mention-subscribed agents actually wake;
+        2. if the CLI rejects because a resolved pubkey is no longer a
+           member (membership drift), retry without the explicit mentions —
+           deliver the message rather than lose it;
+        3. if the CLI's preflight rejects an unresolvable presentation
+           ``@token`` in prose, escape exactly that token with an invisible
+           separator and retry (#82646 / #78797);
+        4. if the error persists and we know our own pubkey, retry once with
+           ``--mention <self>`` — supplying any explicit identity downgrades
+           unresolvable @names to presentation-only text (#83414); the echo
+           de-dupe already suppresses self-notification.
+        """
+        mention_args: List[str] = []
+        for pk in mention_pubkeys or []:
+            mention_args += ["--mention", pk]
+        code, out, err = await self._run_cli(args + mention_args, input_text=content)
         if code == 0:
             return code, out, err
+        if mention_args and "not channel members" in (err or ""):
+            # Membership drifted between resolution and publish (or the
+            # fallback candidate source over-approximated): never let a
+            # stale mention kill the message.
+            code, out, err = await self._run_cli(args, input_text=content)
+            if code == 0:
+                return code, out, err
         escaped = _escape_unresolved_presentation_mention(content, err)
-        if escaped is None:
-            return code, out, err
-        logger.info(
-            "Buzz: retrying message after unresolved presentation-mention preflight"
-        )
-        return await self._run_cli(args, input_text=escaped)
+        if escaped is not None:
+            logger.info(
+                "Buzz: retrying message after unresolved presentation-mention preflight"
+            )
+            code, out, err = await self._run_cli(args, input_text=escaped)
+            if code == 0:
+                return code, out, err
+        if (
+            code != 0
+            and "does not match a current channel member" in (err or "")
+            and getattr(self, "_self_pubkey", None)
+        ):
+            code, out, err = await self._run_cli(
+                args + ["--mention", self._self_pubkey], input_text=content
+            )
+        return code, out, err
 
     async def send(
         self,
@@ -927,7 +1128,8 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_message_send(args, content)
+        mention_pubkeys = await self._mention_pubkeys_for(chat_id, content)
+        code, out, err = await self._run_message_send(args, content, mention_pubkeys)
         if code != 0:
             return SendResult(
                 success=False,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -621,6 +621,21 @@ class BuzzAdapter(BasePlatformAdapter):
             if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
         }
 
+        # Verified local-agent identities may acknowledge explicit tags without
+        # gaining prompt/dispatch authority. This keeps the human allow-list
+        # intact while providing receipt visibility for agent-authored notes.
+        raw_reaction_only = (
+            os.getenv("BUZZ_REACTION_ONLY_USERS")
+            or extra.get("reaction_only_users", [])
+        )
+        if isinstance(raw_reaction_only, str):
+            raw_reaction_only = raw_reaction_only.split(",")
+        self._reaction_only_pubkeys: set = {
+            normalized
+            for entry in raw_reaction_only
+            if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
+        }
+
         # Secret — resolved lazily (never at import/registration time and
         # never logged).  connect() re-resolves it to fail fast with a clear
         # error when it is missing.
@@ -1423,6 +1438,19 @@ class BuzzAdapter(BasePlatformAdapter):
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
         if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
+            explicitly_tagged = any(
+                isinstance(tag, (list, tuple))
+                and len(tag) > 1
+                and tag[0] == "p"
+                and str(tag[1]).lower() == self._self_pubkey
+                for tag in event.get("tags") or []
+            )
+            if (
+                pubkey in self._reaction_only_pubkeys
+                and explicitly_tagged
+                and self._is_mentioned(content)
+            ):
+                await self.send_reaction(channel_id, event_id, "👀")
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
             return
 
@@ -1898,6 +1926,11 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         if isinstance(allowed, (list, tuple)):
             allowed = ",".join(str(a) for a in allowed)
         os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
+    reaction_only = extra.get("reaction_only_users")
+    if reaction_only is not None and not _skip_env_bridge and not os.getenv("BUZZ_REACTION_ONLY_USERS"):
+        if isinstance(reaction_only, (list, tuple)):
+            reaction_only = ",".join(str(v) for v in reaction_only)
+        os.environ["BUZZ_REACTION_ONLY_USERS"] = str(reaction_only)
     if "allow_all_users" in extra and not _skip_env_bridge and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REQUIRE_MENTION"):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -186,6 +186,40 @@ _CHAT_KIND = 9
 # deliberately keeps the kind-9-only check: widening it there would let a
 # p-tagged forum post be reclassified as a DM and bypass mention gating.
 _DISPATCH_KINDS = frozenset({_CHAT_KIND, 45001, 45003})
+_UNRESOLVED_MENTION_ERROR_RE = re.compile(
+    r"mention '@(?P<name>[^']+)' does not match a current channel member"
+)
+_BUZZ_PRESENTATION_MENTION_SEPARATOR = "\u200b"
+
+
+def _escape_unresolved_presentation_mention(content: str, error: str) -> Optional[str]:
+    """Make one CLI-rejected ``@name`` token presentation-only.
+
+    Buzz resolves whitespace-prefixed ``@name`` tokens into notification
+    p-tags before signing or publishing. Ordinary prose such as a Hermes
+    ``@session:...`` link can therefore fail mention preflight. Insert an
+    invisible separator only after the rejected ``@`` so the rendered text
+    remains readable while valid member mentions remain unchanged.
+
+    Return ``None`` for unrelated errors or absent tokens. Callers retry at
+    most once.
+    """
+    match = _UNRESOLVED_MENTION_ERROR_RE.search(error or "")
+    if match is None:
+        return None
+    name = match.group("name")
+    if not name:
+        return None
+    token = re.compile(
+        rf"(?<!\S)@{re.escape(name)}(?=$|[^A-Za-z0-9._-])",
+        re.IGNORECASE,
+    )
+    escaped, count = token.subn(
+        lambda found: "@" + _BUZZ_PRESENTATION_MENTION_SEPARATOR + found.group(0)[1:],
+        content,
+    )
+    return escaped if count else None
+
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -860,6 +894,19 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    async def _run_message_send(self, args: List[str], content: str):
+        """Run one send with a single unresolved-mention preflight retry."""
+        code, out, err = await self._run_cli(args, input_text=content)
+        if code == 0:
+            return code, out, err
+        escaped = _escape_unresolved_presentation_mention(content, err)
+        if escaped is None:
+            return code, out, err
+        logger.info(
+            "Buzz: retrying message after unresolved presentation-mention preflight"
+        )
+        return await self._run_cli(args, input_text=escaped)
+
     async def send(
         self,
         chat_id: str,
@@ -880,7 +927,7 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
+        code, out, err = await self._run_message_send(args, content)
         if code != 0:
             return SendResult(
                 success=False,
@@ -1034,7 +1081,7 @@ class BuzzAdapter(BasePlatformAdapter):
             )
             if reply_target and self._reply_to_mode != "off":
                 args += ["--reply-to", str(reply_target)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            code, out, err = await self._run_message_send(args, caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
             try:
@@ -2050,6 +2097,20 @@ async def _standalone_send(
             auth_tag=auth_tag,
             input_text=message,
         )
+        if code != 0:
+            escaped = _escape_unresolved_presentation_mention(message, err)
+            if escaped is not None:
+                logger.info(
+                    "Buzz: retrying standalone message after unresolved "
+                    "presentation-mention preflight"
+                )
+                code, out, err = await _exec_buzz(
+                    cli_path,
+                    args,
+                    relay_url=relay,
+                    private_key=private_key,
+                    input_text=escaped,
+                )
     except asyncio.CancelledError:
         raise
     except OSError as e:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -624,6 +624,8 @@ class BuzzAdapter(BasePlatformAdapter):
         # Verified local-agent identities may acknowledge explicit tags without
         # gaining prompt/dispatch authority. This keeps the human allow-list
         # intact while providing receipt visibility for agent-authored notes.
+        # If a pubkey appears in both sets, allowed_users takes precedence: the
+        # normal authorized dispatch path runs and this reaction-only path does not.
         raw_reaction_only = (
             os.getenv("BUZZ_REACTION_ONLY_USERS")
             or extra.get("reaction_only_users", [])

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1318,10 +1318,8 @@ class BuzzAdapter(BasePlatformAdapter):
         ``dms list`` is only a best-effort source: on some hosted relays it
         returns ``[]`` even when DM conversations exist (#68871).  Those DMs
         DO surface in ``channels list`` as entries named "DM" with an empty
-        description, so that listing is scanned as a fallback.  Fallback
-        finds are watched as ``group`` and latch to ``dm`` via p-tag
-        detection (_is_direct_message_event) rather than trusting the name
-        alone to unlock the mention-free DM path.
+        description, so that exact metadata shape is the fallback.  Named
+        rooms and missing metadata still fail closed as groups.
         """
         code, out, _err = await self._run_cli(["dms", "list"])
         if code == 0:
@@ -1344,12 +1342,15 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+            if not self._may_reclassify_as_dm(ch_id):
+                continue
+            if ch_id in self._channel_state:
+                self._channel_state[ch_id]["chat_type"] = "dm"
                 continue
             if seed:
-                await self._seed_channel(ch_id, chat_type="group")
+                await self._seed_channel(ch_id, chat_type="dm")
             else:
-                self._channel_state[ch_id] = self._new_channel_state("group")
+                self._channel_state[ch_id] = self._new_channel_state("dm")
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1459,10 +1460,10 @@ class BuzzAdapter(BasePlatformAdapter):
     # ``buzz dms list`` returns [] on some hosted relays even when DM
     # conversations exist, so DMs can leak in through ``channels list`` as
     # chat_type="group".  Relay-materialized DMs are named "DM" with an empty
-    # description, and their messages carry a structural p-tag to us.  Only
-    # that explicit metadata shape may latch to DM; named channels and missing
-    # metadata fail closed.  In normal channels the same p-tag is an addressing
-    # signal and must wake the agent without changing the conversation type.
+    # description, which periodic discovery promotes to DM even when messages
+    # omit recipient p-tags.  Named channels and missing metadata fail closed.
+    # In normal channels a p-tag is only an addressing signal and must wake the
+    # agent without changing the conversation type.
 
     def _may_reclassify_as_dm(self, channel_id: str) -> bool:
         """True when the conversation's metadata does not rule out a DM.

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -175,6 +175,15 @@ from gateway.config import Platform
 # returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
 # dispatched to the agent.
 _CHAT_KIND = 9
+# Kinds that carry agent-relevant conversation content and are dispatched
+# (#90309): chat messages (9) plus the Buzz forum kinds — 45001 is a forum
+# post (thread root) and 45003 a comment reply on it.  Block's own ACP
+# harness documents this set (``buzz-acp --kinds 9,46010,40007,45001,
+# 45002,45003``); the stream kinds (46010/40007/45002) are left out until
+# their dispatch semantics are confirmed.  ``_is_direct_message_event``
+# deliberately keeps the kind-9-only check: widening it there would let a
+# p-tagged forum post be reclassified as a DM and bypass mention gating.
+_DISPATCH_KINDS = frozenset({_CHAT_KIND, 45001, 45003})
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -1091,7 +1100,7 @@ class BuzzAdapter(BasePlatformAdapter):
         request = [
             "REQ",
             subscription_id,
-            {"kinds": [_CHAT_KIND], "#h": [channel_id], "since": since},
+            {"kinds": sorted(_DISPATCH_KINDS), "#h": [channel_id], "since": since},
         ]
         await websocket.send(json.dumps(request, separators=(",", ":")))
 
@@ -1309,7 +1318,7 @@ class BuzzAdapter(BasePlatformAdapter):
         state["seen"][event_id] = None
         state["last_ts"] = max(state["last_ts"], created_at)
 
-        if int(event.get("kind") or 0) != _CHAT_KIND:
+        if int(event.get("kind") or 0) not in _DISPATCH_KINDS:
             return
         pubkey = str(event.get("pubkey") or "").lower()
         content = event.get("content")

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -690,6 +690,67 @@ class TestMentionGating:
     async def test_name_mention_dispatched(self, adapter):
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["text"] == "hey @Chip can you help?"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Chip should stay silent",
+            "ask @Chipmunk instead",
+            "ask @Chip-bot instead",
+            "email chip@example.com",
+        ],
+    )
+    async def test_bare_or_prefix_name_does_not_dispatch(self, adapter, content):
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("identity", [SELF_NPUB, SELF_PUBKEY])
+    async def test_identity_text_dispatches(self, adapter, identity):
+        await self._poll_with(
+            adapter,
+            _event("e1", content=f"please check {identity}", created_at=10),
+        )
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [f"a{SELF_PUBKEY}b", f"x{SELF_NPUB}y"],
+    )
+    async def test_identity_substring_does_not_dispatch(self, adapter, content):
+        await self._poll_with(
+            adapter,
+            _event("e1", content=content, created_at=10),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_signed_recipient_tag_dispatches_without_text_mention(self, adapter):
+        event = _event("e1", content="please take a look", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+        await self._poll_with(adapter, event)
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_other_recipient_tag_does_not_dispatch(self, adapter):
+        event = _event("e1", content="please take a look", created_at=10)
+        event["tags"].append(["p", "b" * 64])
+        await self._poll_with(adapter, event)
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_require_mention_false_still_dispatches_unaddressed_message(self, adapter):
+        adapter.require_mention = False
+        await self._poll_with(adapter, _event("e1", content="just chatting", created_at=10))
+        assert len(adapter._dispatched) == 1
+
+    def test_strip_mention_requires_at_for_display_name(self, adapter):
+        assert adapter._strip_mention("@Chip: /whoami") == "/whoami"
+        assert adapter._strip_mention("Chip: please review") == "Chip: please review"
+        assert adapter._strip_mention("@Chip-bot: please review") == "@Chip-bot: please review"
 
 
     @pytest.mark.asyncio
@@ -1034,9 +1095,8 @@ class TestDmClassification:
 
 
     @pytest.mark.asyncio
-    async def test_channel_like_metadata_blocks_latch_even_without_mention(self, adapter):
-        """Second guard on its own: even a p-tagged, un-mentioned message
-        cannot reclassify a conversation whose metadata says real channel."""
+    async def test_channel_ptag_dispatches_without_latching(self, adapter):
+        """A signed recipient tag wakes a channel without turning it into a DM."""
         adapter._channel_meta[CHANNEL]["description"] = ""
         adapter._channel_meta[CHANNEL]["name"] = "announcements"
         await self._poll_with(
@@ -1044,7 +1104,26 @@ class TestDmClassification:
             _tagged_event("e1", CHANNEL, content="fyi everyone", p=SELF_PUBKEY),
         )
         assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
-        assert adapter._dispatched == []
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event(
+                "e2", CHANNEL, content="plain follow-up", created_at=1001, p=None
+            ),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_missing_metadata_never_latches_group_as_dm(self, adapter):
+        adapter._channel_meta.pop(CHANNEL)
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event("e1", CHANNEL, content="tag-only mention", p=SELF_PUBKEY),
+        )
+        assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._may_reclassify_as_dm(CHANNEL) is False
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1129,7 +1129,7 @@ class TestDmClassification:
     @pytest.mark.asyncio
     async def test_dm_shaped_channel_discovered_when_dms_list_empty(self):
         """Fallback discovery: with `dms list` broken (returns []), a
-        DM-shaped `channels list` entry gets watched; real channels not
+        DM-shaped `channels list` entry becomes a DM; real channels not
         already watched are left alone."""
         a = _make_adapter()
         cli = _ScriptedCli()
@@ -1141,11 +1141,26 @@ class TestDmClassification:
         ])
         a._run_cli = cli
         await a._discover_dms(seed=False)
-        # Watched as group; the p-tag latch flips it on the first real DM.
-        assert a._channel_state[DM_CHANNEL]["chat_type"] == "group"
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "dm"
         assert a._may_reclassify_as_dm(DM_CHANNEL) is True
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
+
+    @pytest.mark.asyncio
+    async def test_dm_metadata_promotes_existing_group_without_recipient_tag(self, adapter):
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [adapter._channel_meta[DM_CHANNEL]])
+        adapter._run_cli = cli
+        await adapter._discover_dms(seed=False)
+        assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
+        await self._poll_with(
+            adapter, DM_CHANNEL,
+            _tagged_event("e1", DM_CHANNEL, content="no mention and no p tag"),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._dispatched[0]["chat_type"] == "dm"
 
 
 class TestThreadRoots:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -31,6 +31,7 @@ _standalone_send = _buzz_mod._standalone_send
 SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
 SELF_NPUB = "npub1nl2u0wnd8mezfknc74q7pl9ec58h9nrrakce4tnk434qgaxl4psqe5twr6"
 OTHER_PUBKEY = "a" * 64
+AGENT_PUBKEY = "b" * 64
 CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
 # Real DM conversation as materialized by a hosted relay: `dms list` returns
 # [] for it (#68871) while `channels list` shows it as name "DM", empty
@@ -43,6 +44,7 @@ _ENV_VARS = (
     "BUZZ_CHANNELS",
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
+    "BUZZ_REACTION_ONLY_USERS",
     "BUZZ_ALLOW_ALL_USERS",
     "BUZZ_POLL_INTERVAL",
     "BUZZ_AUTH_TAG",
@@ -757,6 +759,46 @@ class TestMentionGating:
     async def test_allowlist_blocks_unauthorized(self, adapter):
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_agent_tag_reacts_without_dispatch(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_agent_message_without_explicit_recipient_gets_no_reaction(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await self._poll_with(
+            adapter,
+            _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10),
+        )
+
+        adapter.send_reaction.assert_not_awaited()
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_sender_tag_gets_no_reaction(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey="c" * 64, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_not_awaited()
         assert adapter._dispatched == []
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -20,6 +20,7 @@ _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
 _resolve_private_key = _buzz_mod._resolve_private_key
 _resolve_auth_tag = _buzz_mod._resolve_auth_tag
+_event_reply_parent_id = _buzz_mod._event_reply_parent_id
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
@@ -698,19 +699,20 @@ class TestMentionGating:
         assert adapter._dispatched == []
 
 
-# ── DM classification via p-tags (issue #68871) ──────────────────────────
+# ── NIP-10 thread replies as addressed (issue #75826) ────────────────────
 #
-# `buzz dms list` returns [] on some hosted relays, so DM conversations leak
-# in via `channels list` and get seeded chat_type="group".  The adapter must
-# reclassify them from the Nostr tags of real traffic: DM messages are
-# p-tagged to our own pubkey WITHOUT the text mentioning us, while channel
-# messages only ever p-tag us when the text visibly @mentions us.
+# With require_mention (default), channel replies whose direct parent is the
+# agent's own message must dispatch even when the text has no @name — Buzz
+# Desktop's natural reply affordance for /approve never types a mention.
 
 
 def _tagged_event(event_id, channel, *, content, pubkey=OTHER_PUBKEY,
-                  created_at=1000, kind=9, p=None, reply_to=None):
+                  created_at=1000, kind=9, p=None, reply_to=None, root=None):
     """Event with the tag shapes observed on a live relay (h/p/e tags)."""
     tags = [["h", channel]]
+    # NIP-10 order as Desktop emits: root first, then reply (when both set).
+    if root:
+        tags.append(["e", root, "", "root"])
     if reply_to:
         tags.append(["e", reply_to, "", "reply"])
     if p:
@@ -723,6 +725,245 @@ def _tagged_event(event_id, channel, *, content, pubkey=OTHER_PUBKEY,
         "kind": kind,
         "tags": tags,
     }
+
+
+class TestNip10ThreadReplyMentionGate:
+    """require_mention + NIP-10 reply-to-own-message (#75826)."""
+
+    @pytest.fixture
+    def adapter(self):
+        a = _make_adapter()
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        a._channel_state[CHANNEL] = a._new_channel_state("group")
+        return a
+
+    async def _poll_with(self, adapter, *events):
+        cli = _ScriptedCli()
+        cli.script("messages", "get", list(events))
+        adapter._run_cli = cli
+        await adapter._poll_channel(CHANNEL)
+
+    def test_event_reply_parent_prefers_reply_marker(self):
+        ev = _tagged_event(
+            "child", CHANNEL, content="ok", root="root-id", reply_to="parent-id"
+        )
+        assert _event_reply_parent_id(ev) == "parent-id"
+        assert _event_reply_parent_id(
+            _tagged_event("c2", CHANNEL, content="ok", root="only-root")
+        ) == "only-root"
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_to_own_message_dispatches_without_mention(self, adapter):
+        # Live agent prompt lands first (self-echo is cached, not dispatched).
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "agent-prompt",
+                CHANNEL,
+                content="⚠️ Dangerous command requires approval",
+                pubkey=SELF_PUBKEY,
+                created_at=10,
+            ),
+            _tagged_event(
+                "user-reply",
+                CHANNEL,
+                content="sure go ahead",
+                root="agent-prompt",
+                reply_to="agent-prompt",
+                created_at=11,
+            ),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["user-reply"]
+        assert adapter._dispatched[0]["text"] == "sure go ahead"
+        assert adapter._dispatched[0]["reply_to_message_id"] == "agent-prompt"
+        assert adapter._dispatched[0]["reply_to_is_own_message"] is True
+        assert "approval" in (adapter._dispatched[0]["reply_to_text"] or "")
+
+    @pytest.mark.asyncio
+    async def test_approve_thread_reply_dispatches(self, adapter):
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "agent-approve-prompt",
+                CHANNEL,
+                content="⚠️ Dangerous command requires approval",
+                pubkey=SELF_PUBKEY,
+                created_at=20,
+            ),
+            _tagged_event(
+                "approve-msg",
+                CHANNEL,
+                content="/approve session",
+                root="agent-approve-prompt",
+                reply_to="agent-approve-prompt",
+                created_at=21,
+            ),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["approve-msg"]
+        assert adapter._dispatched[0]["text"] == "/approve session"
+        assert adapter._dispatched[0]["reply_to_is_own_message"] is True
+
+    @pytest.mark.asyncio
+    async def test_reply_to_other_user_stays_gated(self, adapter):
+        third = "c" * 64
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "other-msg",
+                CHANNEL,
+                content="anyone around?",
+                pubkey=third,
+                created_at=30,
+            ),
+            _tagged_event(
+                "reply-other",
+                CHANNEL,
+                content="yeah I'm here",
+                root="other-msg",
+                reply_to="other-msg",
+                created_at=31,
+            ),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_reply_to_unknown_parent_stays_gated(self, adapter):
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "orphan-reply",
+                CHANNEL,
+                content="/approve session",
+                root="never-seen",
+                reply_to="never-seen",
+                created_at=40,
+            ),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_seeded_own_history_matches_thread_reply(self, adapter):
+        """Replies to agent messages sent before a gateway restart still match."""
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "get",
+            [
+                _tagged_event(
+                    "pre-restart-agent",
+                    CHANNEL,
+                    content="⚠️ Dangerous command requires approval",
+                    pubkey=SELF_PUBKEY,
+                    created_at=50,
+                ),
+            ],
+        )
+        adapter._run_cli = cli
+        await adapter._seed_channel(CHANNEL, chat_type="group")
+        assert "pre-restart-agent" in adapter._channel_state[CHANNEL]["event_meta"]
+        assert adapter._dispatched == []
+
+        cli.responses.clear()
+        cli.script(
+            "messages",
+            "get",
+            [
+                _tagged_event(
+                    "post-restart-approve",
+                    CHANNEL,
+                    content="/approve always",
+                    root="pre-restart-agent",
+                    reply_to="pre-restart-agent",
+                    created_at=51,
+                ),
+            ],
+        )
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["post-restart-approve"]
+        assert adapter._dispatched[0]["reply_to_is_own_message"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_recorded_id_matches_thread_reply(self, adapter):
+        """send()'s returned event_id is cached even without a WS/poll echo."""
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "sent-prompt", "message": ""},
+        )
+        adapter._run_cli = cli
+        result = await adapter.send(
+            CHANNEL, "⚠️ Dangerous command requires approval"
+        )
+        assert result.success is True
+        assert "sent-prompt" in adapter._channel_state[CHANNEL]["event_meta"]
+        meta = adapter._channel_state[CHANNEL]["event_meta"]["sent-prompt"]
+        assert meta[0] == SELF_PUBKEY
+
+        cli.responses.clear()
+        cli.script(
+            "messages",
+            "get",
+            [
+                _tagged_event(
+                    "reply-to-send",
+                    CHANNEL,
+                    content="/approve session",
+                    root="sent-prompt",
+                    reply_to="sent-prompt",
+                    created_at=61,
+                ),
+            ],
+        )
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["reply-to-send"]
+        assert adapter._dispatched[0]["reply_to_is_own_message"] is True
+        assert adapter._dispatched[0]["reply_to_message_id"] == "sent-prompt"
+
+    @pytest.mark.asyncio
+    async def test_mention_path_still_populates_reply_context(self, adapter):
+        """Visible @mention + thread reply still fills reply_to_* on dispatch."""
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "agent-prior",
+                CHANNEL,
+                content="previous answer",
+                pubkey=SELF_PUBKEY,
+                created_at=70,
+            ),
+            _tagged_event(
+                "mentioned-reply",
+                CHANNEL,
+                content="@Chip follow up please",
+                root="agent-prior",
+                reply_to="agent-prior",
+                created_at=71,
+            ),
+        )
+        assert len(adapter._dispatched) == 1
+        d = adapter._dispatched[0]
+        assert d["message_id"] == "mentioned-reply"
+        assert d["text"] == "follow up please"  # leading @Chip stripped
+        assert d["reply_to_message_id"] == "agent-prior"
+        assert d["reply_to_author_id"] == SELF_PUBKEY
+        assert d["reply_to_is_own_message"] is True
+        assert d["reply_to_text"] == "previous answer"
+
+
+# ── DM classification via p-tags (issue #68871) ──────────────────────────
+#
+# `buzz dms list` returns [] on some hosted relays, so DM conversations leak
+# in via `channels list` and get seeded chat_type="group".  The adapter must
+# reclassify them from the Nostr tags of real traffic: DM messages are
+# p-tagged to our own pubkey WITHOUT the text mentioning us, while channel
+# messages only ever p-tag us when the text visibly @mentions us.
 
 
 class TestDmClassification:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -775,6 +775,19 @@ class TestMentionGating:
         assert adapter._dispatched == []
 
     @pytest.mark.asyncio
+    async def test_allowlist_takes_precedence_over_reaction_only(self, adapter):
+        adapter._allowed_pubkeys = {AGENT_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_not_awaited()
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
     async def test_agent_message_without_explicit_recipient_gets_no_reaction(self, adapter):
         adapter._allowed_pubkeys = {OTHER_PUBKEY}
         adapter._reaction_only_pubkeys = {AGENT_PUBKEY}

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1393,11 +1393,15 @@ class TestBuzzAdapterSend:
 
         assert result.success is True
         assert result.message_id == "evt124"
-        assert len(cli.calls) == 2
-        assert cli.calls[0][1] == (
+        # Composed with #83414 mention resolution: resolution probes
+        # (channels members / messages get) precede the sends; assert on the
+        # publish calls only.
+        sends = [c for c in cli.calls if tuple(c[0][:2]) == ("messages", "send")]
+        assert len(sends) == 2
+        assert sends[0][1] == (
             "Continue in @session:default/20260809_092321_24aa09."
         )
-        assert cli.calls[1][1] == (
+        assert sends[1][1] == (
             "Continue in @\u200bsession:default/20260809_092321_24aa09."
         )
 
@@ -1417,7 +1421,10 @@ class TestBuzzAdapterSend:
         result = await adapter.send(CHANNEL, "hello @session")
 
         assert result.success is False
-        assert len(cli.calls) == 1
+        # Unrelated failures never retry the publish (mention-resolution
+        # probes for "@" content are not sends).
+        sends = [c for c in cli.calls if tuple(c[0][:2]) == ("messages", "send")]
+        assert len(sends) == 1
 
     @pytest.mark.asyncio
     async def test_send_image_retries_unresolved_presentation_mention(self, tmp_path):
@@ -1814,6 +1821,7 @@ class TestStandaloneSend:
             *,
             relay_url,
             private_key,
+            auth_tag="",
             input_text=None,
             timeout=30.0,
         ):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1365,6 +1365,95 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--reply-to") + 1] == "stable-root"
 
+    @pytest.mark.asyncio
+    async def test_send_retries_unresolved_presentation_mention_without_notifying(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@session' does not match a current channel member; "
+                "retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt124", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Continue in @session:default/20260809_092321_24aa09.",
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt124"
+        assert len(cli.calls) == 2
+        assert cli.calls[0][1] == (
+            "Continue in @session:default/20260809_092321_24aa09."
+        )
+        assert cli.calls[1][1] == (
+            "Continue in @\u200bsession:default/20260809_092321_24aa09."
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_unrelated_cli_failure(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="relay unavailable",
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "hello @session")
+
+        assert result.success is False
+        assert len(cli.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_image_retries_unresolved_presentation_mention(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@session' does not match a current channel member; "
+                "retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt127", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="See @session:default/example.",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 2
+        assert cli.calls[0][1] == "See @session:default/example."
+        assert cli.calls[1][1] == "See @\u200bsession:default/example."
+
+
 
 # ── Thread anchoring ──────────────────────────────────────────────────────
 
@@ -1705,6 +1794,59 @@ class TestStandaloneSend:
         assert result == {"success": True, "message_id": "evt-key"}
         assert captured["private_key"] == "nsec1x"
         assert captured["auth_tag"] == ""
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_retries_unresolved_presentation_mention(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        sent = []
+
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            input_text=None,
+            timeout=30.0,
+        ):
+            sent.append(input_text)
+            if len(sent) == 1:
+                return (
+                    1,
+                    "",
+                    "user_error: mention '@session' does not match a current "
+                    "channel member; retry with --mention <pubkey>",
+                )
+            return (
+                0,
+                json.dumps(
+                    {"accepted": True, "event_id": "evt-standalone", "message": ""}
+                ),
+                "",
+            )
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "See @session:default/example.",
+        )
+
+        assert result == {"success": True, "message_id": "evt-standalone"}
+        assert sent == [
+            "See @session:default/example.",
+            "See @\u200bsession:default/example.",
+        ]
+
 
 
 # ── Editing and deleting (streaming) ──────────────────────────────────

--- a/tests/gateway/test_buzz_forum_kinds.py
+++ b/tests/gateway/test_buzz_forum_kinds.py
@@ -1,0 +1,137 @@
+"""Regression tests for Buzz forum-kind dispatch (#90309).
+
+The inbound path hardcoded Nostr kind 9 (chat) at both the WebSocket
+subscription filter and the dispatch gate, so forum channels (kind 45001
+thread roots and 45003 comment replies) were silently never dispatched.
+The DM-reclassification check deliberately stays kind-9-only: widening it
+would let a p-tagged forum post be reclassified as a DM and bypass
+mention gating.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.buzz.adapter import (
+    _CHAT_KIND,
+    _DISPATCH_KINDS,
+    BuzzAdapter,
+)
+
+CHANNEL = "7c83e8f7bb1d4db2bb4074d5c14f2a7f6a9e1c21d3b5a90f8e7d6c5b4a392801"
+SELF_PUBKEY = "aa" * 32
+OTHER_PUBKEY = "bb" * 32
+
+
+def _dummy_nsec() -> str:
+    # Test-only placeholder, assembled to avoid a credential-shaped literal.
+    return "-".join(("nsec", "1", "test"))
+
+
+def _event(event_id, content="hey @Chip", kind=9, p_tag_self=False):
+    tags = [["h", CHANNEL]]
+    if p_tag_self:
+        tags.append(["p", SELF_PUBKEY])
+    return {
+        "id": event_id,
+        "pubkey": OTHER_PUBKEY,
+        "content": content,
+        "created_at": 100,
+        "kind": kind,
+        "tags": tags,
+    }
+
+
+def _make_group_adapter():
+    adapter = BuzzAdapter(
+        PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay"})
+    )
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._self_npub = "npub1" + "a" * 50
+    adapter._display_name = "Chip"
+    adapter._private_key = _dummy_nsec()
+    adapter._dispatched = []
+
+    async def capture(**kwargs):
+        adapter._dispatched.append(kwargs)
+
+    adapter._dispatch_message = capture
+    adapter._message_handler = AsyncMock()
+    adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+    return adapter
+
+
+class _ScriptedCli:
+    def __init__(self, events):
+        import copy
+
+        self._events = copy.deepcopy(events)
+
+    async def __call__(self, args, *, input_text=None):
+        return 0, json.dumps(self._events), ""
+
+
+class TestForumKindDispatch:
+    @pytest.mark.asyncio
+    async def test_forum_post_root_dispatched(self):
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli([_event("f1", kind=45001)])
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["f1"]
+
+    @pytest.mark.asyncio
+    async def test_forum_comment_reply_dispatched(self):
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli([_event("f2", kind=45003)])
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["f2"]
+
+    @pytest.mark.asyncio
+    async def test_undocumented_stream_kind_still_ignored(self):
+        """Stream kinds stay out of scope until their dispatch semantics are
+        confirmed — the dispatch set must not widen beyond chat + forum."""
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli(
+            [_event("s1", kind=46010), _event("s2", kind=40007)]
+        )
+        await adapter._poll_channel(CHANNEL)
+        assert adapter._dispatched == []
+
+
+class TestSubscriptionFilter:
+    @pytest.mark.asyncio
+    async def test_websocket_subscription_includes_forum_kinds(self):
+        """The REQ filter must subscribe to every dispatchable kind, or the
+        live path never even receives forum events to drop."""
+        adapter = _make_group_adapter()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, payload):
+                sent.append(json.loads(payload))
+
+        adapter._channel_state[CHANNEL]["last_ts"] = 100
+        await adapter._send_channel_subscription(_FakeWS(), "sub-1", CHANNEL)
+        assert sent, "subscription request must be sent"
+        assert sent[0][2]["kinds"] == sorted(_DISPATCH_KINDS)
+        assert 45001 in sent[0][2]["kinds"] and 45003 in sent[0][2]["kinds"]
+
+
+class TestDmReclassificationStaysChatOnly:
+    def test_ptagged_forum_post_is_not_a_dm(self):
+        """Security pin: a p-tagged kind-45001 post must NOT be reclassified
+        as a DM — that would bypass mention gating for forum content
+        (#90309 caveat). The DM check keeps the kind-9-only comparison."""
+        adapter = _make_group_adapter()
+        adapter._may_reclassify_as_dm = lambda channel_id: True
+        assert adapter._is_direct_message_event(
+            CHANNEL, _event("f3", kind=45001, p_tag_self=True)
+        ) is False
+
+    def test_ptagged_chat_message_can_still_be_a_dm(self):
+        adapter = _make_group_adapter()
+        adapter._may_reclassify_as_dm = lambda channel_id: True
+        event = _event("d1", kind=_CHAT_KIND, p_tag_self=True, content="no mention")
+        assert adapter._is_direct_message_event(CHANNEL, event) is True

--- a/tests/gateway/test_buzz_mention_resolution.py
+++ b/tests/gateway/test_buzz_mention_resolution.py
@@ -286,6 +286,34 @@ class TestSendRecovery:
         adapter = _make_adapter()
         cli = _wire(adapter, _ScriptedCli())
         cli.script("channels", "members", _members())  # nobody to resolve
+        unresolved = json.dumps({
+            "error": "user_error",
+            "message": "mention '@-mention' does not match a current channel member",
+        })
+        # Composed ladder (#82646 + #83414): the presentation-escape retry
+        # fires first; when the CLI still rejects, the self-mention downgrade
+        # is the last rung.
+        cli.script("messages", "send", "", code=1, stderr=unresolved)
+        cli.script("messages", "send", "", code=1, stderr=unresolved)
+        cli.script("messages", "send", {"accepted": True, "event_id": "e3"})
+
+        result = await adapter.send(CHANNEL, "just @-mention me")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 3
+        # Rung 3: escaped presentation token, no mention flags.
+        assert "--mention" not in sends[1][0]
+        assert "\u200b" in (sends[1][1] or "")
+        # Rung 4: self-mention downgrade with the original content.
+        assert ["--mention", SELF_PUBKEY] == sends[2][0][-2:]
+        assert sends[2][1] == "just @-mention me"
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_token_escape_retry_delivers(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members())
         cli.script(
             "messages", "send", "",
             code=1,
@@ -294,11 +322,12 @@ class TestSendRecovery:
                 "message": "mention '@-mention' does not match a current channel member",
             }),
         )
-        cli.script("messages", "send", {"accepted": True, "event_id": "e3"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "e4"})
 
         result = await adapter.send(CHANNEL, "just @-mention me")
 
         assert result.success
         sends = self._send_calls(cli)
         assert len(sends) == 2
-        assert ["--mention", SELF_PUBKEY] == sends[1][0][-2:]
+        assert "--mention" not in sends[1][0]
+        assert sends[1][1] == "just @\u200b-mention me"

--- a/tests/gateway/test_buzz_mention_resolution.py
+++ b/tests/gateway/test_buzz_mention_resolution.py
@@ -1,0 +1,304 @@
+"""Tests for the Buzz adapter's @mention resolution (PR #83414).
+
+Covers ``_mention_pubkeys_for`` / ``_channel_member_pubkeys`` and the
+``send()`` recovery paths: membership-accurate candidate sourcing, token
+boundaries on both sides of the @name, duplicate-name ambiguity, and the
+non-member / unresolvable-token publish retries.
+"""
+
+import json
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_buzz_mod = load_plugin_adapter("buzz")
+
+BuzzAdapter = _buzz_mod.BuzzAdapter
+
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+FIZZ_PUBKEY = "b" * 64
+BUZZ_PUBKEY = "c" * 64
+DUPE_PUBKEY = "d" * 64
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+
+_ENV_VARS = (
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_CHANNELS",
+    "BUZZ_HOME_CHANNEL",
+    "BUZZ_ALLOWED_USERS",
+    "BUZZ_ALLOW_ALL_USERS",
+    "BUZZ_POLL_INTERVAL",
+    "BUZZ_CLI_PATH",
+    "BUZZ_CREDENTIALS_FILE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path / "no-creds")
+    yield
+
+
+def _make_adapter(extra=None):
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay", **(extra or {})})
+    adapter = BuzzAdapter(cfg)
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._private_key = "nsec1test"
+    return adapter
+
+
+class _ScriptedCli:
+    """Fake ``_run_cli`` that routes on the buzz subcommand and records calls."""
+
+    def __init__(self):
+        self.responses = {}
+        self.calls = []
+
+    def script(self, group, cmd, payload, code=0, stderr=""):
+        stdout = payload if isinstance(payload, str) else json.dumps(payload)
+        self.responses.setdefault((group, cmd), []).append((code, stdout, stderr))
+
+    async def __call__(self, args, *, input_text=None):
+        self.calls.append((list(args), input_text))
+        queue = self.responses.get((args[0], args[1]), [])
+        if len(queue) > 1:
+            return queue.pop(0)
+        if queue:
+            return queue[0]
+        return 0, "[]", ""
+
+
+def _wire(adapter, cli):
+    adapter._run_cli = cli
+    return cli
+
+
+def _members(*pubkeys):
+    return [{"pubkey": pk} for pk in pubkeys]
+
+
+def _profile(pubkey, name):
+    return [{"pubkey": pubkey, "display_name": name}]
+
+
+# ── candidate sourcing ────────────────────────────────────────────────────
+
+
+class TestChannelMemberPubkeys:
+
+    @pytest.mark.asyncio
+    async def test_members_subcommand_is_primary_source(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY, BUZZ_PUBKEY))
+
+        pks = await adapter._channel_member_pubkeys(CHANNEL)
+
+        assert pks == [FIZZ_PUBKEY, BUZZ_PUBKEY]
+        assert ("messages", "get") not in {(c[0][0], c[0][1]) for c in cli.calls}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_recent_traffic_when_members_unavailable(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", "", code=1, stderr="unknown subcommand")
+        cli.script(
+            "messages",
+            "get",
+            [
+                {"pubkey": FIZZ_PUBKEY, "tags": [["p", BUZZ_PUBKEY]]},
+            ],
+        )
+
+        pks = await adapter._channel_member_pubkeys(CHANNEL)
+
+        assert FIZZ_PUBKEY in pks and BUZZ_PUBKEY in pks
+
+
+# ── token matching ────────────────────────────────────────────────────────
+
+
+class TestMentionTokenMatching:
+
+    async def _resolve(self, content, members=None, profiles=None):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(*(members or [FIZZ_PUBKEY])))
+        for pk, name in (profiles or {FIZZ_PUBKEY: "Fizz"}).items():
+            cli.script("users", "get", _profile(pk, name))
+        return await adapter._mention_pubkeys_for(CHANNEL, content)
+
+    @pytest.mark.asyncio
+    async def test_clean_mention_resolves(self):
+        assert await self._resolve("hey @Fizz, ping") == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_trailing_punctuation_resolves(self):
+        assert await self._resolve("@Fizz!! wake up") == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_right_boundary_rejects_longer_token(self):
+        assert await self._resolve("@FizzBuzz is a game") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_email_like_text(self):
+        assert await self._resolve("mail me at email@Fizz today") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_adjacent_word_char(self):
+        assert await self._resolve("x@Fizz") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_double_at(self):
+        assert await self._resolve("@@Fizz") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_is_unicode_aware(self):
+        # 山 is a word character: "山田@Fizz" is email-shaped text in a
+        # non-ASCII script, not a mention.
+        assert await self._resolve("山田@Fizz") == []
+
+    @pytest.mark.asyncio
+    async def test_no_at_sign_short_circuits_without_cli_calls(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        assert await adapter._mention_pubkeys_for(CHANNEL, "no mentions here") == []
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_longest_name_wins_and_consumes_span(self):
+        result = await self._resolve(
+            "@Hermes Matt please review",
+            members=[FIZZ_PUBKEY, BUZZ_PUBKEY],
+            profiles={FIZZ_PUBKEY: "Hermes Matt", BUZZ_PUBKEY: "Hermes"},
+        )
+        assert result == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_display_names_tag_nobody(self):
+        result = await self._resolve(
+            "@Fizz which one of you is real",
+            members=[FIZZ_PUBKEY, DUPE_PUBKEY],
+            profiles={FIZZ_PUBKEY: "Fizz", DUPE_PUBKEY: "Fizz"},
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_self_is_never_a_candidate(self):
+        result = await self._resolve(
+            "@Chip and @Fizz",
+            members=[SELF_PUBKEY, FIZZ_PUBKEY],
+            profiles={SELF_PUBKEY: "Chip", FIZZ_PUBKEY: "Fizz"},
+        )
+        assert result == [FIZZ_PUBKEY]
+
+
+# ── caching ───────────────────────────────────────────────────────────────
+
+
+class TestResolutionCaching:
+
+    @pytest.mark.asyncio
+    async def test_member_list_cached_within_ttl(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz one") == [FIZZ_PUBKEY]
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz two") == [FIZZ_PUBKEY]
+
+        member_calls = [c for c in cli.calls if (c[0][0], c[0][1]) == ("channels", "members")]
+        assert len(member_calls) == 1, "second resolve must hit the member cache"
+
+    @pytest.mark.asyncio
+    async def test_profile_name_expires_after_ttl(self, monkeypatch):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "FizzRenamed"))
+
+        clock = [1000.0]
+        monkeypatch.setattr(_buzz_mod.time, "monotonic", lambda: clock[0])
+
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz hi") == [FIZZ_PUBKEY]
+        # Inside both TTLs: rename not visible yet, no new lookups needed.
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@FizzRenamed hi") == []
+        # Past the name TTL (and member TTL): the rename resolves.
+        clock[0] += _buzz_mod._PROFILE_NAME_TTL + 1
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@FizzRenamed hi") == [FIZZ_PUBKEY]
+
+
+# ── send() recovery paths ─────────────────────────────────────────────────
+
+
+class TestSendRecovery:
+
+    def _sending_adapter(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+        return adapter, cli
+
+    def _send_calls(self, cli):
+        return [c for c in cli.calls if (c[0][0], c[0][1]) == ("messages", "send")]
+
+    @pytest.mark.asyncio
+    async def test_resolved_mention_attached_to_publish(self):
+        adapter, cli = self._sending_adapter()
+        cli.script("messages", "send", {"accepted": True, "event_id": "e1"})
+
+        result = await adapter.send(CHANNEL, "@Fizz hello")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 1
+        assert ["--mention", FIZZ_PUBKEY] == sends[0][0][-2:]
+
+    @pytest.mark.asyncio
+    async def test_non_member_mention_retries_without_mentions(self):
+        adapter, cli = self._sending_adapter()
+        cli.script(
+            "messages", "send", "",
+            code=1,
+            stderr=json.dumps({"error": "user_error", "message": "mentioned pubkeys are not channel members"}),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "e2"})
+
+        result = await adapter.send(CHANNEL, "@Fizz hello")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 2
+        assert "--mention" in sends[0][0]
+        assert "--mention" not in sends[1][0]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_token_retries_with_self_mention(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members())  # nobody to resolve
+        cli.script(
+            "messages", "send", "",
+            code=1,
+            stderr=json.dumps({
+                "error": "user_error",
+                "message": "mention '@-mention' does not match a current channel member",
+            }),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "e3"})
+
+        result = await adapter.send(CHANNEL, "just @-mention me")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 2
+        assert ["--mention", SELF_PUBKEY] == sends[1][0][-2:]

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -29,6 +29,55 @@ def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
+def test_buzz_uuid_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "buzz", "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
+    )
+
+    assert chat_id == "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:
+    buzz = Platform("buzz")
+    buzz_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={buzz: buzz_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(
+            chat_id="93b1a8c9-7093-4117-9db1-7199bacabd48"
+        ),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw Buzz UUID should not resolve via directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "buzz:e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
+                    "message": "exact DM",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        buzz,
+        buzz_cfg,
+        "e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
+        "exact DM",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
+
+
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
     whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
     config = SimpleNamespace(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -53,6 +53,12 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# Buzz channels and DMs use native UUID identifiers. They are explicit
+# targets and must never substitute the configured home channel.
+_BUZZ_UUID_RE = re.compile(
+    r"^\s*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\s*$",
+    re.IGNORECASE,
+)
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -594,6 +600,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # through to the _PHONE_PLATFORMS handler below.
         if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
+    if platform_name == "buzz" and _BUZZ_UUID_RE.fullmatch(target_ref):
+        return target_ref.strip(), None, True
     stripped_target = target_ref.strip()
     if platform_name == "signal" and stripped_target.startswith("group:"):
         group_id = stripped_target[len("group:"):].strip()


### PR DESCRIPTION
## Summary
Buzz dispatch stops missing real triggers and stops waking on noise: forum kinds dispatch, NIP-10 replies to the agent's own messages pass `require_mention` (unblocking /approve), group addressing requires an explicit @mention or signed p-tag, DM classification comes from authoritative metadata, and outbound @mentions resolve to real pubkeys.
Fixes #75826, #90309, #87899, #77987, #78798, #78797.

## Changes
- #90314 (@liuhao1024): forum kinds 45001/45003 join `_DISPATCH_KINDS` at the WS filter AND the dispatch gate.
- #75953 (@arimu1): NIP-10 reply-parent resolution + per-channel event_meta cache — thread replies to the agent's own messages dispatch under require_mention (fixes #75826, the /approve deadlock).
- #92781 (@conrelma): explicit group addressing (@-required display-name with token boundaries OR signed recipient p-tag); meta-less channels fail closed as groups; DM-shaped channel entries promote to DM at discovery — fixes #78798 bare-name wake (one incident: 21+ API calls/~148k tokens), #87899, #77987.
- #89751 (@camaragon): `reaction_only_users` — trusted agent tags get a 👀 receipt, zero dispatch authority.
- #82646 (@blunkjamie-dev) + #83414 (@mattlutzz) composed: @Name→pubkey resolution with explicit `--mention`, 4-rung send-recovery ladder (resolved mentions → drop on membership drift → U+200B escape retry → self-mention downgrade); buzz UUID targets never fall through to home channel — fixes #78797 silent reply drops.
- Gate composition: reply-to-own OR _is_addressed OR mention — the three semantics compose rather than compete. #78582 (DM-disable mode) deferred as a real feature.

## Validation
95 targeted tests green; 4 sabotage-checks each tripped tests; ruff clean.

**Live repro:** 11/11 E2E with real adapter imports + synthetic Nostr events (kinds 9/45001/45003/46010, p-tag shapes, NIP-10 reply markers) in temp HERMES_HOME.

## Infographic

![Buzz dispatch mention gate](https://v3b.fal.media/files/b/0aa88d72/dcjJvTwL5hlry2BkpZBNe_PrIY1V6O.png)
