### PR TITLE
fix(gateway): run secondary-profile adapter auth setup off the event loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2458,7 +2458,7 @@ async def _reclaim_stale(runner: object) -> None:
 
 
 @_contextmanager
-def _profile_runtime_scope(profile_home: "Path"):
+def _profile_runtime_scope(profile_home: "Path", *, hydrate_secrets: bool = True):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
     Combines the two seams the multiplexer needs:
@@ -2485,7 +2485,8 @@ def _profile_runtime_scope(profile_home: "Path"):
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
+    if hydrate_secrets:
+        hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield
@@ -16582,10 +16583,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter = None
                 try:
                     from hermes_cli.profiles import get_profile_dir
+                    from hermes_cli.env_loader import hydrate_profile_secret_sources
                     from gateway.config import load_gateway_config
 
                     profile_home = get_profile_dir(profile_name)
-                    with _profile_runtime_scope(profile_home):
+                    # Like the #16856 MCP discovery path, hydrate external secret
+                    # sources off-loop so they cannot starve platform heartbeats.
+                    await asyncio.to_thread(
+                        hydrate_profile_secret_sources, profile_home
+                    )
+                    with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                         profile_config = load_gateway_config().platforms.get(platform)
                         if profile_config is None or not profile_config.enabled:
                             return

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,6 +1,8 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
 import logging
 import asyncio
+import threading
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -182,11 +184,15 @@ def _secondary_recovery_runner(*, running=True):
     return runner
 
 
-def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_homes=None):
+def _install_secondary_reconnect_context(
+    monkeypatch, runner, adapter, scoped_homes=None, hydration_flags=None
+):
     @contextmanager
-    def fake_scope(profile_home):
+    def fake_scope(profile_home, *, hydrate_secrets=True):
         if scoped_homes is not None:
             scoped_homes.append(Path(profile_home))
+        if hydration_flags is not None:
+            hydration_flags.append(hydrate_secrets)
         yield
 
     monkeypatch.setattr(gateway_run, "_profile_runtime_scope", fake_scope)
@@ -208,6 +214,61 @@ def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_ho
 
 
 class TestSecondaryProfileFatalRecovery:
