### PR TITLE
fix(desktop): keep model picker on the selected provider

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -20,7 +20,7 @@ import { usePointerQuiet } from '@/components/ui/keyboard-first'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
@@ -39,14 +39,6 @@ import { $defaultReasoningEffort } from '@/store/session'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
-
-/** Whether a catalog row represents the session's current provider. Custom
- *  providers report the canonical `custom:<key>` identity from `model.options`
- *  while the row's slug is the bare config key, so exact slug equality never
- *  matches — check the row's alias set too (#87035). */
-function isCurrentProvider(provider: ModelOptionProvider, currentProvider: string): boolean {
-  return provider.slug === currentProvider || (provider.aliases?.includes(currentProvider) ?? false)
-}
 
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
 // a way to dismiss itself so clicking a model row commits + closes, while the
@@ -258,14 +250,14 @@ export function ModelCatalogMenu({
   const rowIsCurrent = (row: KbRow) =>
     row.kind === 'moa'
       ? current.provider === 'moa' && row.preset === current.model
-      : isCurrentProvider(row.provider, current.provider) &&
+      : catalogProviderMatches(row.provider, current.provider) &&
         (row.family.id === current.model || row.family.fastId === current.model)
 
   const autoIndex = q
     ? kbRows.length > 0
       ? 0
       : -1
-    : kbRows.findIndex(row => rowIsCurrent(row) || (row.kind === 'family' && row.family.fastId === current.model))
+    : kbRows.findIndex(row => rowIsCurrent(row))
 
   const kbIndex = kbOverride !== null && kbOverride < kbRows.length ? kbOverride : autoIndex
   const kbActiveKey = kbIndex >= 0 ? kbRows[kbIndex].key : null
@@ -293,7 +285,7 @@ export function ModelCatalogMenu({
       return
     }
 
-    if (!rowIsCurrent(row) && row.family.fastId !== current.model) {
+    if (!rowIsCurrent(row)) {
       void selectFamily(row.family, row.provider)
     }
 
@@ -400,7 +392,7 @@ export function ModelCatalogMenu({
                     // The active id may be the base or its -fast sibling; either
                     // way this one family row represents both.
                     const activeId =
-                      isCurrentProvider(group.provider, current.provider) &&
+                      catalogProviderMatches(group.provider, current.provider) &&
                       (current.model === family.id || current.model === family.fastId)
                         ? current.model
                         : null
@@ -578,7 +570,7 @@ function groupModels(
     // stable curated order, so selecting a model can't shuffle the list. While
     // SEARCHING the pin is skipped: a query means "show me matches".
     const activeId =
-      !q && isCurrentProvider(provider, current.provider) && current.model
+      !q && catalogProviderMatches(provider, current.provider) && current.model
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -457,6 +457,65 @@ describe('ModelMenuPanel provider collapse', () => {
     })
     expect(onSelectModel).not.toHaveBeenCalled()
   })
+
+  it('does not rewrite the provider when Refresh Models lists the same model id elsewhere', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+
+    const catalog = {
+      model: 'glm-4.5-air',
+      provider: 'zhipu',
+      providers: [
+        { models: ['glm-4.5-air', 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' },
+        { models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' },
+        MOA_PROVIDER
+      ]
+    }
+
+    getGlobalModelOptions.mockResolvedValue(catalog)
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findAllByText(/Glm 4\.5 Air/i)
+    fireEvent.click(await content.findByText('Refresh models'))
+
+    await vi.waitFor(() => {
+      expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
+    })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
+
+  it('marks only the matching provider row current when two providers share a model id', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+    getGlobalModelOptions.mockResolvedValue({
+      model: 'glm-4.5-air',
+      provider: 'zhipu',
+      providers: [
+        { models: ['glm-4.5-air', 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' },
+        { models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' },
+        MOA_PROVIDER
+      ]
+    })
+
+    const { content, onSelectModel } = renderPanel()
+
+    const rows = await content.findAllByText(/Glm 4\.5 Air/i)
+    const items = [...new Set(rows.map(row => row.closest('[role="menuitem"]')))]
+
+    expect(items).toHaveLength(2)
+
+    const checked = items.filter(item => item?.querySelector('.codicon-check'))
+    expect(checked).toHaveLength(1)
+    expect(checked[0]?.closest('[role="group"]')?.textContent).toContain('智谱2')
+    expect(
+      items.find(item => !item?.querySelector('.codicon-check'))?.closest('[role="group"]')?.textContent
+    ).toContain('OpenRouter')
+
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
 })
 
 describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake', () => {

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -109,7 +109,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
       // Group / credential swaps can return a catalog that no longer contains
       // the session's current model. The store + currentPickerSelection would
       // otherwise keep painting the stale id (it is not in the new list).
-      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers)
+      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers, optionsProvider)
 
       if (switchTo) {
         await onSelectModel({ ...switchTo, sessionId: activeSessionId || null })

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
@@ -208,7 +208,7 @@ function ModelResults({
               </div>
             )}
             {models.map(model => {
-              const isCurrent = model === currentModel && provider.slug === currentProvider
+              const isCurrent = model === currentModel && catalogProviderMatches(provider, currentProvider)
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getGlobalModelOptions } from '@/hermes'
 
 import {
+  catalogProviderMatches,
   firstSelectableCatalogModel,
   manualPickRemoved,
   modelOptionsQueryKey,
@@ -220,6 +221,22 @@ describe('manualPickRemoved', () => {
   })
 })
 
+describe('catalogProviderMatches', () => {
+  const cloudflare = {
+    aliases: ['custom:cloudflare', 'cloudflare'],
+    models: ['@cf/meta/llama-3.3-70b-instruct-fp8-fast'],
+    name: 'Cloudflare',
+    slug: 'cloudflare'
+  }
+
+  it('matches slug, display name, and custom-provider aliases', () => {
+    expect(catalogProviderMatches(cloudflare, 'cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'Cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'custom:cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'openrouter')).toBe(false)
+  })
+})
+
 describe('reconcileSelectionAfterCatalogRefresh', () => {
   const zhipu = { name: '智谱2', slug: 'zhipu', models: ['glm-4.5-air', 'glm-5-turbo'] }
 
@@ -231,25 +248,72 @@ describe('reconcileSelectionAfterCatalogRefresh', () => {
 
   const moa = { name: 'Mixture of Agents', slug: 'moa', models: ['default'] }
 
+  const openrouter = {
+    models: ['glm-4.5-air', 'gpt-5.5'],
+    name: 'OpenRouter',
+    slug: 'openrouter'
+  }
+
   it('switches to the first new-group model when the current pick is gone', () => {
-    expect(selectionInCatalog([bytea], 'glm-4.5-air')).toBe(false)
+    expect(selectionInCatalog([bytea], 'glm-4.5-air', 'zhipu')).toBe(false)
     expect(firstSelectableCatalogModel([moa, bytea])).toEqual({
       model: 'deepseek-v4-flash',
       provider: 'byteplus'
     })
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea])).toEqual({
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea], 'zhipu')).toEqual({
       model: 'deepseek-v4-flash',
       provider: 'byteplus'
     })
   })
 
   it('keeps the current pick when it is still in the refreshed catalog', () => {
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa], 'zhipu')).toBeNull()
+  })
+
+  it('keeps the current provider when the same model id exists on another provider', () => {
+    expect(selectionInCatalog([openrouter, zhipu], 'glm-4.5-air', 'zhipu')).toBe(true)
+    expect(selectionInCatalog([openrouter, zhipu], 'glm-4.5-air', 'openrouter')).toBe(true)
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [openrouter, zhipu], 'zhipu')).toBeNull()
+  })
+
+  it('keeps a custom provider pair when OpenRouter lists the same model id', () => {
+    const model = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+
+    const cloudflare = {
+      aliases: ['custom:cloudflare', 'cloudflare'],
+      models: [model],
+      name: 'Cloudflare',
+      slug: 'cloudflare'
+    }
+
+    const openrouterCf = { models: [model, 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' }
+
+    expect(selectionInCatalog([openrouterCf, cloudflare], model, 'custom:cloudflare')).toBe(true)
+    expect(reconcileSelectionAfterCatalogRefresh(model, [openrouterCf, cloudflare], 'custom:cloudflare')).toBeNull()
+  })
+
+  it('does not jump to OpenRouter when the current provider is missing but still lists the same model id', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [openrouter, moa], 'zhipu')).toBeNull()
+  })
+
+  it('keeps the pick when the current provider is present but unconfigured', () => {
+    const emptyZhipu = { models: [], name: '智谱2', slug: 'zhipu' }
+
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [emptyZhipu, openrouter], 'zhipu')).toBeNull()
+  })
+
+  it('falls back when the current provider is populated and dropped the model', () => {
+    const zhipuWithoutAir = { models: ['glm-5-turbo'], name: '智谱2', slug: 'zhipu' }
+
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipuWithoutAir, openrouter], 'zhipu')).toEqual({
+      model: 'glm-5-turbo',
+      provider: 'zhipu'
+    })
   })
 
   it('does not wipe the pick when the refreshed catalog has no selectable models', () => {
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa])).toBeNull()
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [])).toBeNull()
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined)).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa], 'zhipu')).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [], 'zhipu')).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined, 'zhipu')).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,6 +1,37 @@
 import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
 import type { ModelOptionProvider } from '@/types/hermes'
 
