### PR TITLE
fix(config): restore unlimited max-turn defaults

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -395,7 +395,7 @@ def _cli_config_defaults():
         # threshold: fraction of the model's context limit; min_tail: real user messages kept in the tail
         "compression": {"enabled": True, "threshold": 0.50, "min_tail_user_messages": 1},
         "agent": {
-            "max_turns": 500, "verbose": False, "system_prompt": "", "prefill_messages_file": "",  # max_turns shared with subagents
+            "max_turns": None, "verbose": False, "system_prompt": "", "prefill_messages_file": "",  # unset resolves to unlimited
             "reasoning_effort": "", "service_tier": "",
             "personalities": {},  # user overrides merged by name over hermes_cli.personality builtins
         },
@@ -3115,6 +3115,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         # LIVE agent's key: the constructor seeds self.api_key from env before provider
         # resolution, so on non-OpenAI providers it can be another vendor's key.
         from agent.azure_identity_adapter import is_token_provider
+        from hermes_cli.config import TURN_LIMIT_UNLIMITED
 
         display_key = self.api_key
         if self.agent is not None and getattr(self.agent, "api_key", None):
@@ -3133,6 +3134,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
             f"{os.getenv('TERMINAL_SSH_USER', 'not set')}@{os.getenv('TERMINAL_SSH_HOST', 'not set')}"
             f":{os.getenv('TERMINAL_SSH_PORT', '22')}"
         ) if terminal_env == "ssh" else None
