### PR TITLE
fix(prompt): keep bundled AGENTS.md out of Desktop chats (salvage #97465)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -892,8 +892,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
+        context_cwd = resolve_context_cwd()
+        if getattr(agent, "_context_cwd_is_launch_artifact", False):
+            # Desktop session creation pins the backend launch directory so
+            # tools have a deterministic cwd even when the user picked no
+            # workspace. Preserve that tool routing, but let context discovery
+            # see it as the fallback it really is. The install-tree guard can
+            # then reject Hermes's bundled contributor AGENTS.md (#97448).
+            context_cwd = None
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+            cwd=context_cwd, skip_soul=_soul_loaded,
             context_length=_ctx_len,
             allow_install_tree_fallback=agent.platform in ("cli", "tui"),
             home_override=_agent_home(agent))

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -66,6 +66,50 @@ class TestContextFileCwd:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
 
+    def test_desktop_launch_artifact_does_not_load_bundled_agents_md(
+        self, monkeypatch, tmp_path
+    ):
+        import agent.runtime_cwd as runtime_cwd
+
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", tmp_path.resolve())
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "AGENTS.md").write_text("bundled contributor instructions")
+
+        agent = _make_agent(
+            platform="desktop",
+            _context_cwd_is_launch_artifact=True,
+        )
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("agent.system_prompt.resolve_context_cwd", return_value=tmp_path),
+        ):
+            context = build_system_prompt_parts(agent)["context"]
+
+        assert "bundled contributor instructions" not in context
+
+    def test_desktop_explicit_install_tree_workspace_still_loads_agents_md(
+        self, monkeypatch, tmp_path
+    ):
+        import agent.runtime_cwd as runtime_cwd
+
+        monkeypatch.setattr(runtime_cwd, "_PACKAGE_ROOT", tmp_path.resolve())
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "AGENTS.md").write_text("chosen workspace instructions")
+
+        agent = _make_agent(
+            platform="desktop",
+            _context_cwd_is_launch_artifact=False,
+        )
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("agent.system_prompt.resolve_context_cwd", return_value=tmp_path),
+        ):
+            context = build_system_prompt_parts(agent)["context"]
+
+        assert "chosen workspace instructions" in context
+
 
 def _stable_prompt(agent):
     with (

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -496,6 +496,21 @@ def test_desktop_launch_cwd_is_not_persisted_as_a_workspace():
     ) == "/picked/repo"
 
 
