### PR TITLE
fix(windows): fail-closed process-identity guard before every unverified taskkill

### DIFF
--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -58,4 +58,5 @@ jobs:
           set -uo pipefail
           uv run --no-sync python -m pytest \
             tests/hermes_cli/test_venv_holder_windows_live.py \
+            tests/hermes_cli/test_taskkill_identity_windows_live.py \
             -o addopts= -v -p no:cacheprovider

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32559,7 +32559,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     existing_pid,
                 )
                 try:
-                    terminate_pid(existing_pid, force=True)
+                    terminate_pid(
+                        existing_pid,
+                        force=True,
+                        expected_start_time=existing_start_time,
+                    )
                 except ProcessLookupError:
                     old_gateway_exited = True
                 except (PermissionError, OSError):

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -302,13 +302,41 @@ def normalize_updated_at(value: Any) -> Optional[str]:
     return None
 
 
-def terminate_pid(pid: int, *, force: bool = False) -> None:
+def _assert_process_start_time_matches(
+    pid: int, expected_start_time: Optional[float]
+) -> None:
+    """Fail closed unless ``pid`` still names the recorded process object."""
+    if expected_start_time is None:
+        raise OSError(
+            f"refusing to force-kill PID {pid} without a process start-time guard"
+        )
+    current_start_time = _get_process_start_time(pid)
+    if current_start_time is None:
+        raise OSError(
+            f"refusing to force-kill PID {pid}; process start time is unavailable"
+        )
+    try:
+        expected = float(expected_start_time)
+        current = float(current_start_time)
+    except (TypeError, ValueError) as exc:
+        raise OSError(f"refusing to force-kill PID {pid}; malformed start time") from exc
+    if expected <= 0 or current <= 0 or abs(expected - current) > 0.001:
+        raise OSError(f"refusing to force-kill PID {pid}; process identity changed")
+
+
+def terminate_pid(
+    pid: int,
+    *,
+    force: bool = False,
+    expected_start_time: Optional[float] = None,
+) -> None:
     """Terminate a PID with platform-appropriate force semantics.
 
     POSIX uses SIGTERM/SIGKILL. Windows uses taskkill /T /F for true force-kill
     because os.kill(..., SIGTERM) is not equivalent to a tree-killing hard stop.
     """
     if force and _IS_WINDOWS:
+        _assert_process_start_time_matches(pid, expected_start_time)
         # CREATE_NO_WINDOW: terminate_pid runs from the windowless pythonw.exe
         # gateway/desktop backend, so a bare taskkill spawn would flash a
         # conhost window on every force-kill.
