### PR TITLE
test(desktop): widen waitFor deadline to absorb saturated-runner starvation in the UI shard

### DIFF
--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -37,4 +37,10 @@ if (typeof (globalThis as any).localStorage === 'undefined') {
 // panels (radix menus, refetch chains) when the full suite runs under xdist
 // CPU contention in CI. Success still resolves the instant the node appears;
 // the wider deadline only absorbs a starved runner, killing timing flakes.
-configure({ asyncUtilTimeout: 5000 })
+// 5s proved insufficient on saturated runners (2026-08-31: gateway-settings,
+// messaging, session-unread-tile, toolset-config-panel each tripped a
+// waitFor(mock-called) deadline on runs whose only common factor was load —
+// including a plugins-only commit on main). 12s mirrors the same reasoning
+// as the 15s testTimeout above it while still finishing below it, so a
+// genuinely hung await still surfaces as this assertion, not a test timeout.
+configure({ asyncUtilTimeout: 12_000 })


### PR DESCRIPTION
## Summary

Kills today's recurring UI-shard flake: `AssertionError: expected "vi.fn()" to be called at least once` from `waitFor(...)` deadlines in `gateway-settings`, `messaging`, `session-unread-tile`, and `toolset-config-panel`. It hit three unrelated runs today — including a plugins-only commit on main (run 33388877089) that cannot touch desktop UI — so the only common factor is runner load.

## Change

One line: `asyncUtilTimeout` 5s → 12s in `apps/desktop/vitest.setup.ts`, with the incident documented in the comment. Same reasoning as the existing 15s `testTimeout`: success still resolves the instant the assertion holds; the wider deadline only absorbs a starved runner, and staying under 15s keeps genuine hangs surfacing as the assertion failure rather than a test timeout.

## Validation

The four flaking files: 40/40 pass locally. Flake was never reproducible locally (5x loop green) — consistent with CPU starvation, not logic.