### PR TITLE
fix(desktop): preserve HUD conversation state on switch

### DIFF
--- a/apps/desktop/src/app/hud/handoff.test.tsx
+++ b/apps/desktop/src/app/hud/handoff.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const openSession = vi.fn()
+
+vi.mock('../open-session', () => ({
+  openSession: (...args: unknown[]) => openSession(...args)
+}))
+
+import { useHudGoto } from './handoff'
+
+describe('useHudGoto', () => {
+  afterEach(() => {
+    cleanup()
+    openSession.mockReset()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('switches conversations through the canonical open-session door without forcing route navigation', () => {
+    let onGoto: ((storedSessionId: string) => void) | undefined
+    const navigate = vi.fn()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        hud: {
+          onGoto: vi.fn((callback: (storedSessionId: string) => void) => {
+            onGoto = callback
+
+            return vi.fn()
+          })
+        }
+      }
+    })
+
+    renderHook(() => useHudGoto(navigate))
+    onGoto?.('stored-session-b')
+
+    expect(openSession).toHaveBeenCalledWith('stored-session-b', navigate)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/hud/handoff.ts
+++ b/apps/desktop/src/app/hud/handoff.ts
@@ -25,7 +25,6 @@ import { isHudWindow } from '@/store/windows'
 
 import { getActiveComposer } from '../chat/composer/focus'
 import { openSession, type OpenSessionNavigate } from '../open-session'
-import { sessionRoute } from '../routes'
 
 /** Session tiles route on `tile:<storedSessionId>` (see session-tile.tsx). */
 const TILE_TARGET_PREFIX = 'tile:'
@@ -111,7 +110,7 @@ export function useHudGoto(navigate: OpenSessionNavigate): void {
   const navigateRef = useRef(navigate)
   navigateRef.current = navigate
 
-  useEffect(() => window.hermesDesktop?.hud?.onGoto?.(id => navigateRef.current(sessionRoute(id))), [])
+  useEffect(() => window.hermesDesktop?.hud?.onGoto?.(id => openSession(id, navigateRef.current)), [])
 }
 
 /** HUD side: keep main told which session this window is on. */


### PR DESCRIPTION
## Summary

- route HUD/voice conversation retargets through the canonical `openSession` door
- focus an already-open conversation surface instead of forcing route navigation and chat rehydration
- add regression coverage proving the HUD retarget callback does not navigate directly

## Root cause

The HUD retarget callback bypassed `openSession` and always navigated to `sessionRoute(id)`. That forced the route/hydration path even when the requested conversation was already open as the main chat or a tile, making a conversation switch look like a full thread reload and disturbing UI state.

## Verification

- `npx vitest run --project ui src/app/hud/handoff.test.tsx src/app/open-session.test.ts` — 26 passed
- `npm run typecheck` — passed
- `npx eslint src/app/hud/handoff.ts src/app/hud/handoff.test.tsx` — passed
- `npx prettier --check src/app/hud/handoff.ts src/app/hud/handoff.test.tsx` — passed
- independent pre-commit review — passed, no security concerns or logic errors

Board task: `58b12a4b-ef79-4aa9-a123-8b870fa9d210`
