### PR TITLE
fix(dashboard): report file entries under their own path, not the resolved target

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2656,9 +2656,13 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
 
     is_dir = resolved.is_dir()
     mime_type = None if is_dir else (mimetypes.guess_type(resolved.name)[0] or "application/octet-stream")
+    # Report the entry's own path, not the resolved target: when a link and its
+    # target sit in the same directory, resolved paths would collide and the
+    # Files page keys rows by this value (#99418). `target` is already resolved
+    # for the single-entry callers (upload/mkdir), so only link entries change.
     return {
         "name": target.name or resolved.name or str(resolved),
-        "path": str(resolved),
+        "path": str(target),
         "is_directory": is_dir,
         "size": None if is_dir else st.st_size,
         "mtime": st.st_mtime,

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -375,3 +375,30 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+def test_link_entries_report_their_own_path(forced_files_client):
+    """Regression test for #99418: a link and its target in the same directory
+    must produce two entries with distinct paths (the Files page keys rows by
+    path, so a resolved collision leaves a phantom row in every folder)."""
+    client, root = forced_files_client
+    # The server reports entries under the resolved locked root.
+    root = root.resolve()
+
+    real_dir = root / "real"
+    real_dir.mkdir(parents=True)
+    link = root / "link"
+    try:
+        link.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlinks are not creatable on this platform")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    entries = {e["name"]: e for e in listing.json()["entries"]}
+    assert set(entries) >= {"real", "link"}
+    assert entries["real"]["path"] == str(real_dir)
+    assert entries["link"]["path"] == str(link)
+    assert entries["link"]["path"] != entries["real"]["path"]
+    # stat still follows the link, so the target's directory flag is preserved.
+    assert entries["link"]["is_directory"] is True
+
+


### PR DESCRIPTION
## What does this PR do?

`GET /api/files` reported every junction/symlink entry with its **resolved** target as `path` (`_managed_file_entry` returned `str(resolved)`). When a link and its target sit in the same directory — the default situation on Windows profiles, where the hidden compatibility junctions (`My Documents` → `Documents`) live next to their targets — one listing contained two entries with the **same `path`** value.

The Files page keys its rows by `entry.path` (`FilesPage.tsx`), so the duplicate key broke React reconciliation: a phantom interactive row for the duplicated path was rendered in **every** folder visited afterwards, including empty ones, and only a full page reload cleared it (#99418). The phantom row carried a live delete button for a directory the user was not looking at.

The fix returns the entry's own path in listings while keeping everything else on the resolved target:

- the locked-root security check still validates the **resolved** path;
- `is_directory` / `size` / `mtime` still come from the resolved target (link semantics unchanged);
- single-entry callers (upload, mkdir) pass an already-resolved path, so their responses are byte-identical.

## Related Issue

Fixes #99418

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `_managed_file_entry` now returns `"path": str(target)` (the entry's own path) instead of `str(resolved)`, with a comment explaining the row-key collision; resolved-path validation and stat behavior are untouched.
- `tests/hermes_cli/test_web_server_files.py` — added `test_link_entries_report_their_own_path`: a directory symlink and its target in the same folder must produce two entries with distinct paths (skipped on platforms where directory symlinks cannot be created).

## How to Test

1. `pytest tests/hermes_cli/test_web_server_files.py -q` — Observed result: `9 passed` (new regression test included).
2. Adjacent suites for the same surface: `pytest tests/hermes_cli/test_web_server_fs.py tests/hermes_cli/test_web_server.py -q -k "file or managed or upload or mkdir"` — Observed result: `21 passed`.
3. Without the fix, the new test fails on `entries["link"]["path"] == str(link)` (it gets the resolved target path instead) — verified red before the one-line change, green after.
4. Manual equivalent of the report's repro on POSIX: `mkdir real && ln -s real link` inside the managed root, then `GET /api/files?path=<root>` now returns `real` and `link` with distinct `path` values, so the Files page rows keep unique keys and no phantom row survives navigation. On Windows the same mechanism applies to profile junctions via `Path.resolve()`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon, Python 3.11)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is Windows-junction-driven and the fix is platform-neutral; the regression test uses POSIX symlinks and skips where they cannot be created
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A