### PR TITLE
fix(gateway): ignore unloaded systemd unit defaults

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -351,12 +351,18 @@ def check_systemd_timing_alignment(
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    manager_flags = (["--user"], [])
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    cgroup_path = line.strip().split(":", 2)[-1]
+                    if "/system.slice/" in cgroup_path:
+                        manager_flags = ([], ["--user"])
+                    elif "/user.slice/" in cgroup_path:
+                        manager_flags = (["--user"], [])
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -369,11 +375,10 @@ def check_systemd_timing_alignment(
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query the manager identified by the process cgroup first.  Fall back to
+    # the other manager when the scope is unknown or its unit is unavailable.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    for flag in manager_flags:
         try:
             result = subprocess.run(
                 [

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -376,24 +376,37 @@ def check_systemd_timing_alignment(
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl",
+                    *flag,
+                    "show",
+                    unit_name,
+                    "--property=LoadState",
+                    "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        properties = {}
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+            if "=" in line:
+                key, value = line.split("=", 1)
+                properties[key] = value.strip()
+        # ``systemctl show`` can succeed for a nonexistent unit and emit the
+        # manager's default TimeoutStopUSec.  Do not let that phantom value
+        # mask a real unit with the same name in the other manager scope.
+        if properties.get("LoadState") != "loaded":
+            continue
+        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        value = properties.get("TimeoutStopUSec", "")
+        # Try numeric microseconds first
+        if value.isdigit():
+            timeout_us = int(value)
+        else:
+            timeout_us = parse_systemd_duration_to_us(value)
         if timeout_us is not None:
             break
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -133,6 +135,42 @@ class TestParseSystemdDuration:
 # ---------------------------------------------------------------------------
 
 class TestCheckSystemdTimingAlignment:
+
+    def test_ignores_unloaded_user_unit_and_checks_system_manager(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *args, **kwargs: io.StringIO(
+                "0::/system.slice/hermes-gateway.service\n"
+            ),
+        )
+        calls = []
+
+        def fake_run(command, **kwargs):
+            is_user = "--user" in command
+            calls.append(is_user)
+            if is_user:
+                stdout = (
+                    "LoadState=not-found\n"
+                    "FragmentPath=\n"
+                    "TimeoutStopUSec=1min 30s\n"
+                )
+            else:
+                stdout = (
+                    "LoadState=loaded\n"
+                    "FragmentPath=/etc/systemd/system/hermes-gateway.service\n"
+                    "TimeoutStopUSec=3min 30s\n"
+                )
+            return SimpleNamespace(returncode=0, stdout=stdout)
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0, 0.0)
+
+        assert calls == [True, False]
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False
 
     def test_returns_none_when_unit_undeterminable(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc")

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -141,7 +141,7 @@ class TestCheckSystemdTimingAlignment:
         monkeypatch.setattr(
             "builtins.open",
             lambda *args, **kwargs: io.StringIO(
-                "0::/system.slice/hermes-gateway.service\n"
+                "0::/hermes-gateway.service\n"
             ),
         )
         calls = []
@@ -171,6 +171,54 @@ class TestCheckSystemdTimingAlignment:
         assert result is not None
         assert result["timeout_stop_sec"] == 210.0
         assert result["mismatch"] is False
+
+    @pytest.mark.parametrize(
+        ("cgroup_path", "expected_user_scope", "expected_timeout", "expected_mismatch"),
+        [
+            ("/system.slice/hermes-gateway.service", False, 210.0, False),
+            (
+                "/user.slice/user-1000.slice/user@1000.service/app.slice/"
+                "hermes-gateway.service",
+                True,
+                90.0,
+                True,
+            ),
+        ],
+    )
+    def test_cgroup_scope_selects_manager_when_both_units_are_loaded(
+        self,
+        monkeypatch,
+        cgroup_path,
+        expected_user_scope,
+        expected_timeout,
+        expected_mismatch,
+    ):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *args, **kwargs: io.StringIO(
+                f"0::{cgroup_path}\n"
+            ),
+        )
+        calls = []
+
+        def fake_run(command, **kwargs):
+            is_user = "--user" in command
+            calls.append(is_user)
+            timeout = "1min 30s" if is_user else "3min 30s"
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"LoadState=loaded\nTimeoutStopUSec={timeout}\n",
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0, 0.0)
+
+        assert calls == [expected_user_scope]
+        assert result is not None
+        assert result["timeout_stop_sec"] == expected_timeout
+        assert result["mismatch"] is expected_mismatch
 
     def test_returns_none_when_unit_undeterminable(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc")


### PR DESCRIPTION
## Summary

- query `LoadState` alongside `TimeoutStopUSec` in the gateway shutdown timing diagnostic
- ignore manager scopes where the named unit is not actually loaded
- continue to the other systemd manager instead of accepting the nonexistent unit's default timeout

## Problem

`systemctl --user show hermes-gateway.service` can return exit status 0 and a default `TimeoutStopUSec=1min 30s` even when that user unit does not exist (`LoadState=not-found`, empty `FragmentPath`). For a gateway actually owned by the system manager with `TimeoutStopSec=210`, the user-first probe accepts the phantom 90-second value and emits a false stale-unit warning.

## Verification

- regression reproduces unloaded user unit at 90s masking loaded system unit at 210s
- `python -m pytest -q tests/gateway/test_shutdown_forensics.py -o addopts=`: 11 passed
- `python -m compileall -q gateway/shutdown_forensics.py tests/gateway/test_shutdown_forensics.py`
- `git diff --check`

## Safety

The diagnostic remains best-effort and non-mutating. Loaded user services retain the existing user-first behavior; unavailable/unloaded scopes now fall through.

## Follow-up review hardening
- derive preferred systemd manager from `/proc/self/cgroup`
- prefer system manager for `/system.slice/` and user manager for `/user.slice/`
- retain manager fallback for unknown scope or unavailable/unloaded preferred units
- regression covers both managers having same-name loaded units in both cgroup scopes
- updated focused suite: 13 passed
