### PR TITLE
fix(install): retry the HTTPS clone and degrade past repo-scoped 429s (salvage #89629)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1470,7 +1470,49 @@ EOF
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."
-            if git clone --depth 1 --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+            # GitHub throttles packfile generation for large repos (this one:
+            # ~9.6k files at HEAD plus thousands of auto-generated branches)
+            # with repo-scoped HTTP 429s that are NOT client IP rate limits —
+            # an anonymous clone of a small repo succeeds and the API quota
+            # is untouched, but the single big pack behind `--depth 1` dies
+            # mid-transfer with "RPC failed; HTTP 429 / expected 'packfile'"
+            # (#89624, same throttle as the update path in #89287). Retry
+            # with backoff, then degrade to a blobless partial clone + fetch
+            # (many small packs instead of one big one — what gets past the
+            # throttle). Fully materialize the tree afterwards so the rest of
+            # the installer sees the normal files.
+            local clone_ok=false
+            local attempt=0
+            local max_attempts=4
+            for attempt in 1 2 3 4; do
+                [ "$attempt" -gt 1 ] && log_info "Retrying HTTPS clone (attempt $attempt/$max_attempts)..."
+                if git clone --depth 1 --single-branch --branch "$BRANCH" \
+                     "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    clone_ok=true
+                    break
+                fi
+                rm -rf "$INSTALL_DIR" 2>/dev/null  # partial clone is unusable
+                [ "$attempt" -lt "$max_attempts" ] && sleep $((attempt * 5))
+            done
+            if [ "$clone_ok" != true ]; then
+                log_info "Direct clone throttled — trying blobless partial clone..."
+                if git clone --depth 1 --single-branch --filter=blob:none \
+                     --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    # Materialize the working tree (fetches blobs in small
+                    # packs; one retry helps when the fetch itself is
+                    # throttled). The checkout git printed during the partial
+                    # clone shows missing-content placeholders until this
+                    # reset runs.
+                    cd "$INSTALL_DIR" 2>/dev/null || true
+                    git reset --hard HEAD >/dev/null 2>&1 \
+                        || git reset --hard HEAD >/dev/null 2>&1 \
+                        || true
+                    clone_ok=true
+                else
+                    rm -rf "$INSTALL_DIR" 2>/dev/null
+                fi
+            fi
+            if [ "$clone_ok" = true ]; then
                 log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1484,7 +1484,7 @@ EOF
             local clone_ok=false
             local attempt=0
             local max_attempts=4
-            for attempt in 1 2 3 4; do
+            for attempt in $(seq 1 "$max_attempts"); do
                 [ "$attempt" -gt 1 ] && log_info "Retrying HTTPS clone (attempt $attempt/$max_attempts)..."
                 if git clone --depth 1 --single-branch --branch "$BRANCH" \
                      "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
@@ -1496,18 +1496,26 @@ EOF
             done
             if [ "$clone_ok" != true ]; then
                 log_info "Direct clone throttled — trying blobless partial clone..."
+                # --no-checkout keeps the clone itself to commits+trees (small,
+                # gets past the pack throttle). Without it the blob fetch runs
+                # inside `git clone`'s own checkout step, the throttle kills
+                # the whole clone, and this fallback degrades to one more
+                # failed clone. The blobs are fetched by the reset below — a
+                # separate request the retry can actually wrap.
                 if git clone --depth 1 --single-branch --filter=blob:none \
-                     --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
-                    # Materialize the working tree (fetches blobs in small
-                    # packs; one retry helps when the fetch itself is
-                    # throttled). The checkout git printed during the partial
-                    # clone shows missing-content placeholders until this
-                    # reset runs.
-                    cd "$INSTALL_DIR" 2>/dev/null || true
-                    git reset --hard HEAD >/dev/null 2>&1 \
-                        || git reset --hard HEAD >/dev/null 2>&1 \
-                        || true
-                    clone_ok=true
+                     --no-checkout --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    # Materialize the working tree: on a --no-checkout clone
+                    # this reset is the step that fetches the blobs (several
+                    # small packs instead of one big one). Fail closed — a
+                    # half-materialized checkout must not report success and
+                    # hand the rest of the installer an unusable tree.
+                    if (cd "$INSTALL_DIR" \
+                        && (git reset --hard HEAD >/dev/null 2>&1 \
+                            || { sleep 5; git reset --hard HEAD >/dev/null 2>&1; })); then
+                        clone_ok=true
+                    else
+                        rm -rf "$INSTALL_DIR" 2>/dev/null  # unusable checkout
+                    fi
                 else
                     rm -rf "$INSTALL_DIR" 2>/dev/null
                 fi

--- a/tests/test_install_clone_throttle_fallback.py
+++ b/tests/test_install_clone_throttle_fallback.py
@@ -11,9 +11,16 @@ The contract pinned here:
 - The HTTPS clone is retried with backoff before giving up.
 - A failed direct attempt is retried after removing the partial clone.
 - When every direct attempt fails, the installer degrades to a blobless
-  partial clone (`--filter=blob:none`) and materializes the working tree
-  with `git reset --hard HEAD` — many small packs instead of one big one,
-  which is what gets past the throttle.
+  partial clone (`--filter=blob:none --no-checkout`) and materializes the
+  working tree with `git reset --hard HEAD` — the clone itself is
+  commits+trees only (small, passes the throttle) and the reset becomes
+  the separate blob fetch the retry can wrap (review of #89629: without
+  --no-checkout the blob fetch runs inside `git clone`'s own checkout,
+  so the throttle kills the whole clone and the fallback degrades to one
+  more failed clone).
+- Materialization fails closed: both reset attempts failing must remove
+  the checkout and report a clone failure, never report success over an
+  unusable tree.
 """
 
 from __future__ import annotations
@@ -46,8 +53,9 @@ def _https_branch() -> str:
 
 def test_https_clone_is_retried_with_backoff():
     branch = _https_branch()
-    assert re.search(r"for attempt in 1 2 3 4", branch), (
-        "the HTTPS clone must be retried a bounded number of times"
+    assert re.search(r"for attempt in \$\(seq 1 \"\$max_attempts\"\)", branch), (
+        "the HTTPS clone must be retried a bounded number of times, with the "
+        "loop bound driven by the same variable the messages report"
     )
     assert re.search(r"sleep \$\(\(attempt \* 5\)\)", branch), (
         "retries must back off between attempts"
@@ -66,9 +74,42 @@ def test_blobless_partial_clone_fallback_exists():
         "after direct attempts fail, degrade to a blobless partial clone "
         "(many small packs — what gets past the repo-scoped 429)"
     )
+    assert re.search(
+        r"git clone --depth 1 --single-branch --filter=blob:none \\\n"
+        r"\s*--no-checkout --branch \"\$BRANCH\"",
+        branch,
+    ), (
+        "the partial clone must defer the checkout (--no-checkout): the blob "
+        "fetch otherwise runs inside git clone's own checkout step, the "
+        "throttle kills the whole clone, and the fallback never engages"
+    )
     assert re.search(r"git reset --hard HEAD", branch), (
         "the partial clone's working tree must be materialized so the rest "
         "of the installer sees the normal files"
+    )
+
+
+def test_materialization_fails_closed():
+    """A failed blob materialization must not report a successful clone.
+
+    The reset on a --no-checkout clone is the step that fetches the blobs,
+    so it is the step most likely to be throttled. `|| true` plus an
+    unconditional `clone_ok=true` would hand the rest of the installer a
+    half-materialized tree while printing "Cloned via HTTPS".
+    """
+    branch = _https_branch()
+    fallback = branch.split('log_info "Direct clone throttled')[1]
+    assert "|| true" not in fallback, (
+        "the materialization retry must not swallow a hard failure"
+    )
+    m = re.search(
+        r"if \(cd \"\$INSTALL_DIR\" \\\n"
+        r"\s*&& \(git reset --hard HEAD",
+        fallback,
+    )
+    assert m is not None, (
+        "the reset must be guarded: its success is the condition that sets "
+        "clone_ok, and a failed reset must clean up the checkout"
     )
 
 

--- a/tests/test_install_clone_throttle_fallback.py
+++ b/tests/test_install_clone_throttle_fallback.py
@@ -1,0 +1,94 @@
+"""Fresh-install clone throttle handling (#89624).
+
+GitHub throttles packfile generation for this repo with repo-scoped HTTP
+429s (not client IP limits): the single big pack behind `--depth 1` dies
+mid-transfer with "RPC failed; HTTP 429 / expected 'packfile'", and
+clone_repo's HTTPS branch had no retry and no fallback — a fresh install
+on an ordinary unauthenticated machine exited 1 at the download stage
+(same throttle as the update path in #89287).
+
+The contract pinned here:
+- The HTTPS clone is retried with backoff before giving up.
+- A failed direct attempt is retried after removing the partial clone.
+- When every direct attempt fails, the installer degrades to a blobless
+  partial clone (`--filter=blob:none`) and materializes the working tree
+  with `git reset --hard HEAD` — many small packs instead of one big one,
+  which is what gets past the throttle.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _https_branch() -> str:
+    text = INSTALL_SH.read_text()
+    m = re.search(
+        r"log_info \"SSH failed, trying HTTPS\.\.\..*?(?=\n    fi\n)",
+        text,
+        re.DOTALL,
+    )
+    assert m is not None, "HTTPS clone branch not found in install.sh"
+    return m.group(0)
+
+
+def test_https_clone_is_retried_with_backoff():
+    branch = _https_branch()
+    assert re.search(r"for attempt in 1 2 3 4", branch), (
+        "the HTTPS clone must be retried a bounded number of times"
+    )
+    assert re.search(r"sleep \$\(\(attempt \* 5\)\)", branch), (
+        "retries must back off between attempts"
+    )
+    # A failed direct attempt leaves a partial clone; it must be removed
+    # before the next attempt or git refuses to clone into a non-empty dir.
+    assert re.search(
+        r"rm -rf \"\$INSTALL_DIR\" 2>/dev/null  # partial clone is unusable",
+        branch,
+    ), "each failed direct attempt must clean up the partial clone"
+
+
+def test_blobless_partial_clone_fallback_exists():
+    branch = _https_branch()
+    assert "--filter=blob:none" in branch, (
+        "after direct attempts fail, degrade to a blobless partial clone "
+        "(many small packs — what gets past the repo-scoped 429)"
+    )
+    assert re.search(r"git reset --hard HEAD", branch), (
+        "the partial clone's working tree must be materialized so the rest "
+        "of the installer sees the normal files"
+    )
+
+
+def test_partial_clone_failure_still_cleans_up_and_exits():
+    branch = _https_branch()
+    m = re.search(
+        r'if \[ "\$clone_ok" = true \]; then\n\s*log_success "Cloned via HTTPS"'
+        r"\n\s*else\n\s*log_error \"Failed to clone repository\"\n\s*exit 1",
+        branch,
+    )
+    assert m is not None, (
+        "when the fallback also fails the installer must still report the "
+        "failure and exit 1"
+    )
+
+
+def test_fallback_runs_only_after_all_direct_attempts_fail():
+    branch = _https_branch()
+    direct = branch.split('log_info "Direct clone throttled')[0]
+    assert re.search(r"clone_ok != true|clone_ok\" != true", direct), (
+        "the blobless fallback must be gated on every direct attempt having "
+        "failed — a successful direct clone must never take the fallback path"
+    )


### PR DESCRIPTION
Salvage of #89629 by @liuhao1024 onto current `main` (authorship preserved via cherry-pick). Fixes #89624.

## Root cause

GitHub throttles packfile generation for this large repo with **repo-scoped HTTP 429s** that are not client IP rate limits — an anonymous clone of a small repo succeeds and the API quota is untouched, but the single big pack behind `--depth 1` dies mid-transfer with `RPC failed; HTTP 429 / expected 'packfile'`. The fresh-install `clone_repo()` HTTPS fallback had **no retry and no fallback**, so a clean machine exited 1 at the download stage and left a half-populated `~/.hermes` (same throttle as the update path in #89287).

## Mechanism

1. **Retry the direct HTTPS clone** up to 4 attempts with linear backoff (`attempt × 5s`), removing the unusable partial clone directory between attempts. Loop bound derives from `$max_attempts` (`seq`), so the reported attempt count can't drift.
2. **Final fallback: blobless partial clone** — `git clone --depth 1 --single-branch --filter=blob:none --no-checkout`, then materialize the working tree with `git reset --hard HEAD` (retried once after 5s). Many small packs instead of one big one, which is what gets past the throttle.
3. **Fail closed**: if both reset attempts fail, the checkout is removed and the installer reports `Failed to clone repository` instead of handing the rest of the install a half-materialized tree printed as a success. The reset runs under a subshell `cd` so a failed materialization never leaves the shell in a deleted cwd.

Credit to reviewer @jackulau for the empirical `--no-checkout` finding: without it, the blob fetch runs *inside* `git clone`'s own checkout step, so the throttle kills the whole clone and the fallback degrades to one more failed clone under exactly the condition it exists for. Verified on a local `file://` filtering remote that the no-checkout clone materializes nothing and the reset alone produces the full working tree.

SSH-first ordering, the existing installation-update branch, and the `--commit` pin flow are unchanged.

## Tests

`tests/test_install_clone_throttle_fallback.py` (text-contract test over `scripts/install.sh`) — 5 passed locally. `bash -n scripts/install.sh` clean.

## Infographic

![install.sh 429 throttle retry + blobless fallback](https://v3b.fal.media/files/b/0aa88f86/ACIPDbzvyc9Gt4M1Q8hW4_BxxtZVJv.png)
