### PR TITLE
fix(compression): honor custom provider context windows

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1855,7 +1855,7 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
             protect_last_n=cs.protect_last, summary_target_ratio=cs.target_ratio,
             summary_model_override=None, quiet_mode=agent.quiet_mode, base_url=agent.base_url,
             api_key=getattr(agent, "api_key", ""), config_context_length=_effective_context_length,
-            provider=agent.provider, api_mode=agent.api_mode,
+            provider=agent.provider, custom_providers=_custom_providers, api_mode=agent.api_mode,
             abort_on_summary_failure=cs.abort_on_summary_failure,
             max_tokens=_compressor_max_tokens(agent), model_thresholds=cs.model_thresholds,
             threshold_tokens_cap=cs.threshold_tokens,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1744,6 +1744,7 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             self._resolved_context_length = get_model_context_length(
                 self.model, base_url=self.base_url, api_key=self.api_key,
                 config_context_length=self._config_context_length, provider=self.provider,
+                custom_providers=self._custom_providers,
             )
             # Raise-only small-context floor; must run after context_length resolves and before threshold_tokens derives.
             self.threshold_percent = self._effective_threshold_percent(self._resolved_context_length, self._base_threshold_percent)
@@ -2259,12 +2260,13 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         self, model: str, threshold_percent: float = 0.50, protect_first_n: int = 3, protect_last_n: int = 20,
         summary_target_ratio: float = 0.20, quiet_mode: bool = False, summary_model_override: str = None,
         base_url: str = "", api_key: str = "", config_context_length: int | None = None, provider: str = "",
-        api_mode: str = "", abort_on_summary_failure: bool = False, max_tokens: int | None = None,
-        model_thresholds: dict[str, float] | None = None, threshold_tokens_cap: Any = None,
+        custom_providers: list | None = None, api_mode: str = "", abort_on_summary_failure: bool = False,
+        max_tokens: int | None = None, model_thresholds: dict[str, float] | None = None, threshold_tokens_cap: Any = None,
         proactive_prune_tokens: int = 0, proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096, min_tail_user_messages: int = 1, tail_mode: str = "lean",
     ):
         self.model, self.base_url, self.api_key, self.provider, self.api_mode = model, base_url, api_key, provider, api_mode
+        self._custom_providers = custom_providers
         # "lean" = small clamped tail + verbatim-user summary section; "legacy" = 0.20*window tail.
         self.tail_mode = tail_mode if tail_mode in ("legacy", "lean") else "lean"
         # Per-model overrides (longest substring match wins); floor applied on top.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2411,6 +2411,23 @@ class TestLazyContextResolution:
             result = c.context_length
             assert result == 200_000
 
+    def test_uses_custom_provider_context_length(self):
+        """A custom endpoint's per-model window must reach the compressor."""
+        custom_providers = [{
+            "name": "ninfer",
+            "base_url": "http://127.0.0.1:8081/v1",
+            "models": {"qwen3.8-27b": {"context_length": 262_144}},
+        }]
+        compressor = ContextCompressor(
+            model="qwen3.8-27b",
+            provider="custom:ninfer",
+            base_url="http://127.0.0.1:8081/v1",
+            custom_providers=custom_providers,
+            quiet_mode=True,
+        )
+
+        assert compressor.context_length == 262_144
+
 
 class TestPreflightSentinelGuard:
     """Regression guards for the preflight token-display seed


### PR DESCRIPTION
Fixes #99286

## Summary
- Thread configured custom providers into the built-in context compressor.
- Honor a custom endpoint’s per-model context window before catalog fallback values.
- Add a regression test for a 262K local Qwen endpoint.

## Tests
- `scripts/run_tests.sh tests/agent/test_context_compressor.py -q`