### PR TITLE
test(cron): pin _REDACT_ENABLED in incident redaction test (cross-collection flake)

### DIFF
--- a/tests/cron/test_cron_incidents.py
+++ b/tests/cron/test_cron_incidents.py
@@ -121,6 +121,14 @@ def test_error_change_mints_new_incident(monkeypatch, tmp_path):
 
 
 def test_redaction_applied_to_incident_error(monkeypatch, tmp_path):
+    # agent.redact snapshots _REDACT_ENABLED from HERMES_REDACT_SECRETS at
+    # module-import time. When another collected test module imports the
+    # gateway/scheduler chain (e.g. test_codex_execution_paths.py), that
+    # import happens at COLLECTION time — before the conftest env scrub —
+    # so a developer shell exporting HERMES_REDACT_SECRETS=false freezes
+    # redaction off and this test fails only in full-directory runs.
+    # Pin the flag explicitly, matching the repo-wide pattern.
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True, raising=False)
     inc = _point_db(monkeypatch, tmp_path)
     secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
 


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-test pollution flake in `tests/cron/`: `test_redaction_applied_to_incident_error` fails when the whole `tests/cron/` directory runs in one pytest process under a shell that exports `HERMES_REDACT_SECRETS=false`, but passes alone or file-alone.

## Root cause

`agent/redact.py` snapshots `_REDACT_ENABLED` from `HERMES_REDACT_SECRETS` at module-import time. `tests/cron/test_codex_execution_paths.py` imports `cron.scheduler` / `gateway.run` / `run_agent` at **collection time** — before the conftest env scrub (`_HERMES_BEHAVIORAL_VARS`) runs — so a developer-shell `HERMES_REDACT_SECRETS=false` freezes redaction off for the whole process. Deselected tests still poison the run: `-k redaction_applied` over the directory fails with 1062 deselected, proving it is import-side-effect pollution, not a runtime leak.

Bisect over the 81 co-collected files converged on `test_codex_execution_paths.py` as the single culprit pairing.

## Fix

Pin the flag inside the test with `monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)` — the exact pattern already used by ~30 other redaction tests across the suite (e.g. `tests/agent/test_redact.py:15`).

**Live repro:** `HERMES_REDACT_SECRETS=false pytest tests/cron/test_codex_execution_paths.py tests/cron/test_cron_incidents.py -k redaction_applied` — before: `1 failed` on origin/main (secret `ghp_…` stored unredacted); after: `1 passed`; full `test_cron_incidents.py` file: 14 passed.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa89115/0SAdBf3u69T_6NpENSk0J_GnUEU6gO.png)
