### PR TITLE
fix(update): reject stash restores that re-apply invalid Python (salvage #94287)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -711,13 +711,11 @@ def _critical_module_import_failures(
         "        if %r:\n"
         "            failures.append((name, str(exc)))\n"
         "    except BaseException as exc:\n"
-        "        if %r:\n"
-        "            failures.append((name, str(exc)))\n"
+        "        failures.append((name, str(exc)))\n"
         "sys.stdout.write('\\n%s' + json.dumps(failures))\n"
         % (
             _UPDATE_CRITICAL_MODULES,
             tuple(sorted(FIRST_PARTY_MODULE_ROOTS)),
-            report_runtime_errors,
             report_runtime_errors,
             marker,
         )
@@ -2498,7 +2496,9 @@ def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str] | None:
     return {path for path in result.stdout.split("\0") if path}
 
 
-def _restored_python_paths(git_cmd: list[str], cwd: Path) -> tuple[str, ...]:
+def _restored_python_paths(
+    git_cmd: list[str], cwd: Path
+) -> tuple[str, ...] | None:
     """Return restored ``.py`` paths changed from ``HEAD``.
 
     This deliberately validates Python source only; non-Python entry scripts
@@ -2512,10 +2512,14 @@ def _restored_python_paths(git_cmd: list[str], cwd: Path) -> tuple[str, ...]:
         encoding="utf-8",
         errors="surrogateescape",
     )
-    paths = set(changed.stdout.split("\0")) if changed.returncode == 0 else set()
+    if changed.returncode != 0:
+        print("  ⚠ Could not enumerate tracked Python files restored from the stash.")
+        return None
+    paths = set(changed.stdout.split("\0"))
     untracked = _git_untracked_paths(git_cmd, cwd)
-    if untracked is not None:
-        paths.update(path for path in untracked if path.endswith(".py"))
+    if untracked is None:
+        return None
+    paths.update(path for path in untracked if path.endswith(".py"))
     paths.discard("")
     return tuple(sorted(paths))
 
@@ -2669,6 +2673,15 @@ def _restore_stashed_changes(
         return False
 
     restored_python = _restored_python_paths(git_cmd, cwd)
+    if restored_python is None:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            "restored Python source discovery",
+            "could not determine which restored Python files require validation",
+        )
     syntax_ok, failing_path, syntax_error = _validate_python_files_syntax(
         cwd, restored_python
     )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -741,6 +741,10 @@ def _critical_module_import_failures(
             errors="replace",
             timeout=120,
         )
+    except subprocess.TimeoutExpired:
+        return {
+            "critical-module probe": "timed out before reporting import health"
+        }
     except (OSError, subprocess.SubprocessError):
         # Can't run the probe — don't block the update on our own tooling.
         return {}
@@ -2475,8 +2479,8 @@ def _park_stashed_changes(stash_ref: str) -> None:
     print(f"  Restore manually with: git stash apply {stash_ref}")
 
 
-def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str]:
-    """Return untracked, non-ignored paths without Git's quoting ambiguity."""
+def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str] | None:
+    """Return untracked paths, or ``None`` when Git cannot enumerate them."""
     result = subprocess.run(
         git_cmd + ["ls-files", "--others", "--exclude-standard", "-z"],
         cwd=cwd,
@@ -2490,7 +2494,7 @@ def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str]:
             "  ⚠ Could not enumerate untracked files while validating the "
             "restored stash."
         )
-        return set()
+        return None
     return {path for path in result.stdout.split("\0") if path}
 
 
@@ -2509,7 +2513,9 @@ def _restored_python_paths(git_cmd: list[str], cwd: Path) -> tuple[str, ...]:
         errors="surrogateescape",
     )
     paths = set(changed.stdout.split("\0")) if changed.returncode == 0 else set()
-    paths.update(path for path in _git_untracked_paths(git_cmd, cwd) if path.endswith(".py"))
+    untracked = _git_untracked_paths(git_cmd, cwd)
+    if untracked is not None:
+        paths.update(path for path in untracked if path.endswith(".py"))
     paths.discard("")
     return tuple(sorted(paths))
 
