### PR TITLE
fix(mem0): preserve compatible installed releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,12 +236,12 @@ wake = [
 ]
 honcho = ["honcho-ai==2.2.0"]
 # Cloud memory providers — opt-in, lazy-installed via tools/lazy_deps.py
-# (memory.supermemory / memory.mem0) at first use. Exact pins MUST match the
-# LAZY_DEPS pins (enforced by tests/test_project_metadata.py). Deliberately
+# (memory.supermemory / memory.mem0) at first use. Their specs MUST match the
+# LAZY_DEPS entries (enforced by tests/test_project_metadata.py). Deliberately
 # excluded from [all] like honcho/hindsight so a quarantined upstream release
 # can't break fresh installs.
 supermemory = ["supermemory==3.50.0"]
-mem0 = ["mem0ai==2.0.10"]
+mem0 = ["mem0ai>=2.0.10,<3"]
 # Image resize recovery for the vision tools. Pillow is now a CORE dependency
 # (see the main `dependencies` list above) since the byte/pixel shrink paths are on
 # the default vision-embed path and the mid-session lazy install deadlocked the

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -153,6 +153,14 @@ def test_pyproject_pins_match_lazy_deps_pins():
     )
 
 
+def test_mem0_extra_matches_lazy_dependency_range():
+    """Mem0's explicit extra and first-use installer share one policy."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    mem0_extra = _load_optional_dependencies()["mem0"]
+    assert mem0_extra == list(LAZY_DEPS["memory.mem0"])
+
+
 
 
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -208,6 +208,14 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied("slack-bolt>=1.18.0,<2") is True
 
 
+    def test_mem0_compatible_newer_release_is_satisfied(self, monkeypatch):
+        """A supported Mem0 upgrade must not be reinstalled as an old pin."""
+        self._fake_version(monkeypatch, {"mem0ai": "2.0.19"})
+
+        assert ld._is_satisfied(ld.LAZY_DEPS["memory.mem0"][0]) is True
+        assert ld.feature_missing("memory.mem0") == ()
+
+
     def test_bare_package_name_presence_is_enough(self, monkeypatch):
         # No version constraint — presence alone counts as satisfied.
         self._fake_version(monkeypatch, {"somepkg": "1.0.0"})

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -110,7 +110,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Cloud memory SDKs MUST be allowlisted + ensure()'d at the import site, or they never
     # install on the sealed Docker image (durable-target only).
     "memory.supermemory": ("supermemory==3.50.0",),
-    "memory.mem0": ("mem0ai==2.0.10",),
+    "memory.mem0": ("mem0ai>=2.0.10,<3",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.8",),

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-21T02:30:51.712739Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1986,7 +1986,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'dev'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==2.0.0" },
-    { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.10" },
+    { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=2.0.10,<3" },
     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },


### PR DESCRIPTION
Fixes #99317.

Summary:
- Align the Mem0 extra and lazy installer with the plugin's supported `mem0ai>=2.0.10,<3` range.
- Prevent startup from reinstalling a compatible newer Mem0 release as `2.0.10`.
- Add regression coverage for a newer installed release and metadata alignment.

Tests:
- `scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/plugins/memory/test_memory_lazy_install.py tests/test_project_metadata.py -q`
- `uv lock --check`