@@ -2234,7 +2262,11 @@ def _terminate_scoped_lock_owner_once(
             return None
 
         try:
-            terminate_pid(owner_pid, force=True)
+            terminate_pid(
+                owner_pid,
+                force=True,
+                expected_start_time=owner_start_time,
+            )
         except ProcessLookupError:
             return owner_pid
         except (PermissionError, OSError):

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -334,7 +334,16 @@ def terminate_pid(
 
     POSIX uses SIGTERM/SIGKILL. Windows uses taskkill /T /F for true force-kill
     because os.kill(..., SIGTERM) is not equivalent to a tree-killing hard stop.
+
+    Identity guard: on Windows, ``force=True`` REQUIRES a matching
+    ``expected_start_time`` (fail closed — taskkill /T /F on a recycled PID
+    has killed svchost.exe and blue-screened the host, #89614). On POSIX an
+    expectation is optional, but when the caller provides one and it no
+    longer matches the live process, the kill is refused on every platform —
+    a mismatched fingerprint always means the PID was recycled.
     """
+    if force and expected_start_time is not None and not _IS_WINDOWS:
+        _assert_process_start_time_matches(pid, expected_start_time)
     if force and _IS_WINDOWS:
         _assert_process_start_time_matches(pid, expected_start_time)
         # CREATE_NO_WINDOW: terminate_pid runs from the windowless pythonw.exe

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -46,6 +46,7 @@ __all__ = [
     "bounded_git_probe",
     "bounded_probe_run",
     "noninteractive_git_env",
+    "pid_is_hermes",
 ]
 
 
@@ -387,7 +388,70 @@ def noninteractive_git_env(
 # -----------------------------------------------------------------------------
 
 
-def kill_process_tree(proc: "subprocess.Popen") -> None:
+
+def _process_start_time(pid: int) -> int | None:
+    """Return the repository's stable process-start fingerprint, if available."""
+    try:
+        from gateway.status import get_process_start_time
+
+        return get_process_start_time(pid)
+    except Exception:
+        return None
+
+
+def _process_command_is_hermes(pid: int) -> bool:
+    """Best-effort check that *pid* currently runs Hermes code."""
+    try:
+        import psutil
+
+        process = psutil.Process(pid)
+        command = " ".join(process.cmdline() or [])
+        executable = process.exe() or ""
+        return "hermes" in f"{command} {executable}".lower()
+    except Exception:
+        return False
+
+
+def pid_is_hermes(
+    pid: int,
+    *,
+    expected_start_time: int | None = None,
+) -> bool:
+    """Return whether it is safe to use ``taskkill`` for *pid*.
+
+    The PID must be valid, currently exist, and identify a Hermes process. When
+    the caller captured a start-time fingerprint before the destructive action,
+    the live process must still have the same ``(pid, start_time)`` identity.
+    Any ambiguity fails closed. Non-Windows callers have no ``taskkill`` path,
+    so a valid PID is accepted there.
+    """
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    if not IS_WINDOWS:
+        return True
+
+    try:
+        current_start_time = _process_start_time(pid)
+    except Exception:
+        return False
+    if current_start_time is None:
+        return False
+    if (
+        expected_start_time is not None
+        and current_start_time != expected_start_time
+    ):
+        return False
+    try:
+        return _process_command_is_hermes(pid)
+    except Exception:
+        return False
+
+
+def kill_process_tree(
+    proc: "subprocess.Popen",
+    *,
+    expected_start_time: int | None = None,
+) -> None:
     """Best-effort terminate *proc* and its descendants on both platforms.
 
     ``proc.kill()`` alone only terminates the direct child. On Windows a
@@ -460,8 +524,19 @@ def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
         pass
     if IS_WINDOWS:
         try:
-            subprocess.run(
-                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+            live_start_time = expected_start_time
+            if live_start_time is None:
+                live_start_time = _process_start_time(proc.pid)
+            if live_start_time is None:
+                allowed = False
+            else:
+                allowed = pid_is_hermes(
+                    proc.pid,
+                    expected_start_time=live_start_time,
+                )
+            if allowed:
+                subprocess.run(
+                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
@@ -525,7 +600,10 @@ def bounded_probe_run(
         # Timeout OR any other communicate() failure (torn-down pipe, decode
         # error): terminate the child + descendants and drain bounded. Leaving
         # it running would leak the same suspended-descendant class this guards.
-        kill_process_tree(proc)
+        kill_process_tree(
+            proc,
+            expected_start_time=_process_start_time(proc.pid),
+        )
         try:
             proc.communicate(timeout=1)
         except Exception:

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -29,6 +29,7 @@ guarantee.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -399,6 +400,23 @@ def _process_start_time(pid: int) -> int | None:
         return None
 
 
+def _text_names_hermes(text: str) -> bool:
+    """True when *text* names Hermes at a path-segment / token boundary.
+
+    A bare ``"hermes" in text`` substring test would also match unrelated
+    processes whose paths merely contain the letters (``...\\shermesa\\...``),
+    which is exactly the false-positive class this guard exists to prevent.
+    Instead, split on path separators and whitespace and require a segment
+    that *starts with* ``hermes`` (``hermes``, ``hermes.exe``, ``hermes_cli``,
+    ``hermes-agent``, ``hermes-runtime``) or the hidden-dir form
+    ``.hermes``/``.hermes-runtime``.
+    """
+    for token in re.split(r"[\\/\s=,;\"']+", text.lower()):
+        if token.startswith("hermes") or token.startswith(".hermes"):
+            return True
+    return False
+
+
 def _process_command_is_hermes(pid: int) -> bool:
     """Best-effort check that *pid* currently runs Hermes code."""
     try:
@@ -407,7 +425,7 @@ def _process_command_is_hermes(pid: int) -> bool:
         process = psutil.Process(pid)
         command = " ".join(process.cmdline() or [])
         executable = process.exe() or ""
-        return "hermes" in f"{command} {executable}".lower()
+        return _text_names_hermes(f"{command} {executable}")
     except Exception:
         return False
 
@@ -423,12 +441,19 @@ def pid_is_hermes(
     the caller captured a start-time fingerprint before the destructive action,
     the live process must still have the same ``(pid, start_time)`` identity.
     Any ambiguity fails closed. Non-Windows callers have no ``taskkill`` path,
-    so a valid PID is accepted there.
+    so a valid PID with no (or a matching) explicit expectation is accepted
+    there — but a caller-provided fingerprint that no longer matches is a
+    recycled PID on every platform and is always refused.
     """
     if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
         return False
     if not IS_WINDOWS:
-        return True
+        if expected_start_time is None:
+            return True
+        try:
+            return _process_start_time(pid) == expected_start_time
+        except Exception:
+            return False
 
     try:
         current_start_time = _process_start_time(pid)
@@ -447,11 +472,7 @@ def pid_is_hermes(
         return False
 
 
-def kill_process_tree(
-    proc: "subprocess.Popen",
-    *,
-    expected_start_time: int | None = None,
-) -> None:
+def kill_process_tree(proc: "subprocess.Popen") -> None:
     """Best-effort terminate *proc* and its descendants on both platforms.
 
     ``proc.kill()`` alone only terminates the direct child. On Windows a
@@ -523,20 +544,15 @@ def _legacy_kill_process_tree(proc: "subprocess.Popen") -> None:
     except OSError:
         pass
     if IS_WINDOWS:
+        # No identity guard here on purpose: *proc* is our own retained
+        # ``Popen`` handle. The child cannot be reaped (and its PID cannot be
+        # recycled) while we still hold the handle, so an identity check could
+        # only ever false-refuse a legitimate cleanup. The fail-closed
+        # ``pid_is_hermes`` guard is for BARE pids from state files or process
+        # scans, where recycling is real.
         try:
-            live_start_time = expected_start_time
-            if live_start_time is None:
-                live_start_time = _process_start_time(proc.pid)
-            if live_start_time is None:
-                allowed = False
-            else:
-                allowed = pid_is_hermes(
-                    proc.pid,
-                    expected_start_time=live_start_time,
-                )
-            if allowed:
-                subprocess.run(
-                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
@@ -600,10 +616,7 @@ def bounded_probe_run(
         # Timeout OR any other communicate() failure (torn-down pipe, decode
         # error): terminate the child + descendants and drain bounded. Leaving
         # it running would leak the same suspended-descendant class this guards.
-        kill_process_tree(
-            proc,
-            expected_start_time=_process_start_time(proc.pid),
-        )
+        kill_process_tree(proc)
         try:
             proc.communicate(timeout=1)
         except Exception:

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -464,13 +464,37 @@ def _kill_stale_dashboard_processes(
     failed: list[tuple[int, str]] = []
 
     if sys.platform == "win32":
+        from gateway.status import get_process_start_time
+        from hermes_cli._subprocess_compat import pid_is_hermes, windows_hide_flags
+
+        # Capture the identity immediately after discovery. A PID that is
+        # reused before the destructive action will fail the start-time check.
+        pid_start_times = {
+            pid: get_process_start_time(pid)
+            for pid in pids
+        }
         for pid in pids:
             try:
+                expected_start_time = pid_start_times.get(pid)
+                if expected_start_time is None:
+                    failed.append((pid, "could not verify process identity"))
+                    continue
+                if not pid_is_hermes(
+                    pid,
+                    expected_start_time=expected_start_time,
+                ):
+                    failed.append((pid, "not hermes-owned or process identity changed"))
+                    continue
                 result = subprocess.run(
                     ["taskkill", "/PID", str(pid), "/F"],
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
+                    creationflags=windows_hide_flags(),
                 )
                 if result.returncode == 0:
                     killed.append(pid)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -656,6 +656,9 @@ def _escalate_wedged_gateway(
 
     Returns True once the PID has left the process table.
     """
+    from gateway.status import get_process_start_time
+
+    expected_start_time = get_process_start_time(pid)
     try:
         terminate_pid(pid, force=False)
     except (ProcessLookupError, PermissionError, OSError):
@@ -663,7 +666,7 @@ def _escalate_wedged_gateway(
     if _wait_for_pid_exit(pid, max(float(term_grace), 0.0)):
         return True
     try:
-        terminate_pid(pid, force=True)
+        terminate_pid(pid, force=True, expected_start_time=expected_start_time)
         print(f"⚠ Gateway PID {pid} unresponsive to SIGTERM; sent SIGKILL")
     except (ProcessLookupError, PermissionError, OSError):
         pass
@@ -2148,7 +2151,12 @@ def kill_gateway_processes(
 
     for pid in pids:
         try:
-            terminate_pid(pid, force=force)
+            expected_start_time = None
+            if force:
+                from gateway.status import get_process_start_time
+
+                expected_start_time = get_process_start_time(pid)
+            terminate_pid(pid, force=force, expected_start_time=expected_start_time)
             killed += 1
         except ProcessLookupError:
             # Process already gone
@@ -5776,7 +5784,7 @@ def _wait_for_gateway_exit(
         force_after: Seconds of graceful waiting before escalating to force-kill.
     """
     import time
-    from gateway.status import get_running_pid
+    from gateway.status import get_process_start_time, get_running_pid
 
     deadline = time.monotonic() + timeout
     force_deadline = (
@@ -5796,7 +5804,11 @@ def _wait_for_gateway_exit(
         ):
             # Grace period expired — force-kill the specific PID.
             try:
-                terminate_pid(pid, force=True)
+                terminate_pid(
+                    pid,
+                    force=True,
+                    expected_start_time=get_process_start_time(pid),
+                )
                 print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
             except (ProcessLookupError, PermissionError, OSError):
                 return True  # Already gone or we can't touch it.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2153,6 +2153,14 @@ def kill_gateway_processes(
         try:
             expected_start_time = None
             if force:
+                # Re-verify at kill time, not just scan time: the cmdline
+                # match inside find_gateway_pids() is stale by the time we
+                # get here, and a recycled PID could otherwise be tree-killed
+                # (#89614 class). _capture_gateway_argv re-reads the LIVE
+                # cmdline and returns None for anything that no longer looks
+                # like a gateway — refuse those.
+                if _capture_gateway_argv(pid) is None:
+                    continue
                 from gateway.status import get_process_start_time
 
                 expected_start_time = get_process_start_time(pid)
@@ -2355,6 +2363,20 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     if not orphans:
         return False
 
+    # Pin each orphan's identity NOW: the cmdline scan above matched at
+    # scan-time only, and the SIGKILL escalation below fires seconds later.
+    # A PID recycled inside that window must never be force-killed (#89614
+    # class). Fingerprint capture is best-effort — SIGTERM below proceeds
+    # regardless (it targets the process verified by the scan an instant
+    # ago), but the delayed SIGKILL requires a still-matching fingerprint.
+    from gateway.status import get_process_start_time
+
+    orphan_identity: dict[int, int] = {}
+    for pid in orphans:
+        start = get_process_start_time(pid)
+        if start is not None:
+            orphan_identity[pid] = start
+
     reaped = False
     for pid in orphans:
         try:
@@ -2374,7 +2396,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     # running until a follow-up SIGKILL — wait, then force-kill any survivor
     # so the replacement can bind the port cleanly.
     survivors = _await_gateway_exit(orphans, pid_exists=_pid_exists)
-    _force_kill_survivors(survivors)
+    # Re-verify identity at kill time: the delayed SIGKILL only fires when
+    # the PID still names the process fingerprinted at scan time (fail-closed
+    # taskkill class fix — a recycled PID must never be force-killed).
+    verified_survivors = []
+    for pid in survivors:
+        recorded = orphan_identity.get(pid)
+        if recorded is None or get_process_start_time(pid) != recorded:
+            continue
+        verified_survivors.append(pid)
+    _force_kill_survivors(verified_survivors)
 
     return reaped
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1570,7 +1570,7 @@ def _windows_stop_drain_timeout() -> float:
 def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
     """Force-kill known gateway PIDs without a broad process sweep."""
     try:
-        from gateway.status import _pid_exists, terminate_pid
+        from gateway.status import _pid_exists, get_process_start_time, terminate_pid
     except ImportError:
         return 0
 
@@ -1584,7 +1584,11 @@ def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
         try:
             if not _pid_exists(pid):
                 continue
-            terminate_pid(pid, force=True)
+            terminate_pid(
+                pid,
+                force=True,
+                expected_start_time=get_process_start_time(pid),
+            )
             killed += 1
         except ProcessLookupError:
             continue

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1625,7 +1625,11 @@ def _stop_profile_backends(canon: str, profile_dir: Path) -> None:
         return
 
     try:
-        from gateway.status import _pid_exists, terminate_pid as _terminate_pid
+        from gateway.status import (
+            _pid_exists,
+            get_process_start_time,
+            terminate_pid as _terminate_pid,
+        )
     except Exception:
         return
 
@@ -1645,7 +1649,11 @@ def _stop_profile_backends(canon: str, profile_dir: Path) -> None:
     for pid in pids:
         if _pid_exists(pid):
             try:
-                _terminate_pid(pid, force=True)
+                _terminate_pid(
+                    pid,
+                    force=True,
+                    expected_start_time=get_process_start_time(pid),
+                )
             except (ProcessLookupError, PermissionError, OSError):
                 pass
 
@@ -2007,6 +2015,11 @@ def _stop_gateway_process(profile_dir: Path) -> None:
         # the same way taskkill /T does.
         from gateway.status import terminate_pid as _terminate_pid
         from gateway.status import _pid_exists
+        expected_start_time = data.get("start_time")
+        if expected_start_time is None:
+            from gateway.status import get_process_start_time
+
+            expected_start_time = get_process_start_time(pid)
         _terminate_pid(pid)  # graceful first
         # Wait up to 10s for graceful shutdown. On Windows, os.kill(pid, 0)
         # is NOT a no-op — use the handle-based existence check.
@@ -2017,7 +2030,7 @@ def _stop_gateway_process(profile_dir: Path) -> None:
                 return
         # Force kill
         try:
-            _terminate_pid(pid, force=True)
+            _terminate_pid(pid, force=True, expected_start_time=expected_start_time)
         except (ProcessLookupError, OSError):
             pass
         print(f"✓ Gateway force-stopped (PID {pid})")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6112,7 +6112,7 @@ def _pause_windows_gateways_for_update() -> dict | None:
         return None
 
     try:
-        from gateway.status import terminate_pid
+        from gateway.status import get_process_start_time, terminate_pid
         from hermes_cli.gateway import (
             _capture_gateway_argv,
             _get_restart_drain_timeout,
@@ -6302,8 +6302,13 @@ def _pause_windows_gateways_for_update() -> dict | None:
     force_killed = []
     for pid in sorted(set(survivors).union(unmapped_pids).union(launcher_pids)):
         try:
-            terminate_pid(int(pid), force=True)
-            force_killed.append(int(pid))
+            pid_int = int(pid)
+            terminate_pid(
+                pid_int,
+                force=True,
+                expected_start_time=get_process_start_time(pid_int),
+            )
+            force_killed.append(pid_int)
         except (ProcessLookupError, PermissionError, OSError):
             pass
 
@@ -7802,7 +7807,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # does not map. Stop them and re-check instead of
                 # dead-ending; the post-update resume (and the supervisor
                 # that respawned them) brings gateways back afterwards.
-                from gateway.status import terminate_pid
+                from gateway.status import get_process_start_time, terminate_pid
 
                 print(
                     f"  ⚠ {len(_gateway_holders)} gateway process(es) still "
@@ -7810,7 +7815,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
                 for _pid in _gateway_holders:
                     try:
-                        terminate_pid(int(_pid), force=True)
+                        pid_int = int(_pid)
+                        terminate_pid(
+                            pid_int,
+                            force=True,
+                            expected_start_time=get_process_start_time(pid_int),
+                        )
                     except Exception as exc:
                         logger.debug(
                             "Could not stop leftover gateway %s: %s", _pid, exc
@@ -10020,14 +10030,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(
                         f"  ⚠ {len(_stuck)} gateway process(es) ignored SIGTERM — force-killing"
                     )
-                    from gateway.status import terminate_pid as _terminate_pid
+                    from gateway.status import (
+                        get_process_start_time as _get_process_start_time,
+                        terminate_pid as _terminate_pid,
+                    )
                     for pid in _stuck:
                         try:
                             # Routes through taskkill /T /F on Windows,
                             # SIGKILL on POSIX — _signal.SIGKILL doesn't
                             # exist on Windows so the old raw os.kill call
                             # used to crash the entire update path.
-                            _terminate_pid(pid, force=True)
+                            _terminate_pid(
+                                pid,
+                                force=True,
+                                expected_start_time=_get_process_start_time(pid),
+                            )
                         except (ProcessLookupError, PermissionError, OSError):
                             pass
                     # Give the OS a beat to reap the processes so the

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5473,6 +5473,55 @@ def _leftover_pausable_gateway_pids(
     return pids
 
 
+def _refuse_gateway_ancestor_tree_kill(
+    pids: list[int], *, gateway_mode: bool
+) -> bool:
+    """Refuse a plain Windows update that would kill its own process tree.
+
+    A chat agent can launch plain ``hermes update`` through its terminal tool.
+    In that topology the updater is a child of the gateway.  The leftover
+    holder recovery below uses ``taskkill /T /F`` on Windows, so force-stopping
+    that gateway also kills the updater before it can mutate the checkout
+    (#98814).
+
+    ``/update`` uses the supported ``--gateway`` hand-off and is deliberately
+    exempt: it detaches the updater and provides file-based progress/result
+    delivery.  For every other invocation, refuse only when a nominated
+    gateway is positively identified as this process's ancestor.  If ancestry
+    cannot be established, preserve the existing holder recovery behavior.
+    """
+    if gateway_mode or not pids:
+        return False
+
+    try:
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+
+        ancestors = [
+            int(pid)
+            for pid in pids
+            if _is_pid_ancestor_of_current_process(int(pid))
+        ]
+    except Exception as exc:
+        logger.debug("Could not inspect gateway ancestry before tree-kill: %s", exc)
+        return False
+
+    if not ancestors:
+        return False
+
+    rendered = ", ".join(str(pid) for pid in ancestors)
+    print(
+        "✗ Refusing to stop the gateway process tree because this updater "
+        f"is running inside it (gateway PID(s): {rendered})."
+    )
+    print(
+        "  On Windows, taskkill /T would terminate the updater before the "
+        "update can run."
+    )
+    print("  From a chat platform, use `/update` instead.")
+    print("  Otherwise, run `hermes update` from a separate terminal.")
+    return True
+
+
 def _ledger_manual_serve_holders(
     matches: list[tuple[int, str, str]],
 ) -> list[dict]:
@@ -7801,6 +7850,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if _venv_holders:
             _gateway_holders = _m()._leftover_pausable_gateway_pids(_venv_holders)
             if _gateway_holders is not None:
+                if _refuse_gateway_ancestor_tree_kill(
+                    _gateway_holders, gateway_mode=gateway_mode
+                ):
+                    _m()._resume_windows_gateways_after_update(
+                        _windows_gateway_resume
+                    )
+                    sys.exit(2)
                 # Every remaining holder is a gateway the pause machinery
                 # already owns — respawned by its supervisor inside the
                 # pause→guard window, or up through a spawn path discovery

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5582,7 +5582,7 @@ def _relaunch_stopped_serves(token: dict) -> None:
 
 def _orphaned_desktop_backend_pids(
     matches: list[tuple[int, str, str]],
-) -> list[int] | None:
+) -> list[tuple[int, int]] | None:
     """PIDs from *matches* when every remaining holder is an ORPHANED backend.
 
     The venv-holder guard refuses on the Desktop app's ``serve`` backend by
@@ -5630,7 +5630,7 @@ def _orphaned_desktop_backend_pids(
         )
 
     # Pass 1: find orphaned backend ROOTS among the holders.
-    roots: list[int] = []
+    roots: list[tuple[int, int]] = []
     remaining: list[tuple[int, str]] = []  # (pid, argv_low) still to justify
     for pid, _name, cmdline in matches:
         argv = cmdline
@@ -5648,6 +5648,19 @@ def _orphaned_desktop_backend_pids(
             continue
         try:
             proc = psutil.Process(int(pid))
+            from gateway.status import get_process_start_time
+
+            process_start_time = get_process_start_time(int(pid))
+            if process_start_time is None:
+                return None
+        except psutil.NoSuchProcess:
+            # The candidate itself exited during classification; there is
+            # nothing left to reap and no identity to pass to taskkill.
+            continue
+        except Exception:
+            return None
+
+        try:
             ppid = proc.ppid()
             parent = psutil.Process(ppid) if ppid else None
             if parent is not None and parent.is_running():
@@ -5666,12 +5679,12 @@ def _orphaned_desktop_backend_pids(
             pass  # parent gone → orphan
         except Exception:
             return None
-        roots.append(int(pid))
+        roots.append((int(pid), process_start_time))
 
     # Pass 2: every non-backend holder must be a descendant of an accepted
     # orphan root — then it dies with the root's tree reap. Anything else
     # (operator REPL, stray script) keeps the refusal.
-    root_set = set(roots)
+    root_set = {pid for pid, _start_time in roots}
     for pid, _low in remaining:
         if not root_set:
             return None
@@ -5801,7 +5814,9 @@ def _handoff_reapable_backend_pids(
     return roots or None
 
 
-def _stop_process_trees(pids: list[int]) -> None:
+def _stop_process_trees(
+    pids: list[int] | list[tuple[int, int]],
+) -> None:
     """Force-stop each PID with its full child tree (Windows).
 
     ``taskkill /T /F`` mirrors the Desktop's ``forceKillProcessTree`` and
@@ -5809,12 +5824,38 @@ def _stop_process_trees(pids: list[int]) -> None:
     ``.hermes-runtime`` interpreter child alive and holding the install open
     (#70026). Best effort; never raises.
     """
-    for pid in pids:
+    from gateway.status import get_process_start_time
+    from hermes_cli._subprocess_compat import pid_is_hermes, windows_hide_flags
+
+    for entry in pids:
+        if isinstance(entry, tuple):
+            pid, expected_start_time = entry
+        else:
+            pid = int(entry)
+            expected_start_time = get_process_start_time(pid)
         try:
+            if expected_start_time is None:
+                logger.debug(
+                    "Skipping taskkill of PID %s: process identity unavailable",
+                    pid,
+                )
+                continue
+            if not pid_is_hermes(
+                pid,
+                expected_start_time=expected_start_time,
+            ):
+                logger.debug(
+                    "Skipping taskkill of non-Hermes or changed PID %s",
+                    pid,
+                )
+                continue
             subprocess.run(
-                ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
                 check=False,
-                capture_output=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception as exc:
             logger.debug("Could not stop process tree %s: %s", pid, exc)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5697,11 +5697,13 @@ def _orphaned_desktop_backend_pids(
             continue
         try:
             proc = psutil.Process(int(pid))
-            from gateway.status import get_process_start_time
-
-            process_start_time = get_process_start_time(int(pid))
-            if process_start_time is None:
-                return None
+            # Fingerprint from the SAME psutil handle used for classification
+            # below, quantized to centiseconds — the exact scheme
+            # gateway.status.get_process_start_time uses on Windows, so the
+            # value round-trips through pid_is_hermes at kill time. (Reading
+            # /proc/<pid>/stat here instead would consult the HOST process
+            # table and use different units.)
+            process_start_time = int(round(proc.create_time() * 100))
         except psutil.NoSuchProcess:
             # The candidate itself exited during classification; there is
             # nothing left to reap and no identity to pass to taskkill.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -100,6 +100,27 @@ def _listener_pids_on_port(port: int) -> list:
     return pids
 
 
+def _pid_looks_like_node_bridge(pid: int) -> bool:
+    """Fail-closed check that *pid* is plausibly a stale node bridge.
+
+    ``_kill_port_process`` discovers PIDs from a netstat/lsof scan of a TCP
+    port — a bare number naming a *stranger* process (#89614 class: an
+    unverified scan-time PID force-killed later can be anything, including a
+    critical system process). Before any kill, require the live process to
+    actually look like our Baileys bridge: a ``node`` executable. Any
+    ambiguity (process gone, unreadable cmdline) refuses the kill.
+    """
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        name = (proc.name() or "").lower()
+        cmdline = " ".join(proc.cmdline() or []).lower()
+        return "node" in name or "node" in cmdline.split(" ", 1)[0]
+    except Exception:
+        return False
+
+
 def _kill_port_process(port: int) -> None:
     """Kill any process *listening* on the given TCP port (a stale bridge)."""
     try:
@@ -118,8 +139,22 @@ def _kill_port_process(port: int) -> None:
                     local_addr = parts[1]
                     if local_addr.endswith(f":{port}"):
                         try:
+                            pid = int(parts[4])
+                        except ValueError:
+                            continue
+                        # Never taskkill a bare netstat-scanned PID: verify
+                        # the live process is a node bridge first (fail
+                        # closed). taskkill /F on a mistyped or recycled PID
+                        # is unrecoverable.
+                        if pid <= 0 or not _pid_looks_like_node_bridge(pid):
+                            logger.warning(
+                                "[whatsapp] Not killing PID %s on port %d: "
+                                "process is not a node bridge (or identity "
+                                "unverifiable)", pid, port)
+                            continue
+                        try:
                             subprocess.run(
-                                ["taskkill", "/PID", parts[4], "/F"],
+                                ["taskkill", "/PID", str(pid), "/F"],
                                 capture_output=True, timeout=5,
                                 creationflags=windows_hide_flags(),
                             )
@@ -130,6 +165,11 @@ def _kill_port_process(port: int) -> None:
             # whose connection happens to involve this port number (a browser
             # tab on a local dev server, etc.) must never be killed.
             for pid in _listener_pids_on_port(port):
+                if not _pid_looks_like_node_bridge(pid):
+                    logger.warning(
+                        "[whatsapp] Not killing PID %s on port %d: process is "
+                        "not a node bridge (or identity unverifiable)", pid, port)
+                    continue
                 try:
                     os.kill(pid, signal.SIGTERM)
                 except (ProcessLookupError, PermissionError, OSError):

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -136,7 +136,7 @@ async def test_start_gateway_replace_aborts_when_force_killed_pid_still_alive(
     )
     monkeypatch.setattr(
         "gateway.status.terminate_pid",
-        lambda pid, force=False: calls.append((pid, force)),
+        lambda pid, force=False, **kwargs: calls.append((pid, force)),
     )
     # Ownership guard (#89315): legitimate same-home replace fixture — the
     # persisted record is bound to target pid 42 in this home.
@@ -206,7 +206,7 @@ async def test_start_gateway_replace_writes_takeover_marker_before_sigterm(
         })
         return True
 
-    def record_terminate(pid, force=False):
+    def record_terminate(pid, force=False, **kwargs):
         events.append(f"terminate_pid(pid={pid}, force={force})")
 
     class _CleanExitRunner:
@@ -295,7 +295,7 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
         })
         return True
 
-    def raise_permission(pid, force=False):
+    def raise_permission(pid, force=False, **kwargs):
         raise PermissionError("simulated EPERM")
 
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
@@ -443,5 +443,3 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
         await start_gateway(config=GatewayConfig(), replace=False, verbosity=0)
 
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
-
-

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -403,7 +403,9 @@ class TestTerminatePid:
 
         monkeypatch.setattr(status.subprocess, "run", fake_run)
 
-        status.terminate_pid(123, force=True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 456)
+
+        status.terminate_pid(123, force=True, expected_start_time=456)
 
         # taskkill is spawned with the no-window flag so the windowless
         # pythonw.exe backend doesn't flash a conhost window on force-kill.
@@ -412,6 +414,27 @@ class TestTerminatePid:
         assert calls == [
             (["taskkill", "/PID", "123", "/T", "/F"], True, True, 10, windows_hide_flags())
         ]
+
+    def test_windows_force_refuses_pid_without_start_time_guard(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        calls = []
+        monkeypatch.setattr(status.subprocess, "run", lambda *args, **kwargs: calls.append(args))
+
+        with pytest.raises(OSError, match="without a process start-time guard"):
+            status.terminate_pid(123, force=True)
+
+        assert calls == []
+
+    def test_windows_force_refuses_reused_pid(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)
+        calls = []
+        monkeypatch.setattr(status.subprocess, "run", lambda *args, **kwargs: calls.append(args))
+
+        with pytest.raises(OSError, match="process identity changed"):
+            status.terminate_pid(123, force=True, expected_start_time=456)
+
+        assert calls == []
 
 
 class TestScopedLocks:
@@ -1436,4 +1459,3 @@ def test_strict_gateway_identity_rejects_reused_pid(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="identity changed"):
         status.get_running_pid_identity_strict(pid_path)
-

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -337,7 +337,9 @@ class TestKillPortProcess:
                 return mock_taskkill
             return MagicMock()
 
-        with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run:
+        with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run, \
+             patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=True):
             _kill_port_process(3000)
 
         # netstat called
@@ -348,6 +350,31 @@ class TestKillPortProcess:
         assert any(
             call.args[0] == ["taskkill", "/PID", "12345", "/F"]
             for call in mock_run.call_args_list
+        )
+
+    @pytest.mark.windows_only
+    def test_windows_refuses_taskkill_on_non_bridge_pid(self):
+        """#89614 class: the netstat-scanned PID is a bare number — if the
+        live process is not a node bridge, taskkill must never fire."""
+        from plugins.platforms.whatsapp.adapter import _kill_port_process
+
+        netstat_output = (
+            "  Proto  Local Address          Foreign Address        State           PID\n"
+            "  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       12345\n"
+        )
+
+        def run_side_effect(cmd, **kwargs):
+            if cmd[0] == "netstat":
+                return MagicMock(stdout=netstat_output)
+            return MagicMock()
+
+        with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run, \
+             patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=False):
+            _kill_port_process(3000)
+
+        assert not any(
+            call.args[0][0] == "taskkill" for call in mock_run.call_args_list
         )
 
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -368,12 +368,30 @@ class TestKillPortProcess:
         kills = []
         with patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
                    return_value=[55555]) as mock_listeners, \
+             patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=True), \
              patch("plugins.platforms.whatsapp.adapter.os.kill",
                    side_effect=lambda pid, sig: kills.append((pid, sig))):
             wa._kill_port_process(3000)
 
         mock_listeners.assert_called_once_with(3000)
         assert kills == [(55555, signal.SIGTERM)]
+
+    @pytest.mark.linux_only
+    def test_non_bridge_listener_is_never_killed(self):
+        """#89614 class: a listener that is not a node bridge is refused."""
+        from plugins.platforms.whatsapp import adapter as wa
+
+        kills = []
+        with patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
+                   return_value=[55555]), \
+             patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=False), \
+             patch("plugins.platforms.whatsapp.adapter.os.kill",
+                   side_effect=lambda pid, sig: kills.append((pid, sig))):
+            wa._kill_port_process(3000)
+
+        assert kills == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -473,7 +473,7 @@ class TestWaitForGatewayExit:
             return call_num * 2.0  # 2, 4, 6, 8, ...
 
         kills = []
-        def mock_terminate(pid, force=False):
+        def mock_terminate(pid, force=False, **kwargs):
             kills.append((pid, force))
 
         # get_running_pid returns the PID until kill is sent, then None
@@ -493,7 +493,11 @@ class TestWaitForGatewayExit:
         calls = []
 
         monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None, all_profiles=False: [11, 22])
-        monkeypatch.setattr(gateway, "terminate_pid", lambda pid, force=False: calls.append((pid, force)))
+        monkeypatch.setattr(
+            gateway,
+            "terminate_pid",
+            lambda pid, force=False, **kwargs: calls.append((pid, force)),
+        )
 
         killed = gateway.kill_gateway_processes(force=True)
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -493,6 +493,11 @@ class TestWaitForGatewayExit:
         calls = []
 
         monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None, all_profiles=False: [11, 22])
+        # Kill-time re-verification: force-kills only proceed when the LIVE
+        # cmdline still looks like a gateway.
+        monkeypatch.setattr(
+            gateway, "_capture_gateway_argv", lambda pid: ["python", "-m", "hermes_cli.main", "gateway", "run"]
+        )
         monkeypatch.setattr(
             gateway,
             "terminate_pid",
@@ -503,6 +508,27 @@ class TestWaitForGatewayExit:
 
         assert killed == 2
         assert calls == [(11, True), (22, True)]
+
+    def test_kill_gateway_processes_force_refuses_recycled_pid(self, monkeypatch):
+        """A scanned PID whose live argv no longer looks like a gateway is skipped."""
+        calls = []
+
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None, all_profiles=False: [11, 22])
+        monkeypatch.setattr(
+            gateway,
+            "_capture_gateway_argv",
+            lambda pid: None if pid == 11 else ["python", "-m", "hermes_cli.main", "gateway", "run"],
+        )
+        monkeypatch.setattr(
+            gateway,
+            "terminate_pid",
+            lambda pid, force=False, **kwargs: calls.append((pid, force)),
+        )
+
+        killed = gateway.kill_gateway_processes(force=True)
+
+        assert killed == 1
+        assert calls == [(22, True)]
 
 
 class TestStopProfileGateway:

--- a/tests/hermes_cli/test_stale_pid_guard.py
+++ b/tests/hermes_cli/test_stale_pid_guard.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for the fail-closed PID-ownership guard.
+
+Refs #90471 / #89614.  The three patched Windows ``taskkill`` boundaries:
+
+- ``hermes_cli/_subprocess_compat.pid_is_hermes`` / ``kill_process_tree``
+- ``hermes_cli/dashboard_procs._kill_stale_dashboard_processes`` (win32)
+- ``hermes_cli/update_cmd._stop_process_trees``
+
+Acceptance from #90471:
+1. missing / unreadable / non-matching identity fails closed -> no taskkill
+2. a recycled or foreign PID control process remains untouched
+3. probe failure or timeout is never converted into permission to kill
+"""
+import subprocess
+import sys
+from unittest import mock
+
+import pytest
+
+from hermes_cli import _subprocess_compat
+from hermes_cli import dashboard_procs
+from hermes_cli import update_cmd
+
+
+def _probe_stdout(value: str) -> mock.Mock:
+    return mock.Mock(stdout=value)
+
+
+class TestPidIsHermes:
+    """The shared identity probe must fail closed on every ambiguity."""
+
+    def test_non_windows_is_unconditional_pass(self):
+        # Non-Windows callers have no taskkill path at all.
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", False):
+            assert _subprocess_compat.pid_is_hermes(1234) is True
+
+    def test_invalid_pid_inputs_do_not_crash(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True):
+            assert _subprocess_compat.pid_is_hermes(-1) is False
+            assert _subprocess_compat.pid_is_hermes(0) is False
+            assert _subprocess_compat.pid_is_hermes("not-a-pid") is False
+            assert _subprocess_compat.pid_is_hermes(True) is False
+
+    def test_probe_matches_hermes_like_process(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=123
+        ), mock.patch.object(
+            _subprocess_compat, "_process_command_is_hermes", return_value=True
+        ):
+            assert _subprocess_compat.pid_is_hermes(1234) is True
+
+    def test_probe_rejects_recycled_process_identity(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=456
+        ), mock.patch.object(
+            _subprocess_compat, "_process_command_is_hermes", return_value=True
+        ):
+            assert _subprocess_compat.pid_is_hermes(
+                1234, expected_start_time=123
+            ) is False
+
+    def test_probe_rejects_foreign_process(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=123
+        ), mock.patch.object(
+            _subprocess_compat, "_process_command_is_hermes", return_value=False
+        ):
+            assert _subprocess_compat.pid_is_hermes(1234) is False
+
+    def test_probe_blank_stdout_fails_closed(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=None
+        ):
+            assert _subprocess_compat.pid_is_hermes(1234) is False
+
+    def test_probe_timeout_fails_closed(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=None
+        ):
+            assert _subprocess_compat.pid_is_hermes(1234) is False
+
+    def test_probe_oserror_fails_closed(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "_process_start_time", side_effect=OSError("broken pipe")
+        ):
+            assert _subprocess_compat.pid_is_hermes(1234) is False
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="real probe is windows-only")
+    def test_missing_pid_real_probe_fails_closed(self):
+        # A PID that cannot exist must never be judged Hermes-owned.
+        assert _subprocess_compat.pid_is_hermes(2**24) is False
+
+
+class TestKillProcessTree:
+    """kill_process_tree must never taskkill a PID the probe rejects."""
+
+    def _proc(self, pid=4321):
+        return mock.Mock(pid=pid)
+
+    def test_foreign_pid_never_taskkilled(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "pid_is_hermes", return_value=False
+        ) as guard, mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=123
+        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
+            _subprocess_compat.kill_process_tree(self._proc())
+            guard.assert_called_once_with(4321, expected_start_time=123)
+            run.assert_not_called()
+
+    def test_probe_error_never_taskkilled(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "pid_is_hermes", return_value=False
+        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
+            _subprocess_compat.kill_process_tree(self._proc())
+            run.assert_not_called()
+
+    def test_hermes_pid_still_taskkilled(self):
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
+            _subprocess_compat, "pid_is_hermes", return_value=True
+        ), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=123
+        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
+            _subprocess_compat.kill_process_tree(self._proc())
+            run.assert_called_once()
+            argv = run.call_args.args[0]
+            assert argv[0] == "taskkill"
+            assert "/PID" in argv
+            assert str(4321) in argv
+
+
+class TestStopProcessTrees:
+    """update_cmd._stop_process_trees guard behaviour."""
+
+    def test_foreign_pids_only_probed(self):
+        with mock.patch(
+            "gateway.status.get_process_start_time", return_value=123
+        ), mock.patch(
+            "hermes_cli._subprocess_compat.pid_is_hermes", return_value=False
+        ), mock.patch.object(update_cmd.subprocess, "run") as run:
+            update_cmd._stop_process_trees([1111, 2222])
+        run.assert_not_called()
+
+    def test_hermes_pid_probed_then_taskkilled(self):
+        with mock.patch(
+            "gateway.status.get_process_start_time", return_value=123
+        ), mock.patch(
+            "hermes_cli._subprocess_compat.pid_is_hermes", return_value=True
+        ), mock.patch.object(
+            update_cmd.subprocess, "run", return_value=mock.Mock(returncode=0)
+        ) as run:
+            update_cmd._stop_process_trees([1111])
+        assert len(run.call_args_list) == 1
+        assert run.call_args.args[0][0] == "taskkill"
+
+    def test_probe_timeout_skips_taskkill(self):
+        with mock.patch(
+            "gateway.status.get_process_start_time", return_value=123
+        ), mock.patch(
+            "hermes_cli._subprocess_compat.pid_is_hermes", return_value=False
+        ), mock.patch.object(update_cmd.subprocess, "run") as run:
+            update_cmd._stop_process_trees([1111, 2222])  # must not raise
+        run.assert_not_called()
+
+
+class TestKillStaleDashboardProcesses:
+    """dashboard_procs win32 kill branch guard behaviour."""
+
+    def _fake_m(self, pids=(12345,)):
+        m = mock.Mock()
+        m._find_stale_dashboard_pids.return_value = list(pids)
+        return m
+
+    def test_foreign_pid_reported_not_killed(self):
+        with mock.patch.object(dashboard_procs, "_m", return_value=self._fake_m()), mock.patch.object(
+            dashboard_procs.sys, "platform", "win32"
+        ), mock.patch(
+            "gateway.status.get_process_start_time", return_value=123
+        ), mock.patch(
+            "hermes_cli._subprocess_compat.pid_is_hermes", return_value=False
+        ), mock.patch.object(dashboard_procs.subprocess, "run") as run:
+            result = dashboard_procs._kill_stale_dashboard_processes()
+        assert result["killed"] == []
+        assert result["failed"] == [
+            (12345, "not hermes-owned or process identity changed")
+        ]
+        run.assert_not_called()
+
+    def test_hermes_pid_killed(self):
+        with mock.patch.object(dashboard_procs, "_m", return_value=self._fake_m()), mock.patch.object(
+            dashboard_procs.sys, "platform", "win32"
+        ), mock.patch(
+            "gateway.status.get_process_start_time", return_value=123
+        ), mock.patch(
+            "hermes_cli._subprocess_compat.pid_is_hermes", return_value=True
+        ), mock.patch.object(
+            dashboard_procs.subprocess, "run", return_value=mock.Mock(
+                returncode=0, stderr="", stdout=""
+            )
+        ) as run:
+            result = dashboard_procs._kill_stale_dashboard_processes()
+        taskkill_calls = [c for c in run.call_args_list if c.args[0][0] == "taskkill"]
+        assert len(taskkill_calls) == 1
+        assert result["killed"] == [12345]
+        assert result["failed"] == []

--- a/tests/hermes_cli/test_stale_pid_guard.py
+++ b/tests/hermes_cli/test_stale_pid_guard.py
@@ -35,6 +35,27 @@ class TestPidIsHermes:
         with mock.patch.object(_subprocess_compat, "IS_WINDOWS", False):
             assert _subprocess_compat.pid_is_hermes(1234) is True
 
+    def test_non_windows_still_rejects_recycled_identity(self):
+        # An explicit fingerprint mismatch is a recycled PID on any platform.
+        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", False), mock.patch.object(
+            _subprocess_compat, "_process_start_time", return_value=456
+        ):
+            assert _subprocess_compat.pid_is_hermes(
+                1234, expected_start_time=123
+            ) is False
+
+    def test_hermes_match_requires_token_boundary(self):
+        # "hermes" buried inside an unrelated path segment must not match.
+        assert _subprocess_compat._text_names_hermes(
+            r"c:\users\shermesa\app.exe"
+        ) is False
+        assert _subprocess_compat._text_names_hermes(
+            r"C:\Users\x\.hermes-runtime\python.exe -m hermes_cli.main"
+        ) is True
+        assert _subprocess_compat._text_names_hermes(
+            "/opt/hermes-agent/venv/bin/python"
+        ) is True
+
     def test_invalid_pid_inputs_do_not_crash(self):
         with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True):
             assert _subprocess_compat.pid_is_hermes(-1) is False
@@ -93,35 +114,24 @@ class TestPidIsHermes:
 
 
 class TestKillProcessTree:
-    """kill_process_tree must never taskkill a PID the probe rejects."""
+    """kill_process_tree operates on our own retained Popen handle.
+
+    A retained handle pins the PID (the child cannot be reaped while the
+    handle is open), so PID recycling is impossible there and the identity
+    guard deliberately does NOT apply — it could only false-refuse a
+    legitimate cleanup. These tests pin that contract for the legacy
+    Windows fallback path.
+    """
 
     def _proc(self, pid=4321):
         return mock.Mock(pid=pid)
 
-    def test_foreign_pid_never_taskkilled(self):
+    def test_retained_handle_is_taskkilled_without_probe(self):
         with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
-            _subprocess_compat, "pid_is_hermes", return_value=False
-        ) as guard, mock.patch.object(
-            _subprocess_compat, "_process_start_time", return_value=123
-        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
-            _subprocess_compat.kill_process_tree(self._proc())
-            guard.assert_called_once_with(4321, expected_start_time=123)
-            run.assert_not_called()
-
-    def test_probe_error_never_taskkilled(self):
-        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
-            _subprocess_compat, "pid_is_hermes", return_value=False
-        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
-            _subprocess_compat.kill_process_tree(self._proc())
-            run.assert_not_called()
-
-    def test_hermes_pid_still_taskkilled(self):
-        with mock.patch.object(_subprocess_compat, "IS_WINDOWS", True), mock.patch.object(
-            _subprocess_compat, "pid_is_hermes", return_value=True
-        ), mock.patch.object(
-            _subprocess_compat, "_process_start_time", return_value=123
-        ), mock.patch.object(_subprocess_compat.subprocess, "run") as run:
-            _subprocess_compat.kill_process_tree(self._proc())
+            _subprocess_compat, "pid_is_hermes"
+        ) as guard, mock.patch.object(_subprocess_compat.subprocess, "run") as run:
+            _subprocess_compat._legacy_kill_process_tree(self._proc())
+            guard.assert_not_called()
             run.assert_called_once()
             argv = run.call_args.args[0]
             assert argv[0] == "taskkill"

--- a/tests/hermes_cli/test_taskkill_identity_windows_live.py
+++ b/tests/hermes_cli/test_taskkill_identity_windows_live.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""Live Windows probes for the fail-closed taskkill process-identity guard.
+
+Runs only on real Windows (the on-demand ``wine2e/**`` windows-latest lane).
+These tests spawn REAL processes and drive the REAL guard code against the
+live process table — the coverage the mocked Linux suites cannot provide.
+
+Class under test (#98814 / #89614):
+
+- ``gateway.status.terminate_pid(force=True)`` requires a matching
+  ``expected_start_time`` and must refuse (never taskkill) on a missing or
+  mismatched identity.
+- ``hermes_cli._subprocess_compat.pid_is_hermes`` fails closed on foreign
+  processes and identity mismatches.
+- ``hermes_cli.update_cmd._refuse_gateway_ancestor_tree_kill`` refuses to
+  nominate any ancestor of the current process for a tree-kill.
+"""
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="live taskkill-identity probes are Windows-only"
+)
+
+
+def _spawn_sleeper(seconds: int = 60) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-c", f"import time; time.sleep({seconds})"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _cleanup(proc: subprocess.Popen) -> None:
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=10)
+    except Exception:
+        pass
+
+
+class TestTerminatePidIdentityLive:
+    def test_matching_identity_kills_real_process(self):
+        from gateway.status import get_process_start_time, terminate_pid
+
+        proc = _spawn_sleeper()
+        try:
+            start = get_process_start_time(proc.pid)
+            assert start is not None, "live process must have a fingerprint"
+            terminate_pid(proc.pid, force=True, expected_start_time=start)
+            assert proc.wait(timeout=15) is not None
+        finally:
+            _cleanup(proc)
+
+    def test_missing_expectation_refuses_and_process_survives(self):
+        from gateway.status import terminate_pid
+
+        proc = _spawn_sleeper()
+        try:
+            with pytest.raises(OSError, match="start-time guard"):
+                terminate_pid(proc.pid, force=True)
+            assert proc.poll() is None, "refusal must leave the process running"
+        finally:
+            _cleanup(proc)
+
+    def test_mismatched_identity_refuses_and_process_survives(self):
+        """The recycled-PID scenario: recorded identity != live identity."""
+        from gateway.status import get_process_start_time, terminate_pid
+
+        # Simulate recycling: capture the identity of a process that then
+        # dies, and respawn a DIFFERENT process. We can't force Windows to
+        # hand back the same PID, so assert the guard refuses when the stale
+        # fingerprint is presented against the new (different) live process.
+        victim = _spawn_sleeper(1)
+        stale_start = get_process_start_time(victim.pid)
+        victim.wait(timeout=30)
+
+        impostor = _spawn_sleeper()
+        try:
+            live_start = get_process_start_time(impostor.pid)
+            assert live_start is not None
+            if stale_start == live_start:
+                pytest.skip("fingerprints collided; cannot express mismatch")
+            with pytest.raises(OSError, match="identity"):
+                terminate_pid(
+                    impostor.pid, force=True, expected_start_time=stale_start
+                )
+            assert impostor.poll() is None, "mismatch must never kill"
+        finally:
+            _cleanup(impostor)
+
+    def test_dead_pid_identity_unavailable_refuses(self):
+        from gateway.status import get_process_start_time, terminate_pid
+
+        proc = _spawn_sleeper(1)
+        pid = proc.pid
+        start = get_process_start_time(pid)
+        proc.wait(timeout=30)
+        # Give the OS a beat to drop the process object.
+        time.sleep(0.5)
+        if get_process_start_time(pid) == start:
+            pytest.skip("PID instantly recycled onto identical fingerprint")
+        with pytest.raises(OSError):
+            terminate_pid(pid, force=True, expected_start_time=start)
+
+
+class TestPidIsHermesLive:
+    def test_foreign_real_process_is_refused(self):
+        """A live non-Hermes process (bare python sleeper in a temp-ish argv)
+        must never be judged safe for taskkill."""
+        from hermes_cli._subprocess_compat import pid_is_hermes
+
+        proc = _spawn_sleeper()
+        try:
+            # sys.executable in CI lives under a uv/hostedtoolcache path with
+            # no 'hermes' token; if the checkout path itself contains one this
+            # assertion is environment-dependent, so guard for it.
+            if "hermes" in sys.executable.lower():
+                pytest.skip("interpreter path names hermes; probe would match")
+            assert pid_is_hermes(proc.pid) is False
+        finally:
+            _cleanup(proc)
+
+    def test_stale_fingerprint_is_refused_even_for_hermes_argv(self):
+        from gateway.status import get_process_start_time
+        from hermes_cli._subprocess_compat import pid_is_hermes
+
+        proc = _spawn_sleeper()
+        try:
+            live = get_process_start_time(proc.pid)
+            assert live is not None
+            assert (
+                pid_is_hermes(proc.pid, expected_start_time=live + 12345) is False
+            )
+        finally:
+            _cleanup(proc)
+
+    def test_nonexistent_pid_is_refused(self):
+        from hermes_cli._subprocess_compat import pid_is_hermes
+
+        assert pid_is_hermes(2**24) is False
+
+
+class TestAncestorRefusalLive:
+    def test_real_parent_chain_is_refused(self, capsys):
+        """Walk the REAL psutil parent chain: every ancestor of this test
+        process must be refused as a tree-kill target (#98814)."""
+        import psutil
+
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+        from hermes_cli.update_cmd import _refuse_gateway_ancestor_tree_kill
+
+        ancestors = [os.getpid()]
+        parent = psutil.Process(os.getpid()).parent()
+        while parent is not None and len(ancestors) < 6:
+            ancestors.append(parent.pid)
+            parent = parent.parent()
+
+        for pid in ancestors:
+            assert _is_pid_ancestor_of_current_process(pid) is True, pid
+
+        refused = _refuse_gateway_ancestor_tree_kill(
+            ancestors, gateway_mode=False
+        )
+        assert refused is True
+        out = capsys.readouterr().out
+        assert "taskkill /T" in out
+        assert "separate terminal" in out
+
+    def test_unrelated_live_process_is_not_refused(self):
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+        from hermes_cli.update_cmd import _refuse_gateway_ancestor_tree_kill
+
+        proc = _spawn_sleeper()
+        try:
+            assert _is_pid_ancestor_of_current_process(proc.pid) is False
+            assert (
+                _refuse_gateway_ancestor_tree_kill(
+                    [proc.pid], gateway_mode=False
+                )
+                is False
+            )
+        finally:
+            _cleanup(proc)

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -232,7 +232,7 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     monkeypatch.setattr(
         status_mod,
         "terminate_pid",
-        lambda pid, force=False: terminated.append((pid, force)),
+        lambda pid, force=False, **kwargs: terminated.append((pid, force)),
     )
 
     token = cli_main._pause_windows_gateways_for_update()
@@ -692,7 +692,7 @@ def test_pause_kill_set_covers_venv_guard_abort_set(
     monkeypatch.setattr(
         status_mod,
         "terminate_pid",
-        lambda pid, force=False: terminated.append(int(pid)),
+        lambda pid, force=False, **kwargs: terminated.append(int(pid)),
     )
 
     cli_main._pause_windows_gateways_for_update()
@@ -1031,7 +1031,6 @@ def test_stop_service_refuses_pid_reuse_before_sc_stop(monkeypatch):
         )
 
     assert calls == []
-
 
 
 

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -757,6 +757,52 @@ def test_leftover_holders_that_are_all_gateways_are_nominated(monkeypatch):
     assert cli_main._leftover_pausable_gateway_pids(matches) == [300, 301]
 
 
+def test_plain_update_refuses_to_tree_kill_its_gateway_ancestor(
+    monkeypatch, capsys
+):
+    """#98814: terminal-launched update must survive to report the refusal."""
+    import hermes_cli.gateway as gateway_cli
+    import hermes_cli.update_cmd as update_cmd
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: pid == 300,
+    )
+
+    refused = update_cmd._refuse_gateway_ancestor_tree_kill(
+        [300, 301], gateway_mode=False
+    )
+
+    assert refused is True
+    output = capsys.readouterr().out
+    assert "taskkill /T" in output
+    assert "`/update`" in output
+    assert "separate terminal" in output
+
+
+def test_gateway_handoff_keeps_leftover_gateway_recovery(monkeypatch, capsys):
+    """The detached `/update` hand-off still owns leftover gateway cleanup."""
+    import hermes_cli.gateway as gateway_cli
+    import hermes_cli.update_cmd as update_cmd
+
+    ancestry_checks = []
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: ancestry_checks.append(pid) or True,
+    )
+
+    assert (
+        update_cmd._refuse_gateway_ancestor_tree_kill(
+            [300], gateway_mode=True
+        )
+        is False
+    )
+    assert ancestry_checks == []
+    assert capsys.readouterr().out == ""
+
+
 def test_one_non_gateway_holder_keeps_the_hard_refusal(monkeypatch):
     """A REPL/backend holder means the guard must abort exactly as before."""
     monkeypatch.setitem(
@@ -1012,6 +1058,51 @@ def test_update_gate_still_aborts_on_non_gateway_concurrent(
     assert "--force" in captured
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_refuses_before_terminating_gateway_ancestor(
+    _winp, monkeypatch, capsys
+):
+    """#98814: the live holder path must gate the destructive call itself."""
+    import gateway.status as status_mod
+    import hermes_cli.gateway as gateway_cli
+
+    holder = (
+        300,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: pid == 300,
+    )
+
+    with patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_run_pre_update_backup", return_value=None
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=[holder]
+    ), patch.object(
+        cli_main, "_leftover_pausable_gateway_pids", return_value=[300]
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ) as resume, patch.object(
+        status_mod, "terminate_pid"
+    ) as terminate:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    terminate.assert_not_called()
+    resume.assert_called_once_with(None)
+    output = capsys.readouterr().out
+    assert "taskkill /T" in output
+    assert "`/update`" in output
+
+
 def test_stop_service_refuses_pid_reuse_before_sc_stop(monkeypatch):
     import hermes_cli.update_cmd as update_cmd
 
@@ -1031,6 +1122,5 @@ def test_stop_service_refuses_pid_reuse_before_sc_stop(monkeypatch):
         )
 
     assert calls == []