@@ -2530,7 +2536,12 @@ def _reject_unsafe_stash_restore(
         for line in str(detail).splitlines()[:6]:
             print(f"    {line}")
 
-    restored_untracked = _git_untracked_paths(git_cmd, cwd) - preexisting_untracked
+    current_untracked = _git_untracked_paths(git_cmd, cwd)
+    restored_untracked = (
+        current_untracked - preexisting_untracked
+        if current_untracked is not None
+        else set()
+    )
     subprocess.run(
         git_cmd + ["reset", "--hard", "HEAD"], cwd=cwd, capture_output=True
     )
@@ -2540,6 +2551,9 @@ def _reject_unsafe_stash_restore(
             cwd=cwd,
             capture_output=True,
         )
+    elif current_untracked is None:
+        print("  ⚠ Untracked restore leftovers could not be cleaned automatically.")
+        print("    Inspect `git status` before retrying the stash.")
 
     print("  The clean updated tree has been restored; the gateway was not restarted.")
     print("  Platform connectivity alone does not mean the agent can execute turns.")
@@ -2586,6 +2600,10 @@ def _restore_stashed_changes(
             return False
 
     preexisting_untracked = _git_untracked_paths(git_cmd, cwd)
+    if preexisting_untracked is None:
+        print("  The stash was not restored because its cleanup baseline is unknown.")
+        print(f"  Restore manually with: git stash apply {stash_ref}")
+        return False
     clean_import_failures = _critical_module_import_failures(
         cwd, report_runtime_errors=True
     )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -708,10 +708,14 @@ def _critical_module_import_failures(
         "    except Exception as exc:\n"
         "        if %r:\n"
         "            failures.append((name, str(exc)))\n"
+        "    except BaseException as exc:\n"
+        "        if %r:\n"
+        "            failures.append((name, str(exc)))\n"
         "sys.stdout.write('\\n%s' + json.dumps(failures))\n"
         % (
             _UPDATE_CRITICAL_MODULES,
             tuple(sorted(FIRST_PARTY_MODULE_ROOTS)),
+            report_runtime_errors,
             report_runtime_errors,
             marker,
         )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -744,7 +744,12 @@ def _critical_module_import_failures(
         return {}
     output = result.stdout or ""
     if marker not in output:
-        return {}
+        return {
+            "critical-module probe": (
+                "terminated before reporting import health "
+                f"(exit code {result.returncode})"
+            )
+        }
     try:
         import json
 
@@ -2470,12 +2475,20 @@ def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str]:
         errors="surrogateescape",
     )
     if result.returncode != 0:
+        print(
+            "  ⚠ Could not enumerate untracked files while validating the "
+            "restored stash."
+        )
         return set()
     return {path for path in result.stdout.split("\0") if path}
 
 
 def _restored_python_paths(git_cmd: list[str], cwd: Path) -> tuple[str, ...]:
-    """Return tracked and untracked Python paths changed from ``HEAD``."""
+    """Return restored ``.py`` paths changed from ``HEAD``.
+
+    This deliberately validates Python source only; non-Python entry scripts
+    remain outside the executable import-health check.
+    """
     changed = subprocess.run(
         git_cmd + ["diff", "--name-only", "-z", "HEAD", "--", "*.py"],
         cwd=cwd,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -657,7 +657,7 @@ _UPDATE_CRITICAL_MODULES = (
 
 def _critical_module_import_failures(
     root, *, report_runtime_errors: bool = False
-) -> dict[str, str]:
+) -> dict[str, tuple[str, str]]:
     """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
 
     ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
@@ -703,19 +703,20 @@ def _critical_module_import_failures(
         # The root set is injected from hermes_constants so this can't drift
         # from the hint the user is shown (they disagreed once already).
         "        missing = (getattr(exc, 'name', '') or '').split('.')[0]\n"
-        "        if missing in %r or missing.startswith('hermes_'):\n"
-        "            failures.append((name, str(exc)))\n"
+        "        if missing in %r or missing.startswith('hermes_') or %r:\n"
+        "            failures.append((name, type(exc).__name__, str(exc)))\n"
         "    except ImportError as exc:\n"
-        "        failures.append((name, str(exc)))\n"
+        "        failures.append((name, type(exc).__name__, str(exc)))\n"
         "    except Exception as exc:\n"
         "        if %r:\n"
-        "            failures.append((name, str(exc)))\n"
+        "            failures.append((name, type(exc).__name__, str(exc)))\n"
         "    except BaseException as exc:\n"
-        "        failures.append((name, str(exc)))\n"
+        "        failures.append((name, type(exc).__name__, str(exc)))\n"
         "sys.stdout.write('\\n%s' + json.dumps(failures))\n"
         % (
             _UPDATE_CRITICAL_MODULES,
             tuple(sorted(FIRST_PARTY_MODULE_ROOTS)),
+            report_runtime_errors,
             report_runtime_errors,
             marker,
         )
@@ -741,7 +742,10 @@ def _critical_module_import_failures(
         )
     except subprocess.TimeoutExpired:
         return {
-            "critical-module probe": "timed out before reporting import health"
+            "critical-module probe": (
+                "TimeoutExpired",
+                "timed out before reporting import health",
+            )
         }
     except (OSError, subprocess.SubprocessError):
         # Can't run the probe — don't block the update on our own tooling.
@@ -750,8 +754,9 @@ def _critical_module_import_failures(
     if marker not in output:
         return {
             "critical-module probe": (
+                "ProbeTerminated",
                 "terminated before reporting import health "
-                f"(exit code {result.returncode})"
+                f"(exit code {result.returncode})",
             )
         }
     try:
@@ -760,15 +765,21 @@ def _critical_module_import_failures(
         failures = json.loads(output.rsplit(marker, 1)[1])
         if not isinstance(failures, list) or any(
             not isinstance(item, list)
-            or len(item) != 2
+            or len(item) != 3
             or not all(isinstance(value, str) for value in item)
             for item in failures
         ):
             raise ValueError("invalid import-health payload")
-        return {str(module): str(detail) for module, detail in failures}
+        return {
+            str(module): (str(kind), str(detail))
+            for module, kind, detail in failures
+        }
     except (TypeError, ValueError):
         return {
-            "critical-module probe": "reported malformed import health data"
+            "critical-module probe": (
+                "MalformedPayload",
+                "reported malformed import health data",
+            )
         }
 
 
@@ -781,7 +792,7 @@ def _validate_critical_modules_import(
     )
     if failures:
         module = next(iter(failures))
-        return False, module, failures[module]
+        return False, module, failures[module][1]
     return True, None, None
 
 def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0) -> str:
@@ -2479,15 +2490,18 @@ def _park_stashed_changes(stash_ref: str) -> None:
 
 def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str] | None:
     """Return untracked paths, or ``None`` when Git cannot enumerate them."""
-    result = subprocess.run(
-        git_cmd + ["ls-files", "--others", "--exclude-standard", "-z"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="surrogateescape",
-    )
-    if result.returncode != 0:
+    try:
+        result = subprocess.run(
+            git_cmd + ["ls-files", "--others", "--exclude-standard", "-z"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    if result is None or result.returncode != 0:
         print(
             "  ⚠ Could not enumerate untracked files while validating the "
             "restored stash."
@@ -2504,15 +2518,18 @@ def _restored_python_paths(
     This deliberately validates Python source only; non-Python entry scripts
     remain outside the executable import-health check.
     """
-    changed = subprocess.run(
-        git_cmd + ["diff", "--name-only", "-z", "HEAD", "--", "*.py"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="surrogateescape",
-    )
-    if changed.returncode != 0:
+    try:
+        changed = subprocess.run(
+            git_cmd + ["diff", "--name-only", "-z", "HEAD", "--", "*.py"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+    except (OSError, subprocess.SubprocessError):
+        changed = None
+    if changed is None or changed.returncode != 0:
         print("  ⚠ Could not enumerate tracked Python files restored from the stash.")
         return None
     paths = set(changed.stdout.split("\0"))
@@ -2546,20 +2563,45 @@ def _reject_unsafe_stash_restore(
         if current_untracked is not None
         else set()
     )
-    subprocess.run(
-        git_cmd + ["reset", "--hard", "HEAD"], cwd=cwd, capture_output=True
-    )
-    if restored_untracked:
-        subprocess.run(
-            git_cmd + ["clean", "-fd", "--", *sorted(restored_untracked)],
-            cwd=cwd,
-            capture_output=True,
+    try:
+        reset = subprocess.run(
+            git_cmd + ["reset", "--hard", "HEAD"], cwd=cwd, capture_output=True
         )
-    elif current_untracked is None:
-        print("  ⚠ Untracked restore leftovers could not be cleaned automatically.")
-        print("    Inspect `git status` before retrying the stash.")
+    except (OSError, subprocess.SubprocessError):
+        reset = None
 
-    print("  The clean updated tree has been restored; the gateway was not restarted.")
+    clean = None
+    if restored_untracked:
+        try:
+            clean = subprocess.run(
+                git_cmd + ["clean", "-fd", "--", *sorted(restored_untracked)],
+                cwd=cwd,
+                capture_output=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            clean = None
+    cleanup_ok = (
+        current_untracked is not None
+        and reset is not None
+        and reset.returncode == 0
+        and (not restored_untracked or (clean is not None and clean.returncode == 0))
+    )
+    if cleanup_ok:
+        try:
+            verify = subprocess.run(
+                git_cmd + ["diff", "--quiet", "HEAD", "--"],
+                cwd=cwd,
+                capture_output=True,
+            )
+            cleanup_ok = verify.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            cleanup_ok = False
+
+    if cleanup_ok:
+        print("  The clean updated tree has been restored; the gateway was not restarted.")
+    else:
+        print("  ⚠ The clean updated tree could not be fully restored automatically.")
+        print("    Inspect `git status` and run `git reset --hard HEAD` before retrying.")
     print("  Platform connectivity alone does not mean the agent can execute turns.")
     print(f"  Your local changes remain preserved in stash: {stash_ref}")
     print(f"  Inspect them with: git stash show --stat {stash_ref}")
@@ -2714,7 +2756,7 @@ def _restore_stashed_changes(
             stash_ref,
             preexisting_untracked,
             f"agent import {failing_module or 'unknown'}",
-            import_error,
+            import_error[1],
         )
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -688,7 +688,9 @@ def _critical_module_import_failures(
     """
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
 
-    marker = "__HERMES_IMPORT_HEALTH__"
+    import secrets
+
+    marker = f"__HERMES_IMPORT_HEALTH_{secrets.token_hex(16)}__"
     probe = (
         "import importlib, json, sys\n"
         "failures = []\n"
@@ -754,9 +756,18 @@ def _critical_module_import_failures(
         import json
 
         failures = json.loads(output.rsplit(marker, 1)[1])
+        if not isinstance(failures, list) or any(
+            not isinstance(item, list)
+            or len(item) != 2
+            or not all(isinstance(value, str) for value in item)
+            for item in failures
+        ):
+            raise ValueError("invalid import-health payload")
         return {str(module): str(detail) for module, detail in failures}
     except (TypeError, ValueError):
-        return {}
+        return {
+            "critical-module probe": "reported malformed import health data"
+        }
 
 
 def _validate_critical_modules_import(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -655,9 +655,9 @@ _UPDATE_CRITICAL_MODULES = (
 )
 
 
-def _validate_critical_modules_import(
+def _critical_module_import_failures(
     root, *, report_runtime_errors: bool = False
-) -> tuple[bool, str | None, str | None]:
+) -> dict[str, str]:
     """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
 
     ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
@@ -680,15 +680,18 @@ def _validate_critical_modules_import(
     different Python than the install's own, and probing the wrong
     interpreter would test a tree the user never runs.
 
-    Returns ``(ok, failing_module, error_message)``. Generic import-time
-    exceptions remain tolerated by default because they can depend on local
-    config or environment. ``report_runtime_errors=True`` exposes them so a
-    caller can compare two states of the same checkout.
+    Returns every failing module in probe order. Generic import-time exceptions
+    remain tolerated by default because they can depend on local config or
+    environment. ``report_runtime_errors=True`` exposes them so a caller can
+    compare two states of the same checkout without an earlier failure masking
+    a later one.
     """
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
 
+    marker = "__HERMES_IMPORT_HEALTH__"
     probe = (
-        "import importlib, sys\n"
+        "import importlib, json, sys\n"
+        "failures = []\n"
         "for name in %r:\n"
         "    try:\n"
         "        importlib.import_module(name)\n"
@@ -699,16 +702,19 @@ def _validate_critical_modules_import(
         # from the hint the user is shown (they disagreed once already).
         "        missing = (getattr(exc, 'name', '') or '').split('.')[0]\n"
         "        if missing in %r or missing.startswith('hermes_'):\n"
-        "            sys.stdout.write(name + '\\n' + str(exc))\n"
-        "            raise SystemExit(3)\n"
+        "            failures.append((name, str(exc)))\n"
         "    except ImportError as exc:\n"
-        "        sys.stdout.write(name + '\\n' + str(exc))\n"
-        "        raise SystemExit(3)\n"
+        "        failures.append((name, str(exc)))\n"
         "    except Exception as exc:\n"
-        "        sys.stdout.write(name + '\\n' + str(exc))\n"
-        "        raise SystemExit(4)\n"
-        "raise SystemExit(0)\n"
-        % (_UPDATE_CRITICAL_MODULES, tuple(sorted(FIRST_PARTY_MODULE_ROOTS)))
+        "        if %r:\n"
+        "            failures.append((name, str(exc)))\n"
+        "sys.stdout.write('\\n%s' + json.dumps(failures))\n"
+        % (
+            _UPDATE_CRITICAL_MODULES,
+            tuple(sorted(FIRST_PARTY_MODULE_ROOTS)),
+            report_runtime_errors,
+            marker,
+        )
     )
     try:
         interpreter = sys.executable
@@ -731,20 +737,29 @@ def _validate_critical_modules_import(
         )
     except (OSError, subprocess.SubprocessError):
         # Can't run the probe — don't block the update on our own tooling.
-        return True, None, None
-    if result.returncode != 0:
-        if result.returncode == 4 and not report_runtime_errors:
-            # Generic import-time failures can depend on local config or env,
-            # so the ordinary post-update guard keeps its historical tolerance.
-            # Stash restoration opts into reporting them and compares the clean
-            # tree with the restored tree to detect failures introduced by the
-            # user's local changes.
-            return True, None, None
-        output = result.stdout or result.stderr or ""
-        parts = output.split("\n", 1)
-        module = parts[0].strip() or "unknown"
-        detail = parts[1].strip() if len(parts) > 1 else ""
-        return False, module, detail
+        return {}
+    output = result.stdout or ""
+    if marker not in output:
+        return {}
+    try:
+        import json
+
+        failures = json.loads(output.rsplit(marker, 1)[1])
+        return {str(module): str(detail) for module, detail in failures}
+    except (TypeError, ValueError):
+        return {}
+
+
+def _validate_critical_modules_import(
+    root, *, report_runtime_errors: bool = False
+) -> tuple[bool, str | None, str | None]:
+    """Return the first critical-module import failure, if any."""
+    failures = _critical_module_import_failures(
+        root, report_runtime_errors=report_runtime_errors
+    )
+    if failures:
+        module = next(iter(failures))
+        return False, module, failures[module]
     return True, None, None
 
 def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0) -> str:
@@ -2543,7 +2558,7 @@ def _restore_stashed_changes(
             return False
 
     preexisting_untracked = _git_untracked_paths(git_cmd, cwd)
-    clean_import_health = _validate_critical_modules_import(
+    clean_import_failures = _critical_module_import_failures(
         cwd, report_runtime_errors=True
     )
     print("→ Restoring local changes...")
@@ -2621,11 +2636,19 @@ def _restore_stashed_changes(
             syntax_error,
         )
 
-    restored_import_health = _validate_critical_modules_import(
+    restored_import_failures = _critical_module_import_failures(
         cwd, report_runtime_errors=True
     )
-    import_ok, failing_module, import_error = restored_import_health
-    if not import_ok and restored_import_health != clean_import_health:
+    changed_import_failure = next(
+        (
+            (module, error)
+            for module, error in restored_import_failures.items()
+            if clean_import_failures.get(module) != error
+        ),
+        None,
+    )
+    if changed_import_failure is not None:
+        failing_module, import_error = changed_import_failure
         _reject_unsafe_stash_restore(
             git_cmd,
             cwd,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -598,6 +598,29 @@ def _editable_install_is_current(git_cmd, cwd, pre_pull_sha: str | None) -> bool
         return False
     return not result.stdout.strip()
 
+def _validate_python_files_syntax(
+    root, relpaths
+) -> tuple[bool, str | None, str | None]:
+    """Compile *relpaths* under *root* without writing bytecode into the tree."""
+    import py_compile
+    import tempfile
+
+    root = Path(root)
+    with tempfile.TemporaryDirectory(prefix="hermes-syntax-check-") as tmpdir:
+        for relpath in relpaths:
+            path = root / relpath
+            if not path.exists():
+                continue
+            cfile = Path(tmpdir) / (str(relpath).replace("/", "__") + "c")
+            try:
+                py_compile.compile(str(path), cfile=str(cfile), doraise=True)
+            except py_compile.PyCompileError as exc:
+                return False, str(path), str(exc)
+            except OSError as exc:
+                return False, str(path), f"could not read: {exc}"
+    return True, None, None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -617,27 +640,7 @@ def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]
     Returns ``(ok, failing_path, error_message)``. ``ok=True`` means every
     file parsed cleanly.
     """
-    import py_compile
-    import tempfile
-
-    root = Path(root)
-    with tempfile.TemporaryDirectory(prefix="hermes-syntax-check-") as tmpdir:
-        for relpath in _UPDATE_CRITICAL_FILES:
-            path = root / relpath
-            if not path.exists():
-                # Missing file is suspicious but not necessarily fatal — a future
-                # refactor may legitimately remove one of these. Skip and move on.
-                continue
-            # Mirror the relative path under the tmpdir so two different
-            # files with the same basename don't collide on the cfile name.
-            cfile = Path(tmpdir) / (relpath.replace("/", "__") + "c")
-            try:
-                py_compile.compile(str(path), cfile=str(cfile), doraise=True)
-            except py_compile.PyCompileError as exc:
-                return False, str(path), str(exc)
-            except OSError as exc:
-                return False, str(path), f"could not read: {exc}"
-    return True, None, None
+    return _validate_python_files_syntax(root, _UPDATE_CRITICAL_FILES)
 
 
 # Modules imported on every agent startup. Unlike _UPDATE_CRITICAL_FILES (which
@@ -2423,6 +2426,72 @@ def _park_stashed_changes(stash_ref: str) -> None:
     print(f"  Restore manually with: git stash apply {stash_ref}")
 
 
+def _git_untracked_paths(git_cmd: list[str], cwd: Path) -> set[str]:
+    """Return untracked, non-ignored paths without Git's quoting ambiguity."""
+    result = subprocess.run(
+        git_cmd + ["ls-files", "--others", "--exclude-standard", "-z"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
+    if result.returncode != 0:
+        return set()
+    return {path for path in result.stdout.split("\0") if path}
+
+
+def _restored_python_paths(git_cmd: list[str], cwd: Path) -> tuple[str, ...]:
+    """Return tracked and untracked Python paths changed from ``HEAD``."""
+    changed = subprocess.run(
+        git_cmd + ["diff", "--name-only", "-z", "HEAD", "--", "*.py"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
+    paths = set(changed.stdout.split("\0")) if changed.returncode == 0 else set()
+    paths.update(path for path in _git_untracked_paths(git_cmd, cwd) if path.endswith(".py"))
+    paths.discard("")
+    return tuple(sorted(paths))
+
+
+def _reject_unsafe_stash_restore(
+    git_cmd: list[str],
+    cwd: Path,
+    stash_ref: str,
+    preexisting_untracked: set[str],
+    failing_target: str,
+    detail: str | None,
+) -> None:
+    """Restore the clean updated tree, preserve the stash, and abort the update."""
+    print()
+    print("✗ Restored local changes made the Hermes agent unexecutable.")
+    print(f"  Health check failed: {failing_target}")
+    if detail:
+        for line in str(detail).splitlines()[:6]:
+            print(f"    {line}")
+
+    restored_untracked = _git_untracked_paths(git_cmd, cwd) - preexisting_untracked
+    subprocess.run(
+        git_cmd + ["reset", "--hard", "HEAD"], cwd=cwd, capture_output=True
+    )
+    if restored_untracked:
+        subprocess.run(
+            git_cmd + ["clean", "-fd", "--", *sorted(restored_untracked)],
+            cwd=cwd,
+            capture_output=True,
+        )
+
+    print("  The clean updated tree has been restored; the gateway was not restarted.")
+    print("  Platform connectivity alone does not mean the agent can execute turns.")
+    print(f"  Your local changes remain preserved in stash: {stash_ref}")
+    print(f"  Inspect them with: git stash show --stat {stash_ref}")
+    print(f"  Restore manually after fixing them: git stash apply {stash_ref}")
+    raise SystemExit(1)
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -2431,15 +2500,17 @@ def _restore_stashed_changes(
     input_fn=None,
 ) -> bool:
     if prompt_user:
+        remote_prompt = input_fn is not None
+        prompt_suffix = "[y/N]" if remote_prompt else "[Y/n]"
         print()
         print("⚠ Local changes were stashed before updating.")
         print(
             "  Restoring them may reapply local customizations onto the updated codebase."
         )
         print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
+        print(f"Restore local changes now? {prompt_suffix}")
         if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
+            response = input_fn(f"Restore local changes now? {prompt_suffix}", "n")
         else:
             try:
                 response = input().strip().lower()
@@ -2450,12 +2521,14 @@ def _restore_stashed_changes(
                 # skip-restore path below, which already explains how to
                 # restore manually from git stash.
                 response = "n"
-        if response not in {"", "y", "yes"}:
+        accepted = response in {"y", "yes"} or (not remote_prompt and response == "")
+        if not accepted:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
             print(f"Restore manually with: git stash apply {stash_ref}")
             return False
 
+    preexisting_untracked = _git_untracked_paths(git_cmd, cwd)
     print("→ Restoring local changes...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
@@ -2516,6 +2589,31 @@ def _restore_stashed_changes(
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
         return False
+
+    restored_python = _restored_python_paths(git_cmd, cwd)
+    syntax_ok, failing_path, syntax_error = _validate_python_files_syntax(
+        cwd, restored_python
+    )
+    if not syntax_ok:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            failing_path or "restored Python source",
+            syntax_error,
+        )
+
+    import_ok, failing_module, import_error = _validate_critical_modules_import(cwd)
+    if not import_ok:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            f"agent import {failing_module or 'unknown'}",
+            import_error,
+        )
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
     if stash_selector is None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -655,7 +655,9 @@ _UPDATE_CRITICAL_MODULES = (
 )
 
 
-def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | None]:
+def _validate_critical_modules_import(
+    root, *, report_runtime_errors: bool = False
+) -> tuple[bool, str | None, str | None]:
     """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
 
     ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
@@ -678,7 +680,10 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
     different Python than the install's own, and probing the wrong
     interpreter would test a tree the user never runs.
 
-    Returns ``(ok, failing_module, error_message)``.
+    Returns ``(ok, failing_module, error_message)``. Generic import-time
+    exceptions remain tolerated by default because they can depend on local
+    config or environment. ``report_runtime_errors=True`` exposes them so a
+    caller can compare two states of the same checkout.
     """
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
 
@@ -699,8 +704,9 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
         "    except ImportError as exc:\n"
         "        sys.stdout.write(name + '\\n' + str(exc))\n"
         "        raise SystemExit(3)\n"
-        "    except Exception:\n"
-        "        pass\n"  # non-import errors (config/env) aren't update breakage
+        "    except Exception as exc:\n"
+        "        sys.stdout.write(name + '\\n' + str(exc))\n"
+        "        raise SystemExit(4)\n"
         "raise SystemExit(0)\n"
         % (_UPDATE_CRITICAL_MODULES, tuple(sorted(FIRST_PARTY_MODULE_ROOTS)))
     )
@@ -726,8 +732,16 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
     except (OSError, subprocess.SubprocessError):
         # Can't run the probe — don't block the update on our own tooling.
         return True, None, None
-    if result.returncode == 3:
-        parts = (result.stdout or "").split("\n", 1)
+    if result.returncode != 0:
+        if result.returncode == 4 and not report_runtime_errors:
+            # Generic import-time failures can depend on local config or env,
+            # so the ordinary post-update guard keeps its historical tolerance.
+            # Stash restoration opts into reporting them and compares the clean
+            # tree with the restored tree to detect failures introduced by the
+            # user's local changes.
+            return True, None, None
+        output = result.stdout or result.stderr or ""
+        parts = output.split("\n", 1)
         module = parts[0].strip() or "unknown"
         detail = parts[1].strip() if len(parts) > 1 else ""
         return False, module, detail
@@ -2529,6 +2543,9 @@ def _restore_stashed_changes(
             return False
 
     preexisting_untracked = _git_untracked_paths(git_cmd, cwd)
+    clean_import_health = _validate_critical_modules_import(
+        cwd, report_runtime_errors=True
+    )
     print("→ Restoring local changes...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
@@ -2604,8 +2621,11 @@ def _restore_stashed_changes(
             syntax_error,
         )
 
-    import_ok, failing_module, import_error = _validate_critical_modules_import(cwd)
-    if not import_ok:
+    restored_import_health = _validate_critical_modules_import(
+        cwd, report_runtime_errors=True
+    )
+    import_ok, failing_module, import_error = restored_import_health
+    if not import_ok and restored_import_health != clean_import_health:
         _reject_unsafe_stash_restore(
             git_cmd,
             cwd,

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -657,6 +657,48 @@ def test_restore_rejects_system_exit_masked_by_preexisting_failure(
     assert "gateway was not restarted" in output
 
 
+def test_restore_rejects_probe_termination(monkeypatch, tmp_path, capsys):
+    """A stash cannot bypass import validation by terminating the probe."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    source = tmp_path / "consumer.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    source.write_text("import os\nos._exit(7)\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "critical-module probe" in output
+    assert "exit code 7" in output
+    assert "gateway was not restarted" in output
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -699,6 +699,24 @@ def test_restore_rejects_probe_termination(monkeypatch, tmp_path, capsys):
     assert "gateway was not restarted" in output
 
 
+def test_restore_stays_parked_when_untracked_baseline_is_unknown(
+    monkeypatch, tmp_path, capsys
+):
+    """Unknown cleanup scope must not turn into a destructive empty baseline."""
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd, "_git_untracked_paths", lambda *_args: None)
+
+    restored = hermes_main._restore_stashed_changes(
+        ["git"], tmp_path, "stash@{0}", prompt_user=False
+    )
+
+    assert restored is False
+    output = capsys.readouterr().out
+    assert "cleanup baseline is unknown" in output
+    assert "git stash apply stash@{0}" in output
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -717,6 +717,24 @@ def test_restore_stays_parked_when_untracked_baseline_is_unknown(
     assert "git stash apply stash@{0}" in output
 
 
+def test_reject_does_not_claim_cleanup_when_git_state_is_unknown(
+    monkeypatch, tmp_path, capsys
+):
+    """Cleanup failures must not be reported as a restored clean tree."""
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd, "_git_untracked_paths", lambda *_args: None)
+
+    with pytest.raises(SystemExit):
+        update_cmd._reject_unsafe_stash_restore(
+            ["git"], tmp_path, "stash@{0}", set(), "consumer.py", "invalid"
+        )
+
+    output = capsys.readouterr().out
+    assert "could not be fully restored automatically" in output
+    assert "The clean updated tree has been restored" not in output
+
+
 def test_restore_rejects_unknown_restored_python_paths(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -435,3 +435,64 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
         assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
     finally:
         os.chmod(pkg, 0o755)
+
+
+def test_restore_rejects_invalid_python_and_keeps_clean_updated_tree(
+    monkeypatch, tmp_path, capsys
+):
+    """A cleanly-applied stash must not be allowed to brick every agent turn."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    source = tmp_path / "tools" / "terminal_tool.py"
+    source.parent.mkdir()
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    source.write_text("<<<<<<< Updated upstream\nVALUE = 2\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ())
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "made the Hermes agent unexecutable" in output
+    assert "gateway was not restarted" in output
+    assert f"git stash apply {stash_ref}" in output
+
+
+def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
+    prompts = []
+
+    restored = hermes_main._restore_stashed_changes(
+        ["git"],
+        tmp_path,
+        "stash@{0}",
+        prompt_user=True,
+        input_fn=lambda prompt, default: prompts.append((prompt, default)) or "",
+    )
+
+    assert restored is False
+    assert prompts == [("Restore local changes now? [y/N]", "n")]
+    assert "still preserved in git stash" in capsys.readouterr().out

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -610,6 +610,53 @@ def test_restore_rejects_later_failure_masked_by_preexisting_failure(
     assert "gateway was not restarted" in output
 
 
+def test_restore_rejects_system_exit_masked_by_preexisting_failure(
+    monkeypatch, tmp_path, capsys
+):
+    """A terminating import must be compared instead of hiding the marker."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "first.py").write_text(
+        "raise RuntimeError('missing local config')\n", encoding="utf-8"
+    )
+    second = tmp_path / "second.py"
+    second.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    second.write_text("raise SystemExit('restored exit')\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("first", "second"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert second.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "agent import second" in output
+    assert "restored exit" in output
+    assert "gateway was not restarted" in output
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -717,6 +717,49 @@ def test_restore_stays_parked_when_untracked_baseline_is_unknown(
     assert "git stash apply stash@{0}" in output
 
 
+def test_restore_rejects_unknown_restored_python_paths(
+    monkeypatch, tmp_path, capsys
+):
+    """A failed post-apply path query cannot skip restored syntax validation."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    source = tmp_path / "consumer.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ())
+    monkeypatch.setattr(update_cmd, "_restored_python_paths", lambda *_args: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "restored Python source discovery" in output
+    assert "gateway was not restarted" in output
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -482,6 +482,87 @@ def test_restore_rejects_invalid_python_and_keeps_clean_updated_tree(
     assert f"git stash apply {stash_ref}" in output
 
 
+def test_restore_rejects_new_import_time_failure_and_preserves_stash(
+    monkeypatch, tmp_path, capsys
+):
+    """A valid-Python stash must not introduce a critical import failure."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    source = tmp_path / "consumer.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    source.write_text("raise RuntimeError('restored local failure')\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "agent import consumer" in output
+    assert "restored local failure" in output
+    assert "gateway was not restarted" in output
+
+
+def test_restore_allows_preexisting_import_time_failure(monkeypatch, tmp_path):
+    """A restore may proceed when it does not worsen an environment failure."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "consumer.py").write_text(
+        "raise RuntimeError('missing local config')\n", encoding="utf-8"
+    )
+    local_file = tmp_path / "local.txt"
+    local_file.write_text("original\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    local_file.write_text("restored\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    assert hermes_main._restore_stashed_changes(
+        ["git"], tmp_path, stash_ref, prompt_user=False
+    )
+    assert local_file.read_text(encoding="utf-8") == "restored\n"
+    assert git("stash", "list").stdout.strip() == ""
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -563,6 +563,53 @@ def test_restore_allows_preexisting_import_time_failure(monkeypatch, tmp_path):
     assert git("stash", "list").stdout.strip() == ""
 
 
+def test_restore_rejects_later_failure_masked_by_preexisting_failure(
+    monkeypatch, tmp_path, capsys
+):
+    """Every critical module must be compared, not only the first failure."""
+    import subprocess
+    from hermes_cli import update_cmd
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "first.py").write_text(
+        "raise RuntimeError('missing local config')\n", encoding="utf-8"
+    )
+    second = tmp_path / "second.py"
+    second.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    second.write_text("raise RuntimeError('restored later failure')\n", encoding="utf-8")
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("first", "second"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._restore_stashed_changes(
+            ["git"], tmp_path, stash_ref, prompt_user=False
+        )
+
+    assert exc_info.value.code == 1
+    assert second.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert git("status", "--porcelain").stdout == ""
+    assert git("stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "agent import second" in output
+    assert "restored later failure" in output
+    assert "gateway was not restarted" in output
+
+
 def test_gateway_restore_prompt_defaults_to_keep_stash(tmp_path, capsys):
     prompts = []
 

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -96,6 +96,45 @@ def test_import_guard_can_report_non_import_errors(monkeypatch, tmp_path):
     assert error == "broken config"
 
 
+def test_import_guard_reports_probe_termination_when_comparing_states(
+    monkeypatch, tmp_path
+):
+    """A terminating import is unsafe when validating a restored stash."""
+    (tmp_path / "consumer.py").write_text("import os\nos._exit(7)\n")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(
+        tmp_path, report_runtime_errors=True
+    )
+
+    assert ok is False
+    assert module == "critical-module probe"
+    assert error == "terminated before reporting import health (exit code 7)"
+
+
+def test_import_guard_reports_probe_termination_by_default(monkeypatch, tmp_path):
+    """A missing health marker must not classify a terminated probe as healthy."""
+    (tmp_path / "consumer.py").write_text("import os\nos._exit(9)\n")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+    assert ok is False
+    assert module == "critical-module probe"
+    assert error == "terminated before reporting import health (exit code 9)"
+
+
+def test_untracked_enumeration_failure_is_visible(monkeypatch, tmp_path, capsys):
+    class Result:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", lambda *_a, **_kw: Result())
+
+    assert update_cmd._git_untracked_paths(["git"], tmp_path) == set()
+    assert "Could not enumerate untracked files" in capsys.readouterr().out
+
+
 def test_import_guard_is_non_fatal_when_probe_cannot_run(monkeypatch, tmp_path):
     """If we can't spawn the probe, don't block the user's update."""
 

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -160,6 +160,21 @@ def test_import_guard_rejects_malformed_health_payload(monkeypatch, tmp_path):
     assert error == "reported malformed import health data"
 
 
+def test_import_guard_reports_probe_timeout(monkeypatch, tmp_path):
+    import subprocess
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["python", "-c", "probe"], 120)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", timeout)
+
+    ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+    assert ok is False
+    assert module == "critical-module probe"
+    assert error == "timed out before reporting import health"
+
+
 def test_untracked_enumeration_failure_is_visible(monkeypatch, tmp_path, capsys):
     class Result:
         returncode = 1
@@ -167,7 +182,7 @@ def test_untracked_enumeration_failure_is_visible(monkeypatch, tmp_path, capsys)
 
     monkeypatch.setattr(update_cmd.subprocess, "run", lambda *_a, **_kw: Result())
 
-    assert update_cmd._git_untracked_paths(["git"], tmp_path) == set()
+    assert update_cmd._git_untracked_paths(["git"], tmp_path) is None
     assert "Could not enumerate untracked files" in capsys.readouterr().out
 
 

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -124,6 +124,18 @@ def test_import_guard_reports_probe_termination_by_default(monkeypatch, tmp_path
     assert error == "terminated before reporting import health (exit code 9)"
 
 
+def test_import_guard_reports_system_exit_by_default(monkeypatch, tmp_path):
+    """Catchable terminating imports must not complete with a healthy marker."""
+    (tmp_path / "consumer.py").write_text("raise SystemExit('stopped')\n")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+    assert ok is False
+    assert module == "consumer"
+    assert error == "stopped"
+
+
 def test_import_guard_does_not_accept_forged_static_marker(monkeypatch, tmp_path):
     """Imported stdout cannot impersonate the per-probe completion marker."""
     (tmp_path / "consumer.py").write_text(

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -82,6 +82,20 @@ def test_import_guard_ignores_non_import_errors(monkeypatch, tmp_path):
     assert ok is True
 
 
+def test_import_guard_can_report_non_import_errors(monkeypatch, tmp_path):
+    """Stash restore can compare runtime failures before and after apply."""
+    (tmp_path / "consumer.py").write_text("raise RuntimeError('broken config')\n")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(
+        tmp_path, report_runtime_errors=True
+    )
+
+    assert ok is False
+    assert module == "consumer"
+    assert error == "broken config"
+
+
 def test_import_guard_is_non_fatal_when_probe_cannot_run(monkeypatch, tmp_path):
     """If we can't spawn the probe, don't block the user's update."""
 

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -96,6 +96,38 @@ def test_import_guard_can_report_non_import_errors(monkeypatch, tmp_path):
     assert error == "broken config"
 
 
+def test_import_guard_can_report_missing_third_party_dependency(
+    monkeypatch, tmp_path
+):
+    """Stash comparison must see newly introduced missing dependencies."""
+    (tmp_path / "consumer.py").write_text("import totally_not_installed_pkg\n")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(
+        tmp_path, report_runtime_errors=True
+    )
+
+    assert ok is False
+    assert module == "consumer"
+    assert error is not None and "totally_not_installed_pkg" in error
+
+
+def test_import_failure_comparison_preserves_exception_type(monkeypatch, tmp_path):
+    source = tmp_path / "consumer.py"
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+    source.write_text("raise RuntimeError('stopped')\n")
+    runtime_failure = update_cmd._critical_module_import_failures(
+        tmp_path, report_runtime_errors=True
+    )
+    source.write_text("raise SystemExit('stopped')\n")
+    terminating_failure = update_cmd._critical_module_import_failures(
+        tmp_path, report_runtime_errors=True
+    )
+
+    assert runtime_failure == {"consumer": ("RuntimeError", "stopped")}
+    assert terminating_failure == {"consumer": ("SystemExit", "stopped")}
+
+
 def test_import_guard_reports_probe_termination_when_comparing_states(
     monkeypatch, tmp_path
 ):

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -124,6 +124,42 @@ def test_import_guard_reports_probe_termination_by_default(monkeypatch, tmp_path
     assert error == "terminated before reporting import health (exit code 9)"
 
 
+def test_import_guard_does_not_accept_forged_static_marker(monkeypatch, tmp_path):
+    """Imported stdout cannot impersonate the per-probe completion marker."""
+    (tmp_path / "consumer.py").write_text(
+        "import os, sys\n"
+        "sys.stdout.write('__HERMES_IMPORT_HEALTH__[]')\n"
+        "sys.stdout.flush()\n"
+        "os._exit(7)\n"
+    )
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+    assert ok is False
+    assert module == "critical-module probe"
+    assert error == "terminated before reporting import health (exit code 7)"
+
+
+def test_import_guard_rejects_malformed_health_payload(monkeypatch, tmp_path):
+    class Result:
+        returncode = 0
+        stdout = ""
+
+    def malformed(cmd, **_kwargs):
+        marker = cmd[-1].split("sys.stdout.write('\\n", 1)[1].split("'", 1)[0]
+        Result.stdout = f"{marker}{{}}"
+        return Result()
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", malformed)
+
+    ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+    assert ok is False
+    assert module == "critical-module probe"
+    assert error == "reported malformed import health data"
+
+
 def test_untracked_enumeration_failure_is_visible(monkeypatch, tmp_path, capsys):
     class Result:
         returncode = 1


### PR DESCRIPTION
Salvage of #94287 by @fangliquanflq (authorship preserved via cherry-pick), rebased onto current `main`.

Fixes #94264

## Root cause

`hermes update` stashes local changes, pulls, and validates the **pulled** code — `_validate_critical_files_syntax` runs *before* the stash is re-applied. Git can apply a stashed file cleanly even when its content is invalid Python (e.g. orphan conflict markers from an abandoned edit), so the update prints `✓ Updated!` while the working tree is broken and every subsequent agent turn dies with `SyntaxError`.

## Mechanism of the fix

After `git stash apply` succeeds, the restore path now fails closed:

- **Compile gate** — every restored local Python file is compiled (`_restored_python_paths` + `_validate_python_files_syntax`) before the stash is accepted.
- **Import smoke test** — critical agent modules are import-probed before *and* after the restore; any import failure newly introduced by the restore (compared per-module against the clean-tree baseline) rejects it. Probe results are authenticated markers; terminated/incomplete probes are treated as failures, not passes.
- **Fail-closed rejection** (`_reject_unsafe_stash_restore`) — resets to the clean updated tree (`git reset --hard` + targeted `git clean` of only the files the restore introduced), verifies the cleanup actually landed, keeps the stash intact, prints recovery instructions, and exits non-zero so the gateway is **not** restarted on a broken tree. Unknown/unverifiable cleanup state is reported as unsafe rather than assumed clean.
- **Remote prompt default** — remote gateway "restore local changes?" prompts now default to **No** (keep changes parked in the stash) instead of Yes.

## Verification

- `tests/hermes_cli/test_update_autostash.py` (30 tests) + `tests/hermes_cli/test_update_import_guard.py` (new, from the PR) pass locally; `test_update_head_moved_gate.py` and `test_update_yes_flag.py` re-run — the handful of failures there reproduce identically on clean `origin/main` in this environment (live-install-dependent), i.e. pre-existing, not introduced by this change.
- Live behavioral check: in a scratch repo, stashed a `mod.py` full of `<<<<<<<` conflict markers and called `_restore_stashed_changes` — the restore is rejected with `SystemExit(1)`, the tree is reset clean, and the stash is preserved with recovery instructions.
- `ruff check` clean on all three touched files.

## Credits

- Fix authored by **@fangliquanflq** (#94287) — all 9 commits cherry-picked with authorship preserved.
- **@ClintonEmok** independently reported/fixed the same issue in #94303, closed earlier as a duplicate in favor of #94287 — credit to them as well.

## Infographic

![reject unsafe stash restores](https://v3b.fal.media/files/b/0aa890ef/4_E5d1QdqB-Mt85W7oXWt_I2AFeGn9.png)
