### PR TITLE
test(buzz): thread-topology fakes accept auth_tag — main is green again

### DIFF
--- a/tests/gateway/test_buzz_thread_topology.py
+++ b/tests/gateway/test_buzz_thread_topology.py
@@ -270,7 +270,7 @@ class TestReplyThreadingConfig:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 
@@ -291,7 +291,7 @@ class TestReplyThreadingConfig:
         fake_cli.chmod(0o755)
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 


### PR DESCRIPTION
## Summary
Main is green again: `test_buzz_thread_topology.py`'s two standalone-send `fake_exec` doubles now accept the `auth_tag` kwarg.

Root cause: the threading cluster (#99429) branched before the auth cluster (#99427) added `auth_tag` to `_exec_buzz`'s signature; merging both left the fakes one kwarg behind — TypeError on main, no behavior change involved. Classic sibling-test blast radius.

## Changes
- tests/gateway/test_buzz_thread_topology.py: both `fake_exec` signatures gain `auth_tag=""`.

## Validation
| | Before | After |
|---|---|---|
| tests/gateway/test_buzz_thread_topology.py | 2 failed, 15 passed (on main) | 17 passed |

## Infographic

![Green again — sibling test repair](https://v3b.fal.media/files/b/0aa88ef8/mjYLEE2Q1w7ksTZ-onfFc_qt1WPcn0.png)
