### PR TITLE
fix(kanban): keep review cards in review on assign

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1758,6 +1758,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
             current_step_key=args.current_step_key,
         )
     if getattr(args, "json", False):
+        # Machine-parseable stdout only — no board header, claim banner, or
+        # diagnostics. Downstream `jq` treats a banner prefix as rc=5.
         print(json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False))
         return 0
     # Passive discoverability: when the user has multiple boards, surface
@@ -1961,6 +1963,19 @@ def _cmd_show(args: argparse.Namespace) -> int:
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
     with kb.connect_closing() as conn:
+        task = kb.get_task(conn, args.task_id)
+        if task is None:
+            print(f"no such task: {args.task_id}", file=sys.stderr)
+            return 1
+        if task.status == "review":
+            print(
+                "kanban: cannot assign a card in review — review is a lane, "
+                "not a claim. Name a reviewer with "
+                "`hermes kanban request-review --reviewer <profile>` "
+                "(or swap the reviewer with `hermes kanban reassign`).",
+                file=sys.stderr,
+            )
+            return 2
         ok = kb.assign_task(conn, args.task_id, profile)
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3715,6 +3715,12 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 
     Refuses to reassign a task that's currently running (claim_lock set).
     Reassign after the current run completes if needed.
+
+    This writes the assignee (and the ``assigned`` event) only.  It never
+    changes ``status``, ``started_at``, or ``claim_lock`` — review is a
+    lane, not a claim.  Naming a reviewer on a ``review`` card belongs to
+    :func:`request_review` (or the dashboard reviewer field), not a status
+    flip.
     """
     profile = _canonical_assignee(profile)
     with write_txn(conn):

--- a/tests/hermes_cli/test_kanban_review_assign.py
+++ b/tests/hermes_cli/test_kanban_review_assign.py
@@ -1,0 +1,140 @@
+"""Assign on a review card must not leave the review lane.
+
+CLI ``kanban assign`` is not a reviewer-naming command — that is
+``request-review`` / ``reassign``. The DB helper still records an
+assignee (dashboard + request-review internals) without flipping
+status, started_at, or claim_lock.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _put_in_review(conn, *, assignee="worker", reviewer="reviewer"):
+    tid = kb.create_task(conn, title="impl a feature", assignee=assignee)
+    claimed = kb.claim_task(conn, tid)
+    assert claimed is not None
+    run_id = kb.get_task(conn, tid).current_run_id
+    assert run_id is not None
+    ok = kb.request_review(
+        conn, tid,
+        summary="implementation complete",
+        reviewer=reviewer,
+        expected_run_id=run_id,
+    )
+    assert ok is True
+    task = kb.get_task(conn, tid)
+    assert task is not None and task.status == "review"
+    return task
+
+
+def test_assign_task_keeps_review_lane(kanban_home):
+    with kb.connect_closing() as conn:
+        task = _put_in_review(conn)
+        tid = task.id
+        started_at = task.started_at
+        claim_lock = task.claim_lock
+        assert claim_lock is None
+
+        assert kb.assign_task(conn, tid, "other-reviewer") is True
+
+        after = kb.get_task(conn, tid)
+        assert after is not None
+        assert after.status == "review"
+        assert after.started_at == started_at
+        assert after.claim_lock is None
+        assert after.assignee == "other-reviewer"
+
+
+def test_cli_assign_refuses_review_card(kanban_home, capsys):
+    with kb.connect_closing() as conn:
+        task = _put_in_review(conn)
+        tid = task.id
+        started_at = task.started_at
+        assignee = task.assignee
+
+    rc = kc._cmd_assign(argparse.Namespace(task_id=tid, profile="other-reviewer"))
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "cannot assign a card in review" in err
+    assert "request-review" in err
+    assert "reassign" in err
+
+    with kb.connect_closing() as conn:
+        after = kb.get_task(conn, tid)
+    assert after is not None
+    assert after.status == "review"
+    assert after.started_at == started_at
+    assert after.claim_lock is None
+    assert after.assignee == assignee
+
+
+def test_cli_reassign_swaps_reviewer_without_leaving_review(kanban_home):
+    with kb.connect_closing() as conn:
+        task = _put_in_review(conn)
+        tid = task.id
+        started_at = task.started_at
+
+    rc = kc._cmd_reassign(
+        argparse.Namespace(
+            task_id=tid, profile="other-reviewer", reclaim=False, reason=None,
+        )
+    )
+    assert rc == 0
+
+    with kb.connect_closing() as conn:
+        after = kb.get_task(conn, tid)
+    assert after is not None
+    assert after.status == "review"
+    assert after.started_at == started_at
+    assert after.claim_lock is None
+    assert after.assignee == "other-reviewer"
+
+
+def test_list_json_running_claimed_is_strictly_parseable(kanban_home, capsys):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="claimed running", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.get_task(conn, tid).claim_lock is not None
+
+    rc = kc._cmd_list(
+        argparse.Namespace(
+            assignee=None,
+            mine=False,
+            status=None,
+            tenant=None,
+            session=None,
+            archived=False,
+            sort=None,
+            workflow_template_id=None,
+            current_step_key=None,
+            json=True,
+        )
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.lstrip()[:1] == "["
+    payload = json.loads(captured.out)
+    assert isinstance(payload, list)
+    row = next(r for r in payload if r["id"] == tid)
+    assert row["status"] == "running"
+    assert captured.err == ""


### PR DESCRIPTION
## What does this PR do?

A field report showed `hermes kanban assign` on a review card coinciding with the card flipping `review` → `running` (and `started_at` getting stamped), plus a downstream `jq` rc=5 blamed on `kanban list --json` growing a claim banner.

On current main, `assign_task` already writes only the assignee + `assigned` event — it does not change status, `started_at`, or `claim_lock`. The observed flip is the dispatcher `claim_review_task` (~30s later) treating assign as a spawn trigger. Review is a lane, not a claim: CLI `kanban assign` now refuses when the card is in `review` and points operators at `hermes kanban request-review --reviewer` (first-class handoff) or `hermes kanban reassign` (reviewer swap). The DB helper stays allowed so the dashboard reviewer field and `request_review(reviewer=…)` keep working, and a regression test pins that `assign_task` leaves `review` / `started_at` / `claim_lock` untouched.

`list --json` on current main already dumps only `json.dumps(...)` (no banner). A golden test now requires stdout to be strictly parseable JSON while a running card holds an active claim. The reported rc=5 is jq's parse-error code, a symptom of a polluted stream, not a kanban CLI exit.

`kanban.review_dispatch` is unchanged: `request-review` + dispatcher `claim_review_task` still spawn reviewers.

## Related Issue

Fixes #99285

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: `_cmd_assign` refuses when the task is in `review` (stderr + exit 2). Comment on `_cmd_list --json` that stdout must stay machine-parseable.
- `hermes_cli/kanban_db.py`: docstring on `assign_task` that it does not mutate status / started_at / claim_lock.
- `tests/hermes_cli/test_kanban_review_assign.py`: assign_task keeps the review lane; CLI assign refuses; CLI reassign still swaps the reviewer in review; `list --json` with a running+claimed task is strict JSON.

## How to Test

From the worktree:

```
uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_review_assign.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_task_updated_hook.py -q
```

Result: **30 passed**.

Also reproduced `hermes kanban list --json` via `python -m hermes_cli.main` against a running+claimed card: stdout was a JSON array starting with `[`, stderr empty, `json.loads` succeeded.

Manual check:

1. Create a task, claim it, `hermes kanban request-review <id> --reviewer critic`.
2. `hermes kanban assign <id> other` — expect stderr `cannot assign a card in review` and exit 2; `show` still says `review`.
3. `hermes kanban reassign <id> other` — expect assignee change, status still `review`.
4. Claim a ready task and `hermes kanban list --json | jq .` — must parse.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

Focused files above were run with `uv run --extra dev python -m pytest … -q` (30 passed). Full `pytest tests/ -q` was not run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
..............................                                           [100%]
30 passed in 1.80s
```
