### PR TITLE
fix(runs): expose cached_tokens in /v1/runs usage payload

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -855,6 +855,13 @@ async def _handle_runs(
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        # input_tokens is cache-inclusive (CanonicalUsage
+                        # prompt_tokens = input + cache_read + cache_write),
+                        # so a warm cached run looks identical to a cold one.
+                        # Expose the cached reads so clients can record and
+                        # split them (#99554); the existing keys keep their
+                        # semantics.
+                        "cached_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
                     }
                     return r, u
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -125,6 +125,7 @@ def _make_slow_agent(**kwargs):
     mock_agent.session_prompt_tokens = 0
     mock_agent.session_completion_tokens = 0
     mock_agent.session_total_tokens = 0
+    mock_agent.session_cache_read_tokens = 0
 
     return mock_agent, ready, interrupted
 
@@ -180,6 +181,7 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 10
                 mock_agent.session_completion_tokens = 5
                 mock_agent.session_total_tokens = 15
+                mock_agent.session_cache_read_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
@@ -219,6 +221,7 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -286,6 +289,7 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -326,6 +330,7 @@ class TestRunStatus:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -346,6 +351,44 @@ class TestRunStatus:
                 assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
 
+    @pytest.mark.asyncio
+    async def test_completed_usage_reports_cached_tokens(self, adapter):
+        """/v1/runs usage must expose cached reads alongside the totals (#99554).
+
+        ``input_tokens`` is cache-inclusive (CanonicalUsage.prompt_tokens =
+        input + cache_read + cache_write), so without a ``cached_tokens`` key
+        a warm cached run is indistinguishable from a cold one and clients
+        record zero cached tokens.
+        """
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 1_000
+                mock_agent.session_completion_tokens = 50
+                mock_agent.session_total_tokens = 1_050
+                mock_agent.session_cache_read_tokens = 900
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                status = {}
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "completed"
+                assert status["usage"]["input_tokens"] == 1_000
+                assert status["usage"]["output_tokens"] == 50
+                assert status["usage"]["total_tokens"] == 1_050
+                assert status["usage"]["cached_tokens"] == 900
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id}/events — SSE event stream
@@ -364,6 +407,7 @@ class TestRunEvents:
                 mock_agent.session_prompt_tokens = 10
                 mock_agent.session_completion_tokens = 5
                 mock_agent.session_total_tokens = 15
+                mock_agent.session_cache_read_tokens = 0
                 mock_create.return_value = mock_agent
 
                 # Start run
@@ -537,6 +581,7 @@ class TestSteerRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 mock_agent.steer = MagicMock(return_value=True)
 
                 def _interrupt(_message=None):
@@ -587,6 +632,7 @@ class TestSteerRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 mock_agent.run_conversation.return_value = {
                     "final_response": "done",
                     "pending_steer": "tighten the ending",
@@ -703,6 +749,7 @@ class TestStopRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
                 started = threading.Event()
 
                 def _run_conversation(*_args, **_kwargs):
@@ -886,6 +933,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 accepted = await cli.post(
                     "/v1/runs", json={"input": "valid"}, headers=headers
@@ -918,6 +966,7 @@ class TestRunIdempotency:
                     agent.session_prompt_tokens = agent.session_completion_tokens = (
                         agent.session_total_tokens
                     ) = 0
+                    agent.session_cache_read_tokens = 0
                     create.return_value = agent
                     accepted = await cli.post(
                         "/v1/runs", json={"input": "valid"}, headers=headers
@@ -943,6 +992,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 headers = {"Idempotency-Key": "retry-1"}
                 first = await cli.post(
@@ -968,6 +1018,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 headers = {"Idempotency-Key": "same-key"}
                 assert (
@@ -1000,6 +1051,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
 
                 async def post():
@@ -1203,6 +1255,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 first = await cli.post("/v1/runs", json={"input": "hello"})
                 second = await cli.post("/v1/runs", json={"input": "hello"})
@@ -1222,6 +1275,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 first_headers = {
                     "Authorization": "Bearer sk-secret",
@@ -1256,6 +1310,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 headers = {
                     "Authorization": "Bearer sk-secret",
@@ -1295,6 +1350,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 started = await cli.post(
                     "/v1/runs",
@@ -1400,6 +1456,7 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 response = await cli.post(
                     "/v1/runs", json={"input": "no stored session"}
@@ -2004,6 +2061,7 @@ class TestHostedRoomRuns:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
                 create.return_value = agent
                 started = await cli.post(
                     "/v1/runs",

--- a/tests/tui_gateway/test_hosted_room_two_gateway_scoped.py
+++ b/tests/tui_gateway/test_hosted_room_two_gateway_scoped.py
@@ -146,6 +146,7 @@ async def test_in_process_scoped_transport_contract_finishes_headlessly(
     agent.session_prompt_tokens = agent.session_completion_tokens = (
         agent.session_total_tokens
     ) = 0
+    agent.session_cache_read_tokens = 0
     with patch.object(target, "_create_agent", return_value=agent):
         home.start()
         home.send(


### PR DESCRIPTION
## What does this PR do?

The `/v1/runs` usage payload reports `input_tokens` from `session_prompt_tokens`, which is cache-inclusive: `CanonicalUsage.prompt_tokens = input + cache_read + cache_write` and that is what accumulates on every API call (`agent/conversation_loop.py`). A client reading the run payload therefore cannot distinguish a prompt served almost entirely from the provider cache from one fully billed as fresh input — the two look identical, and clients that store the buckets as given record zero cached tokens with no way to backfill.

The cache-read counter (`session_cache_read_tokens`) is already maintained right beside the totals but never reached the payload. This PR exposes it as an additive `cached_tokens` key on the run usage object, which rides on the `run.completed` SSE event, the stored run status, and `GET /v1/runs/{run_id}`. The existing three keys keep their semantics, so the split is fully reconstructable (`input_tokens - cached_tokens` = fresh input) with no breaking change.

## Related Issue

Fixes #99554

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server_runs.py` — add `cached_tokens` (from `agent.session_cache_read_tokens`, same `getattr(..., 0) or 0` defensive pattern as the neighbouring keys) to the usage dict built in `_run_sync`
- `tests/gateway/test_api_server_runs.py` — regression test `test_completed_usage_reports_cached_tokens` asserting the completed-run status payload carries the cached count alongside the totals; every mock agent that pins the usage counters now also pins `session_cache_read_tokens` (MagicMock auto-attributes are truthy and would otherwise leak into the SSE JSON payload)
- `tests/tui_gateway/test_hosted_room_two_gateway_scoped.py` — same mock pin for the scoped hosted-room runs path

## How to Test

1. `pytest tests/gateway/test_api_server_runs.py -q` — Observed result: 58 passed (includes the new regression test)
2. `pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_active_work_drain.py tests/gateway/test_api_server_compaction_projection.py tests/gateway/test_session_api.py tests/tui_gateway/test_hosted_room_two_gateway_scoped.py -q` — Observed result: 163 passed
3. Manual end-to-end: start the API server against a provider that reports prompt-cache hits, repeat the same run on one `session_id`, and compare `GET /v1/runs/{run_id}` across the cold and warm runs — should pass: the warm run now shows a non-zero `cached_tokens` while `input_tokens` stays the cache-inclusive total

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass (targeted suites listed under How to Test: 221 passed across the touched surfaces)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure dict-key addition, no platform surface)
- [ ] I have updated tool descriptions/schemas if I changed tool behavior — or N/A