### PR TITLE
fix(desktop): reset stream state for new turns

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -128,6 +128,10 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
         sawAssistantPayload: false,
         interrupted: false,
         interimBoundaryPending: false,
+        // A message.start begins a distinct backend turn. Never let a
+        // dropped completion from the prior turn make its streaming bubble
+        // the target for this turn's first delta.
+        streamId: null,
         // Backend accepted the turn — the no-payload settle gate below may
         // now treat a running=false heartbeat as a real turn end.
         turnLive: true,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -228,6 +228,20 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+  it('starts a fresh bubble after an uncompleted prior stream', async () => {
+    mountStream()
+    await start()
+    await delta('first answer')
+
+    // A transport gap can lose the terminal frame. The next backend turn
+    // must not append its deltas to this abandoned stream bubble.
+    await start()
+    await delta('second answer')
+    await complete('second answer')
+
+    expect(assistantMessages()).toEqual(['first answer', 'second answer'])
+  })
+
   it('appends a distinct previewed final after a message.start reset instead of overwriting the interim', async () => {
     mountStream()
     await start()


### PR DESCRIPTION
Fixes #99416\n\n## Summary\n- Clear a live stream identifier when a new gateway turn begins.\n- Prevent output after a dropped terminal frame from merging into the prior assistant bubble.\n\n## Tests\n- `npm --workspace apps/desktop test -- src/app/session/hooks/use-message-stream/interim-sealing.test.tsx`