### PR TITLE
fix(tools): clear web.search_backend/extract_backend on provider pick

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4693,6 +4693,15 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
                 stale_tiers = web_cfg.get("provider_tier")
                 if isinstance(stale_tiers, dict):
                     stale_tiers.pop(provider["web_backend"], None)
+            # ``web.search_backend`` / ``web.extract_backend`` are the
+            # per-capability overrides the runtime prefers over
+            # ``web.backend`` (agent.web_search_registry reads
+            # ``<capability>_backend or backend``). A fresh provider pick
+            # must clear them, otherwise the wizard reports the new
+            # backend while search/extract silently keep serving from the
+            # stale per-capability selection.
+            web_cfg.pop("search_backend", None)
+            web_cfg.pop("extract_backend", None)
 
     # Set computer_use backend in config if applicable
     if provider.get("computer_use_backend"):
@@ -5419,6 +5428,14 @@ def _reconfigure_provider(
             NOUS_MANAGED_PROVIDER if managed_feature else provider["web_backend"]
         )
         web_cfg.pop("use_gateway", None)
+        # ``web.search_backend`` / ``web.extract_backend`` are the
+        # per-capability overrides the runtime prefers over ``web.backend``
+        # (agent.web_search_registry reads ``<capability>_backend or
+        # backend``). A fresh provider pick must clear them, otherwise the
+        # wizard reports the new backend while search/extract silently keep
+        # serving from the stale per-capability selection.
+        web_cfg.pop("search_backend", None)
+        web_cfg.pop("extract_backend", None)
         if provider.get("web_tier"):
             tiers = web_cfg.setdefault("provider_tier", {})
             if isinstance(tiers, dict):

--- a/tests/tools/test_strict_provider_selection.py
+++ b/tests/tools/test_strict_provider_selection.py
@@ -358,3 +358,34 @@ class TestWriteProviderConfig:
         _write_provider_config(provider, config, managed_feature=None)
         assert config["stt"]["provider"] == "groq"
         assert "use_gateway" not in config["stt"]
+
+    def test_web_pick_clears_stale_per_capability_backends(self):
+        """A fresh web provider pick must clear ``web.search_backend`` /
+        ``web.extract_backend``: the runtime resolves
+        ``<capability>_backend or backend``, so stale per-capability keys
+        would keep serving the old provider after the wizard reports the
+        new one (web.backend) as active."""
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {
+            "web": {
+                "backend": "firecrawl",
+                "search_backend": "firecrawl",
+                "extract_backend": "firecrawl",
+            }
+        }
+        provider = {"name": "Keenable Free", "web_backend": "keenable"}
+        _write_provider_config(provider, config, managed_feature=None)
+        assert config["web"]["backend"] == "keenable"
+        assert "search_backend" not in config["web"]
+        assert "extract_backend" not in config["web"]
+
+    def test_web_pick_without_tier_still_clears_per_capability_backends(self):
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {"web": {"backend": "ddgs", "search_backend": "exa"}}
+        provider = {"name": "SearXNG", "web_backend": "searxng"}
+        _write_provider_config(provider, config, managed_feature=None)
+        assert config["web"]["backend"] == "searxng"
+        assert "search_backend" not in config["web"]
+        assert "extract_backend" not in config["web"]


### PR DESCRIPTION
## Problem

A web provider selection in `hermes setup tools` (and `hermes tools` → Reconfigure) only writes `web.backend` to config.yaml. But the runtime resolves search/extract backends with a per-capability-first lookup (`agent/web_search_registry.py`):

```python
explicit = _read_config_key("web", "search_backend") or _read_config_key("web", "backend")  # search
explicit = _read_config_key("web", "extract_backend") or _read_config_key("web", "backend") # extract
```

Any config that already carries explicit `web.search_backend` / `web.extract_backend` keys (e.g. written by earlier Hermes versions or manual edits) shadows the fresh pick: the wizard prints "✓ Web backend set to: <new>", but search/extract keep silently serving the old provider. To the user, the selection appears to be ignored — we hit this on a Pi install where `search_backend: firecrawl` / `extract_backend: firecrawl` outlived several wizard selections.

## Fix

Clear both per-capability keys wherever a web backend selection is persisted:

- `_write_provider_config` (Configure flow + desktop GUI via `apply_provider_selection`)
- `_reconfigure_provider` (Reconfigure flow)

so the picked provider governs all capabilities, matching the strict-selection policy already documented in `test_strict_provider_selection.py` ("the `hermes tools` choice always wins").

## Testing

- 2 new regression tests in `tests/tools/test_strict_provider_selection.py` (`TestWriteProviderConfig`): a web pick with stale per-capability keys clears them; a pick without a tier does too. Full file: 35 passed.
- E2E against a copy of a real config on an isolated `HERMES_HOME`: `hermes setup tools` → Reconfigure → Web Search → Keenable Free. Before the patch, the resulting config still had `search_backend`/`extract_backend` pointing at the old backend; after, only `backend: keenable` remains.
