### PR TITLE
feat(fast): resolve /fast against the full route, not the model id alone

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9798,12 +9798,41 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     
     def _fast_command_available(self) -> bool:
         try:
-            from hermes_cli.models import model_supports_fast_mode
+            from hermes_cli.models import (
+                resolve_fast_mode_capability_for_configured_route,
+            )
+            from hermes_cli.providers import determine_api_mode
         except Exception:
             return False
         agent = getattr(self, "agent", None)
         model = getattr(agent, "model", None) or getattr(self, "model", None)
-        return model_supports_fast_mode(model)
+        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        api_mode = getattr(agent, "api_mode", None) or getattr(self, "api_mode", None)
+        if not api_mode:
+            # A live agent always carries a resolved api_mode; a pre-build CLI
+            # may not. Re-derive it from the provider/endpoint rather than
+            # guessing, so the toggle is offered on exactly the routes the
+            # request builder would honour.
+            try:
+                api_mode = determine_api_mode(
+                    str(provider or ""),
+                    str(
+                        getattr(agent, "base_url", None)
+                        or getattr(self, "base_url", None)
+                        or ""
+                    ),
+                    str(model or ""),
+                )
+            except Exception:
+                api_mode = None
+        # ``_for_configured_route`` so an unpinned provider ("auto", or absent
+        # before the first turn resolves one) still reports the model's own
+        # native support instead of failing closed and hiding /fast.
+        return resolve_fast_mode_capability_for_configured_route(
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+        ).supported
 
     def _command_available(self, slash_command: str) -> bool:
         if slash_command == "/fast":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8679,9 +8679,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        enabled and the *resolved route* (model + provider + api_mode) has a
