### PR TITLE
fix(security): make desktop secret storage secure by default

### DIFF
--- a/apps/desktop/electron/secret-storage-policy.test.ts
+++ b/apps/desktop/electron/secret-storage-policy.test.ts
@@ -1,16 +1,3 @@
-/**
- * Tests for electron/secret-storage-policy.ts — the "is OS-keychain
- * encryption enabled at all?" decision seam.
- *
- * The behavior this file pins: keychain-backed encryption is OPT-IN
- * (default OFF), and once the one-shot legacy migration has run, a
- * safeStorage blob under an opted-out policy reads as 'drop' — i.e. the
- * caller must treat it as absent WITHOUT touching safeStorage, so a broken
- * macOS login keychain can never raise its password dialog on launch.
- *
- * (Wired into the vitest `electron` project via electron/**\/*.test.ts.)
- */
-
 import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
@@ -18,6 +5,7 @@ import { test } from 'vitest'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
+  SECRET_STORAGE_POLICY_VERSION,
   type SecretStoragePolicyIo,
   writeSecretStoragePolicy
 } from './secret-storage-policy'
@@ -40,64 +28,81 @@ function fakeIo(initial: string | null = null): SecretStoragePolicyIo & { fileTe
   }
 }
 
-// ── defaults ────────────────────────────────────────────────────────────────
+const SECURE_DEFAULT = { on: true, migrated: false }
 
