### PR TITLE
fix(buzz): inbound attachments reach the agent and outbound media uploads natively (salvages #84113 #78051 #95688 #74999 #78046)

### DIFF
--- a/contributors/emails/mathias@gorf.de
+++ b/contributors/emails/mathias@gorf.de
@@ -1,0 +1,1 @@
+frischeDaten

--- a/contributors/emails/pbaker@cteh.com
+++ b/contributors/emails/pbaker@cteh.com
@@ -1,0 +1,1 @@
+chigreen

--- a/contributors/emails/riyaazd29@users.noreply.github.com
+++ b/contributors/emails/riyaazd29@users.noreply.github.com
@@ -1,0 +1,1 @@
+riyaazd29

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3907,11 +3907,26 @@ class BasePlatformAdapter(ABC):
         registered via :meth:`set_authorization_check`. Returns ``None``
         when no check is registered (caller should treat as "trust unknown"
         and preserve legacy behaviour).
+
+        Only the literal booleans are propagated. A callback that returns
+        anything else is treated as "unknown" rather than coerced with
+        ``bool()``: callers that gate a credentialed side effect on an
+        explicit ``is True`` must not have a truthy non-boolean (a status
+        string, a sentinel object) silently promoted to an authorization.
         """
         if not user_id or self._authorization_check is None:
             return None
         try:
-            return bool(self._authorization_check(user_id, chat_type, chat_id))
+            result = self._authorization_check(user_id, chat_type, chat_id)
+            if result is True:
+                return True
+            if result is False:
+                return False
+            logger.warning(
+                "[%s] Authorization check returned %s for user %s; treating as unknown",
+                self.name, type(result).__name__, user_id,
+            )
+            return None
         except Exception:
             logger.warning(
                 "[%s] Authorization check raised for user %s; treating as unknown",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2461,6 +2461,9 @@ class MessageEvent:
     # media_urls: local file paths (for vision tool access)
     media_urls: List[str] = field(default_factory=list)
     media_types: List[str] = field(default_factory=list)
+    # Per-attachment text-inlining contract. None/absent preserves the legacy
+    # assumption that text/* adapters already injected content into ``text``.
+    media_text_inlined: List[Optional[bool]] = field(default_factory=list)
     
     # Reply context
     reply_to_message_id: Optional[str] = None
@@ -2845,10 +2848,22 @@ def merge_pending_message_event(
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)
         incoming_has_media = bool(event.media_urls)
+        incoming_inline_flags: List[Optional[bool]] = []
+        if incoming_has_media:
+            existing_inline_flags = list(getattr(existing, "media_text_inlined", []) or [])
+            existing_inline_flags.extend(
+                [None] * max(0, len(existing.media_urls) - len(existing_inline_flags))
+            )
+            incoming_inline_flags = list(getattr(event, "media_text_inlined", []) or [])
+            incoming_inline_flags.extend(
+                [None] * max(0, len(event.media_urls) - len(incoming_inline_flags))
+            )
+            existing.media_text_inlined = existing_inline_flags
 
         if existing_is_photo and incoming_is_photo:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
+            existing.media_text_inlined.extend(incoming_inline_flags)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
             _invalidate_pending_stt_cache(existing)
@@ -2858,6 +2873,7 @@ def merge_pending_message_event(
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+                existing.media_text_inlined.extend(incoming_inline_flags)
             if event.text:
                 if existing.text:
                     existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3442,11 +3442,18 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
-def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
+def _build_document_context_note(
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    *,
+    content_inlined: bool = True,
+) -> str:
     """Context note prepended to a user turn when they attach a document.
 
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
+    Text documents (``text/*``) are usually inlined upstream by the platform
+    adapter. ``content_inlined=False`` records adapters that cache the file
+    without injecting its content, so the note tells the agent to read it.
 
     Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
     must tell the agent to *extract* the text itself before answering — earlier
@@ -3454,11 +3461,17 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     model into punting back to the user, which is why attached PDFs/DOCX looked
     "unreadable" to the agent even though it has the tools to read them.
     """
-    if mtype.startswith("text/"):
+    if mtype.startswith("text/") and content_inlined:
         return (
             f"[The user sent a text document: '{display_name}'. "
             f"Its content has been included below. "
             f"The file is also saved at: {agent_path}]"
+        )
+    if mtype.startswith("text/"):
+        return (
+            f"[The user sent a text document: '{display_name}'. It is saved at: {agent_path}. "
+            f"Its content is not inlined here. Read the cached file yourself before answering "
+            f"when the user's request involves its contents.]"
         )
     return (
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
@@ -17655,6 +17668,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_id=event.message_id,
                 media_urls=list(getattr(event, "media_urls", []) or []),
                 media_types=list(getattr(event, "media_types", []) or []),
+                media_text_inlined=list(getattr(event, "media_text_inlined", []) or []),
                 reply_to_message_id=event.reply_to_message_id,
                 reply_to_text=event.reply_to_text,
                 reply_to_author_id=event.reply_to_author_id,
@@ -19439,12 +19453,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # mis-routed here as an image and the provider 400s.
                 if _event_media_is_image(event, i):
                     image_paths.append(path)
-                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
-                # MessageType.VOICE = voice message (Opus/OGG) — always STT
-                if event.message_type == MessageType.AUDIO:
-                    audio_file_paths.append(path)
-                elif not _pending_stt_prepared and _event_media_is_stt_input(event, i):
-                    audio_paths.append(path)
+                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT.
+                # Mixed DOCUMENT events also preserve audio as a file path instead of
+                # dropping it or treating it as a voice note.
+                if _event_media_is_audio(event, i):
+                    if event.message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
+                        audio_file_paths.append(path)
+                    elif not _pending_stt_prepared and _event_media_is_stt_input(event, i):
+                        audio_paths.append(path)
                 if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                     video_paths.append(path)
 
@@ -19616,7 +19632,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                context_note = _build_document_context_note(display_name, agent_path, mtype)
+                inline_flags = getattr(event, "media_text_inlined", None) or []
+                inline_flag = inline_flags[i] if i < len(inline_flags) else None
+                context_note = _build_document_context_note(
+                    display_name,
+                    agent_path,
+                    mtype,
+                    content_inlined=inline_flag is not False,
+                )
                 message_text = f"{context_note}\n\n{message_text}"
 
         # Discord: surface the triggering message id per-turn on the user

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -269,7 +269,7 @@ _MEDIA_URL_PATTERN = (
     r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
 )
 _MARKDOWN_MEDIA_RE = re.compile(
-    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    rf"!\[(?P<alt>[^\]]*)\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
     r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
     re.IGNORECASE,
 )
@@ -310,10 +310,10 @@ def _is_relay_media_url(url: str, relay_url: str) -> bool:
 
 def _find_relay_media_refs(
     text: str, relay_url: str
-) -> Tuple[List[str], List[Tuple[int, int]]]:
-    """Find same-relay media URLs and the content spans that contain them."""
+) -> Tuple[List[str], List[Tuple[int, int, str]]]:
+    """Find same-relay media URLs and their safe text replacements."""
     urls: List[str] = []
-    spans: List[Tuple[int, int]] = []
+    replacements: List[Tuple[int, int, str]] = []
     markdown_spans: List[Tuple[int, int]] = []
 
     for match in _MARKDOWN_MEDIA_RE.finditer(text):
@@ -321,7 +321,7 @@ def _find_relay_media_refs(
         if not _is_relay_media_url(url, relay_url):
             continue
         markdown_spans.append(match.span())
-        spans.append(match.span())
+        replacements.append((*match.span(), match.group("alt").strip()))
         if url not in urls:
             urls.append(url)
 
@@ -334,18 +334,17 @@ def _find_relay_media_refs(
         url = match.group(0)
         if not _is_relay_media_url(url, relay_url):
             continue
-        spans.append(match.span())
+        replacements.append((*match.span(), ""))
         if url not in urls:
             urls.append(url)
 
-    return urls, spans
+    return urls, replacements
 
 
-def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
-    chars = list(text)
-    for start, end in sorted(spans, reverse=True):
-        del chars[start:end]
-    cleaned = "".join(chars)
+def _replace_media_refs(text: str, replacements: List[Tuple[int, int, str]]) -> str:
+    cleaned = text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        cleaned = f"{cleaned[:start]}{replacement}{cleaned[end:]}"
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned.strip()
@@ -2369,11 +2368,11 @@ class BuzzAdapter(BasePlatformAdapter):
         Each object is independent: one failed download is logged and skipped
         without discarding the caption or any other successfully cached files.
         """
-        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        urls, replacements = _find_relay_media_refs(text, self.relay_url)
         if not urls:
             return text, [], [], MessageType.TEXT
 
-        cleaned_text = _remove_media_spans(text, spans)
+        cleaned_text = _replace_media_refs(text, replacements)
         media_urls: List[str] = []
         media_types: List[str] = []
         media_kinds: List[str] = []

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1580,7 +1580,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if code != 0:
             return SendResult(
                 success=False,
-                error=_cli_error_message(err, code),
+                error=_cli_error_message(err, code, redact_path=local),
                 retryable=code == 2,
             )
         event_id, receipt_error = _parse_send_receipt(out)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1508,7 +1508,7 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=caption or "")
+        code, out, err = await self._run_message_send(args, caption or "")
         if code != 0:
             return SendResult(
                 success=False,
@@ -1576,7 +1576,7 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=caption or "")
+        code, out, err = await self._run_message_send(args, caption or "")
         if code != 0:
             return SendResult(
                 success=False,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -42,9 +42,11 @@ environment and is never logged.
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import shutil
+import tempfile
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -258,6 +260,95 @@ _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
+
+# Buzz-hosted Blossom media is private to the community. Inbound messages
+# carry media as markdown or bare relay URLs, so the adapter must authenticate
+# and localise those references before the gateway hands them to vision.
+_MEDIA_URL_PATTERN = (
+    r"https?://[^\s<>\[\]()]+/media/"
+    r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
+)
+_MARKDOWN_MEDIA_RE = re.compile(
+    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
+    re.IGNORECASE,
+)
+_BARE_MEDIA_RE = re.compile(_MEDIA_URL_PATTERN, re.IGNORECASE)
+_MEDIA_PATH_RE = re.compile(
+    r"^/media/(?P<sha>[0-9a-f]{64})(?P<ext>\.[a-z0-9]{1,10})?/?$",
+    re.IGNORECASE,
+)
+
+
+def _effective_port(parsed) -> Optional[int]:
+    try:
+        if parsed.port is not None:
+            return parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme in ("https", "wss"):
+        return 443
+    if parsed.scheme in ("http", "ws"):
+        return 80
+    return None
+
+
+def _is_relay_media_url(url: str, relay_url: str) -> bool:
+    """Return whether *url* is a Buzz media object on the configured relay."""
+    candidate = urlsplit(url)
+    relay = urlsplit(relay_url)
+    if candidate.scheme not in ("http", "https"):
+        return False
+    if not candidate.hostname or not relay.hostname:
+        return False
+    if candidate.hostname.lower() != relay.hostname.lower():
+        return False
+    if _effective_port(candidate) != _effective_port(relay):
+        return False
+    return bool(_MEDIA_PATH_RE.fullmatch(candidate.path))
+
+
+def _find_relay_media_refs(
+    text: str, relay_url: str
+) -> Tuple[List[str], List[Tuple[int, int]]]:
+    """Find same-relay media URLs and the content spans that contain them."""
+    urls: List[str] = []
+    spans: List[Tuple[int, int]] = []
+    markdown_spans: List[Tuple[int, int]] = []
+
+    for match in _MARKDOWN_MEDIA_RE.finditer(text):
+        url = match.group("url")
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        markdown_spans.append(match.span())
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    for match in _BARE_MEDIA_RE.finditer(text):
+        if any(
+            start <= match.start() and match.end() <= end
+            for start, end in markdown_spans
+        ):
+            continue
+        url = match.group(0)
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    return urls, spans
+
+
+def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
+    chars = list(text)
+    for start, end in sorted(spans, reverse=True):
+        del chars[start:end]
+    cleaned = "".join(chars)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 def _load_nostr_auth():
@@ -2270,6 +2361,100 @@ class BuzzAdapter(BasePlatformAdapter):
         if not entry or not isinstance(entry, tuple) or len(entry) < 2:
             return None
         return str(entry[0] or ""), str(entry[1] or "")
+    async def _localize_inbound_media(
+        self, text: str, message_id: str
+    ) -> Tuple[str, List[str], List[str], MessageType]:
+        """Authenticate and cache same-relay media references in *text*.
+
+        Each object is independent: one failed download is logged and skipped
+        without discarding the caption or any other successfully cached files.
+        """
+        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        if not urls:
+            return text, [], [], MessageType.TEXT
+
+        cleaned_text = _remove_media_spans(text, spans)
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        media_kinds: List[str] = []
+
+        from gateway.platforms.base import (
+            cache_media_bytes,
+            validate_inbound_media_size,
+        )
+
+        for url in urls:
+            path_match = _MEDIA_PATH_RE.fullmatch(urlsplit(url).path)
+            if path_match is None:
+                continue
+            ext = (path_match.group("ext") or ".bin").lower()
+            label = f"{path_match.group('sha')[:12]}{ext}"
+            try:
+                with tempfile.TemporaryDirectory(prefix="hermes-buzz-media-") as temp_dir:
+                    download_path = Path(temp_dir) / f"buzz_{label}"
+                    code, _out, _err = await self._run_cli(
+                        ["media", "get", "-o", str(download_path), url]
+                    )
+                    if code != 0 or not download_path.is_file():
+                        logger.warning(
+                            "Buzz: failed to localize inbound media %s (exit %d)",
+                            label,
+                            code,
+                        )
+                        continue
+                    validate_inbound_media_size(
+                        download_path.stat().st_size,
+                        media_type="Buzz media",
+                    )
+                    mime_type = (
+                        mimetypes.guess_type(download_path.name)[0]
+                        or "application/octet-stream"
+                    )
+                    cached = cache_media_bytes(
+                        download_path.read_bytes(),
+                        filename=download_path.name,
+                        mime_type=mime_type,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Buzz: failed to localize inbound media %s (%s)",
+                    label,
+                    type(exc).__name__,
+                )
+                continue
+
+            if cached is None:
+                logger.warning("Buzz: rejected invalid inbound media %s", label)
+                continue
+            media_urls.append(cached.path)
+            media_types.append(cached.media_type)
+            media_kinds.append(cached.kind)
+
+        if media_urls:
+            logger.info(
+                "Buzz: localized %d inbound media attachment(s) for message %s",
+                len(media_urls),
+                message_id[:12],
+            )
+
+        if "image" in media_kinds:
+            message_type = MessageType.PHOTO
+        elif "audio" in media_kinds:
+            message_type = MessageType.AUDIO
+        elif "video" in media_kinds:
+            message_type = MessageType.VIDEO
+        elif media_kinds:
+            message_type = MessageType.DOCUMENT
+        else:
+            message_type = MessageType.TEXT
+
+        if not cleaned_text:
+            cleaned_text = (
+                "(attachment)"
+                if media_urls
+                else "(Buzz media attachment unavailable)"
+            )
+        return cleaned_text, media_urls, media_types, message_type
 
     async def _dispatch_message(
         self,
@@ -2290,6 +2475,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._message_handler:
             return
 
+        text, media_urls, media_types, message_type = await self._localize_inbound_media(
+            text, message_id
+        )
+
         source = self.build_source(
             chat_id=chat_id,
             chat_name=self._channel_names.get(chat_id, chat_id),
@@ -2301,7 +2490,7 @@ class BuzzAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             message_id=message_id,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
@@ -2309,6 +2498,8 @@ class BuzzAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             reply_to_author_id=reply_to_author_id,
             reply_to_is_own_message=reply_to_is_own_message,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         await self.handle_message(event)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -666,14 +666,21 @@ async def _exec_buzz(
 _MAX_CLI_MESSAGE_CHARS = 900
 
 
-def _bounded_cli_message(message: str) -> str:
+def _bounded_cli_message(message: str, redact_path: Optional[Path] = None) -> str:
     """Keep untrusted CLI detail useful without exposing unbounded output."""
+    if redact_path is not None:
+        message = message.replace(str(redact_path), redact_path.name)
     if len(message) <= _MAX_CLI_MESSAGE_CHARS:
         return message
     return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
+def _cli_error_message(
+    stderr: str,
+    returncode: int,
+    *,
+    redact_path: Optional[Path] = None,
+) -> str:
     """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
@@ -684,11 +691,15 @@ def _cli_error_message(stderr: str, returncode: int) -> str:
             if isinstance(detail, str) and detail.strip():
                 label = category.strip() if isinstance(category, str) and category.strip() else "error"
                 return _bounded_cli_message(
-                    f"{label}: {detail.strip()} (exit {returncode})"
+                    f"{label}: {detail.strip()} (exit {returncode})",
+                    redact_path,
                 )
     except ValueError:
         pass
-    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
+    return _bounded_cli_message(
+        text or f"buzz CLI failed with exit code {returncode}",
+        redact_path,
+    )
 
 
 def _parse_send_receipt(stdout: str) -> Tuple[Optional[str], Optional[str]]:
@@ -1501,7 +1512,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if code != 0:
             return SendResult(
                 success=False,
-                error=_cli_error_message(err, code),
+                error=_cli_error_message(err, code, redact_path=local),
                 retryable=code == 2,
             )
         event_id, receipt_error = _parse_send_receipt(out)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -2361,15 +2361,36 @@ class BuzzAdapter(BasePlatformAdapter):
             return None
         return str(entry[0] or ""), str(entry[1] or "")
     async def _localize_inbound_media(
-        self, text: str, message_id: str
+        self,
+        text: str,
+        message_id: str,
+        *,
+        user_id: str = "",
+        chat_type: Optional[str] = None,
+        chat_id: Optional[str] = None,
     ) -> Tuple[str, List[str], List[str], MessageType]:
         """Authenticate and cache same-relay media references in *text*.
 
         Each object is independent: one failed download is logged and skipped
         without discarding the caption or any other successfully cached files.
+
+        Downloading spends this agent's Buzz credentials on a URL chosen by
+        the sender, so it runs only when the gateway's authorization callback
+        returns an explicit ``True``. The adapter's own ``allowed_users``
+        list is a pre-filter, not a substitute: a missing, failed, or
+        negative gateway decision leaves the text untouched and no
+        credentialed request is made.
         """
         urls, replacements = _find_relay_media_refs(text, self.relay_url)
         if not urls:
+            return text, [], [], MessageType.TEXT
+
+        if self._is_sender_authorized(user_id, chat_type, chat_id) is not True:
+            logger.warning(
+                "Buzz: not localizing %d media reference(s) in message %s — "
+                "sender %s… is not explicitly authorized",
+                len(urls), message_id[:12], (user_id or "?")[:8],
+            )
             return text, [], [], MessageType.TEXT
 
         cleaned_text = _replace_media_refs(text, replacements)
@@ -2475,7 +2496,11 @@ class BuzzAdapter(BasePlatformAdapter):
             return
 
         text, media_urls, media_types, message_type = await self._localize_inbound_media(
-            text, message_id
+            text,
+            message_id,
+            user_id=user_id,
+            chat_type=chat_type,
+            chat_id=chat_id,
         )
 
         source = self.build_source(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -2779,13 +2779,30 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._message_handler:
             return
 
-        text, media_urls, media_types, message_type = await self._localize_inbound_media(
+        media_urls = list(media_urls or [])
+        media_types = list(media_types or [])
+
+        # Localize authenticated same-relay URL references embedded in the
+        # text, in addition to any native imeta attachments already verified
+        # and cached by the caller. Both paths are gated on the gateway's
+        # explicit-True authorization decision.
+        text, localized_urls, localized_types, localized_type = await self._localize_inbound_media(
             text,
             message_id,
             user_id=user_id,
             chat_type=chat_type,
             chat_id=chat_id,
         )
+        for path, mime in zip(localized_urls, localized_types):
+            if path not in media_urls:
+                media_urls.append(path)
+                media_types.append(mime)
+        if message_type == MessageType.TEXT:
+            message_type = localized_type
+        elif localized_urls and localized_type not in (message_type, MessageType.TEXT):
+            # Mixed media sources must use document semantics so an audio
+            # member is not mistaken for a voice note and sent through STT.
+            message_type = MessageType.DOCUMENT
 
         source = self.build_source(
             chat_id=chat_id,
@@ -2810,8 +2827,6 @@ class BuzzAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             reply_to_author_id=reply_to_author_id,
             reply_to_is_own_message=reply_to_is_own_message,
-            media_urls=media_urls,
-            media_types=media_types,
         )
 
         await self.handle_message(event)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -40,6 +40,7 @@ environment and is never logged.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import mimetypes
@@ -168,9 +169,11 @@ logger = logging.getLogger(__name__)
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    CachedMedia,
     SendResult,
     MessageEvent,
     MessageType,
+    cache_media_bytes,
 )
 from gateway.config import Platform
 
@@ -242,6 +245,57 @@ _CLI_TIMEOUT = 30.0
 # display names change rarely, but must not survive a rename forever.
 _MEMBER_CACHE_TTL = 60.0
 _PROFILE_NAME_TTL = 300.0
+# Inbound attachment limits. Attachments are downloaded only after the sender,
+# mention, and allow-list gates pass; each one must declare and match an exact
+# size and SHA-256 in its NIP-94 ``imeta`` tag.
+_MAX_INBOUND_ATTACHMENTS = 4
+_MAX_INBOUND_ATTACHMENT_BYTES = 20 * 1024 * 1024
+_ATTACHMENT_DOWNLOAD_TIMEOUT = 30.0
+_MAX_ATTACHMENT_FILENAME_BYTES = 120
+
+
+def _safe_attachment_filename(value: str) -> str:
+    """Return a basename that is safe for cache files and agent context."""
+    name = str(value or "").replace("\\", "/").rsplit("/", 1)[-1]
+    name = "".join(
+        character
+        for character in name
+        if ord(character) >= 32 and character != "\x7f"
+    ).strip()
+    if name in {"", ".", ".."}:
+        return "attachment.bin"
+
+    suffix = Path(name).suffix
+    if len(suffix.encode("utf-8")) > 20:
+        suffix = ""
+    stem = name[:-len(suffix)] if suffix else name
+    byte_budget = _MAX_ATTACHMENT_FILENAME_BYTES - len(suffix.encode("utf-8"))
+    safe_stem = (
+        stem.encode("utf-8")[:byte_budget]
+        .decode("utf-8", errors="ignore")
+        .rstrip(" .")
+    )
+    if not safe_stem:
+        safe_stem = "attachment"
+    return f"{safe_stem}{suffix}"
+
+
+def _attachment_origin(value: str) -> Optional[tuple[str, int]]:
+    """Normalize a configured host/URL to an exact HTTPS-equivalent origin."""
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = urlsplit(raw if "://" in raw else f"//{raw}")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        port = parsed.port or 443
+    except ValueError:
+        return None
+    if parsed.scheme and parsed.scheme not in {"https", "wss"}:
+        return None
+    if not host:
+        return None
+    return host, port
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -690,6 +744,21 @@ class BuzzAdapter(BasePlatformAdapter):
         # env — the default profile's bridge output — is not consulted)
         _relay_raw = _scoped_platform_setting("BUZZ_RELAY_URL", extra, "relay_url")
         self.relay_url = (_relay_raw or extra.get("relay_url", "")).strip()
+        
+        configured_attachment_hosts = extra.get("attachment_hosts", [])
+        if isinstance(configured_attachment_hosts, str):
+            configured_attachment_hosts = configured_attachment_hosts.split(",")
+        configured_origins = (
+            _attachment_origin(host)
+            for host in configured_attachment_hosts
+            if isinstance(host, str)
+        )
+        self._attachment_origins = {
+            origin for origin in configured_origins if origin is not None
+        }
+        relay_origin = _attachment_origin(self.relay_url)
+        if relay_origin is not None:
+            self._attachment_origins.add(relay_origin)
         _cli_raw = _scoped_platform_setting("BUZZ_CLI_PATH", extra, "cli_path")
         self.cli_path = _resolve_cli_path(
             str(_cli_raw or "").strip() or str(extra.get("cli_path", "") or "")
@@ -1984,6 +2053,152 @@ class BuzzAdapter(BasePlatformAdapter):
         if self._cursor_mark(state) != before:
             self._save_cursors()
 
+    @staticmethod
+    def _imeta_attachments(event: dict) -> List[dict]:
+        """Return bounded, structurally valid NIP-94 attachment metadata."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return []
+        attachments: List[dict] = []
+        total_declared_bytes = 0
+        for tag in tags:
+            if len(attachments) >= _MAX_INBOUND_ATTACHMENTS:
+                break
+            if not isinstance(tag, (list, tuple)) or not tag or tag[0] != "imeta":
+                continue
+            fields: Dict[str, str] = {}
+            for raw_field in tag[1:]:
+                if not isinstance(raw_field, str):
+                    continue
+                key, separator, value = raw_field.partition(" ")
+                if separator and key not in fields:
+                    fields[key] = value.strip()
+            url = fields.get("url", "")
+            digest = fields.get("x", "").lower()
+            filename = fields.get("filename", "")
+            mime_type = fields.get("m", "")
+            try:
+                size = int(fields.get("size", ""))
+            except (TypeError, ValueError):
+                continue
+            try:
+                parsed = urlsplit(url)
+                parsed_hostname = parsed.hostname
+                # Access validates malformed/non-numeric ports even though exact
+                # origin authorization occurs immediately before downloading.
+                parsed.port
+            except ValueError:
+                continue
+            if (
+                parsed.scheme != "https"
+                or not parsed_hostname
+                or parsed.username
+                or parsed.password
+                or parsed.fragment
+                or not re.fullmatch(r"[0-9a-f]{64}", digest)
+                or not 0 < size <= _MAX_INBOUND_ATTACHMENT_BYTES
+                or total_declared_bytes + size > _MAX_INBOUND_ATTACHMENT_BYTES
+            ):
+                continue
+            total_declared_bytes += size
+            attachments.append(
+                {
+                    "url": url,
+                    "sha256": digest,
+                    "size": size,
+                    "filename": _safe_attachment_filename(filename),
+                    "mime_type": mime_type[:255],
+                }
+            )
+        return attachments
+
+    async def _download_attachment(self, metadata: dict) -> Optional[CachedMedia]:
+        """Download, integrity-check, and cache one authorized Buzz attachment."""
+        url = metadata["url"]
+        try:
+            parsed_url = urlsplit(url)
+            host = (parsed_url.hostname or "").lower().rstrip(".")
+            origin = (host, parsed_url.port or 443)
+        except ValueError:
+            parsed_url = None
+            origin = ("", 0)
+        if (
+            parsed_url is None
+            or parsed_url.scheme != "https"
+            or origin not in self._attachment_origins
+        ):
+            logger.warning(
+                "Buzz: refusing attachment from untrusted origin %s:%s",
+                origin[0] or "<missing>",
+                origin[1],
+            )
+            return None
+
+        import httpx
+
+        try:
+            timeout = httpx.Timeout(_ATTACHMENT_DOWNLOAD_TIMEOUT)
+            async with asyncio.timeout(_ATTACHMENT_DOWNLOAD_TIMEOUT):
+                async with httpx.AsyncClient(
+                    follow_redirects=False,
+                    timeout=timeout,
+                    headers={"Accept-Encoding": "identity"},
+                ) as client:
+                    async with client.stream("GET", url) as response:
+                        if response.status_code != 200:
+                            logger.warning(
+                                "Buzz: attachment download returned HTTP %s",
+                                response.status_code,
+                            )
+                            return None
+                        content_length = response.headers.get("content-length")
+                        if content_length:
+                            try:
+                                declared_response_size = int(content_length)
+                            except ValueError:
+                                return None
+                            if declared_response_size != metadata["size"]:
+                                logger.warning(
+                                    "Buzz: attachment Content-Length does not match imeta size"
+                                )
+                                return None
+                        data = bytearray()
+                        async for chunk in response.aiter_bytes():
+                            data.extend(chunk)
+                            if len(data) > metadata["size"]:
+                                logger.warning("Buzz: attachment exceeded its declared size")
+                                return None
+        except (TimeoutError, httpx.HTTPError, OSError, ValueError) as exc:
+            logger.warning("Buzz: attachment download failed: %s", exc)
+            return None
+
+        if len(data) != metadata["size"]:
+            logger.warning("Buzz: attachment size does not match imeta")
+            return None
+        if hashlib.sha256(data).hexdigest() != metadata["sha256"]:
+            logger.warning("Buzz: attachment SHA-256 does not match imeta")
+            return None
+        try:
+            return cache_media_bytes(
+                bytes(data),
+                filename=metadata["filename"],
+                mime_type=metadata["mime_type"],
+            )
+        except (OSError, ValueError) as exc:
+            logger.warning("Buzz: attachment cache write failed: %s", exc)
+            return None
+
+    async def _cache_inbound_attachments(
+        self,
+        metadata_items: List[dict],
+    ) -> List[CachedMedia]:
+        cached: List[CachedMedia] = []
+        for metadata in metadata_items:
+            attachment = await self._download_attachment(metadata)
+            if attachment is not None:
+                cached.append(attachment)
+        return cached
+
     async def _handle_event(self, channel_id: str, state: dict, event: dict) -> None:
         """De-dupe, filter, and dispatch a single ``messages get`` event."""
         event_id = str(event.get("id") or "")
@@ -1997,7 +2212,12 @@ class BuzzAdapter(BasePlatformAdapter):
             return
         pubkey = str(event.get("pubkey") or "").lower()
         content = event.get("content")
-        if not pubkey or not isinstance(content, str) or not content.strip():
+        attachment_metadata = self._imeta_attachments(event)
+        if (
+            not pubkey
+            or not isinstance(content, str)
+            or (not content.strip() and not attachment_metadata)
+        ):
             return
 
         # Feed the per-channel event cache before any early return so self-echo
@@ -2065,6 +2285,30 @@ class BuzzAdapter(BasePlatformAdapter):
         # Remember where this message sits in the thread graph so our reply
         # can join the SAME thread rather than nesting a new one under it.
         self._record_thread_root(event_id, event)
+        # Network and cache access deliberately happen only after self-echo,
+        # addressing, and sender allow-list authorization have all passed.
+        attachments = await self._cache_inbound_attachments(attachment_metadata)
+        if attachment_metadata and len(attachments) < len(attachment_metadata):
+            failed = len(attachment_metadata) - len(attachments)
+            dispatch_text = (
+                f"{dispatch_text}\n"
+                f"[{failed} Buzz attachment(s) could not be downloaded or failed integrity checks.]"
+            ).strip()
+
+        message_type = MessageType.TEXT
+        if attachments:
+            attachment_kinds = {attachment.kind for attachment in attachments}
+            if len(attachment_kinds) == 1:
+                message_type = {
+                    "image": MessageType.PHOTO,
+                    "video": MessageType.VIDEO,
+                    "audio": MessageType.AUDIO,
+                    "document": MessageType.DOCUMENT,
+                }.get(next(iter(attachment_kinds)), MessageType.DOCUMENT)
+            else:
+                # Mixed media must use document semantics so an audio member is
+                # not mistaken for a voice note and sent through STT.
+                message_type = MessageType.DOCUMENT
 
         await self._dispatch_message(
             text=dispatch_text,
@@ -2079,6 +2323,10 @@ class BuzzAdapter(BasePlatformAdapter):
             reply_to_text=reply_meta[1] if reply_meta else None,
             reply_to_author_id=reply_meta[0] if reply_meta else None,
             reply_to_is_own_message=reply_to_is_own,
+            media_urls=[attachment.path for attachment in attachments],
+            media_types=[attachment.media_type for attachment in attachments],
+            message_type=message_type,
+            raw_message=event,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -2490,6 +2738,10 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_to_text: Optional[str] = None,
         reply_to_author_id: Optional[str] = None,
         reply_to_is_own_message: bool = False,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
+        message_type: MessageType = MessageType.TEXT,
+        raw_message: Any = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -2516,7 +2768,11 @@ class BuzzAdapter(BasePlatformAdapter):
             text=text,
             message_type=message_type,
             source=source,
+            raw_message=raw_message,
             message_id=message_id,
+            media_urls=list(media_urls or []),
+            media_types=list(media_types or []),
+            media_text_inlined=[False] * len(media_urls or []),
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1464,6 +1464,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 caption=caption,
                 reply_to=reply_to,
                 metadata=metadata,
+                probe=False,
             )
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
@@ -1477,10 +1478,16 @@ class BuzzAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        probe: bool = True,
     ) -> SendResult:
-        """Upload a local file and publish it as a native Buzz attachment."""
+        """Upload a local file and publish it as a native Buzz attachment.
+
+        ``probe=False`` skips the existence re-check when the caller already
+        verified the file — a second probe could race into a false
+        "not found" if the file disappears between checks (#74999).
+        """
         local = Path(file_path).expanduser()
-        if not local.is_file():
+        if probe and not local.is_file():
             return SendResult(success=False, error=f"File not found: {local}")
         args = [
             "messages", "send",
@@ -1535,6 +1542,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 caption=caption,
                 reply_to=reply_to,
                 metadata=metadata,
+                probe=False,
             )
         return await super().send_image_file(
             chat_id=chat_id,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -3131,7 +3131,7 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[List[Any]] = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """One-shot send without a live adapter (out-of-process cron delivery).
@@ -3175,7 +3175,8 @@ async def _standalone_send(
         _rtm = "off"
     if thread_id and _rtm != "off":
         args += ["--reply-to", str(thread_id)]
-    for path in media_files or []:
+    for media in media_files or []:
+        path = media[0] if isinstance(media, (list, tuple)) and media else media
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
@@ -3210,7 +3211,10 @@ async def _standalone_send(
         data = json.loads(out or "{}")
     except ValueError:
         data = {}
-    return {"success": True, "message_id": str(data.get("event_id") or "")}
+    result = {"success": True, "message_id": str(data.get("event_id") or "")}
+    if media_files:
+        result["media_delivered"] = True
+    return result
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -2054,17 +2054,19 @@ class BuzzAdapter(BasePlatformAdapter):
             self._save_cursors()
 
     @staticmethod
-    def _imeta_attachments(event: dict) -> List[dict]:
-        """Return bounded, structurally valid NIP-94 attachment metadata."""
+    def _parse_imeta_attachments(event: dict) -> Tuple[List[dict], int]:
+        """Return accepted NIP-94 metadata and the rejected ``imeta`` count."""
         tags = event.get("tags")
         if not isinstance(tags, list):
-            return []
+            return [], 0
         attachments: List[dict] = []
+        rejected = 0
         total_declared_bytes = 0
         for tag in tags:
-            if len(attachments) >= _MAX_INBOUND_ATTACHMENTS:
-                break
             if not isinstance(tag, (list, tuple)) or not tag or tag[0] != "imeta":
+                continue
+            if len(attachments) >= _MAX_INBOUND_ATTACHMENTS:
+                rejected += 1
                 continue
             fields: Dict[str, str] = {}
             for raw_field in tag[1:]:
@@ -2079,15 +2081,13 @@ class BuzzAdapter(BasePlatformAdapter):
             mime_type = fields.get("m", "")
             try:
                 size = int(fields.get("size", ""))
-            except (TypeError, ValueError):
-                continue
-            try:
                 parsed = urlsplit(url)
                 parsed_hostname = parsed.hostname
                 # Access validates malformed/non-numeric ports even though exact
                 # origin authorization occurs immediately before downloading.
                 parsed.port
-            except ValueError:
+            except (TypeError, ValueError):
+                rejected += 1
                 continue
             if (
                 parsed.scheme != "https"
@@ -2099,6 +2099,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 or not 0 < size <= _MAX_INBOUND_ATTACHMENT_BYTES
                 or total_declared_bytes + size > _MAX_INBOUND_ATTACHMENT_BYTES
             ):
+                rejected += 1
                 continue
             total_declared_bytes += size
             attachments.append(
@@ -2110,7 +2111,19 @@ class BuzzAdapter(BasePlatformAdapter):
                     "mime_type": mime_type[:255],
                 }
             )
+        return attachments, rejected
+
+    @staticmethod
+    def _imeta_attachments(event: dict) -> List[dict]:
+        """Return bounded, structurally valid NIP-94 attachment metadata."""
+        attachments, _rejected = BuzzAdapter._parse_imeta_attachments(event)
         return attachments
+
+    @staticmethod
+    def _attachment_rejection_note(rejected: int) -> str:
+        """Return a fixed-width diagnostic for malformed or excess metadata."""
+        shown = str(rejected) if rejected <= 999 else "999+"
+        return f"[{shown} Buzz attachment(s) rejected as malformed or over limits.]"
 
     async def _download_attachment(self, metadata: dict) -> Optional[CachedMedia]:
         """Download, integrity-check, and cache one authorized Buzz attachment."""
@@ -2212,11 +2225,12 @@ class BuzzAdapter(BasePlatformAdapter):
             return
         pubkey = str(event.get("pubkey") or "").lower()
         content = event.get("content")
-        attachment_metadata = self._imeta_attachments(event)
+        attachment_metadata, rejected_attachments = self._parse_imeta_attachments(event)
+        has_imeta = bool(attachment_metadata or rejected_attachments)
         if (
             not pubkey
             or not isinstance(content, str)
-            or (not content.strip() and not attachment_metadata)
+            or (not content.strip() and not has_imeta)
         ):
             return
 
@@ -2285,10 +2299,28 @@ class BuzzAdapter(BasePlatformAdapter):
         # Remember where this message sits in the thread graph so our reply
         # can join the SAME thread rather than nesting a new one under it.
         self._record_thread_root(event_id, event)
-        # Network and cache access deliberately happen only after self-echo,
-        # addressing, and sender allow-list authorization have all passed.
-        attachments = await self._cache_inbound_attachments(attachment_metadata)
-        if attachment_metadata and len(attachments) < len(attachment_metadata):
+        # Attachment fetch/cache is a security-sensitive side effect. Only the
+        # gateway's authoritative callback can permit it, and only an explicit
+        # True is permission: false, absent, or failed checks all fail closed.
+        # The message still dispatches so GatewayRunner can apply denial/pairing.
+        chat_type = "dm" if is_dm else "group"
+        attachment_fetch_allowed = bool(attachment_metadata) and (
+            self._is_sender_authorized(pubkey, chat_type, channel_id) is True
+        )
+        attachments = (
+            await self._cache_inbound_attachments(attachment_metadata)
+            if attachment_fetch_allowed
+            else []
+        )
+        if rejected_attachments:
+            dispatch_text = (
+                f"{dispatch_text}\n"
+                f"{self._attachment_rejection_note(rejected_attachments)}"
+            ).strip()
+        if (
+            attachment_fetch_allowed
+            and len(attachments) < len(attachment_metadata)
+        ):
             failed = len(attachment_metadata) - len(attachments)
             dispatch_text = (
                 f"{dispatch_text}\n"
@@ -2313,7 +2345,7 @@ class BuzzAdapter(BasePlatformAdapter):
         await self._dispatch_message(
             text=dispatch_text,
             chat_id=channel_id,
-            chat_type="dm" if is_dm else "group",
+            chat_type=chat_type,
             user_id=pubkey,
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -663,20 +663,53 @@ async def _exec_buzz(
     )
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
-    """Extract the human-readable message from the CLI's JSON error contract.
+_MAX_CLI_MESSAGE_CHARS = 900
 
-    stderr is ``{"error": "<category>", "message": "<detail>"}`` on failure;
-    fall back to the raw (stripped) stderr when it isn't JSON.
-    """
+
+def _bounded_cli_message(message: str) -> str:
+    """Keep untrusted CLI detail useful without exposing unbounded output."""
+    if len(message) <= _MAX_CLI_MESSAGE_CHARS:
+        return message
+    return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
+
+
+def _cli_error_message(stderr: str, returncode: int) -> str:
+    """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
         data = json.loads(text)
-        if isinstance(data, dict) and data.get("message"):
-            return f"{data.get('error', 'error')}: {data['message']} (exit {returncode})"
+        if isinstance(data, dict):
+            detail = data.get("message")
+            category = data.get("error")
+            if isinstance(detail, str) and detail.strip():
+                label = category.strip() if isinstance(category, str) and category.strip() else "error"
+                return _bounded_cli_message(
+                    f"{label}: {detail.strip()} (exit {returncode})"
+                )
     except ValueError:
         pass
-    return text or f"buzz CLI failed with exit code {returncode}"
+    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
+
+
+def _parse_send_receipt(stdout: str) -> Tuple[Optional[str], Optional[str]]:
+    """Validate the buzz-cli success receipt and return ``(event_id, error)``."""
+    try:
+        data = json.loads(stdout or "{}")
+    except ValueError:
+        return None, "invalid CLI response"
+    if not isinstance(data, dict):
+        return None, "invalid CLI response"
+    if data.get("accepted") is False:
+        detail = data.get("message")
+        if not isinstance(detail, str) or not detail.strip():
+            detail = "message was not accepted"
+        return None, _bounded_cli_message(detail.strip())
+    if data.get("accepted") is not True:
+        return None, "invalid CLI response"
+    event_id = data.get("event_id")
+    if not isinstance(event_id, str) or not event_id.strip():
+        return None, "invalid CLI response"
+    return event_id.strip(), None
 
 
 def _parse_json_list(stdout: str) -> List[dict]:
@@ -1322,25 +1355,19 @@ class BuzzAdapter(BasePlatformAdapter):
                 error=_cli_error_message(err, code),
                 retryable=code == 2,
             )
-        try:
-            data = json.loads(out or "{}")
-        except ValueError:
-            data = {}
-        event_id = data.get("event_id")
-        if event_id:
-            # Belt-and-braces echo suppression: the poll loop already skips
-            # our own pubkey, but marking the id seen makes de-dupe explicit.
-            # Also record event_meta so a thread reply to this send matches
-            # even if the WS/poll echo never arrives (#75826).
-            self._mark_seen(str(chat_id), str(event_id))
-            self._remember_event_meta(
-                str(chat_id), str(event_id), self._self_pubkey, content
-            )
-        return SendResult(
-            success=bool(data.get("accepted", True)),
-            message_id=str(event_id) if event_id else None,
-            raw_response=data,
+        event_id, receipt_error = _parse_send_receipt(out)
+        if receipt_error:
+            return SendResult(success=False, error=receipt_error)
+        assert event_id is not None
+        # Belt-and-braces echo suppression: the poll loop already skips our own
+        # pubkey, but marking the verified id seen makes de-dupe explicit.
+        # Also record event_meta so a thread reply to this send matches even
+        # if the WS/poll echo never arrives (#75826).
+        self._mark_seen(str(chat_id), event_id)
+        self._remember_event_meta(
+            str(chat_id), event_id, self._self_pubkey, content
         )
+        return SendResult(success=True, message_id=event_id)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Buzz has no typing indicator API — no-op."""
@@ -1447,6 +1474,43 @@ class BuzzAdapter(BasePlatformAdapter):
             self._mark_seen(str(chat_id), str(event_id))
         return bool(data.get("accepted", True))
 
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Upload one local file through the Buzz CLI and verify its receipt."""
+        local = Path(file_path).expanduser()
+        if not local.is_file():
+            return SendResult(success=False, error="Media file not found")
+        args = [
+            "messages", "send",
+            "--channel", str(chat_id),
+            "--file", str(local),
+            "--content", "-",
+        ]
+        reply_target = self._resolve_reply_anchor(
+            (metadata or {}).get("thread_id") or reply_to
+        )
+        if reply_target and self._reply_to_mode != "off":
+            args += ["--reply-to", str(reply_target)]
+        code, out, err = await self._run_cli(args, input_text=caption or "")
+        if code != 0:
+            return SendResult(
+                success=False,
+                error=_cli_error_message(err, code),
+                retryable=code == 2,
+            )
+        event_id, receipt_error = _parse_send_receipt(out)
+        if receipt_error:
+            return SendResult(success=False, error=receipt_error)
+        assert event_id is not None
+        self._mark_seen(str(chat_id), event_id)
+        return SendResult(success=True, message_id=event_id)
+
     async def send_image(
         self,
         chat_id: str,
@@ -1488,7 +1552,8 @@ class BuzzAdapter(BasePlatformAdapter):
         """
         local = Path(file_path).expanduser()
         if probe and not local.is_file():
-            return SendResult(success=False, error=f"File not found: {local}")
+            # Never leak host filesystem paths into chat-visible errors.
+            return SendResult(success=False, error="Media file not found")
         args = [
             "messages", "send",
             "--channel", str(chat_id),
@@ -1507,18 +1572,12 @@ class BuzzAdapter(BasePlatformAdapter):
                 error=_cli_error_message(err, code),
                 retryable=code == 2,
             )
-        try:
-            data = json.loads(out or "{}")
-        except ValueError:
-            data = {}
-        event_id = data.get("event_id")
-        if event_id:
-            self._mark_seen(str(chat_id), str(event_id))
-        return SendResult(
-            success=bool(data.get("accepted", True)),
-            message_id=str(event_id) if event_id else None,
-            raw_response=data,
-        )
+        event_id, receipt_error = _parse_send_receipt(out)
+        if receipt_error:
+            return SendResult(success=False, error=receipt_error)
+        assert event_id is not None
+        self._mark_seen(str(chat_id), event_id)
+        return SendResult(success=True, message_id=event_id)
 
     async def send_image_file(
         self,
@@ -3204,14 +3263,14 @@ async def _standalone_send(
     except asyncio.CancelledError:
         raise
     except OSError as e:
-        return {"error": f"Buzz standalone send failed to launch CLI: {e}"}
+        detail = _bounded_cli_message(str(e))
+        return {"error": f"Buzz standalone send failed to launch CLI: {detail}"}
     if code != 0:
         return {"error": f"Buzz standalone send failed: {_cli_error_message(err, code)}"}
-    try:
-        data = json.loads(out or "{}")
-    except ValueError:
-        data = {}
-    result = {"success": True, "message_id": str(data.get("event_id") or "")}
+    event_id, receipt_error = _parse_send_receipt(out)
+    if receipt_error:
+        return {"error": f"Buzz standalone send failed: {receipt_error}"}
+    result = {"success": True, "message_id": event_id}
     if media_files:
         result["media_delivered"] = True
     return result

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1458,41 +1458,60 @@ class BuzzAdapter(BasePlatformAdapter):
         """Send an image: local files upload via --file, URLs go as a link."""
         local = Path(image_url).expanduser() if not image_url.startswith(("http://", "https://")) else None
         if local is not None and local.is_file():
-            args = [
-                "messages", "send",
-                "--channel", str(chat_id),
-                "--file", str(local),
-                "--content", "-",
-            ]
-            reply_target = self._resolve_reply_anchor(
-                (metadata or {}).get("thread_id") or reply_to
-            )
-            if reply_target and self._reply_to_mode != "off":
-                args += ["--reply-to", str(reply_target)]
-            code, out, err = await self._run_message_send(args, caption or "")
-            if code != 0:
-                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
-            try:
-                data = json.loads(out or "{}")
-            except ValueError:
-                data = {}
-            event_id = data.get("event_id")
-            if event_id:
-                self._mark_seen(str(chat_id), str(event_id))
-                self._remember_event_meta(
-                    str(chat_id),
-                    str(event_id),
-                    self._self_pubkey,
-                    caption or "",
-                )
-            return SendResult(
-                success=bool(data.get("accepted", True)),
-                message_id=str(event_id) if event_id else None,
-                raw_response=data,
+            return await self._send_file_attachment(
+                chat_id,
+                local,
+                caption=caption,
+                reply_to=reply_to,
+                metadata=metadata,
             )
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+
+    async def _send_file_attachment(
+        self,
+        chat_id: str,
+        file_path: Path,
+        *,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Upload a local file and publish it as a native Buzz attachment."""
+        local = Path(file_path).expanduser()
+        if not local.is_file():
+            return SendResult(success=False, error=f"File not found: {local}")
+        args = [
+            "messages", "send",
+            "--channel", str(chat_id),
+            "--file", str(local),
+            "--content", "-",
+        ]
+        reply_target = self._resolve_reply_anchor(
+            (metadata or {}).get("thread_id") or reply_to
+        )
+        if reply_target and self._reply_to_mode != "off":
+            args += ["--reply-to", str(reply_target)]
+        code, out, err = await self._run_cli(args, input_text=caption or "")
+        if code != 0:
+            return SendResult(
+                success=False,
+                error=_cli_error_message(err, code),
+                retryable=code == 2,
+            )
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            data = {}
+        event_id = data.get("event_id")
+        if event_id:
+            self._mark_seen(str(chat_id), str(event_id))
+        return SendResult(
+            success=bool(data.get("accepted", True)),
+            message_id=str(event_id) if event_id else None,
+            raw_response=data,
+        )
 
     async def send_image_file(
         self,
@@ -1503,31 +1522,19 @@ class BuzzAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
+        """Upload a local image through Buzz's native ``--file`` path.
+
+        Missing or non-file paths retain the Base fallback so host
+        filesystem paths are never echoed into chat (#74999).
+        """
         local = Path(image_path).expanduser()
         if local.is_file():
-            args = [
-                "messages", "send",
-                "--channel", str(chat_id),
-                "--file", str(local),
-                "--content", "-",
-            ]
-            reply_target = reply_to or (metadata or {}).get("thread_id")
-            if reply_target:
-                args += ["--reply-to", str(reply_target)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
-            if code != 0:
-                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
-            try:
-                data = json.loads(out or "{}")
-            except ValueError:
-                data = {}
-            event_id = data.get("event_id")
-            if event_id:
-                self._mark_seen(str(chat_id), str(event_id))
-            return SendResult(
-                success=bool(data.get("accepted", True)),
-                message_id=str(event_id) if event_id else None,
-                raw_response=data,
+            return await self._send_file_attachment(
+                chat_id,
+                local,
+                caption=caption,
+                reply_to=reply_to,
+                metadata=metadata,
             )
         return await super().send_image_file(
             chat_id=chat_id,
@@ -1536,6 +1543,61 @@ class BuzzAdapter(BasePlatformAdapter):
             reply_to=reply_to,
             metadata=metadata,
             **kwargs,
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local document through Buzz's native ``--file`` path."""
+        return await self._send_file_attachment(
+            chat_id,
+            Path(file_path),
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local video through Buzz's native ``--file`` path."""
+        return await self._send_file_attachment(
+            chat_id,
+            Path(video_path),
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local audio file through Buzz's native ``--file`` path."""
+        return await self._send_file_attachment(
+            chat_id,
+            Path(audio_path),
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1494,6 +1494,50 @@ class BuzzAdapter(BasePlatformAdapter):
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        local = Path(image_path).expanduser()
+        if local.is_file():
+            args = [
+                "messages", "send",
+                "--channel", str(chat_id),
+                "--file", str(local),
+                "--content", "-",
+            ]
+            reply_target = reply_to or (metadata or {}).get("thread_id")
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
+            code, out, err = await self._run_cli(args, input_text=caption or "")
+            if code != 0:
+                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
+            try:
+                data = json.loads(out or "{}")
+            except ValueError:
+                data = {}
+            event_id = data.get("event_id")
+            if event_id:
+                self._mark_seen(str(chat_id), str(event_id))
+            return SendResult(
+                success=bool(data.get("accepted", True)),
+                message_id=str(event_id) if event_id else None,
+                raw_response=data,
+            )
+        return await super().send_image_file(
+            chat_id=chat_id,
+            image_path=image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            **kwargs,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_id = str(chat_id)
         state = self._channel_state.get(chat_id)

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -6,8 +6,9 @@ description: >
   Buzz gateway adapter for Hermes Agent.
   Connects to a Buzz community relay (Block's open-source human+agent
   collaboration platform built on Nostr) and relays messages between
-  channels/DMs and the Hermes agent.  Pure stdlib — shells out to the
-  buzz CLI binary (JSON in/out); no Python packages required.
+  channels/DMs and the Hermes agent. Relay operations shell out to the
+  buzz CLI binary (JSON in/out); verified inbound media uses Hermes' bundled
+  HTTP client.
 author: Nous Research
 # ``requires_env`` entries are surfaced in ``hermes config`` UI via the
 # platform-plugin env var injector in ``hermes_cli/config.py``.

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3253,6 +3253,42 @@ class TestStandaloneSend:
             "See @\u200bsession:default/example.",
         ]
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_extracts_path_from_media_descriptor(self, monkeypatch, tmp_path):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        document = tmp_path / "report.txt"
+        document.write_text("report", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            captured["args"] = args
+            return 0, json.dumps({"accepted": True, "event_id": "evt-media"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "attached",
+            media_files=[(str(document), False)],
+        )
+
+        assert result == {
+            "success": True,
+            "message_id": "evt-media",
+            "media_delivered": True,
+        }
+        file_index = captured["args"].index("--file")
+        assert captured["args"][file_index + 1] == str(document)
+
+
 
 
 # ── Editing and deleting (streaming) ──────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2416,6 +2416,22 @@ class TestBuzzAdapterSend:
         assert str(missing) not in stdin_text
 
     @pytest.mark.asyncio
+    async def test_send_document_uses_native_file_flag(self, tmp_path):
+        document = tmp_path / "package.zip"
+        document.write_bytes(b"PK fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt128", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document), caption="files")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--file") + 1] == str(document)
+        assert stdin_text == "files"
+
+    @pytest.mark.asyncio
     async def test_send_multiple_images_file_url_uses_native_file_send(self, tmp_path):
         img = tmp_path / "shot with spaces.png"
         img.write_bytes(b"\x89PNG fake")
@@ -2916,6 +2932,7 @@ class TestInboundMediaAuthorizationGate:
         assert len(cli_calls) == 1
         assert captured[0].message_type == MessageType.PHOTO
         assert len(captured[0].media_urls) == 1
+
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1602,7 +1602,7 @@ class TestInboundMediaLocalisation:
         return captured, cli_calls
 
     @pytest.mark.asyncio
-    async def test_markdown_relay_image_is_localised_before_dispatch(
+    async def test_markdown_relay_image_preserves_alt_text_before_dispatch(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -1611,7 +1611,7 @@ class TestInboundMediaLocalisation:
         media_url = f"https://test.relay/media/{'a' * 64}.png"
 
         await adapter._dispatch_message(
-            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            text=f"Please inspect this screenshot\n\n![Login error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -1622,7 +1622,7 @@ class TestInboundMediaLocalisation:
 
         assert len(captured) == 1
         event = captured[0]
-        assert event.text == "Please inspect this screenshot"
+        assert event.text == "Please inspect this screenshot\n\nLogin error dialog"
         assert event.message_type == MessageType.PHOTO
         assert event.media_types == ["image/png"]
         assert len(event.media_urls) == 1
@@ -1726,7 +1726,7 @@ class TestInboundMediaLocalisation:
         assert "/cache/documents/" in event.media_urls[0]
 
     @pytest.mark.asyncio
-    async def test_download_failure_keeps_caption_and_dispatches_text(
+    async def test_download_failure_preserves_caption_and_alt_text(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -1735,7 +1735,7 @@ class TestInboundMediaLocalisation:
         captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
 
         await adapter._dispatch_message(
-            text=f"The error is visible here\n![]({media_url})",
+            text=f"The error is visible here\n![Checkout error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -1745,7 +1745,7 @@ class TestInboundMediaLocalisation:
         )
 
         event = captured[0]
-        assert event.text == "The error is visible here"
+        assert event.text == "The error is visible here\nCheckout error dialog"
         assert event.message_type == MessageType.TEXT
         assert event.media_urls == []
         assert event.media_types == []

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,12 +1,14 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import base64
 import json
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+from gateway.platforms.base import MessageType
 
 # Load plugins/platforms/buzz/adapter.py under a unique module name
 # (plugin_adapter_buzz) so it cannot collide with other plugin adapters
@@ -1557,6 +1559,296 @@ class TestThreadAnchoring:
         await adapter.send(CHANNEL, "in-thread answer", reply_to="m3")
         args, _stdin = cli.calls[0]
         assert args[args.index("--reply-to") + 1] == "root1"
+
+
+# ── Inbound media localisation ─────────────────────────────────────────────────
+
+
+class TestInboundMediaLocalisation:
+
+    @staticmethod
+    def _capture_dispatch(adapter, *, failed_urls=None):
+        captured = []
+        cli_calls = []
+        failed_urls = set(failed_urls or [])
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            cli_calls.append(list(args))
+            assert args[:2] == ["media", "get"]
+            url = args[-1]
+            if url in failed_urls:
+                return 2, "", '{"error":"relay_error","message":"denied"}'
+            output_path = args[args.index("-o") + 1]
+            if url.endswith(".jpg"):
+                payload = b"\xff\xd8\xff\xe0JFIF test image"
+            elif url.endswith(".pdf"):
+                payload = b"%PDF-1.4\n% test document\n"
+            else:
+                payload = base64.b64decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+                )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+        return captured, cli_calls
+
+    @pytest.mark.asyncio
+    async def test_markdown_relay_image_is_localised_before_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, cli_calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'a' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="media-event",
+            created_at=1000,
+        )
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.text == "Please inspect this screenshot"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].startswith(str(tmp_path / "hermes" / "cache"))
+        assert media_url not in event.text
+        assert cli_calls[0][-1] == media_url
+
+    @pytest.mark.asyncio
+    async def test_bare_relay_image_url_is_localised(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'b' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"What is in this? {media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="bare-media-event",
+            created_at=1001,
+        )
+
+        event = captured[0]
+        assert event.text == "What is in this?"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_image_only_message_gets_attachment_placeholder(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'5' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="image-only-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "(attachment)"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_are_localised_in_content_order(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        first = f"https://test.relay/media/{'c' * 64}.png"
+        second = f"https://test.relay/media/{'d' * 64}.jpg"
+
+        await adapter._dispatch_message(
+            text=f"Compare these\n![]({first})\n{second}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="multi-media-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare these"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png", "image/jpeg"]
+        assert len(event.media_urls) == 2
+        assert [call[-1] for call in calls] == [first, second]
+
+    @pytest.mark.asyncio
+    async def test_non_image_attachment_is_cached_as_document(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'e' * 64}.pdf"
+
+        await adapter._dispatch_message(
+            text=f"Read this report\n{media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="document-media-event",
+            created_at=1003,
+        )
+
+        event = captured[0]
+        assert event.text == "Read this report"
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["application/pdf"]
+        assert len(event.media_urls) == 1
+        assert "/cache/documents/" in event.media_urls[0]
+
+    @pytest.mark.asyncio
+    async def test_download_failure_keeps_caption_and_dispatches_text(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        media_url = f"https://test.relay/media/{'f' * 64}.png"
+        captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
+
+        await adapter._dispatch_message(
+            text=f"The error is visible here\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="failed-media-event",
+            created_at=1004,
+        )
+
+        event = captured[0]
+        assert event.text == "The error is visible here"
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    @pytest.mark.asyncio
+    async def test_one_failed_download_does_not_drop_other_media(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        failed = f"https://test.relay/media/{'2' * 64}.png"
+        succeeded = f"https://test.relay/media/{'3' * 64}.jpg"
+        captured, calls = self._capture_dispatch(adapter, failed_urls=[failed])
+
+        await adapter._dispatch_message(
+            text=f"Compare what loaded\n![]({failed})\n![]({succeeded})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="partial-media-event",
+            created_at=1005,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare what loaded"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/jpeg"]
+        assert len(event.media_urls) == 1
+        assert [call[-1] for call in calls] == [failed, succeeded]
+
+    @pytest.mark.asyncio
+    async def test_real_event_handler_localises_media_before_gateway_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        captured = []
+        media_url = f"https://test.relay/media/{'4' * 64}.png"
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            if args[:2] == ["users", "get"]:
+                return 0, json.dumps([{"display_name": "Joel"}]), ""
+            assert args[:2] == ["media", "get"]
+            output_path = args[args.index("-o") + 1]
+            payload = base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+            )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+
+        await adapter._handle_event(
+            DM_CHANNEL,
+            adapter._channel_state[DM_CHANNEL],
+            _tagged_event(
+                "handler-media-event",
+                DM_CHANNEL,
+                content=f"Can you read this? ![]({media_url})",
+                p=SELF_PUBKEY,
+            ),
+        )
+
+        assert len(captured) == 1
+        assert captured[0].text == "Can you read this?"
+        assert captured[0].message_type == MessageType.PHOTO
+        assert len(captured[0].media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_external_media_url_is_left_untouched(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        media_url = f"https://cdn.example/media/{'1' * 64}.png"
+        text = f"External reference: ![]({media_url})"
+
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="external-media-event",
+            created_at=1006,
+        )
+
+        event = captured[0]
+        assert event.text == text
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert calls == []
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -367,7 +367,7 @@ class TestMultiplexProfileScope:
 
         async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             calls["relay"] = relay_url
-            return 0, '{"event_id": "e1"}', ""
+            return 0, '{"accepted": true, "event_id": "e1"}', ""
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
         monkeypatch.setattr(
@@ -546,7 +546,7 @@ class TestMultiplexProfileScope:
 
         async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             calls["args"] = args
-            return 0, '{"event_id": "e1"}', ""
+            return 0, '{"accepted": true, "event_id": "e1"}', ""
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
         monkeypatch.setattr(
@@ -2224,6 +2224,7 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--reply-to") + 1] == "stable-root"
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("stdout", "error_fragment"),
         [
@@ -3031,15 +3032,16 @@ class TestInboundMediaAuthorizationGate:
             CHANNEL,
             str(media),
             caption="caption",
-            reply_to="root-event",
-            metadata={"thread_id": "ignored-thread"},
+            reply_to="latest-child",
+            metadata={"thread_id": "stable-root"},
         )
 
         assert result.success is True
         assert result.message_id == "evt-media"
         args, stdin_text = cli.calls[0]
         assert args[args.index("--file") + 1] == str(media)
-        assert args[args.index("--reply-to") + 1] == "root-event"
+        # Threading contract (#99429): stable thread root beats latest-child.
+        assert args[args.index("--reply-to") + 1] == "stable-root"
         assert stdin_text == "caption"
 
     @pytest.mark.asyncio
@@ -3466,7 +3468,7 @@ class TestStandaloneSend:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-media"}), ""
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -88,6 +88,9 @@ def _make_adapter(extra=None):
     adapter._self_npub = SELF_NPUB
     adapter._display_name = "Chip"
     adapter._private_key = "nsec1test"
+    # GatewayRunner installs this callback before intake starts. Attachment
+    # tests are authorized by default and override the callback at the boundary.
+    adapter.set_authorization_check(lambda *_args: True)
     return adapter
 
 
@@ -857,6 +860,9 @@ class TestInboundAttachments:
     @pytest.mark.asyncio
     async def test_unaddressed_channel_attachment_is_not_downloaded(self):
         adapter = _make_adapter()
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+        adapter._cache_inbound_attachments = AsyncMock()
         adapter._download_attachment = AsyncMock()
         adapter._channel_state[CHANNEL] = {
             "chat_type": "group",
@@ -875,6 +881,8 @@ class TestInboundAttachments:
 
         await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
 
+        authorization_check.assert_not_called()
+        adapter._cache_inbound_attachments.assert_not_awaited()
         adapter._download_attachment.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1009,6 +1017,70 @@ class TestInboundAttachments:
         adapter._download_attachment.assert_awaited_once()
         assert dispatched[-1]["media_urls"] == [attachment.path]
         assert dispatched[-1]["message_type"] is MessageType.DOCUMENT
+
+    @pytest.mark.asyncio
+    async def test_malformed_attachment_only_dm_dispatches_once_with_bounded_note(self):
+        adapter = _make_adapter()
+        adapter._download_attachment = AsyncMock()
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        adapter._dispatch_message = AsyncMock()
+        event = _event("malformed-attachment-only", content="")
+        event["tags"].append(["imeta", "url definitely-not-a-url"])
+
+        await adapter._handle_event(DM_CHANNEL, adapter._channel_state[DM_CHANNEL], event)
+        await adapter._handle_event(DM_CHANNEL, adapter._channel_state[DM_CHANNEL], event)
+
+        adapter._download_attachment.assert_not_awaited()
+        adapter._dispatch_message.assert_awaited_once()
+        call = adapter._dispatch_message.await_args
+        assert call is not None
+        dispatched = call.kwargs
+        assert "1 Buzz attachment(s) rejected" in dispatched["text"]
+        assert len(dispatched["text"]) <= 80
+        assert dispatched["media_urls"] == []
+
+    @pytest.mark.asyncio
+    async def test_excess_imeta_is_reported_while_accepted_files_remain_attached(self):
+        adapter = _make_adapter()
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        adapter._download_attachment = AsyncMock(
+            side_effect=lambda metadata: CachedMedia(
+                f"/cache/{metadata['filename']}",
+                metadata["mime_type"],
+                "document",
+                metadata["filename"],
+            )
+        )
+        adapter._dispatch_message = AsyncMock()
+        event = _event("excess-imeta", content="@Chip inspect")
+        for index in range(5):
+            event["tags"].append([
+                "imeta",
+                f"url https://test.relay/media/{index}.bin",
+                "m application/octet-stream",
+                "x " + format(index + 1, "064x"),
+                "size 1",
+                f"filename {index}.bin",
+            ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        assert adapter._download_attachment.await_count == 4
+        call = adapter._dispatch_message.await_args
+        assert call is not None
+        dispatched = call.kwargs
+        assert "1 Buzz attachment(s) rejected" in dispatched["text"]
+        assert len(dispatched["media_urls"]) == 4
 
     def test_imeta_bounds_filename_to_filesystem_safe_utf8_length(self):
         event = _event("long-name", content="@Chip file")
@@ -1210,9 +1282,40 @@ class TestInboundAttachments:
         assert all("@" not in item["url"] and "#" not in item["url"] for item in attachments)
 
     @pytest.mark.asyncio
+    async def test_self_attachment_stops_before_authorization_or_cache(self):
+        adapter = _make_adapter()
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+        adapter._cache_inbound_attachments = AsyncMock()
+        adapter._dispatch_message = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("self-attachment", pubkey=SELF_PUBKEY, content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        authorization_check.assert_not_called()
+        adapter._cache_inbound_attachments.assert_not_awaited()
+        adapter._dispatch_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_unauthorized_sender_attachment_is_not_downloaded(self):
         adapter = _make_adapter()
         adapter._allowed_pubkeys = {"f" * 64}
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+        adapter._cache_inbound_attachments = AsyncMock()
         adapter._download_attachment = AsyncMock()
         adapter._channel_state[CHANNEL] = {
             "chat_type": "group",
@@ -1231,7 +1334,129 @@ class TestInboundAttachments:
 
         await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
 
+        authorization_check.assert_not_called()
+        adapter._cache_inbound_attachments.assert_not_awaited()
         adapter._download_attachment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("authorization", [False, None, "raise"])
+    async def test_non_true_gateway_authority_never_caches_even_for_locally_allowed_sender(
+        self,
+        authorization,
+    ):
+        adapter = _make_adapter()
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        if authorization is None:
+            adapter.set_authorization_check(None)
+        elif authorization == "raise":
+            def raise_unknown(*_args):
+                raise RuntimeError("authorization backend unavailable")
+
+            adapter.set_authorization_check(raise_unknown)
+        else:
+            adapter.set_authorization_check(lambda *_args: False)
+        adapter._cache_inbound_attachments = AsyncMock()
+        adapter._dispatch_message = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event(f"gateway-{authorization}-attachment", content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        adapter._cache_inbound_attachments.assert_not_awaited()
+        adapter._dispatch_message.assert_awaited_once()
+        call = adapter._dispatch_message.await_args
+        assert call is not None
+        assert call.kwargs["media_urls"] == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_true_gateway_authority_caches_attachment(self):
+        adapter = _make_adapter()
+        authorization_check = MagicMock(return_value=True)
+        adapter.set_authorization_check(authorization_check)
+        cached = CachedMedia(
+            "/cache/authorized.bin",
+            "application/octet-stream",
+            "document",
+            "authorized.bin",
+        )
+        adapter._cache_inbound_attachments = AsyncMock(return_value=[cached])
+        adapter._dispatch_message = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("gateway-authorized-attachment", content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        authorization_check.assert_called_once_with(OTHER_PUBKEY, "group", CHANNEL)
+        adapter._cache_inbound_attachments.assert_awaited_once()
+        call = adapter._dispatch_message.await_args
+        assert call is not None
+        assert call.kwargs["media_urls"] == [cached.path]
+
+    @pytest.mark.asyncio
+    async def test_real_gateway_auth_callback_defaults_to_no_attachment_side_effects(
+        self,
+        monkeypatch,
+    ):
+        from gateway.config import GatewayConfig
+        from gateway.run import GatewayRunner
+
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.adapters = {}
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        adapter = _make_adapter()
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter.set_authorization_check(runner._make_adapter_auth_check(adapter.platform))
+        adapter._cache_inbound_attachments = AsyncMock()
+        adapter._dispatch_message = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("gateway-default-denied-attachment", content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        runner.pairing_store.is_approved.assert_called_once_with("buzz", OTHER_PUBKEY)
+        adapter._cache_inbound_attachments.assert_not_awaited()
+        adapter._dispatch_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,11 +2,14 @@
 
 import asyncio
 import base64
+import hashlib
 import json
+from pathlib import Path
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from gateway.platforms.base import CachedMedia, MessageType
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 from gateway.platforms.base import MessageType
 
@@ -659,6 +662,626 @@ class TestPollingDedupe:
         # Poll 2: identical response — the seen-id set must de-dupe
         await adapter._poll_channel(CHANNEL)
         assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_attachment_url_does_not_abort_following_event(self, adapter):
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        malformed = _event("malformed-attachment", content="background chatter", created_at=159)
+        malformed["tags"].append([
+            "imeta",
+            "url https://[invalid/media.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename invalid.bin",
+        ])
+        valid = _event("following-valid", content="@Chip still there?", created_at=160)
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [malformed, valid])
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(CHANNEL)
+
+        assert [item["message_id"] for item in adapter._dispatched] == ["following-valid"]
+
+    @pytest.mark.asyncio
+    async def test_addressed_attachment_is_cached_and_dispatched_to_agent(self, adapter):
+        attachment = CachedMedia(
+            path="/agent/cache/doc_handoff.txt",
+            media_type="text/plain",
+            kind="document",
+            display_name="handoff.txt",
+        )
+        adapter._download_attachment = AsyncMock(return_value=attachment)
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("attachment-event", content="@Chip inspect this", created_at=160)
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/abc.bin",
+            "m text/plain",
+            "x " + "a" * 64,
+            "size 12",
+            "filename handoff.txt",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        adapter._download_attachment.assert_awaited_once()
+        dispatched = adapter._dispatched[-1]
+        assert dispatched["media_urls"] == [attachment.path]
+        assert dispatched["media_types"] == ["text/plain"]
+        assert dispatched["message_type"] is MessageType.DOCUMENT
+        assert attachment.context_note() not in dispatched["text"]
+        assert dispatched["raw_message"] is event
+
+
+class TestInboundAttachments:
+
+    def test_imeta_total_declared_bytes_are_bounded(self):
+        event = _event("bounded", content="@Chip files")
+        per_file_size = 6 * 1024 * 1024
+        for index in range(4):
+            event["tags"].append([
+                "imeta",
+                f"url https://test.relay/media/{index}.bin",
+                "m application/octet-stream",
+                "x " + format(index + 1, "064x"),
+                f"size {per_file_size}",
+                f"filename {index}.bin",
+            ])
+
+        attachments = BuzzAdapter._imeta_attachments(event)
+
+        assert len(attachments) == 3
+        assert sum(item["size"] for item in attachments) <= 20 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_download_caches_only_exact_size_and_sha256(self, monkeypatch):
+        import httpx
+
+        payload = b"verified Buzz attachment"
+        digest = hashlib.sha256(payload).hexdigest()
+        real_async_client = httpx.AsyncClient
+
+        def handler(request):
+            assert request.url.host == "test.relay"
+            return httpx.Response(
+                200,
+                content=payload,
+                headers={"content-length": str(len(payload))},
+            )
+
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(
+                transport=httpx.MockTransport(handler),
+                **kwargs,
+            ),
+        )
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay/media/verified.bin",
+            "sha256": digest,
+            "size": len(payload),
+            "filename": "verified.txt",
+            "mime_type": "text/plain",
+        })
+
+        assert cached is not None
+        assert cached.kind == "document"
+        assert cached.media_type == "text/plain"
+        assert Path(cached.path).read_bytes() == payload
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_untrusted_attachment_host_before_network(self, monkeypatch):
+        import httpx
+
+        def must_not_create_client(**kwargs):
+            raise AssertionError("network client must not be created")
+
+        monkeypatch.setattr(httpx, "AsyncClient", must_not_create_client)
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://untrusted.example/media/file.bin",
+            "sha256": "a" * 64,
+            "size": 12,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_unconfigured_nondefault_port_before_network(self, monkeypatch):
+        import httpx
+
+        def must_not_create_client(**kwargs):
+            raise AssertionError("network client must not be created")
+
+        monkeypatch.setattr(httpx, "AsyncClient", must_not_create_client)
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay:8443/media/file.bin",
+            "sha256": "a" * 64,
+            "size": 12,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_download_allows_explicitly_configured_nondefault_port(self, monkeypatch):
+        import httpx
+
+        payload = b"x"
+        real_async_client = httpx.AsyncClient
+
+        def handler(request):
+            assert request.url.port == 8443
+            return httpx.Response(200, content=payload, headers={"content-length": "1"})
+
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(
+                transport=httpx.MockTransport(handler),
+                **kwargs,
+            ),
+        )
+        adapter = _make_adapter({"attachment_hosts": ["test.relay:8443"]})
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay:8443/media/file.bin",
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "size": 1,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is not None
+
+    @pytest.mark.asyncio
+    async def test_unaddressed_channel_attachment_is_not_downloaded(self):
+        adapter = _make_adapter()
+        adapter._download_attachment = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("unaddressed-attachment", content="shared file")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 12",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        adapter._download_attachment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_attachment_download_is_visible_to_agent(self):
+        adapter = _make_adapter()
+        adapter._download_attachment = AsyncMock(return_value=None)
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        event = _event("failed-attachment", content="@Chip inspect this")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 12",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        assert "could not be downloaded" in dispatched[-1]["text"]
+        assert dispatched[-1]["media_urls"] == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_builds_document_message_event_with_cached_path(self):
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+
+        await adapter._dispatch_message(
+            text="inspect",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="document-event",
+            created_at=1000,
+            media_urls=["/agent/cache/doc_report.pdf"],
+            media_types=["application/pdf"],
+            message_type=MessageType.DOCUMENT,
+            raw_message={"id": "document-event"},
+        )
+
+        call = adapter.handle_message.await_args
+        assert call is not None
+        dispatched_event = call.args[0]
+        assert dispatched_event.message_type is MessageType.DOCUMENT
+        assert dispatched_event.media_urls == ["/agent/cache/doc_report.pdf"]
+        assert dispatched_event.media_types == ["application/pdf"]
+        assert dispatched_event.media_text_inlined == [False]
+        assert dispatched_event.raw_message == {"id": "document-event"}
+
+    def test_imeta_sanitizes_filename_and_rejects_incomplete_metadata(self):
+        event = _event("metadata", content="@Chip files")
+        event["tags"].extend([
+            [
+                "imeta",
+                "url https://test.relay/media/valid.bin",
+                "m text/plain",
+                "x " + "a" * 64,
+                "size 12",
+                "filename ../../private/report.txt",
+            ],
+            [
+                "imeta",
+                "url http://test.relay/media/insecure.bin",
+                "x " + "b" * 64,
+                "size 12",
+                "filename insecure.bin",
+            ],
+            [
+                "imeta",
+                "url https://test.relay/media/no-hash.bin",
+                "size 12",
+                "filename no-hash.bin",
+            ],
+        ])
+
+        attachments = BuzzAdapter._imeta_attachments(event)
+
+        assert len(attachments) == 1
+        assert attachments[0]["filename"] == "report.txt"
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_dm_is_downloaded_and_dispatched(self):
+        adapter = _make_adapter()
+        attachment = CachedMedia(
+            path="/agent/cache/doc_attachment.bin",
+            media_type="application/octet-stream",
+            kind="document",
+            display_name="attachment.bin",
+        )
+        adapter._download_attachment = AsyncMock(return_value=attachment)
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        event = _event("attachment-only", content="")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 12",
+            "filename attachment.bin",
+        ])
+
+        await adapter._handle_event(
+            DM_CHANNEL,
+            adapter._channel_state[DM_CHANNEL],
+            event,
+        )
+
+        adapter._download_attachment.assert_awaited_once()
+        assert dispatched[-1]["media_urls"] == [attachment.path]
+        assert dispatched[-1]["message_type"] is MessageType.DOCUMENT
+
+    def test_imeta_bounds_filename_to_filesystem_safe_utf8_length(self):
+        event = _event("long-name", content="@Chip file")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename " + ("é" * 180) + ".pdf",
+        ])
+
+        filename = BuzzAdapter._imeta_attachments(event)[0]["filename"]
+
+        assert len(filename.encode("utf-8")) <= 120
+        assert filename.endswith(".pdf")
+
+    @pytest.mark.asyncio
+    async def test_cache_write_failure_is_treated_as_failed_attachment(self, monkeypatch):
+        import httpx
+
+        payload = b"x"
+        digest = hashlib.sha256(payload).hexdigest()
+        real_async_client = httpx.AsyncClient
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(
+                        200,
+                        content=payload,
+                        headers={"content-length": "1"},
+                    )
+                ),
+                **kwargs,
+            ),
+        )
+        monkeypatch.setattr(
+            _buzz_mod,
+            "cache_media_bytes",
+            MagicMock(side_effect=OSError(36, "File name too long")),
+        )
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay/media/file.bin",
+            "sha256": digest,
+            "size": 1,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_download_has_total_deadline(self, monkeypatch):
+        import httpx
+
+        payload = b"x"
+        real_async_client = httpx.AsyncClient
+
+        async def slow_handler(_request):
+            await asyncio.sleep(0.05)
+            return httpx.Response(200, content=payload, headers={"content-length": "1"})
+
+        monkeypatch.setattr(_buzz_mod, "_ATTACHMENT_DOWNLOAD_TIMEOUT", 0.01)
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(
+                transport=httpx.MockTransport(slow_handler),
+                **kwargs,
+            ),
+        )
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay/media/file.bin",
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "size": 1,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_mixed_attachments_use_document_semantics(self):
+        adapter = _make_adapter()
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        cached = [
+            CachedMedia("/cache/image.png", "image/png", "image", "image.png"),
+            CachedMedia("/cache/audio.mp3", "audio/mpeg", "audio", "audio.mp3"),
+        ]
+        adapter._cache_inbound_attachments = AsyncMock(return_value=cached)
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        event = _event("mixed", content="@Chip inspect")
+        for index, mime_type in enumerate(("image/png", "audio/mpeg")):
+            event["tags"].append([
+                "imeta",
+                f"url https://test.relay/media/{index}.bin",
+                f"m {mime_type}",
+                "x " + format(index + 1, "064x"),
+                "size 1",
+                f"filename {index}.bin",
+            ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        assert dispatched[-1]["message_type"] is MessageType.DOCUMENT
+        assert dispatched[-1]["media_types"] == ["image/png", "audio/mpeg"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "payload", "headers", "declared_size", "expected_digest"),
+        [
+            (302, b"", {}, 1, "a" * 64),
+            (200, b"x", {"content-length": "invalid"}, 1, hashlib.sha256(b"x").hexdigest()),
+            (200, b"x", {}, 2, hashlib.sha256(b"x").hexdigest()),
+            (200, b"xx", {}, 1, hashlib.sha256(b"xx").hexdigest()),
+            (200, b"x", {}, 1, "a" * 64),
+        ],
+    )
+    async def test_download_rejects_invalid_response_or_integrity(
+        self,
+        monkeypatch,
+        status,
+        payload,
+        headers,
+        declared_size,
+        expected_digest,
+    ):
+        import httpx
+
+        real_async_client = httpx.AsyncClient
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: real_async_client(
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(status, content=payload, headers=headers)
+                ),
+                **kwargs,
+            ),
+        )
+        adapter = _make_adapter()
+
+        cached = await adapter._download_attachment({
+            "url": "https://test.relay/media/file.bin",
+            "sha256": expected_digest,
+            "size": declared_size,
+            "filename": "file.bin",
+            "mime_type": "application/octet-stream",
+        })
+
+        assert cached is None
+
+    def test_imeta_rejects_url_credentials_and_fragments_and_caps_items(self):
+        event = _event("url-safety", content="@Chip files")
+        event["tags"].extend([
+            [
+                "imeta",
+                "url https://user:password@test.relay/media/private.bin",
+                "x " + "a" * 64,
+                "size 1",
+                "filename private.bin",
+            ],
+            [
+                "imeta",
+                "url https://test.relay/media/fragment.bin#hidden",
+                "x " + "b" * 64,
+                "size 1",
+                "filename fragment.bin",
+            ],
+        ])
+        for index in range(6):
+            event["tags"].append([
+                "imeta",
+                f"url https://test.relay/media/{index}.bin",
+                "x " + format(index + 1, "064x"),
+                "size 1",
+                f"filename {index}.bin",
+            ])
+
+        attachments = BuzzAdapter._imeta_attachments(event)
+
+        assert len(attachments) == 4
+        assert all("@" not in item["url"] and "#" not in item["url"] for item in attachments)
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_attachment_is_not_downloaded(self):
+        adapter = _make_adapter()
+        adapter._allowed_pubkeys = {"f" * 64}
+        adapter._download_attachment = AsyncMock()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        event = _event("unauthorized-attachment", content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            "url https://test.relay/media/file.bin",
+            "m application/octet-stream",
+            "x " + "a" * 64,
+            "size 1",
+            "filename file.bin",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        adapter._download_attachment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("kind", "mime_type", "expected_type"),
+        [
+            ("image", "image/png", MessageType.PHOTO),
+            ("video", "video/mp4", MessageType.VIDEO),
+            ("audio", "audio/mpeg", MessageType.AUDIO),
+            ("document", "application/pdf", MessageType.DOCUMENT),
+        ],
+    )
+    async def test_homogeneous_attachment_kind_sets_message_type(
+        self,
+        kind,
+        mime_type,
+        expected_type,
+    ):
+        adapter = _make_adapter()
+        adapter._user_names[OTHER_PUBKEY] = "Other"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+        }
+        cached = CachedMedia(
+            f"/cache/file-{kind}",
+            mime_type,
+            kind,
+            f"file-{kind}",
+        )
+        adapter._cache_inbound_attachments = AsyncMock(return_value=[cached])
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        event = _event(f"homogeneous-{kind}", content="@Chip inspect")
+        event["tags"].append([
+            "imeta",
+            f"url https://test.relay/media/{kind}",
+            f"m {mime_type}",
+            "x " + "a" * 64,
+            "size 1",
+            f"filename file-{kind}",
+        ])
+
+        await adapter._handle_event(CHANNEL, adapter._channel_state[CHANNEL], event)
+
+        assert dispatched[-1]["message_type"] is expected_type
 
 
 # ── Mention gating / DMs / authorization ──────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2340,6 +2340,102 @@ class TestBuzzAdapterSend:
         assert cli.calls[0][1] == "See @session:default/example."
         assert cli.calls[1][1] == "See @\u200bsession:default/example."
 
+    @pytest.mark.asyncio
+    async def test_send_image_file_existing_local_path_stays_native_upload_after_probe_flip(
+        self, tmp_path, monkeypatch
+    ):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126b", "message": ""})
+        adapter._run_cli = cli
+
+        original_is_file = _buzz_mod.Path.is_file
+        probe_results = iter([True, False])
+
+        def sequential_is_file(path):
+            if path == img:
+                return next(probe_results, original_is_file(path))
+            return original_is_file(path)
+
+        monkeypatch.setattr(_buzz_mod.Path, "is_file", sequential_is_file)
+
+        result = await adapter.send_image_file(CHANNEL, str(img), caption="screenshot")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "screenshot"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_uses_metadata_thread_id_when_reply_to_missing(self, tmp_path):
+        img = tmp_path / "reply-shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        thread_id = "b" * 64
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126c", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(
+            CHANNEL,
+            str(img),
+            caption="screenshot",
+            metadata={"thread_id": thread_id},
+        )
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert args[args.index("--reply-to") + 1] == thread_id
+        assert stdin_text == "screenshot"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_missing_local_path_uses_base_fallback_notice(self, tmp_path):
+        missing = tmp_path / "missing.png"
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(CHANNEL, str(missing), caption="screenshot")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert "--file" not in args
+        assert str(missing) not in args
+        assert stdin_text == "screenshot\n⚠️ Couldn't deliver the image attachment."
+        assert str(missing) not in stdin_text
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_file_url_uses_native_file_send(self, tmp_path):
+        img = tmp_path / "shot with spaces.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send_multiple_images(CHANNEL, [(img.as_uri(), "screenshot")])
+
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "screenshot"
+        assert "Couldn't deliver the image attachment." not in stdin_text
+
+
 
 
 # ── Thread anchoring ──────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1339,7 +1339,7 @@ class TestInboundAttachments:
         adapter._download_attachment.assert_not_awaited()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("authorization", [False, None, "raise"])
+    @pytest.mark.parametrize("authorization", [False, None, "raise", "truthy"])
     async def test_non_true_gateway_authority_never_caches_even_for_locally_allowed_sender(
         self,
         authorization,
@@ -1353,6 +1353,8 @@ class TestInboundAttachments:
                 raise RuntimeError("authorization backend unavailable")
 
             adapter.set_authorization_check(raise_unknown)
+        elif authorization == "truthy":
+            adapter.set_authorization_check(lambda *_args: "AUTHORIZED")
         else:
             adapter.set_authorization_check(lambda *_args: False)
         adapter._cache_inbound_attachments = AsyncMock()

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1599,6 +1599,11 @@ class TestInboundMediaLocalisation:
         adapter._message_handler = AsyncMock()
         adapter.send_reaction = AsyncMock(return_value=True)
         adapter._run_cli = cli
+        # Localisation spends the agent's Buzz credentials, so it is gated on
+        # an explicit gateway authorization. The gateway registers this check
+        # on every adapter it constructs; tests are authorized by default and
+        # override the callback where the gate itself is under test.
+        adapter.set_authorization_check(lambda *_args: True)
         return captured, cli_calls
 
     @pytest.mark.asyncio
@@ -1809,6 +1814,9 @@ class TestInboundMediaLocalisation:
         adapter._message_handler = AsyncMock()
         adapter.send_reaction = AsyncMock(return_value=True)
         adapter._run_cli = cli
+        # As the gateway does for every adapter it constructs; the gate itself
+        # is covered by TestInboundMediaAuthorizationGate.
+        adapter.set_authorization_check(lambda *_args: True)
 
         await adapter._handle_event(
             DM_CHANNEL,
@@ -1849,6 +1857,113 @@ class TestInboundMediaLocalisation:
         assert event.message_type == MessageType.TEXT
         assert event.media_urls == []
         assert calls == []
+
+
+class TestInboundMediaAuthorizationGate:
+    """Authenticated retrieval must never run for an unauthorized sender.
+
+    ``buzz media get`` signs the request with this agent's own key, so a
+    relay object named by an unauthorized sender must not be fetched or
+    cached. Every non-``True`` outcome — denial, no registered check, a
+    raising check, or a truthy non-boolean — must fail closed and leave the
+    message text exactly as it arrived.
+    """
+
+    @staticmethod
+    def _media_text():
+        return f"look at this ![shot](https://test.relay/media/{'a' * 64}.png)"
+
+    async def _dispatch_with_check(self, adapter, monkeypatch, tmp_path, check):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        captured, cli_calls = TestInboundMediaLocalisation._capture_dispatch(adapter)
+        adapter.set_authorization_check(check)
+        text = self._media_text()
+
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="gated-media-event",
+            created_at=1007,
+        )
+        return captured, cli_calls, text
+
+    @pytest.mark.asyncio
+    async def test_denied_sender_media_is_not_downloaded(self, monkeypatch, tmp_path):
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: False
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].message_type == MessageType.TEXT
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_missing_authorization_check_blocks_download(self, monkeypatch, tmp_path):
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, None
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_raising_authorization_check_blocks_download(self, monkeypatch, tmp_path):
+        def boom(*_args):
+            raise RuntimeError("auth backend down")
+
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, boom
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_boolean_is_not_an_authorization(self, monkeypatch, tmp_path):
+        """A non-boolean result must not be coerced into a credentialed fetch."""
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: "allowed"
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_adapter_allowlist_does_not_override_gateway_denial(
+        self, monkeypatch, tmp_path
+    ):
+        """``allowed_users`` is a pre-filter, not a second source of truth."""
+        adapter = _make_adapter({"allowed_users": [OTHER_PUBKEY]})
+        captured, cli_calls, _text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: False
+        )
+
+        assert OTHER_PUBKEY in adapter._allowed_pubkeys
+        assert cli_calls == []
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_authorized_sender_still_downloads(self, monkeypatch, tmp_path):
+        """The gate must not break the happy path it protects."""
+        adapter = _make_adapter()
+        captured, cli_calls, _text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: True
+        )
+
+        assert len(cli_calls) == 1
+        assert captured[0].message_type == MessageType.PHOTO
+        assert len(captured[0].media_urls) == 1
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -609,6 +610,18 @@ class TestCliErrorContract:
     def test_parses_json_error(self):
         msg = _cli_error_message('{"error":"relay_error","message":"boom","retryable":false}', 2)
         assert "relay_error" in msg and "boom" in msg and "exit 2" in msg
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "x" * 100_000,
+            json.dumps({"error": "relay_error", "message": "x" * 100_000}),
+        ],
+    )
+    def test_bounds_untrusted_cli_error_output(self, stderr):
+        msg = _cli_error_message(stderr, 2)
+        assert len(msg) <= 900
+        assert msg.endswith("...")
 
 
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
@@ -2211,7 +2224,66 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--reply-to") + 1] == "stable-root"
 
+    @pytest.mark.parametrize(
+        ("stdout", "error_fragment"),
+        [
+            ("not json", "invalid CLI response"),
+            (json.dumps([]), "invalid CLI response"),
+            (json.dumps({"event_id": "evt"}), "invalid CLI response"),
+            (json.dumps({"accepted": True}), "invalid CLI response"),
+            (json.dumps({"accepted": True, "event_id": "   "}), "invalid CLI response"),
+        ],
+    )
+    async def test_send_rejects_invalid_zero_exit_receipt(self, stdout, error_fragment):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(return_value=(0, stdout, ""))
 
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert error_fragment in result.error
+        assert result.message_id is None
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_rejection_is_useful_and_bounded(self):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                0,
+                json.dumps({"accepted": False, "message": "upload rejected " + "x" * 100_000}),
+                "",
+            )
+        )
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert "upload rejected" in result.error
+        assert len(result.error) <= 1024
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_success_exposes_only_verified_receipt(self):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                0,
+                json.dumps({
+                    "accepted": True,
+                    "event_id": " evt-safe ",
+                    "message": "x" * 100_000,
+                    "raw_response": "y" * 100_000,
+                }),
+                "",
+            )
+        )
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is True
+        assert result.message_id == "evt-safe"
+        assert result.raw_response is None
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -2935,6 +3007,101 @@ class TestInboundMediaAuthorizationGate:
 
 
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "suffix"),
+        [
+            ("send_image_file", ".png"),
+            ("send_video", ".mp4"),
+            ("send_voice", ".ogg"),
+            ("send_document", ".pdf"),
+        ],
+    )
+    async def test_live_media_capabilities_upload_local_file_with_caption_and_reply(
+        self, tmp_path, method_name, suffix
+    ):
+        media = tmp_path / f"attachment{suffix}"
+        media.write_bytes(b"media")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-media"})
+        adapter._run_cli = cli
+
+        result = await getattr(adapter, method_name)(
+            CHANNEL,
+            str(media),
+            caption="caption",
+            reply_to="root-event",
+            metadata={"thread_id": "ignored-thread"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt-media"
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--file") + 1] == str(media)
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert stdin_text == "caption"
+
+    @pytest.mark.asyncio
+    async def test_live_media_rejects_zero_exit_without_verified_event_id(self, tmp_path):
+        media = tmp_path / "attachment.pdf"
+        media.write_bytes(b"media")
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(0, json.dumps({"accepted": True}), "")
+        )
+
+        result = await adapter.send_document(CHANNEL, str(media))
+
+        assert result.success is False
+        assert result.error == "invalid CLI response"
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_live_buzz_delivers_all_media(self, monkeypatch, tmp_path):
+        from gateway.config import Platform
+        from tools.send_message_tool import _send_to_platform
+
+        first = tmp_path / "first.txt"
+        second = tmp_path / "second.pdf"
+        first.write_text("first", encoding="utf-8")
+        second.write_text("second", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-text"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-first"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-second"})
+        adapter._run_cli = cli
+        platform = Platform("buzz")
+        runner = SimpleNamespace(adapters={platform: adapter})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_to_platform(
+            platform,
+            SimpleNamespace(enabled=True, token=None, extra={}),
+            CHANNEL,
+            "attached files",
+            thread_id="root-event",
+            media_files=[(str(first), False), (str(second), False)],
+        )
+
+        assert result == {
+            "success": True,
+            "message_id": "evt-second",
+            "media_delivered": True,
+        }
+        assert len(cli.calls) == 3
+        assert cli.calls[0][1] == "attached files"
+        assert [call[0][call[0].index("--file") + 1] for call in cli.calls[1:]] == [
+            str(first),
+            str(second),
+        ]
+        assert all(
+            call[0][call[0].index("--reply-to") + 1] == "root-event"
+            for call in cli.calls
+        )
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 
@@ -3419,6 +3586,73 @@ class TestBuzzAdapterEdit:
 
         assert await adapter.delete_message(CHANNEL, "") is False
         assert cli.calls == []
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "not json",
+            json.dumps([]),
+            json.dumps({"event_id": "evt"}),
+            json.dumps({"accepted": True}),
+            json.dumps({"accepted": True, "event_id": ""}),
+        ],
+    )
+    async def test_standalone_send_rejects_invalid_zero_exit_receipt(
+        self, monkeypatch, tmp_path, stdout
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setattr(
+            _buzz_mod,
+            "_exec_buzz",
+            AsyncMock(return_value=(0, stdout, "")),
+        )
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "hello"
+        )
+
+        assert result == {"error": "Buzz standalone send failed: invalid CLI response"}
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejection_is_useful_bounded_and_not_delivered(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setattr(
+            _buzz_mod,
+            "_exec_buzz",
+            AsyncMock(
+                return_value=(
+                    0,
+                    json.dumps({"accepted": False, "message": "upload rejected " + "x" * 100_000}),
+                    "",
+                )
+            ),
+        )
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "hello",
+            media_files=[("/tmp/report.txt", False)],
+        )
+
+        assert "upload rejected" in result["error"]
+        assert len(result["error"]) <= 1024
+        assert "success" not in result
+        assert "media_delivered" not in result
 # ── Durable channel cursors across restart (#90464) ───────────────────────
 
 
@@ -3569,4 +3803,3 @@ class TestChannelCursorPersistence:
         await adapter._poll_channel(CHANNEL)
 
         assert path.stat().st_mtime_ns == before
-

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1345,6 +1345,8 @@ class TestInboundAttachments:
         authorization,
     ):
         adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(side_effect=AssertionError("authorization test invoked Buzz CLI"))
+        adapter._resolve_user_name = AsyncMock(return_value="Other")
         adapter._allowed_pubkeys = {OTHER_PUBKEY}
         if authorization is None:
             adapter.set_authorization_check(None)
@@ -1385,6 +1387,8 @@ class TestInboundAttachments:
     @pytest.mark.asyncio
     async def test_explicit_true_gateway_authority_caches_attachment(self):
         adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(side_effect=AssertionError("authorization test invoked Buzz CLI"))
+        adapter._resolve_user_name = AsyncMock(return_value="Other")
         authorization_check = MagicMock(return_value=True)
         adapter.set_authorization_check(authorization_check)
         cached = CachedMedia(
@@ -1435,6 +1439,8 @@ class TestInboundAttachments:
         runner.pairing_store.is_approved.return_value = False
 
         adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(side_effect=AssertionError("authorization test invoked Buzz CLI"))
+        adapter._resolve_user_name = AsyncMock(return_value="Other")
         adapter._allowed_pubkeys = {OTHER_PUBKEY}
         adapter.set_authorization_check(runner._make_adapter_auth_check(adapter.platform))
         adapter._cache_inbound_attachments = AsyncMock()

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3058,6 +3058,38 @@ class TestInboundMediaAuthorizationGate:
         assert result.raw_response is None
 
     @pytest.mark.asyncio
+    async def test_live_media_redacts_long_path_before_bounding(self, tmp_path):
+        parent = tmp_path
+        private_parts = []
+        for index in range(6):
+            part = f"private-{index}-" + ("x" * 150)
+            private_parts.append(part)
+            parent = parent / part
+            parent.mkdir()
+        media = parent / "handoff.txt"
+        media.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                2,
+                "",
+                json.dumps(
+                    {
+                        "error": "network",
+                        "message": f"upload failed for {media}: " + ("z" * 1_000),
+                    }
+                ),
+            )
+        )
+
+        result = await adapter.send_document(CHANNEL, str(media))
+
+        assert result.success is False
+        assert all(part not in result.error for part in private_parts)
+        assert "handoff.txt" in result.error
+        assert len(result.error) <= 900
+
+    @pytest.mark.asyncio
     async def test_send_to_platform_live_buzz_delivers_all_media(self, monkeypatch, tmp_path):
         from gateway.config import Platform
         from tools.send_message_tool import _send_to_platform

--- a/tests/gateway/test_document_context_note.py
+++ b/tests/gateway/test_document_context_note.py
@@ -14,6 +14,11 @@ import importlib
 
 import pytest
 
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
 gateway_run = importlib.import_module("gateway.run")
 _build_document_context_note = gateway_run._build_document_context_note
 
@@ -26,6 +31,54 @@ class TestTextDocumentNote:
         assert "notes.txt" in note
         assert "/cache/doc_notes.txt" in note
         assert "included below" in note
+
+    def test_non_inlined_text_note_tells_agent_to_read_cached_path(self):
+        note = _build_document_context_note(
+            "notes.txt",
+            "/cache/doc_notes.txt",
+            "text/plain",
+            content_inlined=False,
+        )
+        assert "included below" not in note
+        assert "/cache/doc_notes.txt" in note
+        assert "read" in note.lower()
+
+    @pytest.mark.asyncio
+    async def test_event_contract_marks_non_inlined_text_and_preserves_path(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+        )
+        runner.adapters = {}
+        runner._pending_native_image_paths_by_session = {}
+        runner._session_model_overrides = {}
+        runner._session_reasoning_overrides = {}
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="text-document",
+            chat_type="dm",
+            user_id="42",
+            user_name="Tester",
+        )
+        event = MessageEvent(
+            text="summarize this",
+            message_type=MessageType.DOCUMENT,
+            source=source,
+            media_urls=["/cache/notes.txt"],
+            media_types=["text/plain"],
+            media_text_inlined=[False],
+        )
+
+        prepared = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+        assert prepared is not None
+        assert "/cache/notes.txt" in prepared
+        assert "included below" not in prepared
+        assert "read the cached file" in prepared.lower()
 
 
 class TestBinaryDocumentNote:

--- a/tests/gateway/test_mixed_attachment_routing.py
+++ b/tests/gateway/test_mixed_attachment_routing.py
@@ -19,13 +19,18 @@ populate media_types.
 
 from types import SimpleNamespace
 
-from gateway.platforms.base import MessageType
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, merge_pending_message_event
 from gateway.run import (
+    GatewayRunner,
     _build_media_placeholder,
     _event_media_is_audio,
     _event_media_is_image,
     _event_media_is_video,
 )
+from gateway.session import SessionSource
 
 
 def _evt(media_urls, media_types, message_type):
@@ -57,3 +62,68 @@ def test_placeholder_document_in_photo_message_is_not_an_image():
     assert "[User sent a file: /c/brief.md]" in out
 
 
+@pytest.mark.asyncio
+async def test_mixed_document_event_preserves_audio_as_non_stt_file_path():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+    )
+    runner.adapters = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="mixed-audio",
+        chat_type="dm",
+        user_id="42",
+        user_name="Tester",
+    )
+    event = MessageEvent(
+        text="inspect both",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/cache/audio.mp3", "/cache/report.pdf"],
+        media_types=["audio/mpeg", "application/pdf"],
+    )
+
+    prepared = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert prepared is not None
+    assert "/cache/audio.mp3" in prepared
+    assert "/cache/report.pdf" in prepared
+    assert "transcrib" in prepared.lower()
+
+
+def test_pending_media_merge_preserves_per_attachment_inline_contract():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="merge",
+        chat_type="dm",
+        user_id="42",
+    )
+    existing = MessageEvent(
+        text="first",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/cache/image.png"],
+        media_types=["image/png"],
+    )
+    incoming = MessageEvent(
+        text="second",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/cache/notes.txt"],
+        media_types=["text/plain"],
+        media_text_inlined=[False],
+    )
+    pending = {"session": existing}
+
+    merge_pending_message_event(pending, "session", incoming)
+
+    assert existing.media_urls == ["/cache/image.png", "/cache/notes.txt"]
+    assert existing.media_text_inlined == [None, False]

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -943,6 +943,72 @@ class TestShouldSendMediaAsAudio:
 # ---------------------------------------------------------------------------
 
 
+class TestIsSenderAuthorized:
+    """``_is_sender_authorized`` is a tri-state: True / False / unknown.
+
+    Callers gate credentialed side effects on an explicit ``is True``, so a
+    truthy non-boolean must resolve to unknown rather than being coerced
+    into an authorization by ``bool()``.
+    """
+
+    def _adapter(self):
+        class StubAdapter(BasePlatformAdapter):
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, *a, **kw):
+                pass
+
+            async def get_chat_info(self, *a):
+                return {}
+
+        from gateway.config import Platform, PlatformConfig
+
+        return StubAdapter(config=PlatformConfig(enabled=True, token="test"),
+                           platform=Platform.TELEGRAM)
+
+    def test_no_check_registered_is_unknown(self):
+        assert self._adapter()._is_sender_authorized("user") is None
+
+    def test_empty_user_id_is_unknown(self):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: True)
+        assert adapter._is_sender_authorized("") is None
+
+    def test_true_and_false_propagate(self):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: True)
+        assert adapter._is_sender_authorized("user") is True
+        adapter.set_authorization_check(lambda *_a: False)
+        assert adapter._is_sender_authorized("user") is False
+
+    @pytest.mark.parametrize("result", ["allowed", 1, object(), [1]])
+    def test_truthy_non_boolean_is_unknown(self, result):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: result)
+        assert adapter._is_sender_authorized("user") is None
+
+    def test_raising_check_is_unknown(self):
+        def boom(*_a):
+            raise RuntimeError("auth backend down")
+
+        adapter = self._adapter()
+        adapter.set_authorization_check(boom)
+        assert adapter._is_sender_authorized("user") is None
+
+    def test_check_receives_chat_context(self):
+        seen = []
+        adapter = self._adapter()
+        adapter.set_authorization_check(
+            lambda user_id, chat_type, chat_id: seen.append((user_id, chat_type, chat_id)) or True
+        )
+        adapter._is_sender_authorized("user", "group", "chan")
+        assert seen == [("user", "group", "chan")]
+
+
 class TestTruncateMessage:
     def _adapter(self):
         """Create a minimal adapter instance for testing static/instance methods."""

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -315,55 +315,6 @@ def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
-def test_buzz_uuid_target_is_explicit() -> None:
-    chat_id, thread_id, is_explicit = _parse_target_ref(
-        "buzz", "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
-    )
-
-    assert chat_id == "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
-    assert thread_id is None
-    assert is_explicit is True
-
-
-def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:
-    buzz = Platform("buzz")
-    buzz_cfg = SimpleNamespace(enabled=True, token=None, extra={})
-    config = SimpleNamespace(
-        platforms={buzz: buzz_cfg},
-        get_home_channel=lambda _platform: SimpleNamespace(
-            chat_id="93b1a8c9-7093-4117-9db1-7199bacabd48"
-        ),
-    )
-
-    with patch("gateway.config.load_gateway_config", return_value=config), \
-         patch("tools.interrupt.is_interrupted", return_value=False), \
-         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw Buzz UUID should not resolve via directory")), \
-         patch("model_tools._run_async", side_effect=_run_async_immediately), \
-         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
-         patch("gateway.mirror.mirror_to_session", return_value=True):
-        result = json.loads(
-            send_message_tool(
-                {
-                    "action": "send",
-                    "target": "buzz:e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
-                    "message": "exact DM",
-                }
-            )
-        )
-
-    assert result["success"] is True
-    assert "note" not in result
-    send_mock.assert_awaited_once_with(
-        buzz,
-        buzz_cfg,
-        "e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
-        "exact DM",
-        thread_id=None,
-        media_files=[],
-        force_document=False,
-    )
-
-
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
     whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
     config = SimpleNamespace(

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -23,29 +23,174 @@ def test_buzz_uuid_target_is_explicit() -> None:
     assert _parse_target_ref("buzz", channel_id) == (channel_id, None, True)
 
 
-def test_plugin_media_receipt_suppresses_omitted_warning() -> None:
-    media_result = {
-        "success": True,
-        "message_id": "evt-media",
-        "media_delivered": True,
-    }
+def test_live_buzz_media_delivers_every_file_with_reply_metadata(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
 
-    with patch(
-        "tools.send_message_tool._send_via_adapter",
-        new=AsyncMock(return_value=media_result),
-    ):
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.pdf"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    calls = []
+
+    class Adapter:
+        async def send(self, *, chat_id, content, metadata=None):
+            calls.append(("text", content, metadata))
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            calls.append(("document", file_path, kwargs))
+            return SendResult(success=True, message_id=f"evt-{len(calls)}")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
         result = asyncio.run(
             _send_to_platform(
-                Platform("buzz"),
+                platform,
                 SimpleNamespace(enabled=True, token=None, extra={}),
                 "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
-                "attached",
-                media_files=[("/tmp/report.txt", False)],
+                "attached files",
+                thread_id="reply-root",
+                media_files=[(str(first), False), (str(second), False)],
             )
         )
 
-    assert result == media_result
-    assert "warnings" not in result
+    assert result["success"] is True
+    assert result["media_delivered"] is True
+    assert calls == [
+        ("text", "attached files", {"thread_id": "reply-root"}),
+        ("document", str(first), {"caption": None, "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}}),
+        ("document", str(second), {"caption": None, "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}}),
+    ]
+
+
+def test_live_buzz_single_image_uses_caption_without_duplicate_text(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    image = tmp_path / "shot.png"
+    image.write_bytes(b"png")
+    calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            calls.append(("text", kwargs))
+            return SendResult(success=True, message_id="unexpected")
+
+        async def send_image_file(self, chat_id, image_path, **kwargs):
+            calls.append(("image", image_path, kwargs))
+            return SendResult(success=True, message_id="evt-image")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "screenshot caption",
+                thread_id="reply-root",
+                media_files=[(str(image), False)],
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "message_id": "evt-image",
+        "media_delivered": True,
+    }
+    assert calls == [
+        ("image", str(image), {"caption": "screenshot caption", "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}})
+    ]
+
+
+def test_live_buzz_media_failure_is_explicit_not_omitted(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    media_calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            media_calls.append(file_path)
+            if file_path == str(second):
+                return SendResult(success=False, error="relay rejected upload")
+            return SendResult(success=True, message_id="evt-first")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached files",
+                media_files=[(str(first), False), (str(second), False)],
+            )
+        )
+
+    assert media_calls == [str(first), str(second)]
+    assert "relay rejected upload" in result["error"]
+    assert "media_delivered" not in result
+
+
+def test_live_adapter_inherited_media_fallback_is_not_claimed_as_delivery(tmp_path) -> None:
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+    platform = Platform("buzz")
+    document = tmp_path / "report.txt"
+    document.write_text("report", encoding="utf-8")
+
+    class Adapter:
+        name = "Fallback-only"
+        send_document = BasePlatformAdapter.send_document
+
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="warning-text-only")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached",
+                media_files=[(str(document), False)],
+            )
+        )
+
+    assert "does not implement native document delivery" in result["error"]
+    assert "media_delivered" not in result
+
+
+def test_live_buzz_adapter_exception_is_bounded() -> None:
+    platform = Platform("buzz")
+
+    class Adapter:
+        async def send(self, **kwargs):
+            raise RuntimeError("x" * 100_000)
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "hello",
+            )
+        )
+
+    assert result["error"].startswith("Plugin platform send failed: ")
+    assert len(result["error"]) <= 1024
 
 
 def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -10,11 +10,80 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import Platform
-from tools.send_message_tool import _parse_target_ref, send_message_tool
+from tools.send_message_tool import _parse_target_ref, _send_to_platform, send_message_tool
 
 
 def _run_async_immediately(coro):
     return asyncio.run(coro)
+
+
+def test_buzz_uuid_target_is_explicit() -> None:
+    channel_id = "31b543d5-80d4-4df5-8a5c-cefca1a58fdd"
+
+    assert _parse_target_ref("buzz", channel_id) == (channel_id, None, True)
+
+
+def test_plugin_media_receipt_suppresses_omitted_warning() -> None:
+    media_result = {
+        "success": True,
+        "message_id": "evt-media",
+        "media_delivered": True,
+    }
+
+    with patch(
+        "tools.send_message_tool._send_via_adapter",
+        new=AsyncMock(return_value=media_result),
+    ):
+        result = asyncio.run(
+            _send_to_platform(
+                Platform("buzz"),
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached",
+                media_files=[("/tmp/report.txt", False)],
+            )
+        )
+
+    assert result == media_result
+    assert "warnings" not in result
+
+
+def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:
+    buzz_platform = Platform("buzz")
+    buzz_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={buzz_platform: buzz_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="home-channel"),
+    )
+    channel_id = "31b543d5-80d4-4df5-8a5c-cefca1a58fdd"
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw UUID should not resolve via directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": f"buzz:{channel_id}",
+                    "message": "hello group",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        buzz_platform,
+        buzz_cfg,
+        channel_id,
+        "hello group",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
 
 
 def test_photon_e164_target_is_explicit() -> None:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -141,6 +141,78 @@ def test_live_buzz_media_failure_is_explicit_not_omitted(tmp_path) -> None:
     assert "media_delivered" not in result
 
 
+def test_live_buzz_media_only_send_reaches_adapter(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    document = tmp_path / "report.txt"
+    document.write_text("report", encoding="utf-8")
+    media_calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            raise AssertionError("media-only send must not emit an empty text message")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            media_calls.append((chat_id, file_path, kwargs))
+            return SendResult(success=True, message_id="evt-document")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "",
+                media_files=[(str(document), False)],
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "message_id": "evt-document",
+        "media_delivered": True,
+    }
+    assert len(media_calls) == 1
+    assert media_calls[0][1] == str(document)
+
+
+def test_live_buzz_media_exception_reports_partial_delivery(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+
+    class Adapter:
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            if file_path == str(second):
+                raise RuntimeError("relay transport failed")
+            return SendResult(success=True, message_id="evt-first")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached files",
+                media_files=[(str(first), False), (str(second), False)],
+            )
+        )
+
+    assert "after 1/2 files" in result["error"]
+    assert "relay transport failed" in result["error"]
+    assert "media_delivered" not in result
+
+
 def test_live_adapter_inherited_media_fallback_is_not_claimed_as_delivery(tmp_path) -> None:
     from gateway.platforms.base import BasePlatformAdapter, SendResult
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1403,7 +1403,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             return result
         last_result = result
 
-    if warning and isinstance(last_result, dict) and last_result.get("success"):
+    if (
+        warning
+        and isinstance(last_result, dict)
+        and last_result.get("success")
+        and not last_result.get("media_delivered")
+    ):
         warnings = list(last_result.get("warnings", []))
         warnings.append(warning)
         last_result["warnings"] = warnings

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -917,7 +917,17 @@ async def _send_live_adapter_media(
                     f"media file {index + 1}/{total} was not sent"
                 )
             }
-        last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        try:
+            last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return {
+                "error": (
+                    f"Adapter media send failed after {index}/{total} files: "
+                    f"{_bounded_send_error(exc)}"
+                )
+            }
         if not last_result.success:
             detail = _bounded_send_error(last_result.error or "media send failed")
             return {
@@ -1456,7 +1466,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
-    if media_files and not message.strip():
+    # Buzz is a plugin platform with verified native media delivery through
+    # _send_via_adapter below, including valid media-only sends.
+    if media_files and not message.strip() and platform.value != "buzz":
         return {
             "error": (
                 f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
@@ -1464,7 +1476,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             )
         }
     warning = None
-    if media_files:
+    if media_files and platform.value != "buzz":
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
             "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -843,6 +843,96 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+def _bounded_send_error(detail, max_chars=900):
+    """Bound untrusted adapter/plugin error detail returned by send_message."""
+    text = str(detail or "send failed")
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max_chars - 3]}..."
+
+
+async def _send_live_adapter_media(
+    adapter,
+    chat_id,
+    message,
+    media_files,
+    *,
+    thread_id=None,
+    metadata=None,
+    force_document=False,
+):
+    """Deliver text and every media descriptor through adapter media APIs."""
+    caption, separate_text = _media_caption_split(
+        message, media_files, max_caption_len=_DEFAULT_CAPTION_LIMIT
+    )
+    last_result = None
+    if separate_text and separate_text.strip():
+        last_result = await adapter.send(
+            chat_id=chat_id, content=separate_text, metadata=metadata
+        )
+        if not last_result.success:
+            return {"error": f"Adapter send failed: {_bounded_send_error(last_result.error)}"}
+
+    total = len(media_files)
+    for index, descriptor in enumerate(media_files):
+        if not isinstance(descriptor, (list, tuple)) or not descriptor:
+            return {"error": f"Adapter media send failed: invalid media descriptor {index + 1}/{total}"}
+        media_path = descriptor[0]
+        is_voice = bool(descriptor[1]) if len(descriptor) > 1 else False
+        if not isinstance(media_path, str) or not media_path:
+            return {"error": f"Adapter media send failed: invalid media descriptor {index + 1}/{total}"}
+        if not os.path.exists(media_path):
+            return {"error": f"Adapter media send failed: media file {index + 1}/{total} was not found"}
+
+        ext = os.path.splitext(media_path)[1].lower()
+        kwargs = {
+            "caption": caption if index == 0 else None,
+            "reply_to": thread_id,
+            "metadata": metadata,
+        }
+        if force_document:
+            method_name = "send_document"
+            media_kind = "document"
+        elif ext in _IMAGE_EXTS:
+            method_name = "send_image_file"
+            media_kind = "image"
+        elif ext in _VIDEO_EXTS:
+            method_name = "send_video"
+            media_kind = "video"
+        elif is_voice or ext in _AUDIO_EXTS:
+            method_name = "send_voice"
+            media_kind = "audio"
+        else:
+            method_name = "send_document"
+            media_kind = "document"
+
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter_method = getattr(type(adapter), method_name, None)
+        base_fallback = getattr(BasePlatformAdapter, method_name)
+        if adapter_method is None or adapter_method is base_fallback:
+            return {
+                "error": (
+                    f"Live adapter does not implement native {media_kind} delivery; "
+                    f"media file {index + 1}/{total} was not sent"
+                )
+            }
+        last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        if not last_result.success:
+            detail = _bounded_send_error(last_result.error or "media send failed")
+            return {
+                "error": f"Adapter media send failed after {index}/{total} files: {detail}"
+            }
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+    return {
+        "success": True,
+        "message_id": last_result.message_id,
+        "media_delivered": True,
+    }
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -886,7 +976,6 @@ async def _send_via_adapter(
                     metadata["publish_topic"] = chat_id
                 if not metadata:
                     metadata = None
-
                 # The adapter's send() uses asyncio.Queue + worker tasks bound
                 # to the gateway's main event loop.  Calling send() from a
                 # different thread/loop (the agent's tool worker thread) causes
@@ -904,6 +993,35 @@ async def _send_via_adapter(
                     gateway_loop is not None
                     and _current_loop is not gateway_loop
                 )
+
+                # Media descriptors route through the adapter's native media
+                # APIs (same cross-loop rules apply — the media helper awaits
+                # adapter methods bound to the gateway loop).
+                if media_files:
+                    def _media_coro():
+                        return _send_live_adapter_media(
+                            adapter,
+                            chat_id,
+                            chunk,
+                            media_files,
+                            thread_id=thread_id,
+                            metadata=metadata,
+                            force_document=force_document,
+                        )
+                    if _need_cross_loop:
+                        if not gateway_loop.is_running():
+                            return {"error": "Gateway loop is not running; cannot dispatch adapter send"}
+                        from agent.async_utils import safe_schedule_threadsafe
+                        media_fut = safe_schedule_threadsafe(
+                            _media_coro(),
+                            gateway_loop,
+                            logger=logger,
+                            log_message="send_message: failed to schedule media send on gateway loop",
+                        )
+                        if media_fut is None:
+                            return {"error": "Gateway loop unavailable for send dispatch"}
+                        return await asyncio.shield(asyncio.wrap_future(media_fut))
+                    return await _media_coro()
 
                 if _need_cross_loop:
                     if not gateway_loop.is_running():
@@ -931,10 +1049,10 @@ async def _send_via_adapter(
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                return {"error": f"Plugin platform send failed: {e}"}
+                return {"error": f"Plugin platform send failed: {_bounded_send_error(e)}"}
             if result.success:
                 return {"success": True, "message_id": result.message_id}
-            return {"error": f"Adapter send failed: {result.error}"}
+            return {"error": f"Adapter send failed: {_bounded_send_error(result.error)}"}
 
     entry = None
     try:
@@ -957,9 +1075,11 @@ async def _send_via_adapter(
             raise
         except Exception as e:
             logger.debug("Plugin standalone send for %s raised", platform_name, exc_info=True)
-            return {"error": f"Plugin standalone send failed: {e}"}
+            return {"error": f"Plugin standalone send failed: {_bounded_send_error(e)}"}
 
         if isinstance(result, dict) and (result.get("success") or result.get("error")):
+            if result.get("error"):
+                return {**result, "error": _bounded_send_error(result["error"])}
             return result
         return {
             "error": (
@@ -1351,7 +1471,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
@@ -1395,7 +1515,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chat_id,
                 chunk,
                 thread_id=thread_id,
-                media_files=media_files,
+                media_files=media_files if i == len(chunks) - 1 else [],
                 force_document=force_document,
             )
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -29,6 +29,7 @@ gateway:
       enabled: true
       extra:
         relay_url: https://mycommunity.communities.buzz.xyz
+        attachment_hosts: []         # additional exact HTTPS host[:port] origins for inbound files
         channels:                  # channel UUIDs to watch (empty = all joined)
           - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
@@ -74,6 +75,7 @@ gateway:
       enabled: true
       extra:
         relay_url: https://mycommunity.communities.buzz.xyz
+        attachment_hosts: []         # additional exact HTTPS host[:port] origins for inbound files
         channels:                         # channel UUIDs to watch (empty = all joined)
           - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
@@ -127,6 +129,21 @@ By default the allow-list is empty, which means every community member who menti
 The allow-list also gates **inbound attachments**: relay media is fetched with the agent's own Buzz credentials, so a download only happens for a sender the gateway explicitly authorizes. A denied, missing, or failed authorization leaves the message text untouched and makes no credentialed request.
 
 Cron jobs and notifications (`deliver=buzz`) are delivered to the **home channel** — `BUZZ_HOME_CHANNEL` if set, otherwise the first watched channel — and work even when cron runs outside the gateway process.
+
+## Inbound attachments
+
+Buzz messages with native NIP-94 `imeta` tags can deliver images, audio,
+video, and documents to the agent. Hermes downloads attachments only after
+the message has passed self-echo, addressing, and sender authorization checks.
+Each file must use HTTPS and declare an exact byte size and SHA-256 digest;
+redirects, URL credentials, fragments, oversized payloads, and integrity
+mismatches are rejected.
+
+The relay's own HTTPS origin is trusted automatically. If a community stores
+media on another public origin, add its exact `host` or `host:port` to
+`attachment_hosts` under `gateway.platforms.buzz.extra`. Non-default ports
+must be listed explicitly. Protected media that requires authenticated
+retrieval through the Buzz CLI is not handled by this native public-URL path.
 
 ## Run the gateway
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -4,6 +4,8 @@ The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) comm
 
 Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id. When progress or status messages are enabled, they inherit the triggering Buzz event as their reply anchor instead of appearing as unrelated top-level channel posts.
 
+Files sent **to** the agent are fetched back off the relay with the agent's authenticated identity and cached locally, so tools receive a real file path rather than a `/media/…` URL that anonymous requests cannot read. Images, audio, video, and documents (PDFs and the like) are all handled.
+
 Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 
 > Run `hermes gateway setup` and pick **Buzz** for a guided walk-through.
@@ -121,6 +123,8 @@ The opt-out applies to **all** send paths — final answers, streamed updates, i
 ## Access control
 
 By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.
+
+The allow-list also gates **inbound attachments**: relay media is fetched with the agent's own Buzz credentials, so a download only happens for a sender the gateway explicitly authorizes. A denied, missing, or failed authorization leaves the message text untouched and makes no credentialed request.
 
 Cron jobs and notifications (`deliver=buzz`) are delivered to the **home channel** — `BUZZ_HOME_CHANNEL` if set, otherwise the first watched channel — and work even when cron runs outside the gateway process.
 


### PR DESCRIPTION
## Summary
The full Buzz media pipeline works: inbound attachments are authenticated-fetched and verified before reaching the agent, and outbound images/video/voice/documents upload natively with verified receipts. 14 contributor commits from 5 PRs cherry-picked with authorship + 3 reconciliation commits.
Fixes #84112, #75979.

## Changes
- Inbound (#84113 @frischeDaten + @joelbrilliant; #78051 @EmpireOperating): same-relay Blossom URLs via authenticated `buzz media get` AND verified NIP-94 imeta attachments (HTTPS-only exact-origin allowlist, size/count caps, Content-Length + byte-count + SHA-256 integrity, no redirects) — cached through gateway media caches, dispatched as media_urls/types.
- Security boundary: credentialed fetch requires the authorization callback to return literal `True`; False/None/raising/truthy-non-bool all fail closed — includes the base-adapter `bool()`-coercion fix in `_is_sender_authorized` (Slack/Discord unaffected).
- Reconciliation: `_dispatch_message` merges imeta + text-localized media with dedupe; mixed-source events use DOCUMENT semantics so audio never mis-routes to STT.
- Outbound (#95688 @chigreen, #74999 @riyaazd29, #78046 @EmpireOperating): one shared `_send_file_attachment` helper for image/video/voice/document, strict JSON receipt contract, path-redacted errors, single-probe race protection; standalone/cron sends deliver (path,is_voice) descriptors natively with `media_delivered` receipts.
- #75614 superseded by #84113 (author consented in-thread; commits live here with authorship).

## Validation
302 + 76 targeted tests green, ruff clean; sabotage: weakening the auth gate fails 3 tests, bypassing receipt verification fails 14.

**Live repro:** 17/17 E2E — real adapter import, real local HTTP server, real fake-CLI subprocess, temp HERMES_HOME: authenticated PNG fetch (byte-identical sha256), all rejection classes fail closed with zero CLI calls, every outbound kind reaches native `--file` upload with verified receipts.

## Infographic

![The media pipeline](https://v3b.fal.media/files/b/0aa88d7a/5ehKo4XHUY2O9SUn9DIH8_lFweBivg.png)
