### PR TITLE
fix(send-message): resolve WEIXIN_HOME_CHANNEL through get_secret

### DIFF
--- a/tests/tools/test_send_message_weixin_home_channel_scope.py
+++ b/tests/tools/test_send_message_weixin_home_channel_scope.py
@@ -1,0 +1,120 @@
+"""Regression test for the WEIXIN_HOME_CHANNEL multiplex secret-scope leak.
+
+``_handle_send``'s weixin home-channel fallback (used when weixin is
+configured purely via ``.env``, with no ``gateway.yaml``/``config.yaml``
+home channel) read ``WEIXIN_HOME_CHANNEL`` through raw ``os.getenv`` instead
+of ``get_secret`` -- unlike the WEIXIN_TOKEN/ACCOUNT_ID/BASE_URL/CDN_BASE_URL
+resolution a few lines above it in the same function, and unlike
+``cron/scheduler.py``'s home-target chat-id resolution, which was fixed to
+read through ``get_secret`` for the same reason. Under multiplexing, a
+secondary profile's ``send_message`` call would resolve the destination
+chat from the shared process's ``os.environ`` (the default profile's value)
+instead of its own ``.env``-scoped ``WEIXIN_HOME_CHANNEL``.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent import secret_scope
+from gateway.config import Platform
+from tools.send_message_tool import send_message_tool
+
+
+@pytest.fixture()
+def multiplex_on():
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+
+def _weixin_config():
+    # No gateway.yaml entry and no configured home channel -- weixin's
+    # "purely via .env" path, which is what reaches the fallback under test.
+    return SimpleNamespace(platforms={}, get_home_channel=lambda _platform: None)
+
+
+def _run_async_immediately(coro):
+    return asyncio.run(coro)
+
+
+class TestWeixinHomeChannelSecretScope:
+    def test_scoped_home_channel_wins_over_environ(self, multiplex_on, monkeypatch):
+        """A secondary profile's own WEIXIN_HOME_CHANNEL must win over the
+        shared process os.environ's (default profile's) value."""
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-token")
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "default-account")
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "default-profile-chat")
+
+        token = secret_scope.set_secret_scope({
+            "WEIXIN_TOKEN": "scoped-token",
+            "WEIXIN_ACCOUNT_ID": "scoped-account",
+            "WEIXIN_HOME_CHANNEL": "scoped-profile-chat",
+        })
+        try:
+            with patch("gateway.config.load_gateway_config", return_value=_weixin_config()), \
+                 patch("tools.interrupt.is_interrupted", return_value=False), \
+                 patch("model_tools._run_async", side_effect=_run_async_immediately), \
+                 patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+                 patch("gateway.mirror.mirror_to_session", return_value=True):
+                result = json.loads(
+                    send_message_tool({"action": "send", "target": "weixin", "message": "hi"})
+                )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.args[0] == Platform.WEIXIN
+        assert send_mock.await_args.args[2] == "scoped-profile-chat"
+
+    def test_scoped_miss_does_not_borrow_environ_home_channel(self, multiplex_on, monkeypatch):
+        """A secondary profile with no WEIXIN_HOME_CHANNEL of its own must
+        fail closed, not send to the default profile's home chat."""
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-token")
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "default-account")
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "default-profile-chat")
+
+        token = secret_scope.set_secret_scope({
+            "WEIXIN_TOKEN": "scoped-token",
+            "WEIXIN_ACCOUNT_ID": "scoped-account",
+        })
+        try:
+            with patch("gateway.config.load_gateway_config", return_value=_weixin_config()), \
+                 patch("tools.interrupt.is_interrupted", return_value=False), \
+                 patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+                result = json.loads(
+                    send_message_tool({"action": "send", "target": "weixin", "message": "hi"})
+                )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert "error" in result
+        assert "WEIXIN_HOME_CHANNEL" in result["error"]
+        send_mock.assert_not_awaited()
+
+    def test_single_profile_deployment_falls_back_to_environ(self, monkeypatch):
+        """Outside multiplexing (the common single-profile deployment, no
+        ``multiplex_on``/no scope installed) ``get_secret`` still falls
+        through to ``os.environ`` -- the fix must not regress this path."""
+        monkeypatch.setenv("WEIXIN_TOKEN", "default-token")
+        monkeypatch.setenv("WEIXIN_ACCOUNT_ID", "default-account")
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "default-profile-chat")
+
+        with patch("gateway.config.load_gateway_config", return_value=_weixin_config()), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool({"action": "send", "target": "weixin", "message": "hi"})
+            )
+
+        assert result["success"] is True
+        assert send_mock.await_args.args[2] == "default-profile-chat"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -443,7 +443,12 @@ def _handle_send(args):
     if not chat_id:
         home = config.get_home_channel(platform)
         if not home and platform_name == "weixin":
