### PR TITLE
fix(state): eliminate unsynchronized reads on the shared SessionDB writer connection (SIGSEGV / SystemError class)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -55,7 +55,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, TypeVar, cast
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -4969,7 +4969,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return self._get_read_conn()
 
     @contextmanager
-    def _read_ctx(self):
+    def _read_ctx(self) -> Iterator[sqlite3.Connection]:
         """Yield a connection for read-only statements.
 
         WAL: a read-only connection borrowed from a bounded pool with NO
@@ -5012,7 +5012,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._close_read_conn(conn)
             return
         with self._lock:
-            yield self._conn
+            yield cast(sqlite3.Connection, self._conn)
 
     # ── Core write helper ──
 
@@ -8201,11 +8201,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -8279,11 +8280,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # No-op fast path: skip the transaction when there is nothing to
         # clear. Read-only, no write lock.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -15244,12 +15246,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
             if not row:
                 return None
             return {
@@ -15266,15 +15268,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            with self._read_ctx() as conn:
+                rows = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                ).fetchall()
+            return [self._session_row_dict(r) for r in rows]
         except Exception:
             return []
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13578,7 +13578,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             if not exists:
                 return []
-            delegate_ids = _collect_delegate_child_ids(self._conn, [session_id])
+            # Use the borrowed read connection, never self._conn: handing the
+            # shared writer connection to a helper here executes on it without
+            # self._lock — the same unsynchronized-read class as #99349/#90734.
+            delegate_ids = _collect_delegate_child_ids(conn, [session_id])
         return [session_id, *sorted(delegate_ids)]
 
     def delete_session(

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -88,11 +88,13 @@ class SessionSearchMixin:
             self._merge_fts_incrementally(
                 max_pages=self._FTS_MERGE_MAX_PAGES_PER_INDEX
             )
-        except sqlite3.Error as exc:
-            # Routine maintenance is best effort, but unexpected SQLite errors
-            # must remain visible instead of being silently mistaken for an
-            # optional missing index.
-            logger.warning("FTS incremental merge failed: %s", exc)
+        except Exception as exc:  # noqa: BLE001 - post-commit maintenance
+            # The canonical write is already committed before this cadence
+            # runs. No maintenance failure — including the bare SystemError
+            # the CPython sqlite3 layer can raise under cross-thread errmsg
+            # scrambling — may escape and make the caller replay an
+            # ambiguous, possibly-durable write (#90734, #85079).
+            logger.warning("FTS incremental merge failed after commit: %s", exc)
 
     def fts_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """Return deferred-rebuild progress, or None when no rebuild pending.

