### PR TITLE
fix(state): self-heal SessionDB writes after close() races an in-flight worker (#94736)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5053,7 +5053,82 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._close_read_conn(conn)
             return
         with self._lock:
+            if self._conn is None:
+                # close() ran while a reader was still unwinding (#94736
+                # class) — reopen instead of yielding None to a .execute.
+                self._reopen_after_close_locked(context="read")
             yield cast(sqlite3.Connection, self._conn)
+
+    def _reopen_after_close_locked(self, context: str = "write") -> None:
+        """Reopen the writer connection after ``close()`` raced a live caller.
+
+        The #94736 failure shape: a teardown owner (cron ``run_job``'s
+        ``finally``, a delegate timeout owner abandoning its worker, agent
+        ``close()``) calls ``SessionDB.close()`` — which sets ``_conn = None``
+        — while a still-unwinding worker thread has one more transcript flush
+        to land. The next ``_execute_write`` then died on
+        ``'NoneType' object has no attribute 'execute'``, the conversation
+        loop force-ended the turn as ``session_persistence_failed``, and the
+        in-flight tail of the subagent/cron session was silently dropped
+        (delivered as ``last_status: ok``).
+
+        The transcript append is THE critical write — losing it destroys the
+        turn — so at this shared persistence boundary we self-heal: reopen a
+        connection to the same database file and let the write land. The
+        reopen is loud (WARNING names the race) and bounded (only fires when
+        ``_conn`` is ``None``, i.e. after an explicit ``close()`` — the
+        constructor never leaves a live instance with a ``None`` handle).
+        ``__del__`` delegates to ``close()``, so the reopened connection is
+        still released at GC/exit time.
+
+        Caller must hold ``self._lock``. Raises ``sqlite3.OperationalError``
+        with an explicit cause when the reopen itself fails, so the surfaced
+        persistence error names the teardown race instead of the opaque
+        ``NoneType`` attribute error.
+        """
+        if self.read_only:
+            raise sqlite3.ProgrammingError(
+                f"SessionDB for {self.db_path} was closed (read-only handle); "
+                f"cannot serve a {context} after close()"
+            )
+        logger.warning(
+            "state.db connection for %s was closed while a %s was still in "
+            "flight — reopening (teardown/worker race, #94736)",
+            self.db_path,
+            context,
+        )
+        try:
+            conn = _connect_tracked_db(
+                str(self.db_path),
+                check_same_thread=False,
+                timeout=1.0,
+                isolation_level=None,
+            )
+        except Exception as exc:
+            raise sqlite3.OperationalError(
+                f"state.db connection was closed while a {context} was still "
+                f"in flight (a session-teardown path called close() before "
+                f"this worker finished — #94736) and the automatic reopen "
+                f"failed: {exc}"
+            ) from exc
+        try:
+            conn.row_factory = sqlite3.Row
+            self._wal_active = (
+                apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+            )
+            apply_database_pragmas(conn, db_label="state.db")
+            conn.execute("PRAGMA foreign_keys=ON")
+            self._fts_cjk_loaded = load_fts5_cjk_extension(conn)
+        except Exception as exc:
+            self._close_connection_quietly(conn)
+            raise sqlite3.OperationalError(
+                f"state.db reopen after close() succeeded but connection "
+                f"setup failed: {exc}"
+            ) from exc
+        # Schema was initialised by this instance's original open; the file
+        # cannot have lost it, so no _init_schema here (no DDL races with
+        # sibling processes during teardown).
+        self._conn = conn
 
     # ── Core write helper ──
 
@@ -5355,6 +5430,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         while True:
             try:
                 with self._lock:
+                    if self._conn is None:
+                        # close() ran while this writer was still unwinding
+                        # (#94736) — reopen instead of dying on None.execute.
+                        self._reopen_after_close_locked(context="write")
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
                         result = fn(self._conn)

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -277,18 +277,22 @@ class TestReaderFlush:
         assert _totals(db, "s-cc")["input_tokens"] == 4
 
 
-    def test_enqueue_after_close_raises_at_call_site(self, tmp_path):
-        """After close() the synchronous fallback surfaces the failure to the
-        caller (whose try/except logs it) — the pre-queue contract — instead
-        of silently dropping the delta."""
+    def test_enqueue_after_close_lands_via_reopen(self, tmp_path):
+        """After close() the synchronous fallback used to surface an opaque
+        AttributeError to the caller and drop the delta. Since the #94736
+        self-heal, a write that reaches the store after a teardown close()
+        reopens the connection and LANDS instead — strictly better than the
+        old raise-and-lose contract: no delta is dropped, and the recovery
+        is loud (WARNING at the persistence boundary)."""
         db = SessionDB(db_path=tmp_path / "closed.db")
         db.create_session("s-closed", "test")
         db.queue_token_counts("s-closed", input_tokens=1, api_call_count=1)
         db.close()
 
-        with pytest.raises(Exception):
-            db.queue_token_counts("s-closed", input_tokens=2, api_call_count=1)
+        db.queue_token_counts("s-closed", input_tokens=2, api_call_count=1)
         assert not db._token_queue  # not parked on a dead queue either
+        assert _totals(db, "s-closed")["input_tokens"] == 1 + 2
+        db.close()
 
 
 # =========================================================================

--- a/tests/state/test_append_message_after_close_94736.py
+++ b/tests/state/test_append_message_after_close_94736.py
@@ -1,0 +1,125 @@
+"""Regression tests for #94736 — append_message after close() raced a live writer.
+
+Subagent/cron sessions were dying mid-run with ``Session DB append_message
+failed: 'NoneType' object has no attribute 'execute'``: a teardown owner
+(cron ``run_job``'s ``finally`` block, a delegate timeout owner abandoning
+its worker, ``AIAgent.close()``) called ``SessionDB.close()`` — which nulls
+``_conn`` — while a still-unwinding worker thread had one more transcript
+flush to land. ``_execute_write`` then hit ``None.execute`` and the
+conversation loop force-ended the turn as ``session_persistence_failed``,
+silently dropping the tail of the session.
+
+The fix self-heals at the shared persistence boundary: when ``_conn`` is
+``None`` (only possible after an explicit ``close()``), the writer reopens
+a connection to the same database file with a loud WARNING, and the write
+lands. These tests exercise the REAL SessionDB against a real sqlite file —
+no mocks of the code under test.
+"""
+
+import logging
+import threading
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+class TestAppendAfterClose:
+    def test_append_message_after_close_reopens_and_lands(self, db, caplog):
+        """The exact #94736 shape: close() then one more transcript flush."""
+        db.create_session("s1", "cli")
+        db.append_message("s1", "user", content="hello")
+
+        db.close()
+        assert db._conn is None
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            msg_id = db.append_message(
+                "s1", "assistant", content="flushed after teardown"
+            )
+
+        assert isinstance(msg_id, int) and msg_id > 0
+        rows = db.get_messages("s1")
+        assert [r["role"] for r in rows] == ["user", "assistant"]
+        assert rows[-1]["content"] == "flushed after teardown"
+        # The recovery is loud, not silent.
+        assert any("reopening" in r.message for r in caplog.records)
+
+    def test_reopened_connection_survives_subsequent_writes_and_close(self, db):
+        """The reopened handle is a full writer: more appends work, and a
+        second close() releases it cleanly (idempotent contract)."""
+        db.create_session("s1", "cli")
+        db.close()
+
+        db.append_message("s1", "user", content="a")
+        db.append_message("s1", "assistant", content="b")
+        assert len(db.get_messages("s1")) == 2
+
+        db.close()
+        assert db._conn is None
+        db.close()  # idempotent
+
+    def test_read_after_close_recovers_too(self, db):
+        """The locked-read fallback path shares the same guard: a read that
+        lands after close() must not die on None.execute either."""
+        db.create_session("s1", "cli")
+        db.append_message("s1", "user", content="hello")
+        db.close()
+
+        rows = db.get_messages("s1")
+        assert len(rows) == 1
+
+    def test_concurrent_close_during_flush_loses_no_writes(self, tmp_path):
+        """Race a teardown close() against a worker mid-flush (the cron
+        inactivity-timeout shape): every append must land or raise loudly —
+        never vanish into a swallowed NoneType error."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", "cli")
+
+        n_writes = 40
+        start = threading.Event()
+        errors: list = []
+
+        def _worker():
+            start.wait()
+            for i in range(n_writes):
+                try:
+                    db.append_message("s1", "tool", content=f"result {i}")
+                except Exception as exc:  # pragma: no cover - failure path
+                    errors.append(exc)
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        start.set()
+        # Teardown owner closes mid-flight, twice for good measure.
+        db.close()
+        db.close()
+        t.join(timeout=30)
+        assert not t.is_alive()
+
+        assert errors == [], f"appends died during teardown race: {errors!r}"
+        rows = db.get_messages("s1")
+        assert len(rows) == n_writes
+        db.close()
+
+    def test_read_only_handle_still_refuses_after_close(self, tmp_path):
+        """A read-only cross-profile handle must NOT silently reopen — it
+        raises an explicit error naming the closed handle."""
+        # Initialise a real DB first with a writable handle.
+        writer = SessionDB(db_path=tmp_path / "state.db")
+        writer.create_session("s1", "cli")
+        writer.append_message("s1", "user", content="hello")
+        writer.close()
+
+        ro = SessionDB(db_path=tmp_path / "state.db", read_only=True)
+        ro.close()
+        with pytest.raises(Exception) as excinfo:
+            ro.get_messages("s1")
+        assert "closed" in str(excinfo.value).lower()


### PR DESCRIPTION
## What Problem This Solves

Closes #94736.

Subagent (`delegate_task`) and cron-dispatched sessions were intermittently dying mid-run with:

```
WARNING run_agent: Session DB append_message failed: 'NoneType' object has no attribute 'execute'
INFO agent.conversation_loop: Turn ended: reason=session_persistence_failed ... response_len=0
```

The reporter traced 13 consecutive subagent/cron sessions killed this way (96 occurrences in `agent.log`), each right after a long/timing-out tool call (~180s terminal, 420s delegate). The turn force-ends regardless of remaining budget, in-progress work (uncommitted files, unpushed branches) is silently orphaned, and the cron delivery reports `last_status: ok`.

## Root Cause

`SessionDB.close()` swaps `self._conn` to `None` **without coordinating with in-flight callers**. In cron/subagent contexts a teardown owner runs concurrently with a still-unwinding worker thread:

- `cron/scheduler.py run_job`'s `finally` block closes the shared `_session_db` after an inactivity timeout / `_cron_future` abandonment — while `run_conversation` is still unwinding on the abandoned pool thread and has one more transcript flush to land.
- `tools/delegate_tool.py` timeout owners abandon the child worker (`future.cancel()` + interrupt) and proceed to `child.close()` → `session_db.close()` (child owns a dedicated handle since #81267) while the worker's flush is still in flight.

The next `_execute_write` (from `append_message`/`append_messages_batch`) then executes `self._conn.execute("BEGIN IMMEDIATE")` on `None` → `AttributeError: 'NoneType' object has no attribute 'execute'` → the flush returns `False` → the conversation loop kills the turn as `session_persistence_failed`. Exactly matches the reporter's observation that every crash followed a tool-timeout by 1–3 log lines, and that only child/cron sessions (which have teardown owners racing workers) are affected.

Note `close()` holds `self._lock` while nulling the handle, and `_execute_write` acquires the same lock — so the write does NOT interleave with the close; it simply arrives **after** it. The bug is lifecycle ordering, not lock discipline: the fix belongs at the shared persistence boundary where the stale-handle state is detected.

## The Fix

`hermes_state.py`:

- New `SessionDB._reopen_after_close_locked()`: when a write or locked-fallback read finds `_conn is None` (only possible after an explicit `close()` — the constructor never leaves a live instance with a `None` handle), reopen a connection to the same database file, reapply WAL/pragmas/row factory/CJK extension, and proceed. The recovery is **loud** (WARNING naming the teardown/worker race and the issue) and **bounded** (fires only on the closed-handle state; a failed reopen raises an `OperationalError` that names the race instead of the opaque `NoneType` message, so `classify_persistence_error` and turn-end explanations get a real cause).
- `_execute_write` and the `_read_ctx` writer-lock fallback both check for the closed handle under `self._lock` before touching `.execute`.
- Read-only (cross-profile) handles do NOT silently reopen — they raise an explicit "was closed" `ProgrammingError` (fail loud, not fail weird).
- Schema re-init is deliberately skipped on reopen: this instance's original open already initialized it, so the reopen takes no DDL and can't race sibling processes during teardown.
- `__del__` delegates to `close()`, so a reopened connection is still released at GC/exit.

Behavioral meaning: the last transcript flush of a torn-down subagent/cron session now **lands in the database** instead of being dropped; the turn no longer ends as `session_persistence_failed`; the tail of the session (including the final assistant response) survives, so cron delivery has real content instead of a silent empty `ok`.

## Why not just fix the two teardown call sites?

PR #94754 defers cron/delegate cleanup to worker-completion callbacks — a good ordering improvement, but it can only cover the two sites it edits. The `close()`-races-writer class has more members (gateway shutdown flush, `AIAgent.close()` step 9, TUI compute host, `__del__`), and the invariant worth enforcing is at the narrow waist: *a transcript write that reaches the store must land or fail with a named cause — never `NoneType.execute`*. This fix establishes that invariant for every caller. Related-but-different open PRs: #94816 (visibility of the failure cause downstream — complementary, doesn't stop the data loss), #78492 (same guard idea inside a larger relay change, no tests, re-runs `_init_schema` on reopen), #90734/#99327 (different SQLite failure classes).

## Live Repro (real SessionDB, real sqlite file, no mocks)

On `main` (a071fc80da):

```
append before close ok, row id: 1
append after close FAILED: AttributeError: 'NoneType' object has no attribute 'execute'
  File "hermes_state.py", line 5305, in _execute_write
    self._conn.execute("BEGIN IMMEDIATE")
```

With this fix:

```
WARNING hermes_state: state.db connection for /tmp/.../state.db was closed while a write was still in flight — reopening (teardown/worker race, #94736)
append before close ok, row id: 1
append after close: SUCCEEDED (recovered)
rows now: 2 ['user', 'assistant']
```

## Tests

`tests/state/test_append_message_after_close_94736.py` (real SessionDB against a real sqlite file in `tmp_path`):

- `test_append_message_after_close_reopens_and_lands` — the exact issue shape; asserts the row lands AND the WARNING fires (loud, not silent). **Red on main, green with fix.**
- `test_reopened_connection_survives_subsequent_writes_and_close` — reopened handle is a full writer; second `close()` stays idempotent.
- `test_read_after_close_recovers_too` — locked-read fallback path shares the guard.
- `test_concurrent_close_during_flush_loses_no_writes` — races a real `close()` against a thread mid-flush (40 appends): zero exceptions, all 40 rows land.
- `test_read_only_handle_still_refuses_after_close` — read-only handles fail loud, never reopen.

Pre-fix: **5/5 fail** (verified by reverting `hermes_state.py` only). Post-fix: **5/5 pass**.

No regressions: `tests/state/test_write_lock_patience.py`, `tests/test_session_db_read_path_split.py`, `tests/state/test_session_turn_lease.py`, `tests/state/test_compression_lineage_guard.py`, `tests/test_state_db_repair_live_writer_guard.py`, `tests/hermes_state/` — **256 passed** total. `ruff check` clean.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Infographic

![session-db-self-heal](https://v3b.fal.media/files/b/0aa88ffc/yf1YOE5KpboYfALuqyahW_lVfgbkMW.png)
