### PR TITLE
hermes cron doctor: one-shot fleet health check catches dead and silently non-firing jobs (salvage #43729)

### DIFF
--- a/docs/cron-doctor-spec.md
+++ b/docs/cron-doctor-spec.md
@@ -1,0 +1,32 @@
+# Cron Doctor Spec
+
+## Problem
+
+Scheduled jobs can silently degrade when a script is moved, a workdir disappears,
+a provider run fails, or delivery starts failing. `hermes cron list` shows some of
+this inline, but there is no compact read-only health check that can be run from a
+terminal, cron job, or CI-style smoke check.
+
+## Goal
+
+Add `hermes cron doctor` as a read-only diagnostic command that summarizes cron
+job health and exits non-zero when actionable issues are found.
+
+## Non-goals
+
+- Do not mutate jobs or auto-repair state.
+- Do not start/stop the gateway.
+- Do not inspect secrets or print credentials.
+
+## Acceptance criteria
+
+- `hermes cron doctor` returns `0` and prints a healthy message when active jobs
+  have no detected issues.
+- It returns `1` and prints grouped job-level issues when any active job has:
+  - last run failure (`last_status` not `ok`),
+  - last delivery failure,
+  - no `next_run_at` while still active,
+  - `no_agent` enabled without a script,
+  - script path missing/outside `HERMES_HOME/scripts`, or
+  - configured workdir path missing.
+- Parser, command dispatch, and focused tests cover the new subcommand.

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -572,6 +572,32 @@ def _script_health_issue(script: str) -> Optional[str]:
     return None
 
 
+# Grace period before an overdue ``next_run_at`` is reported. The ticker runs
+# once a minute and a busy tick can push dispatch a few minutes late; only a
+# next_run_at parked well in the past means the job is silently not firing
+# (ticker dead, gateway down, or a wedged fire-claim).
+_OVERDUE_GRACE_SECONDS = 15 * 60
+
+
+def _next_run_overdue_issue(next_run: str) -> Optional[str]:
+    """Return an issue string when ``next_run_at`` is parked in the past."""
+    from datetime import datetime, timezone
+
+    try:
+        dt = datetime.fromisoformat(next_run.replace("Z", "+00:00"))
+    except ValueError:
+        return f"next_run_at is not a valid timestamp: {next_run!r}"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    overdue_s = (datetime.now(timezone.utc) - dt).total_seconds()
+    if overdue_s > _OVERDUE_GRACE_SECONDS:
+        hours = overdue_s / 3600
+        if hours >= 1:
+            return f"next_run_at is {hours:.1f}h overdue — job is not firing (is the scheduler running?)"
+        return f"next_run_at is {overdue_s / 60:.0f}m overdue — job is not firing (is the scheduler running?)"
+    return None
+
+
 def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
     issues: List[str] = []
 
@@ -585,8 +611,13 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
         issues.append(f"last delivery failed: {delivery_err}")
 
     if job.get("enabled", True) and job.get("state") not in {"paused", "completed"}:
-        if not job.get("next_run_at"):
+        next_run = str(job.get("next_run_at") or "").strip()
+        if not next_run:
             issues.append("active job has no next_run_at")
+        else:
+            overdue = _next_run_overdue_issue(next_run)
+            if overdue:
+                issues.append(overdue)
 
     script = str(job.get("script") or "").strip()
     if job.get("no_agent") and not script:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -542,6 +542,100 @@ def _print_active_jobs_summary(jobs) -> None:
         print("  No active jobs")
 
 
+def _scripts_dir_for_cron() -> Path:
+    """Return the scripts directory used by cron jobs.
+
+    Prefer ``cron.jobs.CRON_DIR.parent`` over a fresh ``get_hermes_home()`` call
+    so tests and profile-aware callers that monkeypatch cron storage inspect the
+    same Hermes home the jobs were loaded from.
+    """
+    from cron.jobs import CRON_DIR
+
+    return CRON_DIR.parent / "scripts"
+
+
+def _script_health_issue(script: str) -> Optional[str]:
+    """Return a human-readable script issue, or ``None`` when the path is OK."""
+    scripts_dir = _scripts_dir_for_cron().resolve()
+    raw = Path(script).expanduser()
+    path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+
+    try:
+        path.relative_to(scripts_dir)
+    except ValueError:
+        return f"script resolves outside HERMES_HOME/scripts: {script!r}"
+
+    if not path.exists():
+        return f"script not found: {path}"
+    if not path.is_file():
+        return f"script path is not a file: {path}"
+    return None
+
+
+def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
+    issues: List[str] = []
+
+    last_status = str(job.get("last_status") or "").strip().lower()
+    if last_status and last_status != "ok":
+        err = str(job.get("last_error") or "unknown error").strip()
+        issues.append(f"last run failed: {err}")
+
+    delivery_err = str(job.get("last_delivery_error") or "").strip()
+    if delivery_err:
+        issues.append(f"last delivery failed: {delivery_err}")
+
+    if job.get("enabled", True) and job.get("state") not in {"paused", "completed"}:
+        if not job.get("next_run_at"):
+            issues.append("active job has no next_run_at")
+
+    script = str(job.get("script") or "").strip()
+    if job.get("no_agent") and not script:
+        issues.append("no-agent job has no script")
+    if script:
+        script_issue = _script_health_issue(script)
+        if script_issue:
+            issues.append(script_issue)
+
+    workdir = str(job.get("workdir") or "").strip()
+    if workdir and not Path(workdir).expanduser().exists():
+        issues.append(f"workdir not found: {workdir}")
+
+    return issues
+
+
+def cron_doctor() -> int:
+    """Run read-only cron health checks and return a shell-friendly status."""
+    from cron.jobs import list_jobs
+
+    jobs = list_jobs(include_disabled=False)
+    findings: List[tuple[Dict[str, Any], List[str]]] = []
+    for job in jobs:
+        issues = _cron_doctor_issues_for_job(job)
+        if issues:
+            findings.append((job, issues))
+
+    if not findings:
+        print(color("✓ Cron doctor found no issues", Colors.GREEN))
+        if jobs:
+            print(color(f"  Checked {len(jobs)} active job(s).", Colors.DIM))
+        else:
+            print(color("  No active jobs configured.", Colors.DIM))
+        return 0
+
+    issue_count = sum(len(issues) for _, issues in findings)
+    print(color(f"Cron doctor found {issue_count} issue(s) across {len(findings)} job(s):", Colors.YELLOW))
+    print()
+    for job, issues in findings:
+        job_id = job.get("id", "?")
+        name = job.get("name", "(unnamed)")
+        print(f"  {color(job_id, Colors.YELLOW)} {name}")
+        for issue in issues:
+            print(f"    - {issue}")
+    print()
+    print(color("Next: fix the listed job config, then run `hermes cron doctor` again.", Colors.DIM))
+    return 1
+
+
 def cron_create(args):
     # The gateway-lifecycle guard lives in cron.jobs.create_job so it fires on
     # every job-creation path (this CLI subcommand AND the agent's `cronjob`
@@ -829,6 +923,9 @@ def cron_command(args):
         cron_status()
         return 0
 
+    if subcmd == "doctor":
+        return cron_doctor()
+
     if subcmd == "tick":
         return cron_tick()
 
@@ -861,5 +958,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|doctor|tick]")
     sys.exit(1)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -321,6 +321,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_notepad.add_argument("key", nargs="?", help="Notepad key (get/set/delete)")
     cron_notepad.add_argument("value", nargs="?", help="Value to store (set)")
 
