### PR TITLE
test(buzz): accept auth tag in standalone send stubs

### DIFF
--- a/tests/gateway/test_buzz_thread_topology.py
+++ b/tests/gateway/test_buzz_thread_topology.py
@@ -270,7 +270,16 @@ class TestReplyThreadingConfig:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            auth_tag=None,
+            input_text=None,
+            timeout=None,
+        ):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 
@@ -291,7 +300,16 @@ class TestReplyThreadingConfig:
         fake_cli.chmod(0o755)
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=None):
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            auth_tag=None,
+            input_text=None,
+            timeout=None,
+        ):
             captured["args"] = args
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
 


### PR DESCRIPTION
## Summary

Update the two `_exec_buzz` test doubles in `test_buzz_thread_topology.py` to accept the new keyword-only `auth_tag` argument passed by `_standalone_send`.

This is a test-contract-only change; production behavior is unchanged.

## Validation

- Reproduced the required CI failure on `26f178e5f`: 15 passed, 2 failed (`unexpected keyword argument auth_tag`).
- Patched file: 17 passed, 0 failed.
- Related Buzz/terminal slice: 121 passed, 0 failed across 7 files.
- `ruff check tests/gateway/test_buzz_thread_topology.py`: passed.
- `git diff --check`: passed.

Upstream failing run: https://github.com/NousResearch/hermes-agent/actions/runs/33403563405/job/99526128826