### PR TITLE
fix(update): preserve transaction state across module purge

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -82,6 +82,7 @@ _STALE_PURGE_PROTECTED = frozenset(
         "hermes_cli",
         "hermes_cli.main",
         "hermes_cli.update_cmd",
+        "hermes_cli.update_receipt",
         "hermes_cli.hermes_logging",
     }
 )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -82,6 +82,7 @@ _STALE_PURGE_PROTECTED = frozenset(
         "hermes_cli",
         "hermes_cli.main",
         "hermes_cli.update_cmd",
+        "hermes_cli.update_inventory",
         "hermes_cli.update_receipt",
         "hermes_cli.hermes_logging",
     }

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -16,6 +16,7 @@ module graph from the updated checkout.
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 
@@ -23,6 +24,7 @@ import pytest
 
 from hermes_cli import main as cli_main
 from hermes_cli import update_cmd
+from hermes_cli import update_receipt
 
 
 @pytest.fixture(autouse=True)
@@ -80,6 +82,22 @@ def test_purge_protects_executing_modules():
     assert sys.modules.get("hermes_cli.update_cmd") is update_cmd
     assert sys.modules.get("hermes_cli.main") is cli_main
     assert "hermes_cli" in sys.modules
+
+
+def test_purge_preserves_active_update_receipt(tmp_path, monkeypatch):
+    """The in-flight receipt must survive the post-pull module purge."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    update_receipt._current = None
+    update_receipt.begin_update_receipt()
+    update_receipt.record_step("pre_pull", True)
+
+    cli_main._purge_stale_hermes_modules()
+
+    reimported = importlib.import_module("hermes_cli.update_receipt")
+    assert reimported is update_receipt
+    path = reimported.finalize_update_receipt("success")
+    assert path is not None
+    assert path.is_file()
 
 
 def test_purge_leaves_prefix_lookalikes_alone():

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -24,6 +24,7 @@ import pytest
 
 from hermes_cli import main as cli_main
 from hermes_cli import update_cmd
+from hermes_cli import update_inventory
 from hermes_cli import update_receipt
 
 
@@ -98,6 +99,42 @@ def test_purge_preserves_active_update_receipt(tmp_path, monkeypatch):
     path = reimported.finalize_update_receipt("success")
     assert path is not None
     assert path.is_file()
+
+
+def test_purge_preserves_update_inventory_type_identity():
+    """Pre-update plan rows must reconcile after the post-pull purge."""
+    plan = update_inventory.UpdatePlan(
+        runtimes=[
+            update_inventory.RuntimeRecord(
+                kind="gateway",
+                profile="personal",
+                pid=123,
+                restart_via="launchd",
+            )
+        ]
+    )
+
+    cli_main._purge_stale_hermes_modules()
+
+    reimported = importlib.import_module("hermes_cli.update_inventory")
+    assert reimported is update_inventory
+    outcomes = reimported.match_runtime_outcomes(
+        plan,
+        restarted_services=["hermes-gateway-personal"],
+        relaunched_profiles=[],
+        externally_supervised_profiles=[],
+        killed_pids=set(),
+        failed_units=[],
+    )
+    assert outcomes == [
+        {
+            "kind": "gateway",
+            "profile": "personal",
+            "pid": 123,
+            "mechanism": "launchd",
+            "outcome": "restarted",
+        }
+    ]
 
 
 def test_purge_leaves_prefix_lookalikes_alone():


### PR DESCRIPTION
Summary:
- preserve the active update receipt module across the post-pull stale-module purge
- preserve update inventory so pre-pull RuntimeRecord objects keep the same class identity through reconciliation
- add regressions for receipt finalization and complete runtime outcome matching after purge

Problem:
The updater continues in the pre-pull Python process after changing the checkout. Purging the receipt module lost its in-flight singleton and produced no receipt. Purging update inventory reimported a new RuntimeRecord class, causing every pre-pull plan row to fail the later class check and yielding an empty runtime outcome list.

Validation:
- 18 focused stale-module and restart-reconciliation tests passed
- ruff and git diff checks passed
- supervised local canary produced a persistent receipt with one outcome per planned runtime