### PR TITLE
fix(gateway): recover agent after session reaped so messages are not silently dropped (salvage #99183)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18321,38 +18321,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._is_session_running(_quick_key):
             try:
                 _reap_store = getattr(self, "session_store", None)
-                # Guard against MagicMock in tests: only run on real SessionStore
-                # (which has a dict _entries and callable _is_session_ended_in_db).
-                _reap_entries = getattr(_reap_store, "_entries", None) if _reap_store else None
-                if not isinstance(_reap_entries, dict):
-                    raise TypeError("not a real SessionStore")
-                _reap_lock = getattr(_reap_store, "_lock", None)
+                # Use the public, lock-held accessors: peek_session_id resolves
+                # key -> session_id under the store lock, and returns a
+                # non-str on stubbed stores in bare test runners — both the
+                # isinstance() gate and the ``is True`` gate below keep this
+                # guard inert unless a real SessionStore answers.
+                _reap_peek = getattr(_reap_store, "peek_session_id", None)
                 _is_ended = getattr(_reap_store, "_is_session_ended_in_db", None)
-                if not callable(_is_ended):
-                    raise TypeError("missing _is_session_ended_in_db")
-                _reap_sid: str | None = None
-                if _reap_lock is not None:
-                    with _reap_lock:
-                        _reap_e = _reap_entries.get(_quick_key)
-                        _reap_sid = getattr(_reap_e, "session_id", None) if _reap_e else None
-                else:
-                    _reap_e = _reap_entries.get(_quick_key)
-                    _reap_sid = getattr(_reap_e, "session_id", None) if _reap_e else None
-                if isinstance(_reap_sid, str) and _reap_sid:
-                    _ended = _is_ended(_reap_sid)
-                    if _ended is True:
-                        logger.warning(
-                            "Evicting stale _running_agents entry for %s — "
-                            "durable session %s is ended (reaped) in state.db; "
-                            "healing routing on next message (#99106)",
-                            _quick_key,
-                            _reap_sid,
-                        )
-                        self._invalidate_session_run_generation(
-                            _quick_key,
-                            reason="reaped_session_eviction",
-                        )
-                        self._release_running_agent_state(_quick_key)
+                _reap_sid = _reap_peek(_quick_key) if callable(_reap_peek) else None
+                if (
+                    isinstance(_reap_sid, str)
+                    and _reap_sid
+                    and callable(_is_ended)
+                    and _is_ended(_reap_sid) is True
+                ):
+                    logger.warning(
+                        "Evicting stale _running_agents entry for %s — "
+                        "durable session %s is ended (reaped) in state.db; "
+                        "healing routing on next message (#99106)",
+                        _quick_key,
+                        _reap_sid,
+                    )
+                    self._invalidate_session_run_generation(
+                        _quick_key,
+                        reason="reaped_session_eviction",
+                    )
+                    self._release_running_agent_state(_quick_key)
             except Exception:
                 logger.debug("reaped-session staleness check failed", exc_info=True)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18307,6 +18307,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 self._release_running_agent_state(_quick_key)
 
+        # #99106: durable-reaped guard.  A session whose routing row was
+        # ended in state.db (e.g. ``ws_orphan_reap`` / ``agent_close``) while
+        # the gateway stayed alive keeps its in-memory turn slot alive
+        # (``_is_session_running`` stays True).  The priority fast-path would
+        # then queue every next user message into the dead runtime instead of
+        # healing the routing via ``get_or_create_session`` → ``reopen``.
+        # This is the live-gateway variant of #54878 and the #632 detached/
+        # 405 suppressions in production.  Evict the stale slot so the next
+        # message falls through to the cold path and re-attaches or creates a
+        # fresh session; /status then correctly shows 代理运行中: 否 before the
+        # heal and a live turn after.
+        if self._is_session_running(_quick_key):
+            try:
+                _reap_store = getattr(self, "session_store", None)
+                # Guard against MagicMock in tests: only run on real SessionStore
+                # (which has a dict _entries and callable _is_session_ended_in_db).
+                _reap_entries = getattr(_reap_store, "_entries", None) if _reap_store else None
+                if not isinstance(_reap_entries, dict):
+                    raise TypeError("not a real SessionStore")
+                _reap_lock = getattr(_reap_store, "_lock", None)
+                _is_ended = getattr(_reap_store, "_is_session_ended_in_db", None)
+                if not callable(_is_ended):
+                    raise TypeError("missing _is_session_ended_in_db")
+                _reap_sid: str | None = None
+                if _reap_lock is not None:
+                    with _reap_lock:
+                        _reap_e = _reap_entries.get(_quick_key)
+                        _reap_sid = getattr(_reap_e, "session_id", None) if _reap_e else None
+                else:
+                    _reap_e = _reap_entries.get(_quick_key)
+                    _reap_sid = getattr(_reap_e, "session_id", None) if _reap_e else None
+                if isinstance(_reap_sid, str) and _reap_sid:
+                    _ended = _is_ended(_reap_sid)
+                    if _ended is True:
+                        logger.warning(
+                            "Evicting stale _running_agents entry for %s — "
+                            "durable session %s is ended (reaped) in state.db; "
+                            "healing routing on next message (#99106)",
+                            _quick_key,
+                            _reap_sid,
+                        )
+                        self._invalidate_session_run_generation(
+                            _quick_key,
+                            reason="reaped_session_eviction",
+                        )
+                        self._release_running_agent_state(_quick_key)
+            except Exception:
+                logger.debug("reaped-session staleness check failed", exc_info=True)
+
         if self._is_session_running(_quick_key):
             # Resolve the command once; every command's mid-run behavior is
             # declared on its CommandDef (busy_policy / busy_handler in

--- a/tests/gateway/test_reaped_session_recovery.py
+++ b/tests/gateway/test_reaped_session_recovery.py
@@ -1,0 +1,213 @@
+"""Regression tests for the durable-reaped session guard in _handle_message (#99106).
+
+A session whose durable row was ended in state.db (``ws_orphan_reap`` /
+``agent_close``) while the gateway process stayed alive keeps its in-memory
+turn slot (``_is_session_running`` stays True). Before the guard, the next
+inbound message took the PRIORITY fast-path and was interrupt()-delivered into
+the dead runtime — silently dropped, never reaching the
+``get_or_create_session`` routing self-heal (#54878). The guard evicts the
+stale slot at routing time so the message falls through to the cold path.
+
+Salvaged from PR #99183 (@Finn763).
+"""
+
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import (
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+    SessionResetPolicy,
+)
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+        self._active_sessions = {}
+
+    async def send(self, *args, **kwargs):
+        pass
+
+
+class _DeadReapedAgent:
+    """Runtime whose turn was reaped: interrupt() lands nowhere."""
+
+    def __init__(self):
+        self.interrupts = []
+
+    def interrupt(self, text):
+        self.interrupts.append(text)
+
+    def get_activity_summary(self):
+        # Recently active — the pre-existing idle-staleness eviction must NOT
+        # fire, so only the durable-reaped guard can heal this shape.
+        return {
+            "seconds_since_activity": 0,
+            "last_activity_desc": "tool",
+            "api_call_count": 1,
+            "max_iterations": 50,
+        }
+
+
+def _make_runner(store) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="x")}
+    )
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._pending_messages = {}
+    runner._voice_mode = {}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._restart_requested = False
+    runner._restart_task_started = False
+    runner._restart_detached = False
+    runner._restart_via_service = False
+    runner._restart_drain_timeout = 0.0
+    runner._stop_task = None
+    runner._exit_code = None
+    runner._update_runtime_status = MagicMock()
+    runner._is_user_authorized = lambda _source: True
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = store
+    runner.delivery_router = MagicMock()
+    return runner
+
+
+def _source(chat_id="555001") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id=chat_id,
+    )
+
+
+def _store(tmp_path) -> SessionStore:
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="none")
+    )
+    return SessionStore(sessions_dir=tmp_path, config=config)
+
+
+def _occupy_turn_slot(runner, key, agent):
+    state = runner._session_state(key)
+    state.turn.agent = agent
+    # Turn started 2 minutes ago — outside the Telegram follow-up grace
+    # window, inside the idle-staleness threshold.
+    state.turn.started_ts = time.time() - 120
+
+
+@pytest.mark.asyncio
+async def test_reaped_session_message_reaches_cold_path(tmp_path):
+    """DB-ended session + live turn slot: next message must heal, not drop."""
+    store = _store(tmp_path)
+    src = _source()
+    entry = store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+
+    runner = _make_runner(store)
+    agent = _DeadReapedAgent()
+    _occupy_turn_slot(runner, key, agent)
+
+    # The durable row is ended out from under the live slot (the reap).
+    store._db.end_session(entry.session_id, "ws_orphan_reap")
+    assert store._is_session_ended_in_db(entry.session_id) is True
+
+    event = MessageEvent(
+        text="hello, are you there?",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+
+    cold_path = AsyncMock(return_value="COLD_PATH_REPLY")
+    with (
+        patch.object(GatewayRunner, "_handle_message_with_agent", cold_path),
+        patch.object(GatewayRunner, "_run_post_turn_hooks", AsyncMock()),
+        patch.object(GatewayRunner, "_clear_durable_active_turn", AsyncMock()),
+        patch.object(GatewayRunner, "_persist_active_agents", lambda self: None),
+    ):
+        result = await runner._handle_message(event)
+
+    assert result == "COLD_PATH_REPLY"
+    assert cold_path.await_count == 1
+    # Nothing was interrupt()-delivered into the dead runtime.
+    assert agent.interrupts == []
+
+
+@pytest.mark.asyncio
+async def test_alive_session_keeps_priority_interrupt_path(tmp_path):
+    """Control: with the durable row still open, the PRIORITY interrupt
+    fast-path must behave exactly as before (no eviction)."""
+    store = _store(tmp_path)
+    src = _source(chat_id="555002")
+    store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+
+    runner = _make_runner(store)
+    agent = _DeadReapedAgent()
+    _occupy_turn_slot(runner, key, agent)
+
+    event = MessageEvent(
+        text="follow-up while running",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+
+    cold_path = AsyncMock(return_value="COLD_PATH_REPLY")
+    with (
+        patch.object(GatewayRunner, "_handle_message_with_agent", cold_path),
+        patch.object(GatewayRunner, "_agent_has_active_subagents", lambda self, a: False),
+        patch.object(
+            GatewayRunner,
+            "_session_has_compression_in_flight",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        result = await runner._handle_message(event)
+
+    assert result is None
+    assert cold_path.await_count == 0
+    assert agent.interrupts == ["follow-up while running"]
+
+
+@pytest.mark.asyncio
+async def test_guard_is_inert_with_stubbed_session_store(tmp_path):
+    """Bare test runners stub session_store with MagicMock; the guard must
+    not evict (peek_session_id returns a Mock, not a str) and must not raise."""
+    store = MagicMock()
+    src = _source(chat_id="555003")
+
+    runner = _make_runner(store)
+    key = runner._session_key_for_source(src)
+    agent = _DeadReapedAgent()
+    _occupy_turn_slot(runner, key, agent)
+
+    event = MessageEvent(
+        text="stub store follow-up",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+
+    with (
+        patch.object(GatewayRunner, "_agent_has_active_subagents", lambda self, a: False),
+        patch.object(
+            GatewayRunner,
+            "_session_has_compression_in_flight",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        result = await runner._handle_message(event)
+
+    # Slot untouched; the message took the normal busy path.
+    assert runner._is_session_running(key) is True
+    assert result is None
+    assert agent.interrupts == ["stub store follow-up"]


### PR DESCRIPTION
Salvages **PR #99183** by @Finn763 onto current `main` (rebase-clean), preserving authorship. Fixes the production-scale silent-drop reported in #99106.

Closes #99106
Supersedes #99183 (credit: @Finn763 — original diagnosis and fix)

## Problem

When a session's durable row is ended in state.db (`ws_orphan_reap` / `agent_close`) while the gateway process stays alive, the in-memory turn slot survives — `_is_session_running()` stays True. The next inbound message then takes the PRIORITY fast-path and is `interrupt()`-delivered into the **dead** runtime: no error, no reply, silently dropped. It never reaches the `get_or_create_session` routing self-heal (#54878), which only runs on the cold path. Production evidence in #99106: 632 `detached/reaped runtime` hits, 405 `Suppressing normal final send`, `/status` showing agent-running: no.

The two pre-existing evictions don't cover this shape:
- the idle-staleness eviction requires the agent to be *idle* past `HERMES_AGENT_TIMEOUT`;
- the #54878 guard lives inside `get_or_create_session`, which the PRIORITY path never calls.

## Fix (Finn763's commit, +49 LOC in `gateway/run.py`)

A durable-reaped guard just before the `_is_session_running` PRIORITY gate in `_handle_message`: if the session_id routed for this key has `end_reason` set in state.db, evict the stale turn slot (`_invalidate_session_run_generation(reason="reaped_session_eviction")` + `_release_running_agent_state`) so the message falls through to the cold path, where the existing #54878 self-heal reopens or recreates the session.

## Our follow-ups on top

1. **Cleanup commit** — replaced the original's private-attr poking (`store._entries` / `store._lock` with a "guard against MagicMock" TypeError hack) with the public lock-held accessor `SessionStore.peek_session_id()`; the `isinstance(str)` + `is True` gates keep the guard inert on stubbed stores without test-shaped exceptions.
2. **Regression suite** — `tests/gateway/test_reaped_session_recovery.py` (3 tests): reaped session heals to the cold path; alive session keeps the PRIORITY interrupt path untouched; guard is inert with a MagicMock store. Sabotage run verified: the heal test FAILS on main's `gateway/run.py` without the guard.

**Live repro:** real `GatewayRunner._handle_message` + real `SessionStore` + real state.db in a temp HERMES_HOME; ended the durable row with `ws_orphan_reap` under a live turn slot, sent a follow-up message — before: message `interrupt()`-delivered into the dead runtime, cold path never reached (silent drop); after: stale slot evicted (`Evicting stale _running_agents entry … (#99106)` logged), message reached the cold path and got a reply.

## Testing

- `tests/gateway/test_reaped_session_recovery.py` — 3/3 pass; heal test fails without the fix (sabotage-verified).
- Targeted neighbors green: `test_session_race_guard.py`, `test_session_store_runtime_stale_guard.py`, `test_running_agent_session_toggles.py` (24 passed).
- Broad `tests/gateway -k "session|reap|stale|busy|race"`: 831 passed; the 3 failures present are pre-existing/order-dependent on main (identical failure set without this branch's test file; `test_api_server_runs` fails on pristine origin/main).
- `ruff check` clean on both files.

## Related

#96870, #97764, #94935, #98106, #98554 (the wider ws_orphan_reap cluster — this PR fixes the gateway-messaging leg only).

## Infographic

![gw-reap-recovery](https://v3b.fal.media/files/b/0aa89058/ejefdChTUmzZp5UnPfsCS_dN66D7cP.png)