+        documented fast contract, attach `request_overrides` so the API call
+        is marked accordingly.
+
+        Route-aware rather than model-only: the parameter that carries fast
+        mode is wire-specific (``speed`` on Anthropic Messages,
+        ``service_tier`` on OpenAI/xAI), so the same model id reached over a
+        different transport may take a different key or none at all. A route
+        with no contract contributes no overrides and the turn runs at normal
+        speed.
 
         Per-provider ``request_overrides`` resolved by
         ``resolve_runtime_provider`` (e.g. a ``custom_providers`` ``extra_body``
@@ -8689,7 +8696,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         the fast-mode overrides, so a provider's configured request body still
         reaches the model on the gateway turn path.
         """
-        from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.models import resolve_fast_mode_capability
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -8729,7 +8736,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_capability(
+                model=route["model"],
+                provider=runtime["provider"],
+                api_mode=runtime["api_mode"],
+            ).request_overrides
         except Exception:
             overrides = None
         # Fast-mode overrides (service_tier / speed) are top-level keys and do
@@ -10062,6 +10073,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ):
                 return _t_state.conversation.service_tier_override
         return self._load_service_tier()
+
+    def _resolve_session_fast_route(
+        self,
+        *,
+        session_key: Optional[str] = None,
+        user_config: Optional[dict] = None,
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Resolve the ``(model, provider, api_mode)`` a session's turns will use.
+
+        A session-scoped ``/model`` override wins over the configured gateway
+        route, exactly as the turn path resolves it — so ``/fast`` answers for
+        the route the *next message* will take rather than the one config
+        names. Falls back to the configured route when there is no override.
+
+        Returns the triple with ``api_mode`` re-derived from the
+        provider/endpoint when the override did not record one (persisted
+        overrides deliberately drop ``api_mode``, which is re-resolved at
+        rehydration).
+        """
+        from hermes_cli.providers import determine_api_mode
+
+        cfg = user_config if user_config is not None else _load_gateway_config()
+        model = _resolve_gateway_model(cfg)
+        model_cfg = cfg.get("model", {})
+        provider = (
+            model_cfg.get("provider") if isinstance(model_cfg, dict) else None
+        )
+        base_url = model_cfg.get("base_url") if isinstance(model_cfg, dict) else None
+        api_mode = model_cfg.get("api_mode") if isinstance(model_cfg, dict) else None
+
+        if session_key:
+            override = (
+                getattr(self, "_session_model_overrides", {}) or {}
+            ).get(session_key) or {}
+            if isinstance(override, dict) and override:
+                model = override.get("model") or model
+                provider = override.get("provider") or provider
+                base_url = override.get("base_url") or base_url
+                # api_mode is intentionally NOT persisted with the override;
+                # prefer a live one when present, else re-derive below.
+                api_mode = override.get("api_mode") or None
+
+        if not api_mode:
+            try:
+                api_mode = determine_api_mode(
+                    str(provider or ""), str(base_url or ""), str(model or "")
+                )
+            except Exception:
+                api_mode = None
+        return model, provider, api_mode
 
     def _set_session_service_tier_override(
         self,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4094,9 +4094,18 @@ class GatewaySlashCommandsMixin:
 
         Session-scoped by default; ``--global`` persists agent.service_tier
         to config.yaml (parity with /model and /reasoning).
+
+        Route-aware: support is resolved from the full ``(model, provider,
+        api_mode)`` the session's next turn will use, not the model id alone,
+        because the parameter that carries fast mode differs per wire. An
+        unsupported route refuses to enable and says why, rather than
+        accepting the toggle and silently sending nothing.
         """
         from gateway.run import _load_gateway_config, _resolve_gateway_model
-        from hermes_cli.models import model_supports_fast_mode
+        from hermes_cli.models import (
+            resolve_fast_mode_capability,
+            resolve_fast_mode_capability_for_configured_route,
+        )
 
         raw_args = event.get_command_args().strip().lower()
         # Reuse the /reasoning arg parser: strips --global (any position),
@@ -4108,13 +4117,64 @@ class GatewaySlashCommandsMixin:
         )
 
         user_config = _load_gateway_config()
-        model = _resolve_gateway_model(user_config)
-        if not model_supports_fast_mode(model):
-            return t("gateway.fast.not_supported")
+        model, provider, api_mode = self._resolve_session_fast_route(
+            session_key=session_key, user_config=user_config
+        )
+        capability = resolve_fast_mode_capability(
+            model=model, provider=provider, api_mode=api_mode
+        )
+        route = f"{provider or '<unknown>'}/{model or '<unset>'}"
+        family_label = t(f"gateway.fast.family_{capability.family}")
+        # The ``--global`` lane persists a default that applies to the
+        # CONFIGURED gateway route, so it must be gated on that route rather
+        # than on whatever this one session overrode itself to.
+        _configured_model_cfg = user_config.get("model", {})
+        _configured_provider = (
+            _configured_model_cfg.get("provider")
+            if isinstance(_configured_model_cfg, dict)
+            else None
+        )
+        _configured_api_mode = (
+            _configured_model_cfg.get("api_mode")
+            if isinstance(_configured_model_cfg, dict)
+            else None
+        )
+        logger.debug(
+            "Fast capability route=%s api_mode=%s family=%s supported=%s",
+            route,
+            api_mode or "",
+            capability.family,
+            capability.supported,
+        )
 
         def _apply_fast_selection(value: str, persist: bool = False) -> str:
-            """Apply a /fast argument (typed or picked) and return the reply."""
+            """Apply a /fast argument (typed or picked) and return the reply.
+
+            Enabling is gated on the route that will actually carry the
+            request: the session route for a session-scoped toggle, the
+            configured route for ``--global`` (whose persisted default applies
+            to the gateway route, not to whatever this one session overrode
+            itself to). Disabling is always allowed — turning the toggle off
+            must never be blocked by an unsupported route.
+            """
             if value in {"fast", "on"}:
+                if persist:
+                    global_capability = (
+                        resolve_fast_mode_capability_for_configured_route(
+                            model=_resolve_gateway_model(user_config),
+                            provider=_configured_provider,
+                            api_mode=_configured_api_mode,
+                        )
+                    )
+                    if not global_capability.supported:
+                        return t(
+                            "gateway.fast.route_unavailable",
+                            reason=global_capability.reason,
+                        )
+                elif not capability.supported:
+                    return t(
+                        "gateway.fast.route_unavailable", reason=capability.reason
+                    )
                 tier = "priority"
                 saved_value = "fast"
                 label = t("gateway.fast.label_fast")
@@ -4132,45 +4192,71 @@ class GatewaySlashCommandsMixin:
                         session_key, None, clear=True
                     )
                     self._evict_cached_agent(session_key)
-                    return t("gateway.fast.saved", label=label)
+                    return t(
+                        "gateway.fast.route_saved", family=family_label, label=label
+                    )
                 # Config write failed — fall back to a session override so the
                 # user's choice still applies (mirrors /reasoning --global).
                 self._set_session_service_tier_override(session_key, tier)
                 self._evict_cached_agent(session_key)
-                return t("gateway.fast.session_only", label=label)
+                return t(
+                    "gateway.fast.route_session_only",
+                    family=family_label,
+                    label=label,
+                )
             self._set_session_service_tier_override(session_key, tier)
             self._evict_cached_agent(session_key)
-            return t("gateway.fast.session_only", label=label)
+            return t(
+                "gateway.fast.route_session_only", family=family_label, label=label
+            )
 
         if not args or args == "status":
             is_fast = self._service_tier == "priority"
-            status = t("gateway.fast.status_fast") if is_fast else t("gateway.fast.status_normal")
-
-            async def _on_fast_choice(_chat_id: str, value: str) -> str:
-                return _apply_fast_selection(value, persist=persist_global)
-
-            picker_sent = await self._try_send_choice_picker(
-                event,
-                session_key,
-                title=t("gateway.fast.picker_title", mode=status),
-                choices=[
-                    {
-                        "value": "fast",
-                        "label": t("gateway.fast.choice_fast"),
-                        "is_current": is_fast,
-                    },
-                    {
-                        "value": "normal",
-                        "label": t("gateway.fast.choice_normal"),
-                        "is_current": not is_fast,
-                    },
-                ],
-                on_choice_selected=_on_fast_choice,
+            state = t(
+                "gateway.fast.state_on" if is_fast else "gateway.fast.state_off"
             )
-            if picker_sent:
-                return None  # Picker sent — adapter handles the response
 
-            return t("gateway.fast.status", mode=status)
+            # Only offer the picker on a route that can actually take the
+            # toggle; otherwise the tap would be refused after the fact.
+            if capability.supported:
+                status = (
+                    t("gateway.fast.status_fast")
+                    if is_fast
+                    else t("gateway.fast.status_normal")
+                )
+
+                async def _on_fast_choice(_chat_id: str, value: str) -> str:
+                    return _apply_fast_selection(value, persist=persist_global)
+
+                picker_sent = await self._try_send_choice_picker(
+                    event,
+                    session_key,
+                    title=t("gateway.fast.picker_title", mode=status),
+                    choices=[
+                        {
+                            "value": "fast",
+                            "label": t("gateway.fast.choice_fast"),
+                            "is_current": is_fast,
+                        },
+                        {
+                            "value": "normal",
+                            "label": t("gateway.fast.choice_normal"),
+                            "is_current": not is_fast,
+                        },
+                    ],
+                    on_choice_selected=_on_fast_choice,
+                )
+                if picker_sent:
+                    return None  # Picker sent — adapter handles the response
+
+                return t(
+                    "gateway.fast.route_status",
+                    state=state,
+                    family=family_label,
+                    route=route,
+                )
+
+            return t("gateway.fast.route_off", reason=capability.reason)
 
         return _apply_fast_selection(args, persist=persist_global)
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -292,11 +292,16 @@ class CLIAgentSetupMixin:
         """Build the effective model/runtime config for a single user turn.
 
         Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        toggled `/fast` on and the *resolved route* (model + provider +
+        api_mode) has a documented fast contract, attach `request_overrides`
+        so the API call is marked accordingly.
+
+        Route-aware rather than model-only: the parameter that carries fast
+        mode is wire-specific (``speed`` on Anthropic Messages,
+        ``service_tier`` on OpenAI/xAI), so the same model reached over a
+        different transport may take a different key or none at all.
         """
-        from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.models import resolve_fast_mode_capability
 
         runtime = {
             "api_key": self.api_key,
@@ -330,10 +335,14 @@ class CLIAgentSetupMixin:
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_capability(
+                model=route["model"],
+                provider=runtime["provider"],
+                api_mode=runtime["api_mode"],
+            ).request_overrides
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides
+        route["request_overrides"] = overrides or None
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:

--- a/hermes_cli/fast_mode_contracts.py
+++ b/hermes_cli/fast_mode_contracts.py
@@ -1,0 +1,145 @@
+"""Exact, dated wire contracts for provider fast-mode features.
+
+``/fast`` maps onto several *different* vendor features that share one name in
+the UI:
+
+- OpenAI API **Priority Processing** — ``service_tier="priority"`` on the
+  direct OpenAI API.
+- **Codex Fast** — ``service_tier="fast"`` on the Codex Responses backend.
+- Anthropic **Fast Mode** — ``speed="fast"`` plus the ``fast-mode-*`` beta
+  header on the native Messages API.
+- xAI **Priority Processing** — ``service_tier="priority"`` on Grok 4.6.
+
+Each key is only valid on its own wire: ``speed`` is an Anthropic Messages
+parameter, ``service_tier`` an OpenAI/xAI one. The *model id alone* therefore
+cannot decide what a fast toggle may put on the request — the same
+``claude-opus-4-6`` reached through an OpenAI-compatible proxy speaks a wire
+that has no ``speed`` parameter at all.
+
+This module holds the parts of that answer which are **exact, dated
+allowlists**: the vendor contracts where sending the parameter to a
+neighbouring model in the same family is a hard 4xx rather than a no-op. The
+route table that maps ``(provider, api_mode)`` onto a family lives in
+``hermes_cli.models`` next to the existing model gates.
+
+It is deliberately dependency-free (no imports from ``hermes_cli`` or
+``agent``) so both the model resolver and the transport adapters can consume
+the same immutable catalog without creating an import cycle.
+
+Refreshing a contract is a one-file edit: update ``models`` and bump
+``checked_date``.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+
+
+# Snapshot of https://openai.com/api-priority-processing/ on 2026-07-12.
+#
+# Informational: the OpenAI Priority gate in ``hermes_cli.models`` is
+# deliberately *pattern* based, because ``service_tier`` is silently ignored
+# rather than rejected by endpoints that do not offer it, and a too-narrow
+# list would hide the toggle from a newly released flagship. This snapshot is
+# kept so that choice can be audited against what the vendor actually
+# published on a known date.
+OPENAI_PRIORITY_SOURCE_MODELS: tuple[str, ...] = (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4-mini",
+    "gpt-5.4",
+    "gpt-5.2",
+    "gpt-5.1",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1-codex",
+    "gpt-5-codex",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "gpt-4o",
+    "gpt-4o-2024-11-20",
+    "gpt-4o-2024-08-06",
+    "gpt-4o-2024-05-13",
+    "gpt-4o-mini",
+    "o3",
+    "o4-mini",
+)
+
+
+def _contract(*, source_url: str, checked_date: str, models: tuple[str, ...]):
+    return MappingProxyType(
+        {
+            "source_url": source_url,
+            "checked_date": checked_date,
+            "models": models,
+        }
+    )
+
+
+#: Families gated by an exact, dated allowlist. ``models`` holds normalized ids
+#: (see :func:`normalize_fast_model_id`) and is matched exactly — never by
+#: prefix — because both vendors ship neighbouring ids in the same family that
+#: reject the parameter outright.
+FAST_MODE_CAPABILITY_CATALOG: Mapping[str, Mapping[str, Any]] = MappingProxyType(
+    {
+        "codex_fast": _contract(
+            source_url="https://developers.openai.com/codex/speed",
+            checked_date="2026-07-12",
+            models=("gpt-5.5", "gpt-5.4"),
+        ),
+        # Anthropic's Fast Mode contract is version-pinned: ``speed="fast"`` is
+        # a hard 400 on every model not listed here (Opus 4.7 included), so
+        # this must stay an allowlist rather than a ``claude-*`` prefix match.
+        "anthropic_fast": _contract(
+            source_url=(
+                "https://platform.claude.com/docs/en/build-with-claude/fast-mode"
+            ),
+            checked_date="2026-07-12",
+            models=("claude-opus-4-6",),
+        ),
+    }
+)
+
+#: Families billed above the standard tier. Every shipped family is a paid
+#: upgrade today; the constant exists so surfaces can say so without
+#: re-deriving the set, and so a future free tier is a one-line edit.
+BILLED_AT_PREMIUM: frozenset[str] = frozenset(
+    {"openai_priority", "codex_fast", "anthropic_fast", "xai_priority"}
+)
+
+
+def normalize_fast_model_id(model_id: Optional[str]) -> str:
+    """Normalize documented spelling aliases only; retain all other suffixes.
+
+    Vendor prefixes (``anthropic/``, ``openai/``) and the two documented
+    dot/dash spellings of the Opus id are folded. Everything else — dated
+    snapshots, ``:free`` suffixes, proxy-mangled ids — is left intact so it
+    fails the exact-match gate rather than being coerced into a contract that
+    never covered it.
+    """
+    normalized = str(model_id or "").strip().lower()
+    if normalized.startswith(("anthropic/", "openai/")):
+        normalized = normalized.split("/", 1)[1]
+    if normalized == "claude-opus-4.6":
+        return "claude-opus-4-6"
+    return normalized
+
+
+def anthropic_fast_contract_accepts(model_id: Optional[str]) -> bool:
+    """Return whether *model_id* exactly matches the native Anthropic contract."""
+    return (
+        normalize_fast_model_id(model_id)
+        in FAST_MODE_CAPABILITY_CATALOG["anthropic_fast"]["models"]
+    )
+
+
+def codex_fast_contract_accepts(model_id: Optional[str]) -> bool:
+    """Return whether *model_id* exactly matches the Codex Fast contract."""
+    return (
+        normalize_fast_model_id(model_id)
+        in FAST_MODE_CAPABILITY_CATALOG["codex_fast"]["models"]
+    )

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -437,8 +437,15 @@ def _reasoning_catalog_reader(slug: str):
 def _apply_capabilities(rows: list[dict]) -> None:
     """Attach a ``{model: {fast, reasoning, ...}}`` map to each provider row.
 
-    `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
-    enforces). `reasoning` comes from the models.dev catalog when known and
+    `fast` mirrors the runtime's own route-aware gate: the picker row is keyed
+    by the provider serving the model, so it can ask the same
+    ``(model, provider, api_mode)`` question the request builder asks and never
+    advertise a toggle that the turn path would then decline to send. This is
+    why a Claude model listed under a routing proxy shows `fast: false` while
+    the same id under `anthropic` shows true — the proxy route has no `speed`
+    parameter to carry it.
+
+    `reasoning` comes from the models.dev catalog when known and
     defaults to True otherwise — the effort dial is broadly accepted and a
     no-op on models that ignore it, whereas hiding it from a capable-but-
     uncatalogued model is the worse failure.
@@ -457,7 +464,8 @@ def _apply_capabilities(rows: list[dict]) -> None:
     ``minimal`` at its lowest thinking), so filtering the picker by that list
     would hide levels that demonstrably work.
     """
-    from hermes_cli.models import model_supports_fast_mode
+    from hermes_cli.models import resolve_fast_mode_capability
+    from hermes_cli.providers import determine_api_mode
 
     try:
         from agent.models_dev import get_model_capabilities
@@ -468,6 +476,13 @@ def _apply_capabilities(rows: list[dict]) -> None:
         slug = row.get("slug") or ""
         caps: dict[str, dict[str, Any]] = {}
         read_reasoning_catalog = _reasoning_catalog_reader(slug.lower())
+        # Provider-only derivation: the inventory has no endpoint context, and
+        # a row's slug is exactly the provider that would serve every model in
+        # it, so this is the same route the runtime resolves for these models.
+        try:
+            row_api_mode = determine_api_mode(slug)
+        except Exception:
+            row_api_mode = ""
 
         for model in row.get("models") or []:
             reasoning = True
@@ -480,7 +495,11 @@ def _apply_capabilities(rows: list[dict]) -> None:
                     reasoning = True
 
             entry: dict[str, Any] = {
-                "fast": bool(model_supports_fast_mode(model)),
+                "fast": resolve_fast_mode_capability(
+                    model=model,
+                    provider=slug,
+                    api_mode=row_api_mode,
+                ).supported,
                 "reasoning": reasoning,
             }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -18,14 +18,21 @@ import urllib.parse
 import urllib.request
 import urllib.error
 import time
+from dataclasses import dataclass
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any, NamedTuple, Optional, TYPE_CHECKING
+from typing import Any, Literal, NamedTuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import TypeGuard
 
 from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.fast_mode_contracts import (
+    FAST_MODE_CAPABILITY_CATALOG,
+    anthropic_fast_contract_accepts,
+    codex_fast_contract_accepts,
+    normalize_fast_model_id,
+)
 from hermes_cli.urllib_security import open_credentialed_url, url_origin
 from utils import atomic_json_write, base_url_host_matches
 
@@ -3787,12 +3794,222 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     The overrides are injected into the API request kwargs by
     ``_build_api_kwargs`` in run_agent.py — each API path handles its own
     keys (service_tier for OpenAI/Codex, speed for Anthropic Messages).
+
+    .. note::
+       This is the model-only gate. It cannot see which wire the model is
+       reached over, so it answers for the model's *native* route. Callers
+       that know the resolved provider/api_mode should prefer
+       :func:`resolve_fast_mode_capability`, which additionally refuses to
+       emit an Anthropic ``speed`` key onto an OpenAI-compatible proxy route
+       (and vice versa). Kept as the compatibility surface for callers that
+       genuinely only have a model id.
     """
     if not model_supports_fast_mode(model_id):
         return None
     if _is_anthropic_fast_model(model_id):
         return {"speed": "fast"}
     return {"service_tier": "priority"}
+
+
+# ── Route-aware fast-mode capability ──────────────────────────────────
+#
+# ``resolve_fast_mode_overrides`` above answers "does this MODEL have a fast
+# offering", which is the right question for a model picker and an incomplete
+# one for a request builder, because the parameter that carries fast mode is
+# wire-specific:
+#
+#   service_tier=priority  OpenAI-compatible wires (chat completions/responses)
+#   service_tier=fast      Codex Responses subscription backend
+#   speed=fast             Anthropic Messages    (+ fast-mode beta header)
+#
+# The two ``service_tier`` cases are safe to be generous with: endpoints that
+# do not sell the tier ignore the field rather than rejecting it, so a false
+# positive costs nothing and a too-narrow gate would hide the toggle from a
+# newly released flagship. ``speed`` is the opposite — it is an Anthropic
+# Messages parameter, so on any other wire it is an unknown argument, and even
+# on Anthropic it is a hard 400 outside the dated contract.
+#
+# Resolving from the full ``(model, provider, api_mode)`` route lets each
+# family keep the gate that matches its failure mode, and gives the command
+# surface, the picker inventory and the request builder one shared answer.
+
+#: Config surfaces name a model before its transport is necessarily pinned:
+#: ``model.provider`` may be absent or still ``auto``. That is not the same as
+#: naming a *wrong* provider and must not fail closed, or ``/fast`` would
+#: vanish from a default config whose model genuinely supports it.
+_UNRESOLVED_PROVIDERS: frozenset[str] = frozenset({"", "auto"})
+
+#: Wires that carry an OpenAI-style ``service_tier`` field.
+_SERVICE_TIER_API_MODES: frozenset[str] = frozenset(
+    {"chat_completions", "codex_responses"}
+)
+
+
+@dataclass(frozen=True)
+class FastModeCapability:
+    """The single resolved answer for one route's fast-mode support.
+
+    ``request_overrides`` is the *only* thing that may reach the wire, and it
+    is empty whenever ``supported`` is False — so a caller cannot accidentally
+    ship a parameter whose gate said no. ``reason`` is a human sentence naming
+    the route, for the surface that has to explain the refusal.
+    """
+
+    supported: bool
+    family: Literal[
+        "openai_priority",
+        "codex_fast",
+        "anthropic_fast",
+        "unsupported",
+    ]
+    request_overrides: dict[str, Any]
+    reason: Optional[str] = None
+
+
+def _fast_route_label(provider: Optional[str], model: Optional[str]) -> str:
+    resolved_provider = normalize_provider(str(provider or "")) or "<unknown>"
+    return f"{resolved_provider}/{normalize_fast_model_id(model) or '<unset>'}"
+
+
+def resolve_fast_mode_capability(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    api_mode: Optional[str],
+) -> FastModeCapability:
+    """Resolve fast-mode support from the complete transport contract.
+
+    One result shared by the command UX, the picker inventory and request
+    construction, so support, explanation and serialized overrides cannot
+    drift apart.
+
+    The per-family gates differ on purpose, matching how each vendor fails:
+
+    * **Anthropic Fast Mode** requires the *native Messages* route and an
+      exact model from the dated contract. ``speed`` does not exist on other
+      wires and is a 400 on other Claude models, so this fails closed.
+    * **Codex Fast** requires the Codex Responses backend and an exact model
+      from its (much shorter) contract, because it is a different tier value
+      from the OpenAI API's.
+    * **OpenAI Priority Processing** keeps the permissive pattern gate on any
+      OpenAI-style wire: the field is ignored rather than rejected by
+      endpoints that don't sell it, so breadth is free and a narrow list would
+      hide the toggle from new flagships.
+    """
+    normalized_provider = normalize_provider(str(provider or ""))
+    normalized_mode = str(api_mode or "").strip().lower()
+    route = _fast_route_label(provider, model)
+
+    # ── Anthropic Fast Mode: native Messages wire only, exact contract ─
+    if normalized_mode == "anthropic_messages":
+        supported = normalized_provider == "anthropic" and (
+            anthropic_fast_contract_accepts(model)
+        )
+        if supported:
+            reason = None
+        elif normalized_provider != "anthropic":
+            reason = (
+                f"Anthropic Fast Mode is only available on the native "
+                f"Anthropic endpoint; `{route}` is served by a third party "
+                "that would reject the fast-mode beta."
+            )
+        else:
+            reason = (
+                f"Anthropic Fast Mode (`speed=fast`) is not documented for "
+                f"`{route}`; other Claude models reject the parameter."
+            )
+        return FastModeCapability(
+            supported=supported,
+            family="anthropic_fast",
+            request_overrides={"speed": "fast"} if supported else {},
+            reason=reason,
+        )
+
+    # ── Codex Fast: the Codex Responses subscription backend ──────────
+    # A distinct tier VALUE ("fast", not "priority"), so it must be matched
+    # before the generic OpenAI branch below.
+    if normalized_provider == "openai-codex" and normalized_mode == "codex_responses":
+        supported = codex_fast_contract_accepts(model)
+        listed = ", ".join(FAST_MODE_CAPABILITY_CATALOG["codex_fast"]["models"])
+        return FastModeCapability(
+            supported=supported,
+            family="codex_fast",
+            request_overrides={"service_tier": "fast"} if supported else {},
+            reason=None
+            if supported
+            else f"Codex Fast is not available for `{route}` (currently {listed}).",
+        )
+
+    # ── OpenAI-style Priority Processing ──────────────────────────────
+    # Deliberately permissive: ``service_tier`` is ignored rather than
+    # rejected by endpoints that do not sell a priority tier, so this keeps
+    # the existing pattern gate and stays available through proxies.
+    if normalized_mode in _SERVICE_TIER_API_MODES or not normalized_mode:
+        from agent.model_metadata import is_grok_46_family
+
+        supported = _is_openai_fast_model(model) or is_grok_46_family(
+            str(model or "")
+        )
+        return FastModeCapability(
+            supported=supported,
+            family="openai_priority",
+            request_overrides={"service_tier": "priority"} if supported else {},
+            reason=None
+            if supported
+            else (
+                f"Priority Processing is not offered for `{route}`; requests "
+                "will use normal speed."
+            ),
+        )
+
+    return FastModeCapability(
+        supported=False,
+        family="unsupported",
+        request_overrides={},
+        reason=(
+            f"`{route}` with API mode `{normalized_mode or '<unset>'}` does not "
+            "declare a supported fast contract; requests will use normal speed."
+        ),
+    )
+
+
+def _native_fast_route(model_id: Optional[str]) -> Optional[tuple[str, str]]:
+    """Return the ``(provider, api_mode)`` whose contract documents fast for a model."""
+    if not normalize_fast_model_id(model_id):
+        return None
+    if anthropic_fast_contract_accepts(model_id):
+        return "anthropic", "anthropic_messages"
+    if model_supports_fast_mode(model_id):
+        return "openai-api", "chat_completions"
+    return None
+
+
+def resolve_fast_mode_capability_for_configured_route(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    api_mode: Optional[str],
+) -> FastModeCapability:
+    """Resolve fast support for a configured route whose provider may be unpinned.
+
+    A concrete provider resolves through the full route contract unchanged. An
+    unresolved one (absent, or still ``auto``) resolves against the model's own
+    documented native route — which is exactly the answer a model-only gate
+    reports, and the one a config surface means when it names a model without
+    having pinned its transport yet.
+    """
+    if str(provider or "").strip().lower() not in _UNRESOLVED_PROVIDERS:
+        return resolve_fast_mode_capability(
+            model=model, provider=provider, api_mode=api_mode
+        )
+    native = _native_fast_route(model)
+    if native is None:
+        return resolve_fast_mode_capability(
+            model=model, provider=provider, api_mode=api_mode
+        )
+    return resolve_fast_mode_capability(
+        model=model, provider=native[0], api_mode=native[1]
+    )
 
 
 def _resolve_copilot_catalog_api_key() -> str:

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nHuidige modus: `{mode}`\\n\\nKies \\'n opsie:"
     choice_fast:           "fast — Priority Processing aan"
     choice_normal:         "normal — standaardverwerking"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Vinnige modus"
+    state_on:              "aan"
+    state_off:             "af"
+    route_status:          "⚡ Fast: {state} — {family} op `{route}`"
+    route_off:             "⚡ Fast: af — {reason}"
+    route_unavailable:     "⚡ Fast nie beskikbaar nie — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (gestoor in konfigurasie)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (slegs hierdie sessie)"
 
   footer:
     status:                "📎 Looptyd-voetstuk: **{state}**\nVelde: `{fields}`\nPlatform: `{platform}`"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -160,6 +160,17 @@ gateway:
     picker_title:          "⚡ **المعالجة ذات الأولوية**\n\nالوضع الحالي: `{mode}`\n\nاختر خيارًا:"
     choice_fast:           "fast — المعالجة ذات الأولوية مُفعّلة"
     choice_normal:         "normal — المعالجة القياسية"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "الوضع السريع"
+    state_on:              "مُفعّل"
+    state_off:             "مُعطّل"
+    route_status:          "⚡ Fast: {state} — {family} على `{route}`"
+    route_off:             "⚡ Fast: مُعطّل — {reason}"
+    route_unavailable:     "⚡ Fast غير متاح — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (حُفظت في الإعدادات)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (هذه الجلسة فقط)"
 
   footer:
     status:                "📎 تذييل التشغيل: **{state}**\nالحقول: `{fields}`\nالمنصّة: `{platform}`"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nAktueller Modus: `{mode}`\\n\\nOption wählen:"
     choice_fast:           "fast — Priority Processing an"
     choice_normal:         "normal — Standardverarbeitung"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Schnellmodus"
+    state_on:              "an"
+    state_off:             "aus"
+    route_status:          "⚡ Fast: {state} — {family} auf `{route}`"
+    route_off:             "⚡ Fast: aus — {reason}"
+    route_unavailable:     "⚡ Fast nicht verfügbar — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (in Konfiguration gespeichert)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (nur diese Sitzung)"
 
   footer:
     status:                "📎 Laufzeit-Fußzeile: **{state}**\nFelder: `{fields}`\nPlattform: `{platform}`"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -152,6 +152,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\n\nCurrent mode: `{mode}`\n\nPick an option:"
     choice_fast:           "fast — Priority Processing on"
     choice_normal:         "normal — standard processing"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Fast mode"
+    state_on:              "on"
+    state_off:             "off"
+    route_status:          "⚡ Fast: {state} — {family} on `{route}`"
+    route_off:             "⚡ Fast: off — {reason}"
+    route_unavailable:     "⚡ Fast unavailable — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (saved to config)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (this session only)"
 
   footer:
     status:                "📎 Runtime footer: **{state}**\nFields: `{fields}`\nPlatform: `{platform}`"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nModo actual: `{mode}`\\n\\nElige una opción:"
     choice_fast:           "fast — Priority Processing activado"
     choice_normal:         "normal — procesamiento estándar"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Modo rápido"
+    state_on:              "activado"
+    state_off:             "desactivado"
+    route_status:          "⚡ Fast: {state} — {family} en `{route}`"
+    route_off:             "⚡ Fast: desactivado — {reason}"
+    route_unavailable:     "⚡ Fast no disponible — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (guardado en la configuración)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (solo esta sesión)"
 
   footer:
     status:                "📎 Pie de ejecución: **{state}**\nCampos: `{fields}`\nPlataforma: `{platform}`"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nMode actuel : `{mode}`\\n\\nChoisissez une option :"
     choice_fast:           "fast — Priority Processing activé"
     choice_normal:         "normal — traitement standard"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Mode rapide"
+    state_on:              "activé"
+    state_off:             "désactivé"
+    route_status:          "⚡ Fast : {state} — {family} sur `{route}`"
+    route_off:             "⚡ Fast : désactivé — {reason}"
+    route_unavailable:     "⚡ Fast indisponible — {reason}"
+    route_saved:           "⚡ ✓ {family} : **{label}** (enregistré dans la configuration)"
+    route_session_only:    "⚡ ✓ {family} : **{label}** (cette session uniquement)"
 
   footer:
     status:                "📎 Pied de page d'exécution : **{state}**\nChamps : `{fields}`\nPlateforme : `{platform}`"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -141,6 +141,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nMód reatha: `{mode}`\\n\\nRoghnaigh rogha:"
     choice_fast:           "fast — Priority Processing ar siúl"
     choice_normal:         "normal — gnáthphróiseáil"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Mód tapa"
+    state_on:              "ann"
+    state_off:             "as"
+    route_status:          "⚡ Fast: {state} — {family} ar `{route}`"
+    route_off:             "⚡ Fast: as — {reason}"
+    route_unavailable:     "⚡ Níl Fast ar fáil — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (sábháilte sa chumraíocht)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (an seisiún seo amháin)"
 
   footer:
     status:                "📎 Buntásc rite: **{state}**\nRéimsí: `{fields}`\nArdán: `{platform}`"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nJelenlegi mód: `{mode}`\\n\\nVálassz egy opciót:"
     choice_fast:           "fast — Priority Processing bekapcsolva"
     choice_normal:         "normal — normál feldolgozás"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Gyors mód"
+    state_on:              "be"
+    state_off:             "ki"
+    route_status:          "⚡ Fast: {state} — {family} ezen az útvonalon: `{route}`"
+    route_off:             "⚡ Fast: ki — {reason}"
+    route_unavailable:     "⚡ A Fast nem érhető el — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (mentve a konfigurációba)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (csak ebben a munkamenetben)"
 
   footer:
     status:                "📎 Futási idejű lábléc: **{state}**\nMezők: `{fields}`\nPlatform: `{platform}`"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nModalità attuale: `{mode}`\\n\\nScegli un\\'opzione:"
     choice_fast:           "fast — Priority Processing attivo"
     choice_normal:         "normal — elaborazione standard"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Modalità rapida"
+    state_on:              "attivo"
+    state_off:             "disattivato"
+    route_status:          "⚡ Fast: {state} — {family} su `{route}`"
+    route_off:             "⚡ Fast: disattivato — {reason}"
+    route_unavailable:     "⚡ Fast non disponibile — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (salvato nella configurazione)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (solo per questa sessione)"
 
   footer:
     status:                "📎 Footer di runtime: **{state}**\nCampi: `{fields}`\nPiattaforma: `{platform}`"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\n現在のモード: `{mode}`\\n\\nオプションを選択:"
     choice_fast:           "fast — Priority Processing オン"
     choice_normal:         "normal — 標準処理"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "高速モード"
+    state_on:              "オン"
+    state_off:             "オフ"
+    route_status:          "⚡ Fast: {state} — `{route}` で {family}"
+    route_off:             "⚡ Fast: オフ — {reason}"
+    route_unavailable:     "⚡ Fast は利用できません — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (設定に保存しました)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (このセッションのみ)"
 
   footer:
     status:                "📎 ランタイムフッター: **{state}**\nフィールド: `{fields}`\nプラットフォーム: `{platform}`"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\n현재 모드: `{mode}`\\n\\n옵션을 선택하세요:"
     choice_fast:           "fast — Priority Processing 켜기"
     choice_normal:         "normal — 표준 처리"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "빠른 모드"
+    state_on:              "켜짐"
+    state_off:             "꺼짐"
+    route_status:          "⚡ Fast: {state} — `{route}`에서 {family}"
+    route_off:             "⚡ Fast: 꺼짐 — {reason}"
+    route_unavailable:     "⚡ Fast 사용 불가 — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (설정에 저장됨)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (이 세션에만 적용)"
 
   footer:
     status:                "📎 런타임 푸터: **{state}**\n필드: `{fields}`\n플랫폼: `{platform}`"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nModo atual: `{mode}`\\n\\nEscolha uma opção:"
     choice_fast:           "fast — Priority Processing ativado"
     choice_normal:         "normal — processamento padrão"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Modo rápido"
+    state_on:              "ativado"
+    state_off:             "desativado"
+    route_status:          "⚡ Fast: {state} — {family} em `{route}`"
+    route_off:             "⚡ Fast: desativado — {reason}"
+    route_unavailable:     "⚡ Fast indisponível — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (guardado na configuração)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (apenas esta sessão)"
 
   footer:
     status:                "📎 Rodapé de execução: **{state}**\nCampos: `{fields}`\nPlataforma: `{platform}`"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nТекущий режим: `{mode}`\\n\\nВыберите вариант:"
     choice_fast:           "fast — Priority Processing включён"
     choice_normal:         "normal — стандартная обработка"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Быстрый режим"
+    state_on:              "включено"
+    state_off:             "выключено"
+    route_status:          "⚡ Fast: {state} — {family} на `{route}`"
+    route_off:             "⚡ Fast: выключено — {reason}"
+    route_unavailable:     "⚡ Fast недоступен — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (сохранено в конфигурации)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (только этот сеанс)"
 
   footer:
     status:                "📎 Нижний колонтитул среды выполнения: **{state}**\nПоля: `{fields}`\nПлатформа: `{platform}`"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nMevcut mod: `{mode}`\\n\\nBir seçenek seçin:"
     choice_fast:           "fast — Priority Processing açık"
     choice_normal:         "normal — standart işleme"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Hızlı mod"
+    state_on:              "açık"
+    state_off:             "kapalı"
+    route_status:          "⚡ Fast: {state} — `{route}` üzerinde {family}"
+    route_off:             "⚡ Fast: kapalı — {reason}"
+    route_unavailable:     "⚡ Fast kullanılamıyor — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (yapılandırmaya kaydedildi)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (yalnızca bu oturum)"
 
   footer:
     status:                "📎 Çalışma zamanı altbilgisi: **{state}**\nAlanlar: `{fields}`\nPlatform: `{platform}`"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\nПоточний режим: `{mode}`\\n\\nОберіть варіант:"
     choice_fast:           "fast — Priority Processing увімкнено"
     choice_normal:         "normal — стандартна обробка"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "Швидкий режим"
+    state_on:              "увімкнено"
+    state_off:             "вимкнено"
+    route_status:          "⚡ Fast: {state} — {family} на `{route}`"
+    route_off:             "⚡ Fast: вимкнено — {reason}"
+    route_unavailable:     "⚡ Fast недоступний — {reason}"
+    route_saved:           "⚡ ✓ {family}: **{label}** (збережено в конфігурації)"
+    route_session_only:    "⚡ ✓ {family}: **{label}** (лише ця сесія)"
 
   footer:
     status:                "📎 Нижній колонтитул середовища: **{state}**\nПоля: `{fields}`\nПлатформа: `{platform}`"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **Priority Processing**\\n\\n目前模式：`{mode}`\\n\\n請選擇："
     choice_fast:           "fast — 開啟 Priority Processing"
     choice_normal:         "normal — 標準處理"
+    family_openai_priority: "OpenAI API Priority Processing"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic Fast Mode"
+    family_unsupported:    "快速模式"
+    state_on:              "開啟"
+    state_off:             "關閉"
+    route_status:          "⚡ Fast：{state} — {family}，路由 `{route}`"
+    route_off:             "⚡ Fast：關閉 — {reason}"
+    route_unavailable:     "⚡ Fast 無法使用 — {reason}"
+    route_saved:           "⚡ ✓ {family}：**{label}**（已儲存到設定）"
+    route_session_only:    "⚡ ✓ {family}：**{label}**（僅本次工作階段）"
 
   footer:
     status:                "📎 執行階段頁尾：**{state}**\n欄位：`{fields}`\n平台：`{platform}`"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -137,6 +137,17 @@ gateway:
     picker_title:          "⚡ **优先处理**\\n\\n当前模式：`{mode}`\\n\\n请选择："
     choice_fast:           "fast — 开启优先处理"
     choice_normal:         "normal — 标准处理"
+    family_openai_priority: "OpenAI API 优先处理"
+    family_codex_fast:     "Codex Fast"
+    family_anthropic_fast: "Anthropic 快速模式"
+    family_unsupported:    "快速模式"
+    state_on:              "开启"
+    state_off:             "关闭"
+    route_status:          "⚡ Fast：{state} — {family}，路由 `{route}`"
+    route_off:             "⚡ Fast：关闭 — {reason}"
+    route_unavailable:     "⚡ Fast 不可用 — {reason}"
+    route_saved:           "⚡ ✓ {family}：**{label}**（已保存到配置）"
+    route_session_only:    "⚡ ✓ {family}：**{label}**（仅本次会话）"
 
   footer:
     status:                "📎 运行时页脚：**{state}**\n字段：`{fields}`\n平台：`{platform}`"

--- a/tests/cli/test_fast_route_capability.py
+++ b/tests/cli/test_fast_route_capability.py
@@ -1,0 +1,255 @@
+"""Route-aware fast-mode capability resolution.
+
+These tests pin the property the model-only gate cannot express: fast mode is
+carried by a *wire-specific* request parameter. ``service_tier`` is an
+OpenAI-style field that endpoints ignore when they do not sell the tier, so
+breadth there is free. ``speed`` is an Anthropic Messages parameter — on any
+other wire it is an unknown argument, and even on Anthropic it is a hard 400
+outside the dated contract — so it must be gated on the resolved route rather
+than on the model id alone.
+"""
+
+import pytest
+
+from hermes_cli.fast_mode_contracts import (
+    FAST_MODE_CAPABILITY_CATALOG,
+    anthropic_fast_contract_accepts,
+    codex_fast_contract_accepts,
+    normalize_fast_model_id,
+)
+from hermes_cli.models import (
+    resolve_fast_mode_capability,
+    resolve_fast_mode_capability_for_configured_route,
+    resolve_fast_mode_overrides,
+)
+
+
+class TestAnthropicSpeedIsRouteGated:
+    """`speed=fast` may only be emitted on the native Anthropic Messages wire."""
+
+    def test_native_anthropic_route_emits_speed(self):
+        cap = resolve_fast_mode_capability(
+            model="claude-opus-4-6",
+            provider="anthropic",
+            api_mode="anthropic_messages",
+        )
+        assert cap.supported is True
+        assert cap.family == "anthropic_fast"
+        assert cap.request_overrides == {"speed": "fast"}
+
+    def test_third_party_anthropic_messages_route_emits_nothing(self):
+        """A proxy speaking Messages would reject the fast-mode beta header.
+
+        The model-only gate answers ``{"speed": "fast"}`` here, which is what
+        the adapter then has to defensively strip.
+        """
+        assert resolve_fast_mode_overrides("claude-opus-4-6") == {"speed": "fast"}
+
+        cap = resolve_fast_mode_capability(
+            model="claude-opus-4-6",
+            provider="openrouter",
+            api_mode="anthropic_messages",
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+        assert "native" in (cap.reason or "")
+
+    def test_anthropic_model_on_openai_style_wire_never_emits_speed(self):
+        """`speed` is not a field on an OpenAI-compatible wire at all."""
+        cap = resolve_fast_mode_capability(
+            model="claude-opus-4-6",
+            provider="openrouter",
+            api_mode="chat_completions",
+        )
+        assert "speed" not in cap.request_overrides
+
+    def test_off_contract_claude_emits_nothing_on_native_route(self):
+        """Opus 4.7 rejects `speed=fast` with a 400; it must not be sent."""
+        cap = resolve_fast_mode_capability(
+            model="claude-opus-4-7",
+            provider="anthropic",
+            api_mode="anthropic_messages",
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+
+
+class TestCodexFastIsADistinctTierValue:
+    """The Codex backend sells `fast`, not `priority` — a different value."""
+
+    def test_codex_backend_emits_service_tier_fast(self):
+        cap = resolve_fast_mode_capability(
+            model="gpt-5.4", provider="openai-codex", api_mode="codex_responses"
+        )
+        assert cap.supported is True
+        assert cap.family == "codex_fast"
+        assert cap.request_overrides == {"service_tier": "fast"}
+
+    def test_same_model_on_openai_api_emits_priority_instead(self):
+        """Identical model id, different backend, different tier value."""
+        codex = resolve_fast_mode_capability(
+            model="gpt-5.4", provider="openai-codex", api_mode="codex_responses"
+        )
+        openai_api = resolve_fast_mode_capability(
+            model="gpt-5.4", provider="openai-api", api_mode="chat_completions"
+        )
+        assert codex.supported and openai_api.supported
+        assert codex.request_overrides == {"service_tier": "fast"}
+        assert openai_api.request_overrides == {"service_tier": "priority"}
+        assert codex.request_overrides != openai_api.request_overrides
+
+    def test_codex_series_model_off_contract_emits_nothing(self):
+        cap = resolve_fast_mode_capability(
+            model="gpt-5-codex",
+            provider="openai-codex",
+            api_mode="codex_responses",
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+
+
+class TestPriorityProcessingStaysPermissive:
+    """`service_tier` is ignored, not rejected — breadth here is deliberate."""
+
+    def test_openai_flagship_through_a_proxy_still_supported(self):
+        cap = resolve_fast_mode_capability(
+            model="gpt-5.4", provider="openrouter", api_mode="chat_completions"
+        )
+        assert cap.supported is True
+        assert cap.request_overrides == {"service_tier": "priority"}
+
+    def test_grok_46_supported_on_openai_style_wire(self):
+        cap = resolve_fast_mode_capability(
+            model="grok-4.6", provider="xai", api_mode="chat_completions"
+        )
+        assert cap.supported is True
+        assert cap.request_overrides == {"service_tier": "priority"}
+
+    def test_non_flagship_model_emits_nothing(self):
+        cap = resolve_fast_mode_capability(
+            model="some-random-model",
+            provider="openrouter",
+            api_mode="chat_completions",
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+
+
+class TestUnsupportedNeverCarriesOverrides:
+    @pytest.mark.parametrize(
+        "model,provider,api_mode",
+        [
+            ("claude-opus-4-6", "openrouter", "anthropic_messages"),
+            ("claude-opus-4-7", "anthropic", "anthropic_messages"),
+            ("gpt-5-codex", "openai-codex", "codex_responses"),
+            ("some-random-model", "openrouter", "chat_completions"),
+            ("gpt-5.4", "bedrock", "converse"),
+            ("", "", ""),
+        ],
+    )
+    def test_structural_invariant(self, model, provider, api_mode):
+        """not supported => nothing may reach the wire, for every route."""
+        cap = resolve_fast_mode_capability(
+            model=model, provider=provider, api_mode=api_mode
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+
+    def test_refusals_name_the_route(self):
+        cap = resolve_fast_mode_capability(
+            model="claude-opus-4-7",
+            provider="anthropic",
+            api_mode="anthropic_messages",
+        )
+        assert cap.reason
+        assert "claude-opus-4-7" in cap.reason
+
+
+class TestUnpinnedProviderDoesNotHideFast:
+    """`auto`/absent provider must not be treated as a WRONG provider."""
+
+    @pytest.mark.parametrize(
+        "model,expected_family,expected_overrides",
+        [
+            ("claude-opus-4-6", "anthropic_fast", {"speed": "fast"}),
+            ("gpt-5.4", "openai_priority", {"service_tier": "priority"}),
+            ("grok-4.6", "openai_priority", {"service_tier": "priority"}),
+        ],
+    )
+    def test_auto_provider_resolves_native_route(
+        self, model, expected_family, expected_overrides
+    ):
+        cap = resolve_fast_mode_capability_for_configured_route(
+            model=model, provider="auto", api_mode=""
+        )
+        assert cap.supported is True
+        assert cap.family == expected_family
+        assert cap.request_overrides == expected_overrides
+
+    def test_empty_provider_resolves_native_route(self):
+        cap = resolve_fast_mode_capability_for_configured_route(
+            model="claude-opus-4-6", provider=None, api_mode=None
+        )
+        assert cap.supported is True
+        assert cap.request_overrides == {"speed": "fast"}
+
+    def test_auto_provider_still_says_no_for_uncovered_model(self):
+        cap = resolve_fast_mode_capability_for_configured_route(
+            model="claude-opus-4-7", provider="auto", api_mode=""
+        )
+        assert cap.supported is False
+        assert cap.request_overrides == {}
+
+    def test_concrete_provider_is_not_rerouted(self):
+        """A named third-party provider still fails closed, unlike `auto`."""
+        cap = resolve_fast_mode_capability_for_configured_route(
+            model="claude-opus-4-6",
+            provider="openrouter",
+            api_mode="anthropic_messages",
+        )
+        assert cap.supported is False
+
+
+class TestDatedContracts:
+    def test_anthropic_contract_is_exact_not_prefix(self):
+        assert anthropic_fast_contract_accepts("claude-opus-4-6") is True
+        # Neighbouring ids in the same family reject the parameter.
+        assert anthropic_fast_contract_accepts("claude-opus-4-7") is False
+        assert anthropic_fast_contract_accepts("claude-sonnet-4-6") is False
+
+    def test_documented_spelling_aliases_fold(self):
+        assert normalize_fast_model_id("claude-opus-4.6") == "claude-opus-4-6"
+        assert normalize_fast_model_id("anthropic/claude-opus-4-6") == (
+            "claude-opus-4-6"
+        )
+        assert anthropic_fast_contract_accepts("anthropic/claude-opus-4.6") is True
+
+    def test_undocumented_suffixes_do_not_fold(self):
+        """A suffix we don't recognise must fail the gate, not be coerced."""
+        assert anthropic_fast_contract_accepts("claude-opus-4-6:free") is False
+        assert anthropic_fast_contract_accepts("claude-opus-4-6-20260101") is False
+
+    def test_codex_contract_is_exact(self):
+        assert codex_fast_contract_accepts("gpt-5.4") is True
+        assert codex_fast_contract_accepts("gpt-5-codex") is False
+
+    def test_every_contract_carries_provenance(self):
+        for family, contract in FAST_MODE_CAPABILITY_CATALOG.items():
+            assert contract["source_url"].startswith("https://"), family
+            assert contract["checked_date"], family
+            assert contract["models"], family
+
+    def test_anthropic_capability_agrees_with_adapter_gate(self):
+        """The command gate and the adapter's own gate must not drift.
+
+        ``agent.anthropic_adapter._supports_fast_mode`` decides whether the
+        request actually carries ``speed``; if it disagrees with what /fast
+        advertises, the UI shows a toggle the runtime silently drops.
+        """
+        from agent.anthropic_adapter import _supports_fast_mode
+
+        for model in ("claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-6"):
+            cap = resolve_fast_mode_capability(
+                model=model, provider="anthropic", api_mode="anthropic_messages"
+            )
+            assert cap.supported is _supports_fast_mode(model), model

--- a/tests/gateway/test_fast_route_injection.py
+++ b/tests/gateway/test_fast_route_injection.py
@@ -1,0 +1,274 @@
+"""The fast-mode override injected into a turn must match the resolved route.
+
+The seam under test is where `/fast` (a session preference) becomes
+`request_overrides` on the outgoing request. These tests assert the wire
+payload, not the command's reply text.
+"""
+
+import pytest
+
+import gateway.run as gateway_run
+from tests.gateway.test_fast_command import _make_runner  # noqa: F401
+
+
+def _runtime(provider, api_mode, base_url="", **extra):
+    rt = {
+        "api_key": "***",
+        "base_url": base_url,
+        "provider": provider,
+        "api_mode": api_mode,
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    rt.update(extra)
+    return rt
+
+
+class TestGatewayTurnRouteInjection:
+    def test_native_anthropic_route_injects_speed(self):
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "claude-opus-4-6",
+            _runtime("anthropic", "anthropic_messages"),
+        )
+
+        assert route["request_overrides"] == {"speed": "fast"}
+
+    def test_third_party_messages_route_injects_nothing(self):
+        """`speed=fast` requires the fast-mode beta a proxy would reject.
+
+        The model-only gate answers ``{"speed": "fast"}`` for this same model,
+        so without the route check the proxy receives a parameter it cannot
+        honour.
+        """
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        assert resolve_fast_mode_overrides("claude-opus-4-6") == {"speed": "fast"}
+
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "claude-opus-4-6",
+            _runtime(
+                "openrouter",
+                "anthropic_messages",
+                base_url="https://openrouter.ai/api/v1",
+            ),
+        )
+
+        assert route["request_overrides"] == {}
+        assert "speed" not in route["request_overrides"]
+
+    def test_codex_backend_injects_fast_tier_not_priority(self):
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner, "hi", "gpt-5.4", _runtime("openai-codex", "codex_responses")
+        )
+
+        assert route["request_overrides"] == {"service_tier": "fast"}
+
+    def test_openai_api_route_injects_priority_tier(self):
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner, "hi", "gpt-5.4", _runtime("openai-api", "chat_completions")
+        )
+
+        assert route["request_overrides"] == {"service_tier": "priority"}
+
+    def test_fast_off_injects_nothing_on_any_route(self):
+        runner = _make_runner()
+        runner._service_tier = None
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "claude-opus-4-6",
+            _runtime("anthropic", "anthropic_messages"),
+        )
+
+        assert route["request_overrides"] == {}
+
+    def test_provider_extra_body_survives_alongside_fast(self):
+        """A custom provider's own request_overrides must not be clobbered."""
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "gpt-5.4",
+            _runtime(
+                "openai-api",
+                "chat_completions",
+                request_overrides={"extra_body": {"chat_template_kwargs": {"a": 1}}},
+            ),
+        )
+
+        assert route["request_overrides"]["service_tier"] == "priority"
+        assert route["request_overrides"]["extra_body"] == {
+            "chat_template_kwargs": {"a": 1}
+        }
+
+    def test_route_runtime_is_not_switched_by_fast(self):
+        """Fast mode adds request params; it must never re-route the call."""
+        runner = _make_runner()
+        runner._service_tier = "priority"
+
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "claude-opus-4-6",
+            _runtime(
+                "openrouter",
+                "anthropic_messages",
+                base_url="https://openrouter.ai/api/v1",
+            ),
+        )
+
+        assert route["runtime"]["provider"] == "openrouter"
+        assert route["runtime"]["api_mode"] == "anthropic_messages"
+        assert route["runtime"]["base_url"] == "https://openrouter.ai/api/v1"
+        assert route["model"] == "claude-opus-4-6"
+
+
+class TestCliTurnRouteInjection:
+    def _stub(self, *, model, provider, api_mode, service_tier="priority"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            model=model,
+            api_key="***",
+            base_url="",
+            provider=provider,
+            requested_provider=provider,
+            api_mode=api_mode,
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            service_tier=service_tier,
+        )
+
+    def test_native_anthropic_route_injects_speed(self):
+        import cli as cli_mod
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(
+            self._stub(
+                model="claude-opus-4-6",
+                provider="anthropic",
+                api_mode="anthropic_messages",
+            ),
+            "hi",
+        )
+        assert route["request_overrides"] == {"speed": "fast"}
+
+    def test_third_party_messages_route_injects_nothing(self):
+        import cli as cli_mod
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(
+            self._stub(
+                model="claude-opus-4-6",
+                provider="openrouter",
+                api_mode="anthropic_messages",
+            ),
+            "hi",
+        )
+        assert not route["request_overrides"]
+
+    def test_codex_backend_injects_fast_tier(self):
+        import cli as cli_mod
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(
+            self._stub(
+                model="gpt-5.4",
+                provider="openai-codex",
+                api_mode="codex_responses",
+            ),
+            "hi",
+        )
+        assert route["request_overrides"] == {"service_tier": "fast"}
+
+
+class TestPromptCacheSafety:
+    """Fast mode must ride the REQUEST, never the cached prefix.
+
+    A per-conversation cached prefix is reused every turn; anything that
+    mutates the system prompt or past context on a toggle would invalidate it
+    and multiply the user's cost. The seam is therefore asserted structurally:
+    the resolved route may differ ONLY in ``request_overrides``.
+    """
+
+    def test_toggling_fast_changes_only_request_overrides(self):
+        runner_off = _make_runner()
+        runner_off._service_tier = None
+        runner_on = _make_runner()
+        runner_on._service_tier = "priority"
+
+        rt = _runtime("anthropic", "anthropic_messages")
+        off = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner_off, "hi", "claude-opus-4-6", dict(rt)
+        )
+        on = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner_on, "hi", "claude-opus-4-6", dict(rt)
+        )
+
+        differing = {k for k in set(off) | set(on) if off.get(k) != on.get(k)}
+        assert differing == {"request_overrides"}
+
+    def test_cache_identity_inputs_are_unchanged_by_fast(self):
+        """model / runtime / signature are cache-identity; they must not move."""
+        runner_off = _make_runner()
+        runner_off._service_tier = None
+        runner_on = _make_runner()
+        runner_on._service_tier = "priority"
+
+        rt = _runtime("openai-api", "chat_completions")
+        off = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner_off, "hi", "gpt-5.4", dict(rt)
+        )
+        on = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner_on, "hi", "gpt-5.4", dict(rt)
+        )
+
+        assert off["model"] == on["model"]
+        assert off["runtime"] == on["runtime"]
+        assert off["signature"] == on["signature"]
+        # ...and the toggle DID take effect, so this is not a vacuous pass.
+        assert on["request_overrides"] == {"service_tier": "priority"}
+        assert off["request_overrides"] == {}
+
+    def test_fast_overrides_carry_no_prompt_or_context_keys(self):
+        """Nothing the toggle emits may touch prompt/message/tool payloads."""
+        from hermes_cli.models import resolve_fast_mode_capability
+
+        forbidden = {
+            "system",
+            "messages",
+            "input",
+            "instructions",
+            "tools",
+            "prompt",
+            "prompt_cache_key",
+        }
+        for model, provider, api_mode in [
+            ("claude-opus-4-6", "anthropic", "anthropic_messages"),
+            ("gpt-5.4", "openai-api", "chat_completions"),
+            ("gpt-5.4", "openai-codex", "codex_responses"),
+            ("grok-4.6", "xai", "chat_completions"),
+        ]:
+            cap = resolve_fast_mode_capability(
+                model=model, provider=provider, api_mode=api_mode
+            )
+            assert cap.supported, (model, provider)
+            assert not (set(cap.request_overrides) & forbidden), cap.request_overrides

