### PR TITLE
fix(desktop): confirm before deleting a session in the Command Center (#99410)

### DIFF
--- a/apps/desktop/src/app/command-center/delete-confirm.test.tsx
+++ b/apps/desktop/src/app/command-center/delete-confirm.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as HermesApi from '@/hermes'
+import type { SessionInfo } from '@/hermes'
+import { $sessions } from '@/store/session'
+
+import { CommandCenterView } from './index'
+
+// #99410: the Command Center → Sessions trash button hard-deleted the session
+// (row + messages + request_dump files) instantly, with no confirmation —
+// e6708af1f (#61470) guarded the sidebar/tab/header entry points via
+// DeleteSessionDialog but missed this independent one. The delete must be
+// gated behind the shared ConfirmDialog: no onDeleteSession call on the trash
+// click alone, the call only after an explicit confirm, and never on cancel.
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<typeof HermesApi>()),
+  getActionStatus: vi.fn(() => Promise.resolve({ running: false })),
+  getLogs: vi.fn(() => Promise.resolve({ lines: [] })),
+  getStatus: vi.fn(() => Promise.resolve({})),
+  getUsageAnalytics: vi.fn(() => Promise.resolve({})),
+  restartGateway: vi.fn(),
+  updateHermes: vi.fn()
+}))
+vi.mock('@/lib/session-export', () => ({ exportSession: vi.fn() }))
+vi.mock('./maintenance', () => ({ MaintenancePanel: () => null }))
+
+afterEach(cleanup)
+
+const SESSION: SessionInfo = {
+  ended_at: null,
+  id: 'sess-1',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1_756_600_000,
+  message_count: 3,
+  model: null,
+  output_tokens: 0,
+  started_at: 1_756_500_000,
+  title: 'Precious conversation'
+} as SessionInfo
+
+function renderCommandCenter(onDeleteSession: (id: string) => Promise<void>) {
+  return render(
+    <MemoryRouter>
+      <CommandCenterView
+        initialSection="sessions"
+        onClose={() => {}}
+        onDeleteSession={onDeleteSession}
+        onOpenSession={() => {}}
+      />
+    </MemoryRouter>
+  )
+}
+
+describe('Command Center session delete confirmation (#99410)', () => {
+  beforeEach(() => {
+    $sessions.set([SESSION])
+  })
+
+  it('does NOT delete on trash click alone — a confirm dialog appears instead', async () => {
+    const onDeleteSession = vi.fn(() => Promise.resolve())
+    renderCommandCenter(onDeleteSession)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete session' }))
+
+    expect(onDeleteSession).not.toHaveBeenCalled()
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+  })
+
+  it('deletes only after explicit confirm', async () => {
+    const onDeleteSession = vi.fn(() => Promise.resolve())
+    renderCommandCenter(onDeleteSession)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete session' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(onDeleteSession).toHaveBeenCalledWith('sess-1'))
+    expect(dialog).toBeTruthy()
+  })
+
+  it('cancel closes the dialog without deleting', async () => {
+    const onDeleteSession = vi.fn(() => Promise.resolve())
+    renderCommandCenter(onDeleteSession)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete session' }))
+    await screen.findByRole('dialog')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(onDeleteSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -3,12 +3,13 @@ import { type MouseEvent, type ReactNode, useCallback, useEffect, useMemo, useRe
 import { LogTail } from '@/components/chat/log-tail'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { SearchField } from '@/components/ui/search-field'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { ResponsiveTabs } from '@/components/ui/tab-dropdown'
 import { Tip } from '@/components/ui/tooltip'
 import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway, updateHermes } from '@/hermes'
-import type { ActionStatusResponse, AnalyticsResponse, StatusResponse } from '@/hermes'
+import type { ActionStatusResponse, AnalyticsResponse, SessionInfo, StatusResponse } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { compactNumber } from '@/lib/format'
@@ -143,6 +144,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const pinnedSessionIds = useStoreSelector($pinnedSessionIds, s => (section === 'sessions' ? s : EMPTY_PINNED))
 
   const [query, setQuery] = useState('')
+  const [pendingDelete, setPendingDelete] = useState<SessionInfo | null>(null)
   const [status, setStatus] = useState<StatusResponse | null>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [logFile, setLogFile] = useState<(typeof LOG_FILES)[number]>('agent')
@@ -395,7 +397,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                           </RowIconButton>
                           <RowIconButton
                             className="hover:text-destructive"
-                            onClick={() => void onDeleteSession(session.id)}
+                            onClick={() => setPendingDelete(session)}
                             title={cc.deleteSession}
                           >
                             <Trash2 className="size-3.5" />
@@ -509,6 +511,19 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
           )}
         </OverlayMain>
       </OverlaySplitLayout>
+      {pendingDelete && (
+        <ConfirmDialog
+          busyLabel={t.sidebar.row.deleting}
+          confirmLabel={t.common.delete}
+          description={t.sidebar.row.deleteDesc(sessionTitle(pendingDelete))}
+          destructive
+          doneLabel={t.sidebar.row.deleted}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={() => void onDeleteSession(pendingDelete.id)}
+          open
+          title={t.sidebar.row.deleteTitle}
+        />
+      )}
     </OverlayView>
   )
 }


### PR DESCRIPTION
Fixes #99410 (P0). Salvages PR #99412 by @zqy1-1 (authorship preserved via cherry-pick) + adds regression tests.

## Problem

The Command Center → Sessions trash button fired `onDeleteSession(session.id)` directly on click — a hard delete (session row + all messages + on-disk `request_dump_*` transcripts, one transaction, no trash, no undo). The confirm-before-delete fix for #61470 (`e6708af1f`) routed sidebar rows, tab menus, and the chat header through `DeleteSessionDialog`, but the Command Center renders its own `RowIconButton` list and never goes through `SessionActionsMenu`, so it stayed unguarded — the last unconfirmed delete entry point.

## Fix (@zqy1-1, cherry-picked from #99412)

`apps/desktop/src/app/command-center/index.tsx`: the trash button now sets `pendingDelete` and the delete goes through the shared `ConfirmDialog` (`destructive`, reusing `t.sidebar.row` delete copy and `t.common.delete`) — same dialog semantics as the sidebar path per the SDK conventions. +17/−2, one file, no new i18n keys.

## Our additions

- `apps/desktop/src/app/command-center/delete-confirm.test.tsx` — 3 regression tests rendering the real `CommandCenterView` + `ConfirmDialog`:
  1. trash click alone does NOT call `onDeleteSession` (dialog appears instead)
  2. delete fires only after explicit confirm
  3. cancel closes without deleting

**Live repro:** vitest ui lane against the real renderer components — before (origin/main's unguarded `command-center/index.tsx`): all 3 tests fail, `onDeleteSession` fires on bare trash click; after (this branch): 3/3 pass. `tsc --noEmit`, eslint, prettier clean.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa88fd1/J9oRnPsQm8BjqD30oWaP7_0Ln1Po8l.png)