+        max_turns_display = "unlimited" if self.max_turns == TURN_LIMIT_UNLIMITED else self.max_turns
         sections = (
             ("Model", (("Model:    ", self.model), ("Base URL: ", self.base_url), ("API Key:  ", api_key_display))),
             ("Terminal", (
@@ -3142,7 +3144,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
                 ("Timeout:     ", f"{terminal_timeout}s"),
             )),
             ("Agent", (
-                ("Max Turns: ", self.max_turns),
+                ("Max Turns: ", max_turns_display),
                 ("Toolsets:  ", ", ".join(self.enabled_toolsets) if self.enabled_toolsets else "all"),
                 ("Verbose:   ", self.verbose),
             )),
@@ -4503,7 +4505,7 @@ def main(
         reasoning: Reasoning effort for this run (none|minimal|low|medium|high|xhigh|max|ultra). Overrides agent.reasoning_effort.
         api_key: API key for authentication
         base_url: Base URL for the API
-        max_turns: Maximum tool-calling iterations (default: 60)
+        max_turns: Maximum tool-calling iterations (default: unlimited)
         verbose: Enable verbose logging
         compact: Use compact display mode
         list_tools: List available tools and exit

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -246,7 +246,7 @@ def _build_chat_parser(subparsers) -> argparse.ArgumentParser:
     add("--checkpoints", action="store_true", default=False,
         help="Enable filesystem checkpoints before destructive file operations (use /rollback to restore)")
     add("--max-turns", type=int, default=None, metavar="N",
-        help="Maximum tool-calling iterations per conversation turn (default: 500, or agent.max_turns in config)")
+        help="Maximum tool-calling iterations per conversation turn (default: unlimited; a positive integer here or agent.max_turns in config opts into a cap)")
     add("--run-budget", type=float, default=None, metavar="SECONDS", dest="run_budget", help=(
         "Optional wall-clock budget in seconds for each conversation run. "
         "At 80%% elapsed the agent gets a one-time wrap-up notice, and "

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -82,6 +82,16 @@ class TestMaxTurnsResolution:
         assert isinstance(cli.max_turns, int)
         assert cli.max_turns == sys.maxsize
 
+    def test_loader_default_max_turns_is_unset(self, monkeypatch, tmp_path):
+        import cli as cli_module
+
+        monkeypatch.setattr(cli_module, "_hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+
+        config = cli_module.load_cli_config()
+
+        assert config["agent"]["max_turns"] is None
+
     def test_explicit_max_turns_honored(self):
         cli = _make_cli(max_turns=25)
         assert cli.max_turns == 25

--- a/tests/cli/test_show_config_credential.py
+++ b/tests/cli/test_show_config_credential.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 from cli import HermesCLI
+from hermes_cli.config import TURN_LIMIT_UNLIMITED
 
 
 def _run_show_config(stand_in, capsys):
@@ -42,6 +43,14 @@ class TestShowConfigCredentialSource:
         )
         assert "nous-REA" in out
         assert "sk-proj-" not in out
+
+    def test_displays_unlimited_turn_limit(self, capsys):
+        stand_in = _make_stand_in(cli_key="nous-REALKEY-abcdef9876", agent_key=None)
+        stand_in.max_turns = TURN_LIMIT_UNLIMITED
+
+        out = _run_show_config(stand_in, capsys)
+
+        assert "Max Turns:  unlimited" in out
 
     def test_falls_back_to_cli_key_without_agent(self, capsys):
         out = _run_show_config(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17909,13 +17909,16 @@ def test_make_agent_nested_max_turns_takes_priority(monkeypatch):
     assert mock_agent.call_args.kwargs["max_iterations"] == 400
 
 
-def test_make_agent_defaults_to_500(monkeypatch):
+def test_make_agent_defaults_to_unlimited(monkeypatch):
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED
+
+    monkeypatch.delenv("HERMES_TUI_MAX_TURNS", raising=False)
     _setup_make_agent_mocks(monkeypatch, {})
 
     with patch("run_agent.AIAgent") as mock_agent:
         server._make_agent("sid1", "key1")
 
-    assert mock_agent.call_args.kwargs["max_iterations"] == 500
+    assert mock_agent.call_args.kwargs["max_iterations"] == TURN_LIMIT_UNLIMITED
 
 
 def test_make_agent_uses_session_runtime_overrides(monkeypatch):
@@ -18035,6 +18038,24 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
     )
 
     assert ["Max Turns", "120"] in agent_rows
+
+
+def test_config_show_displays_unlimited_max_turns_when_absent(monkeypatch):
+    monkeypatch.delenv("HERMES_TUI_MAX_TURNS", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"agent": {}, "enabled_toolsets": [], "verbose": False},
+    )
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    resp = server.handle_request({"id": "1", "method": "config.show", "params": {}})
+    sections = resp["result"]["sections"]
+    agent_rows = next(
+        section["rows"] for section in sections if section["title"] == "Agent"
+    )
+
+    assert ["Max Turns", "unlimited"] in agent_rows
 
 
 def test_notification_poller_delivers_completion(monkeypatch):

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -960,14 +960,16 @@ def _(rid, params: dict) -> dict:
 @_rpc("config.show", 5030)
 def _(rid, params: dict) -> dict:
     cfg = _load_cfg()
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED
     api_key = _tools_mod("agent.secret_scope").get_secret("HERMES_API_KEY", "") or cfg.get("api_key", "")
     masked = f"****{api_key[-4:]}" if len(api_key) > 4 else "(not set)"
     base_url = os.environ.get("HERMES_BASE_URL", "") or cfg.get("base_url", "")
+    max_turns = _cfg_max_turns(cfg, TURN_LIMIT_UNLIMITED)
     sections = [
         {"title": "Model", "rows": [
             ["Model", _resolve_model()], ["Base URL", base_url or "(default)"], ["API Key", masked]]},
         {"title": "Agent", "rows": [
-            ["Max Turns", str(_cfg_max_turns(cfg, 500))],
+            ["Max Turns", "unlimited" if max_turns == TURN_LIMIT_UNLIMITED else str(max_turns)],
             ["Toolsets", ", ".join(cfg.get("enabled_toolsets", [])) or "all"],
             ["Verbose", str(cfg.get("verbose", False))]]},
         {"title": "Environment", "rows": [["Working Dir", os.getcwd()], ["Config File", str(_hermes_home / "config.yaml")]]},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2273,13 +2273,14 @@ def _make_agent(
         with contextlib.suppress(Exception):
             importlib.import_module(_mod).wait_for_mcp_discovery()
     cfg = _load_cfg()
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED
     system_prompt = _startup_system_prompt(cfg, session_id or key)
     model, runtime = _resolve_agent_model_runtime(model_override, provider_override)
     _pr = _load_provider_routing()
     platform = _resolve_agent_platform(platform_override)
     ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
     agent = AIAgent(
-        model=model, max_iterations=_cfg_max_turns(cfg, 500), provider=runtime.get("provider"),
+        model=model, max_iterations=_cfg_max_turns(cfg, TURN_LIMIT_UNLIMITED), provider=runtime.get("provider"),
         base_url=runtime.get("base_url"), api_key=runtime.get("api_key"), api_mode=runtime.get("api_mode"),
         acp_command=runtime.get("command"), acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"), quiet_mode=True,


### PR DESCRIPTION
## What does this PR do?

Why this PR exists: #90708 established that an unset `agent.max_turns` value means unlimited. A user who intentionally leaves that setting unset should therefore receive the same behavior from the primary classic-CLI and TUI entry points. Instead, their default-only paths still injected a finite `500` cap before the shared resolver could apply that established rule. A long tool-driven task could therefore stop unexpectedly at that cap, and the configuration displays did not make the mismatch clear. This patch removes only those stale defaults, so both surfaces match the established contract while explicitly configured positive limits retain their normal precedence.

## Related Issue

Follow-up to #90708. No new issue is required for this focused default-parity correction.

## Type of Change

- ☑ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☐ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☐ 📝 Documentation update
- ☑ ✅ Tests (adding or improving test coverage)
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

- Leaves the absent classic-CLI turn limit unset so the shared resolver supplies unlimited behavior.
- Uses the same unlimited sentinel when creating a new TUI agent.
- Makes CLI and TUI configuration displays report `unlimited` for the absent-default case.
- Updates help text and focused regression coverage for default, display, and explicit-cap behavior.

## How to Test

1. Start with no max-turn configuration or environment override. Verify that a classic CLI session and a newly created TUI agent both report an unlimited turn budget.
2. Set a positive command-line or configuration value. Verify that it remains a finite cap.
3. Run `pytest -q` for the focused default and configuration-display regression checks. Expected result: all selected tests pass.
4. Run `ruff check` for the changed Python files. Expected result: clean.

## Checklist

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ☑ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ☑ My PR contains **only** changes related to this fix/feature (no unrelated commits)
- ☐ I've run `pytest tests/ -q` and all tests pass
- ☑ I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- ☑ I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- ☑ I've updated relevant documentation (README, `docs/`, docstrings) — user-facing help and configuration displays now describe the corrected default; broader documentation drift is tracked separately.
- ☑ I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no configuration key changed.
- ☑ I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no architecture or workflow changed.
- ☑ I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific API or configuration path changed.
- ☑ I've updated tool descriptions/schemas if I changed tool behavior — N/A: no tool schema changed.

## Screenshots / Logs

No screenshot is needed. This PR changes configuration-default and configuration-display behavior.

## Infographic

![Before-and-after technical poster showing CLI and TUI signals moving from a stale 500-turn default through a calibration instrument to matched unlimited outputs, while an explicit-cap control remains available.](https://v3b.fal.media/files/b/0aa8914b/a7nSUvF3AZLi42TPo9J7p_TtnehOsc.png)
