### PR TITLE
fix(cron): fail-closed WSL bash and MSYS script argv on Windows

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4307,6 +4307,71 @@ def _windows_cron_bootstrap_argv(
     return [python_exe, "-c", bootstrap, script_path]
 
 
+def _is_wsl_bash(bash_path: str | os.PathLike[str] | None) -> bool:
+    """True when *bash_path* is Windows' WSL shim, which cannot open Win32 paths.
+
+    Measured 2026-08-31: System32 bash.exe plus a Win32 script path exits 127
+    with a collapsed path (``D:Hermesscriptsx.sh``). Git Bash (MSYS) can open
+    the same file; the WSL shim cannot, even with forward slashes, because
+    ``D:/...`` is not a Linux path. ``_find_bash`` prefers Git for Windows,
+    but still appends ``shutil.which('bash')`` — if that is the only starter,
+    cron must fail closed rather than spawn WSL.
+    """
+    if not bash_path:
+        return False
+    parts = {p.lower() for p in Path(str(bash_path)).parts}
+    if "windowsapps" in parts:
+        return True
+    return "windows" in parts and ("system32" in parts or "sysnative" in parts)
+
+
+def _cron_bash_script_arg(path: Path, is_windows: bool | None = None) -> str:
+    """Script argv for bash. Windows must not use backslashes.
+
+    Git Bash and WSL both treat backslash as an escape, so a native
+    ``D:\\Hermes\\scripts\\x.sh`` collapses to ``D:Hermesscriptsx.sh``.
+    Prefer the shared MSYS form (``_bash_safe_path`` -> ``/d/Hermes/scripts/x.sh``);
+    fall back to ``Path.as_posix()``. On POSIX the native ``str(path)`` is
+    already slash-separated.
+    """
+    if is_windows is None:
+        is_windows = sys.platform == "win32"
+    if not is_windows:
+        return str(path)
+    try:
+        from tools.environments.local import _bash_safe_path
+
+        return _bash_safe_path(str(path))
+    except Exception:
+        return path.as_posix()
+
+
+def _resolve_cron_bash() -> Optional[str]:
+    """Pick a bash that can execute HERMES_HOME/scripts/*.sh.
+
+    Delegates to ``tools.environments.local._find_bash`` (PortableGit,
+    Git for Windows known install dirs, then PATH). Fail closed if the
+    resolved binary is the WSL System32/WindowsApps shim: that process
+    cannot open Win32 script paths (measured 2026-08-31, exit 127).
+    """
+    found: Optional[str] = None
+    try:
+        from tools.environments.local import _find_bash
+
+        found = _find_bash()
+    except RuntimeError:
+        found = None
+    except Exception:
+        found = shutil.which("bash") or (
+            "/bin/bash" if os.path.isfile("/bin/bash") else None
+        )
+    if not found:
+        return None
+    if _is_wsl_bash(found):
+        return None
+    return found
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
@@ -4406,17 +4471,18 @@ def _run_job_script(
         # all work.  On native Windows without Git for Windows installed
         # shutil.which returns None — fall back to a clear error rather
         # than a FileNotFoundError with a confusing "[WinError 2]"
-        # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        # traceback. Prefer Git Bash over the WSL System32 shim: that
+        # shim cannot open Win32 paths (measured 2026-08-31: exit 127,
+        # ``D:Hermesscripts....sh``). Pass the script as posix on Windows
+        # so bash does not eat backslashes as escapes.
+        _bash = _resolve_cron_bash()
         if _bash is None:
             return False, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
-        )
-        argv = [_bash, str(path)]
+            )
+        argv = [_bash, _cron_bash_script_arg(path)]
         env_overlay: dict[str, str] = {}
     else:
         python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -107,6 +107,88 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
