### PR TITLE
fix(simplex): report disconnected message delivery

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -831,6 +831,9 @@ class SimplexAdapter(BasePlatformAdapter):
             content = re.sub(r"MEDIA:\S+", "", content).strip()
 
         if content:
+            if not self._ws:
+                logger.warning("SimpleX: send() called but WebSocket not connected — message dropped")
+                return SendResult(success=False, error="SimpleX WebSocket not connected")
             corr_id = self._make_corr_id()
             # Structured form: addresses by ID, and json.dumps escapes
             # newlines + special chars correctly.  The bare @id text

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -162,6 +162,20 @@ async def test_send_dm():
     assert result.success is True
 
 
+@pytest.mark.asyncio
+async def test_send_fails_when_websocket_is_disconnected():
+    """A disconnected daemon must not turn a dropped message into success (#98949)."""
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"}))
+
+    result = await adapter.send("contact-42", "Hello, SimpleX!")
+
+    assert result.success is False
+    assert result.error == "SimpleX WebSocket not connected"
+    assert not adapter._pending_corr_ids
+
+
 
 @pytest.mark.asyncio
 async def test_send_group():
@@ -386,5 +400,4 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             },
         },
     }
-
 


### PR DESCRIPTION
Fixes #98949

## Summary
- Return a failed delivery result when SimpleX has no live WebSocket instead of silently dropping text and reporting success.
- Add a regression test for the disconnected daemon path.
- Preserve the original implementation author from closed PR [#99091](https://github.com/NousResearch/hermes-agent/pull/99091).

## Tests
- `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py -q`
  - 17 passed