### PR TITLE
fix(desktop): preserve namespace sandbox on Linux update relaunch

### DIFF
--- a/contributors/emails/a.dltorreruiz@gmail.com
+++ b/contributors/emails/a.dltorreruiz@gmail.com
@@ -1,0 +1,2 @@
+4dlt
+# PR #98135 attribution repair

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8184,6 +8184,29 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     return True
 
 
+def _desktop_linux_needs_disable_setuid_sandbox(packaged_executable: Path) -> bool:
+    """Return True when Chromium should skip the present-but-non-setuid helper.
+
+    A user-owned ``chrome-sandbox`` still makes Chromium abort with
+    ``setuid_sandbox_host`` even when the namespace sandbox works. Passing
+    ``--disable-setuid-sandbox`` keeps the userns sandbox and avoids sudo.
+    Call only after ``_desktop_linux_sandbox_fixup`` succeeded without making
+    the helper root-owned 4755 (the userns path). Does not re-probe userns.
+    """
+    if sys.platform != "linux":
+        return False
+    sandbox = packaged_executable.parent / "chrome-sandbox"
+    try:
+        sandbox_lstat = sandbox.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(sandbox_lstat.st_mode):
+        return False
+    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return False
+    return True
+
+
 _LINUX_PASSWORD_STORES = frozenset({"gnome-libsecret", "kwallet", "kwallet5", "kwallet6", "basic"})
 
 
@@ -8578,6 +8601,8 @@ def cmd_gui(args: argparse.Namespace):
             launch_command.append("--no-sandbox")
         else:
             sys.exit(1)
