### PR TITLE
fix(buzz): resolve reply_to_mode/reply_in_thread/reaction_only_users through profile scope

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -841,15 +841,19 @@ class BuzzAdapter(BasePlatformAdapter):
         # id, "off" posts every reply as a normal top-level channel message.
         # Mirrors the Discord/Telegram adapters, which already honor this
         # PlatformConfig field; without it Buzz threaded unconditionally.
-        # Env (BUZZ_REPLY_TO_MODE) overrides config.yaml.
-        _rtm = (os.getenv("BUZZ_REPLY_TO_MODE") or getattr(config, "reply_to_mode", "first")
-                or "first")
+        # Env (BUZZ_REPLY_TO_MODE) overrides config.yaml; under a secondary
+        # multiplex profile scope env is not consulted (same rule as the
+        # other settings above) — reply_to_mode is a first-class
+        # PlatformConfig field, not an extra key, so it reads getattr(config)
+        # rather than going through _scoped_platform_setting.
+        _rtm_env = None if _profile_scoped() else os.getenv("BUZZ_REPLY_TO_MODE")
+        _rtm = (_rtm_env or getattr(config, "reply_to_mode", "first") or "first")
         self._reply_to_mode: str = str(_rtm).strip().lower()
         # Slack-convention alias: platforms.buzz.extra.reply_in_thread: false
         # (the key users already know from Slack) opts out of threading the
         # same way reply_to_mode: off does. Env (BUZZ_REPLY_IN_THREAD)
         # overrides config.yaml. See #95842 / #75082.
-        _rit_raw = os.getenv("BUZZ_REPLY_IN_THREAD")
+        _rit_raw = _scoped_platform_setting("BUZZ_REPLY_IN_THREAD", extra, "reply_in_thread")
         _rit = extra.get("reply_in_thread") if _rit_raw is None else _rit_raw
         if _rit is not None and str(_rit).strip().lower() in ("false", "0", "no", "off"):
             self._reply_to_mode = "off"
@@ -881,10 +885,15 @@ class BuzzAdapter(BasePlatformAdapter):
         # intact while providing receipt visibility for agent-authored notes.
         # If a pubkey appears in both sets, allowed_users takes precedence: the
         # normal authorized dispatch path runs and this reaction-only path does not.
