### PR TITLE
test(compression): make progress timing deterministic

### DIFF
--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -442,21 +442,30 @@ class TestContentBearingProgress:
         seconds_since_progress(); before the fix, every keepalive chunk fed
         through _ChatStreamAccumulator ticked the fence, so a stalled
         summary stream never hit the inactivity timeout."""
-        fence = CompressionCommitFence()
-        accumulator = _ChatStreamAccumulator()
-        keepalive = SimpleNamespace(id=None, model=None, choices=[], usage=None)
-        empty_role_chunk = _chunk(content="", reasoning="")
+        with patch(
+            "agent.conversation_compression.time.monotonic",
+            return_value=100.0,
+        ):
+            fence = CompressionCommitFence()
+            accumulator = _ChatStreamAccumulator()
+            keepalive = SimpleNamespace(id=None, model=None, choices=[], usage=None)
+            empty_role_chunk = _chunk(content="", reasoning="")
 
-        with aux_progress_hook(fence.touch_progress):
-            for _ in range(5):
-                accumulator.feed(keepalive)
-                accumulator.feed(empty_role_chunk)
-        # No substantive payload arrived: the fence must have stayed stale.
-        assert fence.seconds_since_progress() > 0.0
+            with aux_progress_hook(fence.touch_progress):
+                for _ in range(5):
+                    accumulator.feed(keepalive)
+                    accumulator.feed(empty_role_chunk)
+            # No substantive payload arrived: the fence keeps its original
+            # timestamp, so a later observation sees the full elapsed second.
+            with patch(
+                "agent.conversation_compression.time.monotonic",
+                return_value=101.0,
+            ):
+                assert fence.seconds_since_progress() == 1.0
 
-        with aux_progress_hook(fence.touch_progress):
-            accumulator.feed(_chunk(content="token"))
-        assert fence.seconds_since_progress() < 0.05
+            with aux_progress_hook(fence.touch_progress):
+                accumulator.feed(_chunk(content="token"))
+            assert fence.seconds_since_progress() == 0.0
 
     def test_content_free_frames_still_record_ttfp_timing(self):
         """The fast-lane telemetry contract (#96945/#96963) survives the


### PR DESCRIPTION
## Summary

- replace wall-clock inequalities in the compression progress-fence regression with a patched monotonic clock
- verify content-free keepalives preserve the original progress timestamp exactly
- verify a substantive token refreshes the timestamp exactly

## Why

On Windows, two back-to-back `time.monotonic()` calls can quantize to the same tick. The previous `seconds_since_progress() > 0.0` assertion therefore failed even when keepalives correctly did not call `touch_progress`. The matching `< 0.05` assertion also depended on machine scheduling.

## Verification

- `uv run pytest -q tests/agent/test_aux_progress_streaming.py::TestContentBearingProgress::test_keepalive_chunks_do_not_reset_the_compression_fence` → 1 passed
- `uv run pytest -q tests/agent/test_aux_progress_streaming.py` → 49 passed
- `uv run ruff check tests/agent/test_aux_progress_streaming.py` → passed
- `git diff --check` → passed

Test-only change; no runtime behavior changes.