### PR TITLE
fix(update): identify stale v0.20.6 source builds

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -658,8 +658,11 @@ def format_banner_version_label() -> str:
     local = state["local"]
     ahead = int(state.get("ahead") or 0)
 
-    if ahead <= 0 or upstream == local:
+    if upstream == local:
         return f"{base} · upstream {upstream}"
+
+    if ahead <= 0:
+        return f"{base} · upstream {upstream} · local {local}"
 
     carried_word = "commit" if ahead == 1 else "commits"
     return f"{base} · upstream {upstream} · local {local} (+{ahead} carried {carried_word})"

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -17,6 +17,19 @@ def test_format_banner_version_label_on_upstream_main():
     assert "local" not in value
 
 
+def test_format_banner_version_label_identifies_behind_local_build():
+    from hermes_cli import banner
+
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={"upstream": "4f225435", "local": "2a598aad", "ahead": 0},
+    ):
+        value = banner.format_banner_version_label()
+
+    assert value.endswith("· upstream 4f225435 · local 2a598aad")
+
+
 def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     from hermes_cli import banner
 


### PR DESCRIPTION
## What does this PR do?

Hermes source installations now show the installed local revision whenever it differs from the fetched upstream revision, even when Git cannot calculate a positive carried-commit count. This makes affected and fixed builds distinguishable when the package version remains `v0.20.6` across the boundary.

### Symptom

A source checkout can report `Hermes Agent v0.20.6 ... upstream <fixed-sha>` while running a different, older local revision. In shallow or behind graphs, the banner omits the local SHA because its carried-commit count is zero or unavailable.

### Impact

Support diagnostics can misidentify an affected build as the fixed upstream build. Operators may therefore believe a stale `v0.20.6` checkout includes the single-call compaction refactor when its installed HEAD does not.

### Bug Cause

**Trigger:** `hermes_cli/banner.py:format_banner_version_label` when `upstream != local` and `ahead <= 0`.

**Causal chain:**
1. The banner resolves different upstream and installed revisions.
2. A behind or shallow graph produces no positive `origin/main..HEAD` carried-commit count.
3. The formatter treats that zero count like an exact revision match and renders only the upstream SHA.

**Why it is wrong:** Revision identity and carried-commit count are independent. A zero or unavailable carried count does not make two different revisions identical.

**Working sibling / contrast:** When the graph exposes one or more carried commits, the existing formatter already includes both upstream and local SHAs.

**Ruled out:** Current `main` still using multi-call lean compaction was ruled out; commit `4f225435` contains the single-call refactor, while the reported installed HEAD does not contain that commit.

### Fix

The formatter now suppresses the local SHA only for an exact upstream/local match. Differing revisions always render both SHAs, while the existing carried-commit annotation remains limited to positive counts.

## Related Issue

Closes #99511

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/banner.py` - preserve the installed revision in version diagnostics when it differs from upstream.
- `tests/hermes_cli/test_banner_git_state.py` - cover a behind local build with no carried-commit count.

## How to Test

1. Automated (10 passed locally):

```bash
scripts/run_tests.sh tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_banner.py tests/gateway/test_version_command.py -q
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added a regression test for the bug
- [x] I've tested the affected formatter path on Windows 11