+    def test_cron_bash_script_arg_windows_has_no_backslash(self):
+        """Windows bash eats backslashes in the script argv (exit 127).
+
+        Shared `_bash_safe_path` emits the MSYS form `/d/...`; the posix
+        fallback `D:/...` is also accepted. Either form is bash-openable;
+        a native backslash path is not.
+        """
+        from cron.scheduler import _cron_bash_script_arg
+
+        path = Path("D:/Hermes/scripts/exc-dev-watchdog.sh")
+        arg = _cron_bash_script_arg(path, is_windows=True)
+        assert "\\" not in arg
+        assert arg.lower().endswith("/hermes/scripts/exc-dev-watchdog.sh")
+
+    def test_cron_bash_script_arg_posix_keeps_native(self):
+        from cron.scheduler import _cron_bash_script_arg
+
+        path = Path("/home/user/.hermes/scripts/watch.sh")
+        assert _cron_bash_script_arg(path, is_windows=False) == str(path)
+
+    def test_is_wsl_bash_detects_system32_and_windowsapps(self):
+        from cron.scheduler import _is_wsl_bash
+
+        assert _is_wsl_bash(r"C:\Windows\System32\bash.exe") is True
+        assert _is_wsl_bash(r"C:\Windows\Sysnative\bash.exe") is True
+        assert _is_wsl_bash(r"C:\Users\x\AppData\Local\Microsoft\WindowsApps\bash.exe") is True
+        assert _is_wsl_bash(r"C:\Program Files\Git\usr\bin\bash.exe") is False
+        assert _is_wsl_bash("/usr/bin/bash") is False
+
+    def test_resolve_cron_bash_skips_wsl_when_find_bash_returns_shim(self, monkeypatch):
+        """Fail closed: WSL bash cannot see Win32 D: paths even as posix."""
+        from cron import scheduler as sched_mod
+
+        wsl = r"C:\Windows\System32\bash.exe"
+        monkeypatch.setattr("tools.environments.local._find_bash", lambda: wsl)
+        assert sched_mod._resolve_cron_bash() is None
+
+    def test_resolve_cron_bash_runtime_error_is_none(self, monkeypatch):
+        from cron import scheduler as sched_mod
+
+        def _boom():
+            raise RuntimeError("Git Bash not found")
+
+        monkeypatch.setattr("tools.environments.local._find_bash", _boom)
+        assert sched_mod._resolve_cron_bash() is None
+
+    def test_windows_sh_script_argv_is_posix_and_not_wsl(self, cron_env, monkeypatch):
+        """_run_job_script must not hand a backslash path or WSL bash to Popen."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.sh"
+        script.write_text("echo ok\n", encoding="utf-8")
+
+        captured = {}
+
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        git_bash = r"C:\Program Files\Git\usr\bin\bash.EXE"
+        monkeypatch.setattr("tools.environments.local._find_bash", lambda: git_bash)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
+
+        success, output = _run_job_script("probe.sh")
+        assert success is True
+        assert output == "ok"
+        assert captured["argv"][0] == git_bash
+        assert sched_mod._is_wsl_bash(captured["argv"][0]) is False
+        assert "\\" not in captured["argv"][1]
+
 
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
         """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining Windows cron `.sh` fire path that still produced **exit 127** on a live gateway (measured 2026-08-31, `exc-platform-nightly-watchdog`):

```
/bin/bash: D:Hermesscriptsexc-dev-watchdog.sh: No such file or directory
```

Two independent defects, both required:

1. **Interpreter.** `_run_job_script()` used `shutil.which("bash")`. On a Windows gateway/service PATH that is `C:\Windows\System32\bash.exe` (WSL shim). That binary cannot open Win32 `D:\...` paths at all — even `D:/...` is not a Linux path.
2. **Argv.** `argv = [_bash, str(path)]` passes backslashes. Git Bash and WSL both treat `\` as an escape, so `D:\Hermes\scripts\x.sh` collapses to `D:Hermesscriptsx.sh`.

This PR does **not** reimplement Git-Bash discovery. It calls the already-shared `tools.environments.local._find_bash()` (PortableGit → known Git for Windows dirs → PATH), then **fail-closes** if the resolved binary is still the WSL System32 / WindowsApps shim. Script argv uses `_bash_safe_path` (MSYS `/d/...`); posix `D:/...` is the fallback.

Related Layer-1 resolver PRs (#77532 and siblings under #46332) do not cover the argv collapse **and** do not refuse a WSL shim that `_find_bash` still returns as last-resort PATH. Those remain complementary.

## How to Test

```
scripts/run_tests.sh tests/cron/test_cron_script.py -k "cron_bash or is_wsl or resolve_cron_bash or windows_sh_script"
```

Reverse-mutation (must FAIL): restore `argv = [_bash, str(path)]` → `test_windows_sh_script_argv_is_posix_and_not_wsl` asserts a backslash-free argv and fails.

Live (Windows + Git Bash, gateway ticker running): `hermes cron run` on a `no_agent` `.sh` job under `HERMES_HOME/scripts/` must exit 0, not 127.

## Checklist

- [x] Bug fix (non-breaking)
- [x] Whole class at this site: interpreter + argv
- [x] Tests added (WSL shim detection, fail-closed resolver, argv form, Popen capture)
- [x] Reverse-mutation proven
- [x] No new env vars; reuses `_find_bash` / `_bash_safe_path`
- [x] Does not touch factory `D:/Hermes/hermes-agent`

Fixes #46332
