### PR TITLE
fix(agent): bound max-iteration summary overflow

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2948,10 +2948,99 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
-def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
+_MAX_ITERATION_SUMMARY_HISTORY_CHARS = 160_000
+
+
+def _bounded_max_iteration_history(messages: list) -> list:
+    """Return a bounded copy for an emergency iteration-summary retry.
+
+    The normal summary path preserves the full cached transcript.  Native
+    provider compaction can make that transcript much larger than the wire
+    context the main loop actually sends, so replaying it verbatim at the
+    iteration limit may overflow even though the preceding request succeeded.
+    Keep the original goal plus the newest history that fits; the ordinary API
+    sanitizer repairs any tool-call pairs cut by the boundary.
+    """
+    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+    history = [
+        msg.copy()
+        for msg in messages
+        if not (
+            msg.get("role") == "user"
+            and msg.get("content") == MAX_ITERATIONS_SUMMARY_REQUEST
+        )
+    ]
+    if not history:
+        return []
+
+    first_user = next(
+        (msg for msg in history if msg.get("role") == "user"),
+        None,
+    )
+    selected_reversed = []
+    used = 0
+    for msg in reversed(history):
+        try:
+            size = len(json.dumps(msg, default=str, ensure_ascii=False))
+        except Exception:
+            size = len(str(msg))
+        if size > _MAX_ITERATION_SUMMARY_HISTORY_CHARS:
+            # One oversized tool result should not crowd every useful recent
+            # exchange out of the emergency summary request. Its full payload
+            # is already persisted by the tool-result budget machinery.
+            continue
+        if used + size > _MAX_ITERATION_SUMMARY_HISTORY_CHARS:
+            break
+        selected_reversed.append(msg)
+        used += size
+
+    selected = list(reversed(selected_reversed))
+    if first_user is not None and first_user not in selected:
+        goal = first_user.copy()
+        goal_text = flatten_message_text(goal.get("content"))
+        if len(goal_text) > 12_000:
+            goal["content"] = goal_text[:12_000] + "\n...[original request truncated for emergency summary]"
+        selected.insert(0, goal)
+    return selected
+
+
+def _local_max_iteration_fallback(agent, messages: list) -> str:
+    """Produce a bounded, user-facing fallback without another model call."""
+    excerpts = []
+    for msg in reversed(messages):
+        if msg.get("role") != "assistant":
+            continue
+        text = flatten_message_text(msg.get("content")).strip()
+        if not text:
+            continue
+        excerpts.append(text[:800])
+        if len(excerpts) == 3:
+            break
+
+    lines = [
+        f"I reached the maximum tool-iteration limit ({agent.max_iterations}).",
+        "The session and tool results are intact, but the final model-generated summary could not be produced.",
+    ]
+    if excerpts:
+        lines.append("Most recent completed output:")
+        lines.extend(f"- {text}" for text in reversed(excerpts))
+    lines.append('Send "continue" and I will resume from the preserved session state.')
+    return "\n".join(lines)
+
+
+def handle_max_iterations(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    _bounded_retry: bool = False,
+) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     warning = f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
-    if getattr(agent, "suppress_status_output", False):
+    if _bounded_retry:
+        pass
+    elif getattr(agent, "suppress_status_output", False):
         # Strict machine-readable mode (hermes chat -Q, oneshot, background
         # review): keep diagnostics out of stdout so wrappers receive only
         # the final assistant content (#93220 class). Note: plain quiet_mode
@@ -3294,7 +3383,46 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
     except Exception as e:
         logger.warning("Failed to get summary response: %s", e)
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        context_overflow = False
+        try:
+            from agent.error_classifier import classify_api_error
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            classified = classify_api_error(
+                e,
+                provider=str(getattr(agent, "provider", "") or ""),
+                model=str(getattr(agent, "model", "") or ""),
+                approx_tokens=estimate_messages_tokens_rough(messages),
+                context_length=int(
+                    getattr(getattr(agent, "context_compressor", None), "context_length", 0)
+                    or 200_000
+                ),
+                num_messages=len(messages),
+            )
+            context_overflow = classified.reason == FailoverReason.context_overflow
+        except Exception:
+            context_overflow = "context window" in str(e).lower() or "context length" in str(e).lower()
+
+        if context_overflow and not _bounded_retry:
+            bounded = _bounded_max_iteration_history(messages)
+            logger.warning(
+                "Iteration-summary request overflowed; retrying with bounded history "
+                "(%d -> %d messages)",
+                len(messages),
+                len(bounded),
+            )
+            final_response = handle_max_iterations(
+                agent,
+                bounded,
+                api_call_count,
+                _bounded_retry=True,
+            )
+            summary_call_outcome = "success"
+            append_message(messages, {"role": "assistant", "content": final_response})
+        elif _bounded_retry:
+            final_response = _local_max_iteration_fallback(agent, messages)
+        else:
+            final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
     finally:
         from agent import relay_llm
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2770,6 +2770,53 @@ class TestHandleMaxIterations:
         combined = "\n".join(printed) + capsys.readouterr().out
         assert "Reached maximum iterations" in combined
 
+    def test_context_overflow_retries_summary_with_bounded_history(self, agent):
+        agent.client.chat.completions.create.side_effect = [
+            Exception("Your input exceeds the context window of this model"),
+            _mock_response(content="Bounded summary of completed work."),
+        ]
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "Implement and verify this goal: " + "g" * 300_000},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "x" * 400_000},
+        ]
+
+        result = agent._handle_max_iterations(messages, 150)
+
+        assert result == "Bounded summary of completed work."
+        assert agent.client.chat.completions.create.call_count == 2
+        first = agent.client.chat.completions.create.call_args_list[0].kwargs["messages"]
+        second = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        assert sum(len(str(m.get("content", ""))) for m in second) < 200_000
+        assert sum(len(str(m.get("content", ""))) for m in second) < sum(
+            len(str(m.get("content", ""))) for m in first
+        )
+
+    def test_bounded_summary_overflow_uses_local_fallback_without_error_text(self, agent):
+        agent.client.chat.completions.create.side_effect = [
+            Exception("Your input exceeds the context window of this model"),
+            Exception("Your input exceeds the context window of this model"),
+        ]
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "Finish the task."},
+            {"role": "assistant", "content": "The implementation and tests are complete."},
+            {"role": "tool", "tool_call_id": "orphan", "content": "x" * 400_000},
+        ]
+
+        result = agent._handle_max_iterations(messages, 150)
+
+        assert "session and tool results are intact" in result
+        assert "input exceeds the context window" not in result.lower()
+        assert "implementation and tests are complete" in result.lower()
+        assert agent.client.chat.completions.create.call_count == 2
+
     def test_api_failure_returns_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."


### PR DESCRIPTION
## Summary

At the tool-iteration limit, Hermes builds a final-summary request from the complete local transcript. After provider-native compaction, that transcript can be much larger than the context actually sent by the main loop, so the summary request can overflow even though the immediately preceding request succeeded.

This change:

- retries context-overflowed iteration summaries with the original goal plus a bounded recent-history window;
- drops individual oversized tool results from that emergency retry while preserving their persisted copies;
- truncates an exceptionally large original request in the emergency prompt;
- falls back to a deterministic, user-facing status summary if even the bounded model call fails, without exposing the provider context-window error.

The normal max-iteration summary path is unchanged.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q` — 283 passed
- `uvx ruff==0.15.10 check agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py` — clean