-        raw_reaction_only = (
-            os.getenv("BUZZ_REACTION_ONLY_USERS")
-            or extra.get("reaction_only_users", [])
+        # Same multiplex-profile scoping as allowed_users above (#98738) — under
+        # a secondary profile scope env is not consulted, so a missing key
+        # falls back to this profile's own extra.reaction_only_users instead of
+        # silently borrowing the default profile's allowlist.
+        raw_reaction_only = _scoped_platform_setting(
+            "BUZZ_REACTION_ONLY_USERS", extra, "reaction_only_users"
         )
+        if raw_reaction_only is None:
+            raw_reaction_only = extra.get("reaction_only_users", [])
         if isinstance(raw_reaction_only, str):
             raw_reaction_only = raw_reaction_only.split(",")
         self._reaction_only_pubkeys: set = {
@@ -3145,9 +3154,9 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
-    if "reply_in_thread" in extra and not os.getenv("BUZZ_REPLY_IN_THREAD"):
+    if "reply_in_thread" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REPLY_IN_THREAD"):
         os.environ["BUZZ_REPLY_IN_THREAD"] = str(extra["reply_in_thread"]).lower()
-    if "reply_to_mode" in extra and not os.getenv("BUZZ_REPLY_TO_MODE"):
+    if "reply_to_mode" in extra and not _skip_env_bridge and not os.getenv("BUZZ_REPLY_TO_MODE"):
         os.environ["BUZZ_REPLY_TO_MODE"] = str(extra["reply_to_mode"]).lower()
     return None
 
@@ -3232,13 +3241,14 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
-    # Same reply_to_mode / reply_in_thread gate as the live adapter, so
-    # out-of-process cron delivery (deliver=buzz) doesn't thread when the
-    # operator asked for flat channel replies.
-    _rtm = (os.getenv("BUZZ_REPLY_TO_MODE")
-            or getattr(pconfig, "reply_to_mode", "first") or "first")
+    # Same reply_to_mode / reply_in_thread gate as the live adapter (and the
+    # same multiplex-profile scoping, #98738 -- env is not consulted inside a
+    # secondary profile scope), so out-of-process cron delivery (deliver=buzz)
+    # doesn't thread when the operator asked for flat channel replies.
+    _rtm_env = None if _profile_scoped() else os.getenv("BUZZ_REPLY_TO_MODE")
+    _rtm = (_rtm_env or getattr(pconfig, "reply_to_mode", "first") or "first")
     _rtm = str(_rtm).strip().lower()
-    _rit = os.getenv("BUZZ_REPLY_IN_THREAD")
+    _rit = _scoped_platform_setting("BUZZ_REPLY_IN_THREAD", extra, "reply_in_thread")
     if _rit is None:
         _rit = extra.get("reply_in_thread")
     if _rit is not None and str(_rit).strip().lower() in ("false", "0", "no", "off"):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -386,6 +386,106 @@ class TestMultiplexProfileScope:
         assert result.get("success") is True
         assert calls["relay"] == "https://profile.relay"
 
+    def test_secondary_reply_to_mode_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """reply_to_mode is a first-class PlatformConfig field, not an extra
+        key, but must still respect profile scope like every other setting:
+        the default profile's BUZZ_REPLY_TO_MODE bridge output must not
+        override the secondary profile's own reply_to_mode."""
+        from gateway.config import PlatformConfig
+
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "first")
+        multiplex_scope()
+        adapter = BuzzAdapter(PlatformConfig(enabled=True, reply_to_mode="off", extra={}))
+        assert adapter._reply_to_mode == "off"
+
+    def test_secondary_reply_in_thread_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """extra.reply_in_thread must win over the default profile's
+        BUZZ_REPLY_IN_THREAD bridge output under a secondary profile scope."""
+        from gateway.config import PlatformConfig
+
+        monkeypatch.setenv("BUZZ_REPLY_IN_THREAD", "true")
+        multiplex_scope()
+        adapter = BuzzAdapter(
+            PlatformConfig(enabled=True, extra={"reply_in_thread": False})
+        )
+        assert adapter._reply_to_mode == "off"
+
+    def test_secondary_reaction_only_users_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """reaction_only_users must respect profile scope like allowed_users
+        (#98738): the default profile's BUZZ_REACTION_ONLY_USERS bridge
+        output must not override the secondary profile's own
+        extra.reaction_only_users."""
+        from gateway.config import PlatformConfig
+
+        monkeypatch.setenv("BUZZ_REACTION_ONLY_USERS", "default-user-npub")
+        multiplex_scope()
+        adapter = BuzzAdapter(
+            PlatformConfig(enabled=True, extra={"reaction_only_users": [SELF_NPUB]})
+        )
+        assert adapter._reaction_only_pubkeys == {SELF_PUBKEY}
+
+    def test_apply_yaml_config_scoped_skips_reply_settings_env_bridge(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """Same first-writer-wins protection as
+        test_apply_yaml_config_scoped_skips_env_bridge, for the
+        reply_to_mode / reply_in_thread bridge lines specifically."""
+        for var in ("BUZZ_REPLY_TO_MODE", "BUZZ_REPLY_IN_THREAD"):
+            monkeypatch.delenv(var, raising=False)
+        multiplex_scope()
+        _buzz_mod._apply_yaml_config(
+            {},
+            {"extra": {"reply_to_mode": "off", "reply_in_thread": False}},
+        )
+        import os as _os
+
+        assert "BUZZ_REPLY_TO_MODE" not in _os.environ
+        assert "BUZZ_REPLY_IN_THREAD" not in _os.environ
+
+    def test_standalone_send_scoped_reply_to_mode_uses_profile_config(
+        self, multiplex_scope, default_profile_env, monkeypatch, tmp_path
+    ):
+        """cron delivery (out-of-process _standalone_send) must honor the
+        profile's own reply_to_mode, not the default profile's
+        BUZZ_REPLY_TO_MODE bridge output."""
+        monkeypatch.setenv("BUZZ_REPLY_TO_MODE", "first")
+        monkeypatch.delenv("BUZZ_REPLY_IN_THREAD", raising=False)
+        multiplex_scope()
+        from gateway.config import PlatformConfig
+
+        cli = tmp_path / "buzz"
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        calls = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=None):
+            calls["args"] = args
+            return 0, '{"accepted": true, "event_id": "e1"}', ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1profile"
+        )
+        result = asyncio.run(
+            _standalone_send(
+                PlatformConfig(
+                    enabled=True,
+                    reply_to_mode="off",
+                    extra={"relay_url": "https://profile.relay", "cli_path": str(cli)},
+                ),
+                "chan-x",
+                "hello",
+                thread_id="parent-event-id",
+            )
+        )
+        assert result.get("success") is True
+        assert "--reply-to" not in calls["args"]
+
     def test_secondary_partial_extra_fills_missing_keys_from_defaults(
         self, multiplex_scope, default_profile_env
     ):


