### PR TITLE
fix(providers): use chat completions for all Actual routes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -845,6 +845,10 @@ def _routed_client_kwargs(agent, fallback_model, _provider_timeout) -> Dict[str,
     _routed_client, _ = resolve_provider_client(
         agent.provider or "auto", model=agent.model, raw_codex=True)
     if _routed_client is not None:
+        from hermes_cli.providers import is_actual_route, normalize_provider
+        effective_provider = getattr(_routed_client, "_hermes_aux_effective_provider", "")
+        if is_actual_route(effective_provider):
+            agent.provider = normalize_provider(effective_provider)
         return _client_kwargs_from_routed(_routed_client, _provider_timeout)
     # No credentials: try the fallback chain BEFORE failing (an exhausted single-entry pool
     # must not die with a misleading "No LLM provider configured"); only explicitly named
@@ -929,6 +933,11 @@ def _init_openai_client(agent, api_key, base_url, fallback_model, _provider_time
         client_kwargs = _explicit_client_kwargs(agent, api_key, base_url, _provider_timeout)
     else:
         client_kwargs = _routed_client_kwargs(agent, fallback_model, _provider_timeout)
+    from hermes_cli.providers import is_actual_route
+    if is_actual_route(agent.provider, client_kwargs.get("base_url", "")):
+        agent.api_mode = "chat_completions"
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
     try:
         from agent.bedrock_adapter import configure_bedrock_openai_client_kwargs
         configure_bedrock_openai_client_kwargs(client_kwargs, timeout=_provider_timeout)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -373,7 +373,9 @@ _EXPLICIT_API_MODES = {
 def _resolve_api_mode(agent, api_mode, provider_name, base_url):
     """Set ``agent.api_mode`` (and provider rewrites) — ordered ladder, first match wins."""
     host, url = agent._base_url_hostname, agent._base_url_lower
-    if api_mode in _EXPLICIT_API_MODES:
+    if agent.provider == "actual":
+        agent.api_mode = "chat_completions"
+    elif api_mode in _EXPLICIT_API_MODES:
         agent.api_mode = api_mode
     elif agent.provider in {"openai-codex", "xai", "xai-oauth"}:
         agent.api_mode = "codex_responses"

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -372,8 +372,9 @@ _EXPLICIT_API_MODES = {
 
 def _resolve_api_mode(agent, api_mode, provider_name, base_url):
     """Set ``agent.api_mode`` (and provider rewrites) — ordered ladder, first match wins."""
+    from hermes_cli.providers import is_actual_route
     host, url = agent._base_url_hostname, agent._base_url_lower
-    if agent.provider == "actual":
+    if is_actual_route(agent.provider, base_url):
         agent.api_mode = "chat_completions"
     elif api_mode in _EXPLICIT_API_MODES:
         agent.api_mode = api_mode
@@ -418,6 +419,7 @@ def _resolve_api_mode(agent, api_mode, provider_name, base_url):
 
 
 def _finalize_routing(agent, api_mode, credential_pool):
+    from hermes_cli.providers import is_actual_route
     # Credential-pool validation runs AFTER provider auto-detection so a pool scoped to
     # "anthropic" isn't rejected for provider=None + anthropic.com URL.
     # Regression from #63048 which placed this check before the URL-based auto-detection block above (fixed
@@ -470,6 +472,7 @@ def _finalize_routing(agent, api_mode, credential_pool):
         # upgrade for Azure (openai.azure.com), even though it looks OpenAI-compatible.
         api_mode is None
         and agent.api_mode == "chat_completions"
+        and not is_actual_route(agent.provider, agent.base_url)
         and agent.provider != "copilot-acp"
         and not _base_lower.startswith(("acp://", "acp+tcp://"))
         and not agent._is_azure_openai_url()
@@ -2243,6 +2246,10 @@ def init_agent(
     agent.skip_background_review = bool(skip_background_review)
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Effective base URL for feature detection (prompt caching, reasoning, etc.)
+    from hermes_cli.providers import is_actual_route
+    if is_actual_route(provider, base_url):
+        from hermes_cli.auth import normalize_actual_base_url
+        base_url = normalize_actual_base_url(base_url)
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -889,7 +889,8 @@ def _apply_primary_runtime_fields(agent, rt: Dict[str, Any]) -> None:
     agent.provider = rt["provider"]
     agent.requested_provider = rt.get("requested_provider", agent.provider)
     agent.base_url = rt["base_url"]           # setter updates _base_url_lower
-    agent.api_mode = rt["api_mode"]
+    from hermes_cli.providers import is_actual_route
+    agent.api_mode = "chat_completions" if is_actual_route(agent.provider, agent.base_url) else rt["api_mode"]
     if hasattr(agent, "_transport_cache"):
         agent._transport_cache.clear()
     agent.api_key = rt["api_key"]
@@ -1841,7 +1842,7 @@ def _restore_switch_snapshot(agent, snapshot: Dict[str, Any]) -> None:
 
 def _resolve_switch_destination(agent, new_model, new_provider, base_url, api_mode, capabilities, old_norm, new_norm):
     """Resolve ``(api_mode, base_url, destination_capabilities)`` for the switch target."""
-    from hermes_cli.providers import determine_api_mode
+    from hermes_cli.providers import determine_api_mode, is_actual_route
     from agent.native_compaction import resolve_native_compaction_capabilities
     from hermes_cli.models import opencode_provider_family
     # Pass model so dual-wire providers (Nous Portal anthropic/* -> Messages) resolve correctly.
@@ -1855,6 +1856,11 @@ def _resolve_switch_destination(agent, new_model, new_provider, base_url, api_mo
     effective_base_url = base_url
     if not effective_base_url and old_norm == new_norm:
         effective_base_url = getattr(agent, "base_url", "")
+    if is_actual_route(new_provider, effective_base_url):
+        api_mode = "chat_completions"
+        if effective_base_url:
+            from hermes_cli.auth import normalize_actual_base_url
+            base_url = normalize_actual_base_url(effective_base_url)
     destination_capabilities = (
         dict(capabilities)
         if isinstance(capabilities, dict)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1691,6 +1691,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # that specific path; this copy locks the contract so future transport/keepalive work can't reintroduce
     # the same class of bug.
     client_kwargs = dict(client_kwargs)
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(getattr(agent, "provider", ""))
+        if profile is not None:
+            for key, value in profile.build_client_kwargs_extras(
+                base_url=client_kwargs.get("base_url", "")
+            ).items():
+                client_kwargs.setdefault(key, value)
+    except Exception:
+        _ra().logger.debug("Provider client-kwargs hook skipped", exc_info=True)
     # The MoA virtual provider has no OpenAI wire endpoint; the facade *is* the client. Rebuild the
     # facade, never a native client (TypeError; relay re-wire).
     # Rebuilding a native OpenAI client while agent.provider == "moa" (client replacement, stream-retry pool
@@ -1703,7 +1714,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         return build_moa_facade(agent, getattr(agent, "model", None) or "default")
     ssl_ca_cert = client_kwargs.pop("ssl_ca_cert", None)
     ssl_verify_cfg = client_kwargs.pop("ssl_verify", None)
-    httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
+    httpx_verify = resolve_httpx_verify(
+        ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg,
+        base_url=str(client_kwargs.get("base_url", "")),
+    )
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
     # Provider-supplied client (registration seam): a provider whose wire protocol is not

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -936,6 +936,9 @@ def _to_openai_base_url(base_url: str) -> str:
     without it). Anthropic-only gateways keep their path.
     """
     url = str(base_url or "").strip().rstrip("/")
+    if base_url_hostname(url) == "api.actual.inc":
+        from hermes_cli.auth import normalize_actual_base_url
+        return normalize_actual_base_url(url)
     if url.endswith("/anthropic"):
         if base_url_host_matches(url, "open.bigmodel.cn") or base_url_host_matches(url, "api.z.ai"):
             rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
@@ -4469,12 +4472,32 @@ def _log_once_debug(seen: set, key: Any, msg: str, *args: Any) -> None:
         logger.debug(msg, *args)
 
 
+def _is_actual_auxiliary_route(req: _ResolveRequest, base_url: str) -> bool:
+    from hermes_cli.auth import normalize_actual_base_url
+    from hermes_cli.providers import is_actual_route
+    from hermes_cli.route_identity import normalize_route_base_url
+
+    if is_actual_route(req.provider, base_url):
+        return True
+    runtime = _normalize_main_runtime(req.main_runtime)
+    return bool(
+        base_url
+        and is_actual_route(runtime.get("provider", ""), runtime.get("base_url", ""))
+        and normalize_route_base_url(normalize_actual_base_url(base_url))
+        == normalize_route_base_url(
+            normalize_actual_base_url(runtime.get("base_url", ""))
+        )
+    )
+
+
 def _wrap_transport(req: _ResolveRequest, client_obj: Any, final_model_str: str,
                     base_url_str: str = "", api_key_str: str = ""):
     """Wrap a plain OpenAI client in the right transport adapter; specialized wrappers pass through.
     Codex (Responses API): explicit ``api_mode=codex_responses``, else — with no
     explicit api_mode — api.openai.com + codex model. Anthropic (Messages): ``api_mode=anthropic_messages``,
     any ``/anthropic`` suffix, ``api.kimi.com/coding``, or ``api.anthropic.com``."""
+    if _is_actual_auxiliary_route(req, base_url_str):
+        return client_obj._real_client if isinstance(client_obj, CodexAuxiliaryClient) else client_obj
     needs_codex = not (isinstance(client_obj, CodexAuxiliaryClient) or req.raw_codex) and (
         req.api_mode == "codex_responses"
         or (not req.api_mode and base_url_hostname(base_url_str) == "api.openai.com"
@@ -4616,6 +4639,9 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
         if _main_base and _main_key:
             custom_base, custom_key = _main_base, _main_key
     if custom_base and custom_key:
+        if _is_actual_auxiliary_route(req, custom_base):
+            from hermes_cli.auth import normalize_actual_base_url
+            custom_base = normalize_actual_base_url(custom_base)
         final_model = _normalize_resolved_model(
             model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini", provider,
         )
@@ -4678,8 +4704,12 @@ def _resolve_named_custom_branch(req: _ResolveRequest) -> Optional[_ResolveResul
         logger.warning("resolve_provider_client: named custom provider %r has no resolvable "
                        "api_key — request will be sent with placeholder no-key-required "
                        "and will 401 on auth-required endpoints", custom_entry.get("name") or provider)
-    # Explicit per-task api_mode override wins over the provider entry's.
+    # Actual's wire protocol takes precedence over persisted task/provider modes.
     entry_api_mode = (req.api_mode or custom_entry.get("api_mode") or "").strip()
+    if _is_actual_auxiliary_route(req, custom_base):
+        from hermes_cli.auth import normalize_actual_base_url
+        custom_base = normalize_actual_base_url(custom_base)
+        entry_api_mode = "chat_completions"
     if not custom_base:
         logger.warning("resolve_provider_client: named custom provider %r has no base_url", provider)
         return None, None
@@ -4766,7 +4796,7 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
         return None, None
     base_url = _to_openai_base_url(raw_base_url)
     # Explicit base_url override: a fallback_model/custom_providers entry pointing a built-in name elsewhere.
-    if req.explicit_base_url:
+    if req.explicit_base_url and provider != "actual":
         base_url = _to_openai_base_url(req.explicit_base_url.strip().rstrip("/"))
     final_model = _normalize_resolved_model(req.model or _get_aux_model_for_provider(provider), provider)
     if provider == "gemini":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4472,11 +4472,11 @@ def _log_once_debug(seen: set, key: Any, msg: str, *args: Any) -> None:
 def _wrap_transport(req: _ResolveRequest, client_obj: Any, final_model_str: str,
                     base_url_str: str = "", api_key_str: str = ""):
     """Wrap a plain OpenAI client in the right transport adapter; specialized wrappers pass through.
-    Codex (Responses API): explicit ``api_mode=codex_responses`` (or provider ``actual``), else — with no
+    Codex (Responses API): explicit ``api_mode=codex_responses``, else — with no
     explicit api_mode — api.openai.com + codex model. Anthropic (Messages): ``api_mode=anthropic_messages``,
     any ``/anthropic`` suffix, ``api.kimi.com/coding``, or ``api.anthropic.com``."""
     needs_codex = not (isinstance(client_obj, CodexAuxiliaryClient) or req.raw_codex) and (
-        req.provider == "actual" or req.api_mode == "codex_responses"
+        req.api_mode == "codex_responses"
         or (not req.api_mode and base_url_hostname(base_url_str) == "api.openai.com"
             and "codex" in (final_model_str or "").lower())
     )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1449,6 +1449,15 @@ class _CodexCompletionsAdapter:
         return resp_kwargs, model, timeout
 
     def create(self, **kwargs) -> Any:
+        from hermes_cli.providers import is_actual_route
+
+        if is_actual_route(
+            getattr(self._client, "_hermes_aux_effective_provider", ""),
+            str(getattr(self._client, "base_url", "") or ""),
+        ):
+            raise ValueError(
+                "Actual requests require Chat Completions; refusing to call /responses."
+            )
         # Low-level ``responses.create(stream=True)`` and assemble the final response ourselves
         # from ``response.output_item.done``: the high-level ``responses.stream()`` rebuilds from
         # ``response.completed.response.output``, which Codex returns as ``null`` (SDK crash).
@@ -4497,11 +4506,22 @@ def _wrap_transport(req: _ResolveRequest, client_obj: Any, final_model_str: str,
     explicit api_mode — api.openai.com + codex model. Anthropic (Messages): ``api_mode=anthropic_messages``,
     any ``/anthropic`` suffix, ``api.kimi.com/coding``, or ``api.anthropic.com``."""
     if _is_actual_auxiliary_route(req, base_url_str):
-        return client_obj._real_client if isinstance(client_obj, CodexAuxiliaryClient) else client_obj
-    needs_codex = not (isinstance(client_obj, CodexAuxiliaryClient) or req.raw_codex) and (
+        client = (
+            client_obj._real_client
+            if isinstance(client_obj, CodexAuxiliaryClient)
+            else client_obj
+        )
+        client._hermes_aux_effective_provider = "actual"
+        return client
+    needs_codex = not (
+        isinstance(client_obj, CodexAuxiliaryClient) or req.raw_codex
+    ) and (
         req.api_mode == "codex_responses"
-        or (not req.api_mode and base_url_hostname(base_url_str) == "api.openai.com"
-            and "codex" in (final_model_str or "").lower())
+        or (
+            not req.api_mode
+            and base_url_hostname(base_url_str) == "api.openai.com"
+            and "codex" in (final_model_str or "").lower()
+        )
     )
     if needs_codex:
         logger.debug("resolve_provider_client: wrapping client in CodexAuxiliaryClient "

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1872,7 +1872,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 logger.warning("Could not normalize fallback model %r for provider %r: %s", fb_model, fb_provider, _norm_err)
 
             fb_base_url = str(fb_client.base_url)
-            if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
+            from hermes_cli.providers import is_actual_route
+            if is_actual_route(fb_provider, fb_base_url):
+                fb_api_mode = "chat_completions"
+            elif not fb_api_mode_explicit and fb_api_mode == "chat_completions":
                 fb_api_mode = _fallback_api_mode_resolved(agent, fb_provider, fb_model, fb_base_url)
 
             old_model, old_provider, old_base_url = agent.model, agent.provider, agent.base_url

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -677,7 +677,12 @@ class ClientLifecycleMixin:
             env_url = get_env_prefer_dotenv(url_var).strip().rstrip("/") if url_var else ""
             default_base = (pconfig.inference_base_url or "").strip().rstrip("/")
             base_url = env_url or default_base
-            if self.provider in ("kimi-coding", "zai"):
+            if self.provider == "actual":
+                from hermes_cli.auth import normalize_actual_base_url
+                from hermes_cli.runtime_provider import _config_base_url_for_provider, _get_model_config
+                configured_base = _config_base_url_for_provider(_get_model_config(), "actual")
+                base_url = normalize_actual_base_url(configured_base or base_url)
+            elif self.provider in ("kimi-coding", "zai"):
                 from hermes_cli import auth as _auth
                 resolver = _auth._resolve_kimi_base_url if self.provider == "kimi-coding" else _auth._resolve_zai_base_url
                 base_url = resolver(api_key, pconfig.inference_base_url, env_url).rstrip("/")

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -915,6 +915,13 @@ class ClientLifecycleMixin:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        from hermes_cli.providers import is_actual_route
+        if is_actual_route(getattr(self, "provider", ""), runtime_base):
+            from hermes_cli.auth import normalize_actual_base_url
+            runtime_base = normalize_actual_base_url(runtime_base)
+            self.api_mode = "chat_completions"
+            if hasattr(self, "_transport_cache"):
+                self._transport_cache.clear()
         self._credential_pool_entry_id = getattr(entry, "id", None)
         from hermes_cli.route_identity import normalize_route_base_url
         route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(runtime_base)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -918,6 +918,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         return bool(agent._interrupt_requested)
 
     def _open_codex_stream(next_api_kwargs: dict[str, Any]):
+        from hermes_cli.providers import is_actual_route
+
+        if is_actual_route(
+            getattr(agent, "provider", ""),
+            str(getattr(active_client, "base_url", "") or ""),
+        ):
+            raise ValueError(
+                "Actual requests require Chat Completions; refusing to call /responses."
+            )
         stream_kwargs = _sanitize_consumer_codex_request(agent, next_api_kwargs)
         stream_kwargs["stream"] = True
         return active_client.responses.create(**_bypass_sdk_request_transform(stream_kwargs))

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
+    CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
     XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort, is_astra_model,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
@@ -221,8 +221,6 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
 
         # Grok 4.6 accepts xhigh; older Grok tops out at high.
         supported = XAI_GROK46_EFFORTS if is_grok_46_family(model) else XAI_LEGACY_EFFORTS
-    elif (params.get("provider") or "").strip().lower() == "actual":
-        supported = ACTUAL_RELAY_EFFORTS
     else:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
         if declared is not None and not declared:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -128,7 +128,7 @@ def is_actual_local_base_url(base_url: str) -> bool:
 
 def normalize_actual_base_url(base_url: str) -> str:
     """Return Actual's OpenAI-compatible base URL (hosted api.actual.inc or the loopback local server;
-    both expose a /v1 surface for the Responses transport)."""
+    both expose a /v1 surface for the selected OpenAI-compatible transport)."""
     url = str(base_url or "").strip().rstrip("/")
     if not url:
         return DEFAULT_ACTUAL_BASE_URL
@@ -1794,6 +1794,14 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
 
 
 def _provider_env_base_url(pconfig: ProviderConfig) -> str:
+    if pconfig.id == "actual":
+        from hermes_cli.providers import normalize_provider
+
+        model = read_raw_config().get("model")
+        if isinstance(model, dict) and normalize_provider(str(model.get("provider") or "")) == "actual":
+            configured_url = str(model.get("base_url") or "").strip()
+            if configured_url:
+                return configured_url
     return os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2456,9 +2456,6 @@ OPTIONAL_ENV_VARS = {
     "GMI_BASE_URL": _base_url("GMI Cloud"),
     "ACTUAL_API_KEY": _prov("Actual Computer inference key (ac_...)",
         "Actual Computer inference key", "https://actual.inc/user/keys"),
-    "ACTUAL_BASE_URL": _prov(
-        "Actual Computer base URL override (set to http://127.0.0.1:8080 for the local offline "
-        "daemon)", "Actual Computer base URL (leave empty for hosted relay)", None, password=False),
     "FIREWORKS_API_KEY": _prov("Fireworks AI API key", "Fireworks AI API key",
         "https://app.fireworks.ai/settings/users/api-keys"),
     "MINIMAX_API_KEY": _prov("MiniMax API key (international)", "MiniMax API key",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -141,6 +141,7 @@ def _run_and_exit_oneshot(
     skills: object = None,
     usage_file: object = None,
     resume: object = None,
+    reasoning: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -153,6 +154,7 @@ def _run_and_exit_oneshot(
             skills=skills,
             usage_file=usage_file,
             resume=resume,
+            reasoning=reasoning,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -2915,6 +2917,7 @@ def _run_oneshot_from_args(args) -> None:
         skills=getattr(args, "skills", None),
         usage_file=getattr(args, "usage_file", None),
         resume=getattr(args, "resume", None),
+        reasoning=getattr(args, "reasoning", None),
     )
 
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -32,7 +32,7 @@ def _env_base_url(base_url_env: str) -> str:
     return get_env_value(base_url_env) or os.getenv(base_url_env, "")
 
 
-def _prompt_base_url_override(effective_base: str, base_url_env: str) -> str:
+def _prompt_base_url_override(effective_base: str, base_url_env: str, *, persist_env: bool = True) -> str:
     """Optional ``Base URL [...]`` prompt; a valid override is saved to *base_url_env*."""
     from hermes_cli.config import save_env_value
     override = _ask(f"Base URL [{effective_base}]: ", cancel_msg="", on_cancel="")
@@ -40,7 +40,8 @@ def _prompt_base_url_override(effective_base: str, base_url_env: str) -> str:
         if not override.startswith(_HTTP):
             print("  Invalid URL — must start with http:// or https://. Keeping current value.")
         else:
-            save_env_value(base_url_env, override)
+            if persist_env:
+                save_env_value(base_url_env, override)
             return override
     return effective_base
 
@@ -931,6 +932,11 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
                 current_base = str(_m.get("base_url") or "").strip()
     effective_base = current_base or pconfig.inference_base_url
 
+    if provider_id == "actual":
+        model_cfg = config.get("model") or {}
+        if isinstance(model_cfg, dict) and model_cfg.get("provider") == provider_id:
+            effective_base = str(model_cfg.get("base_url") or "").strip() or effective_base
+
     if provider_id == "zai":
         # Four official endpoints with separate billing paths — a picker lets users match
         # the endpoint to their key type.
@@ -939,7 +945,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             save_env_value(base_url_env, chosen_base)
         effective_base = chosen_base
     else:
-        effective_base = _prompt_base_url_override(effective_base, base_url_env)
+        effective_base = _prompt_base_url_override(effective_base, base_url_env, persist_env=provider_id != "actual")
 
     model_list = _api_key_provider_model_list(provider_id, pconfig, existing_key, key_env, effective_base)
     if is_opencode:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -933,8 +933,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     effective_base = current_base or pconfig.inference_base_url
 
     if provider_id == "actual":
+        from hermes_cli.providers import normalize_provider
         model_cfg = config.get("model") or {}
-        if isinstance(model_cfg, dict) and model_cfg.get("provider") == provider_id:
+        if isinstance(model_cfg, dict) and normalize_provider(str(model_cfg.get("provider") or "")) == provider_id:
             effective_base = str(model_cfg.get("base_url") or "").strip() or effective_base
 
     if provider_id == "zai":

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1344,7 +1344,8 @@ def _resolve_switch_credentials(st: _Switch) -> Optional[ModelSwitchResult]:
     # Fills an empty mode (alias cleared it) and overrides a STALE mode carried from previous
     # session state when the host mandates one wire protocol (e.g. gpt-5.x on api.openai.com
     # would otherwise 400 on tools+reasoning).
-    mandated_mode = host_mandated_api_mode(st.base_url)
+    from hermes_cli.providers import is_actual_route
+    mandated_mode = "chat_completions" if is_actual_route(st.target_provider, st.base_url) else host_mandated_api_mode(st.base_url)
     if mandated_mode is not None:
         st.api_mode = mandated_mode
     st.api_mode = st.api_mode or determine_api_mode(st.target_provider, st.base_url)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -168,6 +168,7 @@ def run_oneshot(
     skills: object = None,
     usage_file: Optional[str] = None,
     resume: Optional[str] = None,
+    reasoning: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -223,6 +224,7 @@ def run_oneshot(
                 use_config_toolsets=use_config_toolsets,
                 skills=skills,
                 resume=resume,
+                reasoning=reasoning,
             )
         except BaseException as exc:  # noqa: BLE001
             # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
@@ -413,6 +415,7 @@ def _run_agent(
     use_config_toolsets: bool = True,
     skills: object = None,
     resume: Optional[str] = None,
+    reasoning: object = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn, run one conversation, and return
     ``(final_response, run_result)``. Imports are local to keep CLI startup cheap."""
@@ -437,6 +440,16 @@ def _run_agent(
     )
     if choice.api_mode:
         runtime["api_mode"] = choice.api_mode
+
+    from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+    reasoning_config = resolve_reasoning_config(cfg, choice.model)
+    if reasoning is not None and str(reasoning).strip():
+        parsed_reasoning = parse_reasoning_effort(reasoning)
+        if parsed_reasoning is None:
+            logging.warning("Unknown --reasoning '%s', keeping the configured level", reasoning)
+        else:
+            reasoning_config = parsed_reasoning
 
     # sorted() gives stable ordering for config-derived sets; explicit values preserve user order.
     toolsets_list = _normalize_toolsets(toolsets)
@@ -474,6 +487,7 @@ def _run_agent(
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
+            reasoning_config=reasoning_config,
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -167,6 +167,14 @@ def normalize_provider(name: str) -> str:
     return ALIASES.get(key, key)
 
 
+def is_actual_route(provider: str = "", base_url: str = "") -> bool:
+    """Identify Actual by provider/alias or its hosted endpoint, including custom routes."""
+    return (
+        normalize_provider(provider or "") == "actual"
+        or base_url_hostname(base_url) == "api.actual.inc"
+    )
+
+
 def _models_dev_info(canonical: str, allow_network: bool = True):
     """models.dev entry or None. Single-arg call on the default path: test sites monkeypatch
     ``get_provider_info`` with single-arg lambdas."""
@@ -289,6 +297,8 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
         return None
     url_lower = base_url.rstrip("/").lower()
     hostname = base_url_hostname(base_url)
+    if hostname == "api.actual.inc":
+        return "chat_completions"
     # Exact-hostname matching only — never bare substring — so lookalike hosts
     # (api.openai.com.attacker.test) and path-segment spoofs (proxy.test/api.openai.com/v1) are NOT treated
     # as the real endpoint. (#32243)
@@ -343,6 +353,8 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     """API mode (wire protocol) for a provider/endpoint: host-mandated mode, then Nous dual-wire
     (model-derived — the overlay alone says openai_chat and would pin Claude on the wrong wire),
     then the known provider's transport, then bedrock, else ``chat_completions``."""
+    if is_actual_route(provider, base_url):
+        return "chat_completions"
     mandated = host_mandated_api_mode(base_url)
     if mandated is not None:
         return mandated

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -75,7 +75,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
                          base_url_env_var="GMI_BASE_URL"),
     "fireworks": HermesOverlay(extra_env_vars=("FIREWORKS_API_KEY",),
                                base_url_override="https://api.fireworks.ai/inference/v1"),
-    "actual": HermesOverlay(transport="codex_responses", extra_env_vars=("ACTUAL_API_KEY", "ACTUAL_BASE_URL"),
+    "actual": HermesOverlay(transport="chat_completions", extra_env_vars=("ACTUAL_API_KEY",),
                             base_url_override="https://api.actual.inc/v1", base_url_env_var="ACTUAL_BASE_URL"),
     "upstage": HermesOverlay(extra_env_vars=("UPSTAGE_API_KEY",), base_url_override="https://api.upstage.ai/v1",
                              base_url_env_var="UPSTAGE_BASE_URL"),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -32,7 +32,7 @@ from hermes_cli.auth import (  # resolve_external_process_provider_credentials i
 from hermes_cli import config as _config_mod
 from hermes_cli import models as _models  # attribute access keeps ``hermes_cli.models.<name>`` patches effective
 from hermes_constants import OPENROUTER_BASE_URL
-from hermes_cli.providers import determine_api_mode, is_official_openai_host, nous_api_mode
+from hermes_cli.providers import determine_api_mode, is_actual_route, is_official_openai_host, nous_api_mode
 from utils import base_url_host_matches, base_url_hostname, env_int
 
 
@@ -91,7 +91,7 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
 # so the runtime resolver stays in lockstep: api.meta.ai — prompt caching only on Responses;
 # api.router.com — /v1/chat/completions is a minimal shim; api.anthropic.com — native Messages.
 _HOST_MANDATED_API_MODES = {
-    "api.x.ai": "codex_responses", "api.meta.ai": "codex_responses", "api.actual.inc": "codex_responses",
+    "api.x.ai": "codex_responses", "api.meta.ai": "codex_responses", "api.actual.inc": "chat_completions",
     "api.router.com": "codex_responses", "api.anthropic.com": "anthropic_messages",
 }
 
@@ -144,12 +144,16 @@ def _fallback_api_mode(provider: str, base_url: str, model: str = "") -> str:
     first, then the transport the provider overlay declares via ``providers.determine_api_mode``
     (``openai-api`` pointed at us.api.openai.com 400'd on every tool call without it), then
     ``chat_completions``."""
+    if is_actual_route(provider, base_url):
+        return "chat_completions"
     return _detect_api_mode_for_url(base_url) or determine_api_mode(provider, base_url, model) or "chat_completions"
 
 
 def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> str:
     """api_mode for legacy/plain ``provider: custom`` endpoints — conservative by default: only
     direct OpenAI/xAI/Meta URLs imply Responses; named custom providers opt in via ``api_mode``."""
+    if is_actual_route(base_url=base_url):
+        return "chat_completions"
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     detected_mode = _detect_api_mode_for_url(base_url)
     if configured_mode == "codex_responses" and detected_mode != "codex_responses":
@@ -247,6 +251,9 @@ _NO_ANTHROPIC_CREDENTIALS_MSG = ("No Anthropic credentials found. Set ANTHROPIC_
 
 def _runtime(provider: str, api_mode: str, base_url: Any, api_key: Any, **extra: Any) -> Dict[str, Any]:
     """Build a resolved-runtime dict; ``extra`` carries source/requested_provider/provider-specific keys."""
+    if is_actual_route(provider, base_url):
+        api_mode = "chat_completions"
+        base_url = normalize_actual_base_url(base_url)
     return {"provider": provider, "api_mode": api_mode, "base_url": base_url, "api_key": api_key, **extra}
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -206,6 +206,11 @@ def _configured_or_fallback_api_mode(provider: str, model_cfg: Dict[str, Any], b
     """Persisted ``model.api_mode`` when it belongs to this provider, else URL/transport fallback.
     OpenCode Zen/Go serve both anthropic_messages and chat_completions models, so (when
     ``opencode_by_model``) their mode is always re-derived from the effective model."""
+    if provider == "actual":
+        configured_mode = _configured_api_mode(provider, model_cfg)
+        if configured_mode and configured_mode != "chat_completions":
+            logger.info("Routing built-in Actual through chat_completions instead of persisted api_mode=%s", configured_mode)
+        return "chat_completions"
     if opencode_by_model and _models.opencode_provider_family(provider) is not None:
         return _models.opencode_model_api_mode(provider, effective_model)
     return _configured_api_mode(provider, model_cfg) or _fallback_api_mode(provider, base_url, effective_model)
@@ -216,7 +221,7 @@ def _api_key_provider_api_mode(provider: str, model_cfg: Dict[str, Any], api_key
     """api_mode for a registry ``api_key`` provider (explicit and env/config paths)."""
     if provider == "copilot":
         return _copilot_runtime_api_mode(model_cfg, api_key, target_model=effective_model)
-    if provider in ("xai", "actual"):
+    if provider == "xai":
         # Ramp Router: Responses-native host — /v1/chat/completions is only a minimal compatibility shim,
         # while reasoning and caching support live on /v1/responses (docs.router.com/api/endpoint). Mirrors
         # the host_mandated_api_mode clause in hermes_cli/providers.py so the runtime resolver stays in
@@ -252,7 +257,10 @@ def _cfg_provider(model_cfg: Dict[str, Any]) -> str:
 def _config_base_url_for_provider(model_cfg: Dict[str, Any], provider: str) -> str:
     """``model.base_url`` (stripped, no trailing slash) only when ``model.provider`` is
     ``provider`` — a stale base_url must not leak into another provider."""
-    return str(model_cfg.get("base_url") or "").strip().rstrip("/") if _cfg_provider(model_cfg) == provider else ""
+    configured_provider = _cfg_provider(model_cfg)
+    if provider == "actual":
+        configured_provider = _models.normalize_provider(configured_provider)
+    return str(model_cfg.get("base_url") or "").strip().rstrip("/") if configured_provider == provider else ""
 
 
 def _anthropic_base_url_override_ok(base_url: str) -> bool:
@@ -337,6 +345,8 @@ def _finalize_base_url(provider: str, api_mode: str, base_url: str) -> str:
         base_url = _models.normalize_opencode_base_url(provider, api_mode, base_url)
     if provider == "lmstudio":
         base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
+    if provider == "actual":
+        base_url = normalize_actual_base_url(base_url)
     return base_url
 
 
@@ -431,6 +441,8 @@ _POOL_ENTRY_SIMPLE_MODES: Dict[str, tuple] = {
 
 def _pool_entry_mode_and_url(provider, entry, model_cfg, effective_model, base_url) -> tuple:
     """(api_mode, base_url) for a pool entry of ``provider``."""
+    if provider == "actual" and str(getattr(entry, "source", "")).startswith("env:"):
+        base_url = _config_base_url_for_provider(model_cfg, provider) or base_url
     if provider in _POOL_ENTRY_SIMPLE_MODES:
         api_mode, default_url = _POOL_ENTRY_SIMPLE_MODES[provider]
         return api_mode, base_url or (default_url() if callable(default_url) else default_url)
@@ -570,7 +582,10 @@ def _actual_url(provider: str, base_url: str) -> str:
 
 def _explicit_api_key_provider(provider, pconfig, requested_provider, model_cfg, api_key, base_url, target_model):
     if not base_url:
-        if provider in {"kimi-coding", "kimi-coding-cn"}:
+        if provider == "actual":
+            base_url = (_config_base_url_for_provider(model_cfg, provider)
+                        or resolve_api_key_provider_credentials(provider).get("base_url", ""))
+        elif provider in {"kimi-coding", "kimi-coding-cn"}:
             base_url = resolve_api_key_provider_credentials(provider).get("base_url", "").rstrip("/")
         else:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/") if pconfig.base_url_env_var else ""

--- a/plugins/model-providers/actual/__init__.py
+++ b/plugins/model-providers/actual/__init__.py
@@ -1,6 +1,9 @@
 """Actual Computer provider profile."""
 
 import os
+import sys
+from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -10,24 +13,85 @@ DEFAULT_ACTUAL_BASE_URL = "https://api.actual.inc/v1"
 
 class ActualProfile(ProviderProfile):
     """Actual Computer: hosted at api.actual.inc; local (offline-mode client)
-    inference opted into via ACTUAL_BASE_URL."""
+    inference opted into via model.base_url in config.yaml."""
+
+    def build_client_kwargs_extras(self, **context: Any) -> dict[str, Any]:
+        base_url = str(context.get("base_url") or self.base_url or "")
+        try:
+            hostname = (urlparse(base_url).hostname or "").lower().rstrip(".")
+        except ValueError:
+            return {}
+        if sys.platform != "darwin" or hostname != "api.actual.inc":
+            return {}
+        if any(
+            os.getenv(key)
+            for key in (
+                "HERMES_CA_BUNDLE",
+                "SSL_CERT_FILE",
+                "REQUESTS_CA_BUNDLE",
+                "CURL_CA_BUNDLE",
+            )
+        ):
+            return {}
+        import certifi
+
+        return {"ssl_ca_cert": certifi.where()}
+
+    def supported_reasoning_efforts(self, model: str | None) -> tuple[str, ...] | None:
+        from agent.reasoning_effort import ACTUAL_RELAY_EFFORTS
+
+        return ACTUAL_RELAY_EFFORTS
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+        from agent.reasoning_effort import clamp_effort, requested_effort
+
+        enabled = reasoning_config.get("enabled") is not False
+        if str(reasoning_config.get("effort") or "").strip().lower() == "none":
+            enabled = False
+        extra_body = {"thinking": {"type": "enabled" if enabled else "disabled"}}
+        top_level: dict[str, Any] = {}
+        effort = requested_effort(reasoning_config)
+        if effort is not None:
+            supported = self.supported_reasoning_efforts(context.get("model"))
+            clamped = clamp_effort(effort, supported)
+            if clamped in (supported or ()):
+                top_level["reasoning_effort"] = clamped
+        return extra_body, top_level
 
     def fetch_models(
-        self, *, api_key: str | None = None, base_url: str | None = None, timeout: float = 8.0
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
     ) -> list[str] | None:
-        """ACTUAL_BASE_URL wins over the caller's base_url; bare hosts get ``/v1`` appended."""
-        from hermes_cli.auth import normalize_actual_base_url
+        """Use the selected route, then config.yaml, then the legacy environment override."""
+        from hermes_cli.auth import (
+            normalize_actual_base_url,
+            resolve_api_key_provider_credentials,
+        )
 
-        base_url = normalize_actual_base_url(os.getenv("ACTUAL_BASE_URL", "").strip() or base_url or self.base_url)
+        base_url = normalize_actual_base_url(
+            base_url or resolve_api_key_provider_credentials("actual")["base_url"]
+        )
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 
 
 actual = ActualProfile(
-    name="actual", aliases=("actual-computer", "actualcomputer", "aci"), display_name="Actual Computer",
+    name="actual",
+    aliases=("actual-computer", "actualcomputer", "aci"),
+    display_name="Actual Computer",
     description="Actual Computer - hosted inference via api.actual.inc, or local "
-        "offline inference via ACTUAL_BASE_URL",
-    signup_url="https://actual.inc", env_vars=("ACTUAL_API_KEY", "ACTUAL_BASE_URL"),
-    base_url=DEFAULT_ACTUAL_BASE_URL, auth_type="api_key", api_mode="codex_responses",
+    "offline inference via model.base_url in config.yaml",
+    signup_url="https://actual.inc",
+    env_vars=("ACTUAL_API_KEY",),
+    base_url=DEFAULT_ACTUAL_BASE_URL,
+    auth_type="api_key",
+    api_mode="chat_completions",
 )
 
 register_provider(actual)

--- a/providers/base.py
+++ b/providers/base.py
@@ -178,6 +178,14 @@ class ProviderProfile:
         """
         return {}, {}
 
+    def build_client_kwargs_extras(self, **context: Any) -> dict[str, Any]:
+        """Provider-specific OpenAI client keyword arguments.
+
+        Values are defaults: explicit runtime/custom-provider settings win.
+        The returned mapping must be cheap to build and must not perform I/O.
+        """
+        return {}
+
     def default_vision_model(self) -> str | None:
         """Return a default vision model id for this provider, or None.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -636,10 +636,11 @@ class AIAgent(
     @staticmethod
     def _provider_model_requires_responses_api(model: str, *, provider: Optional[str] = None) -> bool:
         """Return True when this provider/model pair should use Responses API."""
+        from hermes_cli.providers import is_actual_route
         normalized_provider = (provider or "").strip().lower()
         # Nous serves GPT-5.x via chat completions (its /v1/responses returns 404); generic custom endpoints
         # may relay GPT-5 without full Responses semantics — only direct OpenAI/xAI URLs auto-upgrade.
-        if normalized_provider in ("nous", "custom", "actual"):
+        if normalized_provider in ("nous", "custom") or is_actual_route(provider):
             return False
         if normalized_provider == "copilot":
             try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -639,7 +639,7 @@ class AIAgent(
         normalized_provider = (provider or "").strip().lower()
         # Nous serves GPT-5.x via chat completions (its /v1/responses returns 404); generic custom endpoints
         # may relay GPT-5 without full Responses semantics — only direct OpenAI/xAI URLs auto-upgrade.
-        if normalized_provider in ("nous", "custom"):
+        if normalized_provider in ("nous", "custom", "actual"):
             return False
         if normalized_provider == "copilot":
             try:

--- a/tests/agent/test_actual_auxiliary_routing.py
+++ b/tests/agent/test_actual_auxiliary_routing.py
@@ -232,7 +232,17 @@ def test_actual_background_tasks_reach_chat_completions(
     ],
 )
 @pytest.mark.parametrize(
-    "entrypoint", ["init", "auto", "switch", "fallback", "restore", "rotation"]
+    "entrypoint",
+    [
+        "init",
+        "auto",
+        "switch",
+        "fallback",
+        "restore",
+        "rotation",
+        "init_fallback",
+        "init_auto",
+    ],
 )
 def test_actual_runtime_transitions_reach_chat_completions(
     tmp_path, monkeypatch, actual_endpoint, provider, hosted, entrypoint
@@ -266,12 +276,20 @@ def test_actual_runtime_transitions_reach_chat_completions(
     (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
     runtime = resolve_runtime_provider(requested=provider)
     assert runtime["api_mode"] == "chat_completions"
+    initial_base = base_url.removesuffix("/v1")
+    initial_provider = provider
+    initial_key = "actual-test-key"
+    if entrypoint in {"init_fallback", "init_auto"}:
+        initial_base = initial_key = None
+        initial_provider = (
+            "missing-provider" if entrypoint == "init_fallback" else "auto"
+        )
+    elif entrypoint == "rotation":
+        initial_base = base_url.replace("api.actual.inc", "127.0.0.1")
     agent = AIAgent(
-        provider=provider,
-        base_url=base_url.replace("api.actual.inc", "127.0.0.1")
-        if entrypoint == "rotation"
-        else base_url.removesuffix("/v1"),
-        api_key="actual-test-key",
+        provider=initial_provider,
+        base_url=initial_base,
+        api_key=initial_key,
         api_mode=None if entrypoint == "auto" else "codex_responses",
         model="primary-model" if entrypoint == "fallback" else "gpt-5.4",
         enabled_toolsets=[],
@@ -386,7 +404,10 @@ def test_actual_auxiliary_fallback_reaches_chat_completions(
 
 
 @pytest.mark.parametrize("override", ["", "http://127.0.0.1:8081", "invalid-url"])
-def test_actual_setup_keeps_provider_settings_in_yaml(tmp_path, monkeypatch, override):
+@pytest.mark.parametrize("configured_provider", ["actual", "aci"])
+def test_actual_setup_keeps_provider_settings_in_yaml(
+    tmp_path, monkeypatch, override, configured_provider
+):
     from hermes_cli import config as config_module
     from hermes_cli import model_setup_flows as setup
     from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -399,7 +420,7 @@ def test_actual_setup_keeps_provider_settings_in_yaml(tmp_path, monkeypatch, ove
     configured_url = "http://127.0.0.1:8080"
     raw = {
         "model": {
-            "provider": "actual",
+            "provider": configured_provider,
             "default": "old-model",
             "base_url": configured_url,
         }
@@ -435,3 +456,47 @@ def test_actual_setup_keeps_provider_settings_in_yaml(tmp_path, monkeypatch, ove
         runtime = resolve_runtime_provider(requested="actual", **kwargs)
         assert runtime["base_url"] == expected_url + "/v1"
         assert runtime["api_mode"] == "chat_completions"
+
+
+def test_actual_key_reload_keeps_yaml_endpoint(tmp_path, monkeypatch, actual_endpoint):
+    from run_agent import AIAgent
+
+    base_url, requests = actual_endpoint
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    monkeypatch.setenv("ACTUAL_BASE_URL", "http://127.0.0.1:1")
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({
+            "model": {"provider": "aci", "default": "test-model", "base_url": base_url},
+        }),
+        encoding="utf-8",
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_text("ACTUAL_API_KEY=actual-test-key\n", encoding="utf-8")
+    agent = AIAgent(
+        provider="actual",
+        base_url=base_url,
+        api_key="actual-test-key",
+        model="test-model",
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+    )
+    try:
+        assert not agent._try_refresh_env_client_credentials()
+        env_path.write_text("ACTUAL_API_KEY=actual-rotated-key\n", encoding="utf-8")
+        assert agent._try_refresh_env_client_credentials()
+        assert agent.api_key == "actual-rotated-key"
+        assert agent.base_url == base_url + "/v1"
+        assert agent.api_mode == "chat_completions"
+        response = agent._interruptible_api_call(
+            agent._build_api_kwargs([{"role": "user", "content": "Reply briefly."}], [])
+        )
+        assert response.choices[0].message.content == "The task is complete."
+        assert [
+            path for path, body in requests if body.get("model") == "test-model"
+        ] == ["/v1/chat/completions"]
+    finally:
+        agent.client.close()

--- a/tests/agent/test_actual_auxiliary_routing.py
+++ b/tests/agent/test_actual_auxiliary_routing.py
@@ -3,6 +3,7 @@
 import asyncio
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import socket
 import threading
 import time
 
@@ -11,8 +12,24 @@ import yaml
 
 
 @pytest.fixture
-def actual_endpoint():
+def actual_endpoint(monkeypatch):
+    from agent.auxiliary_client import (
+        shutdown_cached_clients,
+        _reset_aux_unhealthy_cache,
+    )
+
+    shutdown_cached_clients()
+    _reset_aux_unhealthy_cache()
     requests = []
+    resolve_address = socket.getaddrinfo
+
+    def local_actual_address(host, *args, **kwargs):
+        if host in ("api.actual.inc", b"api.actual.inc"):
+            host = "127.0.0.1"
+        return resolve_address(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", local_actual_address)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost,api.actual.inc")
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self):
@@ -20,6 +37,20 @@ def actual_endpoint():
             requests.append((self.path, payload))
             if self.path != "/v1/chat/completions":
                 self.send_error(404)
+                return
+            if payload["model"] == "unavailable-model":
+                body = json.dumps({
+                    "error": {
+                        "message": "The model is not supported with this account",
+                        "type": "invalid_request_error",
+                        "code": "unsupported_model",
+                    }
+                }).encode()
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
                 return
             content = (
                 '{"title":"Actual background routing"}'
@@ -62,20 +93,43 @@ def actual_endpoint():
             pass
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread = threading.Thread(
+        target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+    )
     thread.start()
     try:
         yield f"http://127.0.0.1:{server.server_port}", requests
     finally:
+        shutdown_cached_clients()
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
 
 
-@pytest.mark.parametrize("aux_provider", ["auto", "actual", "aci", "custom"])
-@pytest.mark.parametrize("use_api_key", [False, True])
+@pytest.mark.parametrize(
+    "aux_provider",
+    [
+        "auto",
+        "actual",
+        "actual-computer",
+        "actualcomputer",
+        "aci",
+        "custom",
+        "custom:actual-relay",
+    ],
+)
+@pytest.mark.parametrize(
+    "hosted,use_api_key", [(False, False), (False, True), (True, True)]
+)
+@pytest.mark.parametrize("stale_mode", [None, "codex_responses"])
 def test_actual_background_tasks_reach_chat_completions(
-    tmp_path, monkeypatch, actual_endpoint, aux_provider, use_api_key
+    tmp_path,
+    monkeypatch,
+    actual_endpoint,
+    aux_provider,
+    hosted,
+    use_api_key,
+    stale_mode,
 ):
     from agent.auxiliary_client import async_call_llm
     from agent.context_compressor import ContextCompressor
@@ -83,11 +137,13 @@ def test_actual_background_tasks_reach_chat_completions(
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     base_url, requests = actual_endpoint
+    if hosted:
+        base_url = base_url.replace("127.0.0.1", "api.actual.inc")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     if use_api_key:
         monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
         monkeypatch.setenv("ACTUAL_BASE_URL", "http://127.0.0.1:1")
-    aux_model = "override-model" if aux_provider == "custom" else "test-model"
+    aux_model = "override-model" if aux_provider.startswith("custom") else "test-model"
     config = {
         "model": {
             "provider": "aci" if aux_provider == "aci" else "actual",
@@ -98,7 +154,12 @@ def test_actual_background_tasks_reach_chat_completions(
             task: {
                 "provider": aux_provider,
                 "model": aux_model,
-                **({"base_url": base_url + "/v1"} if aux_provider == "custom" else {}),
+                "api_mode": stale_mode,
+                **(
+                    {"base_url": base_url if stale_mode else base_url + "/v1"}
+                    if aux_provider == "custom"
+                    else {}
+                ),
             }
             for task in (
                 "compression",
@@ -107,10 +168,19 @@ def test_actual_background_tasks_reach_chat_completions(
             )
         },
     }
+    config["providers"] = {
+        "actual-relay": {
+            "base_url": base_url if stale_mode else base_url + "/v1",
+            "key_env": "ACTUAL_API_KEY",
+            "transport": stale_mode or "chat_completions",
+        }
+    }
     (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
     runtime = resolve_runtime_provider(requested="actual")
     runtime["model"] = "test-model"
     assert runtime["api_mode"] == "chat_completions"
+    if stale_mode:
+        runtime["api_mode"] = stale_mode
     assert (
         generate_title(
             "Stale conversation", main_runtime=runtime, runtime_validator=lambda: False
@@ -145,10 +215,174 @@ def test_actual_background_tasks_reach_chat_completions(
     )
     assert response.choices[0].message.content == "The task is complete."
     assert len(requests) == 3
-    assert all(
-        path == "/v1/chat/completions" and payload["model"] == aux_model
-        for path, payload in requests
+    assert [(path, payload["model"]) for path, payload in requests] == [
+        ("/v1/chat/completions", aux_model)
+    ] * 3
+
+
+@pytest.mark.parametrize(
+    "provider,hosted",
+    [
+        ("actual", False),
+        ("aci", False),
+        ("actual-computer", False),
+        ("actualcomputer", False),
+        ("custom", True),
+        ("custom:actual-relay", True),
+    ],
+)
+@pytest.mark.parametrize(
+    "entrypoint", ["init", "auto", "switch", "fallback", "restore", "rotation"]
+)
+def test_actual_runtime_transitions_reach_chat_completions(
+    tmp_path, monkeypatch, actual_endpoint, provider, hosted, entrypoint
+):
+    from agent.error_classifier import FailoverReason
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from run_agent import AIAgent
+
+    base_url, requests = actual_endpoint
+    if hosted:
+        base_url = base_url.replace("127.0.0.1", "api.actual.inc")
+    base_url += "/v1"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "actual-test-key")
+    config = {
+        "model": {
+            "provider": provider,
+            "default": "gpt-5.4",
+            "base_url": base_url,
+            "api_mode": "codex_responses",
+        },
+        "providers": {
+            "actual-relay": {
+                "base_url": base_url,
+                "key_env": "ACTUAL_API_KEY",
+                "transport": "codex_responses",
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    runtime = resolve_runtime_provider(requested=provider)
+    assert runtime["api_mode"] == "chat_completions"
+    agent = AIAgent(
+        provider=provider,
+        base_url=base_url.replace("api.actual.inc", "127.0.0.1")
+        if entrypoint == "rotation"
+        else base_url.removesuffix("/v1"),
+        api_key="actual-test-key",
+        api_mode=None if entrypoint == "auto" else "codex_responses",
+        model="primary-model" if entrypoint == "fallback" else "gpt-5.4",
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        fallback_model={
+            "provider": provider,
+            "model": "gpt-5.4",
+            "base_url": base_url.removesuffix("/v1"),
+            "api_key": "actual-test-key",
+            "api_mode": "codex_responses",
+        },
     )
+    try:
+        if entrypoint == "switch":
+            agent.switch_model(
+                "gpt-5.4",
+                provider,
+                api_key="actual-test-key",
+                base_url=base_url.removesuffix("/v1"),
+                api_mode="codex_responses",
+            )
+        elif entrypoint == "fallback":
+            assert agent._try_activate_fallback(FailoverReason.rate_limit)
+        elif entrypoint == "restore":
+            agent._primary_runtime["api_mode"] = "codex_responses"
+            agent._fallback_activated = True
+            assert agent._restore_primary_runtime()
+        elif entrypoint == "rotation":
+            from agent.credential_pool import PooledCredential
+
+            agent._swap_credential(
+                PooledCredential.from_dict(
+                    provider,
+                    {
+                        "id": "rotated",
+                        "access_token": "actual-rotated-key",
+                        "base_url": base_url.removesuffix("/v1"),
+                    },
+                )
+            )
+        assert agent.api_mode == "chat_completions"
+        response = agent._interruptible_api_call(
+            agent._build_api_kwargs([{"role": "user", "content": "Reply briefly."}], [])
+        )
+        assert response.choices[0].message.content == "The task is complete."
+        inference_requests = [
+            (path, body) for path, body in requests if path != "/api/show"
+        ]
+        assert len(inference_requests) == 1
+        assert inference_requests[0][0] == "/v1/chat/completions"
+        assert inference_requests[0][1]["model"] == "gpt-5.4"
+    finally:
+        agent.client.close()
+
+
+@pytest.mark.parametrize("provider", ["actual", "aci", "custom:actual-relay"])
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_actual_auxiliary_fallback_reaches_chat_completions(
+    tmp_path, monkeypatch, actual_endpoint, provider, async_mode
+):
+    from agent.auxiliary_client import call_llm, async_call_llm
+
+    local_url, requests = actual_endpoint
+    actual_url = local_url.replace("127.0.0.1", "api.actual.inc") + "/v1"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    config = {
+        "model": {
+            "provider": "actual",
+            "default": "test-model",
+            "base_url": actual_url,
+        },
+        "providers": {
+            "actual-relay": {
+                "base_url": actual_url,
+                "key_env": "ACTUAL_API_KEY",
+                "transport": "codex_responses",
+            }
+        },
+        "auxiliary": {
+            "session_search": {
+                "provider": "custom",
+                "model": "unavailable-model",
+                "base_url": local_url + "/v1",
+                "fallback_chain": [
+                    {
+                        "provider": provider,
+                        "model": "test-model",
+                        "api_mode": "codex_responses",
+                        "base_url": actual_url,
+                    }
+                ],
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    kwargs = {
+        "task": "session_search",
+        "messages": [{"role": "user", "content": "Summarize the results."}],
+        "timeout": 5,
+    }
+    response = (
+        asyncio.run(async_call_llm(**kwargs)) if async_mode else call_llm(**kwargs)
+    )
+    assert response.choices[0].message.content == "The task is complete."
+    assert requests[0][1]["model"] == "unavailable-model"
+    assert requests[-1][1]["model"] == "test-model"
+    assert all(path == "/v1/chat/completions" for path, _payload in requests)
 
 
 @pytest.mark.parametrize("override", ["", "http://127.0.0.1:8081", "invalid-url"])

--- a/tests/agent/test_actual_auxiliary_routing.py
+++ b/tests/agent/test_actual_auxiliary_routing.py
@@ -1,0 +1,203 @@
+"""Actual background tasks exercise the same configured route as foreground chat."""
+
+import asyncio
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+import time
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def actual_endpoint():
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append((self.path, payload))
+            if self.path != "/v1/chat/completions":
+                self.send_error(404)
+                return
+            content = (
+                '{"title":"Actual background routing"}'
+                if "response_format" in payload
+                else "The task is complete."
+            )
+            response = {
+                "id": "chatcmpl-background",
+                "created": 1,
+                "model": payload["model"],
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }
+            if payload.get("stream"):
+                response["object"] = "chat.completion.chunk"
+                response["choices"][0]["delta"] = response["choices"][0].pop("message")
+                body = f"data: {json.dumps(response)}\n\ndata: [DONE]\n\n".encode()
+                content_type = "text/event-stream"
+            else:
+                body = json.dumps(response).encode()
+                content_type = "application/json"
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("aux_provider", ["auto", "actual", "aci", "custom"])
+@pytest.mark.parametrize("use_api_key", [False, True])
+def test_actual_background_tasks_reach_chat_completions(
+    tmp_path, monkeypatch, actual_endpoint, aux_provider, use_api_key
+):
+    from agent.auxiliary_client import async_call_llm
+    from agent.context_compressor import ContextCompressor
+    from agent.title_generator import generate_title
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    base_url, requests = actual_endpoint
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    if use_api_key:
+        monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+        monkeypatch.setenv("ACTUAL_BASE_URL", "http://127.0.0.1:1")
+    aux_model = "override-model" if aux_provider == "custom" else "test-model"
+    config = {
+        "model": {
+            "provider": "aci" if aux_provider == "aci" else "actual",
+            "default": "test-model",
+            "base_url": base_url,
+        },
+        "auxiliary": {
+            task: {
+                "provider": aux_provider,
+                "model": aux_model,
+                **({"base_url": base_url + "/v1"} if aux_provider == "custom" else {}),
+            }
+            for task in (
+                "compression",
+                "title_generation",
+                "session_search",
+            )
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    runtime = resolve_runtime_provider(requested="actual")
+    runtime["model"] = "test-model"
+    assert runtime["api_mode"] == "chat_completions"
+    assert (
+        generate_title(
+            "Stale conversation", main_runtime=runtime, runtime_validator=lambda: False
+        )
+        is None
+    )
+    assert requests == []
+    assert (
+        generate_title("Check the background routing", timeout=5, main_runtime=runtime)
+        == "Actual background routing"
+    )
+    compressor = ContextCompressor(
+        model=runtime["model"],
+        provider=runtime["provider"],
+        api_key=runtime["api_key"],
+        base_url=runtime["base_url"],
+        api_mode=runtime["api_mode"],
+        config_context_length=32768,
+        quiet_mode=True,
+    )
+    assert (
+        compressor._call_summary_llm("Summarize this conversation.", time.monotonic())
+        == "The task is complete."
+    )
+    response = asyncio.run(
+        async_call_llm(
+            task="session_search",
+            messages=[{"role": "user", "content": "Summarize the results."}],
+            main_runtime=runtime,
+            timeout=5,
+        )
+    )
+    assert response.choices[0].message.content == "The task is complete."
+    assert len(requests) == 3
+    assert all(
+        path == "/v1/chat/completions" and payload["model"] == aux_model
+        for path, payload in requests
+    )
+
+
+@pytest.mark.parametrize("override", ["", "http://127.0.0.1:8081", "invalid-url"])
+def test_actual_setup_keeps_provider_settings_in_yaml(tmp_path, monkeypatch, override):
+    from hermes_cli import config as config_module
+    from hermes_cli import model_setup_flows as setup
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from providers import get_provider_profile
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    monkeypatch.setenv("ACTUAL_BASE_URL", "http://127.0.0.1:8089")
+    configured_url = "http://127.0.0.1:8080"
+    raw = {
+        "model": {
+            "provider": "actual",
+            "default": "old-model",
+            "base_url": configured_url,
+        }
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    env_path = tmp_path / ".env"
+    env_path.write_text("ACTUAL_API_KEY=actual-test-key\n", encoding="utf-8")
+    monkeypatch.setattr(
+        setup,
+        "_ensure_flow_api_key",
+        lambda *_a, **_kw: ("actual-test-key", "actual-test-key", False),
+    )
+    monkeypatch.setattr(setup, "_ask", lambda *_a, **_kw: override)
+    monkeypatch.setattr(setup, "_api_key_provider_model_list", lambda *_a: [])
+    monkeypatch.setattr(setup, "_pick_model_or_prompt", lambda *_a, **_kw: "test-model")
+    setup._model_flow_api_key_provider(config_module.load_config(), "actual")
+
+    expected_url = override if override.startswith("http://") else configured_url
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"]["provider"] == "actual"
+    assert saved["model"]["base_url"] == expected_url
+    assert saved["model"]["default"] == "test-model"
+    assert env_path.read_text(encoding="utf-8") == "ACTUAL_API_KEY=actual-test-key\n"
+    assert get_provider_profile("actual").env_vars == ("ACTUAL_API_KEY",)
+    assert "ACTUAL_BASE_URL" not in config_module.OPTIONAL_ENV_VARS
+    assert "ACTUAL_API_MODE" not in config_module.OPTIONAL_ENV_VARS
+    assert (
+        resolve_api_key_provider_credentials("actual")["base_url"]
+        == expected_url + "/v1"
+    )
+    for kwargs in ({}, {"explicit_api_key": "actual-test-key"}):
+        runtime = resolve_runtime_provider(requested="actual", **kwargs)
+        assert runtime["base_url"] == expected_url + "/v1"
+        assert runtime["api_mode"] == "chat_completions"

--- a/tests/agent/test_actual_auxiliary_routing.py
+++ b/tests/agent/test_actual_auxiliary_routing.py
@@ -348,6 +348,87 @@ def test_actual_runtime_transitions_reach_chat_completions(
         agent.client.close()
 
 
+@pytest.mark.parametrize(
+    "provider,hosted",
+    [
+        ("actual", False),
+        ("aci", False),
+        ("actual-computer", False),
+        ("actualcomputer", False),
+        ("custom", True),
+        ("custom:actual-relay", True),
+    ],
+)
+@pytest.mark.parametrize("send_site", ["main", "auxiliary", "async_auxiliary"])
+def test_actual_rejects_forced_responses_before_http(
+    tmp_path, monkeypatch, actual_endpoint, provider, hosted, send_site
+):
+    from agent.auxiliary_client import (
+        AsyncCodexAuxiliaryClient,
+        CodexAuxiliaryClient,
+        resolve_provider_client,
+    )
+    from run_agent import AIAgent
+
+    base_url, requests = actual_endpoint
+    if hosted:
+        base_url = base_url.replace("127.0.0.1", "api.actual.inc")
+    base_url += "/v1"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {
+        "model": {"provider": provider, "base_url": base_url, "default": "test-model"},
+        "providers": {
+            "actual-relay": {"base_url": base_url, "transport": "codex_responses"}
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    if send_site == "main":
+        agent = AIAgent(
+            provider=provider,
+            base_url=base_url,
+            api_key="actual-test-key",
+            model="test-model",
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            save_trajectories=False,
+        )
+        client = agent.client
+        agent.api_mode = "codex_responses"
+
+        def force_responses():
+            return agent._run_codex_stream(
+                {"model": "test-model", "input": "Reply briefly."}, client=client
+            )
+
+    else:
+        client, model = resolve_provider_client(
+            provider,
+            model="test-model",
+            explicit_base_url=base_url,
+            explicit_api_key="actual-test-key",
+            api_mode="codex_responses",
+        )
+        wrapper = CodexAuxiliaryClient(client, model)
+        if send_site == "async_auxiliary":
+            wrapper = AsyncCodexAuxiliaryClient(wrapper)
+
+        def force_responses():
+            result = wrapper.chat.completions.create(
+                model=model, messages=[{"role": "user", "content": "Reply briefly."}]
+            )
+            return asyncio.run(result) if send_site == "async_auxiliary" else result
+
+    try:
+        initial_requests = list(requests)
+        with pytest.raises(ValueError, match="Actual.*Chat Completions"):
+            force_responses()
+        assert requests == initial_requests
+    finally:
+        client.close()
+
+
 @pytest.mark.parametrize("provider", ["actual", "aci", "custom:actual-relay"])
 @pytest.mark.parametrize("async_mode", [False, True])
 def test_actual_auxiliary_fallback_reaches_chat_completions(

--- a/tests/hermes_cli/test_actual_provider.py
+++ b/tests/hermes_cli/test_actual_provider.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from agent.auxiliary_client import _normalize_aux_provider
 from hermes_cli import runtime_provider as rp
@@ -27,6 +31,7 @@ from providers import get_provider_profile
 def _clear_actual_env(monkeypatch):
     monkeypatch.delenv("ACTUAL_API_KEY", raising=False)
     monkeypatch.delenv("ACTUAL_BASE_URL", raising=False)
+    monkeypatch.delenv("ACTUAL_API_MODE", raising=False)
 
 
 def test_actual_aliases_and_profile_metadata():
@@ -36,15 +41,15 @@ def test_actual_aliases_and_profile_metadata():
     assert profile.name == "actual"
     assert profile.display_name == "Actual Computer"
     assert profile.base_url == DEFAULT_ACTUAL_BASE_URL
-    assert profile.api_mode == "codex_responses"
+    assert profile.api_mode == "chat_completions"
     assert profile.auth_type == "api_key"
-    assert profile.env_vars == ("ACTUAL_API_KEY", "ACTUAL_BASE_URL")
+    assert profile.env_vars == ("ACTUAL_API_KEY",)
     assert normalize_overlay_provider("aci") == "actual"
     assert normalize_model_provider("actualcomputer") == "actual"
     assert resolve_provider("actual-computer") == "actual"
     assert _normalize_aux_provider("aci") == "actual"
     assert get_label("actual") == "Actual Computer"
-    assert determine_api_mode("actual", "https://api.actual.inc") == "codex_responses"
+    assert determine_api_mode("actual", "https://api.actual.inc") == "chat_completions"
 
 
 def test_actual_base_url_normalization():
@@ -108,9 +113,58 @@ def test_actual_runtime_uses_hosted_default(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="actual")
 
     assert resolved["provider"] == "actual"
-    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_mode"] == "chat_completions"
     assert resolved["api_key"] == "actual-test-key"
     assert resolved["base_url"] == DEFAULT_ACTUAL_BASE_URL
+
+
+def test_actual_runtime_repairs_stale_responses_mode(monkeypatch, caplog):
+    _clear_actual_env(monkeypatch)
+    caplog.set_level(logging.INFO, logger="hermes_cli.auth")
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "actual",
+            "default": "actual/test-model",
+            "api_mode": "codex_responses",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="actual")
+    explicit = rp.resolve_runtime_provider(
+        requested="actual",
+        explicit_api_key="actual-test-key",
+        explicit_base_url="https://api.actual.inc/v1",
+    )
+
+    assert resolved["api_mode"] == "chat_completions"
+    assert explicit["api_mode"] == "chat_completions"
+    assert "persisted api_mode=codex_responses" in caplog.text
+
+
+def test_actual_runtime_ignores_legacy_mode_environment(monkeypatch):
+    _clear_actual_env(monkeypatch)
+    monkeypatch.setenv("ACTUAL_API_KEY", "actual-test-key")
+    monkeypatch.setenv("ACTUAL_API_MODE", "codex_responses")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "actual", "default": "actual/test-model"},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="actual")
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def test_actual_hostname_detection_preserves_custom_responses_route():
+    base_url = "https://api.actual.inc/v1"
+
+    assert rp._detect_api_mode_for_url(base_url) == "codex_responses"
+    assert rp._fallback_api_mode("custom", base_url) == "codex_responses"
+    assert rp._resolve_plain_custom_api_mode({}, base_url) == "codex_responses"
 
 
 def test_actual_runtime_uses_local_env_without_key(monkeypatch):
@@ -125,7 +179,7 @@ def test_actual_runtime_uses_local_env_without_key(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="actual")
 
     assert resolved["provider"] == "actual"
-    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_mode"] == "chat_completions"
     assert resolved["api_key"] == ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
     assert resolved["base_url"] == DEFAULT_ACTUAL_LOCAL_BASE_URL
 
@@ -145,7 +199,7 @@ def test_actual_runtime_uses_local_config_without_key(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="actual")
 
     assert resolved["provider"] == "actual"
-    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_mode"] == "chat_completions"
     assert resolved["api_key"] == ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
     assert resolved["base_url"] == DEFAULT_ACTUAL_LOCAL_BASE_URL
 
@@ -165,7 +219,7 @@ def test_actual_runtime_normalizes_explicit_hosted_base_url(monkeypatch):
     )
 
     assert resolved["provider"] == "actual"
-    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_mode"] == "chat_completions"
     assert resolved["api_key"] == "actual-test-key"
     assert resolved["base_url"] == DEFAULT_ACTUAL_BASE_URL
     assert resolved["source"] == "explicit"
@@ -322,36 +376,448 @@ def test_actual_hosted_model_ids_do_not_probe_without_credentials(monkeypatch):
     fetch.assert_not_called()
 
 
-def test_actual_codex_transport_clamps_reasoning_effort():
-    """Actual's SGLang/vLLM backends only accept none/low/medium/high/max.
+def test_actual_profile_translates_explicit_reasoning_controls():
+    profile = get_provider_profile("actual")
 
-    A global xhigh/ultra reasoning_effort must be clamped before the wire,
-    otherwise every request fails with a wrapped HTTP 400. Regression for
-    the field-reported reasoning_effort trap.
-    """
-    from agent.transports.codex import ResponsesApiTransport
-
-    t = ResponsesApiTransport()
-    for requested, expected in (("xhigh", "high"), ("ultra", "max"), ("high", "high")):
-        kwargs = t.build_kwargs(
-            model="glm-5.2-nvfp4",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=None,
-            provider="actual",
-            reasoning_config={"effort": requested},
-            base_url=DEFAULT_ACTUAL_BASE_URL,
-        )
-        assert kwargs["reasoning"]["effort"] == expected, requested
-
-    # Other providers keep the wider values untouched on the generic path.
-    kwargs = t.build_kwargs(
-        model="some-model",
-        messages=[{"role": "user", "content": "hi"}],
-        tools=None,
-        provider="openai-codex",
-        reasoning_config={"effort": "xhigh"},
+    assert profile.build_api_kwargs_extras(reasoning_config=None) == ({}, {})
+    assert profile.supported_reasoning_efforts("zai-org/GLM-5.3") == (
+        "none",
+        "low",
+        "medium",
+        "high",
+        "max",
     )
-    assert kwargs["reasoning"]["effort"] == "xhigh"
+    for config, expected_toggle, expected_effort in (
+        ({"enabled": True, "effort": "high"}, "enabled", "high"),
+        ({"enabled": True, "effort": "xhigh"}, "enabled", "high"),
+        ({"enabled": True, "effort": "ultra"}, "enabled", "max"),
+        ({"enabled": False, "effort": "high"}, "disabled", None),
+        ({"enabled": True, "effort": "none"}, "disabled", "none"),
+    ):
+        extra_body, top_level = profile.build_api_kwargs_extras(
+            reasoning_config=config,
+            model="zai-org/GLM-5.3",
+        )
+        assert extra_body == {"thinking": {"type": expected_toggle}}
+        if expected_effort is None:
+            assert "reasoning_effort" not in top_level
+        else:
+            assert top_level["reasoning_effort"] == expected_effort
+
+
+@pytest.mark.macos_only
+def test_actual_hosted_client_uses_scoped_macos_certifi(monkeypatch):
+    import certifi
+
+    profile = get_provider_profile("actual")
+
+    assert profile.build_client_kwargs_extras(base_url=DEFAULT_ACTUAL_BASE_URL) == {
+        "ssl_ca_cert": certifi.where()
+    }
+    assert (
+        profile.build_client_kwargs_extras(base_url=DEFAULT_ACTUAL_LOCAL_BASE_URL) == {}
+    )
+
+
+@pytest.mark.macos_only
+def test_actual_client_tls_default_does_not_override_explicit_config(monkeypatch):
+    from agent.agent_runtime_helpers import create_openai_client
+
+    captured: list[dict] = []
+
+    def fake_resolve_httpx_verify(**kwargs):
+        captured.append(kwargs)
+        return "resolved-verify"
+
+    class FakeAgent:
+        provider = "actual"
+
+        @staticmethod
+        def _build_keepalive_http_client(base_url, *, verify):
+            assert base_url == DEFAULT_ACTUAL_BASE_URL
+            assert verify == "resolved-verify"
+            return "http-client"
+
+        @staticmethod
+        def _client_log_context():
+            return "test"
+
+    monkeypatch.setattr(
+        "agent.ssl_verify.resolve_httpx_verify", fake_resolve_httpx_verify
+    )
+    monkeypatch.setattr("agent.auxiliary_client._validate_proxy_env_urls", lambda: None)
+    monkeypatch.setattr("agent.auxiliary_client._validate_base_url", lambda _url: None)
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **kwargs: kwargs)
+
+    defaults = create_openai_client(
+        FakeAgent(),
+        {"api_key": "test", "base_url": DEFAULT_ACTUAL_BASE_URL},
+        reason="test",
+        shared=False,
+    )
+    explicit = create_openai_client(
+        FakeAgent(),
+        {
+            "api_key": "test",
+            "base_url": DEFAULT_ACTUAL_BASE_URL,
+            "ssl_ca_cert": "/explicit/corporate-ca.pem",
+        },
+        reason="test",
+        shared=False,
+    )
+
+    assert Path(captured[0]["ca_bundle"]).name == "cacert.pem"
+    assert captured[0]["base_url"] == DEFAULT_ACTUAL_BASE_URL
+    assert captured[1]["ca_bundle"] == "/explicit/corporate-ca.pem"
+    assert defaults["http_client"] == "http-client"
+    assert explicit["http_client"] == "http-client"
+
+
+def test_actual_oneshot_reasoning_override_reaches_agent(monkeypatch):
+    from hermes_cli import oneshot
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, _prompt, **_kwargs):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *_args):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "actual-test-key",
+            "base_url": DEFAULT_ACTUAL_BASE_URL,
+            "provider": "actual",
+            "requested_provider": "actual",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    response, _result = oneshot._run_agent(
+        "hello",
+        model="zai-org/GLM-5.3",
+        provider="actual",
+        reasoning="ultra",
+        toolsets=["terminal"],
+        use_config_toolsets=False,
+    )
+
+    assert response == "ok"
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "ultra"}
+
+
+def test_oneshot_dispatch_forwards_reasoning_override(monkeypatch):
+    from hermes_cli import main as main_mod
+    from hermes_cli import oneshot
+
+    captured = {}
+
+    def fake_run_oneshot(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return 0
+
+    class OneshotExit(Exception):
+        pass
+
+    def fake_exit(_rc):
+        raise OneshotExit
+
+    monkeypatch.setattr(oneshot, "run_oneshot", fake_run_oneshot)
+    monkeypatch.setattr(main_mod, "_cleanup_oneshot_runtime", lambda: None)
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", fake_exit)
+
+    with pytest.raises(OneshotExit):
+        main_mod._run_and_exit_oneshot(
+            "hello",
+            model="zai-org/GLM-5.3",
+            provider="actual",
+            reasoning="high",
+        )
+
+    assert captured["reasoning"] == "high"
+
+
+def test_actual_agent_side_routing_keeps_chat_completions_for_any_model():
+    from run_agent import AIAgent
+
+    for model in ("qwen3.8-27b-Q4_K_M", "zai-org/GLM-5.3", "gpt-5.4"):
+        assert not AIAgent._provider_model_requires_responses_api(
+            model,
+            provider=" Actual ",
+        )
+
+
+def test_actual_agent_init_repairs_stale_responses_mode():
+    from run_agent import AIAgent
+
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="actual-test-key",
+            base_url=DEFAULT_ACTUAL_BASE_URL,
+            provider="actual",
+            api_mode="codex_responses",
+            model="gpt-5.4",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.api_mode == "chat_completions"
+
+
+def test_actual_agent_init_ignores_legacy_mode_environment(monkeypatch):
+    from run_agent import AIAgent
+
+    _clear_actual_env(monkeypatch)
+    monkeypatch.setenv("ACTUAL_API_MODE", "codex_responses")
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="actual-test-key",
+            base_url=DEFAULT_ACTUAL_BASE_URL,
+            provider="actual",
+            api_mode="chat_completions",
+            model="zai-org/GLM-5.3",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.api_mode == "chat_completions"
+
+
+def test_actual_chat_completions_wire_replays_reasoning_through_tool_turn(
+    monkeypatch,
+):
+    import http.server
+    import threading
+
+    from openai import OpenAI
+
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    requests: list[tuple[str, dict]] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            request = json.loads(self.rfile.read(length))
+            requests.append((self.path, request))
+
+            if len(requests) == 1:
+                message = {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning": "I should call the probe tool.",
+                    "reasoning_content": "I should call the probe tool.",
+                    "tool_calls": [
+                        {
+                            "id": "call_actual_probe",
+                            "type": "function",
+                            "function": {
+                                "name": "actual_probe",
+                                "arguments": '{"value":"ok"}',
+                            },
+                        }
+                    ],
+                }
+                finish_reason = "tool_calls"
+            else:
+                message = {
+                    "role": "assistant",
+                    "content": "ACTUAL_CHAT_OK",
+                    "reasoning": "The tool result confirms the answer.",
+                    "reasoning_content": "The tool result confirms the answer.",
+                }
+                finish_reason = "stop"
+
+            body = json.dumps({
+                "id": f"chatcmpl-actual-{len(requests)}",
+                "object": "chat.completion",
+                "created": 1,
+                "model": request["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": finish_reason,
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        _clear_actual_env(monkeypatch)
+        base_url = f"http://127.0.0.1:{server.server_address[1]}/v1"
+        monkeypatch.setenv("ACTUAL_BASE_URL", base_url)
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {"provider": "actual", "default": "actual/test-model"},
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="actual")
+        profile = get_provider_profile(resolved["provider"])
+        transport = ChatCompletionsTransport()
+        client = OpenAI(
+            api_key=resolved["api_key"],
+            base_url=resolved["base_url"],
+            max_retries=0,
+        )
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "actual_probe",
+                    "description": "Return the supplied value.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                        "required": ["value"],
+                    },
+                },
+            }
+        ]
+        messages = [{"role": "user", "content": "Use actual_probe."}]
+        params = {
+            "provider_profile": profile,
+            "reasoning_config": {"enabled": True, "effort": "high"},
+            "base_url": resolved["base_url"],
+        }
+
+        first_raw = client.chat.completions.create(
+            **transport.build_kwargs(
+                model="test-model",
+                messages=messages,
+                tools=tools,
+                **params,
+            )
+        )
+        first = transport.normalize_response(first_raw)
+        assert first.reasoning == "I should call the probe tool."
+        assert first.reasoning_content == "I should call the probe tool."
+        assert first.tool_calls and first.tool_calls[0].name == "actual_probe"
+
+        tool_call = first.tool_calls[0]
+        messages.extend([
+            {
+                "role": "assistant",
+                "content": first.content,
+                "reasoning": first.reasoning,
+                "reasoning_content": first.reasoning_content,
+                "tool_calls": [
+                    {
+                        "id": tool_call.id,
+                        "type": "function",
+                        "function": {
+                            "name": tool_call.name,
+                            "arguments": tool_call.arguments,
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": '{"value":"ok"}',
+            },
+        ])
+        second_raw = client.chat.completions.create(
+            **transport.build_kwargs(
+                model="test-model",
+                messages=messages,
+                tools=tools,
+                **params,
+            )
+        )
+        second = transport.normalize_response(second_raw)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+
+    assert resolved["api_mode"] == "chat_completions"
+    assert [path for path, _ in requests] == [
+        "/v1/chat/completions",
+        "/v1/chat/completions",
+    ]
+    assert requests[0][1]["thinking"] == {"type": "enabled"}
+    assert requests[0][1]["reasoning_effort"] == "high"
+    assert requests[1][1]["reasoning_effort"] == "high"
+    replayed = requests[1][1]["messages"][-2]
+    assert replayed["reasoning"] == "I should call the probe tool."
+    assert replayed["reasoning_content"] == "I should call the probe tool."
+    assert second.content == "ACTUAL_CHAT_OK"
+    assert second.reasoning == "The tool result confirms the answer."
+    assert second.reasoning_content == "The tool result confirms the answer."
+
+
+def test_actual_chat_completion_without_reasoning_keeps_final_content():
+    from types import SimpleNamespace
+
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    content="ACTUAL_NO_REASONING_OK",
+                    reasoning=None,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+            )
+        ],
+        usage=None,
+    )
+
+    normalized = ChatCompletionsTransport().normalize_response(response)
+
+    assert normalized.content == "ACTUAL_NO_REASONING_OK"
+    assert normalized.reasoning is None
+    assert normalized.reasoning_content is None
 
 
 def test_actual_runtime_config_local_base_url_without_key(monkeypatch):
@@ -370,4 +836,4 @@ def test_actual_runtime_config_local_base_url_without_key(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="actual")
 
     assert resolved["api_key"] == ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
-    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_mode"] == "chat_completions"

--- a/tests/hermes_cli/test_actual_provider.py
+++ b/tests/hermes_cli/test_actual_provider.py
@@ -159,12 +159,29 @@ def test_actual_runtime_ignores_legacy_mode_environment(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
-def test_actual_hostname_detection_preserves_custom_responses_route():
+def test_actual_hostname_detection_repairs_custom_responses_route():
+    from hermes_cli.providers import is_actual_route
+
     base_url = "https://api.actual.inc/v1"
 
-    assert rp._detect_api_mode_for_url(base_url) == "codex_responses"
-    assert rp._fallback_api_mode("custom", base_url) == "codex_responses"
-    assert rp._resolve_plain_custom_api_mode({}, base_url) == "codex_responses"
+    assert rp._detect_api_mode_for_url(base_url) == "chat_completions"
+    assert rp._fallback_api_mode("custom", base_url) == "chat_completions"
+    assert rp._resolve_plain_custom_api_mode({}, base_url) == "chat_completions"
+    assert (
+        rp._resolve_plain_custom_api_mode({"api_mode": "codex_responses"}, base_url)
+        == "chat_completions"
+    )
+    for unrelated_url in (
+        "https://api.actual.inc.example/v1",
+        "https://proxy.example/api.actual.inc/v1",
+    ):
+        assert not is_actual_route("custom", unrelated_url)
+        assert (
+            rp._runtime("custom", "codex_responses", unrelated_url, "test-key")[
+                "api_mode"
+            ]
+            == "codex_responses"
+        )
 
 
 def test_actual_runtime_uses_local_env_without_key(monkeypatch):

--- a/tests/hermes_cli/test_api_mode_aliases.py
+++ b/tests/hermes_cli/test_api_mode_aliases.py
@@ -12,7 +12,7 @@ and an unrecognized value was silently ignored at BOTH consumption sites:
 * ``hermes_cli.runtime_provider._parse_api_mode`` returned None, with the
   same fall-through.
 
-For a host with a detection rule (e.g. api.actual.inc -> codex_responses)
+For a host with a detection rule (e.g. api.router.com -> codex_responses)
 the provider silently switched transports after an update and broke:
 observed live as every reasoning-bearing request to a relay's untested
 /v1/responses endpoint failing while chat_completions worked. See the

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -30,7 +30,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
 | **Nebius Token Factory** | `NEBIUS_API_KEY` in `~/.hermes/.env` (provider: `nebius-token-factory`; aliases: `nebius`, `nebius-tf`, `tokenfactory`) |
-| **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay, or `ACTUAL_BASE_URL=http://127.0.0.1:8080` for the local daemon — no key needed on loopback (provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`) |
+| **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay; set `model.base_url` in `config.yaml` for a local daemon (no key needed on loopback). Provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`. |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -602,7 +602,7 @@ The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-se
 
 ### Actual Computer
 
-Your own hardware as a private inference cluster via [Actual Computer](https://actual.inc). Two serving modes, both OpenAI-compatible (Hermes uses the Responses API transport):
+Your own hardware as a private inference cluster via [Actual Computer](https://actual.inc). Two serving modes, both OpenAI-compatible (Hermes defaults to Chat Completions so reasoning and final content are returned together):
 
 - **Hosted relay** — `https://api.actual.inc`, end-to-end encrypted, routes to *your* cluster. Authenticate with an `ac_` inference key from [actual.inc/user/keys](https://actual.inc/user/keys).
 - **Local daemon** — on-device at `http://127.0.0.1:8080`, fully offline. No API key needed: Hermes detects the loopback base URL and authenticates with an internal placeholder automatically.
@@ -611,20 +611,22 @@ Your own hardware as a private inference cluster via [Actual Computer](https://a
 # Hosted relay (ACTUAL_API_KEY in ~/.hermes/.env)
 hermes chat --provider actual --model <model-id-from-your-cluster>
 
-# Local daemon (ACTUAL_BASE_URL=http://127.0.0.1:8080 in ~/.hermes/.env, no key)
+# Local daemon (model.base_url in ~/.hermes/config.yaml, no key)
 hermes chat --provider actual --model <installed-model-name>
 ```
 
-Or set it permanently in `config.yaml`:
+Store provider settings in `~/.hermes/config.yaml`; only the hosted API key belongs in `.env`:
 ```yaml
 model:
   provider: "actual"
   default: "<model-id>"
+  base_url: "http://127.0.0.1:8080/v1" # Omit for the hosted relay.
 ```
 
 Notes:
 - Model IDs come from your cluster's `GET /v1/models` — discover with `hermes model` or `curl -s https://api.actual.inc/v1/models -H "Authorization: Bearer $ACTUAL_API_KEY"`.
-- Bare hosts are normalized: `ACTUAL_BASE_URL=http://127.0.0.1:8080` becomes `http://127.0.0.1:8080/v1` automatically.
+- Bare hosts in `model.base_url` are normalized: `http://127.0.0.1:8080` becomes `http://127.0.0.1:8080/v1` automatically. The legacy `ACTUAL_BASE_URL` environment variable is a fallback when no Actual URL is configured in YAML.
+- The built-in Actual provider uses Chat Completions for chat, compaction, title generation, and other auxiliary tasks. Stale built-in Responses modes are repaired. For an endpoint that requires Responses, configure a named custom provider with `transport: codex_responses` under `providers` in `config.yaml`; per-task `auxiliary.<task>.api_mode` overrides are also supported.
 - Reasoning effort is clamped to Actual's supported range (`none/low/medium/high/max`) — a global `xhigh`/`ultra` setting will not 400 requests.
 - Small local models: Hermes' full default toolset plus the system prompt can exceed a 32k context window, producing an empty-stream error from llama.cpp-family servers. Restrict the toolset (`-t file,web`) or load the model with a larger context. The optional `actual-setup` skill (`hermes skills install official/devops/actual-setup`) covers setup and troubleshooting in detail.
 - Aliases: `actual-computer`, `actualcomputer`, `aci`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -602,7 +602,7 @@ The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-se
 
 ### Actual Computer
 
-Your own hardware as a private inference cluster via [Actual Computer](https://actual.inc). Two serving modes, both OpenAI-compatible (Hermes defaults to Chat Completions so reasoning and final content are returned together):
+Your own hardware as a private inference cluster via [Actual Computer](https://actual.inc). Two serving modes, both using Chat Completions so reasoning and final content are returned together:
 
 - **Hosted relay** — `https://api.actual.inc`, end-to-end encrypted, routes to *your* cluster. Authenticate with an `ac_` inference key from [actual.inc/user/keys](https://actual.inc/user/keys).
 - **Local daemon** — on-device at `http://127.0.0.1:8080`, fully offline. No API key needed: Hermes detects the loopback base URL and authenticates with an internal placeholder automatically.
@@ -626,7 +626,7 @@ model:
 Notes:
 - Model IDs come from your cluster's `GET /v1/models` — discover with `hermes model` or `curl -s https://api.actual.inc/v1/models -H "Authorization: Bearer $ACTUAL_API_KEY"`.
 - Bare hosts in `model.base_url` are normalized: `http://127.0.0.1:8080` becomes `http://127.0.0.1:8080/v1` automatically. The legacy `ACTUAL_BASE_URL` environment variable is a fallback when no Actual URL is configured in YAML.
-- The built-in Actual provider uses Chat Completions for chat, compaction, title generation, and other auxiliary tasks. Stale built-in Responses modes are repaired. For an endpoint that requires Responses, configure a named custom provider with `transport: codex_responses` under `providers` in `config.yaml`; per-task `auxiliary.<task>.api_mode` overrides are also supported.
+- Actual uses `/v1/chat/completions` for chat, compaction, title generation, and every other auxiliary task. This also applies to custom providers targeting `api.actual.inc`, model switches, and fallbacks. Legacy Responses settings in the main model, custom provider, or auxiliary task configuration are overridden automatically.
 - Reasoning effort is clamped to Actual's supported range (`none/low/medium/high/max`) — a global `xhigh`/`ultra` setting will not 400 requests.
 - Small local models: Hermes' full default toolset plus the system prompt can exceed a 32k context window, producing an empty-stream error from llama.cpp-family servers. Restrict the toolset (`-t file,web`) or load the model with a larger context. The optional `actual-setup` skill (`hermes skills install official/devops/actual-setup`) covers setup and troubleshooting in detail.
 - Aliases: `actual-computer`, `actualcomputer`, `aci`.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -46,7 +46,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
 | `ACTUAL_API_KEY` | Actual Computer inference key (`ac_...`, [actual.inc/user/keys](https://actual.inc/user/keys)). Not needed for the local daemon. |
-| `ACTUAL_BASE_URL` | Override Actual Computer base URL (default: `https://api.actual.inc/v1`). Set to `http://127.0.0.1:8080` for the local offline daemon — loopback hosts need no API key. |
+| `ACTUAL_BASE_URL` | Legacy fallback for the Actual base URL. Configure `model.provider: actual` and `model.base_url` in `config.yaml` instead; the YAML URL takes precedence. Defaults to `https://api.actual.inc/v1`. |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## Summary

Use `/v1/chat/completions` for every Actual generation path, including foreground chat, compaction, titles, async tasks, startup resolution, model switches, fallback chains, session restoration, and credential rotation. Store Actual provider settings in `config.yaml` and credentials in `.env`.

## Motivation

The transport switch left multiple ways to select Responses: auxiliary wrappers, the hosted hostname mapping, persisted task/custom-provider modes, aliases, and runtime transitions. Bare endpoint overrides could also lose `/v1`. Environment-backed provider settings could override YAML during setup, credential resolution, or live key reloads.

## Links

- [E-1047](https://linear.app/actualcomputer/issue/E-1047/route-hermes-actual-provider-through-chat-completions-with-reasoning).
- [E-1005: scheduled compatibility detector](https://linear.app/actualcomputer/issue/E-1005).
- Supersedes the Responses-only approach in #80248 and duplicate #80266.
- Original provider integration: #79644.

## Approach

- Recognize Actual by its provider aliases or the exact `api.actual.inc` hostname and enforce Chat Completions when resolving and changing runtimes.
- Override stale Responses settings in Actual auxiliary tasks and custom providers targeting the hosted relay. Auxiliary overrides sharing the active Actual daemon also retain its protocol. Normalize bare Actual endpoints to `/v1`.
- Guard the main Responses send site and the sync/async auxiliary adapter: a known Actual route raises before HTTP even if stale runtime state or a wrapper bypasses resolution. Preserve Actual identity on resolved auxiliary clients.
- Remove the Actual-specific branch from the Responses transport. Preserve reasoning content, tool-turn replay, supported effort clamping, and one-shot `--reasoning` propagation.
- Save endpoint selections in `model.base_url`. Prefer YAML during setup, discovery, credential-pool resolution, and live API-key reloads. Keep `ACTUAL_BASE_URL` as a legacy fallback; credentials remain in `.env`.
- Preserve the hosted macOS TLS default and explicit TLS overrides.
- Rebase onto upstream `main` at `872bafd58d`.

## Reviewer Focus

The HTTP harness in `tests/agent/test_actual_auxiliary_routing.py` exercises the real SDK, title generator, compressor, sync/async calls, provider resolution, and live agent transitions. A local server rejects inference routes other than `/v1/chat/completions`; hosted-route cases resolve `api.actual.inc` to that server. Coverage includes aliases, custom routes, keyed/keyless local endpoints, stale configuration, bare URLs, unsupported-model fallback, startup fallback, restored sessions, credential rotation, and live key reloads.

Regression cases reproduced the old alias/custom routing, startup fallback, and credential-rotation failures before their fixes. **1,900 tests pass across 109 files**, including 121 Actual routing/configuration cases, after rebasing. The 18 forced-Responses cases reproduced outbound HTTP before the send guards and now verify that no HTTP request is sent; normal Actual requests still complete successfully. The suite also exercises the supported Codex Responses paths. Repository Ruff checks and the plugin-compatibility check pass. The routing/configuration review found no remaining material issues. Validation uses local HTTP integration tests; the live hosted Actual service was not exercised in this revision.

GitHub CI, Nix, and Docker workflows at commit `8a6b5b67a7` require upstream workflow approval before running. [Current CI run](https://github.com/NousResearch/hermes-agent/actions/runs/34519089122). The PR has no merge conflicts.

## Failure Modes

- Stale title work is cancelled before any HTTP request.
- Old Actual Responses settings cannot select `/v1/responses`, including after startup fallback, a model switch, or session restoration. Forced entry into the Responses transport raises a clear error before any HTTP request.
- Unsupported-model recovery sends sync and async fallback requests through Chat Completions.
- YAML endpoint selections survive stale environment URLs and API-key reloads. Invalid setup URL input preserves the configured endpoint.
- Exact hostname checks reject lookalike hosts and URL-path spoofing.
- Missing reasoning preserves final content; unsupported reasoning levels are clamped to Actual's supported vocabulary.

## Breaking Changes

Actual routes now override saved Responses transport selections, including custom configurations targeting `api.actual.inc`. No config migration is required. `ACTUAL_API_MODE` was introduced only in an earlier revision of this unmerged PR; existing `ACTUAL_BASE_URL` settings remain a fallback.

## Post-Merge Behavior

Merging triggers upstream CI and the Docker build/publish workflow. Existing Hermes processes receive the fix after updating and restarting. No Actual service deployment or new runtime flag is required. Release smoke: run `hermes -z '<prompt>' --provider actual --model <model> --reasoning high`, generate a title, and compact a conversation; verify outgoing generation requests use `/v1/chat/completions`.

## Diagrams

```mermaid
flowchart LR
    Config[config.yaml provider and endpoint] --> Runtime[Actual route resolution]
    Key[.env API key] --> Runtime
    Legacy[Legacy URL fallback] --> Runtime
    Task[Auxiliary task or custom provider] --> Runtime
    Runtime --> Chat[Chat and startup]
    Runtime --> Aux[Titles, compaction, sync and async tasks]
    Runtime --> Changes[Switch, fallback, restore, key rotation]
    Chat --> API[POST /v1/chat/completions]
    Aux --> API
    Changes --> API
```
