### PR TITLE
fix(skills): fold linked worktrees to the trusted common root

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -707,6 +707,42 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     return None
 
 
+def _linked_worktree_common_root(root: Path) -> Optional[Path]:
+    """Main-checkout root when *root* is a linked git worktree, else None.
+
+    Pure file parsing, no git subprocess (same shape as
+    ``hermes_cli/build_info.py``): a linked worktree's ``.git`` is a FILE
+    holding a ``gitdir:`` pointer into ``<repo>/.git/worktrees/<name>``, and
+    that admin dir's ``commondir`` names the shared ``.git`` dir — whose
+    parent is the one true repo root. A submodule's gitdir has no
+    ``commondir``, so it resolves None. Anything malformed fails closed
+    (None → no trust folding).
+    """
+    dotgit = root / ".git"
+    try:
+        if not dotgit.is_file():
+            return None
+        pointer = dotgit.read_text(encoding="utf-8", errors="replace").strip()
+        if not pointer.startswith("gitdir:"):
+            return None
+        gitdir = Path(pointer[len("gitdir:"):].strip())
+        if not gitdir.is_absolute():
+            gitdir = root / gitdir
+        commondir_file = gitdir / "commondir"
+        if not commondir_file.is_file():
+            return None
+        common = Path(commondir_file.read_text(encoding="utf-8", errors="replace").strip())
+        if not common.is_absolute():
+            common = gitdir / common
+        common = common.resolve()
+        if common.name != ".git":
+            return None
+        parent = common.parent
+        return None if parent == Path(root).resolve() else parent
+    except OSError:
+        return None
+
+
 def _project_trusted_dirs_from_config() -> Set[Path]:
     """Resolved set of trusted project roots from ``skills.trusted_project_dirs``."""
     parsed = _load_raw_config()
@@ -738,6 +774,24 @@ def is_project_root_trusted(root: Path) -> bool:
         return Path(root).resolve() in _project_trusted_dirs_from_config()
     except OSError:
         return False
+
+
+def _effective_trust_root(root: Path) -> Optional[Path]:
+    """*root* when trusted directly; else its linked-worktree common root when
+    THAT is trusted; else None.
+
+    Trust is a REPO-level decision (see the quarantine note below), and a
+    linked worktree is the same repo — same remote, same commits, same skill
+    content provenance — so one ``hermes skills trust`` on the main checkout
+    covers every worktree. Content safety is unaffected: the scan-time
+    quarantine gate still scans each worktree's skill files independently.
+    """
+    if is_project_root_trusted(root):
+        return root
+    common = _linked_worktree_common_root(root)
+    if common is not None and is_project_root_trusted(common):
+        return common
+    return None
 
 
 def _candidate_project_skills_dirs(root: Path) -> List[Path]:
@@ -773,7 +827,7 @@ def get_project_skills_dirs() -> List[Path]:
     root = find_project_root()
     if root is None:
         return []
-    if not is_project_root_trusted(root):
+    if _effective_trust_root(root) is None:
         return []
     return _candidate_project_skills_dirs(root)
 
@@ -790,7 +844,7 @@ def get_untrusted_project_skills_root() -> Optional[Tuple[Path, int]]:
     if isinstance(skills_cfg, dict) and skills_cfg.get("project_discovery") is False:
         return None
     root = find_project_root()
-    if root is None or is_project_root_trusted(root):
+    if root is None or _effective_trust_root(root) is not None:
         return None
     count = 0
     for d in _candidate_project_skills_dirs(root):
@@ -800,7 +854,9 @@ def get_untrusted_project_skills_root() -> Optional[Tuple[Path, int]]:
             continue
     if count == 0:
         return None
-    return root, count
+    # Name the repo (common root) in the trust hint so one decision covers
+    # every worktree; the counted skills are still the ones THIS tree loads.
+    return (_linked_worktree_common_root(root) or root), count
 
 
 def get_scan_ordered_skills_dirs() -> List[Path]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12997,6 +12997,7 @@ def _cmd_skills_trust(args):
     from agent.skill_utils import (
         PROJECT_SKILLS_SUBDIRS,
         _candidate_project_skills_dirs,
+        _linked_worktree_common_root,
         find_project_root,
         iter_skill_index_files,
     )
@@ -13017,6 +13018,13 @@ def _cmd_skills_trust(args):
                 "pass the project root path explicitly."
             )
             return