-test('missing policy file defaults to encryption OFF, not migrated', () => {
-  const policy = readSecretStoragePolicy(fakeIo())
-
-  assert.deepEqual(policy, { on: false, migrated: false })
-})
-
-test('corrupt or non-object policy file reads as the default', () => {
-  for (const bad of ['not-json', '[]', '"on"', 'null', '123']) {
-    assert.deepEqual(readSecretStoragePolicy(fakeIo(bad)), { on: false, migrated: false })
+test('missing or malformed policy fails closed to encryption ON', () => {
+  for (const input of [null, 'not-json', '[]', '"on"', 'null', '123']) {
+    assert.deepEqual(readSecretStoragePolicy(fakeIo(input)), SECURE_DEFAULT)
   }
 })
 
-test('truthy-but-not-true values do NOT enable encryption', () => {
-  // Strict === true coercion: a hand-edited "on": 1 or "yes" must not turn
-  // keychain prompts back on.
-  for (const bad of ['{"on":1}', '{"on":"yes"}', '{"on":"true"}']) {
-    assert.equal(readSecretStoragePolicy(fakeIo(bad)).on, false)
+test('legacy two-field plaintext records do not masquerade as explicit consent', () => {
+  assert.deepEqual(readSecretStoragePolicy(fakeIo('{"on":false,"migrated":true}')), SECURE_DEFAULT)
+  assert.deepEqual(readSecretStoragePolicy(fakeIo('{"on":true,"migrated":false}')), SECURE_DEFAULT)
+})
+
+test('only the exact current schema is authoritative', () => {
+  const invalid = [
+    '{"version":1,"on":false,"migrated":true}',
+    '{"version":2,"on":false}',
+    '{"version":2,"on":0,"migrated":true}',
+    '{"version":2,"on":false,"migrated":true,"unknown":false}',
+    '{"version":2,"on":true,"on":false,"migrated":true}',
+    '{"version":2,"on":false,"migrated":true} trailing'
+  ]
+
+  for (const input of invalid) {
+    assert.deepEqual(readSecretStoragePolicy(fakeIo(input)), SECURE_DEFAULT)
   }
 })
 
-test('round trip preserves both fields', () => {
+test('current-schema explicit opt-out and opt-in are both honored', () => {
+  assert.deepEqual(
+    readSecretStoragePolicy(fakeIo('{"version":2,"on":false,"migrated":true}')),
+    { on: false, migrated: true }
+  )
+  assert.deepEqual(
+    readSecretStoragePolicy(fakeIo('{"version":2,"on":true,"migrated":false}')),
+    { on: true, migrated: false }
+  )
+})
+
+test('writes the current schema and round-trips both policy states', () => {
   const io = fakeIo()
 
-  writeSecretStoragePolicy({ on: true, migrated: true }, io)
-  assert.deepEqual(readSecretStoragePolicy(io), { on: true, migrated: true })
-
   writeSecretStoragePolicy({ on: false, migrated: true }, io)
+  assert.deepEqual(JSON.parse(io.fileText() || ''), {
+    version: SECRET_STORAGE_POLICY_VERSION,
+    on: false,
+    migrated: true
+  })
   assert.deepEqual(readSecretStoragePolicy(io), { on: false, migrated: true })
-})
 
-// ── classification ──────────────────────────────────────────────────────────
+  writeSecretStoragePolicy({ on: true, migrated: false }, io)
+  assert.deepEqual(readSecretStoragePolicy(io), { on: true, migrated: false })
+})
 
 const SAFE_BLOB = { encoding: 'safeStorage', value: 'AAAA' }
 const PLAIN_BLOB = { encoding: 'plain', value: 'tok' }
 
-test('non-safeStorage blobs are always keep, under every policy', () => {
+test('non-safeStorage blobs are always kept', () => {
   for (const policy of [
     { on: false, migrated: false },
     { on: false, migrated: true },
-    { on: true, migrated: true }
+    { on: true, migrated: false }
   ]) {
     assert.equal(classifyStoredSecret(PLAIN_BLOB, policy), 'keep')
     assert.equal(classifyStoredSecret(null, policy), 'keep')
     assert.equal(classifyStoredSecret(undefined, policy), 'keep')
-    assert.equal(classifyStoredSecret({} as any, policy), 'keep')
+    assert.equal(classifyStoredSecret({}, policy), 'keep')
   }
 })
 
-test('safeStorage blob with encryption ON is keep', () => {
-  assert.equal(classifyStoredSecret(SAFE_BLOB, { on: true, migrated: true }), 'keep')
+test('safeStorage blobs stay available while encryption is on', () => {
+  assert.equal(classifyStoredSecret(SAFE_BLOB, { on: true, migrated: false }), 'keep')
 })
 
-test('safeStorage blob, encryption OFF, pre-migration is migrate', () => {
+test('explicit opt-out migrates once and then drops undecryptable blobs without another keychain touch', () => {
   assert.equal(classifyStoredSecret(SAFE_BLOB, { on: false, migrated: false }), 'migrate')
-})
-
-test('safeStorage blob, encryption OFF, post-migration is drop — never touch the keychain again', () => {
   assert.equal(classifyStoredSecret(SAFE_BLOB, { on: false, migrated: true }), 'drop')
 })

--- a/apps/desktop/electron/secret-storage-policy.ts
+++ b/apps/desktop/electron/secret-storage-policy.ts
@@ -1,72 +1,220 @@
 /**
- * secret-storage-policy.ts
+ * Single product policy for desktop secret storage.
  *
- * Single owner of the "do we use the OS keychain at all?" decision for
- * desktop-stored secrets (remote gateway tokens, CF Access headers, native
- * OAuth token sets).
- *
- * Why this exists: Electron safeStorage on macOS parks a per-app key
- * ("Hermes Key") in the login keychain. On machines with a locked, missing,
- * or corrupted default keychain, ANY safeStorage touch — including
- * isEncryptionAvailable() — makes macOS throw a blocking "Keychain Not
- * Found" / password dialog on every launch. That is an unacceptable default
- * for a chat app, so keychain-backed encryption is OPT-IN:
- *
- *   - Setting OFF (default): secrets are written with encoding 'plain' and
- *     NO safeStorage API is ever called. decryptDesktopSecret already
- *     returns non-safeStorage encodings verbatim, so reads need no change.
- *   - Setting ON: the previous behavior — strict safeStorage encryption,
- *     loud failure when the keychain is unavailable, per-save plain-text
- *     confirm dialog as the escape hatch.
- *
- * Legacy blobs written before the flag existed are safeStorage-encoded on
- * disk. With the setting OFF we attempt ONE migration pass (decrypt →
- * rewrite as plain). The pass is recorded in the same settings file whether
- * or not it succeeds, so a broken keychain costs at most one prompt on the
- * first post-update launch — never one per launch.
- *
- * Kept standalone (no `import 'electron'`) so it unit-tests under the
- * electron vitest project, same pattern as native-token-store.ts. main.ts
- * injects the file path and fs.
+ * The secure path is the default and every malformed, missing, ambiguous, or
+ * legacy policy record resolves to it. Plaintext remains available only as an
+ * explicit escape hatch written by this version of the product contract.
  */
 
 export interface SecretStoragePolicy {
-  /** Keychain-backed encryption enabled (explicit user opt-in). */
+  /** Keychain-backed encryption enabled; defaults on, with explicit opt-out. */
   on: boolean
-  /** One-shot legacy-blob migration already attempted. */
+  /** One-shot safeStorage-to-plaintext migration already attempted. */
   migrated: boolean
 }
 
 export const SECRET_STORAGE_POLICY_FILE = 'secure-token-storage.json'
+export const SECRET_STORAGE_POLICY_VERSION = 2
 
 export interface SecretStoragePolicyIo {
   readText: () => string
   writeText: (text: string) => void
 }
 
+interface PersistedSecretStoragePolicy extends SecretStoragePolicy {
+  version: typeof SECRET_STORAGE_POLICY_VERSION
+}
+
+const SECURE_DEFAULT: SecretStoragePolicy = { on: true, migrated: false }
+
 /**
- * Normalize whatever is on disk into a policy. Anything unreadable,
- * unparseable, or hand-mangled is the default: encryption OFF, migration
- * not yet attempted. `on` uses strict `=== true` — a truthy-but-not-true
- * value must not silently enable keychain prompts (mirrors the
- * allowPlainText coercion rule in hardening.ts).
+ * Parse policy JSON without allowing JSON's last-key-wins behavior to turn a
+ * duplicate member into an apparently valid policy. JSON.parse remains the
+ * final syntax validator; this lexical pass only tracks object member names.
+ */
+function parseJsonRejectingDuplicateKeys(text: string): unknown {
+  let index = 0
+
+  const skipWhitespace = () => {
+    while (/\s/.test(text[index] || '')) {
+      index += 1
+    }
+  }
+
+  const scanString = () => {
+    const start = index
+    index += 1
+
+    while (index < text.length) {
+      const character = text[index]
+
+      if (character === '\\') {
+        index += 2
+        continue
+      }
+
+      index += 1
+
+      if (character === '"') {
+        return text.slice(start, index)
+      }
+    }
+
+    throw new Error('Unterminated JSON string')
+  }
+
+  const scanValue = (): void => {
+    skipWhitespace()
+    const character = text[index]
+
+    if (character === '"') {
+      scanString()
+      return
+    }
+
+    if (character === '{') {
+      index += 1
+      skipWhitespace()
+      const keys = new Set<string>()
+
+      if (text[index] === '}') {
+        index += 1
+        return
+      }
+
+      while (index < text.length) {
+        skipWhitespace()
+
+        if (text[index] !== '"') {
+          throw new Error('JSON object member name must be a string')
+        }
+
+        const key = JSON.parse(scanString()) as string
+
+        if (keys.has(key)) {
+          throw new Error(`Duplicate JSON object member: ${key}`)
+        }
+
+        keys.add(key)
+        skipWhitespace()
+
+        if (text[index] !== ':') {
+          throw new Error('JSON object member is missing a colon')
+        }
+
+        index += 1
+        scanValue()
+        skipWhitespace()
+
+        if (text[index] === '}') {
+          index += 1
+          return
+        }
+
+        if (text[index] !== ',') {
+          throw new Error('JSON object member is missing a comma')
+        }
+
+        index += 1
+      }
+
+      throw new Error('Unterminated JSON object')
+    }
+
+    if (character === '[') {
+      index += 1
+      skipWhitespace()
+
+      if (text[index] === ']') {
+        index += 1
+        return
+      }
+
+      while (index < text.length) {
+        scanValue()
+        skipWhitespace()
+
+        if (text[index] === ']') {
+          index += 1
+          return
+        }
+
+        if (text[index] !== ',') {
+          throw new Error('JSON array member is missing a comma')
+        }
+
+        index += 1
+      }
+
+      throw new Error('Unterminated JSON array')
+    }
+
+    const start = index
+
+    while (index < text.length && !/[\s,}\]]/.test(text[index])) {
+      index += 1
+    }
+
+    if (start === index) {
+      throw new Error('Missing JSON value')
+    }
+  }
+
+  scanValue()
+  skipWhitespace()
+
+  if (index !== text.length) {
+    throw new Error('Trailing JSON content')
+  }
+
+  return JSON.parse(text)
+}
+
+function isPersistedPolicy(value: unknown): value is PersistedSecretStoragePolicy {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  const keys = Object.keys(candidate)
+
+  return (
+    keys.length === 3 &&
+    keys.every(key => key === 'version' || key === 'on' || key === 'migrated') &&
+    candidate.version === SECRET_STORAGE_POLICY_VERSION &&
+    typeof candidate.on === 'boolean' &&
+    typeof candidate.migrated === 'boolean'
+  )
+}
+
+/**
+ * Only a version-2 record can authorize plaintext. Two-field records were
+ * written automatically by the former opt-in era, so treating them as consent
+ * would preserve an ambient downgrade. They therefore migrate to secure ON.
  */
 export function readSecretStoragePolicy(io: SecretStoragePolicyIo): SecretStoragePolicy {
   try {
-    const parsed = JSON.parse(io.readText())
+    const parsed = parseJsonRejectingDuplicateKeys(io.readText())
 
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return { on: parsed.on === true, migrated: parsed.migrated === true }
+    if (isPersistedPolicy(parsed)) {
+      return { on: parsed.on, migrated: parsed.migrated }
     }
   } catch {
-    // fall through to default
+    // Missing, unreadable, malformed, duplicate-key, or stale-schema records
+    // all resolve to the product's fail-closed default.
   }
 
-  return { on: false, migrated: false }
+  return { ...SECURE_DEFAULT }
 }
 
 export function writeSecretStoragePolicy(policy: SecretStoragePolicy, io: SecretStoragePolicyIo): void {
-  io.writeText(JSON.stringify({ on: policy.on === true, migrated: policy.migrated === true }))
+  const persisted: PersistedSecretStoragePolicy = {
+    version: SECRET_STORAGE_POLICY_VERSION,
+    on: policy.on === true,
+    migrated: policy.migrated === true
+  }
+
+  io.writeText(JSON.stringify(persisted))
 }
 
 /** One stored secret blob as it appears on disk. */
@@ -78,13 +226,11 @@ interface StoredSecret {
 /**
  * Decide what to do with one stored blob under the current policy.
  *
- *   - 'keep'    — blob is fine as-is under this policy.
- *   - 'migrate' — safeStorage blob while encryption is OFF and migration has
- *                 not run: caller should decrypt once and rewrite as plain.
- *   - 'drop'    — safeStorage blob while encryption is OFF and the migration
- *                 pass already ran (i.e. it could not be decrypted last
- *                 time): treat as absent WITHOUT touching safeStorage, so a
- *                 dead keychain never prompts again.
+ * - keep: blob is usable as-is under this policy.
+ * - migrate: safeStorage blob under explicit plaintext opt-out, before the
+ *   one-shot migration has run.
+ * - drop: undecryptable safeStorage blob after that migration; never touch the
+ *   broken keychain again while the explicit opt-out remains active.
  */
 export function classifyStoredSecret(
   secret: StoredSecret | null | undefined,

--- a/apps/desktop/src/i18n/catalog.ts
+++ b/apps/desktop/src/i18n/catalog.ts
@@ -2,15 +2,16 @@ import { ar } from './ar'
 import { en } from './en'
 import { ja } from './ja'
 import { ru } from './ru'
+import { withSecureSecretStorageCopy } from './secure-secret-storage-copy'
 import type { Locale, Translations } from './types'
 import { zh } from './zh'
 import { zhHant } from './zh-hant'
 
 export const TRANSLATIONS: Record<Locale, Translations> = {
-  en,
-  zh,
-  'zh-hant': zhHant,
-  ja,
-  ar,
-  ru
+  en: withSecureSecretStorageCopy('en', en),
+  zh: withSecureSecretStorageCopy('zh', zh),
+  'zh-hant': withSecureSecretStorageCopy('zh-hant', zhHant),
+  ja: withSecureSecretStorageCopy('ja', ja),
+  ar: withSecureSecretStorageCopy('ar', ar),
+  ru: withSecureSecretStorageCopy('ru', ru)
 }

--- a/apps/desktop/src/i18n/secure-secret-storage-copy.test.ts
+++ b/apps/desktop/src/i18n/secure-secret-storage-copy.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { TRANSLATIONS } from './catalog'
+import { en } from './en'
+import {
+  SECURE_SECRET_STORAGE_DESCRIPTIONS,
+  withSecureSecretStorageCopy
+} from './secure-secret-storage-copy'
+import type { Locale } from './types'
+
+const LOCALES: Locale[] = ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru']
+
+test('secure-default secret-storage copy covers every supported locale', () => {
+  assert.deepEqual(Object.keys(SECURE_SECRET_STORAGE_DESCRIPTIONS).sort(), [...LOCALES].sort())
+
+  for (const locale of LOCALES) {
+    assert.equal(
+      TRANSLATIONS[locale].settings.gateway.keychainEncryptionDesc,
+      SECURE_SECRET_STORAGE_DESCRIPTIONS[locale]
+    )
+    assert.match(SECURE_SECRET_STORAGE_DESCRIPTIONS[locale], /\S/)
+  }
+})
+
+test('catalog overlay is immutable and removes the shipped default-off claim', () => {
+  const originalDescription = en.settings.gateway.keychainEncryptionDesc
+  const overlaid = withSecureSecretStorageCopy('en', en)
+
+  assert.notEqual(overlaid, en)
+  assert.equal(en.settings.gateway.keychainEncryptionDesc, originalDescription)
+  assert.equal(overlaid.settings.gateway.keychainEncryptionDesc, SECURE_SECRET_STORAGE_DESCRIPTIONS.en)
+  assert.doesNotMatch(overlaid.settings.gateway.keychainEncryptionDesc, /off by default/i)
+})

--- a/apps/desktop/src/i18n/secure-secret-storage-copy.ts
+++ b/apps/desktop/src/i18n/secure-secret-storage-copy.ts
@@ -1,0 +1,25 @@
+import type { Locale, Translations } from './types'
+
+export const SECURE_SECRET_STORAGE_DESCRIPTIONS: Record<Locale, string> = {
+  en: 'Enabled by default. Saved gateway tokens and sign-in credentials are encrypted with the OS keychain (Keychain Access, GNOME Keyring, or Windows DPAPI). Turn this off only as an explicit plaintext escape hatch when the system keychain is unavailable.',
+  zh: '默认启用。保存的网关令牌和登录凭据会使用操作系统钥匙串加密（钥匙串访问、GNOME Keyring 或 Windows DPAPI）。仅当系统钥匙串不可用时，才应明确关闭并使用明文应急模式。',
+  'zh-hant':
+    '預設啟用。已儲存的 Gateway 權杖與登入憑證會使用作業系統鑰匙圈加密（「鑰匙圈存取」、GNOME Keyring 或 Windows DPAPI）。只有在系統鑰匙圈無法使用時，才應明確關閉並使用明文應急模式。',
+  ja: '既定で有効です。保存されたゲートウェイトークンとサインイン資格情報は、OS のキーチェーン（キーチェーンアクセス、GNOME Keyring、または Windows DPAPI）で暗号化されます。システムキーチェーンが使用できない場合に限り、明示的な平文の退避手段として無効にしてください。',
+  ar: 'مفعّل افتراضيًا. تُشفَّر رموز البوابة وبيانات اعتماد تسجيل الدخول المحفوظة باستخدام سلسلة مفاتيح نظام التشغيل (Keychain Access أو GNOME Keyring أو Windows DPAPI). عطّل هذا الخيار صراحةً فقط كمسار احتياطي بنص صريح عندما لا تتوفر سلسلة مفاتيح النظام.',
+  ru: 'Включено по умолчанию. Сохранённые токены шлюза и учётные данные для входа шифруются системным хранилищем ключей (Keychain Access, GNOME Keyring или Windows DPAPI). Отключайте это только явно, как аварийный переход к открытому тексту, если системное хранилище ключей недоступно.'
+}
+
+/** Keep policy copy in one product-level owner across every supported locale. */
+export function withSecureSecretStorageCopy(locale: Locale, translations: Translations): Translations {
+  return {
+    ...translations,
+    settings: {
+      ...translations.settings,
+      gateway: {
+        ...translations.settings.gateway,
+        keychainEncryptionDesc: SECURE_SECRET_STORAGE_DESCRIPTIONS[locale]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Makes protected desktop secret storage the safe default: connection tokens and headers are encrypted at rest via the OS keychain-backed `safeStorage`, malformed or duplicate storage policies fail closed, migration to the secure format is crash-consistent, legacy bare-string headers/tokens are normalized before migration so no plaintext survives, and native OAuth token persistence is wired to the real crypto functions. The secret-storage responsibility cluster is extracted out of the 17,612-line `apps/desktop/electron/main.ts` godfile into dedicated shard modules.

## Related Issue

No public issue was filed. The class was isolated by a source-pinned adversarial review; live dedup search found no matching issue or implementation PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Reproduction

1. On a desktop install with a legacy `connection.json` containing a bare-string global header or raw token (no `encoding` envelope), enable secure storage.
2. Before this patch the legacy shapes have no `encoding` field, so the migration scan and the encryption-enable predicate both skip them — plaintext bytes remain in `connection.json` while the policy reports secure storage enabled.
3. After this patch all accepted legacy secret shapes are normalized to the envelope form before predicate evaluation; migration and the ON toggle remove the raw values from disk.

## Changes Made

- `apps/desktop/electron/secret-storage-policy.ts` — secure-by-default policy; malformed/duplicate policy fails closed; opt-out is explicit and auditable.
- `apps/desktop/electron/desktop-secret-storage.ts` (new) — codec seam: token/header envelope encryption and decryption via `safeStorage`.
- `apps/desktop/electron/native-token-store.ts` — native OAuth token persistence through the encrypted IO seam; truncated/corrupt stores fail closed with a recovery path.
- `apps/desktop/electron/secret-storage-connections.ts` (new) — connection persistence and migration; legacy bare-string headers/tokens normalized before `shouldRewrite`/`blockNeedsRewrite` and before the encryption-enable predicate; migration rewrites the file removing raw values.
- `apps/desktop/electron/secret-storage-oauth.ts` (new) — OAuth session/token cluster; native IO receives callable encrypt/decrypt (composition-order fix).
- `apps/desktop/electron/secret-storage-ssh.ts` (new) — managed SSH token persistence.
- `apps/desktop/electron/desktop-update-checks.ts`, `desktop-window-management.ts`, `window-theme` shards (new) — extraction continuation.
- `apps/desktop/electron/main.ts` — 17,612 → 13,736 lines; moved names resolve identically through the original namespace (seam identity); residual extraction continues under the 2K plan.
- `apps/desktop/e2e/at-rest-connection-token.spec.ts`, `apps/desktop/electron/*.test.ts` — full regression matrix.

## How to Test

1. Run `npx vitest run --project electron electron/desktop-secret-storage.test.ts electron/secret-storage-policy.test.ts electron/native-token-store.test.ts electron/desktop-update-checks.test.ts`.
2. Confirm `50 passed`.
3. Run `npm run check:lint` (0 errors).
4. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the repository baseline is non-green on this host; the exact affected matrix is green and recorded below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration or command changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `safeStorage` is OS-backed; Windows executed natively
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Why this matters to users

Desktop connection tokens were stored in plaintext by default. This makes encrypted-at-rest storage the safe default, ensures migration cannot leave legacy plaintext behind, and keeps native OAuth persistence working end to end.

## Verification

- Candidate HEAD: `865e1f5b8cc82acaa1ee0137cccf4a711703be31` (rebased onto current main)
- Focused Electron matrix: `50 passed` (4 files)
- `npm run check:lint`: 0 errors
- `git diff --check`: pass
- 2K gates: every new shard ≤2,000 lines; `main.ts` reduced 17,612 → 13,736 (residual extraction in progress on the agreed plan)

## Campaign methodology

Source pin `f751a8c5467c41500e505d90cb0eb8b70929080f`; current-main remediation base `d0351e32309bd68a1012c302157947b955323fca`. The class passed five analyst lanes, five mutually blind witness lanes, five adjudicators, TDD implementation/fix lanes, and exact-head review. Machine evidence is preserved in the campaign manifest and patch SHA receipts.

## Coordination / dedup

Related work searched live before push: no matching issue or implementation PR. Builds on: new class-specific implementation. Merge order: standalone; no sibling PR dependency.
