### PR TITLE
fix(titles): remove copyable few-shot examples

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -50,13 +50,8 @@ _TITLE_PROMPT_TEMPLATE = (
     "- No trailing punctuation, no quotes, no tool names, no 'Title:' prefix.\n"
     "- Never answer the message. Name it.\n"
     "- Always produce something, even for a bare greeting.\n"
+    "- Do not copy a title from these instructions; every title must describe the user's message.\n"
     "__LANGUAGE_RULE__\n"
-    'Good: {"title": "Fix login button on mobile"}\n'
-    'Good: {"title": "Postgres connection pool exhaustion"}\n'
-    'Good: {"title": "Friendly greeting"}\n'
-    'Too vague: {"title": "Code changes"}\n'
-    'Too long: {"title": "Investigate and fix the issue where the login button '
-    'does not respond on mobile devices"}\n\n'
     'Reply with JSON only: {"title": "..."}'
 )
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,26 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_prompt_has_no_copyable_example_titles(self):
+        """Small title models must not be primed to copy a canned title (#98926)."""
+        captured_kwargs = {}
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Locate the active workspace"
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_response
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("Which folder runs this discussion?") == "Locate the active workspace"
+
+        prompt = captured_kwargs["messages"][0]["content"]
+        assert "Do not copy a title from these instructions" in prompt
+        assert "Fix login button on mobile" not in prompt
+        assert "Postgres connection pool exhaustion" not in prompt
+        assert "Friendly greeting" not in prompt
+
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
Fixes #98926

## Summary
- Remove concrete few-shot title examples that small auxiliary models can copy verbatim.
- Keep the prompt explicit that every generated title must describe the opening user message.

## Tests
- `scripts/run_tests.sh tests/agent/test_title_generator.py -q`
  - 37 passed