### PR TITLE
fix(desktop): bot roster click reconciles with the canonical registry instead of trusting a stale persisted tile (#90102)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-open-focus-identity.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-open-focus-identity.test.ts
@@ -34,6 +34,7 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
 })
 
 vi.mock('./canonical-chat', () => ({
+  CANONICAL_CHAT_TITLE: 'Bot Chat',
   ensureBotMetadata: vi.fn(async () => ({})),
   notifyBotOpenFailure: vi.fn(),
   openBotCanonicalChat,

--- a/apps/desktop/src/plugins/hermes-bots/bot-row-keeps-closed-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-keeps-closed-chat.test.ts
@@ -24,6 +24,7 @@ const { openBotCanonicalChat, prepareBotSource } = vi.hoisted(() => ({
 }))
 
 vi.mock('./canonical-chat', () => ({
+  CANONICAL_CHAT_TITLE: 'Bot Chat',
   ensureBotMetadata: vi.fn(async () => ({})),
   notifyBotOpenFailure: vi.fn(),
   openBotCanonicalChat,
@@ -76,7 +77,7 @@ describe('a row click returns to the tabs the bot already has open', () => {
     try {
       await expect(openRosterBot(bot)).resolves.toBe(true)
 
-      expect(focus).toHaveBeenCalledWith('bot:alpha')
+      expect(focus).toHaveBeenCalledWith('bot:alpha', expect.any(Function))
       expect(openBotCanonicalChat).not.toHaveBeenCalled()
       // Open tabs need no source activation either — the bot is already live.
       expect(prepareBotSource).not.toHaveBeenCalled()
@@ -124,6 +125,105 @@ describe('the canonical chat still opens when it is what was asked for', () => {
       await expect(openRosterBot(bot, { canonical: true })).resolves.toBe(true)
 
       expect(focus).not.toHaveBeenCalled()
+      expect($openBotChat.get()?.openedRegistryId).toBe('bot-chat')
+    } finally {
+      restore()
+    }
+  })
+})
+
+describe('the fronted-tab shortcut reconciles with the canonical registry (#90102)', () => {
+  // The stuck shape: a persisted "Bot Chat" tile names a session the
+  // registry no longer resolves to (superseded pointer-era row, re-minted
+  // canonical chat, stale finished session). The roster click must judge
+  // that tile against the server-resolved canonical_session and fall
+  // through to the authoritative registry open instead of fronting it.
+  const staleBot = {
+    connectionId: 'local',
+    name: 'alpha',
+    canonical_session: { id: 'bot-chat', resolved_id: 'bot-chat-tip' }
+  } as RosterRow
+
+  /** The probe openRosterBot hands the focus verb, captured. */
+  function captureProbe() {
+    let probe: ((tile: { storedSessionId: string; workspaceTabTitle?: string }) => boolean) | undefined
+
+    const focus = vi.fn((_key: string, isStaleTile?: typeof probe) => {
+      probe = isStaleTile
+
+      return null
+    })
+
+    return { focus, probe: () => probe }
+  }
+
+  it('classifies a canonical-titled tile at a foreign id as stale', async () => {
+    const { focus, probe } = captureProbe()
+    const restore = withFocusApi(focus as unknown as () => null | string)
+
+    try {
+      await openRosterBot(staleBot)
+
+      const isStale = probe()!
+      expect(isStale({ storedSessionId: 'old-finished-session', workspaceTabTitle: 'Bot Chat' })).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  it('keeps the tile that matches the registry row or its lineage tip', async () => {
+    const { focus, probe } = captureProbe()
+    const restore = withFocusApi(focus as unknown as () => null | string)
+
+    try {
+      await openRosterBot(staleBot)
+
+      const isStale = probe()!
+      expect(isStale({ storedSessionId: 'bot-chat', workspaceTabTitle: 'Bot Chat' })).toBe(false)
+      expect(isStale({ storedSessionId: 'bot-chat-tip', workspaceTabTitle: 'Bot Chat' })).toBe(false)
+    } finally {
+      restore()
+    }
+  })
+
+  it('never judges side-chat tabs — only canonical-titled tiles carry registry identity', async () => {
+    const { focus, probe } = captureProbe()
+    const restore = withFocusApi(focus as unknown as () => null | string)
+
+    try {
+      await openRosterBot(staleBot)
+
+      const isStale = probe()!
+      expect(isStale({ storedSessionId: 'scratch-thread', workspaceTabTitle: 'Group: writers' })).toBe(false)
+      expect(isStale({ storedSessionId: 'scratch-thread' })).toBe(false)
+    } finally {
+      restore()
+    }
+  })
+
+  it('an older gateway without canonical_session cannot judge — every tile survives', async () => {
+    const { focus, probe } = captureProbe()
+    const restore = withFocusApi(focus as unknown as () => null | string)
+
+    try {
+      await openRosterBot(bot) // no canonical_session on this row
+
+      const isStale = probe()!
+      expect(isStale({ storedSessionId: 'anything', workspaceTabTitle: 'Bot Chat' })).toBe(false)
+    } finally {
+      restore()
+    }
+  })
+
+  it('falls through to the authoritative canonical open when the stale tile was the only tab', async () => {
+    // The store discards the stale tile and reports null; the click must
+    // then resolve the registry — the backend-truth path — not give up.
+    const restore = withFocusApi(() => null)
+
+    try {
+      await expect(openRosterBot(staleBot)).resolves.toBe(true)
+
+      expect(openBotCanonicalChat).toHaveBeenCalled()
       expect($openBotChat.get()?.openedRegistryId).toBe('bot-chat')
     } finally {
       restore()

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -42,8 +42,10 @@ const canonicalCreations = new Map<string, CanonicalCreation>()
 export const PROFILE_SESSION_LIST_LIMIT = 200
 
 /** The one canonical title. (profile, CANONICAL_CHAT_TITLE) IS the bot's
- *  forever-chat identity — see the header above. */
-const CANONICAL_CHAT_TITLE = 'Bot Chat'
+ *  forever-chat identity — see the header above. Exported for the roster
+ *  click path's tile-staleness probe (hermes-agent#90102), which must
+ *  recognize canonical-titled tabs without restating the literal. */
+export const CANONICAL_CHAT_TITLE = 'Bot Chat'
 
 /** A `session.list` row as the registry lookup reads it. CanonicalSession
  *  models the roster's `canonical_session` field, which carries no

--- a/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
@@ -33,6 +33,7 @@ vi.mock('@hermes/plugin-sdk', async () => {
 })
 
 vi.mock('./canonical-chat', () => ({
+  CANONICAL_CHAT_TITLE: 'Bot Chat',
   notifyBotOpenFailure: (...args: unknown[]) => {
     failures.push(args)
   },

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
@@ -53,6 +53,7 @@ vi.mock('./shared', () => ({
 // The open path drags the whole group-chat surface in; the poll under test
 // touches none of it.
 vi.mock('./canonical-chat', () => ({
+  CANONICAL_CHAT_TITLE: 'Bot Chat',
   notifyBotOpenFailure: vi.fn(),
   openBotCanonicalChat: vi.fn(),
   prepareBotSource: vi.fn()

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -11,7 +11,7 @@
 import { ackStoredSessionId, atom, haptic, host, markSessionUnreadFinished } from '@hermes/plugin-sdk'
 
 import { $openBotChat, $selectedBot, rosterWatermarks, saveSelectedRosterBot } from './bot-state'
-import { notifyBotOpenFailure, openBotCanonicalChat, prepareBotSource } from './canonical-chat'
+import { CANONICAL_CHAT_TITLE, notifyBotOpenFailure, openBotCanonicalChat, prepareBotSource } from './canonical-chat'
 import { $botMeta, botActivitySession, botRosterKey, botSelectionKey, newBotChat } from './data'
 import { $groupChats, $groupChatWorkspace } from './group-chat'
 import { openGroupChat } from './group-chat-view'
@@ -112,14 +112,37 @@ export function trackInboundActivity(roster: RosterRow[]) {
  *  beside every newer thread on every bot switch, and nothing records a close
  *  (this plugin keeps no closed set; core's tile bucket only forgets), so the
  *  only honest signal is the open set itself. Feature-detected — older shells
- *  fall through to the canonical open. */
+ *  fall through to the canonical open.
+ *
+ *  The open set is a Local Storage cache, and it must reconcile with backend
+ *  truth before it wins (hermes-agent#90102): a persisted "Bot Chat" tile can
+ *  name a session the registry no longer resolves to — a superseded row from
+ *  the retired pointer design, a re-minted canonical chat, a stale finished
+ *  session. Fronting it re-pinned the roster click to that stale (often
+ *  hidden) session forever while the row's preview described the live one.
+ *  The staleness probe compares each canonical-titled tile against the
+ *  roster's server-resolved `canonical_session` (identity by NAME, resolved
+ *  fresh on every profiles.list): a mismatch means the registry moved on, so
+ *  the tile is discarded and the click falls through to the authoritative
+ *  registry open. Side-chat tabs (any other title) carry no registry identity
+ *  and are never judged; an older gateway without `canonical_session` cannot
+ *  judge either — both keep the tile, the pre-#90102 behavior. */
 function focusExistingBotTab(bot: RosterRow): null | string {
   if (typeof host.focusOpenWorkspaceSession !== 'function') {
     return null
   }
 
+  const canonical = bot?.canonical_session
+  const canonicalIds = [canonical?.id, canonical?.resolved_id].filter(Boolean).map(String)
+
+  const isStaleTile = (tile: { storedSessionId: string; workspaceTabTitle?: string }) =>
+    canonicalIds.length > 0 &&
+    typeof tile.workspaceTabTitle === 'string' &&
+    tile.workspaceTabTitle === CANONICAL_CHAT_TITLE &&
+    !canonicalIds.includes(String(tile.storedSessionId))
+
   try {
-    const focused = host.focusOpenWorkspaceSession(botWorkspaceOwnerKey(bot))
+    const focused = host.focusOpenWorkspaceSession(botWorkspaceOwnerKey(bot), isStaleTile)
 
     return typeof focused === 'string' && focused ? focused : null
   } catch {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1207,9 +1207,18 @@ export const host = {
    *  `null` when the owner has nothing open. A roster click asks this before
    *  resolving the canonical chat, so the tabs the user left (and the ones
    *  they closed) are respected. Presentation only: no gateway activation,
-   *  no session create. Feature-detect on older desktops. */
-  focusOpenWorkspaceSession: (workspaceOwnerKey: string): null | string =>
-    focusWorkspaceOwnerSessionTile(workspaceOwnerKey),
+   *  no session create. Feature-detect on older desktops.
+   *
+   *  `isStaleTile` (hermes-agent#90102): the caller's reconciliation probe
+   *  against backend truth. The tile bucket is a Local Storage cache — a
+   *  persisted bot tile can name a session the backend has since superseded,
+   *  and fronting it pinned the roster click to a stale finished session
+   *  forever. Tiles the probe rejects are discarded (never fronted), so the
+   *  caller falls through to its authoritative open path. */
+  focusOpenWorkspaceSession: (
+    workspaceOwnerKey: string,
+    isStaleTile?: (tile: { storedSessionId: string; workspaceTabTitle?: string }) => boolean
+  ): null | string => focusWorkspaceOwnerSessionTile(workspaceOwnerKey, isStaleTile),
 
   /** Reactive on-screen visibility of a contributed pane: true while it is in
    *  the layout tree, not dismissed/hidden, its zone un-minimized, AND holding

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -395,6 +395,58 @@ describe('focusWorkspaceOwnerSessionTile', () => {
     expect(focusWorkspaceOwnerSessionTile('bot:a')).toBeNull()
     expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['other-bot-chat'])
   })
+
+  describe('staleness probe (#90102): the tile bucket reconciles with backend truth before it wins', () => {
+    it('discards a stale tile and reports null so the caller runs its authoritative open', () => {
+      openSessionTile('stale-bot-chat', 'center', 'workspace', undefined, botA)
+
+      expect(focusWorkspaceOwnerSessionTile('bot:a', tile => tile.storedSessionId === 'stale-bot-chat')).toBeNull()
+      // Discard, not close: resurrecting the tile would just front the stale
+      // session again on the next click.
+      expect($sessionTiles.get()).toEqual([])
+    })
+
+    it('fronts the surviving fresh tile after discarding the stale one', () => {
+      openSessionTile('stale-bot-chat', 'center', 'workspace', undefined, botA)
+      openSessionTile('live-thread', 'center', 'workspace', undefined, botA)
+      $layoutTree.set(
+        group(['workspace', tilePane('stale-bot-chat'), tilePane('live-thread')], { active: 'workspace', id: 'main' })
+      )
+      // The stale tile is even the remembered one — the exact stuck shape.
+      rememberActivePane(workspaceScopeKey('bots', 'bot:a'), tilePane('stale-bot-chat'))
+
+      expect(focusWorkspaceOwnerSessionTile('bot:a', tile => tile.storedSessionId === 'stale-bot-chat')).toBe(
+        'live-thread'
+      )
+      expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['live-thread'])
+    })
+
+    it("only judges the probed owner's tiles — other owners keep theirs", () => {
+      openSessionTile('other-bot-chat', 'center', 'workspace', undefined, botB)
+      openSessionTile('stale-bot-chat', 'center', 'workspace', undefined, botA)
+
+      expect(focusWorkspaceOwnerSessionTile('bot:a', () => true)).toBeNull()
+      expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['other-bot-chat'])
+    })
+
+    it('a throwing probe keeps the tile — reconciliation must not break the click', () => {
+      openSessionTile('bot-chat', 'center', 'workspace', undefined, botA)
+
+      expect(
+        focusWorkspaceOwnerSessionTile('bot:a', () => {
+          throw new Error('probe blew up')
+        })
+      ).toBe('bot-chat')
+      expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['bot-chat'])
+    })
+
+    it('no probe keeps the old behavior byte for byte', () => {
+      openSessionTile('bot-chat', 'center', 'workspace', undefined, botA)
+
+      expect(focusWorkspaceOwnerSessionTile('bot:a')).toBe('bot-chat')
+      expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['bot-chat'])
+    })
+  })
 })
 
 describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1500,11 +1500,44 @@ export function focusOpenSession(
  *  with open tabs comes back to the one the user left, instead of re-opening
  *  its canonical Bot Chat beside them: nothing records a tab close except the
  *  tile bucket forgetting it, so any open path that ignores the open set
- *  resurrects closed chats on every bot switch. */
-export function focusWorkspaceOwnerSessionTile(workspaceOwnerKey: string): null | string {
-  const owned = $sessionTiles
+ *  resurrects closed chats on every bot switch.
+ *
+ *  `isStaleTile`: the caller's reconciliation probe against backend truth
+ *  (hermes-agent#90102). The tile bucket is a Local Storage cache, and a
+ *  persisted bot tile can outlive the session it names — a superseded
+ *  "Bot Chat" from the retired pointer design, a re-minted canonical row, a
+ *  finished session that stopped being the bot's chat. Fronting such a tile
+ *  made the row's click target a stale (often hidden) session forever while
+ *  the preview described the live one. A tile the probe rejects is DISCARDED
+ *  (resurrecting it would just front the stale session again — same
+ *  no-undo rationale as discardSessionTile) and never fronted, so the caller
+ *  falls through to its authoritative open. No probe = the old behavior. */
+export function focusWorkspaceOwnerSessionTile(
+  workspaceOwnerKey: string,
+  isStaleTile?: (tile: SessionTile) => boolean
+): null | string {
+  const allOwned = $sessionTiles
     .get()
     .filter(tile => tile.workspaceMode === 'bots' && tile.workspaceOwnerKey === workspaceOwnerKey)
+
+  let owned = allOwned
+
+  if (typeof isStaleTile === 'function') {
+    const stale = allOwned.filter(tile => {
+      try {
+        return isStaleTile(tile)
+      } catch {
+        // A throwing probe must not break the click path — keep the tile.
+        return false
+      }
+    })
+
+    for (const tile of stale) {
+      discardSessionTile(tile.storedSessionId)
+    }
+
+    owned = allOwned.filter(tile => !stale.includes(tile))
+  }
 
   if (owned.length === 0) {
     return null


### PR DESCRIPTION
## Summary

Clicking a bot in the BOTS roster no longer opens a stale finished session. The roster click consulted the persisted session-tile bucket (Electron Local Storage `sessionTiles.v2`) BEFORE the authoritative canonical-chat name-registry — and trusted it unconditionally. A persisted 'Bot Chat' tile naming a session the backend no longer resolves to was fronted on every click and re-remembered as the zone's active pane, so the click target stuck forever while the row's preview/age described the live session. A Local Storage wipe only healed until the next click re-persisted it.

Fixes #90102 (and the #91749 duplicate's repro).

## Changes

- `apps/desktop/src/store/session-states.ts`: `focusWorkspaceOwnerSessionTile` accepts an optional `isStaleTile` probe — rejected tiles are DISCARDED (`discardSessionTile` semantics) and never fronted.
- `apps/desktop/src/plugins/hermes-bots/roster-actions.ts`: the roster click supplies the probe — a canonical-titled tile whose stored session id matches neither `canonical_session.id` nor `.resolved_id` is stale, so the click falls through to the authoritative name-registry open.
- Fail-safe scoping: side-chat tabs are never judged; older gateways without `canonical_session` and shells without the probe keep byte-identical prior behavior; a throwing probe keeps the tile.

Per the Desktop guide: backend is authoritative, the renderer copy is a cache that must reconcile — this makes the roster click reconcile instead of trust.

## Validation

A/B on origin/main: with src stashed to main the 8 new regression tests fail (stale tile fronted, click pinned); with the fix all pass. 13 new tests total across the two suites. Full blast radius: 174 files / 1992 tests pass (hermes-bots + store + sdk); typecheck (3 tsconfigs), eslint, prettier clean.

Adjacent-but-distinct (not touched): #97527 (tab identity across backend restarts), #96159 (colliding tile ids).

## Infographic

![Trust the backend — stale tile discarded, canonical wins](https://v3b.fal.media/files/b/0aa88df1/QADqBmgj3gjcWCGg3yI-T_TIJNANuN.png)
