### PR TITLE
feat(desktop): add DingTalk and WeCom brand icons

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.test.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PlatformAvatar } from './platform-icon'
+
+afterEach(cleanup)
+
+describe('PlatformAvatar brand glyphs', () => {
+  it.each([
+    ['dingtalk', 'DingTalk'],
+    ['wecom', 'WeCom'],
+    ['wecom_callback', 'WeCom (app)']
+  ])('renders a brand glyph for %s instead of a letter fallback', (platformId, platformName) => {
+    const { container } = render(<PlatformAvatar platformId={platformId} platformName={platformName} />)
+
+    expect(container.querySelector('svg')).toBeTruthy()
+    expect(screen.queryByText(platformName.charAt(0))).toBeNull()
+  })
+
+  it('keeps the initial fallback for an unknown platform', () => {
+    const { container } = render(<PlatformAvatar platformId="custom_chat" platformName="Custom Chat" />)
+
+    expect(container.querySelector('svg')).toBeNull()
+    expect(screen.getByText('C')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -34,6 +34,35 @@ function PhotonIcon(props: React.SVGProps<SVGSVGElement>) {
   )
 }
 
+// DingTalk and WeCom are absent from Simple Icons, but both marks are available
+// in permissively licensed icon sets already represented by Desktop's icon
+// dependencies: Tabler (MIT) and Tencent TDesign (MIT), respectively.
+function DingTalkIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-18 0a9 9 0 0 1 18 0" />
+      <path d="m8 7.5 7.02 2.632a1 1 0 0 1 .567 1.33L14.5 14H16l-5 4 1-4c-3.1.03-3.114-3.139-4-6.5" />
+    </svg>
+  )
+}
+
+function WeComIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg fill="currentColor" viewBox="0 0 24 24" {...props}>
+      <path d="M9.95 2C4.47 2 0 5.88 0 10.66c0 2.93 1.67 5.64 4.4 7.25l-.55 2.3a.7.7 0 0 0 .98.79l2.46-1.25c.86.25 1.75.38 2.66.38.71 0 1.42-.08 2.11-.22a3.28 3.28 0 0 1-.43-1.87 11.1 11.1 0 0 1-1.68.13c-.34 0-.68-.02-1.03-.06a9.1 9.1 0 0 1-1.52-.29l-.76-.22-1.23.62.21-.88-.98-.79C2.9 15.15 2 12.91 2 10.66 2 6.98 5.56 4 9.95 4c3.45 0 6.39 1.85 7.49 4.44.24.56.39 1.14.43 1.72a3.3 3.3 0 0 1 2.01.1c-.07-.91-.32-1.82-.76-2.71C17.62 4.36 14.09 2 9.95 2Z" />
+      <path d="M18.73 10.1a3.2 3.2 0 0 0-1.94 5.75 5.2 5.2 0 0 1-2.23 2.23 3.2 3.2 0 1 0 4.75 2.8 5.2 5.2 0 0 1 2.22-2.23 3.2 3.2 0 1 0-2.8-8.55Zm0 2a1.2 1.2 0 1 1 0 2.4 1.2 1.2 0 0 1 0-2.4Zm-3.04 4.76a1.2 1.2 0 1 1 0 2.4 1.2 1.2 0 0 1 0-2.4Zm6.11-1.02a1.2 1.2 0 1 1 0 2.4 1.2 1.2 0 0 1 0-2.4Z" />
+    </svg>
+  )
+}
+
 // We render simpleicons.org brand glyphs for platforms whose owners publish a
 // usable mark (telegram, discord, matrix, ...). A few brands — Slack, Dingtalk,
 // Feishu, WeCom — have been removed from Simple Icons at the brand owner's
@@ -68,6 +97,9 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   webhook: { Icon: LinkIcon, color: '#71717A', kind: 'generic' },
   api_server: { Icon: Globe, color: '#64748B', kind: 'generic' },
   weixin: { Icon: SiWechat, color: '#07C160', kind: 'brand' },
+  wecom: { Icon: WeComIcon, color: '#2BAD13', kind: 'brand' },
+  wecom_callback: { Icon: WeComIcon, color: '#2BAD13', kind: 'brand' },
+  dingtalk: { Icon: DingTalkIcon, color: '#0089FF', kind: 'brand' },
   qqbot: { Icon: SiQq, color: '#EB1923', kind: 'brand' },
   yuanbao: { Icon: SiBilibili, color: '#FB7299', kind: 'brand' }
 }


### PR DESCRIPTION
## Summary
- replace DingTalk's gray letter fallback with its brand glyph
- replace both WeCom variants' gray letter fallback with the WeCom mark
- keep unknown messaging platforms on the existing monogram fallback

## Scope
This PR only covers DingTalk and WeCom. Broader messaging-platform icon coverage will be proposed separately so the review scope and platform labels stay accurate.

## Test plan
Run from apps/desktop:
- npm run test:ui -- src/app/messaging/platform-icon.test.tsx
- npm exec tsc -- -p . --noEmit
- git diff --check

Prepared with AI assistance; implementation and test output were verified locally.