+def test_desktop_launch_cwd_is_marked_as_context_artifact():
+    assert server._context_cwd_is_launch_artifact(
+        {"source": "desktop", "cwd": "/opt/hermes"}
+    ) is True
+
+
+def test_explicit_desktop_and_terminal_cwds_are_context_workspaces():
+    assert server._context_cwd_is_launch_artifact(
+        {"source": "desktop", "cwd": "/picked/repo", "explicit_cwd": True}
+    ) is False
+    assert server._context_cwd_is_launch_artifact(
+        {"source": "tui", "cwd": "/opt/hermes"}
+    ) is False
+
+
 def test_home_container_dirs_are_never_a_workspace(tmp_path):
     """`/home` and `/Users` hold homes; they are not workspaces themselves.
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -509,6 +510,51 @@ def test_explicit_desktop_and_terminal_cwds_are_context_workspaces():
     assert server._context_cwd_is_launch_artifact(
         {"source": "tui", "cwd": "/opt/hermes"}
     ) is False
+
+
+@pytest.mark.parametrize(
+    ("explicit_cwd", "launch_artifact"),
+    [(True, False), (False, True)],
+)
+def test_desktop_agent_rebuild_preserves_workspace_provenance(
+    monkeypatch, explicit_cwd, launch_artifact
+):
+    captured = {}
+    session = {
+        "agent": object(),
+        "attached_images": [],
+        "cwd": "/picked/repo" if explicit_cwd else "/opt/hermes",
+        "edit_snapshots": {},
+        "explicit_cwd": explicit_cwd,
+        "history": ["old"],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "image_counter": 0,
+        "running": False,
+        "session_key": "stored-session",
+        "show_reasoning": False,
+        "source": "desktop",
+        "tool_progress_mode": "off",
+        "tool_started_at": {},
+    }
+
+    def _make_agent(*_args, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: None)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+
+    server._reset_session_agent("live-session", session)
+
+    assert captured["context_cwd_is_launch_artifact"] is launch_artifact
 
 
 def test_home_container_dirs_are_never_a_workspace(tmp_path):

--- a/tests/tui_gateway/test_session_db_ownership_teardown.py
+++ b/tests/tui_gateway/test_session_db_ownership_teardown.py
@@ -368,6 +368,34 @@ def test_deferred_build_transfers_the_handle_on_success(
     assert session["agent"]._owns_session_db is True
 
 
+def test_deferred_build_uses_the_preserved_desktop_workspace_provenance(
+    build_env, registered, monkeypatch
+):
+    captured: dict = {}
+
+    def _fake_make_agent(*_args, session_db=None, **kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(_session_db=session_db, _owns_session_db=False)
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
+    monkeypatch.setattr(
+        server, "_session_source", lambda current: current.get("source")
+    )
+    sid, session = "sid-workspace", _session(build_env.profile_home)
+    session.update(
+        {
+            "cwd": "C:/picked/repo",
+            "explicit_cwd": True,
+            "source": "desktop",
+        }
+    )
+    registered(sid, session)
+
+    _run_build(sid, session)
+
+    assert captured["context_cwd_is_launch_artifact"] is False
+
+
 def test_deferred_build_closes_the_handle_when_the_session_is_reaped_midbuild(
     build_env, registered, monkeypatch
 ):

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -134,6 +134,28 @@ def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
     assert scoped[0].closed == 1
 
 
+def test_deferred_desktop_resume_keeps_stored_workspace_provenance(
+    profile_dbs, monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    def _factory(db_path=None, **kwargs):
+        db = _RecordingDB(db_path=db_path, **kwargs)
+        db.rows["s1"] = {"id": "s1", "cwd": str(workspace)}
+        profile_dbs.append(db)
+        return db
+
+    monkeypatch.setattr("hermes_state.SessionDB", _factory)
+
+    resp = _resume(session_id="s1", profile="work", source="desktop")
+    session = server._sessions[resp["result"]["session_id"]]
+
+    assert session["cwd"] == str(workspace)
+    assert session["explicit_cwd"] is True
+    assert server._context_cwd_is_launch_artifact(session) is False
+
+
 def test_resume_closes_profile_db_when_reopen_fails(profile_dbs, monkeypatch):
     """The 'resume failed' early return must not leak the handle."""
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -573,6 +573,9 @@ class ComputeHost:
                 reasoning_config_override=frame.get("reasoning_config_override"),
                 service_tier_override=frame.get("service_tier_override"),
                 platform_override=frame.get("source"),
+                context_cwd_is_launch_artifact=bool(
+                    frame.get("context_cwd_is_launch_artifact", False)
+                ),
                 session_db=session_db,
             )
             if server._transfer_db_to_agent(agent, session_db):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -689,6 +689,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 lazy=True,
                 todo_state=_todo_state_from_history(history),
+                explicit_cwd=bool(profile_resume_cwd),
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -760,6 +761,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                explicit_cwd=bool(profile_resume_cwd),
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -860,6 +862,7 @@ def _(rid, params: dict) -> dict:
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
                 todo_state=_todo_state_from_history(history),
+                explicit_cwd=bool(profile_resume_cwd),
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -998,6 +1001,7 @@ def _(rid, params: dict) -> dict:
                         cwd=profile_resume_cwd,
                         session_db=db,
                         source=source,
+                        explicit_cwd=bool(profile_resume_cwd),
                     )
                     # Ownership TRANSFER — the registered session's agent now
                     # holds this handle for its whole life, and _init_session
@@ -3324,6 +3328,7 @@ def _(rid, params: dict) -> dict:
                 session_db=branch_db,
                 source=source,
                 profile_home=parent_home,
+                explicit_cwd=bool(session.get("explicit_cwd")),
             )
             # Ownership TRANSFER — the branched session's agent holds this
             # handle for its whole life and closes it on teardown. Drop is

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -945,6 +945,10 @@ def _(rid, params: dict) -> dict:
                     session_id=target,
                     session_db=db,
                     platform_override=source,
+                    context_cwd_is_launch_artifact=(
+                        source in _LAUNCH_CWD_NOT_A_WORKSPACE
+                        and not profile_resume_cwd
+                    ),
                     **stored_runtime_overrides,
                 )
             finally:
@@ -3304,6 +3308,9 @@ def _(rid, params: dict) -> dict:
                     session_id=new_key,
                     session_db=branch_db,
                     platform_override=source,
+                    context_cwd_is_launch_artifact=(
+                        _context_cwd_is_launch_artifact(session)
+                    ),
                 )
             finally:
                 _clear_session_context(tokens)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2634,6 +2634,7 @@ def _compute_host_turn_frame(
         "history_version": history_version,
         "cols": int(session.get("cols", 80) or 80),
         "cwd": _session_cwd(session),
+        "context_cwd_is_launch_artifact": _context_cwd_is_launch_artifact(session),
         "profile_home": session.get("profile_home") or "",
         "model_override": session.get("model_override"),
         "reasoning_config_override": session.get("create_reasoning_override"),
@@ -3566,6 +3567,15 @@ def _session_cwd(session: dict | None) -> str:
 # a workspace the user picked. Everything else is terminal-started: the process
 # runs in a directory the user deliberately cd'd into.
 _LAUNCH_CWD_NOT_A_WORKSPACE = {"desktop"}
+
+
+def _context_cwd_is_launch_artifact(session: dict | None) -> bool:
+    """Whether the session cwd came from app launch rather than user intent."""
+    return bool(
+        session
+        and not session.get("explicit_cwd")
+        and _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE
+    )
 
 
 def _persisted_session_cwd(session: dict) -> str | None:
@@ -8822,6 +8832,7 @@ def _make_agent(
     reasoning_config_override: dict | None = None,
     service_tier_override: str | None = None,
     platform_override: str | None = None,
+    context_cwd_is_launch_artifact: bool | None = None,
 ):
     # AC-4 test seam: dead unless explicitly armed by the isolated certify
     # harness. Both inline and compute-host paths construct through _make_agent,
@@ -8951,7 +8962,7 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
-    return AIAgent(
+    agent = AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
@@ -8998,6 +9009,16 @@ def _make_agent(
         fallback_model=_load_fallback_model(),
         **_agent_cbs(sid),
     )
+    if context_cwd_is_launch_artifact is None:
+        with _sessions_lock:
+            context_session = _sessions.get(sid)
+        context_cwd_is_launch_artifact = _context_cwd_is_launch_artifact(
+            context_session
+        )
+    agent._context_cwd_is_launch_artifact = bool(
+        context_cwd_is_launch_artifact
+    )
+    return agent
 
 
 def _init_session(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3221,7 +3221,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session
                 # instead of starting a fresh one under the same key.
-                kw = {"session_db": session_db}
+                kw = {
+                    "session_db": session_db,
+                    "context_cwd_is_launch_artifact": (
+                        _context_cwd_is_launch_artifact(current)
+                    ),
+                }
                 if resume_sid := current.get("resume_session_id"):
                     kw["session_id"] = resume_sid
                 kw["platform_override"] = _session_source(current)
@@ -8662,6 +8667,9 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
             session["session_key"],
             session_id=session["session_key"],
             platform_override=_session_source(session),
+            context_cwd_is_launch_artifact=(
+                _context_cwd_is_launch_artifact(session)
+            ),
         )
     finally:
         _clear_session_context(tokens)
@@ -9031,6 +9039,7 @@ def _init_session(
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
+    explicit_cwd: bool = False,
 ):
     now = time.time()
     with _sessions_lock:
@@ -9047,6 +9056,7 @@ def _init_session(
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
+            "explicit_cwd": bool(explicit_cwd),
             "cols": cols,
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
@@ -10452,6 +10462,7 @@ def _deferred_session_record(
     model_override=None,
     resume_runtime_overrides: dict | None = None,
     todo_state: dict | None = None,
+    explicit_cwd: bool = False,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -10468,7 +10479,7 @@ def _deferred_session_record(
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
         "edit_snapshots": {},
-        "explicit_cwd": False,
+        "explicit_cwd": bool(explicit_cwd),
         "history": history,
         "history_lock": threading.Lock(),
         "history_version": 0,


### PR DESCRIPTION
Fixes #97448. Salvages PR #97465 by @fangliquanflq (2 commits cherry-picked, authorship preserved; conflicts hand-resolved against current main).

## Problem

On a fresh Desktop install with no selected workspace, the first prompt could approach ~100 KB because the Hermes install tree's own contributor `AGENTS.md` was loaded into the user context. Desktop session creation resolves the backend launch directory as the live session cwd (correct for terminal/file tool routing) and `_set_session_context` exposed it to `resolve_context_cwd()` as if it were a user-selected workspace — bypassing the #65485 install-tree fallback guard in `build_context_files_prompt()`. The cwd had two meanings (execution routing vs. context authority) and only one was user intent.

## Fix (@fangliquanflq, from #97465)

Track whether a session cwd is an unselected Desktop launch artifact (provenance flag through `_init_session` / `_deferred_session_record` / compute-host turn isolation / session rebuild), and map ONLY that provenance back to a fallback cwd before context discovery — the existing install-tree guard then rejects the bundled instructions. Tool cwd routing, explicit Desktop workspace selection, and CLI/TUI launch-directory context loading are unchanged. Second commit preserves resumed-workspace provenance (`explicit_cwd` on profile resume paths).

Conflict resolution notes: the branch was ~420 commits behind; conflicts in `methods_session.py` / `server.py` were both-sides-added parameter lists (`todo_state` from main + `explicit_cwd` from the PR) — both kept. Verified no PR hunks were lost (`git diff pr-97465 -- <files>` shows no missing `explicit_cwd`/`launch_artifact` lines).

## Verification

**Live repro (sabotage A/B):** with the fix's non-test files reverted to origin/main, `test_desktop_launch_artifact_does_not_load_bundled_agents_md` FAILS (bundled AGENTS.md loads); with the fix, passes.

Targeted suites: `tests/agent/test_system_prompt.py` + `tests/tui_gateway/test_projects_rpc.py` — 84 passed; `test_session_db_ownership_teardown.py` + `test_session_resume_db_ownership.py` (lease/ownership code from 39f1e1881a that landed after the PR branched) — 28 passed.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa891be/y3X0ZADFoKcbPGUWdSUO2_aR3NQKkk.png)
