### PR TITLE
fix(kanban): reject assign to unknown profiles

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1958,9 +1958,45 @@ def _cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def _is_known_kanban_assignee(conn, profile: str) -> bool:
+    """True if *profile* is an on-disk Hermes profile or already on this board."""
+    try:
+        canon = kb._canonical_assignee(profile)
+    except ValueError:
+        return False
+    if not canon:
+        return False
+    try:
+        from hermes_cli.profiles import profile_exists
+        if profile_exists(canon):
+            return True
+    except Exception:
+        pass
+    known = {entry["name"] for entry in kb.known_assignees(conn)}
+    return canon in known or profile in known
+
+
+def _reject_unknown_assignee(conn, profile: Optional[str]) -> Optional[int]:
+    """Refuse a brand-new typo assignee. Unassign (profile is None) is always ok."""
+    if profile is None:
+        return None
+    if _is_known_kanban_assignee(conn, profile):
+        return None
+    print(
+        f"kanban: unknown profile {profile!r} — not an on-disk profile "
+        "or an existing board assignee. Create it with "
+        f"`hermes -p {profile} setup`, or unassign with 'none'.",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
     with kb.connect_closing() as conn:
+        refused = _reject_unknown_assignee(conn, profile)
+        if refused is not None:
+            return refused
         ok = kb.assign_task(conn, args.task_id, profile)
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)
@@ -2012,6 +2048,9 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
 def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
     with kb.connect_closing() as conn:
+        refused = _reject_unknown_assignee(conn, profile)
+        if refused is not None:
+            return refused
         ok = kb.reassign_task(
             conn, args.task_id, profile,
             reclaim_first=bool(getattr(args, "reclaim", False)),

--- a/tests/hermes_cli/test_kanban_assign_known_profile.py
+++ b/tests/hermes_cli/test_kanban_assign_known_profile.py
@@ -1,0 +1,115 @@
+"""CLI assign/reassign must refuse names that are not known assignees.
+
+A typo like ``critic-typo`` used to be written onto the card with exit 0,
+leaving review work permanently unclaimable. Known names are on-disk
+profiles (``profile_exists`` / ``list_profiles_on_disk``) or names already
+present as a board assignee. Unassign tokens stay allowed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _write_profile(home: Path, name: str) -> None:
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+
+def _assign(task_id: str, profile: str) -> int:
+    return kc._cmd_assign(argparse.Namespace(task_id=task_id, profile=profile))
+
+
+def _reassign(task_id: str, profile: str) -> int:
+    return kc._cmd_reassign(
+        argparse.Namespace(
+            task_id=task_id, profile=profile, reclaim=False, reason=None,
+        )
+    )
+
+
+def _assignee(task_id: str) -> str | None:
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task.assignee
+
+
+def test_assign_rejects_unknown_profile_typo(kanban_home, capsys):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="review card", assignee="default")
+
+    rc = _assign(tid, "critic-typo")
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "unknown profile" in err
+    assert "critic-typo" in err
+    assert _assignee(tid) == "default"
+
+
+def test_reassign_rejects_unknown_profile_typo(kanban_home, capsys):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="review card", assignee="default")
+
+    rc = _reassign(tid, "critic-typo")
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "unknown profile" in err
+    assert _assignee(tid) == "default"
+
+
+def test_assign_accepts_on_disk_profile(kanban_home, capsys):
+    _write_profile(kanban_home, "critic")
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="review card")
+
+    rc = _assign(tid, "critic")
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Assigned" in out
+    assert _assignee(tid) == "critic"
+
+
+def test_assign_unassign_tokens_still_work(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="review card", assignee="default")
+
+    for token in ("none", "-", "null", "NONE"):
+        with kb.connect_closing() as conn:
+            assert kb.assign_task(conn, tid, "default") is True
+        rc = _assign(tid, token)
+        assert rc == 0, token
+        assert _assignee(tid) is None
+
+
+def test_assign_accepts_name_already_on_the_board(kanban_home, capsys):
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="already assigned", assignee="legacy-worker")
+        tid = kb.create_task(conn, title="retarget me")
+
+    rc = _assign(tid, "legacy-worker")
+
+    assert rc == 0
+    assert "Assigned" in capsys.readouterr().out
+    assert _assignee(tid) == "legacy-worker"
+    assert not (kanban_home / "profiles" / "legacy-worker").exists()


### PR DESCRIPTION
## What does this PR do?

`hermes kanban assign <task> <profile>` (and `reassign`) accepted any non-empty string as an assignee. A typo like `critic-typo` was written onto the card with exit 0, so review work sat in `review` forever — no real profile can claim it, and nothing flagged the dead assignee.

Assign and reassign now refuse a non-empty name that is not an on-disk Hermes profile (`profile_exists` / `list_profiles_on_disk`) and not already present as a board assignee. Unassign tokens (`none` / `-` / `null`) still work. The DB helper is unchanged so existing programmatic callers and tests that seed fake names via `create_task` keep working; this is the CLI hole the field report hit.

## Related Issue

Fixes #99284

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: `_cmd_assign` and `_cmd_reassign` reject unknown profile names with a stderr message and exit 2. Known names are on-disk profiles or names already used as a board assignee.
- `tests/hermes_cli/test_kanban_assign_known_profile.py`: typo rejected; real on-disk profile accepted; unassign tokens work; already-on-board name accepted even when it is not on disk.

## How to Test

From the worktree:

```
uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_assign_known_profile.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_exit_status.py tests/hermes_cli/test_kanban_task_updated_hook.py -q
```

Result: **13 passed**.

Manual check of the field-report shape:

1. `hermes kanban create "review card" --assignee default`
2. `hermes kanban assign <id> critic-typo` — expect stderr `unknown profile 'critic-typo'` and exit 2; `hermes kanban show <id>` still shows `default`.
3. Create a real profile (`hermes -p critic setup` or a `profiles/critic/config.yaml` under the Hermes home) and `hermes kanban assign <id> critic` — expect exit 0.
4. `hermes kanban assign <id> none` — expect unassigned.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

Focused files above were run with `uv run --extra dev python -m pytest … -q` (13 passed). Full `pytest tests/ -q` was not run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Profile lookup uses existing `profile_exists` / `known_assignees` helpers, which already go through `Path` rather than POSIX-only paths.

## Screenshots / Logs

```
.............                                                            [100%]
13 passed in 1.43s
```