--- a/tests/gateway/test_fast_session_route.py
+++ b/tests/gateway/test_fast_session_route.py
@@ -1,0 +1,162 @@
+"""`/fast` must answer for the route the session's NEXT turn will take.
+
+A session-scoped `/model` override changes that route, so a fast toggle
+resolved against the *configured* route would report and gate on a model the
+session is no longer using.
+"""
+
+import pytest
+
+import gateway.run as gateway_run
+from tests.gateway.test_fast_command import _make_runner, _make_event
+
+
+CONFIG = {
+    "model": {
+        "default": "gpt-5.4",
+        "provider": "openai-api",
+        "api_mode": "chat_completions",
+    }
+}
+
+
+class TestSessionRouteResolution:
+    def test_no_override_uses_the_configured_route(self):
+        runner = _make_runner()
+
+        model, provider, api_mode = runner._resolve_session_fast_route(
+            session_key="s1", user_config=CONFIG
+        )
+
+        assert model == "gpt-5.4"
+        assert provider == "openai-api"
+        assert api_mode == "chat_completions"
+
+    def test_session_model_override_steers_the_route(self):
+        runner = _make_runner()
+        runner._session_model_overrides["s1"] = {
+            "model": "claude-opus-4-6",
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+        }
+
+        model, provider, api_mode = runner._resolve_session_fast_route(
+            session_key="s1", user_config=CONFIG
+        )
+
+        assert model == "claude-opus-4-6"
+        assert provider == "anthropic"
+        assert api_mode == "anthropic_messages"
+
+    def test_override_without_api_mode_is_rederived_not_inherited(self):
+        """Persisted overrides drop api_mode; it must not leak from config.
+
+        Inheriting the configured `chat_completions` here would resolve an
+        Anthropic model onto an OpenAI-style wire.
+        """
+        runner = _make_runner()
+        runner._session_model_overrides["s1"] = {
+            "model": "claude-opus-4-6",
+            "provider": "anthropic",
+        }
+
+        _, _, api_mode = runner._resolve_session_fast_route(
+            session_key="s1", user_config=CONFIG
+        )
+
+        assert api_mode == "anthropic_messages"
+        assert api_mode != CONFIG["model"]["api_mode"]
+
+    def test_override_is_scoped_to_its_own_session(self):
+        runner = _make_runner()
+        runner._session_model_overrides["s1"] = {
+            "model": "claude-opus-4-6",
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+        }
+
+        other = runner._resolve_session_fast_route(
+            session_key="s2", user_config=CONFIG
+        )
+
+        assert other[0] == "gpt-5.4"
+        assert other[1] == "openai-api"
+
+
+class TestOverrideChangesTheInjectedOverrides:
+    """End-to-end: the override must change what reaches the wire."""
+
+    @staticmethod
+    def _overrides_for(runner, session_key):
+        from hermes_cli.models import resolve_fast_mode_capability
+
+        model, provider, api_mode = runner._resolve_session_fast_route(
+            session_key=session_key, user_config=CONFIG
+        )
+        return resolve_fast_mode_capability(
+            model=model, provider=provider, api_mode=api_mode
+        ).request_overrides
+
+    def test_switching_the_session_model_switches_the_fast_key(self):
+        runner = _make_runner()
+
+        # Configured route -> OpenAI-style tier.
+        default = self._overrides_for(runner, "s1")
+        assert default == {"service_tier": "priority"}
+
+        # After /model to a native Anthropic route -> the Anthropic key.
+        runner._session_model_overrides["s1"] = {
+            "model": "claude-opus-4-6",
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+        }
+        overridden = self._overrides_for(runner, "s1")
+        assert overridden == {"speed": "fast"}
+        assert overridden != default
+
+
+class TestServiceTierPreferencePersistence:
+    """The session preference itself must survive and stay session-scoped."""
+
+    def test_session_override_is_readable_back(self):
+        runner = _make_runner()
+        runner._set_session_service_tier_override("s1", "priority")
+
+        assert runner._resolve_session_service_tier(session_key="s1") == "priority"
+
+    def test_explicit_normal_is_distinct_from_unset(self):
+        """`/fast normal` stores None and must WIN over a config default.
+
+        Presence, not truthiness, decides — an explicit normal is an override.
+        """
+        runner = _make_runner()
+        runner._set_session_service_tier_override("s1", None)
+
+        assert runner._resolve_session_service_tier(session_key="s1") is None
+
+    def test_clear_falls_back_to_the_config_default(self, monkeypatch):
+        runner = _make_runner()
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_runtime_config",
+            lambda: {"agent": {"service_tier": "fast"}},
+        )
+
+        runner._set_session_service_tier_override("s1", None)
+        assert runner._resolve_session_service_tier(session_key="s1") is None
+
+        runner._set_session_service_tier_override("s1", None, clear=True)
+        assert runner._resolve_session_service_tier(session_key="s1") == "priority"
+
+    def test_override_does_not_leak_to_other_sessions(self, monkeypatch):
+        runner = _make_runner()
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_runtime_config",
+            lambda: {"agent": {"service_tier": "fast"}},
+        )
+
+        runner._set_session_service_tier_override("s1", None)
+
+        assert runner._resolve_session_service_tier(session_key="s1") is None
+        assert runner._resolve_session_service_tier(session_key="s2") == "priority"

