### PR TITLE
fix(desktop): re-home session tiles across compression tip rotation — one surface per conversation (#98622)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -71,7 +71,7 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
+import { $sessionTiles, clearAllSessionStates, publishSessionState, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -303,6 +303,35 @@ describe('active stored-session id rotation routing', () => {
     expect($selectedStoredSessionId.get()).toBe('stored-A-next')
     expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-A-next'), { replace: true })
     expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('leaves only the rotated main session when handleTransition publishes before route-follow', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-ordering' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-previous' }
+    const navigate = vi.fn()
+
+    setActiveSessionId('runtime-ordering')
+    setSelectedStoredSessionId('stored-previous')
+    $sessionTiles.set([{ storedSessionId: 'stored-previous' }])
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-previous'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    act(() => {
+      publishSessionState('runtime-ordering', createClientSessionState('stored-previous'))
+      publishSessionState('runtime-ordering', createClientSessionState('stored-next'))
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('stored-next'))
+    expect($selectedStoredSessionId.get()).toBe('stored-next')
+    expect($sessionTiles.get()).toEqual([])
+
+    clearAllSessionStates()
   })
 
   it('keeps draft on the previous tip when the new tip row is not loaded yet', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -19,10 +19,12 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
+  setSelectedStoredSessionId,
   setTurnStartedAt
 } from '@/store/session'
 import {
   $sessionStates,
+  $sessionTiles,
   clearAllSessionStates,
   reconcileBusyStatesOnReconnect,
   type SessionTileDelegate,
@@ -44,6 +46,7 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     cleanup()
     setActiveSessionId(null)
     setActiveSessionStoredIdRotation(null)
+    setSelectedStoredSessionId(null)
   })
 
   it('emits the previous, next, and runtime ids and removes the stale reverse mapping', () => {
@@ -84,6 +87,48 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     expect($activeSessionStoredIdRotation.get()).toBeNull()
     expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
     expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
+  })
+
+  it('re-homes an open tile on a cache-path rotation even when the runtime is background (#98622)', () => {
+    let cache!: Cache
+
+    // Background runtime: the rotation atom stays null, but the tile keyed on
+    // the pre-rotation id must still re-home to the new tip.
+    setActiveSessionId('runtime-B')
+    render(
+      <Harness activeSessionId="runtime-B" onReady={value => (cache = value)} selectedStoredSessionId="stored-B" />
+    )
+
+    act(() => {
+      $sessionTiles.set([{ storedSessionId: 'stored-A' }])
+      cache.updateSessionState('runtime-A', state => state, 'stored-A')
+      cache.updateSessionState('runtime-A', state => state, 'stored-A-next')
+    })
+
+    const tiles = $sessionTiles.get()
+    expect(tiles.find(t => t.storedSessionId === 'stored-A')).toBeUndefined()
+    expect(tiles.find(t => t.storedSessionId === 'stored-A-next')).toBeDefined()
+  })
+
+  it('drops the stale tile on a cache-path rotation when the new tip is the main selection (#98622)', () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-A')
+    render(
+      <Harness activeSessionId="runtime-A" onReady={value => (cache = value)} selectedStoredSessionId="stored-A-next" />
+    )
+
+    act(() => {
+      // The drop decision reads the GLOBAL selection atom, not the harness prop.
+      setSelectedStoredSessionId('stored-A-next')
+      $sessionTiles.set([{ storedSessionId: 'stored-A' }])
+      cache.updateSessionState('runtime-A', state => state, 'stored-A')
+      cache.updateSessionState('runtime-A', state => state, 'stored-A-next')
+    })
+
+    // Main already shows the conversation on the new tip: the tile is dropped
+    // entirely (main OR tile — never both).
+    expect($sessionTiles.get()).toHaveLength(0)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -1,8 +1,9 @@
-import { act, cleanup, render } from '@testing-library/react'
-import { type MutableRefObject, useLayoutEffect } from 'react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { type MutableRefObject, useLayoutEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionStoredIdRotation,
   $currentFastMode,
@@ -11,6 +12,7 @@ import {
   $currentReasoningEffort,
   $currentServiceTier,
   $messages,
+  $selectedStoredSessionId,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -26,11 +28,14 @@ import {
   $sessionStates,
   $sessionTiles,
   clearAllSessionStates,
+  closeSessionTile,
+  openSessionTile,
   reconcileBusyStatesOnReconnect,
   type SessionTileDelegate,
   setSessionTileDelegate
 } from '@/store/session-states'
 
+import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
 
 type Cache = ReturnType<typeof useSessionStateCache>
@@ -44,9 +49,11 @@ interface HarnessProps {
 describe('useSessionStateCache — stored-id rotation provenance', () => {
   afterEach(() => {
     cleanup()
+    clearAllSessionStates()
     setActiveSessionId(null)
     setActiveSessionStoredIdRotation(null)
     setSelectedStoredSessionId(null)
+    $sessionTiles.set([])
   })
 
   it('emits the previous, next, and runtime ids and removes the stale reverse mapping', () => {
@@ -110,6 +117,86 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     expect(tiles.find(t => t.storedSessionId === 'stored-A-next')).toBeDefined()
   })
 
+  it('rekeys the persisted owner profile when its runtime rotates while another profile is visible', () => {
+    let cache!: Cache
+    const profileA = 'rotation-profile-a-98622'
+    const profileB = 'rotation-profile-b-98622'
+    const previousStoredSessionId = 'stored-profile-previous'
+    const nextStoredSessionId = 'stored-profile-next'
+
+    try {
+      act(() => {
+        $activeGatewayProfile.set(profileA)
+        closeSessionTile(previousStoredSessionId)
+        closeSessionTile(nextStoredSessionId)
+        openSessionTile(previousStoredSessionId)
+        $activeGatewayProfile.set(profileB)
+      })
+
+      setActiveSessionId('runtime-visible-b')
+      render(
+        <Harness activeSessionId="runtime-visible-b" onReady={value => (cache = value)} selectedStoredSessionId={null} />
+      )
+
+      act(() => {
+        cache.updateSessionState('runtime-a', state => state, previousStoredSessionId)
+        cache.updateSessionState('runtime-a', state => state, nextStoredSessionId)
+      })
+
+      act(() => {
+        $activeGatewayProfile.set(profileA)
+      })
+      expect($sessionTiles.get().map(tile => tile.storedSessionId)).toEqual([nextStoredSessionId])
+    } finally {
+      act(() => {
+        $activeGatewayProfile.set(profileA)
+        closeSessionTile(previousStoredSessionId)
+        closeSessionTile(nextStoredSessionId)
+        $activeGatewayProfile.set('default')
+      })
+    }
+  })
+
+  it('leaves only the rotated main session when ensureSessionState publishes before route-follow', async () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-cache-ordering')
+    setSelectedStoredSessionId('stored-cache-previous')
+    $sessionTiles.set([{ storedSessionId: 'stored-cache-previous' }])
+    render(
+      <RotationHarness
+        activeSessionId="runtime-cache-ordering"
+        onReady={value => (cache = value)}
+        selectedStoredSessionId="stored-cache-previous"
+      />
+    )
+
+    act(() => {
+      cache.updateSessionState('runtime-cache-ordering', state => state, 'stored-cache-previous')
+      cache.updateSessionState('runtime-cache-ordering', state => state, 'stored-cache-next')
+    })
+
+    await waitFor(() => expect($selectedStoredSessionId.get()).toBe('stored-cache-next'))
+    expect($sessionTiles.get()).toEqual([])
+  })
+
+  it('preserves the old tile when a cache update detaches its stored session id', () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-detach')
+    $sessionTiles.set([{ storedSessionId: 'stored-detach-old' }])
+    render(
+      <Harness activeSessionId="runtime-detach" onReady={value => (cache = value)} selectedStoredSessionId={null} />
+    )
+
+    act(() => {
+      cache.updateSessionState('runtime-detach', state => state, 'stored-detach-old')
+      cache.updateSessionState('runtime-detach', state => state, null)
+    })
+
+    expect($sessionTiles.get()).toEqual([{ storedSessionId: 'stored-detach-old' }])
+  })
+
   it('drops the stale tile on a cache-path rotation when the new tip is the main selection (#98622)', () => {
     let cache!: Cache
 
@@ -142,6 +229,44 @@ function Harness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessP
     setAwaitingResponse: () => undefined,
     setBusy: () => undefined,
     setMessages: () => undefined
+  })
+
+  onReady(cache)
+
+  return null
+}
+
+function RotationHarness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessProps) {
+  const busyRef = useRef(false)
+  const activeSessionIdRef = useRef<string | null>(activeSessionId)
+  const selectedStoredSessionIdRef = useRef<string | null>(selectedStoredSessionId)
+
+  const cache = useSessionStateCache({
+    activeSessionId,
+    busyRef,
+    selectedStoredSessionId,
+    setAwaitingResponse: () => undefined,
+    setBusy: () => undefined,
+    setMessages: () => undefined
+  })
+
+  useSessionActions({
+    activeSessionId,
+    activeSessionIdRef,
+    busyRef,
+    creatingSessionRef: useRef(false),
+    ensureSessionState: cache.ensureSessionState,
+    getRouteToken: () => 'rotation-test',
+    getRoutedStoredSessionId: () => selectedStoredSessionId,
+    navigate: vi.fn() as never,
+    requestGateway: async () => ({}) as never,
+    resetViewSync: cache.resetViewSync,
+    runtimeIdByStoredSessionIdRef: cache.runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef: cache.sessionStateByRuntimeIdRef,
+    syncSessionStateToView: cache.syncSessionStateToView,
+    updateSessionState: cache.updateSessionState
   })
 
   onReady(cache)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -172,7 +172,9 @@ export function useSessionStateCache({
             // rotates here too, and its pane would otherwise keep the stale id
             // (duplicate/differently-titled tabs). Mirrors handleTransition's
             // rekey, which this path can skip when the state updater is a no-op.
-            rekeySessionTile(existing.storedSessionId, storedSessionId ?? '')
+            if (storedSessionId) {
+              rekeySessionTile(existing.storedSessionId, storedSessionId, sessionId)
+            }
 
             // A rotation event needs a real next id — a null/cleared stored id
             // is a detach, not a rotation the route-follow effect should chase.

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -20,7 +20,13 @@ import {
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
-import { $sessionStates, $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
+import {
+  $sessionStates,
+  $sessionTiles,
+  publishSessionState,
+  rekeySessionTile,
+  releaseSessionTranscript
+} from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
 import { SessionStateCache } from '../session-state-cache'
@@ -160,6 +166,13 @@ export function useSessionStateCache({
           // tracks compression without needing a dummy state write.
           if (existing.storedSessionId && existing.storedSessionId !== storedSessionId) {
             runtimeIdByStoredSessionIdRef.current.delete(existing.storedSessionId)
+
+            // Re-home any open tile keyed on the pre-rotation id (#98622).
+            // Ungated on the active runtime: a background tile's conversation
+            // rotates here too, and its pane would otherwise keep the stale id
+            // (duplicate/differently-titled tabs). Mirrors handleTransition's
+            // rekey, which this path can skip when the state updater is a no-op.
+            rekeySessionTile(existing.storedSessionId, storedSessionId ?? '')
 
             // A rotation event needs a real next id — a null/cleared stored id
             // is a detach, not a rotation the route-follow effect should chase.

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1233,13 +1233,19 @@ describe('isSessionRemote (#94640)', () => {
 
 describe('rekeySessionTile (#98622 — pane identity across compression tip rotation)', () => {
   beforeEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
     $sessionTiles.set([])
     $selectedStoredSessionId.set(null)
+    setSessions([])
   })
 
   afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
     $sessionTiles.set([])
     $selectedStoredSessionId.set(null)
+    setSessions([])
   })
 
   it('re-keys the open tile to the new tip, preserving placement', () => {
@@ -1255,6 +1261,83 @@ describe('rekeySessionTile (#98622 — pane identity across compression tip rota
     const rekeyed = tiles.find(t => t.storedSessionId === 'tip-new')
     expect(rekeyed).toMatchObject({ anchor: 'workspace', before: null, dir: 'right' })
     expect(tiles.find(t => t.storedSessionId === 'unrelated')).toBeDefined()
+  })
+
+  it('keeps a Bot tile when the same stored session is selected in Sessions main', () => {
+    const botTile = {
+      ownerRoute: {
+        connectionId: 'bot-owner',
+        mode: 'remote' as const,
+        profile: 'default'
+      },
+      storedSessionId: 'tip-old',
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'bot:bot-owner::default'
+    }
+
+    $selectedStoredSessionId.set('tip-new')
+    $sessionTiles.set([botTile])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    expect($sessionTiles.get()).toEqual([{ ...botTile, storedSessionId: 'tip-new' }])
+  })
+
+  it('keeps a tile owned by another backend route beside the Sessions main', () => {
+    const ownerA = { connectionId: 'owner-a', mode: 'remote' as const, profile: 'default' }
+    const ownerB = { connectionId: 'owner-b', mode: 'remote' as const, profile: 'default' }
+
+    setSessions([{ connection_id: 'owner-b', id: 'tip-new', profile: 'default' } as never])
+    $selectedStoredSessionId.set('tip-new')
+    $sessionTiles.set([
+      { ownerRoute: ownerA, storedSessionId: 'tip-old' },
+      { ownerRoute: ownerB, storedSessionId: 'tip-new' }
+    ])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    expect($sessionTiles.get()).toEqual([
+      { ownerRoute: ownerA, storedSessionId: 'tip-new' },
+      { ownerRoute: ownerB, storedSessionId: 'tip-new' }
+    ])
+  })
+
+  it('coalesces a minimal next tile without losing the live previous tile metadata', () => {
+    const ownerRoute = {
+      connectionId: 'connection-a',
+      mode: 'remote' as const,
+      profile: 'writer',
+      targetProfile: 'writer'
+    }
+
+    const previous = {
+      anchor: 'session-tile:anchor',
+      before: 'session-tile:next-sibling',
+      dir: 'left' as const,
+      error: 'resume failed',
+      ownerRoute,
+      runtimeId: 'runtime-live',
+      storedSessionId: 'tip-old',
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'bot:connection-a::writer',
+      workspaceTabTitle: 'Live bot chat'
+    }
+
+    const next = { storedSessionId: 'tip-new' }
+    const paneId = tilePane('tip-new')
+
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'workspace-group' }),
+        group([paneId], { active: paneId, id: 'tile-group' })
+      ])
+    )
+    $sessionTiles.set([previous, next])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    expect($sessionTiles.get()).toEqual([{ ...previous, storedSessionId: 'tip-new' }])
+    expect(findGroupOfPane($layoutTree.get()!, paneId)).toMatchObject({ active: paneId, id: 'tile-group' })
   })
 
   it('drops the stale tile when the new tip already has a tile (one pane per conversation)', () => {

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -34,6 +34,7 @@ import {
   orderTilesByTree,
   patchSessionTile,
   recordSessionEventScope,
+  rekeySessionTile,
   releaseSessionTranscript,
   requestForOwnedSession,
   resetTileRuntimeBindings,
@@ -1227,5 +1228,68 @@ describe('isSessionRemote (#94640)', () => {
     setSessions([{ id: 'stored-2', profile: 'loki' } as never])
 
     expect(isSessionRemote('stored-2')).toBe(true)
+  })
+})
+
+describe('rekeySessionTile (#98622 — pane identity across compression tip rotation)', () => {
+  beforeEach(() => {
+    $sessionTiles.set([])
+    $selectedStoredSessionId.set(null)
+  })
+
+  afterEach(() => {
+    $sessionTiles.set([])
+    $selectedStoredSessionId.set(null)
+  })
+
+  it('re-keys the open tile to the new tip, preserving placement', () => {
+    $sessionTiles.set([
+      { anchor: 'workspace', before: null, dir: 'right', storedSessionId: 'tip-old' },
+      { storedSessionId: 'unrelated' }
+    ])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    const tiles = $sessionTiles.get()
+    expect(tiles.find(t => t.storedSessionId === 'tip-old')).toBeUndefined()
+    const rekeyed = tiles.find(t => t.storedSessionId === 'tip-new')
+    expect(rekeyed).toMatchObject({ anchor: 'workspace', before: null, dir: 'right' })
+    expect(tiles.find(t => t.storedSessionId === 'unrelated')).toBeDefined()
+  })
+
+  it('drops the stale tile when the new tip already has a tile (one pane per conversation)', () => {
+    $sessionTiles.set([{ storedSessionId: 'tip-old' }, { storedSessionId: 'tip-new' }])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    const tiles = $sessionTiles.get()
+    expect(tiles).toHaveLength(1)
+    expect(tiles[0].storedSessionId).toBe('tip-new')
+  })
+
+  it('drops the stale tile when the new tip is already the main selection (main OR tile, never both)', () => {
+    $selectedStoredSessionId.set('tip-new')
+    $sessionTiles.set([{ storedSessionId: 'tip-old' }])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    expect($sessionTiles.get()).toHaveLength(0)
+  })
+
+  it('is a no-op when no tile carries the previous id', () => {
+    $sessionTiles.set([{ storedSessionId: 'other' }])
+
+    rekeySessionTile('tip-old', 'tip-new')
+
+    expect($sessionTiles.get()).toEqual([{ storedSessionId: 'other' }])
+  })
+
+  it('ignores degenerate inputs (empty id, same id)', () => {
+    $sessionTiles.set([{ storedSessionId: 'tip-old' }])
+
+    rekeySessionTile('', 'tip-new')
+    rekeySessionTile('tip-old', 'tip-old')
+
+    expect($sessionTiles.get()).toEqual([{ storedSessionId: 'tip-old' }])
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -82,10 +82,15 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 // ---------------------------------------------------------------------------
 
 const sessionScopeByRuntimeId = new Map<string, string>()
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
   if (event.session_id && event.connectionId) {
     sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+    sessionOwnerByRuntimeId.set(event.session_id, {
+      connectionId: event.connectionId,
+      profile: normalizeProfileKey(event.profile)
+    })
   }
 }
 
@@ -364,7 +369,7 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
     // conversation keeps ONE pane (#98622). Not gated on the active runtime:
     // a background tile's conversation rotates too, and its pane would
     // otherwise keep the stale id forever (duplicate/differently-titled tabs).
-    rekeySessionTile(previous.storedSessionId, next.storedSessionId)
+    rekeySessionTile(previous.storedSessionId, next.storedSessionId, runtimeId)
 
     clearSettled(previous.storedSessionId)
     setSessionStalled(previous.storedSessionId, false)
@@ -512,6 +517,7 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
   sessionScopeByRuntimeId.delete(runtimeId)
+  sessionOwnerByRuntimeId.delete(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -538,6 +544,7 @@ export function clearAllSessionStates() {
   settledExpiry.clear()
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
+  sessionOwnerByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
 }
@@ -911,6 +918,18 @@ function saveTiles(tiles: SessionTile[]) {
   $sessionTiles.set(tiles)
 }
 
+function saveTileBucket(bucket: string, tiles: SessionTile[]) {
+  const stored = tiles.map(toStored)
+
+  if (stored.length > 0) {
+    tilesByProfile[bucket] = stored
+  } else {
+    delete tilesByProfile[bucket]
+  }
+
+  persistTiles()
+}
+
 // Profile switch: surface the new profile's tiles with runtime ids cleared so
 // they re-resume against the now-current gateway. (Fires immediately on
 // subscribe; harmless — the init value already matches.) A secondary window
@@ -925,6 +944,158 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
   saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
 }
 
+function isSessionOwnerRoute(value: SessionOwnerScope): value is SessionOwnerRoute {
+  return Boolean(value && typeof value === 'object' && 'connectionId' in value)
+}
+
+function sameSessionOwner(left: SessionOwnerScope, right: SessionOwnerScope): boolean {
+  if (isSessionOwnerRoute(left) && isSessionOwnerRoute(right)) {
+    return (
+      left.connectionId.trim() === right.connectionId.trim() &&
+      normalizeProfileKey(left.profile) === normalizeProfileKey(right.profile) &&
+      normalizeProfileKey(left.targetProfile ?? left.profile) === normalizeProfileKey(right.targetProfile ?? right.profile)
+    )
+  }
+
+  if (typeof left === 'string' && typeof right === 'string') {
+    return normalizeProfileKey(left) === normalizeProfileKey(right)
+  }
+
+  return false
+}
+
+function tileWorkspaceMode(tile: SessionTile): WorkspaceMode {
+  return tile.workspaceMode ?? 'sessions'
+}
+
+function tilesShareOwner(left: SessionTile, right: SessionTile): boolean {
+  if (left.workspaceMode && right.workspaceMode && left.workspaceMode !== right.workspaceMode) {
+    return false
+  }
+
+  const workspaceMode = left.workspaceMode ?? right.workspaceMode ?? 'sessions'
+
+  if (workspaceMode === 'bots') {
+    if (left.workspaceOwnerKey && right.workspaceOwnerKey) {
+      return left.workspaceOwnerKey === right.workspaceOwnerKey
+    }
+
+    if (left.ownerRoute && right.ownerRoute) {
+      return sameSessionOwner(left.ownerRoute, right.ownerRoute)
+    }
+
+    return true
+  }
+
+  if (left.ownerRoute && right.ownerRoute) {
+    return sameSessionOwner(left.ownerRoute, right.ownerRoute)
+  }
+
+  return true
+}
+
+function tileBelongsToMain(
+  tile: SessionTile,
+  selectedStoredSessionId: string,
+  tileProfile = profileKey()
+): boolean {
+  if (tileWorkspaceMode(tile) === 'bots') {
+    return false
+  }
+
+  const mainOwner = knownSessionOwner(ownerLookupSessionRows(), selectedStoredSessionId) ?? profileKey()
+
+  if (tile.ownerRoute) {
+    return isSessionOwnerRoute(mainOwner) && sameSessionOwner(tile.ownerRoute, mainOwner)
+  }
+
+  return typeof mainOwner === 'string' && normalizeProfileKey(mainOwner) === normalizeProfileKey(tileProfile)
+}
+
+function mergeSessionTile(previous: SessionTile, next: SessionTile, storedSessionId: string): SessionTile {
+  const merged: SessionTile = { ...previous, storedSessionId }
+
+  if (next.anchor !== undefined) {
+    merged.anchor = next.anchor
+  }
+
+  if (next.before !== undefined) {
+    merged.before = next.before
+  }
+
+  if (next.dir !== undefined) {
+    merged.dir = next.dir
+  }
+
+  if (next.error !== undefined) {
+    merged.error = next.error
+  }
+
+  if (next.ownerRoute !== undefined) {
+    merged.ownerRoute = next.ownerRoute
+  }
+
+  if (next.runtimeId !== undefined) {
+    merged.runtimeId = next.runtimeId
+  }
+
+  if (next.workspaceMode !== undefined) {
+    merged.workspaceMode = next.workspaceMode
+  }
+
+  if (next.workspaceOwnerKey !== undefined) {
+    merged.workspaceOwnerKey = next.workspaceOwnerKey
+  }
+
+  if (next.workspaceTabTitle !== undefined) {
+    merged.workspaceTabTitle = next.workspaceTabTitle
+  }
+
+  return merged
+}
+
+function rekeyTileList(
+  tiles: SessionTile[],
+  tileProfile: string,
+  previousStoredSessionId: string,
+  nextStoredSessionId: string
+): SessionTile[] | null {
+  const stale = tiles.find(t => t.storedSessionId === previousStoredSessionId)
+
+  if (!stale) {
+    return null
+  }
+
+  const selectedStoredSessionId = $selectedStoredSessionId.get()
+
+  const mainOwnsRotation =
+    Boolean(selectedStoredSessionId) &&
+    (selectedStoredSessionId === previousStoredSessionId || selectedStoredSessionId === nextStoredSessionId) &&
+    tileBelongsToMain(stale, selectedStoredSessionId!, tileProfile)
+
+  const nextTile = tiles.find(t => t.storedSessionId === nextStoredSessionId && tilesShareOwner(stale, t))
+
+  if (mainOwnsRotation) {
+    return tiles.filter(t => t !== stale)
+  }
+
+  if (nextTile) {
+    return tiles
+      .map(t => (t === nextTile ? mergeSessionTile(stale, t, nextStoredSessionId) : t))
+      .filter(t => t !== stale)
+  }
+
+  return tiles.map(t => (t === stale ? { ...t, storedSessionId: nextStoredSessionId } : t))
+}
+
+function ownerProfileKey(owner: SessionOwnerScope): string | undefined {
+  if (isSessionOwnerRoute(owner)) {
+    return normalizeProfileKey(owner.profile)
+  }
+
+  return typeof owner === 'string' ? normalizeProfileKey(owner) : undefined
+}
+
 /**
  * Re-home an open tile after auto-compression rotates the conversation's stored
  * id (#98622). Without this, the tile stays keyed on the pre-rotation id while
@@ -936,37 +1107,62 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
  * re-docks the re-keyed tile in the same slot; pane-mirror's wanted-set diff
  * disposes the old pane and adopts the new one from this single change.
  *
- * Two degenerate cases, both resolving to ONE visible surface:
- * - A tile already exists on the new tip → drop the stale one (the surviving
- *   tile represents the conversation; the mirror removes the old pane).
- * - The new tip is already the MAIN selection → drop the stale tile entirely
- *   (a session is either main OR a tile — never both; openSessionTile enforces
- *   the same invariant at open time).
+ * Main-vs-tile reconciliation is scoped to the same Sessions workspace/owner.
+ * Bot tiles and tiles on distinct backend routes remain independent surfaces.
+ * When a rotation arrives for a background runtime, the persisted profile bucket
+ * owning that runtime is updated without replacing the active profile's atom.
  */
-export function rekeySessionTile(previousStoredSessionId: string, nextStoredSessionId: string) {
-  if (!previousStoredSessionId || previousStoredSessionId === nextStoredSessionId) {
+export function rekeySessionTile(
+  previousStoredSessionId: string,
+  nextStoredSessionId: string,
+  runtimeSessionId?: string
+) {
+  if (!previousStoredSessionId || !nextStoredSessionId || previousStoredSessionId === nextStoredSessionId) {
     return
   }
 
-  const tiles = $sessionTiles.get()
-  const stale = tiles.find(t => t.storedSessionId === previousStoredSessionId)
+  const visibleTiles = $sessionTiles.get()
 
-  if (!stale) {
-    return
-  }
+  if (visibleTiles.some(t => t.storedSessionId === previousStoredSessionId)) {
+    const nextTiles = rekeyTileList(visibleTiles, profileKey(), previousStoredSessionId, nextStoredSessionId)
 
-  const nextIsSelected = nextStoredSessionId === $selectedStoredSessionId.get()
-  const nextHasTile = tiles.some(t => t.storedSessionId === nextStoredSessionId)
-
-  if (nextIsSelected || nextHasTile) {
-    saveTiles(tiles.filter(t => t.storedSessionId !== previousStoredSessionId))
+    if (nextTiles) {
+      saveTiles(nextTiles)
+    }
 
     return
   }
 
-  saveTiles(
-    tiles.map(t => (t.storedSessionId === previousStoredSessionId ? { ...t, storedSessionId: nextStoredSessionId } : t))
+  const candidateBuckets = Object.entries(tilesByProfile).filter(([, tiles]) =>
+    tiles.some(t => t.storedSessionId === previousStoredSessionId)
   )
+
+  if (candidateBuckets.length === 0) {
+    return
+  }
+
+  const owner =
+    (runtimeSessionId ? knownOwnerForSession(runtimeSessionId) : undefined) ??
+    knownSessionOwner(ownerLookupSessionRows(), previousStoredSessionId)
+
+  const resolvedProfile = ownerProfileKey(owner)
+
+  const candidate = resolvedProfile
+    ? candidateBuckets.find(([bucket]) => bucket === resolvedProfile)
+    : candidateBuckets.length === 1
+      ? candidateBuckets[0]
+      : undefined
+
+  if (!candidate) {
+    return
+  }
+
+  const [bucket, storedTiles] = candidate
+  const nextTiles = rekeyTileList(storedTiles, bucket, previousStoredSessionId, nextStoredSessionId)
+
+  if (nextTiles) {
+    saveTileBucket(bucket, nextTiles)
+  }
 }
 
 export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRoute | undefined {
@@ -1031,6 +1227,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
   return (
+    sessionOwnerByRuntimeId.get(sessionId) ??
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
     knownSessionOwner(ownerLookupSessionRows(), storedSessionId)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -360,6 +360,12 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
       })
     }
 
+    // Re-home any open tile keyed on the pre-rotation id to the new tip so the
+    // conversation keeps ONE pane (#98622). Not gated on the active runtime:
+    // a background tile's conversation rotates too, and its pane would
+    // otherwise keep the stale id forever (duplicate/differently-titled tabs).
+    rekeySessionTile(previous.storedSessionId, next.storedSessionId)
+
     clearSettled(previous.storedSessionId)
     setSessionStalled(previous.storedSessionId, false)
   }
@@ -917,6 +923,50 @@ if (!isSecondaryWindow() && !isBrowserWindow()) {
 
 export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>) {
   saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
+}
+
+/**
+ * Re-home an open tile after auto-compression rotates the conversation's stored
+ * id (#98622). Without this, the tile stays keyed on the pre-rotation id while
+ * the rest of the app (selection, route, composer) moves to the new tip — the
+ * same conversation then renders as two tabs (identical or differently-titled,
+ * since each tip is titled independently).
+ *
+ * Placement fields (`dir`/`anchor`/`before`) are preserved so the pane mirror
+ * re-docks the re-keyed tile in the same slot; pane-mirror's wanted-set diff
+ * disposes the old pane and adopts the new one from this single change.
+ *
+ * Two degenerate cases, both resolving to ONE visible surface:
+ * - A tile already exists on the new tip → drop the stale one (the surviving
+ *   tile represents the conversation; the mirror removes the old pane).
+ * - The new tip is already the MAIN selection → drop the stale tile entirely
+ *   (a session is either main OR a tile — never both; openSessionTile enforces
+ *   the same invariant at open time).
+ */
+export function rekeySessionTile(previousStoredSessionId: string, nextStoredSessionId: string) {
+  if (!previousStoredSessionId || previousStoredSessionId === nextStoredSessionId) {
+    return
+  }
+
+  const tiles = $sessionTiles.get()
+  const stale = tiles.find(t => t.storedSessionId === previousStoredSessionId)
+
+  if (!stale) {
+    return
+  }
+
+  const nextIsSelected = nextStoredSessionId === $selectedStoredSessionId.get()
+  const nextHasTile = tiles.some(t => t.storedSessionId === nextStoredSessionId)
+
+  if (nextIsSelected || nextHasTile) {
+    saveTiles(tiles.filter(t => t.storedSessionId !== previousStoredSessionId))
+
+    return
+  }
+
+  saveTiles(
+    tiles.map(t => (t.storedSessionId === previousStoredSessionId ? { ...t, storedSessionId: nextStoredSessionId } : t))
+  )
 }
 
 export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRoute | undefined {


### PR DESCRIPTION
## What does this PR do?

Prevents a Desktop conversation from remaining on both the main workspace and a session tile when compression rotates its stored session tip.

The pane mirror projects from `$sessionTiles`, so this reconciles identity at that source rather than rewriting the global pane tree. It handles both rotation producers and preserves the existing ownership rules that allow intentional Bot-workspace coexistence.

Fixes #98622.

## Changes made

- Re-home an existing session tile from the previous stored tip to the rotated tip.
- Remove a matching Sessions tile when main owns either side of the active previous → next rotation, covering production ordering before route-follow changes selection.
- Wire reconciliation into both producer paths:
  - normal session-state transitions
  - cache/no-op publish transitions
- When old and new tiles already coexist, merge them deterministically while preserving live runtime, placement, error, title, workspace, and exact owner-route metadata.
- Preserve intentional Bot-workspace tiles and tiles with distinct backend owner routes.
- Resolve and update the persisted bucket for an inactive profile when a background runtime rotates; ambiguous ownership fails closed rather than rewriting the wrong profile.
- Treat a null stored id as detach, not rotation, and reject empty/degenerate rekey inputs.
- Add regressions for production ordering, both producers, metadata/layout retention, Bot and multi-owner coexistence, inactive-profile persistence, and detach behavior.

## Why a separate PR from #98752?

#98752 currently canonicalizes tiles to the lineage root, but its selected-workspace fixture permits `workspace` and the canonical root tile to coexist. Against its current head, a focused regression starting with the rotated tip selected in main leaves the root tile present (**1 failed, 70 passed**), preserving the duplicate-surface condition from #98622.

This PR explicitly enforces the existing **main OR matching Sessions tile** invariant while retaining intentional Bot and distinct-owner tiles. It also covers inactive-profile persistence, metadata-preserving coalescence, and detach handling.

## Validation

Exact publication comparison: `origin/main @ 26f178e5fa` → `14ae8875c4`.

- `npx vitest run src/store/session-states.test.ts src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-session-actions.test.tsx`
  - **3 files, 187 tests passed**
- `npm run test:ui`
  - **684 files, 6,796 tests passed**
- `npx tsc -p tsconfig.json --noEmit`
  - clean
- `npx eslint src/app/session/hooks/use-session-actions.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-session-state-cache.ts src/store/session-states.test.ts src/store/session-states.ts`
  - clean
- `git diff --check origin/main...HEAD`
  - clean
- Worktree
  - clean

Existing Vite native-config and jsdom canvas warnings remain non-failing. `npm install` also reports two pre-existing high-severity dependency audit findings; this PR does not force-upgrade unrelated dependencies.

## Scope / risk

- No protocol, schema, migration, credential, or platform-specific API changes.
- Title drift on deep compression lineages remains out of scope.
- Ambiguous inactive profile/owner matches intentionally fail closed instead of risking mutation of the wrong persisted tile bucket.

## Notes from independent review

Read-only review verdict: **APPROVED, no blocking findings** (session `20260831_104920_5d1501`). Non-blocking notes carried forward:

- LOW: the runtime-owner disambiguation rung (`sessionOwnerByRuntimeId`) is structurally sound but not behaviorally covered by a multi-candidate fail-closed test.
- INFO: #98752 implements the same issue differently (lineage-root canonicalization + tree-pane coalescing); if both merged, tile identity would double-reconcile — merge/sequence decision for maintainers.

## Checklist

- [x] I read the contributing guide and applicable Desktop architecture/design instructions.
- [x] The commits follow Conventional Commits.
- [x] I searched open, closed, and merged PRs using the issue number and symptom variants.
- [x] The change is limited to Desktop session-tile identity and its regression coverage.
- [x] I ran targeted tests, the full Desktop UI suite, TypeScript, ESLint, and `git diff --check` on the exact rebased head.
- [x] Python `pytest` is not applicable; this is a Desktop TypeScript-only change.
- [x] The implementation uses existing cross-platform TypeScript state primitives.

<!-- pr-quality:no-visual-required: this is state reconciliation covered by deterministic store/layout regressions. -->