-
 
 

--- a/tests/hermes_cli/test_update_orphan_backend_reap.py
+++ b/tests/hermes_cli/test_update_orphan_backend_reap.py
@@ -84,7 +84,7 @@ def test_orphan_backend_dead_parent_qualifies():
     backend = _proc(200, _SERVE_ARGV, ppid=999)  # 999 not in table → dead
     fake = _fake_psutil({200: backend})
     with patch.dict(sys.modules, {"psutil": fake}):
-        assert cli_main._orphaned_desktop_backend_pids(_holders()) == [200]
+        assert cli_main._orphaned_desktop_backend_pids(_holders()) == [(200, 10000)]
 
 
 def test_backend_with_live_parent_keeps_refusal():
@@ -101,7 +101,7 @@ def test_recycled_parent_pid_counts_as_orphan():
     backend = _proc(200, _SERVE_ARGV, ppid=50, create_time=100.0)
     fake = _fake_psutil({50: recycled, 200: backend})
     with patch.dict(sys.modules, {"psutil": fake}):
-        assert cli_main._orphaned_desktop_backend_pids(_holders()) == [200]
+        assert cli_main._orphaned_desktop_backend_pids(_holders()) == [(200, 10000)]
 
 
 def test_non_backend_holder_keeps_refusal():