+    # cron doctor
+    cron_subparsers.add_parser("doctor", help="Check scheduled jobs for common health issues")
+
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import create_job, get_job, list_jobs, load_jobs, save_jobs
 from hermes_cli import cron as cron_cli
 from hermes_cli.cron import cron_command
 from hermes_cli.subcommands.cron import build_cron_parser
@@ -128,6 +128,37 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
 
+
+class TestCronDoctor:
+    def test_doctor_reports_cron_health_issues(self, tmp_cron_dir, capsys):
+        job = create_job(prompt="Daily digest", schedule="every 1h", script="missing.py")
+        jobs = load_jobs()
+        jobs[0]["last_status"] = "error"
+        jobs[0]["last_error"] = "Provider returned error"
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Cron doctor found 3 issue(s)" in out
+        assert job["id"] in out
+        assert "last run failed: Provider returned error" in out
+        assert "last delivery failed: telegram timeout" in out
+        assert "script not found" in out
+
+    def test_doctor_reports_healthy_jobs(self, tmp_cron_dir, capsys):
+        scripts_dir = tmp_cron_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "ok.py").write_text("print('ok')\n", encoding="utf-8")
+        create_job(prompt="Daily digest", schedule="every 1h", script="ok.py")
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "✓ Cron doctor found no issues" in out
 
 
 class TestGatewayNotRunningWarning:

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -160,6 +160,38 @@ class TestCronDoctor:
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
 
