### PR TITLE
fix(desktop): recover after late local backend readiness

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -199,6 +199,7 @@ function fakeDesktop() {
       return !key || key === 'default' ? primaryConn : coderConn
     }),
     getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
+    getConnectionConfig: vi.fn(async () => ({ mode: 'local' })),
     getBootProgress: vi.fn(async () => ({
       error: null as null | string,
       fakeMode: false,
@@ -1228,6 +1229,66 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     })
 
     expect($desktopBoot.get().error).toBeTruthy()
+  })
+
+  it('re-attaches once when a local backend becomes ready after the initial renderer timeout (#98124)', async () => {
+    // The main process keeps starting the local child after withTimeout()
+    // rejects in the renderer. Its later backend.ready must re-run the normal
+    // connection + WebSocket handshake exactly once instead of leaving the
+    // failure overlay latched forever.
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise(() => undefined))
+      .mockResolvedValue(primaryConn)
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000)
+    })
+
+    expect($desktopBoot.get().error).toContain('Timed out connecting to Hermes backend')
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      desktop.emitBootProgress({
+        error: null,
+        fakeMode: false,
+        message: 'Hermes backend is ready. Finalizing desktop startup',
+        phase: 'backend.ready',
+        progress: 94,
+        running: true,
+        timestamp: Date.now()
+      })
+    })
+    await flushAsync()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
+
+    // Duplicate ready notifications cannot create a second socket or restart
+    // the finished boot path.
+    act(() => {
+      desktop.emitBootProgress({
+        error: null,
+        fakeMode: false,
+        message: 'Hermes backend is ready. Finalizing desktop startup',
+        phase: 'backend.ready',
+        progress: 94,
+        running: true,
+        timestamp: Date.now()
+      })
+    })
+    await flushAsync()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+    expect(FakeWebSocket.instances).toHaveLength(1)
   })
 
   it('softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever (#93454)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -8,7 +8,12 @@ import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+import {
+  BACKEND_BOOT_WAIT_TIMEOUT_MS,
+  isTimeoutError,
+  RECONNECT_ATTEMPT_TIMEOUT_MS,
+  withTimeout
+} from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -243,6 +248,13 @@ export function useGatewayBoot({
     // Bounded automatic boot retry for transient REMOTE failures (#82679).
     let bootRetryAttempt = 0
     let bootRetryTimer: ReturnType<typeof setTimeout> | null = null
+    // A local backend can finish booting after the renderer's bounded initial
+    // getConnection() wait expires. The timeout intentionally does not cancel
+    // the main-process boot, so keep one narrowly-scoped chance to attach when
+    // that same local backend later publishes backend.ready (#98124).
+    let lateLocalBootRecoveryArmed = false
+    let lateLocalBootRecoveryStarted = false
+    let localPrimaryBoot: boolean | null = null
 
     const clearBootRetryTimer = () => {
       if (bootRetryTimer !== null) {
@@ -263,6 +275,27 @@ export function useGatewayBoot({
       } catch {
         return false
       }
+    }
+
+    const primaryBootIsLocal = async (): Promise<boolean> => {
+      if (localPrimaryBoot !== null) {
+        return localPrimaryBoot
+      }
+
+      try {
+        const config = await withTimeout(
+          desktop.getConnectionConfig(),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out resolving the desktop connection mode'
+        )
+        localPrimaryBoot = config.mode === 'local'
+      } catch {
+        // This check only controls an optional recovery. When IPC is unhealthy,
+        // retain the ordinary terminal boot failure instead of guessing.
+        localPrimaryBoot = false
+      }
+
+      return localPrimaryBoot
     }
 
     // Wrap the live getter in a call so TS control-flow analysis doesn't narrow
@@ -696,6 +729,42 @@ export function useGatewayBoot({
       }
     }
 
+    const recoverLateLocalBoot = (payload: { error: string | null; phase: string; running: boolean }) => {
+      if (
+        cancelled ||
+        bootCompleted ||
+        $gatewaySwitching.get() ||
+        !lateLocalBootRecoveryArmed ||
+        lateLocalBootRecoveryStarted ||
+        payload.error !== null ||
+        payload.phase !== 'backend.ready' ||
+        !payload.running
+      ) {
+        return
+      }
+
+      lateLocalBootRecoveryArmed = false
+      lateLocalBootRecoveryStarted = true
+      // Explicitly clear the timeout overlay before retrying the same local
+      // connection. The backend is already healthy; this is an attach retry,
+      // not another spawn or an unbounded reconnect loop.
+      resumeDesktopBootForRetry(translateNow('boot.steps.startingDesktopConnection'))
+      void boot()
+    }
+
+    const armLateLocalBootRecovery = () => {
+      void primaryBootIsLocal().then(isLocal => {
+        if (cancelled || bootCompleted || lateLocalBootRecoveryStarted || !isLocal) {
+          return
+        }
+
+        lateLocalBootRecoveryArmed = true
+        // backend.ready can arrive before the connection-mode IPC reply above.
+        // Re-read the current snapshot so that race still gets its one attach.
+        void desktop.getBootProgress().then(recoverLateLocalBoot).catch(() => undefined)
+      })
+    }
+
     const offBootProgress = desktop.onBootProgress(payload => {
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
       // cold-boot CONNECTING overlay stays down. Post-boot errors are gated:
@@ -711,11 +780,15 @@ export function useGatewayBoot({
       }
 
       applyDesktopBootProgress(payload)
+      recoverLateLocalBoot(payload)
     })
 
     void desktop
       .getBootProgress()
-      .then(snapshot => applyDesktopBootProgress(snapshot))
+      .then(snapshot => {
+        applyDesktopBootProgress(snapshot)
+        recoverLateLocalBoot(snapshot)
+      })
       .catch(() => undefined)
 
     setDesktopBootStep({
@@ -1078,6 +1151,10 @@ export function useGatewayBoot({
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
+
+          if (isTimeoutError(err) && !lateLocalBootRecoveryStarted) {
+            armLateLocalBootRecovery()
+          }
 
           // Transient remote failure (dropped SSH/HTTP registered connection,
           // mint timeout): self-heal with bounded, jittered retries instead of


### PR DESCRIPTION
Fixes #98124

## Summary
- Retry the normal renderer handshake once when a locally managed backend becomes ready after the initial 45-second wait expires.
- Preserve the current remote retry policy and ignore duplicate readiness notifications.

## Tests
- `npm --workspace apps/desktop test -- src/app/gateway/hooks/use-gateway-boot.test.tsx`
- `npm --workspace apps/desktop run typecheck`