### PR DESCRIPTION
## Problem

`aaa5f27d0f`'s systematic sweep applied `_scoped_platform_setting()`/`_skip_env_bridge` to every Buzz setting present at the time (relay, cli_path, channels, home_channel, poll_interval, require_mention, transport, allowed_users) so a secondary multiplex profile's own `config.yaml` is authoritative and the shared process env (the default profile's YAML-to-env bridge output) is never consulted.

Three settings added after that sweep never got the same treatment and still read raw `os.getenv`/`os.environ` in `plugins/platforms/buzz/adapter.py`:

1. **`reply_to_mode` / `reply_in_thread`** — added by the thread-topology work (`5d73a11a97`, `972f0314de`). Three sites: `BuzzAdapter.__init__`, `_standalone_send()` (out-of-process cron delivery), and `_apply_yaml_config()` (the YAML-to-env bridge, missing the `_skip_env_bridge` guard).
2. **`reaction_only_users`** — added by `99431` ("acknowledge trusted agent tags without dispatch"). One site: `BuzzAdapter.__init__` still reads bare `os.getenv("BUZZ_REACTION_ONLY_USERS")` right next to `allowed_users` a few lines above, which already uses `_scoped_platform_setting()`. Its write side (`_apply_yaml_config`) already has the `_skip_env_bridge` guard from the original sweep — only the read site was missed.

**Net effect** in a multiplex gateway with 2+ Buzz profiles: whichever profile's config loads first pins its choice into the shared env, and every other Buzz profile silently inherits it regardless of its own `config.yaml` — the exact cross-profile setting leak `aaa5f27d0f` was designed to prevent, just for fields added after that sweep. For `reaction_only_users` specifically, a secondary profile can silently inherit a foreign allowlist of pubkeys that get reaction-only (no-dispatch) treatment.

## Fix

- `reply_in_thread` and `reaction_only_users` live in `PlatformConfig.extra`, so they now go through the existing `_scoped_platform_setting()` helper directly, same as `allowed_users` and every other `extra`-backed field.
- `reply_to_mode` is a first-class `PlatformConfig` field (not an `extra` key), so it gates the raw `os.getenv` read on `_profile_scoped()` directly and falls back to `getattr(config/pconfig, "reply_to_mode", "first")` — mirroring the helper's contract without misusing it for a non-`extra` field.
- The write-bridge (`_apply_yaml_config`) gets the same `_skip_env_bridge` guard as every sibling field, for `reply_to_mode`/`reply_in_thread`.
- `_standalone_send` does not read `reaction_only_users` at all, so no fix is needed there for that field.

## Testing

Added 5 regression tests to `TestMultiplexProfileScope` in `tests/gateway/test_buzz_adapter.py`, mirroring its established fixtures (`multiplex_scope`, `default_profile_env`):
- a secondary profile's own `reply_to_mode` wins over the default profile's `BUZZ_REPLY_TO_MODE` bridge output
- a secondary profile's own `extra.reply_in_thread` wins over the default profile's `BUZZ_REPLY_IN_THREAD` bridge output
- a secondary profile's own `extra.reaction_only_users` wins over the default profile's `BUZZ_REACTION_ONLY_USERS` bridge output
- `_apply_yaml_config` no longer pins a secondary profile's reply settings into the shared process env
- `_standalone_send` (cron delivery) honors the profile's own `reply_to_mode` instead of the shared env

Mutation-verified: all 5 tests fail when their respective fix is reverted (confirmed individually via `git stash` on the source file only, isolated from the test file).

Also fixed a rebase-drift failure surfaced while rebasing this branch onto current `main`: `test_standalone_send_scoped_reply_to_mode_uses_profile_config`'s `fake_exec` fixture was missing the `"accepted": true` field that `_parse_send_receipt` started requiring after this branch was originally opened. Confirmed pre-existing and unrelated to this fix (fails identically with the fix stashed).

```
tests/gateway/test_buzz_adapter.py, test_buzz_authz.py, test_buzz_thread_topology.py,
test_buzz_progress_thread_routing.py, test_buzz_websocket.py,
tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py,
test_multiplex_profile_authz.py, test_multiplex_lifecycle.py: 268 passed
```
(1 pre-existing, unrelated failure deselected — `test_live_media_redacts_long_path_before_bounding` hits a macOS filename-length OS limit unrelated to Buzz config; confirmed failing identically with this fix stashed.)

## Scope note

Left untouched: `_env_enablement()` already returns `None` entirely under a secondary profile scope before it reads any `BUZZ_*` env var, so it isn't affected by this bug class.