### PR TITLE
feat(desktop): install uBlock Origin Lite on demand for Preview

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -11,7 +11,7 @@
 
 <table>
 <tr><td><b>Chat with the full agent</b></td><td>Streaming responses, live tool activity, structured tool summaries, and the same conversation history as every other Hermes surface.</td></tr>
-<tr><td><b>Side-by-side previews</b></td><td>Render web pages, files, and tool outputs in a right-hand pane while you keep chatting.</td></tr>
+<tr><td><b>Side-by-side previews</b></td><td>Render web pages, files, and tool outputs in a right-hand pane while you keep chatting. Optional uBlock Origin Lite content blocking can be enabled for Desktop Preview in Settings → Advanced; it is disabled by default.</td></tr>
 <tr><td><b>File browser</b></td><td>Explore and preview the working directory without leaving the app.</td></tr>
 <tr><td><b>Voice</b></td><td>Talk to Hermes and hear it back.</td></tr>
 <tr><td><b>Settings & onboarding</b></td><td>Manage providers, models, tools, and credentials from a real UI. First-run setup gets you to your first message in seconds.</td></tr>

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -281,6 +281,9 @@ import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { PreviewReachRegistry } from './preview-reach'
+import { createPreviewUblockController, type PreviewUblockController } from './preview-ublock'
+import { createPreviewUblockInstaller } from './preview-ublock-installer'
+import { readPreviewUblockSettings, writePreviewUblockSettings } from './preview-ublock-settings'
 import {
   createPrimaryRemoteConnection,
   FirstRunSetupResetError,
@@ -462,6 +465,19 @@ const GLASS_SUPPORTED = glassSupportedOn(process.platform, os.release())
 // there and Settings drops the row entirely.
 const TRANSLUCENCY_SUPPORTED = translucencySupportedOn(process.platform)
 const APP_ROOT = app.getAppPath()
+
+const previewUblockSettingsPath = path.join(app.getPath('userData'), 'preview-ublock.json')
+
+let previewUblockController: PreviewUblockController | null = null
+let previewUblockEnabled = false
+
+function requirePreviewUblockController(): PreviewUblockController {
+  if (!previewUblockController) {
+    throw new Error('uBlock Origin Lite is not ready')
+  }
+
+  return previewUblockController
+}
 
 // Device-local preference: block F12 from opening DevTools.
 // Set dynamically via IPC from the renderer Settings → Advanced.
@@ -16684,6 +16700,22 @@ ipcMain.on('hermes:devtools:disable-f12', (_event, on) => {
   }
 })
 
