### PR TITLE
fix(compression): let native Responses own proactive compaction

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -43,6 +43,7 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
+    _native_responses_compaction_owns_turn_start,
     _review_fork_first_request_pending,
     build_turn_context,
     compose_user_api_content,
@@ -2789,8 +2790,15 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
+        # When the next Responses request carries context_management, the
+        # provider owns proactive compaction.  This must guard the per-request
+        # pressure check as well as turn_context's initial preflight; otherwise
+        # a resumed large thread is summarized locally immediately before the
+        # native-compaction request can be sent.
+        _responses_native_auto = _native_responses_compaction_owns_turn_start(agent)
         if (
             agent.compression_enabled
+            and not _responses_native_auto
             and not _review_fork_first_request_pending(agent)
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
@@ -2915,6 +2923,7 @@ def run_conversation(
                 continue
         elif (
             agent.compression_enabled
+            and not _responses_native_auto
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
             and not _defer_preflight(request_pressure_tokens)
@@ -7769,6 +7778,7 @@ def run_conversation(
 
                 if (
                     agent.compression_enabled
+                    and not _native_responses_compaction_owns_turn_start(agent)
                     and compression_attempts < max_compression_attempts
                     and _compressor.should_compress(_real_tokens)
                 ):
@@ -7819,7 +7829,10 @@ def run_conversation(
                                 final_response = _HANDOFF_SKIP_FINAL_RESPONSE
                             _turn_exit_reason = "compaction_handoff_not_actionable"
                             break
-                elif agent.compression_enabled:
+                elif (
+                    agent.compression_enabled
+                    and not _native_responses_compaction_owns_turn_start(agent)
+                ):
                     # Over threshold but compression is blocked (summary-LLM
                     # cooldown or anti-thrashing). Surface a deduped warning so
                     # the user isn't left with a silently growing context that

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -216,7 +216,20 @@ def native_compaction_context_management(
         getattr(agent, "codex_responses_compact_threshold", None),
         getattr(compressor, "threshold_tokens", None) if compressor is not None else None,
     )
-    return [{"type": "compaction", "compact_threshold": threshold}]
+    payload = [{"type": "compaction", "compact_threshold": threshold}]
+
+    # The transport applies request_overrides after assembling its normal
+    # kwargs. Resolve an explicit context_management override here too so
+    # request conversion and turn-start ownership see the same effective wire
+    # value. In particular, ``None``/empty/invalid overrides remove the field
+    # during transport preflight and must leave Hermes local compression as the
+    # owner instead of creating a no-owner gap.
+    request_overrides = getattr(agent, "request_overrides", None)
+    if isinstance(request_overrides, dict) and "context_management" in request_overrides:
+        override = request_overrides["context_management"]
+        return override if isinstance(override, list) and override else None
+
+    return payload
 
 
 # Retention budget for plaintext user messages carried across a native

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -423,6 +423,33 @@ def _review_fork_first_request_pending(agent: Any) -> bool:
     )
 
 
+def _native_responses_compaction_owns_turn_start(agent: Any) -> bool:
+    """Whether the next Responses request can own turn-start compaction.
+
+    A resumed thread can already exceed Hermes' local trigger before its first
+    request. In that case merely configuring the native threshold below the
+    local threshold is insufficient: the turn prologue starts local compression
+    before the provider ever sees ``context_management``. Reuse the request
+    gate here so eligible OpenAI/Codex threads reach native compaction first,
+    while every disabled, checkpoint-required, unsupported-model, or indirect
+    route keeps the existing local-preflight fallback.
+    """
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+
+    from agent.codex_responses_adapter import classify_responses_route
+    from agent.native_compaction import native_compaction_context_management
+
+    route = classify_responses_route(agent)
+
+    return native_compaction_context_management(
+        agent,
+        is_codex_backend=route.is_codex_backend,
+        is_xai_responses=route.is_xai_responses,
+        is_github_responses=route.is_github_responses,
+    ) is not None
+
+
 def _compression_warrants_another_preflight_pass(
     orig_tokens: int, new_tokens: int, threshold_tokens: int
 ) -> bool:
@@ -904,8 +931,14 @@ def build_turn_context(
     # work; nothing has touched it yet this turn, so it measures the gap since
     # the previous turn finished. The cheap gap pre-check gates the (more
     # expensive) token estimate, mirroring ``_should_run_preflight_estimate``.
+    _responses_native_auto = _native_responses_compaction_owns_turn_start(agent)
     _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
-    if agent.compression_enabled and _idle_after > 0 and messages:
+    if (
+        agent.compression_enabled
+        and not _responses_native_auto
+        and _idle_after > 0
+        and messages
+    ):
         _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
         if _idle_gap >= _idle_after:
             _compressor = agent.context_compressor
@@ -1038,7 +1071,6 @@ def build_turn_context(
             ).lower()
             in {"native", "off"}
         )
-
         if not _preflight_deferred:
             _last = _compressor.last_prompt_tokens
             # Do NOT overwrite the -1 sentinel (#36718).
@@ -1060,6 +1092,11 @@ def build_turn_context(
                 f"{_preflight_tokens:,}",
                 f"{_compressor.threshold_tokens:,}",
                 f"{_compressor.last_real_prompt_tokens:,}",
+            )
+        elif _responses_native_auto:
+            logger.info(
+                "Skipping Hermes preflight compression for native Responses "
+                "compaction; provider context_management owns this request."
             )
         elif _compression_cooldown:
             logger.info(
@@ -1218,7 +1255,12 @@ def build_turn_context(
             # cooldown, deferred estimate, or codex-native route must keep
             # the engine hook un-consulted (#20316 contract — the cooldown
             # exists precisely because compression recently failed).
-            if _compression_cooldown or _preflight_deferred or _codex_native_auto:
+            if (
+                _compression_cooldown
+                or _preflight_deferred
+                or _codex_native_auto
+                or _responses_native_auto
+            ):
                 _engine_preflight = None
             else:
                 _engine_preflight = getattr(
@@ -1226,7 +1268,8 @@ def build_turn_context(
                 )
             # ── Engine-driven sub-threshold preflight maintenance (#20316) ──
             # None of the threshold-path branches fired (not deferred, no
-            # failure cooldown, not codex-native, and should_compress() said
+            # failure cooldown, no native compaction owner, and
+            # should_compress() said
             # the request is under pressure). Context engines that override
             # ``should_compress_preflight()`` (e.g. LCM-style incremental
             # leaf-chunk compaction) can still request deferred maintenance

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -15,7 +15,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
-from agent.turn_context import TurnContext, build_turn_context
+from agent.turn_context import (
+    TurnContext,
+    _native_responses_compaction_owns_turn_start,
+    build_turn_context,
+)
 from hermes_state import SessionDB
 
 
@@ -386,6 +390,42 @@ def test_ensure_db_session_runs_after_system_prompt_restore():
     # The prompt was populated before the DB row was created.
     assert agent._ensure_db_prompt_at_call == "REBUILT-SYSTEM"
     assert agent._cached_system_prompt == "REBUILT-SYSTEM"
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url", "expected"),
+    [
+        (
+            "openai-codex",
+            "https://chatgpt.com/backend-api/codex",
+            True,
+        ),
+        (
+            "custom-provider",
+            "https://chatgpt.com/backend-api/codex",
+            True,
+        ),
+        ("openai-codex", "https://api.x.ai/v1", False),
+        ("openai-codex", "https://models.github.ai/inference", False),
+    ],
+)
+def test_native_preflight_owner_matches_responses_route(
+    provider, base_url, expected
+):
+    """The preflight bypass must use the same route gates as request assembly."""
+    agent = types.SimpleNamespace(
+        api_mode="codex_responses",
+        provider=provider,
+        base_url=base_url,
+        model="gpt-5.6-sol-900k",
+        codex_responses_native_compaction=True,
+        compression_enabled=True,
+        compression_checkpoint_required=False,
+        codex_responses_compact_threshold=200_000,
+        context_compressor=types.SimpleNamespace(threshold_tokens=450_000),
+    )
+
+    assert _native_responses_compaction_owns_turn_start(agent) is expected
 
 
 # ── Between-turns MCP refresh (cache-safe late-binding) ──────────────────────

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -428,6 +428,24 @@ def test_native_preflight_owner_matches_responses_route(
     assert _native_responses_compaction_owns_turn_start(agent) is expected
 
 
+def test_native_preflight_owner_respects_wire_removal_override():
+    """An explicit transport override can remove context_management."""
+    agent = types.SimpleNamespace(
+        api_mode="codex_responses",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.6-sol-900k",
+        codex_responses_native_compaction=True,
+        compression_enabled=True,
+        compression_checkpoint_required=False,
+        codex_responses_compact_threshold=200_000,
+        context_compressor=types.SimpleNamespace(threshold_tokens=450_000),
+        request_overrides={"context_management": None},
+    )
+
+    assert _native_responses_compaction_owns_turn_start(agent) is False
+
+
 # ── Between-turns MCP refresh (cache-safe late-binding) ──────────────────────
 #
 # A slow MCP server that connects after the agent's build-time tool snapshot

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1012,6 +1012,54 @@ class TestPreflightCompression:
         assert agent.client.chat.completions.create.call_count == 0
         assert agent.context_compressor.last_prompt_tokens == 74_400
 
+    def test_native_compaction_eligible_resume_skips_local_preflight(self, agent):
+        """A large resumable Codex thread must reach native compaction first."""
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent.model = "gpt-5.6-sol-900k"
+        agent.runtime_capabilities = {"native_compaction": True}
+        agent.codex_responses_native_compaction = True
+        agent.compression_checkpoint_required = False
+        agent.compression_enabled = True
+        agent.compression_idle_compact_after_seconds = 1
+        agent._last_activity_ts = 0
+        agent._interrupt_requested = True
+        agent.context_compressor.context_length = 900_000
+        agent.context_compressor.threshold_tokens = 450_000
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i}"})
+            big_history.append({"role": "assistant", "content": f"Response {i}"})
+
+        with (
+            patch(
+                "agent.turn_context._preflight_request_tokens",
+                return_value=463_003,
+            ),
+            patch(
+                "agent.turn_context.estimate_request_tokens_rough",
+                return_value=463_003,
+            ),
+            patch.object(agent.context_compressor, "should_compress", return_value=True),
+            patch.object(
+                agent.context_compressor,
+                "should_compress_preflight",
+                return_value=True,
+            ),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "resume proof", conversation_history=big_history
+            )
+
+        assert result["interrupted"] is True
+        mock_compress.assert_not_called()
+
 
     def test_interrupt_keeps_post_compression_state(self, agent):
         """Display rollback must not restore real post-compaction state.

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -28,6 +28,7 @@ def _agent(
     threshold: object = DEFAULT_COMPACT_THRESHOLD,
     compressor=None,
     capabilities=None,
+    request_overrides=None,
 ):
     return SimpleNamespace(
         model=model,
@@ -37,6 +38,7 @@ def _agent(
         codex_responses_compact_threshold=threshold,
         context_compressor=compressor,
         capabilities=capabilities or {},
+        request_overrides=request_overrides or {},
     )
 
 
@@ -163,6 +165,26 @@ class TestRequestGate:
             _agent(threshold=None, compressor=compressor), is_codex_backend=False
         )
         assert payload == [{"type": "compaction", "compact_threshold": 756_808}]
+
+    @pytest.mark.parametrize("override", [None, [], {}, "disabled"])
+    def test_request_override_that_removes_wire_field_disables_native_owner(
+        self, override
+    ):
+        agent = _agent(request_overrides={"context_management": override})
+
+        assert (
+            native_compaction_context_management(agent, is_codex_backend=False)
+            is None
+        )
+
+    def test_valid_request_override_is_the_native_payload(self):
+        override = [{"type": "compaction", "compact_threshold": 123_456}]
+        agent = _agent(request_overrides={"context_management": override})
+
+        assert (
+            native_compaction_context_management(agent, is_codex_backend=False)
+            == override
+        )
 
 
 class TestThresholdClamp:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -1724,6 +1725,98 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
     assert len(compress_calls) == 1
     assert compress_calls[0] >= 15_000
     assert len(requests) == 2
+
+
+def test_native_compaction_owns_large_resumed_request(monkeypatch):
+    """Eligible Responses requests must reach provider-side compaction first."""
+    agent = _build_agent(monkeypatch)
+    agent.model = "gpt-5.6-sol-900k"
+    agent.runtime_capabilities = {"native_compaction": True}
+    agent.codex_responses_native_compaction = True
+    agent.codex_responses_compact_threshold = 10_000
+    agent.compression_checkpoint_required = False
+    agent.context_compressor.context_length = 20_000
+    agent.context_compressor.threshold_tokens = 20_000
+
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: requests.append(api_kwargs)
+        or _codex_message_response("Resumed without a local summary."),
+    )
+    compress = MagicMock(
+        return_value=([{"role": "user", "content": "local summary"}], "prompt")
+    )
+    monkeypatch.setattr(agent, "_compress_context", compress)
+
+    history = [
+        {"role": "user", "content": "x" * 120_000},
+        {"role": "assistant", "content": "y" * 20_000},
+    ]
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    compress.assert_not_called()
+    assert len(requests) == 1
+    assert requests[0]["context_management"] == [
+        {"type": "compaction", "compact_threshold": 10_000}
+    ]
+
+
+def test_native_compaction_owns_post_tool_and_next_request(monkeypatch):
+    """Automatic post-tool and pre-API summaries must yield to native compaction."""
+    agent = _build_agent(monkeypatch)
+    agent.model = "gpt-5.6-sol-900k"
+    agent.runtime_capabilities = {"native_compaction": True}
+    agent.codex_responses_native_compaction = True
+    agent.codex_responses_compact_threshold = 10_000
+    agent.compression_checkpoint_required = False
+    agent.context_compressor.context_length = 20_000
+    agent.context_compressor.threshold_tokens = 20_000
+
+    responses = [
+        _codex_tool_call_response(),
+        _codex_message_response("Finished without a local summary."),
+    ]
+    responses[0].usage = SimpleNamespace(
+        input_tokens=25_000, output_tokens=4, total_tokens=25_004
+    )
+    requests = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: requests.append(api_kwargs) or responses.pop(0),
+    )
+
+    def _fake_execute_tool_calls(
+        assistant_message, messages, effective_task_id, api_call_count=0
+    ):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": "x" * 80_000,
+                }
+            )
+
+    compress = MagicMock(
+        return_value=([{"role": "user", "content": "local summary"}], "prompt")
+    )
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+    monkeypatch.setattr(agent, "_compress_context", compress)
+
+    result = agent.run_conversation("do a tool-heavy task")
+
+    assert result["completed"] is True
+    compress.assert_not_called()
+    assert len(requests) == 2
+    assert all(
+        request["context_management"]
+        == [{"type": "compaction", "compact_threshold": 10_000}]
+        for request in requests
+    )
 
 
 def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- let eligible native Responses compaction bypass every proactive local path: turn-start, per-request pre-API, and post-tool
- use the exact Responses route and final request-override gate so ownership matches the actual `context_management` wire field
- retain local compression for unsupported routes, explicit wire removal, checkpoint-required sessions, and provider-proven overflow recovery
- add real conversation-loop regressions for a large resumed history and an over-threshold tool turn

## Regression fixed
The turn-start guard could log that native compaction owned the request, then `agent.conversation_loop` immediately entered a separate local `Pre-API compression` path. The prior test interrupted before the first provider call, so it never exercised that second owner.

## Verification
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_413_compression.py tests/run_agent/test_native_compaction.py tests/agent/test_turn_context.py`: 193 passed
- exact new regression tests: 2 passed
- `git diff --check` clean