### PR TITLE
fix(bot-mode): pin default profile for peer dm so the peer registry resolves from non-default profiles

### DIFF
--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -304,7 +304,17 @@ def message_agent_tool(
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
         return _start_delivery(
-            ["hermes", "peer", "dm", dm_target],
+            # Pin the DEFAULT profile for the peer registry lookup. The
+            # `hermes peer` CLI resolves its registry (bot_peers / peers
+            # store) from the CURRENT profile's config, but peers are
+            # registered in the default profile's config.yaml. Without -p,
+            # a session running under a non-default profile (e.g. a
+            # reviewer bot) executes `hermes peer dm` in that profile's
+            # context, finds an empty registry, and fails with "No peer
+            # named '<peer>'" even though the peer is registered and works
+            # from the default profile (#93935). The local-teammate path
+            # below already pins its profile the same way.
+            ["hermes", "-p", "default", "peer", "dm", dm_target],
             prefix + body,
             label,
             stdin_file=True,


### PR DESCRIPTION
message_agent peer delivery failed from non-default profiles with 'No peer named X' because the runner called 'hermes peer dm' without -p. The peer CLI resolves its registry from the CURRENT profile's config, which is empty for non-default profiles since peers are registered in the default profile's config.yaml. The local-teammate path in the same file already pins its profile; this makes the peer path consistent.

Fixes #93935