### PR TITLE
fix(state): archive carried-forward compaction tail as rewind rows (#86366 salvage of #93160)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -252,6 +252,13 @@ COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
 # rolling summary, so dropping or rewriting one destroys history.
 MICRO_COMPACT_MARKER_KEY = "_micro_compact_marker"
 _DB_PERSISTED_MARKER = "_db_persisted"
+# Marks a message dict as carried-forward compaction tail (verbatim rows the
+# compressor protected from summarization). archive_and_compact() archives
+# these originals as rewind-style (active=0, compacted=0) instead of
+# compacted=1, so they stop satisfying search_messages' recall filter and
+# duplicating their live copies (#86366). Never persisted: _insert_message_rows
+# only reads known columns.
+_COMPACTION_TAIL_MARKER = "_compaction_tail"
 PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY = "_proactive_prune_rearm_tokens"
 
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
@@ -7368,7 +7375,15 @@ This compaction should PRIORITISE preserving all information related to the focu
         if not session_db or not session_id:
             return
         try:
-            session_db.archive_and_compact(session_id, compacted_messages)
+            # The splice result is [..verbatim prefix.., summary_marker,
+            # ..verbatim suffix..]: every row except the single marker is a
+            # carried-forward original (#86366) — archive their pre-splice
+            # originals rewind-style instead of compacted=1.
+            session_db.archive_and_compact(
+                session_id,
+                compacted_messages,
+                tail_count=max(0, len(compacted_messages) - 1),
+            )
             # Shared post-commit contract with the in-place batch commit and
             # the proactive prune (#98450) — one stamp site for the class.
             stamp_db_persisted_markers(compacted_messages)
@@ -8223,6 +8238,11 @@ This compaction should PRIORITISE preserving all information related to the focu
         if _force_user_leading and first_tail_visible_idx is not None:
             _merge_target_idx = first_tail_visible_idx
         for tail_idx, msg in enumerate(tail_messages):
+            # Tag the carried-forward tail so archive_and_compact() can
+            # classify these rows' originals as superseded-duplicate
+            # (rewind semantics) instead of "summarized away" (#86366).
+            if isinstance(msg, dict):
+                msg[_COMPACTION_TAIL_MARKER] = True
             if _merge_summary_into_tail and tail_idx == _merge_target_idx:
                 # Merge the summary into the tail message that collided.
                 old_content = msg.get("content", "")

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4559,6 +4559,15 @@ def compress_context(
                         PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY,
                     )
 
+                    # Tail rows carry the _compaction_tail tag from compress()
+                    # (#86366): their originals must be archived as
+                    # superseded duplicates (rewind-style), not compacted=1.
+                    _tail_count = sum(
+                        1
+                        for m in reversed(compressed)
+                        if isinstance(m, dict)
+                        and m.pop("_compaction_tail", None)
+                    )
                     agent._session_db.archive_and_compact(
                         agent.session_id,
                         compressed,
@@ -4567,6 +4576,7 @@ def compress_context(
                         },
                         watermark=_commit_watermark,
                         lock_holder=_lock_holder,
+                        tail_count=_tail_count,
                     )
                     split_status = "in_place_committed"
                     # Post-commit contract (#98450, mirrors

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4427,6 +4427,21 @@ def compress_context(
                 # away regardless of whether the id rotates).
                 agent.commit_memory_session(messages)
 
+                # Pop the #86366 carried-forward-tail tags BEFORE the size
+                # estimate and BEFORE any non-in-place path can see them:
+                # the private `_compaction_tail` key must not inflate the
+                # anti-growth token estimate (it tipped break-even
+                # transcripts into a false "would grow" refusal) and must
+                # not ride rotation handoffs into the provider payload.
+                # Remember the tagged dicts by identity — the salvage pass
+                # below may swap `compressed` for a subset, and tail_count
+                # must describe the FINAL committed list.
+                _tail_tagged_ids = {
+                    id(m)
+                    for m in compressed
+                    if isinstance(m, dict) and m.pop("_compaction_tail", None)
+                }
+
                 # Anti-growth guard at the COMMIT SITE: never persist a
                 # compression that makes the transcript larger (observed:
                 # 379K -> 687K when the generated summary plus retained
@@ -4559,14 +4574,14 @@ def compress_context(
                         PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY,
                     )
 
-                    # Tail rows carry the _compaction_tail tag from compress()
-                    # (#86366): their originals must be archived as
+                    # Tail rows carried the _compaction_tail tag from
+                    # compress() (#86366; popped above, before the size
+                    # estimate): their originals must be archived as
                     # superseded duplicates (rewind-style), not compacted=1.
+                    # Count against the FINAL list — salvage may have
+                    # dropped rows.
                     _tail_count = sum(
-                        1
-                        for m in reversed(compressed)
-                        if isinstance(m, dict)
-                        and m.pop("_compaction_tail", None)
+                        1 for m in compressed if id(m) in _tail_tagged_ids
                     )
                     agent._session_db.archive_and_compact(
                         agent.session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11975,28 +11975,46 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Rewind-target ids: the originals of the carried-forward tail
             # rows (tail_count), captured BEFORE any flag flips. Named apart
             # from the watermark `tail_ids` below on purpose — the two are
-            # different sets (#86366).
+            # different sets (#86366): rewind targets sit AT/BELOW the
+            # watermark (the compressor only saw rows up to it), while
+            # `tail_ids` are concurrent appends ABOVE it. Without the bound,
+            # a concurrent append would steal a LIMIT slot and leave a real
+            # carried-forward original stamped compacted=1.
             rewind_tail_ids: Optional[list[int]] = None
             if tail_count > 0:
-                tail_rows = conn.execute(
-                    "SELECT id FROM messages "
-                    "WHERE session_id = ? AND active = 1 ORDER BY id DESC LIMIT ?",
-                    (session_id, int(tail_count)),
-                ).fetchall()
+                if watermark is not None:
+                    tail_rows = conn.execute(
+                        "SELECT id FROM messages "
+                        "WHERE session_id = ? AND active = 1 AND id <= ? "
+                        "ORDER BY id DESC LIMIT ?",
+                        (session_id, int(watermark), int(tail_count)),
+                    ).fetchall()
+                else:
+                    tail_rows = conn.execute(
+                        "SELECT id FROM messages "
+                        "WHERE session_id = ? AND active = 1 ORDER BY id DESC LIMIT ?",
+                        (session_id, int(tail_count)),
+                    ).fetchall()
                 rewind_tail_ids = [int(row["id"]) for row in tail_rows]
 
-            if rewind_tail_ids:
-                placeholders = ",".join("?" for _ in rewind_tail_ids)
+            # The watermark clone below re-inserts `tail_ids` rows byte-exact
+            # as live rows — their originals are the SAME superseded-duplicate
+            # class as the carried-forward tail (#86366), so they take the
+            # rewind flags too instead of double-matching the recall filter.
+            rewind_ids = [*(rewind_tail_ids or []), *tail_ids]
+
+            if rewind_ids:
+                placeholders = ",".join("?" for _ in rewind_ids)
                 conn.execute(
                     "UPDATE messages SET active = 0, compacted = 0 "
                     f"WHERE session_id = ? AND id IN ({placeholders})",
-                    [session_id, *rewind_tail_ids],
+                    [session_id, *rewind_ids],
                 )
                 conn.execute(
                     "UPDATE messages SET active = 0, compacted = 1 "
                     "WHERE session_id = ? AND active = 1 "
                     f"AND id NOT IN ({placeholders})",
-                    [session_id, *rewind_tail_ids],
+                    [session_id, *rewind_ids],
                 )
             else:
                 conn.execute(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11857,6 +11857,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         model_config_patch: Optional[Dict[str, Any]] = None,
         watermark: Optional[int] = None,
         lock_holder: Optional[str] = None,
+        tail_count: int = 0,
     ) -> int:
         """Non-destructive in-place compaction for a single durable session id.
 
@@ -11895,6 +11896,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         held by that holder and unexpired — a compression whose lease was
         reclaimed (crash cleanup, TTL expiry, competing writer) fails the
         commit instead of clobbering the winner's transcript.
+
+        *tail_count* (default 0) names how many of the LAST rows of
+        *compacted_messages* are the verbatim carried-forward tail the
+        compressor protected rather than summarized (#86366). Those rows'
+        ORIGINALS — which this call archives as a side effect of the blanket
+        soft-archive — are superseded byte-identical duplicates, not
+        "summarized away" content, so they are stamped rewind-style
+        (``active=0, compacted=0``, hidden from search_messages) instead of
+        ``compacted=1``. Without this the tail originals satisfy the recall
+        filter alongside their live clones and session_search returns every
+        carried-forward message once per compaction. Callers that cannot know
+        their tail shape keep the historical archive-everything behavior.
 
         ``message_count`` is set to the ACTIVE count after commit, matching
         what the live load returns. ``model_config_patch`` is merged into the
@@ -11955,13 +11968,42 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # rewind/undo's active=0+compacted=0, which means "user took it
             # back"). search_messages includes compacted=1 rows by default so
             # the pre-compaction transcript stays discoverable; live-context
-            # loads (active=1 only) still exclude them. Tail originals are
-            # archived too — their clones (below) carry the live copy.
-            conn.execute(
-                "UPDATE messages SET active = 0, compacted = 1 "
-                "WHERE session_id = ? AND active = 1",
-                (session_id,),
-            )
+            # loads (active=1 only) still exclude them. Tail originals whose
+            # verbatim clones ride inside *compacted_messages* (tail_count)
+            # are superseded duplicates instead (#86366): they get the
+            # rewind-style flags so they stop matching the recall filter.
+            # Rewind-target ids: the originals of the carried-forward tail
+            # rows (tail_count), captured BEFORE any flag flips. Named apart
+            # from the watermark `tail_ids` below on purpose — the two are
+            # different sets (#86366).
+            rewind_tail_ids: Optional[list[int]] = None
+            if tail_count > 0:
+                tail_rows = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE session_id = ? AND active = 1 ORDER BY id DESC LIMIT ?",
+                    (session_id, int(tail_count)),
+                ).fetchall()
+                rewind_tail_ids = [int(row["id"]) for row in tail_rows]
+
+            if rewind_tail_ids:
+                placeholders = ",".join("?" for _ in rewind_tail_ids)
+                conn.execute(
+                    "UPDATE messages SET active = 0, compacted = 0 "
+                    f"WHERE session_id = ? AND id IN ({placeholders})",
+                    [session_id, *rewind_tail_ids],
+                )
+                conn.execute(
+                    "UPDATE messages SET active = 0, compacted = 1 "
+                    "WHERE session_id = ? AND active = 1 "
+                    f"AND id NOT IN ({placeholders})",
+                    [session_id, *rewind_tail_ids],
+                )
+            else:
+                conn.execute(
+                    "UPDATE messages SET active = 0, compacted = 1 "
+                    "WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, compacted_messages
             )

--- a/tests/hermes_state/test_86366_tail_rewind_semantics.py
+++ b/tests/hermes_state/test_86366_tail_rewind_semantics.py
@@ -1,0 +1,258 @@
+"""Tests for issue #86366 — carried-forward compaction tail must not satisfy
+the search recall filter as "summarized away" content.
+
+``archive_and_compact()`` soft-archives every active row with
+``compacted = 1`` and then re-inserts ``compacted_messages`` as fresh live
+rows. When the compressor's protected tail rides inside that list verbatim,
+its ORIGINALS end up stored twice: ``(active=0, compacted=1)`` next to the
+live clone — and since ``search_messages()`` recalls both flags, every
+carried-forward message came back once per compaction, mislabeled as
+archived history.
+
+The fix adds a ``tail_count`` parameter: the last *tail_count* archived rows
+are superseded byte-identical duplicates (rewind semantics:
+``active=0, compacted=0``, hidden from recall) instead of compacted history.
+Callers without tail knowledge keep the archive-everything behavior.
+
+Pinned here at the persistence layer:
+
+* ``tail_count > 0`` → tail originals hidden from ``search_messages``,
+  non-tail originals still recalled;
+* default (``tail_count=0``) → historical behavior unchanged;
+* live-context load and counters unaffected by the new split.
+
+And at the compressor boundary:
+
+* batch ``compress()`` tags its carried-forward tail dicts so the caller can
+  count them for the commit.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> SessionDB:
+    d = SessionDB(tmp_path / "state.db")
+    d.create_session("sess1", source="test")
+    return d
+
+
+def _seed(db: SessionDB, n: int = 6) -> None:
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        db.append_message("sess1", role=role, content=f"turn {i}")
+
+
+SUMMARY = [
+    {"role": "user", "content": "[CONTEXT COMPACTION] summary of earlier turns"},
+    {"role": "assistant", "content": "Continuing from the summary."},
+]
+
+
+def _recall(db: SessionDB, query: str, include_inactive: bool = False):
+    return db.search_messages(query, include_inactive=include_inactive)
+
+
+def _rows(db: SessionDB):
+    """All rows of the fixture session with lifecycle flags via the public API.
+
+    include_inactive=True returns archived rows too; each row carries the
+    ``active`` / ``compacted`` flags the recall filter keys on.
+    """
+    rows = db.get_messages("sess1", include_inactive=True)
+    out = []
+    for r in rows:
+        out.append({
+            "id": r.get("id"),
+            "active": r.get("active"),
+            "compacted": r.get("compacted"),
+            "content": r.get("content"),
+        })
+    return out
+
+
+class TestTailCountArchivesAsRewindSemantics:
+    def test_tail_originals_hidden_from_recall(self, db: SessionDB) -> None:
+        """tail_count>0: the tail's original rows must NOT come back from
+        session_search alongside their live clones (#86366)."""
+        _seed(db)
+        # Compact keeping the last 2 messages verbatim in the new set.
+        compacted = [*SUMMARY, {"role": "user", "content": "turn 4"},
+                     {"role": "assistant", "content": "turn 5"}]
+        count = db.archive_and_compact(
+            "sess1", compacted, tail_count=len(compacted) - len(SUMMARY)
+        )
+
+        assert count == 4
+
+        rows = _rows(db)
+        turn5 = [r for r in rows if r["content"] == "turn 5"]
+        assert len(turn5) == 2, "one archived original + one live clone"
+        originals = [r for r in turn5 if r["active"] == 0]
+        lives = [r for r in turn5 if r["active"] == 1]
+        assert len(originals) == 1 and len(lives) == 1
+        # THE fix: the original is rewind-stamped, NOT compacted=1 — so it
+        # stops satisfying search_messages' recall filter (#86366).
+        assert originals[0]["compacted"] == 0
+
+        # The rewind-stamped original must never satisfy the recall filter;
+        # only the summary-side content remains searchable from that turn.
+        recalled_snippets = [h.get("snippet", "") for h in _recall(db, "turn 5")]
+        assert all(
+            ">>>turn 5<<<" not in s or "[CONTEXT COMPACTION]" in s
+            for s in recalled_snippets
+        ) or all("turn 5" not in s.lower() or "[context compaction]" in s.lower()
+                 for s in recalled_snippets), (
+            f"tail originals must not be recalled: {recalled_snippets}"
+        )
+
+    def test_non_tail_originals_still_recalled_as_compacted(
+        self, db: SessionDB
+    ) -> None:
+        """Summarized-away turns keep their discoverability — the fix must
+        narrow only the tail originals."""
+        _seed(db)
+        compacted = [*SUMMARY, {"role": "user", "content": "turn 4"},
+                     {"role": "assistant", "content": "turn 5"}]
+        db.archive_and_compact(
+            "sess1", compacted, tail_count=len(compacted) - len(SUMMARY)
+        )
+
+        rows = _rows(db)
+        turn1 = [r for r in rows if r["content"] == "turn 1"]
+        assert turn1 and turn1[0]["compacted"] == 1 and turn1[0]["active"] == 0, (
+            "non-tail originals must stay compacted=1 (discoverable)"
+        )
+        assert any(
+            "turn" in (h.get("snippet") or "") and "1" in (h.get("snippet") or "")
+            for h in _recall(db, "turn 1")
+        ), (
+            "summarized-away turns must remain recallable: "
+            f"{[h.get('snippet') for h in _recall(db, 'turn 1')]}"
+        )
+
+    def test_default_zero_keeps_archive_everything(self, db: SessionDB) -> None:
+        """Without tail_count the historical behavior is untouched."""
+        _seed(db)
+        db.archive_and_compact("sess1", SUMMARY)
+
+        rows = _rows(db)
+        archived = [r for r in rows if r["content"] == "turn 5"]
+        assert archived and all(
+            r["compacted"] == 1 and r["active"] == 0 for r in archived
+        ), "default must still archive everything as compacted=1"
+
+    def test_live_context_load_unaffected(self, db: SessionDB) -> None:
+        """get_messages (active=1) returns exactly the compacted set either
+        way; the rewind-stamped originals never leak into live loads."""
+        _seed(db)
+        compacted = [*SUMMARY, {"role": "user", "content": "turn 4"},
+                     {"role": "assistant", "content": "turn 5"}]
+        db.archive_and_compact(
+            "sess1", compacted, tail_count=len(compacted) - len(SUMMARY)
+        )
+
+        live = [r["content"] for r in db.get_messages("sess1")]
+        assert live == [
+            "[CONTEXT COMPACTION] summary of earlier turns",
+            "Continuing from the summary.",
+            "turn 4",
+            "turn 5",
+        ]
+
+    def test_message_count_reflects_active_set(self, db: SessionDB) -> None:
+        import json as _json
+
+        _seed(db)
+        compacted = [*SUMMARY, {"role": "user", "content": "turn 4"},
+                     {"role": "assistant", "content": "turn 5"}]
+        returned = db.archive_and_compact(
+            "sess1", compacted, tail_count=len(compacted) - len(SUMMARY)
+        )
+        assert returned == 4
+
+        # Read through the same connection era — get_session exposes the
+        # persisted counters without fighting the WAL view.
+        session_row = db.get_session("sess1")
+        assert session_row is not None
+        mc = session_row.get("message_count")
+        if mc is None and "config" in session_row:
+            cfg = session_row.get("config") or {}
+            mc = cfg.get("message_count")
+        if mc is not None:
+            assert int(mc) == 4
+
+
+class TestCompressTagsCarriedTail:
+    def test_compress_marks_carried_forward_tail_dicts(self):
+        """compress() must tag its carried-forward tail dicts so the caller
+        can pass an accurate tail_count to the commit (#86366)."""
+        from agent.context_compressor import (
+            _COMPACTION_TAIL_MARKER,
+            ContextCompressor,
+        )
+        from unittest.mock import patch
+
+        compressor = ContextCompressor.__new__(ContextCompressor)
+
+        long_history = []
+        for i in range(12):
+            role = "user" if i % 2 == 0 else "assistant"
+            long_history.append({
+                "role": role,
+                "content": f"filler turn {i} " + "x" * 400,
+            })
+
+        captured: dict = {}
+
+        class _DB:
+            def archive_and_compact(self, session_id, messages, **kwargs):
+                captured["messages"] = messages
+                captured["tail_count"] = kwargs.get("tail_count", 0)
+                return len(messages)
+
+        with (
+            patch.object(compressor, "_session_db", _DB(), create=True),
+            patch.object(compressor, "_session_id", "sessX", create=True),
+            patch.object(
+                compressor, "quiet_mode", True, create=True
+            ),
+        ):
+            # Drive compress() far enough to assemble compressed+tail by
+            # stubbing the LLM summarizer with a deterministic summary.
+            with (
+                patch.object(
+                    compressor,
+                    "_generate_summary",
+                    return_value="deterministic summary",
+                    create=True,
+                ),
+                patch.object(
+                    compressor, "_prune_old_tool_results",
+                    side_effect=lambda msgs, **k: (msgs, 0),
+                    create=True,
+                ),
+            ):
+                try:
+                    out = compressor.compress(list(long_history))
+                except Exception:
+                    pytest.skip(
+                        "compress() requires more runtime wiring than this "
+                        "unit context provides; tag contract covered by the "
+                        "persistence-layer tests above"
+                    )
+
+            tagged = [
+                m for m in (captured.get("messages") or [])
+                if isinstance(m, dict) and m.pop(_COMPACTION_TAIL_MARKER, None)
+            ]
+            # The marker is popped by the production caller before insert;
+            # here we just require it existed on the trailing dicts.
+            assert out is not None

--- a/tests/hermes_state/test_86366_watermark_interplay.py
+++ b/tests/hermes_state/test_86366_watermark_interplay.py
@@ -1,0 +1,159 @@
+"""Regression tests for #86366 × watermark interplay in archive_and_compact.
+
+Two sibling sites of the superseded-duplicate class:
+
+* carried-forward tail originals (tail_count) — the compressor's protected
+  tail rides inside compacted_messages verbatim; originals must take rewind
+  flags (active=0, compacted=0), not compacted=1.
+* concurrent-tail originals (watermark clone, #75316) — rows appended during
+  the summary call are re-inserted byte-exact as live clones; their originals
+  are the SAME superseded-duplicate class and must take rewind flags too.
+
+And the interaction bound: with both watermark and tail_count set, the
+rewind-target LIMIT walk must not consume concurrent-append rows (above the
+watermark) as if they were carried-forward tail.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    handle = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+def _flags(db: SessionDB, session_id: str):
+    conn = sqlite3.connect(db.db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return [
+            dict(r)
+            for r in conn.execute(
+                "SELECT id, active, compacted, content FROM messages "
+                "WHERE session_id = ? ORDER BY id",
+                (session_id,),
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+class TestWatermarkTailCountInterplay:
+    def test_rewind_walk_bounded_at_watermark(self, db: SessionDB) -> None:
+        """A concurrent append above the watermark must not steal a rewind
+        LIMIT slot from a genuine carried-forward tail original."""
+        sid = "s-wm-bound"
+        db.create_session(sid, source="cli")
+        for i in range(4):
+            db.append_message(sid, "user", content=f"seen-{i}")
+        watermark = db.get_active_message_watermark(sid)
+        # Concurrent append AFTER the compressor snapshotted its input.
+        db.append_message(sid, "user", content="concurrent-append")
+
+        db.archive_and_compact(
+            sid,
+            [
+                {"role": "user", "content": "SUMMARY"},
+                {"role": "user", "content": "seen-2"},
+                {"role": "user", "content": "seen-3"},
+            ],
+            watermark=watermark,
+            tail_count=2,
+        )
+
+        rows = _flags(db, sid)
+        by_content = {}
+        for r in rows:
+            by_content.setdefault(r["content"], []).append(r)
+
+        # Carried-forward tail originals: rewind flags (hidden from recall).
+        for content in ("seen-2", "seen-3"):
+            originals = [
+                r for r in by_content[content] if r["active"] == 0
+            ]
+            assert originals, content
+            assert all(r["compacted"] == 0 for r in originals), (
+                f"{content} original stamped compacted=1 — recall duplicate"
+            )
+            live = [r for r in by_content[content] if r["active"] == 1]
+            assert len(live) == 1
+
+        # Summarized-away rows keep discoverability.
+        for content in ("seen-0", "seen-1"):
+            (row,) = by_content[content]
+            assert (row["active"], row["compacted"]) == (0, 1)
+
+    def test_concurrent_tail_original_takes_rewind_flags(
+        self, db: SessionDB
+    ) -> None:
+        """The watermark clone's original is a superseded byte-identical
+        duplicate — it must not satisfy recall next to its live clone."""
+        sid = "s-wm-clone"
+        db.create_session(sid, source="cli")
+        for i in range(3):
+            db.append_message(sid, "user", content=f"old-{i}")
+        watermark = db.get_active_message_watermark(sid)
+        db.append_message(sid, "user", content="mid-flight zqx-token")
+
+        db.archive_and_compact(
+            sid,
+            [{"role": "user", "content": "SUMMARY"}],
+            watermark=watermark,
+        )
+
+        rows = _flags(db, sid)
+        copies = [r for r in rows if "zqx-token" in r["content"]]
+        assert len(copies) == 2  # archived original + live clone
+        original = next(r for r in copies if r["active"] == 0)
+        clone = next(r for r in copies if r["active"] == 1)
+        assert original["compacted"] == 0, (
+            "concurrent-tail original stamped compacted=1 — it would be "
+            "recalled alongside its live clone (same class as #86366)"
+        )
+        assert clone["compacted"] == 0
+
+        # Recall filter surfaces exactly ONE copy.
+        hits = [
+            r
+            for r in db.search_messages("zqx-token")
+            if r.get("session_id") == sid
+        ]
+        assert len(hits) == 1
+
+    def test_recall_stable_across_generations(self, db: SessionDB) -> None:
+        """search_messages hit count for a carried-forward message must not
+        grow with compaction generations."""
+        sid = "s-gen"
+        db.create_session(sid, source="cli")
+        for i in range(5):
+            db.append_message(sid, "user", content=f"turn-{i} gentok-{i}")
+
+        payload = [
+            {"role": "user", "content": "SUMMARY"},
+            {"role": "user", "content": "turn-3 gentok-3"},
+            {"role": "user", "content": "turn-4 gentok-4"},
+        ]
+        counts = []
+        for _ in range(3):
+            db.archive_and_compact(sid, list(payload), tail_count=2)
+            counts.append(
+                len(
+                    [
+                        r
+                        for r in db.search_messages("gentok-3")
+                        if r.get("session_id") == sid
+                    ]
+                )
+            )
+        assert counts == [1, 1, 1], counts


### PR DESCRIPTION
## What does this PR do?

Salvages PR #93160 (author **BrunoBza**, cherry-picked with authorship preserved) onto current main and closes the watermark interplay gap.

`SessionDB.archive_and_compact()` stamps `compacted = 1` on **every** live row it archives — including the verbatim carried-forward tail it is about to re-insert as fresh live rows. Both copies satisfy the recall filter `(active = 1 OR compacted = 1)`, so `session_search` returned each carried-forward message once more per compaction generation (field reports: up to 4x hits, a 12.1 GB state.db, Desktop TTS re-speaking replies 2–3x), and still-live content was mislabeled "summarized away".

### Fix (from #93160)

New `tail_count` parameter on `archive_and_compact()`: the last *tail_count* archived rows are superseded byte-identical duplicates of live rows, so they take **rewind-style flags** (`active=0, compacted=0`, hidden from recall) — exactly the semantics the docstring already assigns to rewind/undo rows. Callers wired: batch in-place compaction (via a private `_compaction_tail` tag stamped by `compress()`), micro-compaction sync (`len - 1`).

### Follow-up in this salvage (class completion)

1. **Rewind walk bounded at the watermark.** With a concurrent append above the compression-start watermark, the naive `ORDER BY id DESC LIMIT tail_count` walk would consume the append's row as "tail" and leave a real carried-forward original stamped `compacted=1`. The walk now applies `id <= watermark` when a watermark is present.
2. **Concurrent-tail originals join the rewind set.** The #75316 watermark clone re-inserts concurrent-append rows byte-exact as live rows — their originals are the *same* superseded-duplicate class and previously double-matched recall the identical way. They now take rewind flags too.

## Related Issue

Fixes #86366
Refs #68858 (disk-I/O half of the same mechanism), salvages #93160.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Live repro

**Live repro:** real-import harness against a temp `HERMES_HOME` + real `state.db` (create session → append 5 turns → `archive_and_compact([summary]+tail)` ×2 generations → inspect flags + `search_messages`) — before (main): tail originals `active=0, compacted=1`, `search_messages` hits **2 → 3** (grows once per generation); after (this branch): tail originals `active=0, compacted=0`, hits **1 → 1** across generations.

## Test Plan

- `tests/hermes_state/test_86366_tail_rewind_semantics.py` (from #93160): tail rewind flags, non-tail rows keep discoverability, `tail_count=0` keeps historical behavior, live load + message_count unaffected.
- `tests/hermes_state/test_86366_watermark_interplay.py` (new): rewind walk bounded at watermark, concurrent-tail original rewound, recall hit count stable across 3 generations. **Sabotage-verified**: all 3 fail on main, pass here.
- Sibling suites green: `tests/agent/test_micro_compaction.py`, `tests/agent/test_compression_concurrent_fork.py`, `tests/run_agent/test_in_place_compaction.py`, `tests/run_agent/test_in_place_persist_marker_98450.py` — 97 passed.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa890b7/rc5gIMhvIiCzQ1QjEhWXZ_uQuOiMY8.png)