+    @pytest.mark.asyncio
+    async def test_reconnect_hydrates_secrets_off_the_event_loop(self, monkeypatch):
+        runner = _secondary_recovery_runner()
+        replacement = _SecondaryRecoveryAdapter()
+        hydration_flags = []
+        _install_secondary_reconnect_context(
+            monkeypatch, runner, replacement, hydration_flags=hydration_flags
+        )
+        loop_thread_id = threading.get_ident()
+        hydration_started = threading.Event()
+        hydration_finished = threading.Event()
+        hydration_thread_ids = []
+        stop_ticker = asyncio.Event()
+        ticks_during_hydration = 0
+
+        def slow_hydrate(profile_home):
+            hydration_thread_ids.append(threading.get_ident())
+            hydration_started.set()
+            time.sleep(0.05)
+            hydration_finished.set()
+
+        async def ticker():
+            nonlocal ticks_during_hydration
+            while not stop_ticker.is_set():
+                if hydration_started.is_set() and not hydration_finished.is_set():
+                    ticks_during_hydration += 1
+                await asyncio.sleep(0)
+
+        async def connect(adapter, platform, *, is_reconnect=False):
+            assert adapter is replacement
+            assert platform is Platform.DISCORD
+            assert is_reconnect is True
+            return True
+
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.hydrate_profile_secret_sources", slow_hydrate
+        )
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
+        ticker_task = asyncio.create_task(ticker())
+        reconnect_task = asyncio.create_task(
+            runner._run_secondary_profile_reconnect("reviewer", Platform.DISCORD)
+        )
+        try:
+            assert await asyncio.to_thread(hydration_started.wait, 1.0)
+            await reconnect_task
+        finally:
+            stop_ticker.set()
+            await ticker_task
+
+        assert len(hydration_thread_ids) == 1
+        assert hydration_thread_ids[0] != loop_thread_id
+        assert ticks_during_hydration > 0
+        assert hydration_flags == [False]
+        assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+
     @pytest.mark.asyncio
     async def test_retryable_secondary_fatal_reconnects_with_its_profile_scope(
         self, monkeypatch


### PR DESCRIPTION
## What does this PR do?

Moves secondary-profile reconnect secret-source hydration off the gateway event loop while preserving the existing profile home and secret `ContextVar` scope around config loading, adapter construction/configuration, and the async connect.

`_profile_runtime_scope()` synchronously calls `hydrate_profile_secret_sources()`. That helper can resolve external secret backends and wait on a process-global cache lock. `_run_secondary_profile_reconnect()` entered that scope directly on the gateway loop, so one slow reconnect setup could starve every platform heartbeat.

This follows the architectural precedent documented in `gateway/run.py` for #16856: blocking MCP discovery moved to an executor because it froze gateway heartbeats. This is a conceptual precedent, not a mechanical copy—the reconnect path pre-hydrates one explicit profile home, then installs the normal ContextVars on the original task.

### Operational evidence

On 2026-08-31 the affected multiplex gateway recorded:
- 8 `shutdown_watchdog` CRITICAL exits with code 75;
- 85 Slack Socket Mode unhealthy/reconnect events;
- a 15:06 watchdog stack in secondary reconnect setup: `_run_secondary_profile_reconnect` → `_configure_profile_adapter` → `_make_adapter_auth_check`.

Source tracing showed `_make_adapter_auth_check` only constructs a callback. The preceding `_profile_runtime_scope` entry is the blocking seam: it calls `hydrate_profile_secret_sources`, which performs synchronous external-source work under `_SECRET_SOURCE_CACHE_LOCK`.

## Related Issue

No exact issue or PR found. Mandatory searches covered `_run_secondary_profile_reconnect`, `_profile_runtime_scope`, `secondary profile reconnect blocking`, `secret hydration event loop`, and `Slack Socket Mode reconnect blocking`. PR #75047 is related—it adds cold-profile external-secret hydration—but does not move reconnect hydration off-loop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - add a default-preserving `hydrate_secrets` switch to `_profile_runtime_scope`;
  - pre-hydrate the reconnect profile with `asyncio.to_thread`;
  - enter the normal profile scope with duplicate hydration disabled, keeping config/create/configure/connect scoped on the original task.
- `tests/gateway/test_multiplex_adapter_registry.py`
  - add a slow synchronous hydration regression test that proves the event-loop ticker advances, hydration runs on another thread, the in-scope duplicate call is skipped, and the replacement adapter is published.

## Reproduction

1. Enable multiplex profiles and configure a secondary profile with an external secret source.
2. Make that source slow (or contend `_SECRET_SOURCE_CACHE_LOCK`) and trigger a retryable secondary adapter reconnect.
3. On `main`, reconnect enters `_profile_runtime_scope` synchronously and gateway heartbeat tasks do not advance until hydration returns. The new test copied unchanged onto `upstream/main` fails at its liveness seam (`assert False` because no off-loop hydration occurs).

## How to Test

1. `python -m pytest tests/gateway/test_multiplex_adapter_registry.py::TestSecondaryProfileFatalRecovery::test_reconnect_hydrates_secrets_off_the_event_loop -q`
2. `scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py -q` — **23 passed** in the hermetic per-file runner.
3. `python -m py_compile gateway/run.py tests/gateway/test_multiplex_adapter_registry.py && ruff check gateway/run.py tests/gateway/test_multiplex_adapter_registry.py && git diff --check`

Full-suite note: `pytest tests/ -q` was attempted in a clean external Python 3.12 venv with `[all,dev,messaging]`. This repository currently contains ~36,000 tests; the direct run timed out at 18%, and the canonical per-file runner timed out at 66% after 26,625 passes with 42 unrelated failures. The changed gateway test file is green under both direct and canonical isolated runners; I am not marking the full-suite checkbox as passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; see bounded full-suite note)
- [x] I've added tests for my changes
- [x] I've tested on macOS Darwin 25.4, Apple Silicon arm64

### Documentation & Housekeeping

- [x] Documentation update — N/A; private implementation detail and regression test only
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture or workflow change
- [x] Cross-platform impact considered: `asyncio.to_thread` and ContextVars are existing cross-platform project mechanisms
- [x] Tool descriptions/schemas — N/A; no tool behavior changed

## Screenshots / Logs

Focused hermetic result:

```text
Discovered 1 test files (~22 tests)
[100.0%] 23 passed, 0 failed
```