--- a/tests/state/test_writer_conn_thread_safety.py
+++ b/tests/state/test_writer_conn_thread_safety.py
@@ -1,0 +1,258 @@
+"""Cross-thread races on the shared writer connection (2026-08-20 incident).
+
+``SessionDB`` shares ONE writer connection (``check_same_thread=False``)
+guarded by ``self._lock``.  A handful of read-only methods executed
+statements on that same connection object WITHOUT taking the lock
+(``get_compression_lock_holder``, ``list_pending_handoffs``,
+``get_handoff_state``, and the no-op fast path of
+``clear_session_activity_labels``).  When one of those SELECTs raced a
+turn-boundary ``append_messages_batch`` on the same connection, CPython's
+sqlite3 layer raised a bare ``SystemError`` ("<Connection> returned NULL
+without setting an exception") — which is NOT a ``sqlite3.Error``, so it
+escaped ``_execute_write``'s entire retry net and destroyed the user's
+turn as ``session_persistence_failed``.
+
+Two independent layers are asserted here:
+
+1. The unlocked readers now route through ``_read_ctx()`` (per-thread
+   read-only connections under WAL), so hammering them concurrently with
+   turn-shaped batch writes must produce ZERO errors on either side.
+2. Exactly-once containment: a bare ``SystemError`` inside the transaction
+   callback is never replayed, while post-commit maintenance failures are
+   logged without invalidating the already-durable write.
+"""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 2.0)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 0.001)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 0.005)
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+class TestConcurrentReadersDoNotRaceTheWriter:
+    """Layer 1: the formerly-unlocked readers, hammered against batch writes.
+
+    Before the fix this reproduced the production ``SystemError`` within a
+    few seconds on every run (each reader independently); after routing the
+    readers through ``_read_ctx()`` the writer and readers touch different
+    connection objects and the race is structurally gone.
+    """
+
+    READER_METHODS = (
+        "get_compression_lock_holder",
+        "list_pending_handoffs",
+        "get_handoff_state",
+        "clear_session_activity_labels",
+    )
+
+    def _run_race(self, db, reader_fn, duration_s=3.0):
+        sid = db.create_session("race-sess", "test")
+        errors = []
+        stop = threading.Event()
+
+        def writer():
+            n = 0
+            while not stop.is_set():
+                try:
+                    db.append_messages_batch(sid, [
+                        {"role": "user", "content": "u%d" % n},
+                        {"role": "assistant", "content": "a%d" % n},
+                        {"role": "tool", "content": "t%d" % n,
+                         "tool_name": "x", "tool_call_id": "c%d" % n},
+                    ])
+                    n += 1
+                except Exception as exc:  # noqa: BLE001 — the assertion IS the catch
+                    errors.append(("writer", type(exc).__name__, str(exc)))
+                    stop.set()
+                    return
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    reader_fn(db, sid)
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(("reader", type(exc).__name__, str(exc)))
+                    stop.set()
+                    return
+
+        threads = [threading.Thread(target=writer)] + [
+            threading.Thread(target=reader) for _ in range(3)
+        ]
+        for t in threads:
+            t.start()
+        deadline = time.monotonic() + duration_s
+        while time.monotonic() < deadline and not stop.is_set():
+            time.sleep(0.05)
+        stop.set()
+        for t in threads:
+            t.join(timeout=10)
+        return errors
+
+    def test_compression_lock_holder_reads_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: d.get_compression_lock_holder(sid)
+        )
+        assert errors == []
+
+    def test_pending_handoff_reads_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: (d.list_pending_handoffs(),
+                                d.get_handoff_state(sid))
+        )
+        assert errors == []
+
+    def test_activity_label_noop_fast_path_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: d.clear_session_activity_labels(sid)
+        )
+        assert errors == []
+
+    def test_unlocked_writer_conn_use_is_enumerated(self):
+        """Sibling-sweep tripwire: no method may touch ``self._conn``
+        outside ``with self._lock`` (or the __init__/close lifecycle, which
+        runs before/after any concurrent access is possible).
+
+        This is the AST sweep that found the four incident sites, frozen as
+        a test so a future convenience read can't quietly reintroduce the
+        class.
+        """
+        import ast
+        import inspect
+
+        import hermes_state as hs
+
+        src = inspect.getsource(hs)
+        tree = ast.parse(src)
+
+        ALLOWED_FUNCS = {
+            # Lifecycle: run before the instance is shared / after readers
+            # are drained. Not reachable concurrently with writers.
+            "__init__", "_connect_and_init",
+            "_connect_and_init_with_lock_patience", "close",
+        }
+
+        def is_lock_with(node):
+            if isinstance(node, ast.With):
+                for item in node.items:
+                    ctx = item.context_expr
+                    if (isinstance(ctx, ast.Attribute)
+                            and ctx.attr == "_lock"
+                            and isinstance(ctx.value, ast.Name)
+                            and ctx.value.id == "self"):
+                        return True
+            return False
+
+        violations = []
+
+        class Sweep(ast.NodeVisitor):
+            def __init__(self):
+                self.lock_depth = 0
+                self.func_stack = []
+
+            @staticmethod
+            def _is_conn_attr(node):
+                return (isinstance(node, ast.Attribute)
+                        and isinstance(node.value, ast.Name)
+                        and node.value.id == "self"
+                        and node.attr == "_conn")
+
+            def _flag(self, node):
+                fn = self.func_stack[-1] if self.func_stack else "<module>"
+                if fn not in ALLOWED_FUNCS:
+                    violations.append((node.lineno, fn))
+
+            def generic_visit(self, node):
+                locked = is_lock_with(node)
+                is_func = isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                )
+                if locked:
+                    self.lock_depth += 1
+                if is_func:
+                    self.func_stack.append(node.name)
+                if isinstance(node, ast.Call) and self.lock_depth == 0:
+                    # A method call ON the connection (self._conn.execute(...))
+                    func = node.func
+                    if (isinstance(func, ast.Attribute)
+                            and self._is_conn_attr(func.value)):
+                        self._flag(func.value)
+                    # ...or the connection handed to a helper that will
+                    # execute on it (e.g. _collect_delegate_child_ids(self._conn, ...)).
+                    for arg in list(node.args) + [k.value for k in node.keywords]:
+                        if self._is_conn_attr(arg):
+                            self._flag(arg)
+                super().generic_visit(node)
+                if locked:
+                    self.lock_depth -= 1
+                if is_func:
+                    self.func_stack.pop()
+
+        Sweep().visit(tree)
+        assert violations == [], (
+            "self._conn used outside 'with self._lock' in: %r — route reads "
+            "through _read_ctx() (or take the lock); an unlocked statement "
+            "on the shared writer connection races concurrent writers and "
+            "raises SystemError, destroying the turn as "
+            "session_persistence_failed" % (violations,)
+        )
+
+
+class TestSystemErrorTransactionBoundary:
+    """A bare SystemError must never replay an ambiguous write."""
+
+    def test_matching_error_inside_callback_is_not_replayed(self, db):
+        calls = {"n": 0}
+
+        def broken(_conn):
+            calls["n"] += 1
+            raise SystemError(
+                "<TrackedConnection object at 0x0> returned NULL "
+                "without setting an exception"
+            )
+
+        with pytest.raises(SystemError, match="returned NULL"):
+            db._execute_write(broken)
+        assert calls["n"] == 1
+
+    def test_post_commit_maintenance_error_does_not_replay_message(
+        self, db, monkeypatch
+    ):
+        db.create_session("s1", "cli")
+        before = db._write_count
+        maintenance_calls = {"n": 0}
+
+        def fail_once(*, max_pages):
+            maintenance_calls["n"] += 1
+            if maintenance_calls["n"] == 1:
+                raise SystemError(
+                    "<TrackedConnection object at 0x0> returned NULL "
+                    "without setting an exception"
+                )
+            return 0
+
+        monkeypatch.setattr(db, "_FTS_MERGE_EVERY_N_WRITES", 1)
+        monkeypatch.setattr(db, "_merge_fts_incrementally", fail_once)
+
+        message_id = db.append_message("s1", "user", "exactly-once")
+        matching = [
+            row for row in db.get_messages("s1")
+            if row["content"] == "exactly-once"
+        ]
+
+        assert isinstance(message_id, int)
+        assert len(matching) == 1
+        assert db.get_session("s1")["message_count"] == 1
+        assert db._write_count == before + 1
+        assert maintenance_calls["n"] == 1

