### PR TITLE
fix(state): route lock-free SessionDB reads through _read_ctx (segfault racing close())

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8122,11 +8122,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        # _read_ctx, never a bare self._conn read: an unlocked execute on
+        # the shared writer connection races close() inside pysqlite's
+        # statement cache and segfaults the process (#99349).
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -8198,13 +8202,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         from agent.session_activity import ActivityProvenance
 
         # No-op fast path: skip the transaction when there is nothing to
-        # clear. Read-only, no write lock.
+        # clear. Read-only, but NOT lock-free on the writer connection: this
+        # runs in the turn's finally, exactly when an interrupted session is
+        # also tearing down, and a bare self._conn.execute racing close()
+        # segfaults inside pysqlite's statement cache (#99349). _read_ctx
+        # borrows a pooled read connection, so the write-patience budget
+        # this fast path exists to protect is still never touched.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -15165,12 +15175,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
             if not row:
                 return None
             return {
@@ -15187,15 +15197,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            with self._read_ctx() as conn:
+                rows = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                ).fetchall()
+            return [self._session_row_dict(r) for r in rows]
         except Exception:
             return []
 

--- a/tests/test_hermes_state_conn_lock_audit.py
+++ b/tests/test_hermes_state_conn_lock_audit.py
@@ -1,0 +1,109 @@
+"""Lock audit for every call on the shared writer connection (#99349).
+
+``SessionDB._conn`` is opened with ``check_same_thread=False`` and shared
+across threads (``AsyncSessionDB`` offloads every method via
+``asyncio.to_thread``), so every *call* on it must hold ``self._lock``.
+A lock-free ``self._conn.execute(...)`` — even a pure SELECT — can run
+concurrently with ``close()`` deallocating the connection's pysqlite
+statement cache, which segfaults the interpreter (observed in the field:
+``_PyDict_GetItem_KnownHash`` via ``bounded_lru_cache_wrapper`` on one
+thread while ``pysqlite_connection_close`` tears the cache down on
+another). "Read-only" is not an exemption: the race is on the connection
+object, not the database file.
+
+Reads that must not contend on the writer lock go through
+``SessionDB._read_ctx()`` instead — it borrows a pooled read connection
+(exclusively checked out for the block) and its non-WAL fallback is the
+writer connection *under* ``self._lock``.
+
+This is an AST audit in the spirit of
+``tests/gateway/test_async_session_db.py``: it fails on the next
+``self._conn.<method>(...)`` call site added outside ``with self._lock:``.
+"""
+
+import ast
+from pathlib import Path
+
+# Functions allowed to touch self._conn without the lock: construction-time
+# code that runs before the instance is ever shared with another thread.
+_ALLOWED_UNLOCKED_FNS = frozenset({
+    "__init__",
+    "_connect_and_init",
+    "_connect_and_init_with_lock_patience",
+})
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _nearest_enclosing_fn(tree: ast.AST) -> dict:
+    """Map id(node) -> name of the nearest enclosing function ("<module>"
+    at module level). Nested defs override their parents."""
+    enclosing: dict = {}
+
+    def visit(node: ast.AST, current: str) -> None:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            current = node.name
+        enclosing[id(node)] = current
+        for child in ast.iter_child_nodes(node):
+            visit(child, current)
+
+    visit(tree, "<module>")
+    return enclosing
+
+
+def _unlocked_conn_calls(tree: ast.AST):
+    """Return (lineno, enclosing_fn, method) for each self._conn.<m>(...)
+    call that is not lexically inside a ``with self._lock:`` block."""
+    locked_ids = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                ctx = item.context_expr
+                if (
+                    isinstance(ctx, ast.Attribute)
+                    and ctx.attr == "_lock"
+                    and isinstance(ctx.value, ast.Name)
+                    and ctx.value.id == "self"
+                ):
+                    locked_ids.update(id(child) for child in ast.walk(node))
+
+    enclosing = _nearest_enclosing_fn(tree)
+
+    offending = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "_conn"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "self"
+        ):
+            continue
+        if id(node) in locked_ids:
+            continue
+        fn = enclosing.get(id(node), "<module>")
+        if fn in _ALLOWED_UNLOCKED_FNS:
+            continue
+        offending.append((node.lineno, fn, func.attr))
+    return offending
+
+
+def test_every_conn_call_outside_construction_holds_the_lock():
+    src = (_repo_root() / "hermes_state.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    offending = _unlocked_conn_calls(tree)
+    assert not offending, (
+        "self._conn.<method>() called without `with self._lock:` — this "
+        "races SessionDB.close() inside pysqlite's statement cache and "
+        "segfaults the process (#99349). Use `with self._read_ctx() as "
+        "conn:` for reads, or take self._lock. Sites: "
+        + ", ".join(
+            f"line {lineno} in {fn}(): self._conn.{meth}(...)"
+            for lineno, fn, meth in offending
+        )
+    )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6184,9 +6184,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
+                    # Probe WITHOUT calling: isawaitable(_watch_children())
+                    # minted a real coroutine that nothing ever awaited — a
+                    # "never awaited" RuntimeWarning on every stdio tool call
+                    # (asyncio.iscoroutinefunction also accepts AsyncMock).
                     _watch_ok = (
                         _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        and asyncio.iscoroutinefunction(_watch_children)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:


### PR DESCRIPTION
## What does this PR do?

Fixes a process-killing SIGSEGV: four `SessionDB` read helpers ran `self._conn.execute(...)` on the shared writer connection **without `self._lock`**, so they could race `close()` inside pysqlite's statement cache (a `functools.lru_cache` C object). `AsyncSessionDB` offloads every method via `asyncio.to_thread`, so the race is real and observed in the field — full two-thread native stack traces in #99349. The observed trigger: an interrupted turn runs `clear_session_activity_labels` in its `finally` exactly while session teardown is closing the DB.

The fix routes all four reads through the existing `_read_ctx()` helper, exactly like the neighbouring lookup methods (`get_telegram_topic_binding` etc.): under WAL it borrows a pooled read connection (exclusively checked out; pool teardown is already coordinated with `close()` via `_read_conns_closed`), and the non-WAL fallback is the writer connection **under `self._lock`** — the lock these sites were missing. `clear_session_activity_labels`'s fast path stays off the write-patience budget it exists to protect (#76354 contract preserved).

A second, independent one-liner in the same investigation: `tools/mcp_tool.py` probed the stdio child watcher with `inspect.isawaitable(_watch_children())`, minting a coroutine that nothing ever awaited — a `RuntimeWarning: coroutine 'MCPServerTask._watch_stdio_children' was never awaited` on every stdio tool call. Now probes with `asyncio.iscoroutinefunction` (no side effect; still accepts the fast-fail tests' `async def` stubs and `AsyncMock`).

## Related Issue

Fixes #99349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: `get_compression_lock_holder`, `clear_session_activity_labels` (fast path), `get_handoff_state`, `list_pending_handoffs` — bare `self._conn.execute(...)` → `with self._read_ctx() as conn:`.
- `tests/test_hermes_state_conn_lock_audit.py` (new): AST audit in the spirit of `tests/gateway/test_async_session_db.py` — fails on the next `self._conn.<method>(...)` call site outside `with self._lock:` (construction-time helpers excepted). Catches all four pre-fix sites when run against the old code.
- `tools/mcp_tool.py`: watcher probe `inspect.isawaitable(_watch_children())` → `asyncio.iscoroutinefunction(_watch_children)`.

## How to Test

1. `pytest tests/test_hermes_state_conn_lock_audit.py -q` — the new audit; revert the `hermes_state.py` hunks to see it report all four sites.
2. `pytest tests/test_hermes_state_compression_locks.py tests/hermes_cli/test_session_handoff.py tests/run_agent/test_session_activity_persist.py tests/gateway/test_async_session_db.py tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_stdio_children_dead.py -q` — 44 passed (covers every touched method plus the fast-fail watcher race machinery).
3. Field validation of the crash itself is in #99349 (macOS arm64, Python 3.11): two `asyncio.to_thread` workers, one in `pysqlite_connection_close` tearing down the statement cache, the faulting one in `bounded_lru_cache_wrapper` → `_PyDict_GetItem_KnownHash` at `0x8`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` (chunked per directory) — remaining failures on my machine are environment-bound, not from this change: the `state_db_repair` family is refused by the disk-headroom guard (needs ≥20 GB free), a few tests reach a live endpoint (HTTP 401), and two large chunks get OOM-killed. A sampled re-run of failing tests on clean `main` (`1f99a4b2f2`) vs this branch produces **identical** outcomes, and several full-run failures pass in isolation (test cross-talk). The 44 tests covering every touched code path pass.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments at the touched sites) — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered: the race is platform-independent (any OS, any thread timing); fix uses existing portable helpers only
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

Crash signature (Apple crash report, faulting thread):

```
0 python3.11  _PyDict_GetItem_KnownHash + 32   ← KERN_INVALID_ADDRESS at 0x8
1 python3.11  bounded_lru_cache_wrapper + 292  ← pysqlite statement cache
3 python3.11  _pysqlite_query_execute + 268
4 python3.11  pysqlite_connection_execute + 104
9 python3.11  context_run + 144                ← asyncio.to_thread worker
```

while a second thread was inside `pysqlite_connection_close → lru_cache_dealloc → lru_cache_tp_clear → stmt_dealloc → take_gil`. Full report in #99349.

RuntimeWarning fixed by the second commit:

```
/tools/mcp_tool.py:6189: RuntimeWarning: coroutine 'MCPServerTask._watch_stdio_children' was never awaited
  and inspect.isawaitable(_watch_children())
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