-            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+            # Read through get_secret (not raw os.getenv), mirroring the
+            # WEIXIN_TOKEN/ACCOUNT_ID/BASE_URL/CDN_BASE_URL resolution above:
+            # under multiplex the winning profile's secret scope is installed
+            # around this call (cron delivery, or a live agent turn), and
+            # os.environ may hold a different profile's WEIXIN_HOME_CHANNEL.
+            wx_home = get_secret("WEIXIN_HOME_CHANNEL", "").strip()
             if wx_home:
                 from gateway.config import HomeChannel
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")


### PR DESCRIPTION
## Problem

`_handle_send`'s weixin fallback (`tools/send_message_tool.py`) reads `WEIXIN_HOME_CHANNEL` through raw `os.getenv` instead of `get_secret`, when weixin has no home channel configured via `gateway.yaml`/`config.yaml` and is set up purely through `.env` (a documented supported pattern, per the function's own comment):

```python
if not home and platform_name == "weixin":
    wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
```

This is a sibling gap on two fronts in the *same file*:
- The `WEIXIN_TOKEN`/`WEIXIN_ACCOUNT_ID`/`WEIXIN_BASE_URL`/`WEIXIN_CDN_BASE_URL` resolution 35 lines above it, in the *same function*, already reads through `get_secret` (#59674, landed via #65629's salvage cluster).
- `_send_qqbot()`'s `QQ_APP_ID`/`QQ_CLIENT_SECRET` resolution, also in this file, was moved to profile-scoped resolution by #76665.

Under a multiplex gateway (`gateway.multiplex_profiles`), a profile's own `.env`-scoped secrets are installed as a `set_secret_scope` around cron job execution and around live agent turns (`_profile_runtime_scope`), so `get_secret` resolves the *owning* profile's value while raw `os.getenv`/`os.environ` may hold a different profile's value in the same shared process. `cron/scheduler.py`'s home-target chat-id/thread-id resolution (`_env_home_target_chat_id`/`_get_home_target_thread_id`) was fixed for exactly this reason very recently in the ongoing multiplex profile-isolation series.

**Impact:** a `send_message(platform="weixin")` tool call with no explicit target — reachable both from cron delivery and from a live agent turn — resolves the destination chat from the shared process's `os.environ` (likely the default profile's value) instead of the job-owning/secondary profile's own `.env`, sending the message to the wrong profile's home chat.

## Fix

Read `WEIXIN_HOME_CHANNEL` through `get_secret` (already imported in this file), matching the resolution pattern used a few lines above it in the same function.

## Testing

Added `tests/tools/test_send_message_weixin_home_channel_scope.py`:
- a secondary profile's own `WEIXIN_HOME_CHANNEL` wins over the default profile's `os.environ` value under multiplexing
- a scoped miss fails closed (returns the "no home channel" error) instead of borrowing the default profile's environ value
- the single-profile (non-multiplex) deployment still falls back to `os.environ` correctly — the fix does not regress the common case

Mutation-verified: reverting the fix makes the first two tests fail (with the expected wrong-chat / no-fail-closed behavior) while the third is unaffected, confirming the tests exercise the bug.

```
tests/gateway/test_weixin.py, test_weixin_secret_scope.py, test_weixin_typing.py,
tests/tools/test_send_message_weixin_home_channel_scope.py: 45 passed
tests/tools/test_send_message_tool.py (full file): 49 passed
```

## Scope note

Left untouched: `gateway/platforms/weixin.py`'s own `_wx_secret()` wrapper (which additionally catches `UnscopedSecretError` and falls back to `os.getenv` for the default-profile-adapter-construction-at-boot path) is a different call site with a different reachability story than the mid-turn tool call this PR fixes; `tools/send_message_tool.py`'s own sibling lines (`WEIXIN_TOKEN` etc.) use bare `get_secret` the same way this fix does, so this keeps the file internally consistent with the existing, already-landed pattern rather than introducing a second helper.