### PR TITLE
fix(discord): gate relay-only thread rename kwargs off the native lane (#78487)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24478,18 +24478,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "relay" if use_connector_guard else "native",
             thread_name,
         )
+        rename_kwargs = (
+            {
+                "prefer_connector_created": True,
+                "parent_chat_id": parent_chat_id,
+            }
+            if use_connector_guard
+            else {"only_if_current_name": guard_name}
+        )
         try:
             renamed = await rename_thread(
                 target_thread_id,
                 thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
+                **rename_kwargs,
             )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,
                 bool(renamed),
+            )
+        except TypeError:
+            logger.warning(
+                "Discord semantic thread rename raised TypeError (adapter=%s)",
+                type(adapter).__name__,
+                exc_info=True,
             )
         except Exception:
             logger.debug("Failed to rename Discord auto-thread for generated session title", exc_info=True)

--- a/tests/gateway/test_session_title_rename_lane.py
+++ b/tests/gateway/test_session_title_rename_lane.py
@@ -14,7 +14,7 @@ import types
 import pytest
 
 from gateway.config import Platform
-from gateway.run import TurnRunner
+from gateway.run import GatewayRunner, TurnRunner
 
 
 def _attach(lane):
@@ -53,3 +53,51 @@ def test_the_rename_waits_for_the_model_title(lane):
 
     callback("Fix flaky auth test", "llm")
     assert renames == ["Fix flaky auth test"]
+
+
+@pytest.mark.asyncio
+async def test_native_thread_rename_passes_only_the_initial_name_guard():
+    """The shared rename lane must honor the strict native adapter contract."""
+    calls: list[tuple[str, str, str | None]] = []
+
+    class StrictNativeAdapter:
+        async def rename_thread(
+            self,
+            thread_id: str,
+            name: str,
+            *,
+            only_if_current_name: str | None = None,
+        ) -> bool:
+            calls.append((thread_id, name, only_if_current_name))
+            return True
+
+    class NativeRenameRunner:
+        _is_discord_auto_thread_lane = GatewayRunner._is_discord_auto_thread_lane
+        _sanitize_discord_thread_title = GatewayRunner._sanitize_discord_thread_title
+        _rename_discord_auto_thread_for_session_title = (
+            GatewayRunner._rename_discord_auto_thread_for_session_title
+        )
+
+        def __init__(self, adapter):
+            self.adapters = {Platform.DISCORD: adapter}
+
+        def _adapter_for_source(self, source):
+            return self.adapters[source.platform]
+
+    source = types.SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        thread_id="999",
+        auto_thread_created=True,
+        auto_thread_initial_name="Initial words",
+    )
+
+    runner = NativeRenameRunner(StrictNativeAdapter())
+    await runner._rename_discord_auto_thread_for_session_title(
+        source,
+        "session-1",
+        "Semantic Session Title",
+    )
+
+    assert calls == [("999", "Semantic Session Title", "Initial words")]


### PR DESCRIPTION
Fixes #78487.

## Problem

Since the relay thread-rename changes (#75912 / #76465), the shared semantic-rename lane in `gateway/run.py` (`_rename_discord_auto_thread_for_session_title`) passes `prefer_connector_created=` and `parent_chat_id=` **unconditionally** to whichever adapter's `rename_thread` it resolved. Only the relay adapter (`gateway/relay/adapter.py`) accepts those kwargs — the native Discord adapter's contract is strictly `rename_thread(thread_id, name, *, only_if_current_name=None)`.

On the native lane this raises `TypeError` at call binding, which the bare `except Exception` swallows at DEBUG. Result: the INFO "attempt" line fires, no result line ever follows, and native auto-threads silently keep their placeholder titles. Confirmed live-repro on baseline `26f178e5fa`:

```
DIRECT CALL: TypeError fired -> DiscordAdapter.rename_thread() got an unexpected keyword argument 'prefer_connector_created'
LOG INFO: discord auto-thread rename: thread=999 lane=native new_title='Semantic Title'
LOG DEBUG: Failed to rename Discord auto-thread ... [TypeError: ... 'prefer_connector_created']
```

## Fix (call-site gating — salvage of #82911 by @quocanh261997)

- `gateway/run.py`: build the kwargs per lane — relay lane gets `prefer_connector_created=True` + `parent_chat_id`; native lane gets only `only_if_current_name`. The native adapter's strict contract is preserved (the connector kwargs are relay-egress concepts and have no meaning for the direct Discord API path — widening the native signature to swallow them, as #78495/#84501 do, papers over the next contract drift).
- A dedicated `except TypeError` now logs at **WARNING** with the adapter class name, so any future contract mismatch on this seam is visible instead of a DEBUG-swallowed silent failure.
- Regression test: `test_native_thread_rename_passes_only_the_initial_name_guard` drives the REAL `GatewayRunner._rename_discord_auto_thread_for_session_title` against a signature-strict native adapter and asserts the exact call `("999", "Semantic Title", "Initial words")`.

Cherry-picked with authorship preserved (Michael Nguyen). Duplicate cluster on this issue: #78495, #80869, #82911, #84501, #97090 — this lands the call-site-gating approach the issue thread converged on (recommended by three independent commenters incl. the original feature author of #56792).

## Live repro / verification

**Live repro:** real-import harness (worktree `sys.path`, real `DiscordAdapter` + real `GatewayRunner._rename_discord_auto_thread_for_session_title`, no mocks of code under test) — before: TypeError fired and was swallowed at DEBUG, no result log; after: call binds cleanly, lane reaches the adapter body, native adapter receives exactly `(thread_id, name, only_if_current_name=...)`.

- Sabotage run: reverting `gateway/run.py` to main makes the new regression test FAIL (call receives the relay kwargs); fixed code passes.
- Targeted tests: `tests/gateway/test_session_title_rename_lane.py` + `tests/gateway/relay/test_relay_threads.py` — 21 passed.
- `ruff check` clean on both touched files (format --check noise on `gateway/run.py` is pre-existing across the whole file, untouched here).

## Infographic

![discord-thread-rename](https://v3b.fal.media/files/b/0aa88f90/0_YVem9Uc0QMFiYbtJ-9I_qCWbhZTy.png)
