### PR TITLE
fix(gemini): inline local schema references

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -23,10 +23,60 @@ def _stringify_enum_value(item: Any) -> Any:
     return item if isinstance(item, str) else None
 
 
+def _inline_local_schema_refs(
+    schema: Any,
+    definitions: Dict[str, Any] | None = None,
+    resolving: frozenset[str] = frozenset(),
+) -> Any:
+    """Inline local ``$defs`` / ``definitions`` references for Gemini.
+
+    Gemini's function-schema subset does not support ``$ref``.  Resolve only
+    local definition references; external references remain unsupported and
+    are subsequently stripped by the normal schema sanitizer.
+    """
+
+    if isinstance(schema, list):
+        return [
+            _inline_local_schema_refs(item, definitions, resolving)
+            for item in schema
+        ]
+    if not isinstance(schema, dict):
+        return schema
+
+    if definitions is None:
+        candidate_defs = schema.get("$defs") or schema.get("definitions")
+        definitions = candidate_defs if isinstance(candidate_defs, dict) else {}
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        prefix, _, name = ref.rpartition("/")
+        if prefix in {"#/$defs", "#/definitions"} and name in definitions:
+            siblings = {
+                key: _inline_local_schema_refs(value, definitions, resolving)
+                for key, value in schema.items()
+                if key != "$ref"
+            }
+            if name in resolving:
+                return {"type": "object", **siblings}
+            target = _inline_local_schema_refs(
+                definitions[name], definitions, resolving | {name}
+            )
+            if isinstance(target, dict):
+                return {**target, **siblings}
+            return siblings
+
+    return {
+        key: _inline_local_schema_refs(value, definitions, resolving)
+        for key, value in schema.items()
+        if key not in {"$defs", "definitions"}
+    }
+
+
 def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     """Gemini-compatible copy of a tool parameter schema: keeps only the documented subset
     (drops e.g. ``$schema`` / ``additionalProperties``) and recursively sanitizes nested
     ``properties`` / ``items`` / ``anyOf``."""
+    schema = _inline_local_schema_refs(schema)
     if not isinstance(schema, dict):
         return {}
     cleaned: Dict[str, Any] = {}

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -77,6 +77,71 @@ class TestSanitizeGeminiSchema:
         assert sanitize_gemini_schema("not a schema") == {}
         assert sanitize_gemini_schema([1, 2, 3]) == {}
 
+    def test_inlines_local_defs_for_tool_parameters(self):
+        schema = {
+            "type": "object",
+            "properties": {"task": {"$ref": "#/$defs/Task"}},
+            "required": ["task"],
+            "$defs": {
+                "Task": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"],
+                }
+            },
+        }
+
+        cleaned = sanitize_gemini_schema(schema)
+
+        assert "$defs" not in cleaned
+        assert cleaned["properties"]["task"] == {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+        }
+
+    def test_local_ref_siblings_override_definition_metadata(self):
+        schema = {
+            "properties": {
+                "task": {
+                    "$ref": "#/definitions/Task",
+                    "description": "Task supplied by this tool",
+                }
+            },
+            "definitions": {
+                "Task": {
+                    "type": "object",
+                    "description": "Generic task",
+                    "properties": {"title": {"type": "string"}},
+                }
+            },
+        }
+
+        cleaned = sanitize_gemini_schema(schema)
+
+        assert cleaned["properties"]["task"]["description"] == "Task supplied by this tool"
+        assert cleaned["properties"]["task"]["properties"] == {
+            "title": {"type": "string"}
+        }
+
+    def test_recursive_local_defs_terminate_with_object_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"node": {"$ref": "#/$defs/Node"}},
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/$defs/Node"}},
+                }
+            },
+        }
+
+        cleaned = sanitize_gemini_schema(schema)
+
+        assert cleaned["properties"]["node"]["properties"]["child"] == {
+            "type": "object"
+        }
+
 
 class TestRequiredPropertyPruning:
     """Gemini rejects ``required`` names missing from the node's ``properties``.


### PR DESCRIPTION
Fixes #99438\n\n## Summary\n- Inline local `$defs` and legacy `definitions` references before translating tool schemas for Gemini.\n- Preserve local reference siblings and safely terminate recursive definitions.\n\n## Tests\n- `scripts/run_tests.sh tests/agent/test_gemini_schema.py -q`