### PR TITLE
fix(mcp): honor a configured loopback redirect_uri port for the OAuth callback listener (#99503)

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -567,6 +567,66 @@ class TestCallbackPortReservation:
 
 
 # ---------------------------------------------------------------------------
+# Configured loopback redirect_uri pins the callback port (#99503)
+# ---------------------------------------------------------------------------
+
+class TestConfiguredRedirectUriPort:
+    """A pinned ``oauth.redirect_uri: http://localhost:<N>/callback`` (no
+    ``oauth.redirect_port``) must make the callback listener bind port ``<N>``,
+    so it matches the port the authorize URL advertises. Before #99503 the
+    listener took an ephemeral port and every approval was lost."""
+
+    def test_loopback_redirect_uri_pins_listener_port(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {"cimd": False, "redirect_uri": "http://localhost:3118/callback"}
+        port = mod._configure_callback_port(cfg)
+
+        assert port == 3118
+        assert cfg["_resolved_port"] == 3118
+        # A fixed, known port is not parked in the ephemeral reservation table.
+        assert 3118 not in mod._reserved_sockets
+        # The advertised redirect_uri and the listener now agree on the port.
+        assert mod._resolve_redirect_uri(cfg, port) == "http://localhost:3118/callback"
+
+    def test_explicit_redirect_port_still_wins(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {
+            "cimd": False,
+            "redirect_port": 49512,
+            "redirect_uri": "http://localhost:3118/callback",
+        }
+        assert mod._configure_callback_port(cfg) == 49512
+
+    def test_proxy_redirect_uri_keeps_ephemeral_listener(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {"cimd": False, "redirect_uri": "https://oauth.example.ts.net/callback"}
+        port = mod._configure_callback_port(cfg)
+        try:
+            # Not derived from the (non-loopback) proxy URL — a real ephemeral pick.
+            assert port not in (0, 3118)
+            assert port in mod._reserved_sockets
+        finally:
+            sock = mod._reserved_sockets.pop(port, None)
+            if sock is not None:
+                sock.close()
+
+    @pytest.mark.parametrize("uri, expected", [
+        ("http://localhost:3118/callback", 3118),
+        ("http://127.0.0.1:8899/callback", 8899),
+        ("https://oauth.example.ts.net/callback", None),  # proxy — independent listener
+        ("http://localhost/callback", None),              # no port
+        ("", None),
+    ])
+    def test_port_from_configured_redirect_uri(self, uri, expected):
+        from tools.mcp_oauth import _port_from_configured_redirect_uri
+
+        assert _port_from_configured_redirect_uri({"redirect_uri": uri} if uri else {}) == expected
+
+
+# ---------------------------------------------------------------------------
 # remove_oauth_tokens
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -304,6 +304,35 @@ def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
     return None
 
 
+def _port_from_configured_redirect_uri(cfg: dict) -> int | None:
+    """Return the port of a configured loopback ``oauth.redirect_uri``.
+
+    When a server pins ``oauth.redirect_uri: http://localhost:<N>/callback``
+    but no ``oauth.redirect_port``, the authorize URL advertises port ``<N>``
+    (``_resolve_redirect_uri`` returns the configured URI verbatim) while the
+    callback listener would otherwise bind an ephemeral port — the redirect
+    then hits a dead port and login times out. Deriving the port here keeps
+    the listener and the advertised ``redirect_uri`` on the same port. A
+    non-loopback (proxy) ``redirect_uri`` returns ``None`` so those flows keep
+    their independent ephemeral listener.
+    """
+    configured = cfg.get("redirect_uri")
+    if not configured:
+        return None
+    try:
+        parsed = urlparse(str(configured))
+    except (TypeError, ValueError):
+        return None
+    if (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.path == "/callback"
+        and parsed.port is not None
+    ):
+        return int(parsed.port)
+    return None
+
+
 def _cached_redirect_uri(storage: "HermesTokenStorage | None") -> str | None:
     """Return a cached non-loopback redirect URI, if one was registered."""
     if storage is None:
@@ -1547,9 +1576,10 @@ def _configure_callback_port(
 
     Port choice precedence:
     1. explicit ``oauth.redirect_port`` config
-    2. cached client registration redirect URI port
-    3. a pinned CIMD port, when the flow is CIMD-eligible
-    4. newly allocated free port
+    2. port of a configured loopback ``oauth.redirect_uri``
+    3. cached client registration redirect URI port
+    4. a pinned CIMD port, when the flow is CIMD-eligible
+    5. newly allocated free port
 
     A CIMD-eligible flow also records the client_id URL in
     ``cfg['_cimd_url']`` for the provider constructors to forward.
@@ -1580,15 +1610,22 @@ def _configure_callback_port(
         _oauth_port = port
         return port
     requested = int(cfg.get("redirect_port", 0))
-    # Precedence: explicit config port → cached client-registration port →
-    # fresh ephemeral port. The cached port keeps re-auth consistent with the
-    # redirect URI pinned at dynamic client registration (providers reject a
-    # mismatched URI). Only a truly fresh ephemeral pick goes through
-    # _reserve_callback_port(), which keeps the socket bound until
+    # Precedence: explicit config port → port of a configured loopback
+    # redirect_uri → cached client-registration port → fresh ephemeral port.
+    # A configured loopback redirect_uri is what _resolve_redirect_uri puts in
+    # the authorize request, so the listener must bind that same port or the
+    # redirect lands on a dead port (#99503). The cached port keeps re-auth
+    # consistent with the redirect URI pinned at dynamic client registration
+    # (providers reject a mismatched URI). Only a truly fresh ephemeral pick
+    # goes through _reserve_callback_port(), which keeps the socket bound until
     # _wait_for_callback adopts it — closing the select→bind TOCTOU race
-    # (#22161). Explicit and cached ports are fixed, known values and bind
-    # via the reuse_address path instead.
-    port = requested or _cached_redirect_port(storage) or _reserve_callback_port()
+    # (#22161). Fixed, known ports bind via the reuse_address path instead.
+    port = (
+        requested
+        or _port_from_configured_redirect_uri(cfg)
+        or _cached_redirect_port(storage)
+        or _reserve_callback_port()
+    )
     # A cached port can be one of the pinned CIMD ports, left behind by an
     # earlier CIMD login for this server. Claim it so a sibling server's
     # _pick_cimd_port doesn't hand the same port out a second time.


### PR DESCRIPTION
## What does this PR do?

`hermes mcp login <server>` starts the OAuth callback HTTP listener on a
**different port than the `redirect_uri` it advertises in the authorize URL**,
whenever a per-server `oauth.redirect_uri` is configured without an explicit
`oauth.redirect_port`:

```yaml
mcp_servers:
  slack:
    url: https://mcp.slack.com/mcp
    auth: oauth
    oauth:
      client_id: "<client-id>"
      redirect_uri: http://localhost:3118/callback   # port 3118
```

`_resolve_redirect_uri()` returns the configured URI verbatim (port 3118), but
`_configure_callback_port()` chooses the listener port as:

```python
port = requested or _cached_redirect_port(storage) or _reserve_callback_port()
```

— it never looks at `cfg["redirect_uri"]`. And the `mcp login` path **guarantees**
the cache miss: `_reauth_oauth_server()` deletes `<server>.client.json` before
probing, so `_cached_redirect_port()` returns `None` and the picker falls through
to an ephemeral port (e.g. 54916). The browser redirect to `localhost:3118` gets
connection-refused, `_make_callback_waiter` waits out the full 300 s, and login
ends with an empty `✗ Authentication failed:` — every time.

### Fix

Add `_port_from_configured_redirect_uri(cfg)` and slot it into the existing port
precedence, right after the explicit `redirect_port`:

```
1. explicit oauth.redirect_port
2. port of a configured loopback oauth.redirect_uri   ← new
3. cached client-registration port
4. pinned CIMD port
5. fresh ephemeral port
```

Only **loopback `http`** URIs (`127.0.0.1` / `localhost`, path `/callback`, explicit
port) are matched — mirroring the existing `_cached_redirect_port()` check. A proxy
`redirect_uri` (Tailscale Funnel, etc.) returns `None` and keeps its independent
ephemeral listener, exactly as today. Explicit `redirect_port` still wins.

## Related Issue

Fixes #99503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth.py` — new `_port_from_configured_redirect_uri()` helper;
  `_configure_callback_port()` consults it in the port-precedence chain; docstring
  + inline precedence comment updated.
- `tests/tools/test_mcp_oauth.py` — new `TestConfiguredRedirectUriPort`:
  - loopback `redirect_uri` pins the listener to its port and it matches
    `_resolve_redirect_uri()` (fails on `main` — listener took an ephemeral port);
  - explicit `redirect_port` still wins;
  - proxy (`https`) `redirect_uri` still gets an ephemeral reserved listener;
  - parametrized unit coverage of the helper (loopback w/ port, `127.0.0.1`,
    proxy, no-port, empty).

## How to Test

```bash
pytest tests/tools/test_mcp_oauth.py -q
```

`TestConfiguredRedirectUriPort::test_loopback_redirect_uri_pins_listener_port`
fails on `main` (ephemeral port ≠ 3118), passes with this change. Adjacent suites
green: `tests/tools/test_mcp_cimd.py`, `tests/tools/test_mcp_dashboard_oauth.py`
(120 passed together).

Manual: configure a remote OAuth MCP server with
`oauth.redirect_uri: http://localhost:3118/callback` (no `redirect_port`), run
`hermes mcp login <server>`, and confirm
`lsof -nP -iTCP:3118 -sTCP:LISTEN` shows the listener during the flow.

## What platforms

Tested on macOS (Python 3.11). Pure port-selection logic; no OS-specific paths.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(mcp): …`)
- [x] I searched existing issues/PRs — no PR references #99503, no competing `_configure_callback_port` redirect_uri PR
- [x] PR contains only changes related to this fix
- [x] Ran `pytest tests/tools/test_mcp_oauth.py` (+ cimd/dashboard suites), all pass
- [x] Added regression tests (the key one fails without the fix)
- [x] Tested on my platform: macOS / Python 3.11.16

### Documentation & Housekeeping

- [x] Docs — N/A (behavior now matches the documented `redirect_uri` contract)
- [x] `cli-config.yaml.example` — N/A (no new config keys; `oauth.redirect_uri` already documented)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — port-selection only
- [x] Tool descriptions/schemas — N/A