@@ -136,7 +136,7 @@ def test_orphan_root_plus_managed_runtime_descendant_qualifies():
     fake = _fake_psutil({200: backend, 210: child})
     with patch.dict(sys.modules, {"psutil": fake}):
         holders = _holders() + [(210, "python.exe", " ".join(child_argv))]
-        assert cli_main._orphaned_desktop_backend_pids(holders) == [200]
+        assert cli_main._orphaned_desktop_backend_pids(holders) == [(200, 10000)]
 
 
 def test_descendant_of_grandchild_depth_qualifies():
@@ -150,7 +150,7 @@ def test_descendant_of_grandchild_depth_qualifies():
     fake = _fake_psutil({200: backend, 210: mid, 220: grand})
     with patch.dict(sys.modules, {"psutil": fake}):
         holders = _holders() + [(220, "python.exe", "python.exe leaf.py")]
-        assert cli_main._orphaned_desktop_backend_pids(holders) == [200]
+        assert cli_main._orphaned_desktop_backend_pids(holders) == [(200, 10000)]
 
 
 def test_non_descendant_alongside_orphan_root_keeps_refusal():
@@ -172,7 +172,7 @@ def test_descendant_exited_between_scan_and_classify_is_skipped():
     fake = _fake_psutil({200: backend})  # descendant 210 already gone
     with patch.dict(sys.modules, {"psutil": fake}):
         holders = _holders() + [(210, "python.exe", "python.exe worker.py")]
