### PR TITLE
test(buzz): thread-topology stubs no longer break when _exec_buzz gains kwargs

### DIFF
--- a/tests/gateway/test_buzz_thread_topology.py
+++ b/tests/gateway/test_buzz_thread_topology.py
@@ -270,7 +270,7 @@ class TestReplyThreadingConfig:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None, **kwargs):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 
@@ -291,7 +291,7 @@ class TestReplyThreadingConfig:
         fake_cli.chmod(0o755)
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None, **kwargs):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 


### PR DESCRIPTION
## Summary
Main's CI is red: `_exec_buzz` grew an `auth_tag` keyword (26f178e5fa) and the two `TestReplyThreadingConfig` `fake_exec` stubs in `tests/gateway/test_buzz_thread_topology.py` pinned the old signature, raising `TypeError` on every run. The stubs now accept `**kwargs`, so this and future keyword additions no longer break them.

## Changes
- `tests/gateway/test_buzz_thread_topology.py`: both `fake_exec` stubs gain `**kwargs` (2 lines).

## Validation
| | Before | After |
|---|---|---|
| `tests/gateway/test_buzz_thread_topology.py` | 2 failed (TypeError: unexpected keyword argument 'auth_tag') | 17/17 pass |

Also red on main's own CI (run 33403563405) — pre-existing breakage, not introduced by any open PR.

## Infographic

![CI back to green: test stubs catch up](https://v3b.fal.media/files/b/0aa88f2d/Bh2YMk3pTIp_uwCB9v1Nw_i82BrdWv.png)
