### PR TITLE
fix(memory): forward checkpoint requirement to v2 providers (salvage #97063)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1122,7 +1122,13 @@ class MemoryManager:
             if is_checkpoint_provider and evidence_messages is not None:
                 provider_messages = evidence_messages
             try:
-                result = provider.on_pre_compress(provider_messages)
+                if is_checkpoint_provider:
+                    result = provider.on_pre_compress(
+                        provider_messages,
+                        require_checkpoint=require_checkpoint,
+                    )
+                else:
+                    result = provider.on_pre_compress(provider_messages)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -41,6 +41,36 @@ from tools.registry import tool_error
 # historical best-effort contract (API v1).
 _LEGACY_PRE_COMPRESS_API_VERSION = 1
 
+
+def _accepts_require_checkpoint(fn: Callable[..., Any]) -> bool:
+    """True if ``fn`` can receive the ``require_checkpoint`` keyword.
+
+    Checkpoint (v2) providers written against the original docs example use
+    the bare ``on_pre_compress(self, messages)`` signature; calling them with
+    the keyword would raise ``TypeError`` — which, under
+    ``require_checkpoint=True``, the host would re-raise as a checkpoint
+    failure even though the provider's durable write succeeded. Inspect the
+    signature and fall back to the legacy call shape when the keyword (or a
+    ``**kwargs`` catch-all) is absent. Unreadable signatures (C callables,
+    exotic proxies) conservatively report False.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if (
+            param.name == "require_checkpoint"
+            and param.kind in (
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ):
+            return True
+    return False
+
 logger = logging.getLogger(__name__)
 
 # How long shutdown_all() waits for in-flight background sync/prefetch work
@@ -1122,12 +1152,19 @@ class MemoryManager:
             if is_checkpoint_provider and evidence_messages is not None:
                 provider_messages = evidence_messages
             try:
-                if is_checkpoint_provider:
+                if is_checkpoint_provider and _accepts_require_checkpoint(
+                    provider.on_pre_compress
+                ):
                     result = provider.on_pre_compress(
                         provider_messages,
                         require_checkpoint=require_checkpoint,
                     )
                 else:
+                    # Legacy (v1) providers keep the strict one-argument
+                    # contract. v2 providers written against the original
+                    # docs example (``def on_pre_compress(self, messages)``)
+                    # also land here instead of dying on an unexpected
+                    # kwarg — they simply never see the requirement signal.
                     result = provider.on_pre_compress(provider_messages)
                 if result and result.strip():
                     parts.append(result)

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -215,6 +215,49 @@ def test_checkpoint_provider_receives_false_in_best_effort_mode():
     assert durable.require_checkpoint_calls == [False]
 
 
+def test_v2_provider_with_bare_signature_still_works():
+    """v2 providers written against the original docs example
+    (``def on_pre_compress(self, messages)``) must not TypeError when the
+    host forwards the checkpoint requirement — they fall back to the legacy
+    call shape and simply never see the signal."""
+    manager = MemoryManager()
+
+    class _BareSignatureCheckpointProvider(_BaseStubProvider):
+        pre_compress_checkpoint_api_version = PRE_COMPRESS_CHECKPOINT_API_VERSION
+
+    bare = _BareSignatureCheckpointProvider("bare-v2")
+    manager.add_provider(bare)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+        require_checkpoint=True,
+    )
+
+    assert combined == "bare-v2 context"
+    assert bare.pre_compress_calls
+
+
+def test_v2_provider_with_kwargs_catchall_receives_signal():
+    manager = MemoryManager()
+    observed = {}
+
+    class _KwargsCheckpointProvider(_BaseStubProvider):
+        pre_compress_checkpoint_api_version = PRE_COMPRESS_CHECKPOINT_API_VERSION
+
+        def on_pre_compress(self, messages, **kwargs):
+            observed.update(kwargs)
+            return "kw context"
+
+    manager.add_provider(_KwargsCheckpointProvider("kw"))
+
+    manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+        require_checkpoint=True,
+    )
+
+    assert observed == {"require_checkpoint": True}
+
+
 def test_manager_require_checkpoint_propagates_checkpoint_provider_failure():
     manager = MemoryManager()
     manager.add_provider(_FailingCheckpointProvider("durable"))

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -50,10 +50,21 @@ class _BaseStubProvider(MemoryProvider):
 class _CheckpointProvider(_BaseStubProvider):
     pre_compress_checkpoint_api_version = PRE_COMPRESS_CHECKPOINT_API_VERSION
 
+    def __init__(self, name="stub"):
+        super().__init__(name)
+        self.require_checkpoint_calls = []
+
+    def on_pre_compress(self, messages, *, require_checkpoint=False):
+        self.require_checkpoint_calls.append(require_checkpoint)
+        return super().on_pre_compress(messages)
+
 
 class _FailingCheckpointProvider(_CheckpointProvider):
-    def on_pre_compress(self, messages):
-        raise RuntimeError("durable store unreachable")
+    def on_pre_compress(self, messages, *, require_checkpoint=False):
+        self.require_checkpoint_calls.append(require_checkpoint)
+        if require_checkpoint:
+            raise RuntimeError("durable store unreachable")
+        return ""
 
 
 class _FailingLegacyProvider(_BaseStubProvider):
@@ -163,6 +174,45 @@ def test_manager_require_checkpoint_raises_without_capable_provider():
             require_checkpoint=True,
             checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
         )
+
+
+def test_manager_passes_required_signal_to_checkpoint_provider():
+    manager = MemoryManager()
+    durable = _CheckpointProvider("durable")
+    manager.add_provider(durable)
+
+    manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+        require_checkpoint=True,
+    )
+
+    assert durable.require_checkpoint_calls == [True]
+
+
+def test_manager_does_not_pass_checkpoint_keyword_to_legacy_provider():
+    manager = MemoryManager()
+    legacy = _BaseStubProvider("legacy")
+    manager.add_provider(legacy)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+    )
+
+    assert combined == "legacy context"
+    assert legacy.pre_compress_calls
+
+
+def test_checkpoint_provider_receives_false_in_best_effort_mode():
+    manager = MemoryManager()
+    durable = _FailingCheckpointProvider("durable")
+    manager.add_provider(durable)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+    )
+
+    assert combined == ""
+    assert durable.require_checkpoint_calls == [False]
 
 
 def test_manager_require_checkpoint_propagates_checkpoint_provider_failure():

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -148,7 +148,9 @@ class MyArchivingProvider(MemoryProvider):
     # contract: best-effort semantics, raw message list.
     pre_compress_checkpoint_api_version = 2
 
-    def on_pre_compress(self, messages):
+    def on_pre_compress(self, messages, *, require_checkpoint=False):
+        # require_checkpoint mirrors the operator's checkpoint_required
+        # setting: True means a raise here blocks the lossy rewrite.
         ids = self._archive(messages)   # must be durable before returning
         return f"checkpoint: {ids}"     # forwarded into the summary prompt
 ```


### PR DESCRIPTION
## Summary

Salvage of #97063 by @Soju06 (cherry-picked preserving authorship), plus a compatibility hardening commit on top.

### The bug (confirmed on main @ a071fc80da)

With `compression.checkpoint_required: true` and a memory provider advertising `pre_compress_checkpoint_api_version = 2`, `MemoryManager.on_pre_compress()` detects the v2 provider, selects `evidence_messages` for it, and is prepared to re-raise its failures — but the actual call never forwards the flag:

```python
result = provider.on_pre_compress(provider_messages)
```

The provider therefore always runs in its default best-effort mode (`require_checkpoint=False`). A failing durable write does not block compression; the host treats the checkpoint as succeeded and the lossy rewrite proceeds — silently defeating the guarantee `checkpoint_required` exists to provide.

### Fix (commit 1, @Soju06)

Forward `require_checkpoint` to providers advertising the requested checkpoint API version; legacy v1 providers keep the strict one-argument contract (passing the kwarg unconditionally would `TypeError` on every bundled v1 provider).

### Hardening (commit 2)

The shipped docs example for v2 providers (`website/docs/developer-guide/memory-provider-plugin.md`) uses the bare `def on_pre_compress(self, messages)` signature. Any provider written against that example would `TypeError` the moment the host forwards the keyword — and under `require_checkpoint=True` the host re-raises that as a checkpoint failure even though the durable write succeeded. Added `_accepts_require_checkpoint()` (signature inspection, `**kwargs` aware, conservative on unreadable signatures) so bare-signature v2 providers fall back to the legacy call shape, and updated the docs example to advertise the keyword.

## Verification

- `tests/agent/test_pre_compress_checkpoint_contract.py`: **22 passed** (existing 16 + @Soju06's 4 + 2 new: bare-signature v2 survives required mode; `**kwargs` catch-all receives the signal).
- Live real-import run (temp `HERMES_HOME`, real `MemoryManager` + real `MemoryProvider` ABC subclasses):
  - `require_checkpoint=True` arrives at the v2 provider; its failure propagates and blocks compression ✅
  - best-effort mode forwards `False`, no raise ✅
  - bare-signature v2 provider called without the kwarg — no `TypeError` ✅
- `ruff check` clean on touched files.

## Relationship to #96779

Independent. #96779 guards the *summary output* side (truncated `finish_reason=length` summaries never become the compaction checkpoint); this PR fixes the *pre-compress memory checkpoint* signal path. Different files, no overlap; they stack cleanly.

## Credit

Fix authored by @Soju06 (#97063) — cherry-picked with authorship preserved. Closes #97063.

## Infographic

![checkpoint requirement forwarding — before/after](https://v3b.fal.media/files/b/0aa88f98/ULFuvzq4jKs-_hYSjE9Ep_cEddgUep.png)