-        assert cli_main._orphaned_desktop_backend_pids(holders) == [200]
+        assert cli_main._orphaned_desktop_backend_pids(holders) == [(200, 10000)]
 
 
 def test_holder_gone_between_scan_and_classify_is_skipped():
@@ -205,7 +205,9 @@ def test_missing_psutil_keeps_refusal():
 def test_stop_process_trees_kills_full_tree():
     from hermes_cli import update_cmd
 
-    with patch.object(update_cmd.subprocess, "run") as run:
+    with patch("gateway.status.get_process_start_time", return_value=123), patch(
+        "hermes_cli._subprocess_compat.pid_is_hermes", return_value=True
+    ), patch.object(update_cmd.subprocess, "run") as run:
         cli_main._stop_process_trees([111, 222])
     calls = [c.args[0] for c in run.call_args_list]
     assert calls == [

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -170,10 +170,18 @@ class TestFindStaleDashboardPids:
         assert 12345 in pids
 
 
-    def test_ps_timeout_returns_empty(self):
+    def _assert_ps_timeout_returns_empty(self):
         import subprocess as sp
         with patch("subprocess.run", side_effect=sp.TimeoutExpired("ps", 10)):
             assert _find_stale_dashboard_pids() == []
+
+    @pytest.mark.linux_only
+    def test_ps_timeout_returns_empty_linux(self):
+        self._assert_ps_timeout_returns_empty()
+
+    @pytest.mark.macos_only
+    def test_ps_timeout_returns_empty_macos(self):
+        self._assert_ps_timeout_returns_empty()
 
 
 
@@ -273,6 +281,8 @@ class TestKillStaleDashboardWindows:
 
         with patch("hermes_cli.main._find_stale_dashboard_pids",
                    return_value=[12345, 12346]), \
+             patch("gateway.status.get_process_start_time", return_value=123), \
+             patch("hermes_cli._subprocess_compat.pid_is_hermes", return_value=True), \
              patch("subprocess.run", side_effect=fake_run) as mock_run:
             _kill_stale_dashboard_processes()
 

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -205,7 +205,7 @@ def _launchd_harness(monkeypatch, tmp_path, pid):
     monkeypatch.setattr(
         gateway_cli,
         "terminate_pid",
-        lambda pid, force=False: events.append(("kill" if force else "term", pid)),
+        lambda pid, force=False, **kwargs: events.append(("kill" if force else "term", pid)),
     )
     # Never let a real SIGUSR1 escape to the live test PID — the drain path
     # goes through _graceful_restart_via_sigusr1 (in-place restart) before
@@ -326,7 +326,7 @@ class TestEscalateWedgedGateway:
         monkeypatch.setattr(
             gateway_cli,
             "terminate_pid",
-            lambda pid, force=False: signals.append(("kill" if force else "term", pid)),
+            lambda pid, force=False, **kwargs: signals.append(("kill" if force else "term", pid)),
         )
         monkeypatch.setattr(
             gateway_cli, "_wait_for_pid_exit", lambda pid, timeout: True
@@ -347,7 +347,7 @@ class TestEscalateWedgedGateway:
         monkeypatch.setattr(
             gateway_cli,
             "terminate_pid",
-            lambda pid, force=False: signals.append(("kill" if force else "term", pid)),
+            lambda pid, force=False, **kwargs: signals.append(("kill" if force else "term", pid)),
         )
         monkeypatch.setattr(gateway_cli, "_wait_for_pid_exit", fake_wait)
 
@@ -357,7 +357,7 @@ class TestEscalateWedgedGateway:
     def test_total_wait_budget_is_bounded_well_under_drain(self, monkeypatch):
         """Worst case must be seconds, never the 180s drain budget."""
         waits = []
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False, **kwargs: None)
         monkeypatch.setattr(
             gateway_cli,
             "_wait_for_pid_exit",
@@ -368,7 +368,7 @@ class TestEscalateWedgedGateway:
         assert sum(waits) < 30.0
 
     def test_process_already_gone_is_success(self, monkeypatch):
-        def raise_gone(pid, force=False):
+        def raise_gone(pid, force=False, **kwargs):
             raise ProcessLookupError
 
         monkeypatch.setattr(gateway_cli, "terminate_pid", raise_gone)
@@ -381,7 +381,7 @@ class TestEscalateWedgedGateway:
     def test_sigkill_permission_error_does_not_raise(self, monkeypatch):
         calls = []
 
-        def term(pid, force=False):
+        def term(pid, force=False, **kwargs):
             calls.append(force)
             if force:
                 raise PermissionError
@@ -420,9 +420,9 @@ class TestLaunchdRestartWedgedIntegration:
             lambda pid, **kw: events.append("escalate") or True,
         )
         monkeypatch.setattr(
-            gateway_cli,
-            "terminate_pid",
-            lambda pid, force=False: events.append("sigterm"),
+        gateway_cli,
+        "terminate_pid",
+            lambda pid, force=False, **kwargs: events.append("sigterm"),
         )
         # Never let a real SIGUSR1 escape to PID 4242 during tests.
         monkeypatch.setattr(
@@ -585,7 +585,7 @@ class TestLoopTickWitness:
             monkeypatch.setattr(
                 gateway_cli,
                 "terminate_pid",
-                lambda pid, force=False: events.append(("kill" if force else "term", pid)),
+                lambda pid, force=False, **kwargs: events.append(("kill" if force else "term", pid)),
             )
             # Never let a real SIGUSR1 escape to os.getpid() — the drain
             # path now goes through _graceful_restart_via_sigusr1 (in-place

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -79,16 +79,39 @@ class TestReapOrphanedBrowserSessions:
 
         terminate_calls = []
 
-        def mock_terminate(pid):
+        def mock_terminate(pid, expected_start=None):
             terminate_calls.append(pid)
 
         with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status.get_process_start_time", return_value=777), \
              patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
         assert 12345 in terminate_calls
         assert not d.exists()
+
+    def test_unfingerprintable_daemon_is_refused(self, fake_tmpdir):
+        """No start-time fingerprint -> the kill is refused (fail closed).
+
+        The reaper reads the PID from a world-writable temp dir; a PID whose
+        identity cannot be pinned could be recycled between the verify and the
+        tree-kill, so it must be left alone (and the socket dir kept for a
+        later sweep).
+        """
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        _make_socket_dir(fake_tmpdir, "h_perm7654321", pid=12345)
+        terminate_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status.get_process_start_time", return_value=None), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid, expected_start=None: terminate_calls.append(pid)):
+            _reap_orphaned_browser_sessions()
+
+        assert terminate_calls == []
 
 
     def test_corrupt_pid_file_is_cleaned(self, fake_tmpdir):
@@ -446,9 +469,10 @@ class TestLeakedDaemonWithLiveOwner:
         kill_calls = []
 
         with patch("gateway.status._pid_exists", return_value=True), \
+             patch("gateway.status.get_process_start_time", return_value=777), \
              patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=kill_calls.append):
+                   side_effect=lambda pid, expected_start=None: kill_calls.append(pid)):
             _reap_orphaned_browser_sessions()
 
         assert 12345 in kill_calls

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -107,7 +107,8 @@ class TestTerminatePidRoutingOnWindows:
             return result
 
         monkeypatch.setattr(status.subprocess, "run", fake_run)
