### PR TITLE
chore: contributor mapping for adria.arrufat@gmail.com (PR #99312)

### DIFF
--- a/contributors/emails/adria.arrufat@gmail.com
+++ b/contributors/emails/adria.arrufat@gmail.com
@@ -1,0 +1,2 @@
+arrufat
+# PR #99312 Lightpanda Browser Use engine


### PR DESCRIPTION
Adds the email→login mapping for @arrufat (adria.arrufat@gmail.com) ahead of merging #99312, so the attribution CI check passes. @smarzola's email on #81673 is a users.noreply address and auto-skips.