### PR TITLE
fix(desktop): deliver kanban review-lifecycle events to TUI/desktop sessions (#99436)

### DIFF
--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -264,6 +264,61 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_review_requested_surfaces_handoff(self):
+        ev = SimpleNamespace(
+            kind="review_requested",
+            payload={"summary": "implemented parser\ndetails"},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "main")
+        assert text is not None
+        assert "t_abc123" in text
+        assert "ready for review" in text
+        assert "implemented parser" in text
+        assert "details" not in text  # only the first handoff line
+
+    def test_changes_requested_includes_reason_and_provenance(self):
+        ev = SimpleNamespace(
+            kind="changes_requested",
+            payload={
+                "reason": "tests missing",
+                "reviewer": "rev",
+                "implementer": "impl",
+            },
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "main")
+        assert text is not None
+        assert "t_abc123" in text
+        assert "changes/BLOCK" in text
+        assert "tests missing" in text
+        assert "@rev" in text
+        assert "@impl" in text
+
+    def test_changes_requested_defaults_reason_when_absent(self):
+        ev = SimpleNamespace(kind="changes_requested", payload={})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert text is not None
+        assert "reviewer feedback requires changes" in text
+
+    def test_block_loop_detected_routes_to_triage(self):
+        ev = SimpleNamespace(
+            kind="block_loop_detected",
+            payload={"reason": "same failure", "recurrences": 3},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "main")
+        assert text is not None
+        assert "TRIAGE" in text
+        assert "same failure" in text
+        assert "3x" in text
+
+    def test_notify_kinds_mirror_gateway_review_lifecycle(self):
+        """The TUI poller must claim the same review-lifecycle kinds the gateway
+        notifier does, or TUI/Desktop sessions never see review parks (#99436).
+        """
+        from tui_gateway.server import _KANBAN_NOTIFY_KINDS
+
+        for kind in ("review_requested", "changes_requested", "block_loop_detected"):
+            assert kind in _KANBAN_NOTIFY_KINDS
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -111,7 +111,8 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 
 # Mirror gateway/kanban_watchers.py TERMINAL_KINDS: claim silent kinds (archived/unblocked) too so the cursor advances
 # past them and they can't wedge a later completed/blocked event behind an unclaimed row.
-_KANBAN_NOTIFY_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+_KANBAN_NOTIFY_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked",
+                        "block_loop_detected", "review_requested", "changes_requested")
 _KANBAN_POLL_SECONDS = _LOOP_POLL_SECONDS = 5.0  # /loop and /heartbeat share one idle-poll cadence
 
 
@@ -255,7 +256,40 @@ def _kb_timed_out(task, payload: dict, title: str) -> str:
     return " timed out (max_runtime=0s); will retry"
 
 
+def _kb_safe_review_reason(value: Any, limit: int = 160) -> str:
+    """Clip/redact reviewer-supplied text, reusing the gateway notifier's helper for parity; fall back to a plain
+    whitespace-collapsed clip if that import is unavailable (keeps the poller import-safe)."""
+    try:
+        from gateway.kanban_watchers_notifier import _safe_review_reason
+    except Exception:
+        return " ".join(("" if value is None else str(value)).split())[:limit]
+    return _safe_review_reason(value, limit)
+
+
+def _kb_review_requested(task, payload: dict, title: str) -> str:
+    handoff = _kb_first_line(payload["summary"], 200) if payload.get("summary") else ""
+    return f" ready for review — {title}{handoff}"
+
+
+def _kb_changes_requested(task, payload: dict, title: str) -> str:
+    reason = _kb_safe_review_reason(payload.get("reason")) or "reviewer feedback requires changes"
+    reviewer = _kb_safe_review_reason(payload.get("reviewer"), 48)
+    implementer = _kb_safe_review_reason(payload.get("implementer"), 48)
+    provenance = f" — reviewer @{reviewer}" if reviewer else ""
+    if implementer:
+        provenance += f" → implementer @{implementer}"
+    return f" review requested changes/BLOCK: {reason}{provenance}"
+
+
+def _kb_block_loop_detected(task, payload: dict, title: str) -> str:
+    rc = f" (blocked {payload['recurrences']}x for the same cause)" if payload.get("recurrences") else ""
+    reason = f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+    return f" routed to TRIAGE — needs a human decision{rc}{reason}"
+
+
 # kind -> (glyph, suffix after "Kanban <id>"); silent kinds (archived/unblocked) are absent → None.
+# The review-lifecycle kinds mirror gateway/kanban_watchers_notifier.py so TUI/Desktop sessions (served only by this
+# poller, no "tui" messaging adapter — #59890) see review parks the gateway already surfaces elsewhere (#99436).
 _KANBAN_EVENT_FORMATTERS = {
     "completed": ("✔", _kb_completed),
     "blocked": ("⏸", lambda t, p, title: " blocked" + (f": {str(p.get('reason'))[:160]}" if p.get("reason") else "")),
@@ -264,6 +298,9 @@ _KANBAN_EVENT_FORMATTERS = {
     "crashed": ("✖", lambda t, p, title: " worker crashed (pid gone); dispatcher will retry"),
     "timed_out": ("⏱", _kb_timed_out),
     "status": ("🔄", lambda t, p, title: f" → {p.get('status') or ''}"),
+    "review_requested": ("👀", _kb_review_requested),
+    "changes_requested": ("🛑", _kb_changes_requested),
+    "block_loop_detected": ("🛑", _kb_block_loop_detected),
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #99436. The TUI/desktop kanban notification poller silently dropped **review-lifecycle** events, so Desktop/TUI sessions got no ping when a card parked into review — while gateway platforms (Telegram, etc.) did.

`tui_gateway/server.py`'s `_KANBAN_NOTIFY_KINDS` omitted `review_requested`, `changes_requested`, and `block_loop_detected`, even though the set's own comment says it mirrors `gateway/kanban_watchers.py`'s `TERMINAL_KINDS` — which includes all three (added deliberately: *"review_requested wakes the origin subscriber like a block does"*). TUI-platform subscriptions are served **exclusively** by this poller (there is no TUI messaging adapter, #59890), so those events were structurally undeliverable to Desktop sessions — the exact sessions that dispatch review flows.

## Changes Made

- `tui_gateway/server.py`
  - add `review_requested`, `changes_requested`, `block_loop_detected` to `_KANBAN_NOTIFY_KINDS` (parity with the gateway `TERMINAL_KINDS`).
  - add a formatter branch for each in `_format_kanban_event_text`, mirroring the gateway notifier's wording (`👀 … ready for review`, `🛑 … review requested changes/BLOCK`, `🛑 … routed to TRIAGE`). `changes_requested` reuses the gateway's `_safe_review_reason` for redaction parity, with an inline fallback if the import is unavailable.
- `tests/tui_gateway/test_kanban_notify_poller.py`
  - cover the three new kinds (handoff surfacing, reason+provenance, default reason, triage recurrence) and a parity assertion that `_KANBAN_NOTIFY_KINDS` carries the review-lifecycle kinds.

The included `block_loop_detected` addresses the issue's whole-class note ("`block_loop_detected` is also gateway-only; consider it in the same pass").

## How to Test

```
scripts/run_tests.sh tests/tui_gateway/test_kanban_notify_poller.py
```

All pass (19 tests).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #99436