### PR TITLE
fix(web): surface Firecrawl refusals as errors in keyed web_extract

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -759,9 +759,46 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
 
                 # Choose markdown vs html according to the requested format
                 if format == "markdown" or (format is None and content_markdown):
-                    chosen_content = content_markdown
+                    chosen_content = content_markdown or ""
                 else:
                     chosen_content = content_html or content_markdown or ""
+
+                # A non-2xx scrape that yielded nothing is a refusal, not an
+                # empty page. Firecrawl's /scrape returns the target's real
+                # status in metadata.statusCode instead of raising, so without
+                # this gate the refusal presents as a successful empty result
+                # and the keyless rescue in web_tools._rescue_extract (which
+                # fires only when every result carries an error) never runs.
+                try:
+                    scrape_status = int(metadata.get("statusCode") or 0)
+                except (TypeError, ValueError):
+                    scrape_status = 0
+                if (
+                    chosen_content == ""
+                    and scrape_status
+                    and not 200 <= scrape_status < 300
+                ):
+                    reason = metadata.get("error")
+                    logger.info(
+                        "Firecrawl scrape refused for %s: HTTP %s",
+                        final_url,
+                        scrape_status,
+                    )
+                    results.append(
+                        {
+                            "url": final_url,
+                            "title": title,
+                            "content": "",
+                            "raw_content": "",
+                            "error": (
+                                f"Target returned HTTP {scrape_status} with no "
+                                f"content"
+                                + (f": {reason}" if reason else "")
+                            ),
+                            "metadata": metadata,
+                        }
+                    )
+                    continue
 
                 results.append(
                     {

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -329,3 +329,101 @@ class TestErrorResponseShapes:
     """When credentials are missing, plugins return typed errors, not raises."""
 
 
+# ---------------------------------------------------------------------------
+# Firecrawl keyed extract: refusal vs empty page (issue #99533)
+# ---------------------------------------------------------------------------
+
+
+class TestFirecrawlKeyedExtractRefusals:
+    """A non-2xx Firecrawl scrape with no content must surface as an
+    ``error`` result, not a successful empty extraction.
+
+    Firecrawl's /scrape endpoint does not raise for 401/403/404/5xx — it
+    returns a payload whose ``metadata.statusCode`` carries the target's
+    real status while ``markdown``/``html`` are empty. Without the gate,
+    the refusal is indistinguishable from a genuinely blank page and the
+    keyless rescue in ``web_tools._rescue_extract`` (which fires only
+    when every result carries an error) never runs (issue #99533).
+    """
+
+    @staticmethod
+    def _provider_with_payload(
+        monkeypatch: pytest.MonkeyPatch, payload: dict
+    ) -> "object":
+        import plugins.web.firecrawl.provider as p
+
+        class FakeClient:
+            def scrape(self, url=None, formats=None):
+                return payload
+
+        monkeypatch.setattr(p, "_use_keyless_ring", lambda: False)
+        monkeypatch.setattr(p, "_get_firecrawl_client", lambda: FakeClient())
+        monkeypatch.setattr(p, "check_website_access", lambda u: None)
+        monkeypatch.setattr(p, "is_safe_url", lambda u: True)
+        return p.FirecrawlWebSearchProvider()
+
+    def test_refusal_with_no_content_becomes_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {
+            "markdown": "",
+            "html": "",
+            "metadata": {
+                "title": "Access denied",
+                "sourceURL": "https://example.com/paywalled",
+                "statusCode": 403,
+                "error": "Forbidden",
+            },
+        }
+        prov = self._provider_with_payload(monkeypatch, payload)
+        out = asyncio.run(
+            prov.extract(["https://example.com/paywalled"], format="markdown")
+        )
+        assert "error" in out[0]
+        assert "HTTP 403" in out[0]["error"]
+        assert "Forbidden" in out[0]["error"]
+        assert out[0]["content"] == ""
+
+    def test_non_2xx_with_usable_content_stays_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A soft-blocked page that still yields text must not be gated.
+        payload = {
+            "markdown": "partial text behind a soft block",
+            "html": "<p>partial text behind a soft block</p>",
+            "metadata": {
+                "title": "Soft block",
+                "sourceURL": "https://example.com/soft",
+                "statusCode": 403,
+            },
+        }
+        prov = self._provider_with_payload(monkeypatch, payload)
+        out = asyncio.run(
+            prov.extract(["https://example.com/soft"], format="markdown")
+        )
+        assert "error" not in out[0]
+        assert out[0]["content"] == "partial text behind a soft block"
+
+    def test_2xx_empty_page_stays_empty_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {
+            "markdown": "",
+            "html": "",
+            "metadata": {
+                "title": "",
+                "sourceURL": "https://example.com/blank",
+                "statusCode": 200,
+            },
+        }
+        prov = self._provider_with_payload(monkeypatch, payload)
+        out = asyncio.run(
+            prov.extract(["https://example.com/blank"], format="markdown")
+        )
+        assert "error" not in out[0]
+        # content is a str on every path — the markdown branch used to
+        # leak None when Firecrawl returned no markdown (issue #99533).
+        assert out[0]["content"] == ""
+        assert isinstance(out[0]["content"], str)
+
+


### PR DESCRIPTION
## What does this PR do?

Firecrawl's `/scrape` endpoint does not raise when the target site refuses the fetch (401/403/404/5xx) — it returns a normal payload whose `metadata.statusCode` carries the target's real status while `markdown`/`html` are empty. The keyed (non-keyless) extract path in `plugins/web/firecrawl/provider.py` read `metadata` only for `title` and `sourceURL`, so a refusal was flattened into a **successful, empty result with no `error` key**:

- The caller cannot tell "this page has no content" from "we were refused".
- The keyless rescue in `tools/web_tools.py::_rescue_extract` fires only when **every** result carries an `error`, so a flattened refusal makes the whole batch read as succeeded and the ring is never walked.
- Downstream failure classification (`_detect_tool_failure`) likewise sees a success, and the model receives an empty string as if the page were genuinely blank.

This PR gates the success path on the scrape status: a **non-2xx response with no extracted content** becomes an error result (carrying the HTTP status, Firecrawl's `metadata.error` reason when present, and the original `metadata` for evidence), while soft-blocked pages that still yield usable text remain successful. It also coerces the `format="markdown"` branch to `""` so `content`/`raw_content` stay `str` on every path — that branch used to leak `None` when Firecrawl returned no markdown, an unannounced type change for consumers.

The gate is intentionally conservative (`not chosen_content and not 200 <= status < 300`) so the only behavior change is exactly the case nothing useful can be returned anyway.

## Related Issue

Fixes #99533

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/firecrawl/provider.py` — after the post-redirect SSRF/policy gates, parse `metadata.statusCode` (defensively via `int(... or 0)` with `TypeError`/`ValueError` fallback) and, when the scrape is non-2xx **and** no content was extracted, append an error result (`"Target returned HTTP <status> with no content[: reason]"`) instead of a successful empty one; `metadata` is preserved on the error item. Also `chosen_content = content_markdown or ""` on the markdown branch to keep the result `str`-typed.
- `tests/plugins/web/test_web_search_provider_plugins.py` — new `TestFirecrawlKeyedExtractRefusals` with three regression cases (see How to Test).

## How to Test

Added `TestFirecrawlKeyedExtractRefusals` covering the three contract points with a stubbed Firecrawl client (keyed path forced via `_use_keyless_ring → False`):

1. `403 + empty markdown/html → result carries "error"` containing `"HTTP 403"` and Firecrawl's `"Forbidden"` reason — Observed result: passes (before the fix the result had no `error` key and `content: ""`).
2. `403 + usable markdown → stays a success` with the extracted text — Observed result: passes (soft-blocked pages with text are not gated).
3. `200 + empty markdown/html → stays an empty success` and `content` is a `str` — Observed result: passes (genuinely blank pages are unaffected; the `None` leak is gone).

Also ran the surrounding consumer surface: `tests/plugins/web/ tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py tests/tools/test_web_keyless_fallback.py` → 129 passed; the 2 failures in `TestParallelClientConfig` reproduce identically on a clean `upstream/main` checkout (pre-existing, unrelated to this change). `ruff check` on both touched files passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A