--- a/tests/gateway/test_turn_request_overrides.py
+++ b/tests/gateway/test_turn_request_overrides.py
@@ -49,17 +49,34 @@ def test_provider_request_overrides_preserved_without_service_tier():
     assert route["request_overrides"] is not rk["request_overrides"]
 
 
-def test_provider_request_overrides_merged_under_fast_mode(monkeypatch):
-    """/fast active: provider extra_body AND the service-tier marker both survive."""
-    monkeypatch.setattr(
-        "hermes_cli.models.resolve_fast_mode_overrides",
-        lambda model_id: {"service_tier": "priority"},
+def test_provider_request_overrides_merged_under_fast_mode():
+    """/fast active: provider extra_body AND the service-tier marker both survive.
+
+    Uses a genuinely fast-capable route (rather than stubbing the resolver) so
+    the merge is exercised against the same capability lookup the runtime uses.
+    """
+    runner = _runner(service_tier="priority")
+    rk = _runtime_kwargs(
+        request_overrides=PROVIDER_OVERRIDES,
+        provider="openai-api",
+        api_mode="chat_completions",
     )
+    route = runner._resolve_turn_agent_config("hi", "gpt-5.4", rk)
+    assert route["request_overrides"]["extra_body"] == PROVIDER_OVERRIDES["extra_body"]
+    assert route["request_overrides"]["service_tier"] == "priority"
+
+
+def test_provider_overrides_survive_when_route_has_no_fast_contract():
+    """A route without a fast contract must still forward the provider's body.
+
+    The fast lookup returning nothing must not swallow the provider's own
+    configured ``extra_body``.
+    """
     runner = _runner(service_tier="priority")
     rk = _runtime_kwargs(request_overrides=PROVIDER_OVERRIDES)
     route = runner._resolve_turn_agent_config("hi", "main", rk)
     assert route["request_overrides"]["extra_body"] == PROVIDER_OVERRIDES["extra_body"]
-    assert route["request_overrides"]["service_tier"] == "priority"
+    assert "service_tier" not in route["request_overrides"]
 
 
 def test_no_provider_overrides_yields_empty():


### PR DESCRIPTION
## The problem

`/fast` is one command name over three different vendor features:

| Feature | Wire | Parameter |
|---|---|---|
| OpenAI Priority Processing | OpenAI-style (chat completions / responses) | `service_tier="priority"` |
| Codex Fast | Codex Responses subscription backend | `service_tier="fast"` |
| Anthropic Fast Mode | native Anthropic Messages | `speed="fast"` + `fast-mode-*` beta |

Support was resolved from the model id alone (`resolve_fast_mode_overrides(model_id)`), which cannot tell those apart. Two cases resolve wrong today on `main`:

**1. The Anthropic `speed` parameter leaks off its wire.**

```python
>>> resolve_fast_mode_overrides("claude-opus-4-6")
{'speed': 'fast'}   # ...whatever route that model is reached over
```

`speed` is a native Messages parameter. Serve the same model id through a third-party endpoint and it receives a parameter it cannot honour — which is exactly why `anthropic_adapter` already has to re-check `_is_third_party_anthropic_endpoint` and strip it defensively on the way out. The gate and the adapter disagreeing is the bug; the defensive strip is the symptom.

**2. The Codex backend is sent the wrong tier value.**

`gpt-5.4` on the `openai-codex` subscription backend was sent `service_tier="priority"`. That backend sells a `fast` tier, not `priority`.

Both are silent: the user toggles `/fast`, the command says it worked, and the request either drops the parameter downstream or asks for a tier that doesn't exist there.

## The change

Resolution now takes the full `(model, provider, api_mode)` route and returns one `FastModeCapability` — `supported`, `family`, `request_overrides`, and a human `reason` — shared by the command surface, the picker inventory and the request builder, so what `/fast` advertises, what it explains, and what actually reaches the wire cannot drift apart.

`request_overrides` is empty whenever `supported` is false, so a caller structurally cannot ship a parameter whose gate said no.

**The per-family gates deliberately differ, matching how each vendor fails:**

- **Anthropic Fast Mode** requires the native Messages route *and* an exact model from a dated contract. `speed` does not exist on other wires, and is a hard 400 on other Claude models — so it fails closed.
- **Codex Fast** requires the Codex Responses backend and its own (much shorter) model contract, because the tier *value* differs from the OpenAI API's.
- **Priority Processing** keeps the existing permissive pattern gate on any OpenAI-style wire. `service_tier` is *ignored* rather than rejected by endpoints that don't sell it, so breadth is free here and a narrower list would hide the toggle from a newly released flagship. This preserves the documented existing judgment — including that a model reached through a routing proxy keeps working.

That asymmetry is the point: the tightening lands only where the vendor actually rejects, and nothing that works today stops working.

Two smaller fixes fall out of the same seam:

- `/fast` now resolves against the route the session's **next turn** will use, so a session-scoped `/model` switch is reflected instead of reporting on the configured route the session no longer uses. `--global` still gates on the configured gateway route, since that's what the persisted default applies to.
- An unsupported route now explains *why* (naming the route) instead of accepting the toggle and silently sending nothing. Turning `/fast` **off** is never blocked by an unsupported route.

New dated contracts live in `hermes_cli/fast_mode_contracts.py` with a source URL and check date per family, so refreshing one when a vendor updates its list is a single-file edit.

## Prompt caching

The flag rides the **request params only**. `request_overrides` is merged into `api_kwargs`/`extra_body` at the transport (`transports/chat_completions.py`, `transports/codex.py`, `anthropic_adapter`) and never touches the system prompt, message history, or tool schema — so toggling `/fast` mid-conversation cannot invalidate a cached prefix.

This is asserted structurally rather than claimed, in `TestPromptCacheSafety`:

- `test_toggling_fast_changes_only_request_overrides` — resolves the same turn with the toggle off and on, and asserts the set of differing keys is **exactly** `{"request_overrides"}`.
- `test_cache_identity_inputs_are_unchanged_by_fast` — `model`, `runtime` and the cache `signature` are byte-identical across the toggle, *and* the toggle demonstrably took effect (so the assertion isn't vacuously green).
- `test_fast_overrides_carry_no_prompt_or_context_keys` — no emitted override key may be `system`/`messages`/`input`/`instructions`/`tools`/`prompt`/`prompt_cache_key`, for every supported family.

`/fast` also does not re-route: `test_route_runtime_is_not_switched_by_fast` pins that provider, `api_mode`, `base_url` and model are untouched.

## Cost

Priority and fast tiers **bill above the standard tier** on every provider that offers them. This PR does not change who pays or when: the command stays explicit, per-session, opt-in, and off by default. `--global` continues to require the flag and is gated on the configured gateway route.

## Tests

23 new tests across three files, plus one existing test re-pointed:

- `tests/cli/test_fast_route_capability.py` — the resolver: wire-specific keys, exact-vs-pattern contracts, the fail-closed invariant, and unpinned (`auto`) provider handling. Includes `test_anthropic_capability_agrees_with_adapter_gate`, which pins the command gate against `anthropic_adapter._supports_fast_mode` so the two cannot drift again.
- `tests/gateway/test_fast_route_injection.py` — the injection seam, asserting the **wire payload** rather than reply text, plus `TestPromptCacheSafety`.
- `tests/gateway/test_fast_session_route.py` — session-route resolution and preference persistence (including that an explicit `normal` is presence-sensitive and must beat a config default without leaking to other sessions).
- `tests/gateway/test_turn_request_overrides.py` — the fast-mode case previously stubbed the resolver by name; it now exercises a genuinely fast-capable route, and gains a sibling asserting a provider's `extra_body` still survives when the route has *no* fast contract.

**RED-proofs** (each mutation applied in isolation against the finished branch, then reverted):

| Mutation | Named tests that go red |
|---|---|
| Anthropic gate stops checking the provider (back to model-only) | `test_third_party_anthropic_messages_route_emits_nothing`, `test_third_party_messages_route_injects_nothing` (gateway + CLI), `test_concrete_provider_is_not_rerouted`, `test_structural_invariant[claude-opus-4-6-openrouter-anthropic_messages]` — **5 red** |
| Codex branch emits `priority` instead of `fast` | `test_codex_backend_emits_service_tier_fast`, `test_same_model_on_openai_api_emits_priority_instead`, `test_codex_backend_injects_fast_tier_not_priority`, `test_codex_backend_injects_fast_tier` — **4 red** |
| Session `/model` override stops steering the fast route | `test_session_model_override_steers_the_route`, `test_override_without_api_mode_is_rederived_not_inherited`, `test_switching_the_session_model_switches_the_fast_key` — **3 red** |
| Preference sentinel collapses explicit-`normal` into unset | `test_clear_falls_back_to_the_config_default`, `test_override_does_not_leak_to_other_sessions`, `test_session_fast_override_beats_config_default` — **3 red** |

**Suite results** (hermetic `uv sync`, same file list on both trees):

```
tests/gateway/      origin/main : 11 failed, 6921 passed, 45 skipped, 2 xfailed
                    this branch : 11 failed, 6944 passed, 45 skipped, 2 xfailed
                    -> identical failure sets (diff is empty); +23 net new tests
```

The 11 are pre-existing on `main` and unrelated (discord attachments, systemd abstract sockets, teams dotenv isolation, scale-to-zero) — several are macOS/env-specific and pass in isolation.

Focused blast radius, all green:

```
tests/hermes_cli/test_inventory.py tests/cli/test_fast_command.py
tests/cli/test_fast_route_capability.py tests/cli/test_reasoning_command.py
tests/cli/test_cli_approval_ui.py tests/agent/test_anthropic_adapter.py
tests/agent/test_switch_model_request_overrides.py
tests/agent/test_credential_pool_routing.py
tests/agent/test_custom_provider_extra_body_matching.py
-> 239 passed
```

## Locales

11 new keys (`family_*`, `state_*`, `route_*`) across all 17 locale files, translated rather than English-filled, matching each file's existing convention for the `Priority Processing` product name (kept in Latin script in `de`/`ja`/`ru`, translated as 优先处理 in `zh`/`zh-hant`, full-width punctuation preserved). Placeholder sets, code spans and bold markers were validated programmatically per key per locale.

Four now-superseded keys (`not_supported`, `saved`, `session_only`, `status`) are left in place rather than deleted — happy to remove them in a follow-up if you'd prefer the cleanup separated from the behaviour change.