+    elif _desktop_linux_needs_disable_setuid_sandbox(packaged_executable):
+        launch_command.append("--disable-setuid-sandbox")
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8098,6 +8098,37 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
 
 
+def _desktop_linux_userns_sandbox_available() -> bool:
+    """Return True when Chromium's unprivileged user-namespace sandbox works.
+
+    When an unprivileged process can create a user namespace, Chromium uses the
+    namespace sandbox and never consults the setuid ``chrome-sandbox`` helper,
+    so requiring the helper to be root-owned 4755 (and prompting for sudo) is
+    unnecessary. Probe the real capability with ``unshare`` instead of reading
+    distro-specific sysctls: the probe fails closed on hosts where user
+    namespaces are disabled or AppArmor-restricted, which then follow the
+    existing setuid-helper path.
+    """
+    if sys.platform != "linux":
+        return False
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [unshare, "--user", "--map-root-user", "true"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
     """Return True when ``chrome-sandbox`` exists as a regular file."""
     if sys.platform != "linux":
@@ -8134,6 +8165,10 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return False
 
     if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    if _desktop_linux_userns_sandbox_available():
+        print("✓ Using Chromium's user-namespace sandbox (setuid helper not needed).")
         return True
 
     sudo = shutil.which("sudo")

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -316,6 +316,10 @@ linux_gate() {
   sb="$unpacked/chrome-sandbox"
   if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
   if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
+  # Namespace sandbox usable => Electron never consults the setuid helper,
+  # so a non-root chrome-sandbox does not block relaunch (mirrors the
+  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
+  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
 
   case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
   [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -298,14 +298,23 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 #     apps/desktop/release/linux-unpacked (anchored, path-segment-aware --
 #     proof the update we just ran replaced the selected executable);
 #   * chrome-sandbox ABSENT is fine (namespace-sandbox build; nothing to
-#     block on), PRESENT means root-owned AND setuid or Electron refuses to
-#     boot ("quit and never came back");
+#     block on), PRESENT means root-owned AND setuid unless a live userns
+#     probe succeeds; that path replays --disable-setuid-sandbox so Chromium
+#     cannot abort on the present-but-unconfigured helper;
 #   * a user sandbox opt-out (ELECTRON_DISABLE_SANDBOX=1/true in our
 #     inherited env, --no-sandbox among the replayed launch args, or the
 #     Desktop vouching via --sandbox-fallback) makes the relaunch safe
 #     despite a failed preflight.
 # Outcomes mirror decideRelaunchOutcome: relaunch | skew | manual.
 GATE="" GATE_MSG=""
+append_relaunch_arg_once() {
+  local wanted="$1" arg
+  for arg in ${RELAUNCH_ARGS[@]+"${RELAUNCH_ARGS[@]}"}; do
+    [ "$arg" = "$wanted" ] && return
+  done
+  RELAUNCH_ARGS+=("$wanted")
+}
+
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
   case "$RELAUNCH_TARGET" in
@@ -316,10 +325,14 @@ linux_gate() {
   sb="$unpacked/chrome-sandbox"
   if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
   if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
-  # Namespace sandbox usable => Electron never consults the setuid helper,
-  # so a non-root chrome-sandbox does not block relaunch (mirrors the
-  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
-  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
+  # Namespace sandbox usable => keep the relaunch sandboxed without sudo.
+  # The CLI launch path adds this switch too: a present-but-non-setuid helper
+  # can otherwise make Chromium abort before it selects the namespace sandbox.
+  if unshare --user --map-root-user true 2>/dev/null; then
+    append_relaunch_arg_once --disable-setuid-sandbox
+    GATE=relaunch
+    return
+  fi
 
   case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
   [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }

--- a/scripts/desktop-update/repro.sh
+++ b/scripts/desktop-update/repro.sh
@@ -97,22 +97,31 @@ case "$MODE" in
     # exits without running an update.
     G="/tmp/hermes-gate-test.$$"
     UNPACKED="$G/hermes-agent/apps/desktop/release/linux-unpacked"
-    mkdir -p "$UNPACKED"
+    PROBE_BIN="$G/bin"
+    mkdir -p "$UNPACKED" "$PROBE_BIN"
     touch "$UNPACKED/hermes" && chmod +x "$UNPACKED/hermes"
+    set_userns_probe() {
+      printf '#!/bin/sh\nexit %s\n' "$1" > "$PROBE_BIN/unshare"
+      chmod +x "$PROBE_BIN/unshare"
+    }
+    set_userns_probe 1
 
     fails=0
     expect() { # name expected actual
       if [ "$2" = "$3" ]; then printf 'ok   %s -> %s\n' "$1" "$3"
       else printf 'FAIL %s -> %s (want %s)\n' "$1" "$3" "$2"; fails=$((fails+1)); fi
     }
-    decide() { bash "$SCRIPT_DIR/posix.sh" --self-test-gate --install-root "$G/hermes-agent" "$@" | cut -d: -f1; }
+    decide() { PATH="$PROBE_BIN:$PATH" bash "$SCRIPT_DIR/posix.sh" --self-test-gate --install-root "$G/hermes-agent" "$@" | cut -d: -f1; }
 
     expect "appimage (not under unpacked)"      skew     "$(decide --relaunch-target /opt/Hermes/hermes)"
     expect "sibling-prefix dir not fooled"      skew     "$(decide --relaunch-target "$UNPACKED-evil/hermes")"
     expect "no chrome-sandbox (namespace)"      relaunch "$(decide --relaunch-target "$UNPACKED/hermes")"
 
     touch "$UNPACKED/chrome-sandbox"
-    expect "sandbox not root/setuid"            manual   "$(decide --relaunch-target "$UNPACKED/hermes")"
+    expect "sandbox not root/setuid, no userns" manual   "$(decide --relaunch-target "$UNPACKED/hermes")"
+    set_userns_probe 0
+    expect "sandbox not root/setuid, userns"    relaunch "$(decide --relaunch-target "$UNPACKED/hermes")"
+    set_userns_probe 1
     expect "opt-out: --sandbox-fallback"        relaunch "$(decide --relaunch-target "$UNPACKED/hermes" --sandbox-fallback)"
     expect "opt-out: --no-sandbox launch arg"   relaunch "$(decide --relaunch-target "$UNPACKED/hermes" -- --no-sandbox)"
     expect "opt-out: ELECTRON_DISABLE_SANDBOX"  relaunch "$(ELECTRON_DISABLE_SANDBOX=1 decide --relaunch-target "$UNPACKED/hermes")"
@@ -120,7 +129,7 @@ case "$MODE" in
     # Result JSON must survive hostile strings (git allows `"` in branch
     # names; messages carry arbitrary text) -- parse it back with python.
     QHOME="$G/qhome"; mkdir -p "$QHOME/hermes-agent"
-    bash "$SCRIPT_DIR/posix.sh" --no-ui --no-marker-cleanup --desktop-pid 0 \
+    bash "$SCRIPT_DIR/posix.sh" --no-ui --no-marker-cleanup --daemonized --desktop-pid 0 \
       --install-root "$QHOME/hermes-agent" --branch 'evil"branch\n$(x)' >/dev/null 2>&1 || true
     if python3 -c "import json,sys; d=json.load(open('$QHOME/.hermes-update-result.json')); sys.exit(0 if d['branch']=='evil\"branch\\\\n\$(x)' and d['ok']==False else 1)"; then
       printf 'ok   result JSON escapes hostile branch/message\n'
@@ -157,7 +166,7 @@ case "$MODE" in
     mkdir -p "$UNPACKED"
     printf '#!/bin/sh\nexit 1\n' > "$UNPACKED/hermes"; chmod +x "$UNPACKED/hermes"
     if [ "$(uname)" != "Darwin" ]; then
-      bash "$SCRIPT_DIR/posix.sh" --no-ui --desktop-pid 0 --install-root "$L/hermes-agent" \
+      bash "$SCRIPT_DIR/posix.sh" --no-ui --daemonized --desktop-pid 0 --install-root "$L/hermes-agent" \
         --relaunch-target "$UNPACKED/hermes" >/dev/null 2>&1 || true
       expect_msg "instant-exit relaunch downgrades to manual" "d['ok']==True and d['manual']==True and 'Reopen Hermes' in d['message']"
     else
@@ -171,10 +180,45 @@ case "$MODE" in
     # 2. gated skew: success result carries the skew message (the manual
     #    event's payload), never a bare "Update complete."
     stub_install
-    bash "$SCRIPT_DIR/posix.sh" --no-ui --desktop-pid 0 --install-root "$L/hermes-agent" \
+    bash "$SCRIPT_DIR/posix.sh" --no-ui --daemonized --desktop-pid 0 --install-root "$L/hermes-agent" \
       --relaunch-target /opt/Hermes/hermes >/dev/null 2>&1 || true
     if [ "$(uname)" != "Darwin" ]; then
       expect_msg "skew outcome surfaces in result message" "d['ok']==True and d['manual']==True and 'was not changed' in d['message']"
+    fi
+
+    # 3. userns-capable Linux relaunch: the gate must carry the same
+    #    --disable-setuid-sandbox switch as the normal CLI launch path. Merely
+    #    changing GATE to relaunch can revive the original "quit and never came
+    #    back" failure on Electron builds that reject a present 0755 helper.
+    if [ "$(uname)" != "Darwin" ]; then
+      stub_install
+      UNPACKED="$L/hermes-agent/apps/desktop/release/linux-unpacked"
+      PROBE_BIN="$L/bin"
+      ARG_LOG="$L/relaunch.args"
+      PID_LOG="$L/relaunch.pid"
+      mkdir -p "$UNPACKED" "$PROBE_BIN"
+      printf '#!/bin/sh\nexit 0\n' > "$PROBE_BIN/unshare"; chmod +x "$PROBE_BIN/unshare"
+      cat > "$UNPACKED/hermes" <<'SH'
+#!/bin/sh
+printf '%s\n' "$@" > "${HERMES_RELAUNCH_ARG_LOG:?}"
+printf '%s\n' "$$" > "${HERMES_RELAUNCH_PID_LOG:?}"
+exec sleep 30
+SH
+      chmod +x "$UNPACKED/hermes"
+      touch "$UNPACKED/chrome-sandbox"
+      PATH="$PROBE_BIN:$PATH" \
+        HERMES_RELAUNCH_ARG_LOG="$ARG_LOG" HERMES_RELAUNCH_PID_LOG="$PID_LOG" \
+        bash "$SCRIPT_DIR/posix.sh" --no-ui --daemonized --desktop-pid 0 \
+          --install-root "$L/hermes-agent" --relaunch-target "$UNPACKED/hermes" \
+          -- --deep-link=test >/dev/null 2>&1 || true
+      disable_count="$(grep -cx -- '--disable-setuid-sandbox' "$ARG_LOG" 2>/dev/null || true)"
+      if [ "$disable_count" = "1" ] && grep -qx -- '--deep-link=test' "$ARG_LOG" 2>/dev/null; then
+        printf 'ok   userns relaunch preserves sandbox and launch args\n'
+      else
+        printf 'FAIL userns relaunch args -> %s\n' "$(tr '\n' ' ' < "$ARG_LOG" 2>/dev/null || echo missing)"
+        fails=$((fails+1))
+      fi
+      [ ! -f "$PID_LOG" ] || kill "$(cat "$PID_LOG")" 2>/dev/null || true
     fi
 
     rm -rf "$L"

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -130,7 +130,11 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
-    assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args_list[1].args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
@@ -968,7 +972,11 @@ def test_gui_launches_even_when_desktop_entry_install_fails(tmp_path, monkeypatc
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
-    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args.args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
 
 
 @pytest.mark.macos_only

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -1,0 +1,116 @@
+"""Tests for the Linux desktop sandbox-helper fixup and the userns probe.
+
+``_desktop_linux_sandbox_fixup`` historically demanded a root-owned 4755
+``chrome-sandbox`` on every Linux host and shelled out to ``sudo`` to get it
+— which fails silently when the desktop entry launches ``hermes desktop``
+without a TTY (#88032, #51327), and blocked the updater's relaunch gate
+(#58593). On hosts where unprivileged user namespaces work, Chromium uses
+its namespace sandbox and never consults the setuid helper, so the fixup now
+probes for that capability first and skips the sudo path entirely.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+
+class TestDesktopLinuxUsernsSandboxAvailable:
+    def test_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_unshare_is_missing(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_true_when_probe_succeeds(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            assert cli_main._desktop_linux_userns_sandbox_available() is True
+        probe = run.call_args.args[0]
+        assert probe[0] == "/usr/bin/unshare"
+        assert "--user" in probe
+
+    def test_false_when_probe_fails(self, monkeypatch):
+        """EPERM from the kernel (userns disabled or AppArmor-restricted)."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 1
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_probe_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(
+                 cli_main.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired(cmd="unshare", timeout=5),
+             ):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+
+class TestDesktopLinuxSandboxFixup:
+    def _fake_packaged_app(self, tmp_path):
+        """Unpacked-app layout with a non-root, non-setuid chrome-sandbox."""
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_userns_host_skips_sudo_and_succeeds(self, monkeypatch, tmp_path):
+        """A user-owned helper must not trigger sudo when userns works.
+
+        This is the .desktop-launch regression: no TTY means sudo cannot
+        prompt, so reaching the sudo path at all kills the launch.
+        """
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ), \
+             patch.object(cli_main.subprocess, "run") as run:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        run.assert_not_called()
+
+    def test_restricted_host_without_sudo_still_fails(self, monkeypatch, tmp_path):
+        """The pre-existing strict path is preserved when userns is unusable."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+    def test_root_owned_setuid_helper_short_circuits(self, monkeypatch, tmp_path):
+        """A correctly configured helper wins before the userns probe runs."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available"
+             ) as probe:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        probe.assert_not_called()

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -114,3 +114,50 @@ class TestDesktopLinuxSandboxFixup:
              ) as probe:
             assert cli_main._desktop_linux_sandbox_fixup(exe) is True
         probe.assert_not_called()
+
+
+class TestDesktopLinuxNeedsDisableSetuidSandbox:
+    def _fake_packaged_app(self, tmp_path):
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_true_for_user_owned_helper_when_userns_works(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+            cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+        ):
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is True
+
+    def test_false_for_root_owned_setuid_helper(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ) as probe:
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False
+        probe.assert_not_called()
+
+    def test_false_when_helper_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False


### PR DESCRIPTION
## Problem

This is a focused follow-up to the maintainer-prepared `fix/p1-chrome-sandbox` branch / #98135.

That branch correctly adds `--disable-setuid-sandbox` to the normal CLI launch when a live user-namespace probe succeeds. The detached Linux update hand-off only changes `GATE` to `relaunch`, though; `launch_app()` then replays `RELAUNCH_ARGS` unchanged.

If the running app did not already carry `--disable-setuid-sandbox` (for example, it started while the helper was still `root:root 4755`), an update can rebuild `chrome-sandbox` as user-owned `0755`, pass the new userns gate, and relaunch without the switch. On Electron builds that reject a present-but-unconfigured helper, that recreates the exact “quit and never came back” failure the gate exists to prevent.

## Fix

- After the fail-closed `unshare --user --map-root-user` probe succeeds, append `--disable-setuid-sandbox` to the replay args exactly once.
- Preserve all original relaunch args.
- Make the gate matrix deterministic by stubbing both userns capability branches.
- Add a full hand-off regression that runs the real gate + relaunch path and asserts the relaunched process receives both the sandbox switch and its original deep-link argument.
- Run existing hand-off harness cases with `--daemonized` so they wait for the result instead of racing the intentional detach/re-exec.

No `--no-sandbox` path is added; Chromium's namespace sandbox remains enabled.

## Verification

```text
bash scripts/desktop-update/repro.sh gate
# gate matrix: all pass

bash scripts/desktop-update/repro.sh launch
# launch matrix: all pass

scripts/run_tests.sh \
  tests/hermes_cli/test_linux_sandbox_fixup.py \
  tests/hermes_cli/test_gui_command.py -q
# 52 passed, 9 skipped

bash -n scripts/desktop-update/posix.sh scripts/desktop-update/repro.sh
git diff --check
```

Refs #51327, #58593, #98135.

Prepared with GPT-5.6-sol via pi; the commands and outputs above were verified locally.