+
+    # Trust is repo-level: fold a linked worktree to its main checkout so one
+    # entry covers every worktree (and survives `git worktree remove`).
+    common = _linked_worktree_common_root(root)
+    if common is not None:
+        print(f"Linked worktree of {common} — using the repo root (covers all its worktrees).")
+        root = common
 
     config = load_config()
     skills_cfg = config.setdefault("skills", {})

--- a/tests/agent/test_project_skills.py
+++ b/tests/agent/test_project_skills.py
@@ -172,6 +172,110 @@ class TestNonInteractiveInheritance:
         assert su.find_project_root(start=project_env["repo"]) == project_env["repo"].resolve()
 
 
+def _make_linked_worktree(tmp_path, name="wt"):
+    """A repo + linked worktree laid out exactly as `git worktree add` does,
+    built by hand so the tests need no git binary (same idiom as
+    tests/tools/test_self_repo_guard.py)."""
+    repo = tmp_path / "repo"
+    admin = repo / ".git" / "worktrees" / name
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    wt = tmp_path / name
+    wt.mkdir()
+    (wt / ".git").write_text(f"gitdir: {admin}\n")
+    return repo, wt
+
+
+class TestLinkedWorktreeCommonRoot:
+    def test_resolves_for_linked_worktree(self, tmp_path):
+        repo, wt = _make_linked_worktree(tmp_path)
+        assert su._linked_worktree_common_root(wt) == repo.resolve()
+
+    def test_relative_gitdir_pointer_resolves(self, tmp_path):
+        # `git worktree add` writes absolute pointers, but relative ones are
+        # legal (git supports them after moves); resolve against the worktree.
+        repo, wt = _make_linked_worktree(tmp_path)
+        (wt / ".git").write_text("gitdir: ../repo/.git/worktrees/wt\n")
+        assert su._linked_worktree_common_root(wt) == repo.resolve()
+
+    def test_none_for_normal_clone(self, tmp_path):
+        repo = tmp_path / "clone"
+        (repo / ".git").mkdir(parents=True)
+        assert su._linked_worktree_common_root(repo) is None
+
+    def test_none_for_submodule_pointer(self, tmp_path):
+        # A submodule's .git file points into the superproject's modules dir,
+        # which has NO commondir file — must not fold.
+        superproject = tmp_path / "super"
+        moddir = superproject / ".git" / "modules" / "sub"
+        moddir.mkdir(parents=True)
+        sub = superproject / "sub"
+        sub.mkdir()
+        (sub / ".git").write_text(f"gitdir: {moddir}\n")
+        assert su._linked_worktree_common_root(sub) is None
+
+    def test_none_on_malformed_pointer(self, tmp_path):
+        wt = tmp_path / "broken"
+        wt.mkdir()
+        (wt / ".git").write_text("this is not a gitdir pointer\n")
+        assert su._linked_worktree_common_root(wt) is None
+
+    def test_none_on_dangling_pointer(self, tmp_path):
+        wt = tmp_path / "dangling"
+        wt.mkdir()
+        (wt / ".git").write_text(f"gitdir: {tmp_path / 'gone' / 'worktrees' / 'x'}\n")
+        assert su._linked_worktree_common_root(wt) is None
+
+
+class TestWorktreeTrustFolding:
+    """A linked worktree of a trusted repo is the same repo: project skills
+    load from the worktree's own tree without a per-worktree trust entry."""
+
+    @pytest.fixture
+    def wt_env(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        (home / "skills").mkdir(parents=True)
+        config = home / "config.yaml"
+        config.write_text("skills:\n  external_dirs: []\n")
+        repo, wt = _make_linked_worktree(tmp_path)
+        ag = wt / ".agents" / "skills" / "wt-skill"
+        ag.mkdir(parents=True)
+        (ag / "SKILL.md").write_text(
+            "---\nname: wt-skill\ndescription: from worktree\n---\nbody\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.chdir(wt)
+        su._external_dirs_cache_clear()
+        yield {"home": home, "config": config, "repo": repo, "wt": wt}
+        su._external_dirs_cache_clear()
+
+    def test_worktree_of_trusted_repo_loads_project_skills(self, wt_env):
+        _trust(wt_env["config"], wt_env["repo"])  # trust the MAIN checkout only
+        dirs = su.get_project_skills_dirs()
+        assert dirs == [(wt_env["wt"] / ".agents" / "skills").resolve()]
+
+    def test_worktree_of_untrusted_repo_loads_nothing(self, wt_env):
+        assert su.get_project_skills_dirs() == []
+
+    def test_directly_trusted_worktree_still_works(self, wt_env):
+        # Existing per-worktree trust entries keep working (no regression).
+        _trust(wt_env["config"], wt_env["wt"])
+        assert su.get_project_skills_dirs() != []
+
+    def test_untrusted_notice_suppressed_for_trusted_common_root(self, wt_env):
+        _trust(wt_env["config"], wt_env["repo"])
+        assert su.get_untrusted_project_skills_root() is None
+
+    def test_untrusted_notice_names_common_root(self, wt_env):
+        # Nothing trusted: the `hermes skills trust` hint should name the
+        # repo, so one trust decision covers every worktree.
+        notice = su.get_untrusted_project_skills_root()
+        assert notice is not None
+        root, count = notice
+        assert root == wt_env["repo"].resolve()
+        assert count == 1
+
+
 class TestQuarantine:
     """#48974: dangerous scan verdict excludes a project skill everywhere."""
 

--- a/tests/hermes_cli/test_skills_trust_cmd.py
+++ b/tests/hermes_cli/test_skills_trust_cmd.py
@@ -1,0 +1,94 @@
+"""`hermes skills trust` folds linked-worktree paths to the repo root.
+
+Trusting a worktree path would accrete per-worktree entries that die with
+`git worktree remove`; trust is repo-level, so the command stores the
+common root instead (agent/skill_utils._linked_worktree_common_root).
+"""
+
+import argparse
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _make_linked_worktree(tmp_path, name="wt"):
+    """Repo + linked worktree laid out as `git worktree add` does (file-only,
+    no git binary needed — same fixture as tests/agent/test_project_skills.py)."""
+    repo = tmp_path / "repo"
+    admin = repo / ".git" / "worktrees" / name
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    wt = tmp_path / name
+    wt.mkdir()
+    (wt / ".git").write_text(f"gitdir: {admin}\n")
+    return repo, wt
+
+
+@pytest.fixture
+def cli_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    (home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import agent.skill_utils as su
+
+    su._external_dirs_cache_clear()
+    yield home
+    su._external_dirs_cache_clear()
+
+
+def _trusted_dirs(home: Path):
+    cfg = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    return [str(p) for p in (cfg.get("skills", {}).get("trusted_project_dirs") or [])]
+
+
+def _run_trust(path=None, action="trust"):
+    from hermes_cli.main import _cmd_skills_trust
+
+    args = argparse.Namespace(skills_action=action, path=str(path) if path else None)
+    _cmd_skills_trust(args)
+
+
+class TestSkillsTrustWorktreeFolding:
+    def test_explicit_worktree_path_stores_common_root(
+        self, cli_home, tmp_path, capsys
+    ):
+        repo, wt = _make_linked_worktree(tmp_path)
+        _run_trust(path=wt)
+        assert _trusted_dirs(cli_home) == [str(repo.resolve())]
+        out = capsys.readouterr().out
+        assert "worktree" in out.lower()
+
+    def test_cwd_inside_worktree_stores_common_root(
+        self, cli_home, tmp_path, monkeypatch, capsys
+    ):
+        repo, wt = _make_linked_worktree(tmp_path)
+        monkeypatch.chdir(wt)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        _run_trust()
+        assert _trusted_dirs(cli_home) == [str(repo.resolve())]
+
+    def test_plain_repo_unchanged(self, cli_home, tmp_path, capsys):
+        repo = tmp_path / "plain"
+        (repo / ".git").mkdir(parents=True)
+        _run_trust(path=repo)
+        assert _trusted_dirs(cli_home) == [str(repo.resolve())]
+
+    def test_worktree_of_already_trusted_repo_reports_already_trusted(
+        self, cli_home, tmp_path, capsys
+    ):
+        repo, wt = _make_linked_worktree(tmp_path)
+        _run_trust(path=repo)
+        capsys.readouterr()
+        _run_trust(path=wt)
+        assert _trusted_dirs(cli_home) == [str(repo.resolve())]
+        assert "Already trusted" in capsys.readouterr().out
+
+    def test_untrust_via_worktree_path_removes_repo_entry(
+        self, cli_home, tmp_path, capsys
+    ):
+        repo, wt = _make_linked_worktree(tmp_path)
+        _run_trust(path=repo)
+        _run_trust(path=wt, action="untrust")
+        assert _trusted_dirs(cli_home) == []


### PR DESCRIPTION
## What does this PR do?

Makes project skills load inside linked git worktrees of a trusted repo.

Today the trust gate tests the worktree's own root against `skills.trusted_project_dirs`. `find_project_root()` stops at the nearest `.git`, a worktree's `.git` file counts, and the exact-path membership test in `is_project_root_trusted()` fails because the config lists the main checkout. `get_project_skills_dirs()` returns `[]` (`agent/skill_utils.py:812` on current main). Every surface that consumes it goes dark at once: the Desktop `/` popover, dispatch by full name, and CLI skill loading. The Desktop sidebar's "New worktree" button makes this a two-click reproduction.

The fix folds a linked worktree to its main-checkout root for the trust decision only. A new helper, `_linked_worktree_common_root()`, parses `.git` → `gitdir:` pointer → `commondir` → common `.git` dir → its parent. File reads only, no git subprocess. `hermes_cli/build_info.py` and `tui_gateway/git_probe.py:common_repo_root()` already use this exact resolution for other purposes; this PR applies it to trust. Discovery is unchanged: skill dirs are still read from the worktree's own tree, so a branch that edits a skill loads its own version.

Why folding is correct: trust is documented in this file as a repo-level decision, and a linked worktree is the same repo, sharing its remote, its commits, and the provenance of its skill content. Content safety does not depend on the trust path either way, because the scan-time quarantine gate (#48974) still scans each worktree's skill files independently.

Everything fails closed. A submodule's gitdir has no `commondir`, and malformed or dangling pointers cannot be resolved; both cases return None, which leaves the trust test running exactly as it does today.

## Related Issue

Fixes #99566.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — `_linked_worktree_common_root()` (file-only worktree resolution) and `_effective_trust_root()` (direct trust first, folded trust second, None otherwise). `get_project_skills_dirs()` and `get_untrusted_project_skills_root()` use the folded check. The untrusted notice now names the common root, so the `hermes skills trust` hint points at the repo instead of one worktree.
- `hermes_cli/main.py` — `hermes skills trust`/`untrust` fold a worktree path to the repo root before touching config, with a one-line notice. Trusting from inside a worktree stores one entry that covers all worktrees and survives `git worktree remove`.
- `tests/agent/test_project_skills.py` — 11 new tests: 6 for the resolver (linked worktree, relative pointer, normal clone, submodule, malformed, dangling) and 5 for trust folding (loads with repo-only trust, loads nothing untrusted, direct worktree trust still works, notice suppressed when repo trusted, notice names the common root).
- `tests/hermes_cli/test_skills_trust_cmd.py` — new file, 5 tests for the CLI command (explicit path, cwd inside worktree, plain repo unchanged, already-trusted dedupe, untrust via worktree path).

## How to Test

1. `python -m pytest tests/agent/test_project_skills.py tests/hermes_cli/test_skills_trust_cmd.py -v` — 38 passed.
2. Red verification: with the two source files reverted to main and the new tests kept, 13 of 16 fail. The 3 that pass before the fix are fail-closed negatives (untrusted loads nothing, plain repo unchanged) kept as regression guards.
3. End-to-end against a real worktree, not the hand-built fixture: `git init` + commit a skill under `.agents/skills/` + `git worktree add`, trust only the main repo in a temp `HERMES_HOME`, then from the worktree:
   ```
   project_root: .../realwt
   common_root : .../realrepo
   skill dirs  : ['.../realwt/.agents/skills']
   ```
4. Suite baselines on this branch, Windows 11: `tests/test_tui_gateway_server.py` 618 passed, 2 failed (the two pre-existing toolset failures, identical on clean main); `tests/agent/test_skill_commands.py` 27 passed, 2 failed (pre-existing Windows path drift, identical on clean main).

## Relationship to #90234 / #96514

Independent, and stacking. #96514 makes `find_project_root()` read the session's cwd; #90234 scopes the completion/dispatch RPCs and caches. Neither changes trust identity, so with both merged a Desktop worktree session resolves the worktree root correctly and still fails the trust test. This PR touches none of the files those PRs change. #90234's scan memo keys by resolved project root, so two worktrees get separate cache entries, which is the correct behavior.

Out of scope: #55371 (`.hermes/` gitignored, so skill files are absent from the worktree). That is a missing-files problem. This PR fixes the present-but-untrusted case; a worktree with no skill files on disk still loads nothing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites; failures are the documented pre-existing ones (details above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on every touched function) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; `trusted_project_dirs` semantics widen, docstrings updated)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (path logic is `pathlib` throughout; developed and tested on Windows, where the resolve/realpath pitfalls live)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