+type CatalogProviderIdentity = Pick<ModelOptionProvider, 'aliases' | 'name' | 'slug'>
+
+/** True when `currentProvider` is this catalog row — slug, display name, or
+ *  a custom-provider alias (`custom:<key>` vs the bare config key, #87035). */
+export function catalogProviderMatches(provider: CatalogProviderIdentity, currentProvider: string): boolean {
+  if (!currentProvider) {
+    return false
+  }
+
+  return (
+    provider.slug === currentProvider ||
+    provider.name === currentProvider ||
+    (provider.aliases?.includes(currentProvider) ?? false)
+  )
+}
+
+function findCatalogProvider(
+  providers: ModelOptionProvider[] | undefined,
+  provider: string
+): ModelOptionProvider | undefined {
+  if (!providers?.length || !provider) {
+    return undefined
+  }
+
+  return providers.find(row => catalogProviderMatches(row, provider))
+}
+
+function catalogHasModel(providers: ModelOptionProvider[] | undefined, model: string): boolean {
+  return Boolean(model) && (providers?.some(provider => (provider.models ?? []).includes(model)) ?? false)
+}
+
 /**
  * True only when a persisted **manual** composer pick has been removed from the
  * catalog (its provider still ships models, but no longer this one) — so a new
@@ -17,7 +48,7 @@ export function manualPickRemoved(
     return false
   }
 
-  const row = providers.find(p => p.slug === provider || p.name === provider)
+  const row = findCatalogProvider(providers, provider)
 
   if (!row) {
     return false
@@ -36,14 +67,21 @@ export function manualPickRemoved(
 
 const MOA_PROVIDER_SLUG = 'moa'
 
-/** True when `model` appears in any provider's live list. Used after Refresh
- *  Models so a group/catalog swap can tell "still offered" from "gone". */
-export function selectionInCatalog(providers: ModelOptionProvider[] | undefined, model: string): boolean {
-  if (!providers?.length || !model) {
+/** True when THIS provider still lists `model`. Identity is the (provider,
+ *  model) pair: the same id on OpenRouter does not count as the custom /
+ *  first-party pick still being offered. */
+export function selectionInCatalog(
+  providers: ModelOptionProvider[] | undefined,
+  model: string,
+  provider?: string
+): boolean {
+  if (!providers?.length || !model || !provider) {
     return false
   }
 
-  return providers.some(provider => (provider.models ?? []).includes(model))
+  const row = findCatalogProvider(providers, provider)
+
+  return Boolean(row && (row.models ?? []).includes(model))
 }
 
 /** First real (non-MoA) catalog row that still has models. */
@@ -70,14 +108,20 @@ export function firstSelectableCatalogModel(
 }
 
 /**
- * After Refresh Models replaces the catalog: keep the current pick when it is
- * still listed; otherwise switch to the first available model in the new
- * catalog. Returns null when the catalog is empty/unloaded so we never wipe
- * a selection on a failed or still-hydrating refresh.
+ * After Refresh Models replaces the catalog: keep the current **pair** when
+ * that provider still lists the model. Never rewrite the provider just because
+ * another catalog row (OpenRouter, …) exposes the same model id.
+ *
+ * Conservative like `manualPickRemoved` when the current provider is absent or
+ * unconfigured (empty models) — except a fully gone model (group / credential
+ * swap that dropped the id everywhere) still falls back to the first
+ * selectable row. Returns null when the catalog is empty/unloaded so we never
+ * wipe a selection on a failed or still-hydrating refresh.
  */
 export function reconcileSelectionAfterCatalogRefresh(
   currentModel: string,
-  providers: ModelOptionProvider[] | undefined
+  providers: ModelOptionProvider[] | undefined,
+  currentProvider?: string
 ): { model: string; provider: string } | null {
   const next = firstSelectableCatalogModel(providers)
 
@@ -85,7 +129,40 @@ export function reconcileSelectionAfterCatalogRefresh(
     return null
   }
 
-  if (selectionInCatalog(providers, currentModel)) {
+  if (!currentModel) {
+    return next
+  }
+
+  if (currentProvider) {
+    if (selectionInCatalog(providers, currentModel, currentProvider)) {
+      return null
+    }
+
+    const row = findCatalogProvider(providers, currentProvider)
+
+    // Present but empty: re-auth / unconfigured, not "model dropped".
+    if (row && (row.models ?? []).length === 0) {
+      return null
+    }
+
+    // This provider still ships models and dropped this one — fall back.
+    if (row) {
+      return next
+    }
+
+    // Provider missing from the refreshed catalog. Another provider listing
+    // the same id is NOT a reason to switch (the OpenRouter collision).
+    if (catalogHasModel(providers, currentModel)) {
+      return null
+    }
+
+    return next
+  }
+
+  // No provider on the current pair: keep when the id is still offered
+  // anywhere, otherwise fall back. Callers that know the provider must pass it
+  // so a shared id cannot retarget the pick.
+  if (catalogHasModel(providers, currentModel)) {
     return null
   }
 


### PR DESCRIPTION
## What does this PR do?

Desktop model identity is a **(provider, model)** pair. The picker was treating a model id as unique across the catalog, so a custom/first-party pick jumped to OpenRouter whenever that provider also listed the same id (repro: `custom:cloudflare` + `@cf/meta/llama-3.3-70b-instruct-fp8-fast`).

This keeps the selected provider unless *that* provider dropped the model from a populated catalog. Sharing an id with OpenRouter is not a reason to switch.

## Related Issue

Fixes #99389

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/model-options.ts` — `selectionInCatalog` requires the given provider (slug, name, or custom alias) to still list the model. `reconcileSelectionAfterCatalogRefresh` takes `currentProvider` and never retargets to another provider just because it also lists the same id. Absent/unconfigured providers stay conservative (keep); a populated provider that dropped the model still falls back to `firstSelectableCatalogModel`.
- `apps/desktop/src/app/shell/model-menu-panel.tsx` — Refresh Models passes the current provider into reconcile.
- `apps/desktop/src/app/shell/model-catalog-menu.tsx` — keyboard highlight/commit no longer treats a matching `-fast` id on a *different* provider as current.
- `apps/desktop/src/components/model-picker.tsx` — `ModelResults` marks current by provider+model (including name/alias), not slug-only.
- Tests in `model-options.test.ts` and `model-menu-panel.test.tsx` covering glm-4.5-air on both zhipu and OpenRouter, plus the Cloudflare/OpenRouter collision.

## How to Test

1. From `apps/desktop`:
   ```bash
   npx vitest run src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx src/app/shell/model-catalog-menu.test.tsx src/lib/model-status-label.test.ts src/app/session/hooks/use-model-controls.test.tsx src/app/chat/composer/model-pill.test.tsx
   ```
   All 91 tests passed.
2. Repro: configure `custom:cloudflare` with `@cf/meta/llama-3.3-70b-instruct-fp8-fast` (also in the OpenRouter catalog). Open the Desktop model picker, select that pair, Refresh Models. The pick must stay on `custom:cloudflare`, not jump to OpenRouter.
3. CLI `/model … --provider` is unchanged (already worked).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  (N/A — Desktop-only TypeScript; ran the vitest files listed above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (vitest in `apps/desktop`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — picker identity is covered by vitest (shared model id on zhipu + OpenRouter keeps zhipu; Cloudflare alias pair stays off OpenRouter).
