### PR TITLE
fix(copilot): per-model api_mode routing wins over persisted model.api_mode for multi-endpoint routing

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -406,8 +406,6 @@ def _copilot_runtime_api_mode(
 ) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
-        return configured_mode
 
     # Use the model being resolved for this runtime, not the persisted global
     # default. MoA slots, fallback models, and mid-session model switches all
@@ -417,14 +415,31 @@ def _copilot_runtime_api_mode(
     # fail with "model ... does not support Responses API".
     model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
+        # No model to route on: fall back to a persisted explicit api_mode if
+        # the user set one, else the endpoint default.
+        if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+            return configured_mode
         return "chat_completions"
 
+    # Copilot is a multi-endpoint provider: GPT-5+ models require the
+    # Responses API (/responses), Claude requires /v1/messages, everything
+    # else /chat/completions. A persisted api_mode was correct only for the
+    # model that was selected when it was written; honouring it for a
+    # different model sends Responses-only models to /chat/completions and
+    # fails with a misleading HTTP 400 that reads like an entitlement
+    # problem (#94881). Per-model routing always wins here; the persisted
+    # mode is only consulted when the model itself cannot be resolved.
     try:
         from hermes_cli.models import copilot_model_api_mode
 
-        return copilot_model_api_mode(model_name, api_key=api_key)
+        resolved = copilot_model_api_mode(model_name, api_key=api_key)
+        if resolved:
+            return resolved
     except Exception:
-        return "chat_completions"
+        pass
+    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+        return configured_mode
+    return "chat_completions"
 
 
 _VALID_API_MODES = {

--- a/tests/hermes_cli/test_copilot_api_mode_routing.py
+++ b/tests/hermes_cli/test_copilot_api_mode_routing.py
@@ -1,0 +1,67 @@
+"""Regression tests for #94881: Copilot per-model api_mode routing must win
+over a persisted model.api_mode.
+
+Copilot is a multi-endpoint provider (GPT-5+ -> /responses, Claude ->
+/v1/messages, rest -> /chat/completions). A persisted api_mode was only
+correct for the model selected when it was written; honouring it for a
+different model sends Responses-only models to /chat/completions with a
+misleading HTTP 400.
+"""
+
+from unittest.mock import patch
+
+
+def _cfg(api_mode="chat_completions", default="gpt-5.4"):
+    return {"provider": "copilot", "api_mode": api_mode, "default": default}
+
+
+class TestCopilotPerModelRoutingWins:
+    def test_persisted_chat_completions_ignored_for_responses_model(self):
+        """A persisted chat_completions must NOT pin a Responses-only model."""
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        with patch("hermes_cli.models.copilot_model_api_mode",
+                   return_value="codex_responses"):
+            mode = _copilot_runtime_api_mode(_cfg(), "key", target_model="gpt-5.6-sol")
+        assert mode == "codex_responses"
+
+    def test_persisted_mode_ignored_for_claude(self):
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        with patch("hermes_cli.models.copilot_model_api_mode",
+                   return_value="anthropic_messages"):
+            mode = _copilot_runtime_api_mode(_cfg(), "key", target_model="claude-sonnet-4")
+        assert mode == "anthropic_messages"
+
+    def test_falls_back_to_persisted_when_catalog_lookup_fails(self):
+        """Model unresolvable -> persisted explicit mode still honoured."""
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        with patch("hermes_cli.models.copilot_model_api_mode",
+                   side_effect=RuntimeError("catalog unreachable")):
+            mode = _copilot_runtime_api_mode(_cfg(), "key", target_model="mystery-model")
+        assert mode == "chat_completions"
+
+    def test_no_model_at_all_uses_persisted(self):
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        cfg = {"provider": "copilot", "api_mode": "codex_responses", "default": ""}
+        with patch("hermes_cli.models.copilot_model_api_mode") as m:
+            mode = _copilot_runtime_api_mode(cfg, "key", target_model=None)
+        m.assert_not_called()
+        assert mode == "codex_responses"
+
+    def test_no_model_no_persisted_defaults_to_chat(self):
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        cfg = {"provider": "copilot", "default": ""}
+        mode = _copilot_runtime_api_mode(cfg, "key", target_model=None)
+        assert mode == "chat_completions"
+
+    def test_empty_resolution_falls_through_to_persisted(self):
+        """copilot_model_api_mode returning '' falls back to persisted mode."""
+        from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+        with patch("hermes_cli.models.copilot_model_api_mode", return_value=""):
+            mode = _copilot_runtime_api_mode(_cfg(), "key", target_model="gpt-5.6-sol")
+        assert mode == "chat_completions"

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
Copilot routes per model (GPT-5+ -> /responses, Claude -> /v1/messages, rest -> /chat/completions), so a single persisted api_mode is wrong by construction. When the setup flow wrote chat_completions and the user later switched to a Responses-only model, every call failed with a misleading HTTP 400 that looked like an entitlement problem (6 of 23 catalog models unreachable).

Reorder _copilot_runtime_api_mode: per-model routing (copilot_model_api_mode) always wins when a target model is resolvable. The persisted mode is only consulted when the catalog lookup fails or no model is available. 6 regression tests.

Fixes #94881