### PR TITLE
fix(desktop): give actionable error when Electron source tree absent from wheel/Brew installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8271,7 +8271,18 @@ def cmd_gui(args: argparse.Namespace):
     """Build and launch the native Electron desktop GUI."""
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
     if not (desktop_dir / "package.json").exists():
+        # Wheel/Brew installs land hermes_cli inside site-packages, which
+        # does not ship apps/desktop — the Electron source tree is only
+        # present in git/managed installs. Point the user at the install
+        # method that actually carries the desktop app instead of a bare
+        # "source not found" that reads like corruption (#61056).
         print(f"Desktop GUI source not found at: {desktop_dir}")
+        print()
+        print("This Hermes install does not include the Electron desktop")
+        print("source tree (it ships only with git and managed installs).")
+        print("To use the Desktop app, install via the managed installer:")
+        print("    curl -fsSL https://hermes.nousresearch.com/install.sh | bash")
+        print("or clone the repository and run from the checkout root.")
         sys.exit(1)
 
     try:

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
Brew installs land hermes_cli inside site-packages, and the wheel does not ship apps/desktop — so 'hermes desktop' printed 'source not found at ...site-packages/apps/desktop' which read like corruption, and doctor's pip-install -e suggestion also failed in a Cellar.

The tree is only present in git/managed installs by design. Replace the bare one-liner with an explanation of why the tree is absent and the two supported paths to get the Desktop app (managed installer or git checkout).

Fixes #61056