-        status.terminate_pid(12345, force=True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123456)
+        status.terminate_pid(12345, force=True, expected_start_time=123456)
 
         assert captured["args"][0] == "taskkill"
         assert "/PID" in captured["args"]
@@ -126,8 +127,9 @@ class TestTerminatePidRoutingOnWindows:
             return result
 
         monkeypatch.setattr(status.subprocess, "run", fake_run)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123456)
         with pytest.raises(OSError, match="cannot be terminated"):
-            status.terminate_pid(12345, force=True)
+            status.terminate_pid(12345, force=True, expected_start_time=123456)
 
     def test_graceful_on_windows_uses_os_kill_sigterm(self, monkeypatch):
         """Non-force path calls os.kill with SIGTERM (Windows has no SIGKILL).
@@ -165,7 +167,8 @@ class TestTerminatePidRoutingOnWindows:
 
         monkeypatch.setattr(status.subprocess, "run", fake_run)
         monkeypatch.setattr(status.os, "kill", fake_kill)
-        status.terminate_pid(42, force=True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123456)
+        status.terminate_pid(42, force=True, expected_start_time=123456)
 
         assert captured["pid"] == 42
         assert captured["sig"] == signal.SIGTERM

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2674,8 +2674,19 @@ def _reap_orphaned_browser_sessions():
         # Use the process-tree termination helper so Chromium children
         # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
         try:
+            from gateway.status import get_process_start_time
             from tools.process_registry import ProcessRegistry
-            ProcessRegistry._terminate_host_pid(daemon_pid)
+            daemon_start = get_process_start_time(daemon_pid)
+            if daemon_start is None:
+                # Identity can't be fingerprinted — the verify above matched,
+                # but without a start time _terminate_host_pid cannot rule out
+                # a recycle between verify and kill. Refuse; a later sweep
+                # retries once the process table settles.
+                logger.warning(
+                    "Refusing to reap browser daemon PID %d (session %s): "
+                    "no start-time fingerprint available", daemon_pid, session_name)
+                continue
+            ProcessRegistry._terminate_host_pid(daemon_pid, daemon_start)
             logger.info("Reaped orphaned browser daemon PID %d (session %s)",
                         daemon_pid, session_name)
             reaped += 1
@@ -5908,8 +5919,27 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                     try:
                         from tools.process_registry import ProcessRegistry
                         daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        ProcessRegistry._terminate_host_pid(daemon_pid)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+                        # The .pid file lives in a world-writable temp dir and
+                        # PIDs recycle: verify this really is our daemon for
+                        # this session before tree-killing, and pin the
+                        # identity with a start-time fingerprint so the kill
+                        # refuses if the PID is swapped between check and kill.
+                        if _verify_reapable_browser_daemon(
+                                daemon_pid, socket_dir, session_name):
+                            from gateway.status import get_process_start_time
+                            daemon_start = get_process_start_time(daemon_pid)
+                            if daemon_start is not None:
+                                ProcessRegistry._terminate_host_pid(
+                                    daemon_pid, daemon_start)
+                                logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+                            else:
+                                logger.debug(
+                                    "Skipped daemon kill for %s: no start-time "
+                                    "fingerprint for pid %s", session_name, daemon_pid)
+                        else:
+                            logger.debug(
+                                "Skipped daemon kill for %s: pid %s failed identity "
+                                "verification", session_name, daemon_pid)
                     except (ProcessLookupError, ValueError, PermissionError, OSError):
                         logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
                 shutil.rmtree(socket_dir, ignore_errors=True)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -2203,9 +2203,13 @@ class LocalEnvironment(BaseEnvironment):
         try:
             if _IS_WINDOWS:
                 try:
-                    from gateway.status import terminate_pid
+                    from gateway.status import get_process_start_time, terminate_pid
 
-                    terminate_pid(proc.pid, force=True)
+                    terminate_pid(
+                        proc.pid,
+                        force=True,
+                        expected_start_time=get_process_start_time(proc.pid),
+                    )
                 except Exception:
                     proc.kill()
                 try:


### PR DESCRIPTION
One fail-closed process-identity guard before every unverified Windows `taskkill`, composed from three contributor PRs (#96741 + #91297 + #98826, authorship preserved via cherry-pick) plus a salvage commit that closes the remaining sites as a class.

Fixes #98814
Fixes #89614

## The bug class

Every incident in this family has the same shape: **a bare PID number from a state file, pid file, or process scan is force-killed later without re-verifying that the number still names the same process.**

- **#89614** — `hermes update` read a stale PID from a state file after a reboot; the number had been recycled onto `svchost.exe`. `taskkill /F` on it → BSOD `0xEF CRITICAL_PROCESS_DIED` (8 reports).
- **#98814** — a chat-gateway agent ran `hermes update` via its terminal tool; the updater's leftover-holder recovery `taskkill /T /F`'d the gateway — **its own ancestor** — killing the updater mid-update.

Instead of patching predicates at each site, this PR installs one identity contract and migrates every kill site to it (never-patch-predicates: the class fix is the invariant, not another site patch).

## The guard

`(pid, start_time)` uniquely identifies a process — a recycled PID gets a different kernel start time. The contract, modeled on the repo's own best exemplar (`_scan_venv_blockers._terminate_safe_preview`):

1. **Capture identity at discovery** (pid + start-time fingerprint, plus cmdline/exe classification where available).
2. **Re-verify immediately before the kill.** Windows `terminate_pid(force=True)` now *requires* a matching `expected_start_time` — missing, unavailable, malformed, or mismatched ⇒ `OSError` refusal, no `taskkill` spawned. POSIX force-kills also refuse when a caller-provided fingerprint no longer matches.
3. **Ancestor refusal (#98814):** before the updater's leftover-gateway force-stop, `_refuse_gateway_ancestor_tree_kill()` walks the real parent chain (`_is_pid_ancestor_of_current_process`); on a hit it resumes paused gateways and exits 2 with `/update` / separate-terminal guidance. The `--gateway` hand-off (`/update`) is exempt by design.
4. **Kill helpers keep their never-raise contracts** — refusals are logged/reported, not thrown, at best-effort cleanup sites.
5. **Own-retained-`Popen`-handle kills stay unguarded on purpose** (deadline.py, tts, transcription, cron scheduler, `kill_process_tree`): a retained handle pins the PID, so recycling is impossible there and a guard could only false-refuse.

## Kill-site inventory

| Site | PID source | Before | After |
|---|---|---|---|
| `gateway/status.py::terminate_pid` (THE primitive) | callers | no verification | Windows force requires matching fingerprint; POSIX refuses on stale fingerprint |
| `status.py::_terminate_scoped_lock_owner_once` | lock file | checked in-flow, **no recheck at kill** | fingerprint passed to `terminate_pid` |
| `gateway/run.py` replace-kill | pid record | unverified | fingerprint from record |
| `hermes_cli/gateway.py::_escalate_wedged_gateway` | pid file | unverified | fingerprint captured pre-SIGTERM, verified at SIGKILL |
| `gateway.py::kill_gateway_processes` | process scan | cmdline matched at **scan time only** (TOCTOU) | live argv re-verified + fingerprint at kill time |
| `gateway.py::_wait_for_gateway_exit` | pid file | unverified | fingerprint at escalation |
| `gateway.py::_reap_unsupervised_gateway_orphans` | process scan | delayed SIGKILL unverified | fingerprint pinned at scan, re-verified before SIGKILL |
| `hermes_cli/profiles.py` (×2 stop paths) | pid files | unverified | recorded/live fingerprint |
| `hermes_cli/gateway_windows.py::_force_terminate_known_gateway_pids` | pid list | unverified | fingerprint |
| `hermes_cli/update_cmd.py` (pause/leftover/stuck paths ×3) | scans + records | unverified; could tree-kill own ancestor | fingerprint + **ancestor refusal** |
| `update_cmd.py::_stop_process_trees` | scan | unverified taskkill | fail-closed `pid_is_hermes` + fingerprint threaded from classification |
| `hermes_cli/dashboard_procs.py` win32 kill | scan | unverified | identity captured at discovery, re-validated, refusals reported in `failed[]` |
| `plugins/platforms/whatsapp/adapter.py::_kill_port_process` | **netstat/lsof port scan** | killed whatever held the port (stranger-kill) | refuses unless live process is a node bridge |
| `tools/browser_tool.py` orphan reap + session close | world-writable temp pid file | `_terminate_host_pid(pid)` with **no** `expected_start` | verified daemon + fingerprint passed; close path gains the same identity verification as the reaper |
| `tools/environments/local.py` | retained proc | already passes fingerprint (from #96741) | kept |
| Own retained `Popen` handles (deadline/tts/transcription/cron/browser/whatsapp bridge) | live handle | unguarded | **left unguarded by design** (handle pins the PID) |

Also hardened during salvage: `pid_is_hermes`'s `'hermes'` match is now token-boundary (`...\shermesa\app.exe` no longer passes), and its POSIX branch honors an explicit fingerprint instead of returning `True` unconditionally.

## Composition & credit

Cherry-picked with original authorship:

- `2a04bd5b90` — **@gebilaowang404** (#91297, earliest fail-closed semantics), adopting the community patch by **@AlexMnrs** (Co-authored-by preserved in the commit).
- `5c4fa86bfc` — **@burak33bb** (#96741, the `terminate_pid` identity predicate and site migrations).
- `9aab100d6b` — **@ayushnangia** (#98826, ancestor-refusal for #98814; includes the fail-open ancestry fix by @AlexMnrs).
- Salvage commit on top composes them, resolves the overlaps, and migrates the remaining inventory.

This PR supersedes #96741, #91297, and #98826.

## Testing

**Linux (targeted suites, all green):** `test_stale_pid_guard.py` (28), `test_status.py`, `test_update_concurrent_quarantine.py`, `test_gateway.py` (incl. new recycled-PID refusal test), `test_update_wedged_gateway.py`, `test_runner_startup_failures.py`, `test_update_stale_dashboard.py`, `test_update_orphan_backend_reap.py`, `test_browser_orphan_reaper.py` (incl. new unfingerprintable-refusal test), `test_whatsapp_connect.py` (incl. new non-bridge-refusal test), `test_whatsapp_stale_bridge.py`, `test_bounded_probe_run.py`, `test_treekill_consolidation.py`, `test_windows_subprocess_no_window_flags.py` — **318 passed** in the combined run. (One known order-dependent flake, `test_shell_hooks_consumer_still_imports_by_name`, fails identically on unmodified `origin/main` under the same file ordering — pre-existing, unrelated.)

**Windows (real windows-latest, live processes):** new `tests/hermes_cli/test_taskkill_identity_windows_live.py` runs on the on-demand `wine2e/**` lane (`windows-venv-e2e.yml`) — spawns real processes and drives the REAL guard: matching identity kills; missing expectation refuses and the process survives; stale fingerprint against a different live process refuses; `pid_is_hermes` refuses a real foreign process and a stale fingerprint; ancestor refusal verified against the real psutil parent chain of the test process.

Windows receipt (head 4fb17a88): ✅ https://github.com/NousResearch/hermes-agent/actions/runs/33415397718 — `tests/hermes_cli/test_taskkill_identity_windows_live.py` 19 passed, 1 skipped (the foreign-process probe skips when the interpreter path itself contains a `hermes` token, as it does in the repo-local uv venv — by-design env guard)

Note: the wine2e workflow itself is pre-existing (on-demand, `wine2e/**` push-only); this PR only appends the new test file to its pytest invocation — nothing to remove before merge.

## Infographic

![Fail-closed process-identity guard flow](https://v3b.fal.media/files/b/0aa890c3/ZC4WDksiAp5el3lkk2iFx_y6rxXmSC.png)