+ipcMain.handle('hermes:preview-ublock:get', async () => requirePreviewUblockController().getState())
+
+ipcMain.handle('hermes:preview-ublock:set-enabled', async (_event, enabled) => {
+  const requestedEnabled = enabled === true
+  const nextState = await requirePreviewUblockController().setEnabled(requestedEnabled)
+  previewUblockEnabled = nextState.enabled
+
+  try {
+    writePreviewUblockSettings(previewUblockSettingsPath, { enabled: previewUblockEnabled })
+  } catch (error) {
+    rememberLog(`[preview] uBlock preference write failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  return nextState
+})
+
 ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
@@ -17328,7 +17360,108 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  // Load optional uBlock Origin Lite into Preview's exact persistent session
+  // before any Preview webview is created. Startup only reuses a verified
+  // local cache; an explicit Settings action is required for network access.
+  const previewSession = session.fromPartition('persist:hermes-preview')
+  const persistedUblockEnabled = readPreviewUblockSettings(previewUblockSettingsPath).enabled
+  const previewUblockInstaller = createPreviewUblockInstaller({ userDataPath: app.getPath('userData') })
+
+  const ublock = createPreviewUblockController({
+    bootstrap: async extension => {
+      const bootstrapWindow = new BrowserWindow({
+        show: false,
+        webPreferences: { session: previewSession }
+      })
+
+      try {
+        await bootstrapWindow.loadURL(`${extension.url}/dashboard.html`)
+
+        return await bootstrapWindow.webContents.executeJavaScript(
+          `(async () => {
+            const configured = await chrome.runtime.sendMessage({ what: 'getEnabledRulesets' })
+            const enabled = await chrome.declarativeNetRequest.getEnabledRulesets()
+            const staticIds = Array.isArray(configured)
+              ? configured.filter(id => typeof id === 'string' && id.includes('://') === false)
+              : []
+            const missing = staticIds.filter(id => enabled.includes(id) === false)
+            if (missing.length !== 0) {
+              await chrome.declarativeNetRequest.updateEnabledRulesets({ enableRulesetIds: missing })
+            }
+            const after = await chrome.declarativeNetRequest.getEnabledRulesets()
+            return staticIds.every(id => after.includes(id))
+          })()`
+        )
+      } catch {
+        return false
+      } finally {
+        bootstrapWindow.destroy()
+      }
+    },
+    enabled: persistedUblockEnabled,
+    installer: previewUblockInstaller,
+    onStaleCache: error => {
+      rememberLog(
+        `[preview] uBlock Origin Lite update failed; using the cached release: ${error instanceof Error ? error.message : String(error)}`
+      )
+    },
+    session: previewSession
+  })
+
+  previewUblockController = ublock
+  const ublockState = await ublock.initialize()
+  previewUblockEnabled = ublockState.enabled
+  if (persistedUblockEnabled && !ublockState.enabled) {
+    try {
+      writePreviewUblockSettings(previewUblockSettingsPath, { enabled: false })
+    } catch (error) {
+      rememberLog(`[preview] uBlock preference reset failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    rememberLog('[preview] uBlock Origin Lite cache unavailable; content blocking remains disabled')
+  }
+  rememberLog(
+    ublockState.available
+      ? `[preview] loaded uBlock Origin Lite ${ublockState.version ?? 'unknown'} (${ublockState.extensionId}); rulesetsReady=${ublockState.rulesetsReady}`
+      : '[preview] uBlock Origin Lite unavailable'
+  )
+
+  if (process.env.HERMES_UBOL_SMOKE === '1') {
+    try {
+      const smokeState = await ublock.setEnabled(true)
+      if (!smokeState.available || !smokeState.rulesetsReady || !smokeState.dashboardUrl) {
+        throw new Error('uBlock Origin Lite did not become available')
+      }
+
+      const smokeWindow = new BrowserWindow({ show: false, webPreferences: { session: previewSession } })
+      try {
+        await smokeWindow.loadURL(smokeState.dashboardUrl)
+        const matchResult = await smokeWindow.webContents.executeJavaScript(
+          `(async () => chrome.declarativeNetRequest.testMatchOutcome({
+            url: 'http://000491b06a.com/blocked.png',
+            initiator: 'http://localhost/',
+            method: 'get',
+            type: 'image'
+          }))()`
+        )
+        const matchedRules = (matchResult as { matchedRules?: unknown[] })?.matchedRules
+        if (!Array.isArray(matchedRules) || matchedRules.length === 0) {
+          throw new Error('the known blocked URL did not match a uBlock ruleset')
+        }
+      } finally {
+        smokeWindow.destroy()
+      }
+      await ublock.setEnabled(false)
+      console.log('uBlock Origin Lite smoke test passed')
+      app.exit(0)
+      return
+    } catch (error) {
+      console.error(error)
+      app.exit(1)
+      return
+    }
+  }
+
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -281,6 +281,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),
   reachPreviewUrl: url => ipcRenderer.invoke('hermes:preview:reach', url),
   setActiveConnectionRoute: route => ipcRenderer.send('hermes:connection:active-route', route),
+  previewUblock: {
+    getState: () => ipcRenderer.invoke('hermes:preview-ublock:get'),
+    setEnabled: (enabled: boolean) => ipcRenderer.invoke('hermes:preview-ublock:set-enabled', enabled)
+  },
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   resolveFavicon: url => ipcRenderer.invoke('hermes:resolveFavicon', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),

--- a/apps/desktop/electron/preview-ublock-installer.test.ts
+++ b/apps/desktop/electron/preview-ublock-installer.test.ts
@@ -1,0 +1,183 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { zipSync } from 'fflate'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  applyCompatibilityPatches,
+  canonicalArchiveUrl,
+  createPreviewUblockInstaller,
+  extractArchive,
+  PREVIEW_UBLOCK_RELEASE_API,
+  validateExtensionDirectory
+} from './preview-ublock-installer'
+
+const TAG = '2026.825.1619'
+const temporaryDirectories: string[] = []
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preview-ublock-'))
+  temporaryDirectories.push(directory)
+
+  return directory
+}
+
+function archiveFiles(version = TAG): Uint8Array {
+  const background = `browser.permissions.onRemoved.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('removed', ...args);
+        });
+    });
+browser.permissions.onAdded.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('added', ...args);
+        });
+    });
+browser.commands.onCommand.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onCommand(...args);
+        });
+    });`
+
+  const extUtils = `export async function hasBroadHostPermissions() {
+    return browser.permissions.getAll().then(permissions =>
+        permissions.origins.includes('<all_urls>')
+    );
+}`
+
+  const modeManager = `async function getBrowserPermissions() {
+    return browser.permissions.getAll();
+}
+
+export async function persistHostPermissions(iter) {
+    if ( iter === undefined ) {
+        const permissions = await browser.permissions.getAll();
+            iter = hostnamesFromMatches(permissions.origins) || [];
+    }
+}`
+
+  const manifest = JSON.stringify({
+    background: { service_worker: '/js/background.js' },
+    manifest_version: 3,
+    name: 'uBlock Origin Lite',
+    version
+  })
+
+  return zipSync({
+    'LICENSE.txt': new TextEncoder().encode('MPL-2.0'),
+    'dashboard.html': new TextEncoder().encode('<!doctype html>'),
+    'js/background.js': new TextEncoder().encode(background),
+    'js/ext-utils.js': new TextEncoder().encode(extUtils),
+    'js/mode-manager.js': new TextEncoder().encode(modeManager),
+    'manifest.json': new TextEncoder().encode(manifest),
+    'rulesets/main/easylist.json': new TextEncoder().encode('[]'),
+    'rulesets/main/easyprivacy.json': new TextEncoder().encode('[]'),
+    'rulesets/main/ublock-filters.json': new TextEncoder().encode('[]')
+  })
+}
+
+function releaseFor(archive: Uint8Array, tag = TAG) {
+  const digest = Buffer.from(awaitableDigest(archive)).toString('hex')
+
+  return {
+    assets: [
+      {
+        browser_download_url: canonicalArchiveUrl(tag),
+        content_type: 'application/zip',
+        digest: `sha256:${digest}`,
+        name: `uBOLite_${tag}.chromium.zip`,
+        size: archive.length,
+        state: 'uploaded'
+      }
+    ],
+    draft: false,
+    prerelease: false,
+    tag_name: tag
+  }
+}
+
+function awaitableDigest(value: Uint8Array): Uint8Array {
+  const hash = new Uint8Array(32)
+  Buffer.from(crypto.createHash('sha256').update(value).digest()).copy(hash)
+
+  return hash
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe('preview uBlock installer', () => {
+  it('validates a release, applies Electron patches, and reuses a valid cache', async () => {
+    const archive = archiveFiles()
+    const release = releaseFor(archive)
+
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(new TextEncoder().encode(JSON.stringify(release)))
+      .mockResolvedValueOnce(archive)
+
+    const installer = createPreviewUblockInstaller({ request, userDataPath: temporaryDirectory() })
+
+    const installed = await installer.resolve('latest')
+    expect(installed?.version).toBe(TAG)
+    expect(fs.existsSync(path.join(installed!.path, 'manifest.json'))).toBe(true)
+    expect(await installer.resolve('cached')).toEqual(installed)
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(() => applyCompatibilityPatches(installed!.path)).not.toThrow()
+    validateExtensionDirectory(installed!.path, TAG)
+  })
+
+  it('does not use the network for a cached resolution', async () => {
+    const request = vi.fn()
+    const installer = createPreviewUblockInstaller({ request, userDataPath: temporaryDirectory() })
+
+    await expect(installer.resolve('cached')).resolves.toBeNull()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('rejects a checksum mismatch and leaves no partial cache', async () => {
+    const archive = archiveFiles()
+    const release = releaseFor(archive)
+    release.assets[0].digest = `sha256:${'0'.repeat(64)}`
+
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(new TextEncoder().encode(JSON.stringify(release)))
+      .mockResolvedValueOnce(archive)
+
+    const cache = temporaryDirectory()
+    const installer = createPreviewUblockInstaller({ request, userDataPath: cache })
+
+    await expect(installer.resolve('latest')).rejects.toThrow(/checksum/i)
+    expect(fs.existsSync(path.join(cache, 'preview-ublock', 'current'))).toBe(false)
+  })
+
+  it('rejects a non-canonical release asset URL before downloading', async () => {
+    const archive = archiveFiles()
+    const release = releaseFor(archive)
+    release.assets[0].browser_download_url = 'https://example.com/uBOLite.zip'
+    const request = vi.fn().mockResolvedValue(new TextEncoder().encode(JSON.stringify(release)))
+    const installer = createPreviewUblockInstaller({ request, userDataPath: temporaryDirectory() })
+
+    await expect(installer.resolve('latest')).rejects.toThrow(/canonical/i)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith(PREVIEW_UBLOCK_RELEASE_API, expect.any(Object))
+  })
+
+  it.each(['../escape.txt', '/absolute.txt', 'C:/drive.txt', 'nested\\escape.txt', 'nested/../escape.txt'])(
+    'rejects unsafe ZIP path %s before writing files',
+    unsafePath => {
+      const staging = path.join(temporaryDirectory(), 'staging')
+      const archive = zipSync({ [unsafePath]: new TextEncoder().encode('blocked') })
+
+      expect(() => extractArchive(archive, staging, TAG)).toThrow(/unsafe path/i)
+      expect(fs.existsSync(staging)).toBe(false)
+    }
+  )
+})

--- a/apps/desktop/electron/preview-ublock-installer.ts
+++ b/apps/desktop/electron/preview-ublock-installer.ts
@@ -1,0 +1,968 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import https from 'node:https'
+import path from 'node:path'
+
+import { unzipSync } from 'fflate'
+
+export type UblockInstallIntent = 'cached' | 'latest'
+
+export interface InstalledUblock {
+  path: string
+  version: string
+}
+
+export interface PreviewUblockInstaller {
+  resolve(intent: UblockInstallIntent): Promise<InstalledUblock | null>
+}
+
+export interface UblockRelease {
+  archiveSha256: string
+  archiveUrl: string
+  tag: string
+}
+
+export interface PreviewUblockHttpRequestOptions {
+  headers?: Record<string, string>
+  maxBytes: number
+  maxRedirects: number
+  timeoutMs: number
+}
+
+export type PreviewUblockHttpRequest = (url: string, options: PreviewUblockHttpRequestOptions) => Promise<Uint8Array>
+
+export interface PreviewUblockInstallerOptions {
+  cacheDirectory?: string
+  request?: PreviewUblockHttpRequest
+  userDataPath?: string
+}
+
+export interface InstalledUblockMetadata {
+  archiveSha256: string
+  archiveUrl: string
+  schemaVersion: 1
+  version: string
+}
+
+export const PREVIEW_UBLOCK_RELEASE_API = 'https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest'
+export const PREVIEW_UBLOCK_MAX_ARCHIVE_BYTES = 80 * 1024 * 1024
+export const PREVIEW_UBLOCK_MAX_EXPANDED_BYTES = 128 * 1024 * 1024
+export const PREVIEW_UBLOCK_MAX_FILE_BYTES = 32 * 1024 * 1024
+export const PREVIEW_UBLOCK_MAX_FILES = 2_000
+
+const PREVIEW_UBLOCK_CACHE_DIRNAME = 'preview-ublock'
+const INSTALLED_METADATA_FILENAME = 'installed.json'
+const CURRENT_DIRNAME = 'current'
+const MAX_RELEASE_METADATA_BYTES = 1024 * 1024
+const DOWNLOAD_TIMEOUT_MS = 30_000
+const MAX_REDIRECTS = 5
+const RELEASE_TAG_RE = /^[A-Za-z0-9._-]+$/
+const SHA256_RE = /^[0-9a-f]{64}$/
+
+const ALLOWED_NETWORK_HOSTS = new Set([
+  'api.github.com',
+  'github.com',
+  'release-assets.githubusercontent.com',
+  'objects.githubusercontent.com'
+])
+
+const REQUIRED_FILES = [
+  'LICENSE.txt',
+  'manifest.json',
+  'dashboard.html',
+  'rulesets/main/easylist.json',
+  'rulesets/main/easyprivacy.json',
+  'rulesets/main/ublock-filters.json'
+]
+
+const PATCHES: Array<{ file: string; oldText: string; newText: string; marker: string }> = [
+  {
+    file: 'js/background.js',
+    oldText: `browser.permissions.onRemoved.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('removed', ...args);
+        });
+    });`,
+    newText: `if ( browser.permissions?.onRemoved?.addListener ) {
+    browser.permissions.onRemoved.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('removed', ...args);
+        });
+    });
+}`,
+    marker: 'browser.permissions?.onRemoved?.addListener'
+  },
+  {
+    file: 'js/background.js',
+    oldText: `browser.permissions.onAdded.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('added', ...args);
+        });
+    });`,
+    newText: `if ( browser.permissions?.onAdded?.addListener ) {
+    browser.permissions.onAdded.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onPermissionsChanged('added', ...args);
+        });
+    });
+}`,
+    marker: 'browser.permissions?.onAdded?.addListener'
+  },
+  {
+    file: 'js/background.js',
+    oldText: `browser.commands.onCommand.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onCommand(...args);
+        });
+    });`,
+    newText: `if ( browser.commands?.onCommand?.addListener ) {
+    browser.commands.onCommand.addListener((...args) => {
+        isFullyInitialized.then(( ) => {
+            onCommand(...args);
+        });
+    });
+}`,
+    marker: 'browser.commands?.onCommand?.addListener'
+  },
+  {
+    file: 'js/ext-utils.js',
+    oldText: `export async function hasBroadHostPermissions() {
+    return browser.permissions.getAll().then(permissions =>`,
+    newText: `export async function hasBroadHostPermissions() {
+    if ( browser.permissions?.getAll === undefined ) { return true; }
+    return browser.permissions.getAll().then(permissions =>`,
+    marker: 'browser.permissions?.getAll === undefined'
+  },
+  {
+    file: 'js/mode-manager.js',
+    oldText: `async function getBrowserPermissions() {
+    return browser.permissions.getAll();
+}`,
+    newText: `async function getBrowserPermissions() {
+    if ( browser.permissions?.getAll === undefined ) {
+        return { origins: [ '<all_urls>' ] };
+    }
+    return browser.permissions.getAll();
+}`,
+    marker: 'browser.permissions?.getAll === undefined'
+  },
+  {
+    file: 'js/mode-manager.js',
+    oldText: `        const permissions = await browser.permissions.getAll();
+            iter = hostnamesFromMatches(permissions.origins) || [];`,
+    newText: `        if ( browser.permissions?.getAll === undefined ) {
+            iter = [ 'all-urls' ];
+        } else {
+            const permissions = await browser.permissions.getAll();
+            iter = hostnamesFromMatches(permissions.origins) || [];
+        }`,
+    marker: "iter = [ 'all-urls' ]"
+  }
+]
+
+function safeError(message: string): Error {
+  return new Error(`uBlock Origin Lite could not be installed: ${message}`)
+}
+
+function canonicalArchiveUrl(tag: string): string {
+  return `https://github.com/uBlockOrigin/uBOL-home/releases/download/${tag}/uBOLite_${tag}.chromium.zip`
+}
+
+function isAllowedUrl(rawUrl: string): URL {
+  let url: URL
+
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw safeError('the release server returned an invalid URL')
+  }
+
+  if (url.protocol !== 'https:' || url.username || url.password || !ALLOWED_NETWORK_HOSTS.has(url.hostname)) {
+    throw safeError('the release server returned a disallowed URL')
+  }
+
+  return url
+}
+
+function requestHttps(urlString: string, options: PreviewUblockHttpRequestOptions): Promise<Uint8Array> {
+  const visit = (currentUrl: string, redirects: number): Promise<Uint8Array> =>
+    new Promise((resolve, reject) => {
+      const url = isAllowedUrl(currentUrl)
+
+      const request = https.request(url, { headers: options.headers, method: 'GET' }, response => {
+        const status = response.statusCode ?? 0
+
+        if (status >= 300 && status < 400) {
+          const location = response.headers.location
+          response.resume()
+
+          if (!location || redirects >= options.maxRedirects) {
+            reject(safeError('the release download redirected too many times'))
+
+            return
+          }
+
+          let nextUrl: URL
+
+          try {
+            nextUrl = new URL(location, url)
+            isAllowedUrl(nextUrl.toString())
+          } catch (error) {
+            reject(error instanceof Error ? error : safeError('the release download returned an invalid redirect'))
+
+            return
+          }
+
+          void visit(nextUrl.toString(), redirects + 1).then(resolve, reject)
+
+          return
+        }
+
+        if (status < 200 || status >= 300) {
+          response.resume()
+          reject(safeError(`the release server returned HTTP ${status}`))
+
+          return
+        }
+
+        const chunks: Buffer[] = []
+        let total = 0
+        let tooLarge = false
+        response.on('data', chunk => {
+          if (tooLarge) {
+            return
+          }
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+          total += buffer.length
+
+          if (total > options.maxBytes) {
+            tooLarge = true
+            response.destroy(safeError('the release response is too large'))
+
+            return
+          }
+
+          chunks.push(buffer)
+        })
+        response.on('end', () => {
+          if (!tooLarge) {
+            resolve(new Uint8Array(Buffer.concat(chunks)))
+          }
+        })
+        response.on('error', reject)
+      })
+
+      request.setTimeout(options.timeoutMs, () => request.destroy(safeError('the release request timed out')))
+      request.on('error', reject)
+      request.end()
+    })
+
+  return visit(urlString, 0)
+}
+
+function countLineOccurrences(source: string, target: string): number {
+  let count = 0
+  let offset = 0
+
+  while (true) {
+    const index = source.indexOf(target, offset)
+
+    if (index < 0) {
+      return count
+    }
+    if (index === 0 || source[index - 1] === '\n') {
+      count += 1
+    }
+    offset = index + target.length
+  }
+}
+
+function replaceLineOccurrence(source: string, target: string, replacement: string): string {
+  let offset = 0
+
+  while (true) {
+    const index = source.indexOf(target, offset)
+
+    if (index < 0) {
+      return source
+    }
+    if (index === 0 || source[index - 1] === '\n') {
+      return `${source.slice(0, index)}${replacement}${source.slice(index + target.length)}`
+    }
+    offset = index + target.length
+  }
+}
+
+function applyCompatibilityPatches(root: string): void {
+  for (const patch of PATCHES) {
+    const filePath = path.join(root, patch.file)
+    let source: string
+
+    try {
+      source = fs.readFileSync(filePath, 'utf8')
+    } catch {
+      throw safeError(`the required compatibility file is missing: ${patch.file}`)
+    }
+
+    const oldCount = countLineOccurrences(source, patch.oldText)
+    const newCount = countLineOccurrences(source, patch.newText)
+
+    if (oldCount === 1 && newCount === 0) {
+      fs.writeFileSync(filePath, replaceLineOccurrence(source, patch.oldText, patch.newText), {
+        encoding: 'utf8',
+        mode: 0o600
+      })
+    } else if (oldCount !== 0 || newCount !== 1) {
+      throw safeError(`compatibility patch context drifted in ${patch.file}`)
+    }
+  }
+}
+
+function decodeZipName(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch {
+    throw safeError('the archive contains an invalid UTF-8 path')
+  }
+}
+
+function checkedZipPath(name: string): string {
+  if (!name || name.includes('\\') || name.includes('\0') || name.startsWith('/') || /^[A-Za-z]:/.test(name)) {
+    throw safeError('the archive contains an unsafe path')
+  }
+
+  const pathWithoutMarker = name.endsWith('/') ? name.slice(0, -1) : name
+  const segments = pathWithoutMarker.split('/')
+
+  if (!pathWithoutMarker || segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    throw safeError('the archive contains an unsafe path')
+  }
+
+  return segments.join('/')
+}
+
+function readU16(data: Uint8Array, offset: number): number {
+  if (offset < 0 || offset + 2 > data.length) {
+    throw safeError('the archive is truncated')
+  }
+
+  return data[offset] | (data[offset + 1] << 8)
+}
+
+function readU32(data: Uint8Array, offset: number): number {
+  if (offset < 0 || offset + 4 > data.length) {
+    throw safeError('the archive is truncated')
+  }
+
+  return (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >>> 0
+}
+
+interface ZipEntry {
+  compressedSize: number
+  isDirectory: boolean
+  name: string
+  uncompressedSize: number
+}
+
+function inspectZip(archive: Uint8Array): ZipEntry[] {
+  if (archive.length > PREVIEW_UBLOCK_MAX_ARCHIVE_BYTES) {
+    throw safeError('the archive is too large')
+  }
+
+  const minimumEnd = Math.max(0, archive.length - 22 - 65_535)
+  let endOffset = -1
+
+  for (let offset = archive.length - 22; offset >= minimumEnd; offset -= 1) {
+    if (offset >= 0 && readU32(archive, offset) === 0x06054b50) {
+      endOffset = offset
+
+      break
+    }
+  }
+
+  if (endOffset < 0) {
+    throw safeError('the archive has no valid ZIP directory')
+  }
+
+  const diskNumber = readU16(archive, endOffset + 4)
+  const directoryDisk = readU16(archive, endOffset + 6)
+  const entriesOnDisk = readU16(archive, endOffset + 8)
+  const entryCount = readU16(archive, endOffset + 10)
+  const directorySize = readU32(archive, endOffset + 12)
+  const directoryOffset = readU32(archive, endOffset + 16)
+
+  if (diskNumber !== 0 || directoryDisk !== 0 || entriesOnDisk !== entryCount || entryCount === 0xffff) {
+    throw safeError('the archive uses unsupported ZIP features')
+  }
+
+  if (directoryOffset + directorySize > archive.length) {
+    throw safeError('the archive directory is truncated')
+  }
+
+  const entries: ZipEntry[] = []
+  const names = new Set<string>()
+  let offset = directoryOffset
+  let expandedBytes = 0
+  let fileCount = 0
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (readU32(archive, offset) !== 0x02014b50) {
+      throw safeError('the archive has an invalid directory entry')
+    }
+    const flags = readU16(archive, offset + 8)
+    const compression = readU16(archive, offset + 10)
+    const compressedSize = readU32(archive, offset + 20)
+    const uncompressedSize = readU32(archive, offset + 24)
+    const nameLength = readU16(archive, offset + 28)
+    const extraLength = readU16(archive, offset + 30)
+    const commentLength = readU16(archive, offset + 32)
+    const externalAttributes = readU32(archive, offset + 38)
+    const localOffset = readU32(archive, offset + 42)
+    const nameStart = offset + 46
+    const nextOffset = nameStart + nameLength + extraLength + commentLength
+
+    if (nextOffset > directoryOffset + directorySize || nextOffset > archive.length) {
+      throw safeError('the archive is truncated')
+    }
+
+    if (compressedSize === 0xffffffff || uncompressedSize === 0xffffffff || localOffset === 0xffffffff) {
+      throw safeError('the archive uses unsupported ZIP64 features')
+    }
+
+    const rawName = decodeZipName(archive.slice(nameStart, nameStart + nameLength))
+    const name = checkedZipPath(rawName)
+
+    if (names.has(name)) {
+      throw safeError('the archive contains duplicate paths')
+    }
+    names.add(name)
+
+    const unixMode = (externalAttributes >>> 16) & 0xffff
+
+    if ((unixMode & 0xf000) === 0xa000) {
+      throw safeError('the archive contains a symlink')
+    }
+
+    if (flags & 1) {
+      throw safeError('the archive contains an encrypted entry')
+    }
+
+    if (compression !== 0 && compression !== 8) {
+      throw safeError('the archive uses unsupported compression')
+    }
+
+    if (readU32(archive, localOffset) !== 0x04034b50) {
+      throw safeError('the archive has an invalid local entry')
+    }
+
+    const localNameLength = readU16(archive, localOffset + 26)
+    const localExtraLength = readU16(archive, localOffset + 28)
+    const dataOffset = localOffset + 30 + localNameLength + localExtraLength
+
+    if (dataOffset > archive.length || compressedSize > archive.length - dataOffset) {
+      throw safeError('the archive entry is truncated')
+    }
+
+    const isDirectory = rawName.endsWith('/') || (externalAttributes & 0x10) !== 0 || (unixMode & 0xf000) === 0x4000
+
+    if (!isDirectory) {
+      fileCount += 1
+
+      if (fileCount > PREVIEW_UBLOCK_MAX_FILES) {
+        throw safeError('the archive contains too many files')
+      }
+
+      if (uncompressedSize > PREVIEW_UBLOCK_MAX_FILE_BYTES) {
+        throw safeError('an archive file is too large')
+      }
+      expandedBytes += uncompressedSize
+
+      if (expandedBytes > PREVIEW_UBLOCK_MAX_EXPANDED_BYTES) {
+        throw safeError('the expanded archive is too large')
+      }
+    }
+
+    entries.push({ compressedSize, isDirectory, name, uncompressedSize })
+    offset = nextOffset
+  }
+
+  return entries
+}
+
+function ensureInside(root: string, candidate: string): void {
+  const resolvedRoot = path.resolve(root)
+  const resolvedCandidate = path.resolve(candidate)
+
+  if (resolvedCandidate !== resolvedRoot && !resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw safeError('the archive escaped its staging directory')
+  }
+}
+
+function extractArchive(archive: Uint8Array, stagingPath: string, tag: string): void {
+  const entries = inspectZip(archive)
+  const files = unzipSync(archive)
+  let actualExpandedBytes = 0
+  let actualFileCount = 0
+  fs.mkdirSync(stagingPath, { recursive: true, mode: 0o700 })
+  fs.chmodSync(stagingPath, 0o700)
+
+  for (const entry of entries) {
+    const destination = path.join(stagingPath, entry.name)
+    ensureInside(stagingPath, destination)
+
+    if (entry.isDirectory) {
+      fs.mkdirSync(destination, { recursive: true, mode: 0o700 })
+      fs.chmodSync(destination, 0o700)
+
+      continue
+    }
+
+    const data = files[entry.name]
+    actualFileCount += 1
+    actualExpandedBytes += data?.length ?? 0
+    if (actualFileCount > PREVIEW_UBLOCK_MAX_FILES || actualExpandedBytes > PREVIEW_UBLOCK_MAX_EXPANDED_BYTES) {
+      throw safeError('the expanded archive is too large')
+    }
+
+    if (!data || data.length !== entry.uncompressedSize) {
+      throw safeError('the archive contents do not match its directory')
+    }
+    if (data.length > PREVIEW_UBLOCK_MAX_FILE_BYTES) {
+      throw safeError('an archive file is too large')
+    }
+
+    fs.mkdirSync(path.dirname(destination), { recursive: true, mode: 0o700 })
+    fs.writeFileSync(destination, Buffer.from(data), { encoding: null, mode: 0o600 })
+    fs.chmodSync(destination, 0o600)
+  }
+
+  validateExtensionDirectory(stagingPath, tag, false)
+}
+
+function safeManifestPath(value: unknown, fallback: string): string {
+  if (value === undefined) {
+    return fallback
+  }
+
+  if (typeof value !== 'string' || value.includes('\\')) {
+    throw safeError('the manifest contains an unsafe path')
+  }
+
+  return checkedZipPath(value.replace(/^\/+/, ''))
+}
+
+function readManifest(root: string): Record<string, any> {
+  try {
+    const value: unknown = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'))
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('not an object')
+    }
+
+    return value as Record<string, any>
+  } catch {
+    throw safeError('manifest.json is invalid')
+  }
+}
+
+function validateExtensionTree(root: string): void {
+  const rootStat = fs.lstatSync(root)
+
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw safeError('the extension cache root is not a directory')
+  }
+
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name)
+      ensureInside(root, entryPath)
+      const stat = fs.lstatSync(entryPath)
+
+      if (stat.isSymbolicLink()) {
+        throw safeError('the extension cache contains a symlink')
+      }
+
+      if (stat.isDirectory()) {
+        visit(entryPath)
+      } else if (!stat.isFile()) {
+        throw safeError('the extension cache contains a non-regular file')
+      }
+    }
+  }
+
+  visit(root)
+}
+
+function validateCompatibilityMarkers(root: string): void {
+  for (const patch of PATCHES) {
+    const source = fs.readFileSync(path.join(root, patch.file), 'utf8')
+
+    if (source.includes(patch.marker) === false) {
+      throw safeError(`compatibility patch is missing from ${patch.file}`)
+    }
+  }
+}
+
+export function validateExtensionDirectory(root: string, tag: string, requireCompatibilityPatches = true): void {
+  if (!RELEASE_TAG_RE.test(tag)) {
+    throw safeError('the release tag is invalid')
+  }
+  validateExtensionTree(root)
+  const manifest = readManifest(root)
+
+  if (manifest.manifest_version !== 3 || typeof manifest.version !== 'string' || manifest.version !== tag) {
+    throw safeError('the extension manifest is not the requested MV3 release')
+  }
+
+  if (typeof manifest.name !== 'string' || manifest.name.trim() === '') {
+    throw safeError('the extension name is missing')
+  }
+
+  const dashboard = safeManifestPath(manifest.dashboard, 'dashboard.html')
+  const serviceWorker = safeManifestPath(manifest.background?.service_worker, '')
+
+  if (!serviceWorker) {
+    throw safeError('the background service worker is missing')
+  }
+
+  const required = new Set([...REQUIRED_FILES, dashboard, serviceWorker])
+
+  for (const relativePath of required) {
+    const absolutePath = path.join(root, relativePath)
+    ensureInside(root, absolutePath)
+    let stat: fs.Stats
+
+    try {
+      stat = fs.lstatSync(absolutePath)
+    } catch {
+      throw safeError(`required extension file is missing: ${relativePath}`)
+    }
+
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw safeError(`required extension file is not regular: ${relativePath}`)
+    }
+  }
+
+  if (requireCompatibilityPatches) {
+    validateCompatibilityMarkers(root)
+  }
+}
+
+function validateMetadata(value: unknown): value is InstalledUblockMetadata {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  const keys = Object.keys(candidate).sort()
+
+  return (
+    keys.join(',') === 'archiveSha256,archiveUrl,schemaVersion,version' &&
+    candidate.schemaVersion === 1 &&
+    typeof candidate.version === 'string' &&
+    RELEASE_TAG_RE.test(candidate.version) &&
+    typeof candidate.archiveSha256 === 'string' &&
+    SHA256_RE.test(candidate.archiveSha256) &&
+    typeof candidate.archiveUrl === 'string' &&
+    candidate.archiveUrl === canonicalArchiveUrl(candidate.version)
+  )
+}
+
+function metadataPathFor(cacheDirectory: string): string {
+  return path.join(cacheDirectory, INSTALLED_METADATA_FILENAME)
+}
+
+function readMetadata(cacheDirectory: string): InstalledUblockMetadata | null {
+  try {
+    const value: unknown = JSON.parse(fs.readFileSync(metadataPathFor(cacheDirectory), 'utf8'))
+
+    return validateMetadata(value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+function validateCachedInstall(cacheDirectory: string): InstalledUblockMetadata | null {
+  const metadata = readMetadata(cacheDirectory)
+  const currentPath = path.join(cacheDirectory, CURRENT_DIRNAME)
+
+  if (!metadata) {
+    return null
+  }
+
+  try {
+    if (!fs.statSync(currentPath).isDirectory()) {
+      return null
+    }
+    validateExtensionDirectory(currentPath, metadata.version)
+
+    return metadata
+  } catch {
+    return null
+  }
+}
+
+function removePath(target: string): void {
+  fs.rmSync(target, { force: true, recursive: true })
+}
+
+function cacheEntries(cacheDirectory: string, prefix: string): string[] {
+  try {
+    return fs
+      .readdirSync(cacheDirectory)
+      .filter(entry => entry.startsWith(prefix))
+      .map(entry => path.join(cacheDirectory, entry))
+  } catch {
+    return []
+  }
+}
+
+function validateCachedInstallAt(currentPath: string, cacheDirectory: string): boolean {
+  const metadata = readMetadata(cacheDirectory)
+
+  if (!metadata) {
+    return false
+  }
+
+  try {
+    validateExtensionDirectory(currentPath, metadata.version)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+function recoverCache(cacheDirectory: string): void {
+  fs.mkdirSync(cacheDirectory, { recursive: true, mode: 0o700 })
+
+  for (const stagingPath of cacheEntries(cacheDirectory, '.staging-')) {
+    removePath(stagingPath)
+  }
+
+  for (const temporaryMetadataPath of cacheEntries(cacheDirectory, '.installed-')) {
+    removePath(temporaryMetadataPath)
+  }
+
+  const currentPath = path.join(cacheDirectory, CURRENT_DIRNAME)
+  const previousPaths = cacheEntries(cacheDirectory, '.previous-')
+
+  if (!fs.existsSync(currentPath)) {
+    for (const previousPath of previousPaths) {
+      if (validateCachedInstallAt(previousPath, cacheDirectory)) {
+        fs.renameSync(previousPath, currentPath)
+
+        break
+      }
+    }
+  }
+
+  for (const previousPath of cacheEntries(cacheDirectory, '.previous-')) {
+    removePath(previousPath)
+  }
+}
+
+function randomSuffix(): string {
+  return `${process.pid}-${crypto.randomBytes(8).toString('hex')}`
+}
+
+function promoteCache(cacheDirectory: string, stagingPath: string, metadata: InstalledUblockMetadata): void {
+  const currentPath = path.join(cacheDirectory, CURRENT_DIRNAME)
+  const previousPath = path.join(cacheDirectory, `.previous-${randomSuffix()}`)
+  const metadataPath = metadataPathFor(cacheDirectory)
+  const temporaryMetadataPath = path.join(cacheDirectory, `.installed-${randomSuffix()}.json`)
+  const oldMetadata = fs.existsSync(metadataPath) ? fs.readFileSync(metadataPath) : null
+  let previousMoved = false
+  let currentPromoted = false
+
+  try {
+    if (fs.existsSync(currentPath)) {
+      fs.renameSync(currentPath, previousPath)
+      previousMoved = true
+    }
+
+    fs.renameSync(stagingPath, currentPath)
+    currentPromoted = true
+    fs.writeFileSync(temporaryMetadataPath, JSON.stringify(metadata, null, 2), { encoding: 'utf8', mode: 0o600 })
+    fs.renameSync(temporaryMetadataPath, metadataPath)
+
+    if (previousMoved) {
+      removePath(previousPath)
+    }
+  } catch (error) {
+    removePath(temporaryMetadataPath)
+
+    if (currentPromoted) {
+      removePath(currentPath)
+    }
+
+    if (previousMoved && fs.existsSync(previousPath)) {
+      fs.renameSync(previousPath, currentPath)
+    }
+
+    if (oldMetadata) {
+      fs.writeFileSync(metadataPath, oldMetadata, { mode: 0o600 })
+    } else {
+      removePath(metadataPath)
+    }
+
+    throw error
+  }
+}
+
+function parseRelease(payload: Uint8Array): UblockRelease {
+  let value: any
+
+  try {
+    value = JSON.parse(Buffer.from(payload).toString('utf8'))
+  } catch {
+    throw safeError('the release metadata is invalid JSON')
+  }
+
+  if (
+    !value ||
+    value.draft !== false ||
+    value.prerelease !== false ||
+    typeof value.tag_name !== 'string' ||
+    !RELEASE_TAG_RE.test(value.tag_name)
+  ) {
+    throw safeError('the release metadata is not a stable release')
+  }
+
+  const tag = value.tag_name
+  const assetName = `uBOLite_${tag}.chromium.zip`
+  const assets = Array.isArray(value.assets) ? value.assets.filter((asset: any) => asset?.name === assetName) : []
+
+  if (assets.length !== 1) {
+    throw safeError('the stable release has no unique uBlock archive')
+  }
+  const asset = assets[0]
+
+  if (
+    asset.state !== 'uploaded' ||
+    asset.content_type !== 'application/zip' ||
+    !Number.isInteger(asset.size) ||
+    asset.size < 1 ||
+    asset.size > PREVIEW_UBLOCK_MAX_ARCHIVE_BYTES ||
+    typeof asset.digest !== 'string' ||
+    !/^sha256:[0-9a-f]{64}$/.test(asset.digest)
+  ) {
+    throw safeError('the stable release archive metadata is invalid')
+  }
+
+  const archiveUrl = canonicalArchiveUrl(tag)
+
+  if (asset.browser_download_url !== archiveUrl) {
+    throw safeError('the release archive URL is not canonical')
+  }
+
+  return { archiveSha256: asset.digest.slice('sha256:'.length), archiveUrl, tag }
+}
+
+export function createPreviewUblockInstaller({
+  cacheDirectory,
+  request = requestHttps,
+  userDataPath
+}: PreviewUblockInstallerOptions): PreviewUblockInstaller {
+  const resolvedCacheDirectory =
+    cacheDirectory ?? (userDataPath ? path.join(userDataPath, PREVIEW_UBLOCK_CACHE_DIRNAME) : null)
+
+  if (!resolvedCacheDirectory) {
+    throw new Error('uBlock Origin Lite cache directory is not configured')
+  }
+  fs.mkdirSync(resolvedCacheDirectory, { recursive: true, mode: 0o700 })
+  recoverCache(resolvedCacheDirectory)
+
+  let latestPromise: Promise<InstalledUblock> | null = null
+
+  const resolveCached = (): InstalledUblock | null => {
+    const metadata = validateCachedInstall(resolvedCacheDirectory)
+
+    if (!metadata) {
+      removePath(path.join(resolvedCacheDirectory, CURRENT_DIRNAME))
+      removePath(metadataPathFor(resolvedCacheDirectory))
+
+      return null
+    }
+
+    return { path: path.join(resolvedCacheDirectory, CURRENT_DIRNAME), version: metadata.version }
+  }
+
+  const resolveLatest = async (): Promise<InstalledUblock> => {
+    const releasePayload = await request(PREVIEW_UBLOCK_RELEASE_API, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Hermes-Desktop' },
+      maxBytes: MAX_RELEASE_METADATA_BYTES,
+      maxRedirects: MAX_REDIRECTS,
+      timeoutMs: DOWNLOAD_TIMEOUT_MS
+    })
+
+    const release = parseRelease(releasePayload)
+    const cachedMetadata = validateCachedInstall(resolvedCacheDirectory)
+
+    if (
+      cachedMetadata &&
+      cachedMetadata.version === release.tag &&
+      cachedMetadata.archiveSha256 === release.archiveSha256 &&
+      cachedMetadata.archiveUrl === release.archiveUrl
+    ) {
+      return { path: path.join(resolvedCacheDirectory, CURRENT_DIRNAME), version: cachedMetadata.version }
+    }
+
+    if (!cachedMetadata) {
+      removePath(path.join(resolvedCacheDirectory, CURRENT_DIRNAME))
+      removePath(metadataPathFor(resolvedCacheDirectory))
+    }
+
+    const archive = await request(release.archiveUrl, {
+      maxBytes: PREVIEW_UBLOCK_MAX_ARCHIVE_BYTES,
+      maxRedirects: MAX_REDIRECTS,
+      timeoutMs: DOWNLOAD_TIMEOUT_MS
+    })
+
+    const actualDigest = crypto.createHash('sha256').update(archive).digest()
+    const expectedDigest = Buffer.from(release.archiveSha256, 'hex')
+
+    if (actualDigest.length !== expectedDigest.length || !crypto.timingSafeEqual(actualDigest, expectedDigest)) {
+      throw safeError('the downloaded archive checksum did not match GitHub')
+    }
+
+    const stagingPath = path.join(resolvedCacheDirectory, `.staging-${randomSuffix()}`)
+
+    try {
+      extractArchive(archive, stagingPath, release.tag)
+      applyCompatibilityPatches(stagingPath)
+      validateExtensionDirectory(stagingPath, release.tag)
+
+      const metadata: InstalledUblockMetadata = {
+        archiveSha256: release.archiveSha256,
+        archiveUrl: release.archiveUrl,
+        schemaVersion: 1,
+        version: release.tag
+      }
+
+      promoteCache(resolvedCacheDirectory, stagingPath, metadata)
+    } catch (error) {
+      removePath(stagingPath)
+      throw error
+    }
+
+    return { path: path.join(resolvedCacheDirectory, CURRENT_DIRNAME), version: release.tag }
+  }
+
+  return {
+    resolve(intent) {
+      if (intent === 'cached') {
+        return Promise.resolve(resolveCached())
+      }
+
+      if (!latestPromise) {
+        latestPromise = resolveLatest().finally(() => {
+          latestPromise = null
+        })
+      }
+
+      return latestPromise
+    }
+  }
+}
+
+export { applyCompatibilityPatches, canonicalArchiveUrl, extractArchive, parseRelease }

--- a/apps/desktop/electron/preview-ublock-settings.test.ts
+++ b/apps/desktop/electron/preview-ublock-settings.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { readPreviewUblockSettings, writePreviewUblockSettings } from './preview-ublock-settings'
+
+const tempDirectories: string[] = []
+
+function tempSettingsPath(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preview-ublock-settings-'))
+  tempDirectories.push(directory)
+  return path.join(directory, 'nested', 'preview-ublock.json')
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe('preview uBlock settings', () => {
+  it('defaults missing or malformed settings to disabled', () => {
+    const settingsPath = tempSettingsPath()
+
+    expect(readPreviewUblockSettings(settingsPath)).toEqual({ enabled: false })
+
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+    fs.writeFileSync(settingsPath, JSON.stringify({ enabled: 'false' }), 'utf8')
+
+    expect(readPreviewUblockSettings(settingsPath)).toEqual({ enabled: false })
+  })
+
+  it('round-trips a valid disabled setting and creates its parent directory', () => {
+    const settingsPath = tempSettingsPath()
+
+    writePreviewUblockSettings(settingsPath, { enabled: false })
+
+    expect(readPreviewUblockSettings(settingsPath)).toEqual({ enabled: false })
+    expect(JSON.parse(fs.readFileSync(settingsPath, 'utf8'))).toEqual({ enabled: false })
+  })
+})

--- a/apps/desktop/electron/preview-ublock-settings.ts
+++ b/apps/desktop/electron/preview-ublock-settings.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export interface PreviewUblockSettings {
+  enabled: boolean
+}
+
+const DEFAULT_PREVIEW_UBLOCK_SETTINGS: PreviewUblockSettings = { enabled: false }
+
+export function readPreviewUblockSettings(settingsPath: string): PreviewUblockSettings {
+  try {
+    const value: unknown = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
+
+    if (value && typeof value === 'object' && 'enabled' in value && typeof value.enabled === 'boolean') {
+      return { enabled: value.enabled }
+    }
+  } catch {
+    // Missing or malformed local settings use the opt-in default.
+  }
+
+  return { ...DEFAULT_PREVIEW_UBLOCK_SETTINGS }
+}
+
+export function writePreviewUblockSettings(settingsPath: string, settings: PreviewUblockSettings): void {
+  const directory = path.dirname(settingsPath)
+  const temporaryPath = `${settingsPath}.tmp-${process.pid}`
+
+  fs.mkdirSync(directory, { recursive: true })
+  fs.writeFileSync(temporaryPath, JSON.stringify({ enabled: settings.enabled }, null, 2), 'utf8')
+  fs.renameSync(temporaryPath, settingsPath)
+}

--- a/apps/desktop/electron/preview-ublock.test.ts
+++ b/apps/desktop/electron/preview-ublock.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createPreviewUblockController } from './preview-ublock'
+
+function fakeSession() {
+  const extensions = new Map<string, any>()
+  let nextId = 0
+
+  return {
+    extensions: {
+      getAllExtensions: () => [...extensions.values()],
+      getExtension: (id: string) => extensions.get(id) ?? null,
+      loadExtension: async (extensionPath: string) => {
+        const extension = {
+          id: `ublock-${++nextId}`,
+          manifest: { name: 'uBlock Origin Lite', version: '2026.825.1619' },
+          path: extensionPath,
+          url: `chrome-extension://ublock-${nextId}`
+        }
+
+        extensions.set(extension.id, extension)
+
+        return extension
+      },
+      removeExtension: (id: string) => extensions.delete(id)
+    }
+  }
+}
+
+const cached = { path: '/user-data/preview-ublock/current', version: '2026.825.1619' }
+
+function installer(resolve = vi.fn().mockResolvedValue(cached)) {
+  return { resolve }
+}
+
+describe('preview uBlock lifecycle', () => {
+  it('does not resolve or load an extension on default startup', async () => {
+    const resolve = vi.fn()
+    const previewSession = fakeSession()
+    const controller = createPreviewUblockController({ installer: installer(resolve), session: previewSession })
+
+    await expect(controller.initialize()).resolves.toMatchObject({ enabled: false, available: false })
+    expect(resolve).not.toHaveBeenCalled()
+    expect(previewSession.extensions.getAllExtensions()).toEqual([])
+  })
+
+  it('loads a cached extension into the supplied Preview session', async () => {
+    const previewSession = fakeSession()
+    const controller = createPreviewUblockController({ enabled: true, installer: installer(), session: previewSession })
+
+    await expect(controller.initialize()).resolves.toEqual({
+      enabled: true,
+      available: true,
+      dashboardUrl: 'chrome-extension://ublock-1/dashboard.html',
+      extensionId: 'ublock-1',
+      rulesetsReady: true,
+      version: '2026.825.1619'
+    })
+  })
+
+  it('uses latest on explicit enable and unloads without deleting the cache', async () => {
+    const previewSession = fakeSession()
+    const resolve = vi.fn().mockResolvedValue(cached)
+    const controller = createPreviewUblockController({ installer: installer(resolve), session: previewSession })
+
+    await expect(controller.setEnabled(true)).resolves.toMatchObject({ enabled: true, available: true })
+    await expect(controller.setEnabled(false)).resolves.toMatchObject({ enabled: false, available: false })
+    expect(resolve).toHaveBeenCalledWith('latest')
+    expect(previewSession.extensions.getAllExtensions()).toEqual([])
+  })
+
+  it('falls back to a valid cached release when latest resolution fails', async () => {
+    const previewSession = fakeSession()
+    const resolve = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(cached)
+    const onStaleCache = vi.fn()
+
+    const controller = createPreviewUblockController({
+      installer: installer(resolve),
+      onStaleCache,
+      session: previewSession
+    })
+
+    await expect(controller.setEnabled(true)).resolves.toMatchObject({ enabled: true, available: true })
+    expect(resolve).toHaveBeenNthCalledWith(1, 'latest')
+    expect(resolve).toHaveBeenNthCalledWith(2, 'cached')
+    expect(onStaleCache).toHaveBeenCalledOnce()
+  })
+
+  it('rejects first enable failures and leaves the state disabled', async () => {
+    const previewSession = fakeSession()
+    const resolve = vi.fn().mockRejectedValue(new Error('offline'))
+    const controller = createPreviewUblockController({ installer: installer(resolve), session: previewSession })
+
+    await expect(controller.setEnabled(true)).rejects.toThrow('offline')
+    expect(controller.getState()).toMatchObject({ enabled: false, available: false })
+    expect(previewSession.extensions.getAllExtensions()).toEqual([])
+  })
+
+  it('serializes concurrent toggles', async () => {
+    const previewSession = fakeSession()
+    let releaseLatest!: () => void
+
+    const resolve = vi.fn().mockImplementation((intent: string) =>
+      intent === 'latest'
+        ? new Promise(resolvePromise => {
+            releaseLatest = () => resolvePromise(cached)
+          })
+        : Promise.resolve(cached)
+    )
+
+    const controller = createPreviewUblockController({ installer: installer(resolve), session: previewSession })
+
+    const enabling = controller.setEnabled(true)
+    const disabling = controller.setEnabled(false)
+    await Promise.resolve()
+    releaseLatest()
+    await expect(enabling).resolves.toMatchObject({ enabled: true })
+    await expect(disabling).resolves.toMatchObject({ enabled: false })
+    expect(previewSession.extensions.getAllExtensions()).toEqual([])
+  })
+})

--- a/apps/desktop/electron/preview-ublock.ts
+++ b/apps/desktop/electron/preview-ublock.ts
@@ -1,0 +1,202 @@
+import type { PreviewUblockInstaller, UblockInstallIntent } from './preview-ublock-installer'
+
+const UBLOCK_DASHBOARD_PATH = 'dashboard.html'
+
+export interface PreviewUblockExtension {
+  id: string
+  manifest: {
+    name?: string
+    version?: string
+  }
+  path: string
+  url: string
+}
+
+export interface PreviewUblockSession {
+  extensions: {
+    getAllExtensions(): PreviewUblockExtension[]
+    getExtension(extensionId: string): PreviewUblockExtension | null
+    loadExtension(path: string, options?: { allowFileAccess?: boolean }): Promise<PreviewUblockExtension>
+    removeExtension(extensionId: string): void
+  }
+}
+
+export interface PreviewUblockState {
+  enabled: boolean
+  available: boolean
+  dashboardUrl: string | null
+  extensionId: string | null
+  rulesetsReady: boolean
+  version: string | null
+}
+
+export interface PreviewUblockController {
+  dispose(): Promise<void>
+  getState(): PreviewUblockState
+  initialize(): Promise<PreviewUblockState>
+  setEnabled(enabled: boolean): Promise<PreviewUblockState>
+}
+
+interface PreviewUblockControllerOptions {
+  bootstrap?: (extension: PreviewUblockExtension) => Promise<boolean>
+  enabled?: boolean
+  installer: Pick<PreviewUblockInstaller, 'resolve'>
+  onStaleCache?: (error: unknown) => void
+  session: PreviewUblockSession
+}
+
+function extensionState(
+  extension: PreviewUblockExtension | null,
+  enabled: boolean,
+  rulesetsReady: boolean
+): PreviewUblockState {
+  if (!extension) {
+    return {
+      enabled,
+      available: false,
+      dashboardUrl: null,
+      extensionId: null,
+      rulesetsReady: false,
+      version: null
+    }
+  }
+
+  return {
+    enabled,
+    available: true,
+    dashboardUrl: `${extension.url}/${UBLOCK_DASHBOARD_PATH}`,
+    extensionId: extension.id,
+    rulesetsReady,
+    version: extension.manifest.version ?? null
+  }
+}
+
+export function createPreviewUblockController({
+  bootstrap,
+  enabled: initiallyEnabled = false,
+  installer,
+  onStaleCache,
+  session: previewSession
+}: PreviewUblockControllerOptions): PreviewUblockController {
+  let desiredEnabled = initiallyEnabled
+  let extension: PreviewUblockExtension | null = null
+  let initializePromise: Promise<PreviewUblockState> | null = null
+  let lifecycle = Promise.resolve()
+  let rulesetsReady = false
+  let state = extensionState(null, desiredEnabled, rulesetsReady)
+
+  const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = lifecycle.then(operation, operation)
+    lifecycle = next.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return next
+  }
+
+  const removeLoadedExtension = (): void => {
+    if (extension && previewSession.extensions.getExtension(extension.id)) {
+      previewSession.extensions.removeExtension(extension.id)
+    }
+
+    extension = null
+    rulesetsReady = false
+  }
+
+  const loadInstall = async (resolved: { path: string; version: string } | null): Promise<PreviewUblockState> => {
+    if (!resolved) {throw new Error('uBlock Origin Lite is not installed')}
+    const loaded = previewSession.extensions.getAllExtensions().find(item => item.path === resolved.path)
+
+    const candidate =
+      loaded ?? (await previewSession.extensions.loadExtension(resolved.path, { allowFileAccess: false }))
+
+    try {
+      const ready = bootstrap ? await bootstrap(candidate) : true
+
+      if (!ready) {throw new Error('uBlock Origin Lite rulesets could not be enabled')}
+      extension = candidate
+      rulesetsReady = true
+
+      return extensionState(extension, true, rulesetsReady)
+    } catch (error) {
+      if (previewSession.extensions.getExtension(candidate.id)) {previewSession.extensions.removeExtension(candidate.id)}
+      throw error
+    }
+  }
+
+  const loadResolved = async (intent: UblockInstallIntent): Promise<PreviewUblockState> =>
+    loadInstall(await installer.resolve(intent))
+
+  const enable = async (): Promise<PreviewUblockState> => {
+    removeLoadedExtension()
+
+    try {
+      return await loadResolved('latest')
+    } catch (latestError) {
+      try {
+        const fallback = await installer.resolve('cached')
+        const result = await loadInstall(fallback)
+        onStaleCache?.(latestError)
+
+        return result
+      } catch {
+        removeLoadedExtension()
+        state = extensionState(null, false, false)
+        throw latestError
+      }
+    }
+  }
+
+  const initializeEnabled = async (): Promise<PreviewUblockState> => {
+    try {
+      return await loadResolved('cached')
+    } catch {
+      removeLoadedExtension()
+      state = extensionState(null, false, false)
+
+      return state
+    }
+  }
+
+  const disable = async (): Promise<PreviewUblockState> => {
+    removeLoadedExtension()
+    state = extensionState(null, false, false)
+
+    return state
+  }
+
+  const controller: PreviewUblockController = {
+    async dispose() {
+      desiredEnabled = false
+      initializePromise = null
+      await enqueue(async () => {
+        removeLoadedExtension()
+        state = extensionState(null, false, false)
+      })
+    },
+
+    getState() {
+      return state
+    },
+
+    async initialize() {
+      if (!initializePromise) {
+        initializePromise = enqueue(() => (desiredEnabled ? initializeEnabled() : disable()))
+      }
+
+      return initializePromise
+    },
+
+    setEnabled(enabled) {
+      desiredEnabled = enabled
+      initializePromise = null
+
+      return enqueue(() => (enabled ? enable() : disable()))
+    }
+  }
+
+  return controller
+}
+
+export { UBLOCK_DASHBOARD_PATH }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -64,6 +64,7 @@
     "test:ui": "vitest run --project ui",
     "test:desktop:platforms": "vitest run --project electron",
     "test:find-in-page-native": "electron electron/find-in-page-native-fixture",
+    "test:preview-ublock-smoke": "HERMES_UBOL_SMOKE=1 node scripts/preview-ublock-smoke.mjs",
     "test": "vitest run",
     "preview": "node scripts/assert-root-install.mjs && vite preview --host 127.0.0.1 --port 4174",
     "check:test:ui": "npm run test:ui",

--- a/apps/desktop/scripts/preview-ublock-smoke.mjs
+++ b/apps/desktop/scripts/preview-ublock-smoke.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+if (process.env.HERMES_UBOL_SMOKE !== '1') {
+  console.log('Preview uBlock smoke test skipped; set HERMES_UBOL_SMOKE=1 to enable it.')
+  process.exit(0)
+}
+
+const desktopRoot = path.resolve(new URL('..', import.meta.url).pathname)
+const electronBinary = [
+  path.join(desktopRoot, 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron'),
+  path.resolve(desktopRoot, '../../node_modules/electron/dist/Electron.app/Contents/MacOS/Electron')
+].find(candidate => fs.existsSync(candidate))
+
+if (!electronBinary) throw new Error('Electron binary not found')
+
+const mainBundle = path.join(desktopRoot, 'dist/electron-main.mjs')
+if (!fs.existsSync(mainBundle)) throw new Error('Build Desktop before running the Preview uBlock smoke test')
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preview-ublock-smoke-'))
+try {
+  execFileSync(electronBinary, [mainBundle, `--user-data-dir=${userData}`], {
+    cwd: desktopRoot,
+    env: { ...process.env, HERMES_UBOL_SMOKE: '1', ELECTRON_RUN_AS_NODE: '' },
+    stdio: 'inherit'
+  })
+} finally {
+  fs.rmSync(userData, { force: true, recursive: true })
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -29,6 +29,7 @@ interface PreviewBrowserBarProps {
   consoleOpen: boolean
   devToolsOpen: boolean
   loading: boolean
+  onOpenUblockDashboard?: () => void
   onBack: () => void
   onForward: () => void
   onNavigate: (url: string) => void
@@ -94,6 +95,7 @@ export function PreviewBrowserBar({
   consoleOpen,
   devToolsOpen,
   loading,
+  onOpenUblockDashboard,
   onBack,
   onForward,
   onNavigate,
@@ -154,6 +156,13 @@ export function PreviewBrowserBar({
         label={copy.reload}
         onSelect={onReload}
       />
+      {onOpenUblockDashboard && (
+        <PaneStripGlyph
+          icon={<Codicon name="shield" size="0.8125rem" />}
+          label={copy.ublockDashboard}
+          onSelect={onOpenUblockDashboard}
+        />
+      )}
       {/* The copy control lives INSIDE the field, on its right edge — the
           same pre-faded inline icon code blocks use, not a toolbar button.
           It copies what the field shows: on a remote gateway, that is the

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -27,6 +27,7 @@ import {
   popOutBrowserTab,
   type PreviewTarget
 } from '@/store/preview'
+import { $previewUblock, loadPreviewUblock } from '@/store/preview-ublock'
 import { canOpenBrowserWindow, isBrowserWindow } from '@/store/windows'
 
 import { ArtifactPreview } from './preview-artifact'
@@ -233,6 +234,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const previewContentRef = useRef<HTMLDivElement | null>(null)
   const webviewRef = useRef<PreviewWebview | null>(null)
   const previewServerRestart = useStore($previewServerRestart)
+  const previewUblock = useStore($previewUblock)
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
   const [currentUrl, setCurrentUrl] = useState(target.url)
@@ -252,6 +254,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
   const isRemoteHtmlTarget =
     target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
+
+  useEffect(() => {
+    if (isWebPreview) {
+      void loadPreviewUblock()
+    }
+  }, [isWebPreview])
 
   // Hand the live address to storage when this guest is about to go away
   // (pop-out, dock-back, tab close). The other renderer builds from
@@ -457,6 +465,24 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     },
     [copy.unreachableDescription]
   )
+
+  const openUblockDashboard = useCallback(() => {
+    const dashboardUrl = previewUblock.dashboardUrl
+
+    if (!dashboardUrl || !webviewRef.current?.loadURL) {
+      return
+    }
+
+    setLoadError(null)
+    setLoading(true)
+    void webviewRef.current.loadURL(dashboardUrl).catch((error: unknown) => {
+      setLoading(false)
+      setLoadError({
+        description: error instanceof Error ? error.message : copy.failedToLoad,
+        url: dashboardUrl
+      })
+    })
+  }, [copy.failedToLoad, previewUblock.dashboardUrl])
 
   const goBack = useCallback(() => {
     const webview = webviewRef.current
@@ -1035,6 +1061,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
               !isBrowserWindow() && !canOpenBrowserWindow()
                 ? () => void window.hermesDesktop?.openExternal(currentUrl)
                 : undefined
+            }
+            onOpenUblockDashboard={
+              previewUblock.available && previewUblock.rulesetsReady && previewUblock.dashboardUrl ? openUblockDashboard : undefined
             }
             onPopIn={isBrowserWindow() ? () => window.close() : undefined}
             onPopOut={

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -44,6 +44,7 @@ import {
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
+import { PreviewUblockSetting } from './preview-ublock-setting'
 import { EmptyState, ListRow, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { SettingsProfileScope } from './profile-scope'
 import { QuickEntrySettings } from './quick-entry-settings'
@@ -380,6 +381,7 @@ function ConfigSettingsInner({
             label={c.disableF12Title}
             onChange={setDisableF12}
           />
+          <PreviewUblockSetting />
           <QuickEntrySettings />
         </>
       )}

--- a/apps/desktop/src/app/settings/preview-ublock-setting.test.tsx
+++ b/apps/desktop/src/app/settings/preview-ublock-setting.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { notifyError } from '@/store/notifications'
+import { $previewUblock } from '@/store/preview-ublock'
+
+import { PreviewUblockSetting } from './preview-ublock-setting'
+
+const copy = {
+  description:
+    'Downloads uBlock Origin Lite from its official GitHub release, blocks ads and trackers only in Preview, and keeps it locally for later use.',
+  downloading: 'Downloading and enabling uBlock Origin Lite…',
+  failure: 'Could not update the Preview content-blocking setting.',
+  label: 'Enable uBlock Origin Lite in Preview'
+}
+
+function state(enabled: boolean) {
+  return {
+    enabled,
+    available: enabled,
+    dashboardUrl: enabled ? 'chrome-extension://ublock/dashboard.html' : null,
+    extensionId: enabled ? 'ublock' : null,
+    rulesetsReady: enabled,
+    version: enabled ? '2026.825.1619' : null
+  }
+}
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        config: {
+          previewUblockDescription: copy.description,
+          previewUblockDownloading: copy.downloading,
+          previewUblockFailure: copy.failure,
+          previewUblockTitle: copy.label
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+
+describe('PreviewUblockSetting', () => {
+  beforeEach(() => {
+    $previewUblock.set(state(false))
+    window.hermesDesktop = {
+      previewUblock: {
+        getState: vi.fn().mockResolvedValue(state(false)),
+        setEnabled: vi.fn().mockResolvedValue(state(false))
+      }
+    } as any
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders disabled by default', () => {
+    render(<PreviewUblockSetting />)
+
+    expect(screen.getByRole('switch', { name: copy.label }).getAttribute('data-state')).toBe('unchecked')
+    expect(screen.getByText(copy.description)).toBeTruthy()
+  })
+
+  it('shows the download status while enabling', async () => {
+    let resolve: ((value: ReturnType<typeof state>) => void) | undefined
+    $previewUblock.set(state(false))
+    window.hermesDesktop.previewUblock.setEnabled = vi.fn().mockImplementation(
+      () =>
+        new Promise<ReturnType<typeof state>>(nextResolve => {
+          resolve = nextResolve
+        })
+    )
+
+    render(<PreviewUblockSetting />)
+    const toggle = screen.getByRole('switch', { name: copy.label })
+    fireEvent.click(toggle)
+
+    expect(toggle.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText(copy.downloading)).toBeTruthy()
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
+
+    await act(async () => resolve?.(state(true)))
+    expect(toggle.getAttribute('data-state')).toBe('checked')
+  })
+
+  it('disables the switch while turning uBlock off and mirrors the result', async () => {
+    let resolve: ((value: ReturnType<typeof state>) => void) | undefined
+
+    const setEnabled = vi.fn().mockImplementation(
+      () =>
+        new Promise<ReturnType<typeof state>>(nextResolve => {
+          resolve = nextResolve
+        })
+    )
+
+    $previewUblock.set(state(true))
+    window.hermesDesktop.previewUblock.getState = vi.fn().mockResolvedValue(state(true))
+    window.hermesDesktop.previewUblock.setEnabled = setEnabled
+
+    render(<PreviewUblockSetting />)
+    const toggle = screen.getByRole('switch', { name: copy.label })
+
+    fireEvent.click(toggle)
+    expect(setEnabled).toHaveBeenCalledWith(false)
+    expect(toggle.hasAttribute('disabled')).toBe(true)
+
+    await act(async () => {
+      resolve?.(state(false))
+    })
+
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
+    expect(toggle.hasAttribute('disabled')).toBe(false)
+    expect($previewUblock.get()).toMatchObject({ enabled: false, available: false })
+  })
+
+  it('reports a failed toggle without changing the enabled state', async () => {
+    const error = new Error('IPC unavailable')
+    $previewUblock.set(state(true))
+    window.hermesDesktop.previewUblock.getState = vi.fn().mockResolvedValue(state(true))
+    window.hermesDesktop.previewUblock.setEnabled = vi.fn().mockRejectedValue(error)
+
+    render(<PreviewUblockSetting />)
+    fireEvent.click(screen.getByRole('switch', { name: copy.label }))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('switch', { name: copy.label }).getAttribute('data-state')).toBe('checked')
+    expect(notifyError).toHaveBeenCalledWith(error, copy.failure)
+  })
+})

--- a/apps/desktop/src/app/settings/preview-ublock-setting.tsx
+++ b/apps/desktop/src/app/settings/preview-ublock-setting.tsx
@@ -1,0 +1,49 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import { useI18n } from '@/i18n'
+import { notifyError } from '@/store/notifications'
+import { $previewUblock, loadPreviewUblock, setPreviewUblockEnabled } from '@/store/preview-ublock'
+
+import { ToggleRow } from './primitives'
+
+export function PreviewUblockSetting() {
+  const { t } = useI18n()
+  const copy = t.settings.config
+  const previewUblock = useStore($previewUblock)
+  const [pending, setPending] = useState(false)
+
+  useEffect(() => {
+    void loadPreviewUblock()
+  }, [])
+
+  const handleChange = async (enabled: boolean) => {
+    setPending(true)
+
+    try {
+      await setPreviewUblockEnabled(enabled)
+    } catch (error) {
+      notifyError(error, copy.previewUblockFailure)
+      await loadPreviewUblock()
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <ToggleRow
+      below={
+        pending ? (
+          <div className="mt-1 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+            {copy.previewUblockDownloading}
+          </div>
+        ) : undefined
+      }
+      checked={previewUblock.enabled}
+      description={copy.previewUblockDescription}
+      disabled={pending}
+      label={copy.previewUblockTitle}
+      onChange={on => void handleChange(on)}
+    />
+  )
+}

--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -160,13 +160,15 @@ export function ToggleRow({
   description,
   disabled,
   label,
-  onChange
+  onChange,
+  below
 }: {
   checked: boolean
   description?: string
   disabled?: boolean
   label: string
   onChange: (on: boolean) => void
+  below?: ReactNode
 }) {
   return (
     <ListRow
@@ -181,6 +183,7 @@ export function ToggleRow({
           }}
         />
       }
+      below={below}
       description={description}
       title={label}
     />

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1,6 +1,8 @@
 import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
+import type { PreviewUblockState } from '../electron/preview-ublock'
+
 import type { WakeIndicatorState } from './lib/wake-indicator'
 import type {
   PetOverlayBounds,
@@ -445,6 +447,10 @@ declare global {
           registryScoped?: boolean
         } | null
       ) => void
+      previewUblock: {
+        getState: () => Promise<PreviewUblockState>
+        setEnabled: (enabled: boolean) => Promise<PreviewUblockState>
+      }
       onClosePreviewRequested?: (callback: () => void) => () => void
       onPreviewNav?: (callback: (command: 'back' | 'forward' | 'reload') => void) => () => void
       onOpenFolderRequested?: (callback: () => void) => () => void

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -720,6 +720,11 @@ export const en: Translations = {
       keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.',
       disableF12Title: 'Disable F12 DevTools',
       disableF12Desc: 'Block F12 from opening Developer Tools. Ctrl+Shift+I (or Cmd+Opt+I on Mac) still works.',
+      previewUblockTitle: 'Enable uBlock Origin Lite in Preview',
+      previewUblockDescription:
+        'Downloads uBlock Origin Lite from its official GitHub release, blocks ads and trackers only in Preview, and keeps it locally for later use.',
+      previewUblockDownloading: 'Downloading and enabling uBlock Origin Lite…',
+      previewUblockFailure: 'Could not update the Preview content-blocking setting.',
       attachmentSizeTitle: 'Max preview / image load size',
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
@@ -3084,6 +3089,7 @@ export const en: Translations = {
       goBack: 'Back',
       goForward: 'Forward',
       reload: 'Reload page',
+      ublockDashboard: 'uBlock Origin Lite is enabled — open controls',
       address: 'Address',
       addressPlaceholder: 'Enter address',
       blankPageBody: 'Type an address above to browse, or ask Hermes to open a page.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -760,7 +760,12 @@ export const ja = defineLocale({
       imported: '設定をインポートしました',
       invalidJson: '設定 JSON が無効です',
       keepAwakeTitle: 'コンピューターをスリープさせない',
-      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。'
+      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。',
+      previewUblockTitle: 'Preview で uBlock Origin Lite を有効化',
+      previewUblockDescription:
+        '公式 GitHub リリースから uBlock Origin Lite をダウンロードし、Preview のみで広告とトラッカーをブロックします。ダウンロードは後で使えるようローカルに保持されます。',
+      previewUblockDownloading: 'uBlock Origin Lite をダウンロードして有効化しています…',
+      previewUblockFailure: 'Preview のコンテンツブロック設定を更新できませんでした。'
     },
     quickEntry: {
       enabledTitle: 'クイック入力',
@@ -2711,6 +2716,7 @@ export const ja = defineLocale({
       openDevTools: 'プレビュー DevTools を開く',
       goBack: '戻る',
       goForward: '進む',
+      ublockDashboard: 'uBlock Origin Lite は有効です — コントロールを開く',
       reload: 'ページを再読み込み',
       address: 'アドレス',
       addressPlaceholder: 'アドレスを入力',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -603,6 +603,10 @@ export interface Translations {
       keepAwakeDesc: string
       disableF12Title: string
       disableF12Desc: string
+      previewUblockTitle: string
+      previewUblockDescription: string
+      previewUblockDownloading: string
+      previewUblockFailure: string
       attachmentSizeTitle: string
       attachmentSizeDesc: string
       attachmentSizeUnit: string
@@ -2648,6 +2652,7 @@ export interface Translations {
       goBack: string
       goForward: string
       reload: string
+      ublockDashboard: string
       address: string
       addressPlaceholder: string
       blankPageBody: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -743,7 +743,12 @@ export const zhHant = defineLocale({
       imported: '設定已匯入',
       invalidJson: '設定 JSON 無效',
       keepAwakeTitle: '保持電腦喚醒',
-      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。'
+      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。',
+      previewUblockTitle: '在 Preview 中啟用 uBlock Origin Lite',
+      previewUblockDescription:
+        '從官方 GitHub 發行版本下載 uBlock Origin Lite，僅在 Preview 中封鎖廣告與追蹤器，並將下載內容保留在本機供日後使用。',
+      previewUblockDownloading: '正在下載並啟用 uBlock Origin Lite…',
+      previewUblockFailure: '無法更新 Preview 內容封鎖設定。'
     },
     quickEntry: {
       enabledTitle: '快速輸入',
@@ -2620,6 +2625,7 @@ export const zhHant = defineLocale({
       openDevTools: '開啟預覽 DevTools',
       goBack: '上一頁',
       goForward: '下一頁',
+      ublockDashboard: 'uBlock Origin Lite 已啟用 — 開啟控制項',
       reload: '重新載入頁面',
       address: '網址',
       addressPlaceholder: '輸入網址',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -922,6 +922,11 @@ export const zh: Translations = {
       keepAwakeDesc: '阻止本机休眠，让长时间或通宵运行继续进行。屏幕仍可变暗。',
       disableF12Title: '禁用 F12 开发者工具',
       disableF12Desc: '阻止 F12 打开开发者工具。Ctrl+Shift+I（Mac 上为 Cmd+Opt+I）仍然可用。',
+      previewUblockTitle: '在 Preview 中启用 uBlock Origin Lite',
+      previewUblockDescription:
+        '从官方 GitHub 发布下载 uBlock Origin Lite，仅在 Preview 中拦截广告和跟踪器，并将下载内容保留在本地供以后使用。',
+      previewUblockDownloading: '正在下载并启用 uBlock Origin Lite…',
+      previewUblockFailure: '无法更新 Preview 内容拦截设置。',
       attachmentSizeTitle: '预览 / 图片加载大小上限',
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
@@ -3246,6 +3251,7 @@ export const zh: Translations = {
       goBack: '后退',
       goForward: '前进',
       reload: '重新加载页面',
+      ublockDashboard: 'uBlock Origin Lite 已启用 — 打开控制项',
       address: '地址',
       addressPlaceholder: '输入地址',
       blankPageBody: '在上方输入地址开始浏览，或让 Hermes 打开一个页面。',

--- a/apps/desktop/src/store/preview-ublock.test.ts
+++ b/apps/desktop/src/store/preview-ublock.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $previewUblock, loadPreviewUblock, setPreviewUblockEnabled } from './preview-ublock'
+
+const originalBridge = window.hermesDesktop
+
+function state(enabled: boolean) {
+  return {
+    enabled,
+    available: enabled,
+    dashboardUrl: enabled ? 'chrome-extension://ublock/dashboard.html' : null,
+    extensionId: enabled ? 'ublock' : null,
+    rulesetsReady: enabled,
+    version: enabled ? '2026.825.1619' : null
+  }
+}
+
+afterEach(() => {
+  window.hermesDesktop = originalBridge
+  $previewUblock.set({
+    enabled: false,
+    available: false,
+    dashboardUrl: null,
+    extensionId: null,
+    rulesetsReady: false,
+    version: null
+  })
+  vi.restoreAllMocks()
+})
+
+describe('preview uBlock renderer state', () => {
+  it('loads and mirrors the authoritative enabled state', async () => {
+    window.hermesDesktop = {
+      ...originalBridge,
+      previewUblock: {
+        getState: vi.fn().mockResolvedValue(state(true)),
+        setEnabled: vi.fn()
+      }
+    }
+
+    await loadPreviewUblock()
+
+    expect($previewUblock.get()).toEqual(state(true))
+  })
+
+  it('updates the atom from the main-process setter result', async () => {
+    const setEnabled = vi.fn().mockResolvedValue(state(false))
+    window.hermesDesktop = {
+      ...originalBridge,
+      previewUblock: {
+        getState: vi.fn(),
+        setEnabled
+      }
+    }
+
+    await expect(setPreviewUblockEnabled(false)).resolves.toEqual(state(false))
+    expect(setEnabled).toHaveBeenCalledWith(false)
+    expect($previewUblock.get()).toEqual(state(false))
+  })
+
+  it('rejects without changing state when the main-process setter fails', async () => {
+    const setEnabled = vi.fn().mockRejectedValue(new Error('IPC unavailable'))
+    window.hermesDesktop = {
+      ...originalBridge,
+      previewUblock: {
+        getState: vi.fn(),
+        setEnabled
+      }
+    }
+    $previewUblock.set(state(true))
+
+    await expect(setPreviewUblockEnabled(false)).rejects.toThrow('IPC unavailable')
+    expect($previewUblock.get()).toEqual(state(true))
+  })
+})

--- a/apps/desktop/src/store/preview-ublock.ts
+++ b/apps/desktop/src/store/preview-ublock.ts
@@ -1,0 +1,50 @@
+import { atom } from 'nanostores'
+
+import type { PreviewUblockState } from '../../electron/preview-ublock'
+
+const unavailableState = (enabled: boolean): PreviewUblockState => ({
+  enabled,
+  available: false,
+  dashboardUrl: null,
+  extensionId: null,
+  rulesetsReady: false,
+  version: null
+})
+
+function normalizePreviewUblockState(value: Partial<PreviewUblockState> | null | undefined): PreviewUblockState {
+  const enabled = value?.enabled === true
+
+  return {
+    enabled,
+    available: value?.available === true,
+    dashboardUrl: typeof value?.dashboardUrl === 'string' ? value.dashboardUrl : null,
+    extensionId: typeof value?.extensionId === 'string' ? value.extensionId : null,
+    rulesetsReady: value?.rulesetsReady === true,
+    version: typeof value?.version === 'string' ? value.version : null
+  }
+}
+
+export const $previewUblock = atom<PreviewUblockState>(unavailableState(false))
+
+export async function loadPreviewUblock(): Promise<void> {
+  if (typeof window === 'undefined' || typeof window.hermesDesktop?.previewUblock?.getState !== 'function') {
+    return
+  }
+
+  try {
+    $previewUblock.set(normalizePreviewUblockState(await window.hermesDesktop.previewUblock.getState()))
+  } catch {
+    // Keep the last authoritative state if the main process is not ready.
+  }
+}
+
+export async function setPreviewUblockEnabled(enabled: boolean): Promise<PreviewUblockState> {
+  if (typeof window === 'undefined' || typeof window.hermesDesktop?.previewUblock?.setEnabled !== 'function') {
+    throw new Error('Preview uBlock control is unavailable')
+  }
+
+  const next = normalizePreviewUblockState(await window.hermesDesktop.previewUblock.setEnabled(enabled))
+  $previewUblock.set(next)
+
+  return next
+}


### PR DESCRIPTION
## Summary

This replaces #99369 with the same Preview-only content-blocking capability,
but **does not vendor uBlock Origin Lite into the Hermes repository or desktop
package**.

- uBlock Origin Lite is **off by default**.
- Enabling it in **Settings → Advanced** explicitly fetches the latest stable
  official `uBlockOrigin/uBOL-home` Chromium release.
- Hermes verifies GitHub's published SHA-256 asset digest, safely stages and
  validates the archive, applies the narrowly-scoped Electron compatibility
  guards, then atomically promotes one user-data cache.
- The extension is loaded only in `persist:hermes-preview`; it never affects
  the default browser session, remote backends, or other Hermes surfaces.
- Disabling unloads the extension while retaining the verified cache for a fast
  re-enable. Startup never makes a network request; it only uses a valid cache.
- The Preview shield opens **uBlock Origin Lite's own dashboard**. Hermes does
  not duplicate its filter-list, rules, or troubleshooting UI.

## Why this is a new PR

The prior implementation committed the complete upstream extension payload:
approximately **366k lines / 41 MB / 927 files**. This branch replaces that
approach with 2,111 lines of reviewed installer, lifecycle, UI, and test code,
so updating uBOL does not permanently bloat Hermes git history or every Desktop
download.

The work is split into three reviewable commits:

1. `install preview ublock from official release` — release discovery, bounded
   HTTPS download, SHA-256 validation, safe ZIP extraction, atomic cache, and
   upstream compatibility guards.
2. `load preview ublock from opt-in cache` — Preview-session lifecycle, typed
   IPC, device-local preference, startup cache-only behavior, and an opt-in
   upstream smoke script.
3. `clarify preview ublock controls` — Settings copy/pending state, localized
   UI, Preview shield/dashboard action, documentation, and renderer tests.

## Safety and failure behavior

- Only the expected stable GitHub release asset is accepted; metadata, archive
  size, checksum, redirects, ZIP paths, file count, extracted size, manifest,
  and compatibility patch context are validated.
- A failed first install remains disabled and leaves no partial cache.
- A failed update retains and loads the prior valid cache instead of breaking an
  already-enabled Preview.
- A missing or corrupted cache at startup resets the persisted preference to
  disabled and requires an explicit re-enable; it never silently downloads.

## Screenshots

Preview exposes a compact shield control; it opens uBOL's native dashboard
rather than a partial Hermes reimplementation.

<img width="720" alt="uBlock Origin Lite control in Hermes Preview" src="https://github.com/user-attachments/assets/19dec828-7972-4cba-a7a9-027c95daa0bc" />

<img width="720" alt="Preview content-blocking setting" src="https://github.com/user-attachments/assets/70178d67-788f-4e81-b114-e64119c0cdb6" />

<img width="720" alt="uBlock Origin Lite dashboard in Hermes Preview" src="https://github.com/user-attachments/assets/bb8416ef-2ef0-4bf7-a31d-38d78da582ec" />

## Verification

- [x] `vitest` focused Electron installer, lifecycle, and settings tests — 17
  tests
- [x] `vitest` focused renderer store and Settings UI tests — 7 tests
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check` and range check confirming no vendored uBOL resources

`npm run test:preview-ublock-smoke` remains explicitly network-gated; it uses a
temporary user-data directory, downloads the latest upstream asset, loads it in
the isolated Preview session, and verifies a known blocked URL through
`declarativeNetRequest`.
