### PR TITLE
fix(memory): split FTS queries on unicode61 separator characters

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -616,7 +616,11 @@ class FactRetriever:
         # accidentally creating a malformed query.
         _FTS_SPECIAL = '"()*^:-+'
         tokens: list[str] = []
-        for raw in query.lower().split():
+        # FTS5's unicode61 tokenizer treats -, /, _ as separators, so
+        # "llama-swap" is indexed as ("llama", "swap"). Deleting the
+        # hyphen here would query "llamaswap" — a token that can never
+        # exist in the index. Split on the same separators instead.
+        for raw in query.lower().translate(str.maketrans("-/_", "   ")).split():
             cleaned = raw.strip(".,;:!?\"'()[]{}#@<>") .translate(
                 str.maketrans("", "", _FTS_SPECIAL)
             )


### PR DESCRIPTION
## What

`_sanitize_fts_query()` in `plugins/memory/holographic/retrieval.py` strips FTS5 operator characters (including `-`) out of each whitespace-split token. But FTS5's default unicode61 tokenizer treats `-`, `/`, and `_` as token **separators**, so a fact containing "llama-swap" is indexed as the tokens `("llama", "swap")`. Deleting the hyphen from the query instead produces `"llamaswap"` — a token that can never exist in the index — so exact-name queries for hyphenated/slashed/underscored terms (tool names, model names, paths) silently return zero FTS candidates.

## Fix

Split the query on the same separator characters (`-`, `/`, `_` → space) before per-token cleaning, so query tokenization matches index tokenization. The existing operator-stripping and stopword logic is unchanged.

## How to test

Store a fact whose content contains a hyphenated name (e.g. "llama-swap fronts the local endpoint"), then `search("llama-swap")`. Before: the sanitizer queries `"llamaswap"`, FTS returns zero candidates, and the whole hybrid pipeline returns nothing (candidates gate the reranker). After: the query becomes `"llama" "swap"` and the fact is retrieved.

## Platforms

Windows 11, running in production since 2026-07-11. Pure-stdlib change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
