### PR TITLE
fix(cron): move Cronjob Response header to footer so useful content is first

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3155,11 +3155,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
             f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            f"-------------\n"
+            f"Cronjob Response: {task_name}\n"
+            f"(job_id: {job_id})"
         )
     else:
         delivery_content = content

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4760,7 +4760,22 @@ class MessageSender:
 
     @staticmethod
     def strip_cron_wrapper(content: str) -> str:
-        """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output."""
+        """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output.
+
+        Supports both legacy header-style (``Cronjob Response:`` at top) and
+        new footer-style (useful content first, ``Cronjob Response:`` after
+        ``-------------`` separator at bottom) wrappers.
+        """
+        # --- new footer-style: "<body>\n\n-------------\nCronjob Response: ...\n(job_id: ...)" ---
+        footer_marker = "\n\n-------------\nCronjob Response: "
+        footer_pos = content.rfind(footer_marker)
+        if footer_pos >= 0:
+            # Footer header must contain job_id marker to avoid false positives
+            if "\n(job_id: " in content[footer_pos:]:
+                body = content[:footer_pos].strip()
+                return body or content
+
+        # --- legacy header-style: "Cronjob Response: ...\n(job_id: ...)\n-------------\n\n<body>\n\nTo stop..." ---
         if not content.startswith("Cronjob Response: "):
             return content
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -379,7 +379,9 @@ class TestDeliverResultWrapping:
         assert "(job_id: test-job)" in sent_content
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        # Footer-style wrapper: useful payload first, cron identifier after separator
+        assert sent_content.index("Here is today's summary.") < sent_content.index("Cronjob Response:")
+        assert "To stop or manage this job" not in sent_content
 
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):


### PR DESCRIPTION
Content-first delivery: job output appears at the top, cron identifier moves to footer.

## Problem

`cron/scheduler.py:_deliver_result` always prepended the wrapper before the payload:

```
Cronjob Response: <task name>
(job_id: <id>)
-------------
<content>
To stop or manage this job, send me a new message...
```

The header pushed useful content below the fold on chat platforms (Telegram/Discord/etc). For notification jobs (e.g., calendar reminds, daily digests) the first visible line was "which cron ran" instead of "what happened".

## Solution

Invert order in `cron/scheduler.py:3157`:

```diff
- f"Cronjob Response: {task_name}\n(job_id: {job_id})\n-------------\n\n{content}\n\nTo stop..."
+ f"{content}\n\n-------------\nCronjob Response: {task_name}\n(job_id: {job_id})"
```

- Useful payload becomes the header
- `Cronjob Response` + `job_id` become a footer after `-------------`
- Removes verbose `To stop or manage...` line (already covered by bot help)
- Respects existing `cron.wrap_response: false` in `config.yaml` for fully clean output (no wrapper) — no breaking change

## Before / After

**Before:**
```
Cronjob Response: my-daily-digest
(job_id: abc123)
-------------
📅 Daily digest — 3 events
...
```

**After:**
```
📅 Daily digest — 3 events
...
-------------
Cronjob Response: my-daily-digest
(job_id: abc123)
```

Content (digest, reminder, report) is now the first line; debug info stays available as footer.

## Testing

- Manual `hermes cron run <job>` with generic jobs — payload now first, footer last
- `cron.wrap_response: false` → no footer at all (verified)
- Lint ok, no behavior change when wrapping disabled