--- a/tests/test_hermes_state_conn_lock_audit.py
+++ b/tests/test_hermes_state_conn_lock_audit.py
@@ -1,0 +1,109 @@
+"""Lock audit for every call on the shared writer connection (#99349).
+
+``SessionDB._conn`` is opened with ``check_same_thread=False`` and shared
+across threads (``AsyncSessionDB`` offloads every method via
+``asyncio.to_thread``), so every *call* on it must hold ``self._lock``.
+A lock-free ``self._conn.execute(...)`` — even a pure SELECT — can run
+concurrently with ``close()`` deallocating the connection's pysqlite
+statement cache, which segfaults the interpreter (observed in the field:
+``_PyDict_GetItem_KnownHash`` via ``bounded_lru_cache_wrapper`` on one
+thread while ``pysqlite_connection_close`` tears the cache down on
+another). "Read-only" is not an exemption: the race is on the connection
+object, not the database file.
+
+Reads that must not contend on the writer lock go through
+``SessionDB._read_ctx()`` instead — it borrows a pooled read connection
+(exclusively checked out for the block) and its non-WAL fallback is the
+writer connection *under* ``self._lock``.
+
+This is an AST audit in the spirit of
+``tests/gateway/test_async_session_db.py``: it fails on the next
+``self._conn.<method>(...)`` call site added outside ``with self._lock:``.
+"""
+
+import ast
+from pathlib import Path
+
+# Functions allowed to touch self._conn without the lock: construction-time
+# code that runs before the instance is ever shared with another thread.
+_ALLOWED_UNLOCKED_FNS = frozenset({
+    "__init__",
+    "_connect_and_init",
+    "_connect_and_init_with_lock_patience",
+})
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _nearest_enclosing_fn(tree: ast.AST) -> dict:
+    """Map id(node) -> name of the nearest enclosing function ("<module>"
+    at module level). Nested defs override their parents."""
+    enclosing: dict = {}
+
+    def visit(node: ast.AST, current: str) -> None:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            current = node.name
+        enclosing[id(node)] = current
+        for child in ast.iter_child_nodes(node):
+            visit(child, current)
+
+    visit(tree, "<module>")
+    return enclosing
+
+
+def _unlocked_conn_calls(tree: ast.AST):
+    """Return (lineno, enclosing_fn, method) for each self._conn.<m>(...)
+    call that is not lexically inside a ``with self._lock:`` block."""
+    locked_ids = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                ctx = item.context_expr
+                if (
+                    isinstance(ctx, ast.Attribute)
+                    and ctx.attr == "_lock"
+                    and isinstance(ctx.value, ast.Name)
+                    and ctx.value.id == "self"
+                ):
+                    locked_ids.update(id(child) for child in ast.walk(node))
+
+    enclosing = _nearest_enclosing_fn(tree)
+
+    offending = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "_conn"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "self"
+        ):
+            continue
+        if id(node) in locked_ids:
+            continue
+        fn = enclosing.get(id(node), "<module>")
+        if fn in _ALLOWED_UNLOCKED_FNS:
+            continue
+        offending.append((node.lineno, fn, func.attr))
+    return offending
+
+
+def test_every_conn_call_outside_construction_holds_the_lock():
+    src = (_repo_root() / "hermes_state.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    offending = _unlocked_conn_calls(tree)
+    assert not offending, (
+        "self._conn.<method>() called without `with self._lock:` — this "
+        "races SessionDB.close() inside pysqlite's statement cache and "
+        "segfaults the process (#99349). Use `with self._read_ctx() as "
+        "conn:` for reads, or take self._lock. Sites: "
+        + ", ".join(
+            f"line {lineno} in {fn}(): self._conn.{meth}(...)"
+            for lineno, fn, meth in offending
+        )
+    )

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -81,6 +81,34 @@ def test_reads_do_not_take_writer_lock(db):
 
 
 
+@pytest.mark.requires_wal
+def test_background_state_reads_never_touch_shared_writer(db):
+    """Background pollers must not race transcript writes on ``_conn``."""
+    db.try_acquire_compression_lock("s1", "holder", ttl_seconds=60)
+    assert db.request_handoff("s1", "telegram") is True
+    # Open this thread's read connection before poisoning the shared writer.
+    assert db._get_read_conn() is not None
+
+    writer = db._conn
+
+    class PoisonWriter:
+        def execute(self, *_args, **_kwargs):
+            raise AssertionError("read touched shared writer connection")
+
+    db._conn = PoisonWriter()
+    try:
+        assert db.get_compression_lock_holder("s1") == "holder"
+        db.clear_session_activity_labels("s1")
+        assert db.get_handoff_state("s1") == {
+            "state": "pending",
+            "platform": "telegram",
+            "error": None,
+        }
+        assert [row["id"] for row in db.list_pending_handoffs()] == ["s1"]
+    finally:
+        db._conn = writer
+
+
 def test_read_your_writes(db):
     """A fresh committed write must be visible to the read connection."""
     db.append_message("s1", role="user", content="zanzibar checkpoint")


### PR DESCRIPTION
## What does this PR do?

Consolidated class fix for the SQLite crash cluster: **unsynchronized reads on the shared `SessionDB` writer connection**. One `sqlite3.Connection` (`check_same_thread=False`) is shared across threads (`AsyncSessionDB` offloads via `asyncio.to_thread`); a handful of read paths executed on it without `self._lock` or `_read_ctx()`. Depending on timing, that produces:

- native **SIGSEGV** — a lock-free `execute()` races `close()` inside pysqlite's statement-cache teardown (`_PyDict_GetItem_KnownHash` via `bounded_lru_cache_wrapper`; #99349, #98332, #94248 crash dumps all carry this exact signature)
- bare **`SystemError: <connection> returned NULL without setting an exception`** — cross-thread `sqlite3_errmsg` scrambling; not a `sqlite3.Error`, so it escaped every retry net and destroyed turns as `session_persistence_failed` (#94258, #85079, #90734)

## Changes

1. **Route the four unlocked readers through `_read_ctx()`** (`get_compression_lock_holder`, `clear_session_activity_labels` no-op fast path, `get_handoff_state`, `list_pending_handoffs`) — cherry-picked from **PR #82428 by @milnerrad** (earliest submission, Aug 9), authorship preserved. Under WAL they borrow an exclusively-checked-out pooled read connection; the non-WAL fallback is the writer connection *under* `self._lock`. `_read_ctx`'s pool teardown is already coordinated with `close()` via `_read_conns_closed`, so the close() race is structurally gone. The `clear_session_activity_labels` fast path stays off the write-patience budget (#76354 contract preserved).
2. **Contain post-commit FTS maintenance errors** (salvaged from **PR #90734 by @Kyzcreig**, exactly-once refinement by @yuzilongleif-collab): a maintenance failure after the canonical write committed — including the bare `SystemError` — is logged, never re-raised, so callers can't blind-replay an ambiguous, possibly-durable write (the duplicate-row hazard @miroslavb demonstrated on #85065/#90734).
3. **Freeze the invariant with two structural gates**:
   - AST lock audit from **PR #99435 by @dimitrysuen**: every `self._conn.<method>()` call in `hermes_state.py` must sit inside `with self._lock:` (reads belong in `_read_ctx`).
   - The #90734 sweep, extended on top to also flag `self._conn` **passed as an argument** to helpers — which caught a fifth live site on main that all four competing PRs missed: `get_session_delete_targets` handed the writer connection to `_collect_delegate_child_ids` inside a `_read_ctx` block. Fixed here (routed to the borrowed read connection).
4. **Live race-hammer regression tests** (#90734): 4 reader threads × the formerly-unlocked methods against turn-shaped batch appends must produce zero errors on either side; plus the `SystemError` transaction-boundary exactly-once tests.

Deliberately **not** taken: per-site retry/classify patches for the `SystemError` spelling (#99327, #96886, #85065) — retrying a symptom of an unsynchronized read is patching the predicate, not the class; with the reads synchronized the error no longer occurs on this path. Also not taken: `cached_statements=0` (#97920) — disabling the statement cache shrinks the native crash window but leaves concurrent use of one connection undefined; the fix is to never share the connection unsynchronized.

## Live repro (before/after, real SessionDB, temp HERMES_HOME)

Instrumented the shared writer connection with an overlap meter and hammered the four readers against a real turn-shaped writer thread for 8s:

| | overlapping `execute()` calls on the shared conn | errors surfaced |
|---|---|---|
| origin/main `26f178e5fa` | **16,171** (`InterfaceError: bad parameter or other API misuse`, `IndexError` — the same unsynchronized-use class that natively faults on macOS) | 79 |
| this branch | **0** | 0 |

This overlapping use is exactly what the field crash dumps show dying natively (statement-cache dict walk at `0x8`). A close()-loop variant (6 reader threads racing `SessionDB.close()`+reopen) also survives cleanly after the fix.

## Tests

`scripts/run_tests.sh tests/state/ tests/test_session_db_read_path_split.py tests/test_hermes_state_conn_lock_audit.py` — 15 files, **113 passed, 0 failed**. Sabotage check: reverting any one reader to a bare `self._conn.execute` fails both AST gates.

## Credit

- **@milnerrad** (#82428) — first to submit the four-site `_read_ctx` routing (Aug 9); commit cherry-picked, authorship preserved
- **@Kyzcreig** (#90734) — deterministic repro, race-hammer + AST-sweep tests, post-commit containment (with @yuzilongleif-collab)
- **@dimitrysuen** (#99349 + #99435) — the two-thread native crash forensics pinning the close() race, and the lock-audit test
- **@wanliqin** (#86516) — early four-site inventory; **@nevermore131315** (#73803) — earliest handoff-reads-via-_read_ctx PR (partial scope); **@SourceFelony** (#97920) — statement-cache analysis; **@AmigaPrime** (#85065/#85079), **@Genion** (#99327), **@Agi-Asi** (#96886), **@ZoniBoy00** (#94258) — SystemError-spelling reports and fixes; **@jacques-commits** / **@acgh213** (#94248), **@laoli-no1** (#98332) — delegation-timeout crash forensics; **@miroslavb** — the blind-retry duplicate-row counterexample that shaped the exactly-once containment

Fixes #99349. Fixes #94258. Fixes #85079. Fixes #86516. Closes #98332.
Related: #94248 (SessionDB race half fixed here; child-teardown-ordering half tracked in #93992/#98348), #98077 (physical WAL corruption field report — separate storage-level track).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Infographic

![SessionDB class fix infographic](https://v3b.fal.media/files/b/0aa88feb/QZzklpZLxmRH767xDhJjw_UjP1erhw.png)