+    def test_doctor_flags_overdue_next_run(self, tmp_cron_dir, capsys):
+        from datetime import datetime, timedelta, timezone
+
+        create_job(prompt="Hourly ping", schedule="every 1h")
+        jobs = load_jobs()
+        stale = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        jobs[0]["next_run_at"] = stale
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "overdue" in out
+        assert "not firing" in out
+
+    def test_doctor_tolerates_slightly_late_next_run(self, tmp_cron_dir, capsys):
+        from datetime import datetime, timedelta, timezone
+
+        create_job(prompt="Hourly ping", schedule="every 1h")
+        jobs = load_jobs()
+        # 5 minutes late is within the ticker grace window — healthy.
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        jobs[0]["next_run_at"] = recent
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "✓ Cron doctor found no issues" in out
+
 
 class TestGatewayNotRunningWarning:
     """`cron create` / `cron list` must warn when the gateway (and thus the

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -25,8 +25,8 @@ def _build():
 
 def test_cron_subactions_present():
     parser = _build()
-    for action in ("list", "create", "edit", "pause", "resume", "run", "remove", "status", "runs", "tick"):
-        ns = parser.parse_args(["cron", action] if action in ("list", "status", "runs", "tick")
+    for action in ("list", "create", "edit", "pause", "resume", "run", "remove", "status", "runs", "doctor", "tick"):
+        ns = parser.parse_args(["cron", action] if action in ("list", "status", "runs", "doctor", "tick")
                                else ["cron", action, "jobid"] if action in ("pause", "resume", "run", "remove", "edit")
                                else ["cron", "create", "30m"])
         assert ns.command == "cron"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -604,7 +604,7 @@ hermes status [--all] [--deep]
 ## `hermes cron`
 
 ```bash
-hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
+hermes cron <list|create|edit|pause|resume|run|remove|status|runs|incidents|doctor|tick>
 ```
 
 | Subcommand | Description |
@@ -617,6 +617,7 @@ hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
 | `run` | Trigger a job on the next scheduler tick. |
 | `remove` | Delete a scheduled job. |
 | `status` | Check whether the cron scheduler is running. |
+| `doctor` | Read-only fleet health check: failed runs, failed deliveries, overdue/missing `next_run_at`, missing scripts or workdirs. Exits non-zero when issues are found. |
 | `tick` | Run due jobs once and exit. |
 
 The cron **trigger** is pluggable via the `cron.provider` config key. Empty

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -379,6 +379,32 @@ written.
 Recording is always on and costs nothing to ignore — no ping is ever
 suppressed until you explicitly `ack`.
 
+### Fleet health check: `hermes cron doctor`
+
+`hermes cron doctor` is a read-only health check over every active job. It
+prints grouped, per-job issues and exits `1` when anything actionable is
+found (`0` when healthy), so it works from a terminal, a watchdog script, or
+a CI-style smoke check:
+
+```bash
+hermes cron doctor
+```
+
+Checks per active job:
+
+- last run failed (`last_status` not ok, with the recorded error),
+- last delivery failed (the output was produced but never reached you),
+- `next_run_at` missing, or parked in the past beyond a 15-minute ticker
+  grace window — the "job is silently not firing" signal (scheduler dead,
+  gateway down, or a wedged fire-claim),
+- script missing, not a file, or resolving outside `HERMES_HOME/scripts`,
+- `no_agent` job with no script,
+- configured `workdir` that no longer exists.
+
+Doctor never mutates jobs or state — it only reports. Pair it with
+`hermes cron incidents` (durable failure records) and `hermes cron runs`
+(attempt ledger) when digging into a flagged job.
+
 ## Delivery options
 
 When scheduling jobs, you specify where the output goes:


### PR DESCRIPTION
## Summary
`hermes cron doctor` now exists — a read-only fleet health check that reports failed runs, failed deliveries, overdue/missing `next_run_at`, missing scripts, and dead workdirs, exiting non-zero when anything is actionable. Salvages #43729 by @joe102084 onto current main.

This came straight out of live fleet telemetry: a 60-job cron fleet had a job dead for 5 days (content-filter failure) and two watchdogs silently not firing — none of which any single existing surface (`list`/`status`/`incidents`) shows in one shot.

## Changes
- `hermes_cli/cron.py`: `cron_doctor()` + per-job issue checks (salvaged), widened with an overdue-`next_run_at` detector (15-min ticker grace) — the "job is silently not firing" signal
- `hermes_cli/subcommands/cron.py`: `doctor` subparser registered alongside runs/incidents/notepad
- `tests/hermes_cli/test_cron.py`: salvaged doctor tests + 2 new overdue/grace-window tests
- `tests/hermes_cli/test_cron_parser_builder.py`: doctor in the subaction matrix
- `website/docs/user-guide/features/cron.md` + `reference/cli-commands.md`: doctor documented
- `docs/cron-doctor-spec.md`: contributor's spec (salvaged)

## Validation
| | Before (main) | After (branch) |
|---|---|---|
| `hermes cron doctor` | invalid choice error | runs, read-only |
| Live 60-job fleet | n/a | flagged the genuinely-dead `gemini-cli-pr-scout` (content_filter failure), exit 1 |
| Healthy fleet subset | n/a | exit 0, "no issues" |
| Targeted tests | — | 21/21 passed (`test_cron.py`, `test_cron_parser_builder.py`) |

**Live repro:** before — `hermes cron doctor` on installed main errors with `invalid choice: 'doctor'`; after — same command from the branch against the real ~/.hermes fleet reported the one actually-failing job and exited correctly.

Credit: @joe102084 (#43729) for the original implementation; authorship preserved via cherry-pick.

## Infographic

![Cron Doctor holo card](https://v3b.fal.media/files/b/0aa88f7d/8qJK72mi6Q4za95_u42hc_zjsJvNOK.png)
