### PR TITLE
fix(state): corruption detection & heal cluster — 0-byte quarantine race, decode-error probe/heal, CJK never-raises

### DIFF
--- a/contributors/emails/me@alvin.tech
+++ b/contributors/emails/me@alvin.tech
@@ -1,0 +1,1 @@
+alvinveroy

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -451,7 +451,10 @@ def is_zeroed_sqlite_file(
         return False
     if size < 0:
         return False
-    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+    from hermes_cli.sqlite_safe_read import has_live_connection, read_header_bytes_preopen
+
+    if not force and has_live_connection(path):
+        return False
 
     head = read_header_bytes_preopen(
         path, length=max(16, probe_bytes), force=force

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -441,11 +441,18 @@ def is_zeroed_sqlite_file(
 ) -> bool:
     """True when *path* looks like the #68474 zeroed-state.db signature.
 
-    Signature: size > 0, first *probe_bytes* are all NUL (no ``SQLite format 3``
-    header). Used at SessionDB open and for snapshot diagnostics so a silent
+    Signature: no ``SQLite format 3`` header and no data — either empty
+    (size 0, the total-loss case, #97568) or first *probe_bytes* all NUL.
+    Used at SessionDB open and for snapshot diagnostics so a silent
     all-zero file becomes a guided recovery instead of a generic failure.
+
+    Only regular files qualify: a special file at the path (FIFO, device,
+    socket) is never "zeroed" — and probing one could block indefinitely
+    (opening a FIFO for read waits for a writer), so refuse before any I/O.
     """
     try:
+        if not path.is_file():
+            return False
         size = path.stat().st_size
     except OSError:
         return False

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12407,15 +12407,21 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
 
     try:
         return _open_probed()
-    except sqlite3.DatabaseError as exc:
+    except (sqlite3.DatabaseError, UnicodeDecodeError) as exc:
         message = str(exc).lower()
         stale_schema = "no such table" in message or "no such column" in message
-        if not stale_schema and not is_malformed_schema_error(exc):
+        if not stale_schema and not (
+            # UnicodeDecodeError = pysqlite could not decode SQLite's own
+            # error message because corrupt file bytes were embedded in it
+            # (#98924). The one-writable-open heal is the only repair path,
+            # so route it through the same dispatch as malformed schema.
+            is_malformed_schema_error(exc) or isinstance(exc, UnicodeDecodeError)
+        ):
             raise
         SessionDB(db_path=db_path, read_only=False).close()
         try:
             return _open_probed()
-        except sqlite3.DatabaseError as still_stale:
+        except (sqlite3.DatabaseError, UnicodeDecodeError) as still_stale:
             message = str(still_stale).lower()
             if "no such table" not in message and "no such column" not in message:
                 raise

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3928,7 +3928,7 @@ def _connect_tracked_db(path, tracking_path=None, **kwargs):
 def is_zeroed_state_db(
     path: Path, *, probe_bytes: int = 100, force: bool = False
 ) -> bool:
-    """Detect the #68474 zeroed state.db signature (size>0, NUL header).
+    """Detect the #68474/#97568 zeroed state.db signature (0-byte or NUL header).
 
     Byte-level probe, so it is only safe BEFORE any connection to *path*
     exists in this process: ``close()`` cancels every POSIX advisory lock the
@@ -3949,6 +3949,10 @@ def is_zeroed_state_db(
     except Exception:
         pass
     try:
+        if not path.is_file():
+            # Special files (FIFO, device, socket) are never "zeroed", and
+            # probing a FIFO would block until a writer appears.
+            return False
         size = path.stat().st_size
     except OSError:
         return False

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3954,7 +3954,10 @@ def is_zeroed_state_db(
         return False
     if size < 0:
         return False
-    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+    from hermes_cli.sqlite_safe_read import has_live_connection, read_header_bytes_preopen
+
+    if not force and has_live_connection(path):
+        return False
 
     head = read_header_bytes_preopen(
         path, length=max(16, probe_bytes), force=force
@@ -3968,14 +3971,9 @@ def is_zeroed_state_db(
     return all(byte == 0 for byte in head)
 
 
-def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
-    """Move a zeroed state.db aside (preserve bytes) and return quarantine path.
-
-    Uses a cross-process lock (``#68805``) so two concurrent startups cannot
-    race: the first process moves the zeroed file and the second re-checks
-    under the lock, finding the file already gone (or a fresh DB in its place)
-    instead of clobbering the quarantine.
-    """
+@contextlib.contextmanager
+def quarantine_cross_process_lock(path: Path, timeout: float = 5.0):
+    """Acquire the cross-process lock for path.quarantine.lock."""
     import platform
 
     lock_path = path.with_name(path.name + ".quarantine.lock")
@@ -3983,9 +3981,10 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
     handle = lock_path.open("a+b")
     acquired = False
     try:
-        deadline = time.monotonic() + 5.0
+        deadline = time.monotonic() + timeout
         if platform.system() == "Windows":
             import msvcrt
+
             while True:
                 try:
                     handle.seek(0)
@@ -3998,6 +3997,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
                     time.sleep(0.020)
         else:
             import fcntl
+
             while True:
                 try:
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -4007,21 +4007,36 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(0.020)
-        if not acquired:
-            # Fail closed: do NOT proceed without the lock. A slow or paused
-            # startup that still owns the lock can overlap this fallback and
-            # the two processes can act on the same live file (#68805 review).
-            logger.error(
-                "quarantine lock for %s not acquired within 5s — refusing to "
-                "quarantine without the cross-process lock. The zeroed file "
-                "is left in place. If sessions fail to load, restore from "
-                "state-snapshots via `hermes snapshot list` / "
-                "`hermes snapshot restore <id>`.",
-                path,
-            )
-            return None
-        # Re-check under the lock: another process may have already quarantined
-        # the file, leaving a fresh DB (or no file at all) in its place.
+        yield acquired
+    finally:
+        try:
+            if acquired:
+                if platform.system() == "Windows":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except (OSError, AttributeError):
+            pass
+        finally:
+            handle.close()
+
+
+def quarantine_zeroed_state_db(
+    path: Path, *, already_locked: bool = False
+) -> Optional[Path]:
+    """Move a zeroed state.db aside (preserve bytes) and return quarantine path.
+
+    Uses a cross-process lock (``#68805``) so two concurrent startups cannot
+    race: the first process moves the zeroed file and the second re-checks
+    under the lock, finding the file already gone (or a fresh DB in its place)
+    instead of clobbering the quarantine.
+    """
+    def _do_quarantine():
         if not path.exists():
             logger.info(
                 "quarantine_zeroed_state_db: %s already moved by another process",
@@ -4040,12 +4055,9 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             ts = time.strftime("%Y%m%d-%H%M%S")
         except Exception:
             ts = "unknown"
-        # Unique destination with PID suffix to avoid collision across
-        # concurrent startups that somehow both enter the lock.
         dest = path.with_name(
             f"{path.name}.zeroed-{ts}-{os.getpid()}.bak"
         )
-        # Non-clobbering: if dest somehow exists, append a counter.
         n = 0
         while dest.exists():
             n += 1
@@ -4057,7 +4069,6 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
         except OSError as exc:
             logger.error("Failed to quarantine zeroed %s: %s", path, exc)
             return None
-        # Also move empty WAL/SHM if present so a fresh open is clean
         for suffix in ("-wal", "-shm"):
             side = Path(str(path) + suffix)
             if side.exists():
@@ -4066,20 +4077,22 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
                 except OSError:
                     pass
         return dest
-    finally:
-        try:
-            if acquired:
-                if platform.system() == "Windows":
-                    import msvcrt
-                    handle.seek(0)
-                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-                else:
-                    import fcntl
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-        except (OSError, AttributeError):
-            pass
-        finally:
-            handle.close()
+
+    if already_locked:
+        return _do_quarantine()
+
+    with quarantine_cross_process_lock(path) as acquired:
+        if not acquired:
+            logger.error(
+                "quarantine lock for %s not acquired within 5s — refusing to "
+                "quarantine without the cross-process lock. The zeroed file "
+                "is left in place. If sessions fail to load, restore from "
+                "state-snapshots via `hermes snapshot list` / "
+                "`hermes snapshot restore <id>`.",
+                path,
+            )
+            return None
+        return _do_quarantine()
 
 
 # ── Read-only health/stats probes (hermes doctor, dashboards) ──────────
@@ -4669,34 +4682,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if not read_only:
                 preflight_db_writability(self.db_path, db_label="state.db")
 
-            # #68474: zeroed state.db (size>0, all-NUL header) used to fail as a
-            # generic "file is not a database" with no recovery path. Quarantine
-            # the bytes (do not delete) and continue so a fresh DB can open;
-            # point the operator at pre-update snapshots.
-            if (
+            # #68474 / #97568: Serialize startup across zero-byte check, quarantine,
+            # connect, and schema commit so concurrent openers don't race on an
+            # absent-path -> connect -> schema-commit window.
+            needs_startup_guard = (
                 not read_only
-                and self.db_path.exists()
-                and is_zeroed_state_db(self.db_path)
-            ):
-                try:
-                    zsize = self.db_path.stat().st_size
-                except OSError:
-                    zsize = -1
-                qpath = quarantine_zeroed_state_db(self.db_path)
-                snaps = self.db_path.parent / "state-snapshots"
-                msg = (
-                    f"state.db looks ZEROED ({zsize} bytes, no SQLite header). "
-                    f"Preserved at {qpath or '(quarantine failed — file left in place)'}. "
-                    f"Restore from {snaps} via `hermes snapshot list` / "
-                    f"`hermes snapshot restore <id>` if available. "
-                    "Opening a fresh empty database so the agent can start."
+                and (
+                    not self.db_path.exists()
+                    or is_zeroed_state_db(self.db_path)
                 )
-                logger.error(msg)
-                _set_last_init_error(msg)
-                # If quarantine failed, do not open the zeroed file (would fail
-                # opaquely or risk further damage). Raise with the clear message.
-                if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
-                    raise sqlite3.DatabaseError(msg)
+            )
+
+            def _handle_quarantine_if_zeroed(already_locked: bool = False):
+                if (
+                    self.db_path.exists()
+                    and is_zeroed_state_db(self.db_path)
+                ):
+                    try:
+                        zsize = self.db_path.stat().st_size
+                    except OSError:
+                        zsize = -1
+                    qpath = quarantine_zeroed_state_db(
+                        self.db_path, already_locked=already_locked
+                    )
+                    snaps = self.db_path.parent / "state-snapshots"
+                    msg = (
+                        f"state.db looks ZEROED ({zsize} bytes, no SQLite header). "
+                        f"Preserved at {qpath or '(quarantine failed — file left in place)'}. "
+                        f"Restore from {snaps} via `hermes snapshot list` / "
+                        f"`hermes snapshot restore <id>` if available. "
+                        "Opening a fresh empty database so the agent can start."
+                    )
+                    logger.error(msg)
+                    _set_last_init_error(msg)
+                    # If quarantine failed, do not open the zeroed file (would fail
+                    # opaquely or risk further damage). Raise with the clear message.
+                    if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
+                        raise sqlite3.DatabaseError(msg)
 
             def _connect_and_init():
                 self._conn = _connect_tracked_db(
@@ -4758,8 +4780,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             )
                         )
 
+            def _open_with_optional_startup_guard():
+                if needs_startup_guard:
+                    with quarantine_cross_process_lock(self.db_path) as lock_acquired:
+                        if not lock_acquired:
+                            logger.warning(
+                                "startup quarantine lock for %s not acquired within 5s; proceeding",
+                                self.db_path,
+                            )
+                        _handle_quarantine_if_zeroed(already_locked=lock_acquired)
+                        _connect_and_init_with_lock_patience()
+                else:
+                    _handle_quarantine_if_zeroed(already_locked=False)
+                    _connect_and_init_with_lock_patience()
+
             try:
-                _connect_and_init_with_lock_patience()
+                _open_with_optional_startup_guard()
             except sqlite3.DatabaseError as exc:
                 # The malformed-schema class (e.g. a duplicate sqlite_master
                 # row for messages_fts) fails on the very first statement —

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5159,41 +5159,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
               and leave the stale breadcrumb (#self-heal). The table itself
               stays for a later capable open to rebuild.
         """
-        cjk_present = bool(cursor.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
-            "AND name = 'messages_fts_cjk'"
-        ).fetchone())
+        try:
+            cjk_present = bool(cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'messages_fts_cjk'"
+            ).fetchone())
 
-        if not self._fts_cjk_loaded:
-            if cjk_present:
-                live = [
-                    r[0] for r in cursor.execute(
-                        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
-                        f"AND name IN ({','.join('?' for _ in _FTS_CJK_TRIGGERS)})",
-                        _FTS_CJK_TRIGGERS,
-                    ).fetchall()
-                ]
-                if live:
-                    # Self-heal: this process cannot tokenize, so every
-                    # message INSERT would die inside the cjk trigger.
-                    # Breadcrumb FIRST (crash between the two statements is
-                    # merely conservative), then drop.
-                    logger.warning(
-                        "messages_fts_cjk triggers present but the "
-                        "cjk_unicode61 tokenizer is unavailable (%s) — "
-                        "dropping the cjk triggers so message writes keep "
-                        "working. CJK search falls back to trigram/LIKE; "
-                        "run `hermes sessions optimize-storage` on a host "
-                        "with the extension to rebuild.",
-                        fts5_cjk_so_path(),
-                    )
-                    cursor.execute(
-                        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
-                        "ON CONFLICT(key) DO UPDATE SET value = '1'",
-                        (FTS_CJK_STALE_KEY,),
-                    )
-                    for trig in live:
-                        cursor.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            if not self._fts_cjk_loaded:
+                if cjk_present:
+                    live = [
+                        r[0] for r in cursor.execute(
+                            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                            f"AND name IN ({','.join('?' for _ in _FTS_CJK_TRIGGERS)})",
+                            _FTS_CJK_TRIGGERS,
+                        ).fetchall()
+                    ]
+                    if live:
+                        # Self-heal: this process cannot tokenize, so every
+                        # message INSERT would die inside the cjk trigger.
+                        # Breadcrumb FIRST (crash between the two statements is
+                        # merely conservative), then drop.
+                        logger.warning(
+                            "messages_fts_cjk triggers present but the "
+                            "cjk_unicode61 tokenizer is unavailable (%s) — "
+                            "dropping the cjk triggers so message writes keep "
+                            "working. CJK search falls back to trigram/LIKE; "
+                            "run `hermes sessions optimize-storage` on a host "
+                            "with the extension to rebuild.",
+                            fts5_cjk_so_path(),
+                        )
+                        cursor.execute(
+                            "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                            "ON CONFLICT(key) DO UPDATE SET value = '1'",
+                            (FTS_CJK_STALE_KEY,),
+                        )
+                        for trig in live:
+                            cursor.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                self._fts_cjk_available = False
+                return
+        except sqlite3.OperationalError:
+            # Mirror the tokenizer-loaded except below: the presence check
+            # and self-heal above run before the loaded/not-loaded branch is
+            # even known to be safe, so they need the same never-raises
+            # guarantee the docstring promises for the rest of the method.
+            logger.warning(
+                "messages_fts_cjk presence check failed; CJK search stays on "
+                "trigram/LIKE", exc_info=True,
+            )
             self._fts_cjk_available = False
             return
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -517,7 +517,7 @@ class SessionSchemaMixin:
         """Body of :meth:`_recover_stale_fts`; caller holds rebuild authority."""
         try:
             trigram_status = self._fts_table_probe(cursor, "messages_fts_trigram")
-        except sqlite3.DatabaseError:
+        except (sqlite3.DatabaseError, UnicodeDecodeError):
             # A corrupt vtable may fail even a LIMIT 0 probe. It still needs
             # to be included in the drop-and-recreate recovery below.
             trigram_status = True

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -388,18 +388,38 @@ class SessionSchemaMixin:
         try:
             cursor.execute(f"SELECT * FROM {table_name} LIMIT 0")
             return True
-        except sqlite3.OperationalError as exc:
-            if self._is_fts5_unavailable_error(exc):
-                # Only disable FTS entirely when the whole module is missing.
-                # A missing trigram tokenizer only affects trigram searches.
-                if self._is_trigram_unavailable_error(exc):
-                    self._warn_trigram_unavailable(exc)
-                else:
-                    self._warn_fts5_unavailable(exc)
-                return None
-            if "no such table" in str(exc).lower():
-                return False
-            raise
+        except (sqlite3.OperationalError, UnicodeDecodeError) as exc:
+            # UnicodeDecodeError can occur when FTS shadow tables or content
+            # columns hold invalid UTF-8 bytes. On some Python/SQLite builds
+            # it surfaces as a bare UnicodeDecodeError (ValueError subclass,
+            # not sqlite3.Error); on others as OperationalError("Could not
+            # decode to UTF-8 column ..."). Catch both so the probe never
+            # kills the connection or raises to writable-init/recovery flows.
+            if isinstance(exc, sqlite3.OperationalError):
+                if self._is_fts5_unavailable_error(exc):
+                    # Only disable FTS entirely when the whole module is missing.
+                    # A missing trigram tokenizer only affects trigram searches.
+                    if self._is_trigram_unavailable_error(exc):
+                        self._warn_trigram_unavailable(exc)
+                    else:
+                        self._warn_fts5_unavailable(exc)
+                    return None
+                if "no such table" in str(exc).lower():
+                    return False
+                # Re-raise any other OperationalError (e.g. malformed schema,
+                # corrupt vtable that isn't a decode error).
+                if "decode to utf-8" not in str(exc).lower():
+                    raise
+            # Swallow: decode error means the index is degraded but the
+            # store remains accessible. Writable init / recovery will
+            # schedule a rebuild or degrade to LIKE.
+            logger.warning(
+                "%s probe encountered invalid UTF-8 in FTS content; "
+                "search may return incomplete results until FTS is rebuilt: %s",
+                table_name,
+                exc,
+            )
+            return None
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -628,6 +628,36 @@ class TestWebServerEndpoints:
 
         assert opens == [True]
 
+    def test_decode_error_triggers_writable_heal(self, tmp_path, monkeypatch):
+        """UnicodeDecodeError — pysqlite failing to decode SQLite's own error
+        message over corrupt file bytes (#98924) — must route through the
+        same one-writable-open heal as malformed schema."""
+        import hermes_state
+        from hermes_cli import web_server
+
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"not-empty")
+        opens = []
+
+        class _OkDB:
+            _conn = None
+
+            def close(self):
+                pass
+
+        def scripted_open(*_args, **kwargs):
+            opens.append(kwargs.get("read_only", False))
+            if opens == [True]:
+                raise UnicodeDecodeError("utf-8", b"\x81", 0, 1, "invalid start byte")
+            return _OkDB()
+
+        monkeypatch.setattr(hermes_state, "SessionDB", scripted_open)
+
+        db = web_server._open_session_db_at_path(db_path, read_only=True)
+
+        assert isinstance(db, _OkDB)
+        assert opens == [True, False, True]
+
     def test_get_sessions_zero_byte_store_returns_empty_list(self):
         from hermes_constants import get_hermes_home
 

--- a/tests/test_98924_readonly_fts_decode_error.py
+++ b/tests/test_98924_readonly_fts_decode_error.py
@@ -80,3 +80,59 @@ class TestReadOnlyFTSDecodeError:
             assert read_only2._conn is not None
         finally:
             read_only2.close()
+
+
+def _corrupt_schema_with_raw_bytes(db_path: Path) -> None:
+    """Rewrite an FTS vtable's sqlite_master row with invalid UTF-8 bytes.
+
+    This is the fixture that actually reproduces #98924 on main: pysqlite
+    raises a bare UnicodeDecodeError at execute() time when SQLite's own
+    error/schema text carries raw non-UTF-8 file bytes. (Invalid UTF-8 in
+    messages.content alone does NOT make the LIMIT 0 probe raise.)
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("PRAGMA writable_schema=ON")
+        badname = b"tbl_\x81\x82"
+        conn.execute(
+            "UPDATE sqlite_master SET name=CAST(? AS TEXT), "
+            "tbl_name=CAST(? AS TEXT), sql=CAST(? AS TEXT) "
+            "WHERE name='messages_fts_trigram'",
+            (badname, badname, b"CREATE GARBAGE \x81\x82"),
+        )
+        ver = conn.execute("PRAGMA schema_version").fetchone()[0]
+        conn.execute(f"PRAGMA schema_version = {ver + 1}")
+        conn.execute("PRAGMA writable_schema=OFF")
+    finally:
+        conn.close()
+
+
+class TestSchemaBytesDecodeError:
+    def test_read_only_open_survives_raw_bytes_in_schema(self, tmp_path):
+        """Genuine on-main repro of #98924: schema-area corruption whose raw
+        bytes reach pysqlite's error-message decode. Before the fix the probe
+        re-raised the resulting UnicodeDecodeError and killed read-only init.
+        """
+        db_path = tmp_path / "state.db"
+        writable = SessionDB(db_path=db_path)
+        writable.create_session("schema-bytes", source="cli")
+        writable.append_message("schema-bytes", role="user", content="hello")
+        writable.close()
+
+        _corrupt_schema_with_raw_bytes(db_path)
+
+        # Precondition: the raw probe really raises UnicodeDecodeError on
+        # this fixture (guards the test against silently stopping to
+        # exercise the bug on future SQLite versions).
+        raw = sqlite3.connect(str(db_path))
+        try:
+            with pytest.raises(UnicodeDecodeError):
+                raw.execute("SELECT * FROM messages_fts LIMIT 0")
+        finally:
+            raw.close()
+
+        read_only = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert read_only._conn is not None
+        finally:
+            read_only.close()

--- a/tests/test_98924_readonly_fts_decode_error.py
+++ b/tests/test_98924_readonly_fts_decode_error.py
@@ -1,0 +1,82 @@
+"""Test that read-only SessionDB survives invalid UTF-8 in FTS content (issue #98924)."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _write_invalid_utf8_row(db_path: Path) -> None:
+    """Inject a non-UTF-8 byte into an existing message row via low-level API.
+    
+    Python's high-level sqlite3.Connection will not let us write invalid
+    UTF-8 into a TEXT column — it decodes and re-encodes. We use the
+    connection's lower-level interface to force it through.
+    """
+    # CAST(x'61625F816364' AS TEXT) → 'ab_�cd' with 0x81 at position 3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        # Force the bytes through by overwriting an existing row id.
+        conn.execute("UPDATE messages SET content = CAST(x'61625F816364' AS TEXT) WHERE id = 1")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestReadOnlyFTSDecodeError:
+    def test_read_only_open_survives_invalid_utf8_in_fts_content(self, tmp_path):
+        """Non-UTF-8 bytes in messages.content don't kill the read-only open.
+        
+        Regression test for issue #98924: a developer's state.db contained a
+        byte 0x81 in a messages row. External-content FTS5 (v23 layout) reads
+        that column when building a result set. On some Python/SQLite builds
+        the decode failure surfaces as UnicodeDecodeError; on others as
+        OperationalError("Could not decode to UTF-8 column ...").
+        
+        The old code caught only sqlite3.OperationalError and would re-raise
+        any other exception. UnicodeDecodeError (a ValueError, not an
+        sqlite3.Error subclass) therefore bypassed the guard and killed the
+        read-only connection, taking down every read endpoint (GET /api/sessions).
+        
+        The fix catches (sqlite3.OperationalError, UnicodeDecodeError) and
+        treats the decode error the same as "FTS unavailable" — the index is
+        degraded but the connection stays open. Search may return less or fail
+        on that corrupted row, but writes and non-FTS reads keep working.
+        """
+        db_path = tmp_path / "state.db"
+        
+        # Create a fresh DB with v23 external-content FTS.
+        writable = SessionDB(db_path=db_path)
+        writable.create_session("decode-test", source="cli")
+        writable.append_message("decode-test", role="user", content="valid text")
+        writable.close()
+        
+        # Insert a row with invalid UTF-8 through the sqlite3 CLI.
+        _write_invalid_utf8_row(db_path)
+        
+        # Also trigger a rebuild so the invalid bytes are in the FTS index.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+        conn.commit()
+        conn.close()
+        
+        # The shipped regression: SessionDB(read_only=True) should NOT raise.
+        # Before the fix, this raised UnicodeDecodeError from _fts_table_probe.
+        read_only = SessionDB(db_path=db_path, read_only=True)
+        try:
+            # Verify the connection opened — _fts_table_probe didn't kill init.
+            assert read_only._conn is not None
+        finally:
+            read_only.close()
+        
+        # Also verify that the index degraded: _fts_enabled should be None or
+        # False, not True, because the corrupt content prevents probing.
+        read_only2 = SessionDB(db_path=db_path, read_only=True)
+        try:
+            # The index is broken; the store itself must stay accessible.
+            assert read_only2._conn is not None
+        finally:
+            read_only2.close()

--- a/tests/test_fts_update_of_narrowing.py
+++ b/tests/test_fts_update_of_narrowing.py
@@ -265,6 +265,33 @@ def test_cjk_broad_trigger_is_restored_as_update_of(
         db.close()
 
 
+def test_cjk_ensure_survives_presence_check_failure_when_tokenizer_unloaded(
+    tmp_path: Path,
+):
+    """``_ensure_fts_cjk_schema`` is documented never to raise (#98834).
+
+    The tokenizer-not-loaded branch runs its sqlite_master presence check
+    and self-heal statements before any try/except guards them; a transient
+    sqlite3.OperationalError there (e.g. "database is locked") must degrade
+    to "no cjk index", not propagate.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db._fts_cjk_loaded = False
+        db._fts_cjk_available = True
+
+        class _LockedOnMasterCursor:
+            def execute(self, sql, *args, **kwargs):
+                if "sqlite_master" in sql:
+                    raise sqlite3.OperationalError("database is locked")
+                raise AssertionError(f"unexpected query: {sql}")
+
+        db._ensure_fts_cjk_schema(_LockedOnMasterCursor())
+        assert db._fts_cjk_available is False
+    finally:
+        db.close()
+
+
 def test_legacy_migration_does_not_drop_cjk_trigger(tmp_path: Path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -840,3 +840,42 @@ def test_repair_honors_configured_delete_mode(tmp_path, monkeypatch):
 
     assert report["repaired"] is True
     assert _mode_of(db_path) == "delete"
+
+
+# ── #98924 companion: recovery surface beyond the probe fix (#98935) ───────
+
+# The probe itself is fixed in #98935; this test must not depend on it.
+def test_fts_recovery_includes_vtables_that_raise_decode_errors(tmp_path):
+    """Drop-and-recreate recovery must include corrupt vtables whose probe
+    raises UnicodeDecodeError, not only sqlite3.DatabaseError (#98924)."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    db.append_message(sid, role="user", content="searchable needle")
+    cursor = db._conn.cursor()
+
+    original_probe = db._fts_table_probe
+
+    def _decode_boom(probe_cursor, table_name):
+        if table_name == "messages_fts_trigram":
+            raise UnicodeDecodeError("utf-8", b"\x81", 0, 1, "invalid start byte")
+        return original_probe(probe_cursor, table_name)
+
+    db._fts_table_probe = _decode_boom
+    try:
+        assert db._recover_stale_fts(cursor, legacy=False) is True
+    finally:
+        db.close()
+
+    check = sqlite3.connect(str(db_path))
+    try:
+        names = {
+            row[0]
+            for row in check.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts%'"
+            )
+        }
+    finally:
+        check.close()
+    assert "messages_fts" in names
+    assert "messages_fts_trigram" in names

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14276,6 +14276,61 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     assert server._db_error == "locking protocol"
 
 
+def test_ensure_session_db_row_false_when_store_unavailable(monkeypatch):
+    """Store unavailable → False, so prompt.submit can fail the send loudly
+    instead of streaming into a store that will never save it (#98924)."""
+    fake_mod = types.ModuleType("hermes_state")
+
+    class _BrokenSessionDB:
+        def __init__(self):
+            raise RuntimeError("utf-8 boom")
+
+    fake_mod.SessionDB = _BrokenSessionDB
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    assert server._ensure_session_db_row({"session_key": "k1"}) is False
+
+
+def test_ensure_session_db_row_true_when_row_persisted(monkeypatch):
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, **_kwargs):
+            created.append(key)
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    assert server._ensure_session_db_row({"session_key": "k1", "cwd": "/tmp"}) is True
+    assert created == ["k1"]
+
+
+def test_prompt_submit_fails_loudly_when_store_unavailable(monkeypatch):
+    """A send with no persistable store must fail the RPC with a real error
+    (desktop maps it to a toast) instead of streaming the message into a
+    store that will never save it (#98924)."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {}})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_db_error", "utf-8 decode failure")
+
+    server._sessions["lost-sid"] = _session()
+    try:
+        resp = server.handle_request(
+            {
+                "id": "lost",
+                "method": "prompt.submit",
+                "params": {"session_id": "lost-sid", "text": "will vanish"},
+            }
+        )
+    finally:
+        server._sessions.pop("lost-sid", None)
+
+    assert resp["error"]["code"] == 5072
+    assert "session storage unavailable" in resp["error"]["message"]
+
+
 @pytest.mark.real_agent_prewarm
 def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     class _FakeWorker:

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -21,6 +21,26 @@ def test_is_zeroed_state_db_and_quarantine(tmp_path):
     assert q.read_bytes() == bytes(1024)
 
 
+@pytest.mark.skipif(not hasattr(__import__("os"), "mkfifo"), reason="POSIX only")
+def test_is_zeroed_never_probes_special_files(tmp_path):
+    """A FIFO at the state.db path must be rejected without any blocking read.
+
+    Opening a FIFO for reading blocks until a writer appears; the zeroed
+    probe must classify on file type alone (#98017 review, P2).
+    """
+    import os
+
+    import hermes_state as hs
+    from hermes_cli.backup import is_zeroed_sqlite_file
+
+    fifo = tmp_path / "state.db"
+    os.mkfifo(fifo)
+    # Would hang forever before the regular-file guard if either probe
+    # attempted open()+read on the FIFO.
+    assert is_zeroed_sqlite_file(fifo) is False
+    assert hs.is_zeroed_state_db(fifo) is False
+
+
 def test_sessiondb_opens_fresh_after_zeroed_quarantine(tmp_path, monkeypatch):
     import hermes_state as hs
 

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -200,3 +200,82 @@ def test_quarantine_fails_closed_when_lock_held(tmp_path):
     # Release the lock so the background thread can exit cleanly
     release_lock.set()
     holder.join(timeout=5)
+
+
+def test_concurrent_openers_zero_byte_startup_serialization(tmp_path, monkeypatch):
+    """#97580: Verify that two concurrent SessionDB openers on a non-existent
+    database serialize through the startup lock, avoid racing on the initial
+    0-byte creation window, and do not falsely quarantine each other's live file.
+    """
+    import hermes_state as hs
+    import threading
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "state.db"
+
+    errors = [None, None]
+    results = [None, None]
+
+    def worker(idx):
+        try:
+            sdb = hs.SessionDB(db_path=db)
+            try:
+                # Confirm schema is active
+                row = sdb._conn.execute("SELECT 1").fetchone()
+                assert row[0] == 1
+                results[idx] = "ok"
+            finally:
+                sdb.close()
+        except Exception as exc:
+            errors[idx] = exc
+
+    t1 = threading.Thread(target=worker, args=(0,))
+    t2 = threading.Thread(target=worker, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors[0] is None, f"Opener 0 failed: {errors[0]}"
+    assert errors[1] is None, f"Opener 1 failed: {errors[1]}"
+    assert results[0] == "ok"
+    assert results[1] == "ok"
+
+    # No spurious quarantine backups should have been created
+    backups = list(tmp_path.glob("state.db.zeroed-*.bak"))
+    assert len(backups) == 0, f"Expected 0 quarantine backups, got: {backups}"
+    assert db.exists()
+    assert not hs.is_zeroed_state_db(db)
+
+
+def test_live_connection_0_byte_not_quarantined_in_process(tmp_path, monkeypatch):
+    """#97580: A live 0-byte connection tracked in this process must not be
+    quarantined by is_zeroed_state_db / SessionDB.
+    """
+    import hermes_state as hs
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "state.db"
+
+    # Create a live tracked 0-byte connection
+    conn = connect_tracked(str(db))
+    try:
+        assert db.exists() and db.stat().st_size == 0
+        # is_zeroed_state_db must recognize the live connection and refuse to declare it zeroed
+        assert hs.is_zeroed_state_db(db) is False
+
+        # SessionDB open must not quarantine this live file
+        sdb = hs.SessionDB(db_path=db)
+        try:
+            backups = list(tmp_path.glob("state.db.zeroed-*.bak"))
+            assert len(backups) == 0, f"Spurious quarantine occurred: {backups}"
+        finally:
+            sdb.close()
+
+        # The original connection can still write safely
+        conn.execute("CREATE TABLE live_check (id INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -937,7 +937,17 @@ def _(rid, params: dict) -> dict:
     # Disk-full must fail the RPC (not stream silently): desktop maps the error
     # string to a "disk full" toast so the user knows why the send vanished.
     try:
-        _ensure_session_db_row(session)
+        if _ensure_session_db_row(session) is False:
+            # Store unavailable: failing the RPC is the only user-visible
+            # signal — same principle as the disk-full path above (#98924).
+            # _db_error carries the SessionDB open failure for the toast.
+            return _err(
+                rid,
+                5072,
+                "session storage unavailable: "
+                f"{_db_error or 'state.db could not be opened'} — the message "
+                "was not saved; repair state.db and try again",
+            )
         # A branch becomes real here: copy its parent's transcript into the row so it
         # resumes with full context (the agent won't persist the seed itself).
         _persist_branch_seed(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3834,7 +3834,12 @@ def _ensure_session_db_row(session: dict) -> bool:
         db = _get_db()
         close_db = False
     if db is None:
-        return False
+        # Fail loud ONLY when the store actually failed to open (#98924):
+        # _db_error records the SessionDB open exception. A None db with no
+        # recorded error means "no store in this context" (degraded harness,
+        # store deliberately absent) — that keeps the pinned best-effort
+        # contract and stays True.
+        return _db_error is None
     # The session's own model/effort/fast pick — the composer override shipped on
     # session.create, or a restored /model switch — must own the row's model +
     # model_config. The agent isn't built yet at first prompt.submit, so derive

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3788,13 +3788,17 @@ def _register_session_cwd(session: dict | None) -> None:
         pass
 
 
-def _ensure_session_db_row(session: dict) -> None:
+def _ensure_session_db_row(session: dict) -> bool:
     """Idempotently persist the session's DB row on first real activity.
 
     Called from prompt.submit so a row only exists once the user actually sends
     a message — abandoned drafts never leave an empty "Untitled" session behind.
     Uses INSERT OR IGNORE under the hood, so re-calls (and the AIAgent's own
     lazy create) are no-ops.
+    Returns False only when the store is unavailable (no openable state.db);
+    prompt.submit turns that into an RPC error so a send fails loudly with a
+    toast instead of streaming into a store that will never save it (#98924).
+    Every other outcome — no key, best-effort attempt, success — is True.
 
     A cwd the user *chose* is always persisted. When they made no explicit
     choice the launch directory stands in, and whether that is meaningful
@@ -3824,13 +3828,13 @@ def _ensure_session_db_row(session: dict) -> None:
             db = SessionDB(db_path=Path(profile_home) / "state.db")
         except Exception:
             logger.debug("failed to open profile db for session row", exc_info=True)
-            return
+            return False
         close_db = True
     else:
         db = _get_db()
         close_db = False
     if db is None:
-        return
+        return False
     # The session's own model/effort/fast pick — the composer override shipped on
     # session.create, or a restored /model switch — must own the row's model +
     # model_config. The agent isn't built yet at first prompt.submit, so derive
@@ -3949,6 +3953,7 @@ def _ensure_session_db_row(session: dict) -> None:
                 db.close()
             except Exception:
                 pass
+    return True
 
 
 def _persist_branch_seed(session: dict) -> None:


### PR DESCRIPTION
## Summary

Consolidated salvage for the state.db **corruption detection & heal** cluster (issues #97568, #98924, #98834). Two contributor PR chains cherry-picked onto current main with authorship preserved, plus two follow-up hardenings.

### Salvaged work

**Sub-cluster A — 0-byte / zeroed state.db (#97568)** — @loulanyue (PR #97580, earliest complete fix; its first commit already merged via #98017 by @kshitijk4poor):
- `fix(state): serialize startup across zero-byte check, quarantine, connect, and schema commit` — the second, still-unmerged #97580 commit. Addresses @kvnloo's live-repro'd concurrent-startup race on #97580: without it, a second `SessionDB` opener can quarantine a sibling's legitimately-0-byte just-created live DB (its next write then fails `attempt to write a readonly database`). Adds `quarantine_cross_process_lock()` (reusable ctx manager over the existing `#68805` advisory lock), wraps check→quarantine→connect→schema-commit under it, and adds a `has_live_connection()` guard so a tracked live 0-byte connection is never classified zeroed. Two regression tests (concurrent openers; live 0-byte connection protected).

**Sub-cluster B — UnicodeDecodeError escaping FTS probe / heal (#98924)**:
- @kokhlo (PR #98935): `_fts_table_probe` catches `(sqlite3.OperationalError, UnicodeDecodeError)` — a bare decode error (ValueError, not sqlite3.Error) no longer kills read-only SessionDB init and every read endpoint behind it.
- @alvinveroy (PR #98948, disjoint surfaces): web `_open_session_db_at_path` heal catches now include `UnicodeDecodeError` (the one-writable-open heal actually fires); `_recover_stale_fts_locked` includes decode-corrupt vtables in drop-and-recreate; TUI `_ensure_session_db_row` returns False on store-unavailable and `prompt.submit` fails the RPC with code 5072 (toast) instead of silently streaming turns into a store that never saves them.

**Sub-cluster B' — CJK never-raises contract (#98834)** — @chelsealong (PR #98947): the tokenizer-not-loaded branch of `_ensure_fts_cjk_schema` gets the same `OperationalError` guard the loaded branch has, so a transient "database is locked" degrades to no-cjk-index instead of propagating through `_migrate_broad_fts_update_triggers`' quarantine-then-reraise and aborting the whole open (crash loop).

### Follow-ups (ours)

- **Regular-file guard** before the zeroed byte-probe in both `is_zeroed_sqlite_file` and `is_zeroed_state_db` — a FIFO/device/socket at the state.db path is never "zeroed" and opening a FIFO for read blocks forever (addresses the P2 raised in #98017's review). POSIX regression test with a real `mkfifo`.
- **On-main-reproducing #98924 fixture**: invalid UTF-8 in `messages.content` alone does NOT make the `LIMIT 0` probe raise (verified live). The genuine trigger is raw non-UTF-8 bytes in the schema area (`sqlite_master`) reaching pysqlite's error-message decode. Added a `writable_schema` fixture that provably raises `UnicodeDecodeError` on a raw connection (pytest.raises precondition) and asserts read-only init survives.

## Live repro

Surface: real `SessionDB` against isolated temp `HERMES_HOME`, repo venv (SQLite as shipped).

- **Before (main 26f178e5fa):** `is_zeroed_state_db(0-byte) = False`, `SessionDB` open → **no ERROR log, no quarantine backup**, fresh DB silently indistinguishable from a new install. Schema-bytes fixture → `SessionDB(read_only=True)` **raised `UnicodeDecodeError`** from `_fts_table_probe` (hermes_state_schema.py:386).
- **After (this branch):** 0-byte file → `is_zeroed=True`, ERROR log `state.db looks ZEROED (0 bytes...)`, quarantine backup `state.db.zeroed-*.bak` created, fresh DB opens. Same fixture → read-only open succeeds, FTS degraded.

## Tests

`tests/test_zeroed_state_db.py`, `tests/test_98924_readonly_fts_decode_error.py`, `tests/test_fts_update_of_narrowing.py`, `tests/test_state_db_malformed_repair.py`, `tests/hermes_cli/test_backup.py`, targeted `test_web_server.py` / `test_tui_gateway_server.py` selections — **141 passed, 0 failed** locally (memory-capped).

Fixes #98924. Fixes #98834. Completes #97568 (first half landed in #98017).
Closes #98935. Closes #98948. Closes #98947. Closes #99179. Closes #99100.

## Infographic

![state.db corruption recovery](https://v3b.fal.media/files/b/0aa89008/ezybZwPONbYChGDbkypuG_v391QJ5Y.png)
