### PR TITLE
fix(browser): expire Browser Use daemons cleanly

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -908,6 +908,76 @@ class TestSkillTextDescription:
         assert "uv tool install browser-use" in desc
 
 
+class TestBrowserUseManagedLifecycle:
+    @pytest.fixture(autouse=True)
+    def _reset_lifecycle(self):
+        bu_cli._browser_use_sessions.clear()
+        yield
+        bu_cli._browser_use_sessions.clear()
+
+    def test_runtime_is_scoped_to_profile_process_and_session(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        env = {}
+
+        state = bu_cli._managed_browser_use_state("research", env, ["browser-use"])
+
+        assert state is not None
+        assert state["session"] == "research"
+        assert env["BH_RUNTIME_DIR"] == env["BH_TMP_DIR"]
+        assert str(os.getpid()) in env["BH_RUNTIME_DIR"]
+        assert env["BH_RUNTIME_DIR"].endswith("research")
+        if os.name != "nt":
+            assert len(f"{env['BH_RUNTIME_DIR']}/bu.sock".encode()) < 104
+
+    def test_operator_runtime_override_opts_out(self):
+        env = {"BH_RUNTIME_DIR": "/operator/runtime"}
+
+        assert bu_cli._managed_browser_use_state("research", env, ["browser-use"]) is None
+        assert env == {"BH_RUNTIME_DIR": "/operator/runtime"}
+
+    def test_idle_cleanup_removes_state_only_after_confirmed_reload(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        state = bu_cli._managed_browser_use_state("research", {}, ["browser-use"])
+        assert state is not None
+        state["last_activity"] = 0.0
+        monkeypatch.setattr(bu_cli, "_browser_use_inactivity_timeout", lambda: 30)
+        monkeypatch.setattr(bu_cli, "_stop_browser_use_state", lambda current: True)
+
+        bu_cli._expire_idle_browser_use_sessions(now=31.0)
+
+        assert bu_cli._browser_use_sessions == {}
+
+    def test_idle_cleanup_retains_state_when_reload_fails(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        state = bu_cli._managed_browser_use_state("research", {}, ["browser-use"])
+        assert state is not None
+        state["last_activity"] = 0.0
+        monkeypatch.setattr(bu_cli, "_browser_use_inactivity_timeout", lambda: 30)
+        monkeypatch.setattr(bu_cli, "_stop_browser_use_state", lambda current: False)
+
+        bu_cli._expire_idle_browser_use_sessions(now=31.0)
+
+        assert len(bu_cli._browser_use_sessions) == 1
+
+    def test_browser_exec_holds_session_lock_for_full_cli_call(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, "cat > /dev/null\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        state = bu_cli._managed_browser_use_state("research", {}, [cli])
+        assert state is not None
+        monkeypatch.setattr(bu_cli, "_managed_browser_use_state", lambda *_args: state)
+        real_run = bu_cli.subprocess.run
+
+        def checked_run(*args, **kwargs):
+            assert state["operation_lock"].acquire(blocking=False) is False
+            return real_run(*args, **kwargs)
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", checked_run)
+
+        result = json.loads(bu_cli.browser_exec("print(1)", session="research"))
+
+        assert result["success"] is True
+
+
 class TestBrowserExec:
     def test_missing_cli_returns_install_hint(self, monkeypatch):
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: None)
@@ -950,11 +1020,15 @@ class TestBrowserExec:
         assert "boom" in result["stderr"]
 
     def test_timeout_returns_actionable_error(self, tmp_path, monkeypatch):
-        cli = _fake_cli(tmp_path, "cat > /dev/null\nsleep 30\n")
+        cli = _fake_cli(
+            tmp_path,
+            'if [ "${1:-}" = "--reload" ]; then exit 0; fi\ncat > /dev/null\nsleep 30\n',
+        )
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
         monkeypatch.setattr(bu_cli, "_MIN_TIMEOUT_S", 1)
         result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=1))
         assert "timed out" in result["error"]
+        assert "daemon was stopped" in result["error"]
 
 
 class TestFindCliManagedBin:
@@ -1402,10 +1476,10 @@ class TestTimeoutProcessGroupKill:
         # Pre-fix, this hangs until the 60s sleeps expire — and forever with a daemon child.
         assert elapsed < 30
         # The pipe-holding grandchild died with the group instead of leaking.
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
         time.sleep(0.5)
         with pytest.raises(OSError):
-            os.kill(pid, 0)
+            os.kill(pid, 0)  # windows-footgun: ok — this test is skipped on Windows
 
     def test_post_kill_drain_is_bounded(self, monkeypatch):
         """If even the post-kill drain misses its deadline, give up instead of wedging."""

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -4,7 +4,9 @@ When browser.backend is "browser-use", the model gets ``browser_exec`` tool
 instead of default browser tools
 """
 
+import atexit
 import contextlib
+import hashlib
 import importlib
 import json
 import logging
@@ -13,6 +15,8 @@ import re
 import shutil
 import signal
 import subprocess
+import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -75,6 +79,13 @@ _DEFAULT_TIMEOUT_S = 300
 _MIN_TIMEOUT_S = 5
 _MAX_TIMEOUT_S = 1800
 _STDERR_CAP_CHARS = 4000
+_BROWSER_USE_RELOAD_TIMEOUT_S = 10
+_BROWSER_USE_CLEANUP_POLL_S = 5
+
+_browser_use_sessions: Dict[str, Dict[str, Any]] = {}
+_browser_use_sessions_lock = threading.RLock()
+_browser_use_cleanup_started = False
+_browser_use_cleanup_stop = threading.Event()
 
 _TASK_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")  # filesystem-safe task ids
 # Screenshot paths printed by capture_screenshot(): POSIX or Windows drive-letter absolute.
@@ -98,6 +109,128 @@ def _lazy_call(module: str, name: str, default: Any, log_prefix: str) -> Any:
     """Call ``module.name()`` resolved at call time (tests stub the module / patch the
     attribute); on any failure log ``log_prefix`` and return ``default``."""
     return _quiet(lambda: getattr(importlib.import_module(module), name)(), default, log_prefix)
+
+
+def _browser_use_inactivity_timeout() -> int:
+    """Use the existing browser.inactivity_timeout setting."""
+    try:
+        from tools.browser_tool import _get_session_inactivity_timeout
+        return max(30, int(_get_session_inactivity_timeout()))
+    except Exception as e:  # pragma: no cover - defensive import/config path
+        logger.debug("Browser Use inactivity timeout lookup failed: %s", e)
+        return 120
+
+
+def _browser_use_runtime_dir(session: str) -> Path:
+    """Short profile/process/session-scoped Harness runtime path."""
+    try:
+        profile_root = str(Path(get_hermes_home()).expanduser().resolve())
+    except Exception:
+        profile_root = os.path.expanduser("~")
+    profile_key = hashlib.sha256(profile_root.encode("utf-8")).hexdigest()[:12]
+    safe_session = _TASK_ID_SAFE_RE.sub("_", session or "default")[:64] or "default"
+    runtime_base = Path(tempfile.gettempdir()) if os.name == "nt" else Path("/tmp")
+    return runtime_base / f"hermes-bu-{profile_key}" / str(os.getpid()) / safe_session
+
+
+def _managed_browser_use_state(session: str, env: dict, cmd: List[str]) -> Optional[Dict[str, Any]]:
+    """Register one Hermes-owned Harness runtime; explicit BH paths opt out."""
+    if env.get("BH_RUNTIME_DIR") or env.get("BH_TMP_DIR"):
+        return None
+    runtime = _browser_use_runtime_dir(session)
+    runtime.mkdir(parents=True, exist_ok=True)
+    env["BH_RUNTIME_DIR"] = env["BH_TMP_DIR"] = str(runtime)
+    key = str(runtime)
+    with _browser_use_sessions_lock:
+        if (state := _browser_use_sessions.get(key)) is None:
+            state = {"key": key, "runtime_dir": runtime, "session": session or "default",
+                     "cmd": tuple(cmd), "env": dict(env), "last_activity": time.monotonic(),
+                     "inflight": 0, "operation_lock": threading.Lock()}
+            _browser_use_sessions[key] = state
+        else:
+            state["cmd"], state["env"] = tuple(cmd), dict(env)
+    return state
+
+
+def _stop_browser_use_state(state: Dict[str, Any]) -> bool:
+    """Stop exactly one Harness daemon through its public top-level CLI."""
+    try:
+        result = _run_cli_killing_process_group(
+            [*state["cmd"], "--reload"],
+            "",
+            dict(state["env"]),
+            _BROWSER_USE_RELOAD_TIMEOUT_S,
+        )
+    except Exception as e:
+        logger.debug("Browser Use reload failed for %s: %s", state["session"], e)
+        return False
+    if result.returncode != 0:
+        logger.debug("Browser Use reload exited %s for %s: %s", result.returncode, state["session"],
+                     (result.stderr or result.stdout or "").strip()[-500:])
+        return False
+    return True
+
+
+def _expire_idle_browser_use_sessions(now: Optional[float] = None) -> None:
+    """Stop idle Hermes-owned daemons without racing active CLI calls."""
+    current, timeout = time.monotonic() if now is None else now, _browser_use_inactivity_timeout()
+    with _browser_use_sessions_lock:
+        snapshot = list(_browser_use_sessions.items())
+    for key, state in snapshot:
+        if state["inflight"] or current - state["last_activity"] < timeout:
+            continue
+        operation_lock = state["operation_lock"]
+        if not operation_lock.acquire(blocking=False):
+            continue
+        try:
+            with _browser_use_sessions_lock:
+                if (_browser_use_sessions.get(key) is not state or state["inflight"]
+                        or current - state["last_activity"] < timeout):
+                    continue
+            if _stop_browser_use_state(state):
+                with _browser_use_sessions_lock:
+                    if _browser_use_sessions.get(key) is state:
+                        _browser_use_sessions.pop(key, None)
+        finally:
+            operation_lock.release()
+
+
+def _browser_use_cleanup_loop() -> None:
+    while not _browser_use_cleanup_stop.wait(_BROWSER_USE_CLEANUP_POLL_S):
+        try:
+            _expire_idle_browser_use_sessions()
+        except Exception as e:  # pragma: no cover - background defense
+            logger.debug("Browser Use cleanup loop failed: %s", e)
+
+
+def _ensure_browser_use_cleanup_thread() -> None:
+    global _browser_use_cleanup_started
+    with _browser_use_sessions_lock:
+        if _browser_use_cleanup_started:
+            return
+        _browser_use_cleanup_started = True
+    threading.Thread(target=_browser_use_cleanup_loop, name="browser-use-cleanup", daemon=True).start()
+
+
+def _shutdown_browser_use_sessions() -> None:
+    """Best-effort graceful shutdown for daemons owned by this Hermes process."""
+    _browser_use_cleanup_stop.set()
+    with _browser_use_sessions_lock:
+        snapshot = list(_browser_use_sessions.items())
+    for key, state in snapshot:
+        operation_lock = state["operation_lock"]
+        if not operation_lock.acquire(blocking=False):
+            continue
+        try:
+            if _stop_browser_use_state(state):
+                with _browser_use_sessions_lock:
+                    if _browser_use_sessions.get(key) is state:
+                        _browser_use_sessions.pop(key, None)
+        finally:
+            operation_lock.release()
+
+
+atexit.register(_shutdown_browser_use_sessions)
 
 
 def _camofox_active(context: str = "") -> bool:
@@ -623,16 +756,43 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     if "BU_AUTOSPAWN" not in env and is_legacy_browser_use_cloud_config(_read_browser_cfg()):
         env["BU_AUTOSPAWN"] = "1"
 
+    lifecycle_state = _managed_browser_use_state(session, env, cmd)
+    if lifecycle_state is not None:
+        _ensure_browser_use_cleanup_thread()
+
     timeout = _clamp_timeout(timeout_s)
+    operation_lock = None
+    if lifecycle_state is not None:
+        operation_lock = lifecycle_state["operation_lock"]
+        operation_lock.acquire()
+        with _browser_use_sessions_lock:
+            lifecycle_state["inflight"] += 1
+            lifecycle_state["last_activity"] = time.monotonic()
+
     started = time.time()
     try:
-        proc = _run_cli_killing_process_group(cmd, code, env, timeout)
-    except subprocess.TimeoutExpired:
-        return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
-                          f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "
-                          "append to workspace files — anything already written to the workspace is preserved.")
-    except OSError as e:
-        return tool_error(f"Failed to launch browser-use CLI: {e}")
+        try:
+            proc = _run_cli_killing_process_group(cmd, code, env, timeout)
+        except subprocess.TimeoutExpired:
+            stopped = False
+            if lifecycle_state is not None:
+                stopped = _stop_browser_use_state(lifecycle_state)
+                if stopped:
+                    with _browser_use_sessions_lock:
+                        if _browser_use_sessions.get(lifecycle_state["key"]) is lifecycle_state:
+                            _browser_use_sessions.pop(lifecycle_state["key"], None)
+            detail = "The Hermes-owned daemon was stopped" if stopped else "The daemon may still be working"
+            return tool_error(f"browser-use exec timed out after {timeout}s. {detail}; retry "
+                              f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "
+                              "append to workspace files — anything already written to the workspace is preserved.")
+        except OSError as e:
+            return tool_error(f"Failed to launch browser-use CLI: {e}")
+    finally:
+        if operation_lock is not None and lifecycle_state is not None:
+            with _browser_use_sessions_lock:
+                lifecycle_state["inflight"] = max(0, lifecycle_state["inflight"] - 1)
+                lifecycle_state["last_activity"] = time.monotonic()
+            operation_lock.release()
 
     result = {"success": proc.returncode == 0, "exit_code": proc.returncode, "output": proc.stdout}
     if workspace:


### PR DESCRIPTION
## Summary

Wire `browser.inactivity_timeout` to the default Browser Use CLI backend without importing Browser Harness internals or extending the legacy `agent-browser` reaper.

- Give each Hermes-owned Harness daemon a short profile/process/session-scoped runtime through `BH_RUNTIME_DIR` and `BH_TMP_DIR`.
- Serialize same-session CLI calls for their full execution window.
- Stop idle daemons, timed-out daemons, and daemons owned by a normally exiting Hermes process through the public top-level `browser-use --reload` command.
- Preserve lifecycle state when reload fails so cleanup can retry.
- Leave explicit operator-provided `BH_RUNTIME_DIR` / `BH_TMP_DIR` ownership untouched.
- Never kill or close the externally managed Chrome/Brave/Chromium process.

Current-main supersession check: the merged real-profile/agent-browser reaper fixes a different daemon family. It does not own Browser Use Harness runtimes, call serialization, timeout cleanup, or `browser-use --reload`, so this PR remains the complete Browser Use residual.

This is the smaller supported-boundary alternative to #95001 and #95006. It deliberately does not add speculative hard-crash/PID orphan recovery.

## Verification

On head `5f11af74d436c103fe9fc7b7b462dcd856e16963` against upstream `bdb5bf96f39777e335a0fb8cd07145e6033991bb`:

- `scripts/run_tests.sh tests/tools/test_browser_use_cli.py` — 124 passed
- focused Ruff passed
- published commit attributed to `Diaspar4u`
- Windows-footgun and plugin-compat checks passed
- `git diff --check` passed
- Earlier isolated Brave/CDP smoke confirmed that expiry stopped the managed daemon while Brave remained running

Design credit: @JoaoMarcos44 in #95001 established the correct public-CLI ownership boundary.