### PR TITLE
fix(mcp): derive callback port from a configured loopback oauth.redirect_uri

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -567,6 +567,83 @@ class TestCallbackPortReservation:
 
 
 # ---------------------------------------------------------------------------
+# Configured redirect_uri port derivation (#99503)
+# ---------------------------------------------------------------------------
+
+class TestConfiguredRedirectUriPort:
+    """A configured loopback oauth.redirect_uri pins the listener port.
+
+    ``hermes mcp login`` wipes the cached client registration before
+    probing, so a server with ``oauth.redirect_uri:
+    http://localhost:<N>/callback`` and no ``redirect_port`` used to bind a
+    random ephemeral port while the authorize URL advertised ``<N>`` —
+    every approval then died on a connection-refused redirect and the
+    login timed out after the full 300s callback window (#99503).
+    """
+
+    def test_loopback_uri_port_beats_ephemeral(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {
+            "cimd": False,
+            "redirect_uri": "http://localhost:3118/callback",
+        }
+        port = mod._configure_callback_port(cfg)
+        assert port == 3118
+        assert cfg["_resolved_port"] == 3118
+        # Fixed, known port — no ephemeral reservation is left parked.
+        assert 3118 not in mod._reserved_sockets
+
+    def test_explicit_redirect_port_still_wins(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {
+            "cimd": False,
+            "redirect_port": 49399,
+            "redirect_uri": "http://localhost:3118/callback",
+        }
+        assert mod._configure_callback_port(cfg) == 49399
+
+    def test_https_proxy_uri_falls_through_to_ephemeral(self):
+        import tools.mcp_oauth as mod
+
+        # A proxied redirect_uri (e.g. Tailscale Funnel → localhost) must
+        # keep the ephemeral listener: the funnel, not the URI, decides the
+        # local port.
+        cfg: dict = {
+            "cimd": False,
+            "redirect_uri": "https://funnel.example.com/callback",
+        }
+        port = mod._configure_callback_port(cfg)
+        assert port in mod._reserved_sockets
+        reserved = mod._reserved_sockets.pop(port)
+        reserved.close()
+
+    def test_portless_and_nonstandard_uris_fall_through(self):
+        import tools.mcp_oauth as mod
+
+        for uri in (
+            "http://localhost/callback",  # portless loopback
+            "http://localhost:3118/oauth/callback",  # non-standard path
+            "http://192.168.1.4:3118/callback",  # non-loopback host
+        ):
+            cfg: dict = {"cimd": False, "redirect_uri": uri}
+            port = mod._configure_callback_port(cfg)
+            assert port in mod._reserved_sockets, uri
+            reserved = mod._reserved_sockets.pop(port)
+            reserved.close()
+
+    def test_without_configured_uri_ephemeral_stays(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {"cimd": False}
+        port = mod._configure_callback_port(cfg)
+        assert port in mod._reserved_sockets
+        reserved = mod._reserved_sockets.pop(port)
+        reserved.close()
+
+
+# ---------------------------------------------------------------------------
 # remove_oauth_tokens
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -304,6 +304,36 @@ def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
     return None
 
 
+def _port_from_configured_redirect_uri(cfg: dict) -> int | None:
+    """Return the loopback callback port of a configured ``oauth.redirect_uri``.
+
+    When the user pins ``oauth.redirect_uri`` to a loopback http URL with an
+    explicit port, the authorize URL advertises that exact port, so the
+    callback listener must bind it too. Without this derivation, a fresh
+    login (whose cached client registration was just wiped) binds a random
+    ephemeral port and every provider approval dies on a connection-refused
+    redirect (#99503). Non-loopback or portless URIs (e.g. an https proxy
+    funnel forwarding to localhost, where the local port is the funnel's
+    business) return None so the normal fallback chain stays in charge.
+    Mirrors the loopback shape ``_cached_redirect_port`` accepts.
+    """
+    configured = cfg.get("redirect_uri")
+    if not configured:
+        return None
+    try:
+        parsed = urlparse(str(configured))
+    except (TypeError, ValueError):
+        return None
+    if (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.path == "/callback"
+        and parsed.port is not None
+    ):
+        return int(parsed.port)
+    return None
+
+
 def _cached_redirect_uri(storage: "HermesTokenStorage | None") -> str | None:
     """Return a cached non-loopback redirect URI, if one was registered."""
     if storage is None:
@@ -1547,9 +1577,10 @@ def _configure_callback_port(
 
     Port choice precedence:
     1. explicit ``oauth.redirect_port`` config
-    2. cached client registration redirect URI port
-    3. a pinned CIMD port, when the flow is CIMD-eligible
-    4. newly allocated free port
+    2. the port of a configured loopback ``oauth.redirect_uri``
+    3. cached client registration redirect URI port
+    4. a pinned CIMD port, when the flow is CIMD-eligible
+    5. newly allocated free port
 
     A CIMD-eligible flow also records the client_id URL in
     ``cfg['_cimd_url']`` for the provider constructors to forward.
@@ -1580,15 +1611,22 @@ def _configure_callback_port(
         _oauth_port = port
         return port
     requested = int(cfg.get("redirect_port", 0))
-    # Precedence: explicit config port → cached client-registration port →
-    # fresh ephemeral port. The cached port keeps re-auth consistent with the
-    # redirect URI pinned at dynamic client registration (providers reject a
-    # mismatched URI). Only a truly fresh ephemeral pick goes through
-    # _reserve_callback_port(), which keeps the socket bound until
-    # _wait_for_callback adopts it — closing the select→bind TOCTOU race
-    # (#22161). Explicit and cached ports are fixed, known values and bind
-    # via the reuse_address path instead.
-    port = requested or _cached_redirect_port(storage) or _reserve_callback_port()
+    # Precedence: explicit config port → port of a configured loopback
+    # redirect_uri → cached client-registration port → fresh ephemeral port.
+    # The redirect_uri-derived port keeps the listener on the same port the
+    # authorize URL advertises (#99503); the cached port keeps re-auth
+    # consistent with the redirect URI pinned at dynamic client registration
+    # (providers reject a mismatched URI). Only a truly fresh ephemeral pick
+    # goes through _reserve_callback_port(), which keeps the socket bound
+    # until _wait_for_callback adopts it — closing the select→bind TOCTOU
+    # race (#22161). Explicit, derived, and cached ports are fixed, known
+    # values and bind via the reuse_address path instead.
+    port = (
+        requested
+        or _port_from_configured_redirect_uri(cfg)
+        or _cached_redirect_port(storage)
+        or _reserve_callback_port()
+    )
     # A cached port can be one of the pinned CIMD ports, left behind by an
     # earlier CIMD login for this server. Claim it so a sibling server's
     # _pick_cimd_port doesn't hand the same port out a second time.


### PR DESCRIPTION
## What does this PR do?

`hermes mcp login` for a server with an explicit `oauth.redirect_uri` (e.g. `http://localhost:3118/callback`) and no `oauth.redirect_port` binds the OAuth callback listener on a **random ephemeral port** while the authorize URL advertises the configured port — so every provider approval redirects to a dead port and the login hangs for the full 300s callback window, then fails with an empty `✗ Authentication failed:`.

Root cause: `_configure_callback_port()` never derives the port from the configured `redirect_uri`, and on the `mcp login` path the cache fallback is guaranteed to miss because `_reauth_oauth_server()` wipes the cached client registration (`<server>.client.json`) before probing to force a fresh flow. The chain falls through to `_reserve_callback_port()` (ephemeral) while `_resolve_redirect_uri()` returns the configured URI verbatim — the advertised and bound ports diverge on every login for this config shape.

Fix: derive the port from a configured **loopback http** `redirect_uri` (explicit port, `/callback` path — the same shape `_cached_redirect_port()` accepts) and insert it into the existing precedence between the explicit `redirect_port` and the cached-registration port. Non-loopback, `https`-proxied (e.g. Tailscale Funnel → localhost, where the funnel decides the local port), portless, or non-standard-path URIs return `None`, so every existing fallback is unchanged.

## Related Issue

Fixes #99503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth.py`: new `_port_from_configured_redirect_uri(cfg)` helper that extracts the port from a configured loopback `http://127.0.0.1|localhost:<N>/callback` URI (mirrors the loopback shape `_cached_redirect_port` already accepts); wired into `_configure_callback_port()` as `requested or _port_from_configured_redirect_uri(cfg) or _cached_redirect_port(storage) or _reserve_callback_port()`, plus updated precedence docstring.
- `tests/tools/test_mcp_oauth.py`: new `TestConfiguredRedirectUriPort` class — loopback URI pins the port (no ephemeral reservation left parked), explicit `redirect_port` still wins, https-proxied / portless / non-standard-path / non-loopback URIs fall through to the ephemeral branch, and no-configured-URI behavior is unchanged.

## How to Test

1. Unit tests (red → green): `pytest tests/tools/test_mcp_oauth.py::TestConfiguredRedirectUriPort -q`
   - Without the product change, `test_loopback_uri_port_beats_ephemeral` fails (`_configure_callback_port({"cimd": False, "redirect_uri": "http://localhost:3118/callback"})` returned an ephemeral port); with the change it returns `3118`. Observed result: 5 passed.
2. Full file + adjacent OAuth suites: `pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_dashboard_oauth.py tests/tools/test_mcp_cimd.py tests/hermes_cli/test_mcp_config.py -q`
   - Observed result: 181 passed (63 + 118), no regressions.
3. Manual shape check (from the issue): configure a server with `oauth.redirect_uri: http://localhost:3118/callback`, run `hermes mcp login <server>` and verify `lsof -nP -iTCP:3118 -sTCP:LISTEN` now shows the listener while the flow is waiting (previously the listener sat on a random ephemeral port and the redirect to 3118 was refused).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full OAuth/CMD/CLI-related suites listed above pass locally; full-suite run delegated to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — precedence docstring updated in `_configure_callback_port`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; existing `oauth.redirect_uri` semantics honored)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — loopback URL parsing is stdlib `urllib.parse`, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ pytest tests/tools/test_mcp_oauth.py::TestConfiguredRedirectUriPort -q
5 passed in 0.68s

# red check (product change stashed):
FAILED tests/tools/test_mcp_oauth.py::TestConfiguredRedirectUriPort::test_loopback_uri_port_beats_ephemeral
```