### PR TITLE
fix(kanban): respect disabled review skills

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2786,6 +2786,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "skipped_review_disabled_skills": [
+                {"task_id": tid, "assignee": who, "skill": skill}
+                for (tid, who, skill) in res.skipped_review_disabled_skills
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2818,6 +2822,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         for tid, who, current in res.skipped_per_profile_capped:
             print(
                 f"Deferred ({who} at per-profile cap, {current} running): {tid}"
+            )
+    if res.skipped_review_disabled_skills:
+        for tid, who, skill in res.skipped_review_disabled_skills:
+            print(
+                f"Review left for a human ({who} disabled required skill {skill}): {tid}"
             )
     if res.skipped_nonspawnable:
         print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -342,6 +342,7 @@ def _fire_dispatch_tick_hook(
             result.auto_assigned_default,
             result.respawn_guarded,
             result.skipped_per_profile_capped,
+            result.skipped_review_disabled_skills,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
         )):
@@ -8060,6 +8061,9 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_review_disabled_skills: list[tuple[str, str, str]] = field(default_factory=list)
+    """Review tasks left for human review because the assignee disabled the
+    required skill. Entries are ``(task_id, assignee, skill)`` tuples."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -9621,6 +9625,27 @@ def review_dispatch_enabled() -> bool:
         return True
 
 
+def _profile_disables_skill(profile_name: str, skill_name: str) -> bool:
+    """Return whether a worker profile disabled a skill it would preload."""
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_cli.profiles import resolve_profile_env
+
+        token = set_hermes_home_override(resolve_profile_env(profile_name))
+        try:
+            return skill_name in get_disabled_skill_names()
+        finally:
+            reset_hermes_home_override(token)
+    except Exception as exc:
+        _log.debug(
+            "kanban review: could not read disabled skills for profile %s: %s",
+            profile_name,
+            exc,
+        )
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Memory-aware dispatch guard (OOF-30 / OOF-77)
 #
@@ -10339,6 +10364,30 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        if _profile_disables_skill(row["assignee"], "sdlc-review"):
+            result.skipped_review_disabled_skills.append(
+                (row["id"], row["assignee"], "sdlc-review")
+            )
+            if not dry_run:
+                with write_txn(conn):
+                    already_reported = conn.execute(
+                        "SELECT 1 FROM task_events "
+                        "WHERE task_id = ? AND kind = 'review_dispatch_skipped' "
+                        "LIMIT 1",
+                        (row["id"],),
+                    ).fetchone()
+                    if already_reported is None:
+                        _append_event(
+                            conn,
+                            row["id"],
+                            "review_dispatch_skipped",
+                            {
+                                "assignee": row["assignee"],
+                                "reason": "required_skill_disabled",
+                                "skill": "sdlc-review",
+                            },
+                        )
             continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -348,7 +348,8 @@ VALID_HOOKS: Set[str] = {
     #   result: hermes_cli.kanban_db.DispatchResult (spawned, reclaimed,
     #     promoted, reconciled_orphans, crashed, stale, timed_out,
     #     auto_blocked, rate_limited, auto_assigned_default,
-    #     respawn_guarded, skipped_per_profile_capped, skipped_unassigned,
+    #     respawn_guarded, skipped_per_profile_capped,
+    #     skipped_review_disabled_skills, skipped_unassigned,
     #     skipped_nonspawnable, skipped_locked).
     #   Privacy: result carries task ids, assignees, and workspace paths.
     "on_kanban_dispatch_tick",

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -527,6 +527,56 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     assert captured == [["domain-specific-review", "sdlc-review"]]
 
 
+def test_review_dispatch_respects_assignee_disabled_review_skill(
+    kanban_home: Path,
+) -> None:
+    """A disabled review skill leaves the card for a human instead of crashing."""
+    from hermes_cli.profiles import create_profile
+
+    reviewer_home = create_profile("reviewer", no_alias=True)
+    (reviewer_home / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - sdlc-review\n",
+        encoding="utf-8",
+    )
+    spawned: list[str] = []
+
+    def spawn(task, workspace):
+        spawned.append(task.id)
+        return None
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="human review", assignee="reviewer")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            expected_run_id=implementation.current_run_id,
+        )
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "review"
+        assert result.skipped_review_disabled_skills == [
+            (task_id, "reviewer", "sdlc-review"),
+        ]
+        assert _events(conn, task_id, kind="review_dispatch_skipped") == [
+            (
+                "review_dispatch_skipped",
+                {
+                    "assignee": "reviewer",
+                    "reason": "required_skill_disabled",
+                    "skill": "sdlc-review",
+                },
+            ),
+        ]
+
+    assert spawned == []
+
+
 def test_review_dispatch_honors_global_and_per_profile_caps(
     kanban_home: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #99251

## Summary
- Check the reviewer profile’s disabled skills before automatic review dispatch.
- Leave review cards for a human instead of spawning a worker that cannot load its required review skill.
- Report the skip through the dispatcher output and a durable task event.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/agent/test_skill_commands.py -q`