### PR TITLE
fix(profiles): hide internal directories from roster

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -39,6 +39,10 @@ _CLONE_SUBDIR_FILES = ["memories/MEMORY.md", "memories/USER.md"]
 # because they are created dynamically and may be absent at copy time.
 _CLONE_ALL_STRIP: list[str] = ["gateway.pid", "gateway_state.json", "processes.json"]
 
+# Named profiles created before SOUL.md seeding may only have their session
+# store. Infrastructure directories under profiles/ have none of these files.
+_PROFILE_HOME_MARKERS = ("config.yaml", ".env", "SOUL.md", "profile.yaml", "state.db")
+
 # Infrastructure excluded from --clone-all ONLY when the source is the default profile
 # (``~/.hermes``): git checkout (+ ~3 GB venv), worktrees, sibling profiles, shared bins,
 # npm packages. Named profiles never hold these at root, so the gate avoids silently
@@ -695,6 +699,8 @@ def list_profiles() -> List[ProfileInfo]:
     if named:
         alias_map = build_alias_map()  # ONCE, not per profile (was the dominant cost)
         for entry in named:
+            if not any((entry / marker).is_file() for marker in _PROFILE_HOME_MARKERS):
+                continue
             alias_name = alias_map.get(normalize_profile_name(entry.name))
             profiles.append(_profile_info(entry.name, entry, is_default=False, alias_name=alias_name))
     return profiles

--- a/tests/hermes_cli/test_gateway_multiplex_status.py
+++ b/tests/hermes_cli/test_gateway_multiplex_status.py
@@ -20,7 +20,11 @@ def _fake_multiplexer(monkeypatch, tmp_path, *, multiplex: bool):
     import hermes_constants
     import gateway.status as status
 
-    (tmp_path / "profiles" / "beta").mkdir(parents=True)
+    profile_dir = tmp_path / "profiles" / "beta"
+    profile_dir.mkdir(parents=True)
+    # A named profile has its own configuration.  The empty directory used by
+    # this fixture is infrastructure-shaped and must not appear in the roster.
+    (profile_dir / "config.yaml").write_text("{}\n")
     (tmp_path / "config.yaml").write_text(
         f"gateway:\n  multiplex_profiles: {'true' if multiplex else 'false'}\n"
     )

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -524,6 +524,27 @@ class TestListProfiles:
         assert "alpha" in names
         assert "beta" in names
 
+    def test_excludes_internal_directories_without_profile_marker(self, profile_env):
+        profiles_root = profile_env / ".hermes" / "profiles"
+        create_profile("helper", no_alias=True)
+        for name in ("sessions", "skills", "cron", "logs"):
+            (profiles_root / name).mkdir()
+
+        names = [profile.name for profile in list_profiles()]
+
+        assert "helper" in names
+        assert not {"sessions", "skills", "cron", "logs"} & set(names)
+
+    def test_keeps_legacy_profile_with_session_store_only(self, profile_env):
+        profiles_root = profile_env / ".hermes" / "profiles"
+        legacy = profiles_root / "legacy"
+        legacy.mkdir(parents=True)
+        (legacy / "state.db").touch()
+
+        names = [profile.name for profile in list_profiles()]
+
+        assert "legacy" in names
+
 
 # ===================================================================
 # TestActiveProfile
@@ -1170,5 +1191,3 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
-


### PR DESCRIPTION
Fixes #99392

## Summary
- Treat the `SOUL.md` created for every named profile as its roster marker.
- Exclude internal `profiles/` directories from the desktop Bots roster without hiding profiles that have not run setup yet.
- Add regression coverage for internal worker directory names.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q`