### PR TITLE
fix(update): hold respawned dashboard backends to a liveness probe

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8873,12 +8873,19 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
         return None
 
 
+_RESPAWN_LIVENESS_PROBE_SECONDS = 2.0
+
+
 def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
     """Best-effort respawn of manually-started dashboards after ``hermes update``.
 
     Spawns each recovered argv detached (new session, output to the profile's
-    ``logs/dashboard-restart.log``).  Returns the commands that failed to
-    spawn; the caller prints the manual hint for those.
+    ``logs/dashboard-restart.log``).  A successful ``Popen`` only means the
+    spawn request was accepted, so each child is held to a liveness probe:
+    one that exits within ``_RESPAWN_LIVENESS_PROBE_SECONDS`` (e.g. the port
+    is still owned by a stale process) is reported as failed, not restarted
+    (#99518).  Returns the commands that failed to spawn or died during the
+    probe; the caller prints the manual hint for those.
 
     Callers must pre-filter via ``_filter_dashboard_respawn_candidates`` so
     Desktop ``serve|dashboard --port 0`` backends are not replayed and
@@ -8886,6 +8893,7 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
     """
     from hermes_constants import get_hermes_home
 
+    spawned: list[tuple[list[str], subprocess.Popen]] = []
     respawned: list[list[str]] = []
     failed: list[tuple[list[str], str]] = []
     log_path = get_hermes_home() / "logs" / "dashboard-restart.log"
@@ -8901,7 +8909,7 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
             if "dashboard" in command and "--no-open" not in command:
                 command = [*command, "--no-open"]
             with open(log_path, "ab") as log_f:
-                subprocess.Popen(
+                proc = subprocess.Popen(
                     command,
                     stdin=subprocess.DEVNULL,
                     stdout=log_f,
@@ -8909,9 +8917,20 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
                     start_new_session=True,
                     close_fds=True,
                 )
-            respawned.append(command)
+            spawned.append((command, proc))
         except (OSError, ValueError) as exc:
             failed.append((command, str(exc)))
+
+    # Probe once after every spawn has had the same settle window — a child
+    # dying here (bind failure against a stale holder) must not print a check.
+    if spawned:
+        _time.sleep(_RESPAWN_LIVENESS_PROBE_SECONDS)
+    for command, proc in spawned:
+        exit_code = proc.poll()
+        if exit_code is None:
+            respawned.append(command)
+        else:
+            failed.append((command, f"exited with code {exit_code} during startup"))
 
     for command in respawned:
         print(f"    ✓ restarted: {shlex.join(command)}")

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -544,7 +544,11 @@ class TestManualBackendRespawn:
             def __init__(self, cmd, **kwargs):
                 spawned.append(list(cmd))
 
-        with patch.object(live.subprocess, "Popen", _FakePopen):
+            def poll(self):
+                return None
+
+        with patch.object(live.subprocess, "Popen", _FakePopen), \
+             patch("time.sleep"):
             failed = live._respawn_dashboard_processes([
                 ["hermes", "dashboard", "--port", "8300"],
                 ["hermes", "serve", "--host", "0.0.0.0"],
@@ -564,6 +568,37 @@ class TestManualBackendRespawn:
         assert failed == [["hermes", "serve"]]
         out = capsys.readouterr().out
         assert "✗ failed to restart" in out
+
+    def test_respawn_child_dying_during_probe_is_failed(self, tmp_path, monkeypatch, capsys):
+        """A child that exits inside the liveness probe reports failure, not a check mark.
+
+        A successful spawn only means the spawn request was accepted; when the
+        port is still owned by a stale process the child dies on bind within
+        moments and must land in the failed list so the manual hint and the
+        serve_relaunch receipt step record reality (#99518).
+        """
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                self.exit_code = 1 if cmd[1:2] == ["dying"] else None
+
+            def poll(self):
+                return self.exit_code
+
+        with patch.object(live.subprocess, "Popen", _FakePopen), \
+             patch("time.sleep") as probe_wait:
+            failed = live._respawn_dashboard_processes([
+                ["hermes", "dying"],
+                ["hermes", "serve"],
+            ])
+
+        assert failed == [["hermes", "dying"]]
+        probe_wait.assert_called_once()
+        out = capsys.readouterr().out
+        assert "✗ failed to restart (hermes dying): exited with code 1 during startup" in out
+        assert "✓ restarted: hermes serve" in out
 
 
 class TestFilterDashboardRespawnCandidates:


### PR DESCRIPTION
## What does this PR do?

`_respawn_dashboard_processes()` printed `✓ restarted:` as soon as `Popen` returned, but a successful `Popen` only means the spawn request was accepted. When the old backend was never cleared, the freshly spawned child dies on port-bind within moments — and `update.log` still records a success, leaving the operator with a silently mixed-version deployment (old backend in memory, new code on disk) and zero diagnostics (#99518).

This holds every spawned child to a liveness probe: after one shared settle window (`_RESPAWN_LIVENESS_PROBE_SECONDS`, 2.0s), any child whose `poll()` has returned is moved into the existing `failed` path instead of the success list. From there the behavior is already correct and untouched: the caller prints the manual restart hint, and the `serve_relaunch` receipt step records `False` instead of a false success.

The full receipt/hard-fail and PID-lstart ownership checks suggested in the issue are deliberately out of scope here: by respawn time the code update itself has already succeeded, so failing the whole update would misreport it, and the liveness probe catches the dominant failure mode (bind failure against a stale holder) with a minimal, platform-independent diff.

## Related Issue

Fixes #99518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_respawn_dashboard_processes()` now collects `(command, proc)` pairs, sleeps once after all spawns, and reclassifies children that exited during the window into `failed` with `exited with code <N> during startup`; docstring updated to describe the probe contract.
- `tests/hermes_cli/test_update_stale_dashboard.py` — extended the `_FakePopen` in the existing `--no-open` test with a live `poll()` (and patched `time.sleep`), and added `test_respawn_child_dying_during_probe_is_failed` covering the mixed case: a dying child lands in `failed` (✗ line with exit code, no ✓) while a surviving child still reports success.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py -q` — should pass: 44 passed, 2 skipped (Windows-only skips) with this change; the new `test_respawn_child_dying_during_probe_is_failed` fails on `main` (the dying child is reported as `✓ restarted`).
2. `.venv/bin/python -m pytest tests/hermes_cli/test_serve_runtime_inventory.py -q` — should pass: 11 passed (covers the `_relaunch_stopped_serves` caller path).
3. `.venv/bin/python -m ruff check hermes_cli/main.py tests/hermes_cli/test_update_stale_dashboard.py` — should pass; `ty check hermes_cli/main.py` shows the same diagnostics before and after the change (none introduced).

Observed result: all of the above pass locally on the patched worktree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (probe uses `Popen.poll()`, which works on all platforms; the respawn path itself is POSIX-only today)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
