### PR TITLE
fix(agent): persist usage anchors across agent_init

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -37,6 +37,7 @@ from agent.session_activity import ActivityProvenance
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     fetch_model_metadata,
+    init_agent_usage_anchor,
     is_local_endpoint,
     query_ollama_num_ctx,
 )
@@ -2967,10 +2968,12 @@ def init_agent(
     agent._is_user_initiated_turn = False
 
     # Usage-anchored context accounting (agent/model_metadata.py): the last
-    # main-loop provider response's exact usage + transcript snapshot. None
-    # until the first response with usage; invalidated on compaction and
-    # session switches so stale anchors can never suppress compression.
-    agent._usage_anchor = None
+    # main-loop provider response's exact usage + transcript snapshot.
+    # Restored from the session row when the durable transcript still
+    # matches the content fingerprint so a per-turn process spawn
+    # (desktop group-chat) can still skip the estimator. Compaction and
+    # session reset clear the blob; a mismatch leaves None (fail closed).
+    init_agent_usage_anchor(agent)
 
     # Cumulative token usage for the session
     agent.session_prompt_tokens = 0

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -310,6 +310,12 @@ def _record_codex_app_server_compaction(
     # Native compaction rewrote the provider-side context; the usage anchor's
     # transcript snapshot no longer matches what will be sent. Invalidate it.
     agent._usage_anchor = None
+    try:
+        from agent.model_metadata import persist_usage_anchor
+
+        persist_usage_anchor(agent, None)
+    except Exception:
+        pass
 
     agent._last_compaction_in_place = False
     try:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -73,8 +73,10 @@ from agent.context_engine import (
 )
 from agent.memory_provider import PRE_COMPRESS_CHECKPOINT_API_VERSION
 from agent.model_metadata import (
+    USAGE_ANCHOR_MODEL_CONFIG_KEY,
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
+    persist_usage_anchor,
 )
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
 
@@ -4564,6 +4566,7 @@ def compress_context(
                         compressed,
                         model_config_patch={
                             PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY: None,
+                            USAGE_ANCHOR_MODEL_CONFIG_KEY: None,
                         },
                         watermark=_commit_watermark,
                         lock_holder=_lock_holder,
@@ -5146,6 +5149,7 @@ def compress_context(
         # the next response with usage re-anchors (its structural id/index
         # check would also fail closed, but explicit is safer).
         agent._usage_anchor = None
+        persist_usage_anchor(agent, None)
         # Arm the effectiveness verdict only after a completed rewrite crosses
         # the full compaction boundary. Exceptions, aborts, and no-op attempts
         # leave this false, so unrelated later usage cannot be charged to an

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -80,6 +80,7 @@ from agent.model_metadata import (
     get_context_length_from_provider_error,
     is_output_cap_error,
     parse_available_output_tokens_from_error,
+    persist_usage_anchor,
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
@@ -4322,6 +4323,7 @@ def run_conversation(
                     )
                     if _new_anchor is not None:
                         agent._usage_anchor = _new_anchor
+                        persist_usage_anchor(agent, _new_anchor)
                     _compression_threshold = int(
                         getattr(agent.context_compressor, "threshold_tokens", 0)
                         or 0

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3866,10 +3866,60 @@ def estimate_request_tokens_rough(
 #       captured response is NOT yet appended at the capture site; when it
 #       appears at index base_count its cost is covered by completion_tokens,
 #       so the delta walk skips it).
-#   base_last_id / base_last_role — identity fingerprint of the last message
-#       at capture time. Compaction, splices, and history rewrites shift or
-#       replace that element, failing the check and falling back to full
-#       estimation. Belt-and-braces on top of explicit invalidation.
+#   base_last_id / base_last_role — in-process identity of the last message
+#       at capture time. ``id()`` is the fast path and fails closed on any
+#       rewrite that produced new dicts (compaction, splice) even when
+#       values look the same.
+#   base_last_fp — content fingerprint (role + content digest, plus tool
+#       call identity when present). Survives process restart; restore
+#       drops ``base_last_id`` and matches on this instead. Compaction and
+#       session reset clear the persisted blob so a rewritten transcript
+#       cannot suppress compression.
+#
+# Desktop group-chat can spawn a fresh ``--profile <name> serve`` process
+# per turn (#99421). The blob lives on the session row's ``model_config``
+# JSON (same slot as the proactive-prune runway) keyed by session_id.
+
+
+USAGE_ANCHOR_MODEL_CONFIG_KEY = "_usage_anchor"
+
+
+def _stable_json_bytes(value: Any) -> bytes:
+    """Canonical JSON bytes for fingerprinting; never raises."""
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            default=str,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, OverflowError):
+        return repr(value).encode("utf-8", errors="replace")
+
+
+def usage_anchor_message_fingerprint(msg: Any) -> Optional[str]:
+    """Stable hash of one transcript message (role + content digest).
+
+    Persistence-only fields (timestamp, row markers) are omitted so a
+    DB-reloaded dict with the same role/content matches the in-memory
+    capture. Tool-call identity is included so empty-content tool turns
+    do not collide.
+    """
+    if not isinstance(msg, dict):
+        return None
+    payload: Dict[str, Any] = {
+        "role": msg.get("role"),
+        "content": msg.get("content"),
+    }
+    tool_call_id = msg.get("tool_call_id")
+    if tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    tool_calls = msg.get("tool_calls")
+    if tool_calls:
+        payload["tool_calls"] = tool_calls
+    return hashlib.sha256(_stable_json_bytes(payload)).hexdigest()
 
 
 def capture_usage_anchor(
@@ -3889,13 +3939,145 @@ def capture_usage_anchor(
         return None
     base_count = len(messages)
     last = messages[-1] if base_count else None
+    last_dict = last if isinstance(last, dict) else None
     return {
         "prompt_tokens": pt,
         "completion_tokens": max(0, ct),
         "base_count": base_count,
         "base_last_id": id(last) if last is not None else None,
-        "base_last_role": last.get("role") if isinstance(last, dict) else None,
+        "base_last_role": last_dict.get("role") if last_dict is not None else None,
+        "base_last_fp": usage_anchor_message_fingerprint(last),
     }
+
+
+def serialize_usage_anchor(anchor: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Disk-safe subset of an anchor. Drops process-local ``base_last_id``."""
+    if not isinstance(anchor, dict):
+        return None
+    try:
+        pt = int(anchor.get("prompt_tokens") or 0)
+        ct = int(anchor.get("completion_tokens") or 0)
+        base_count = int(anchor.get("base_count") or 0)
+    except (TypeError, ValueError):
+        return None
+    fp = anchor.get("base_last_fp")
+    if pt <= 0 or base_count <= 0 or not isinstance(fp, str) or not fp:
+        return None
+    role = anchor.get("base_last_role")
+    if role is not None and not isinstance(role, str):
+        role = None
+    return {
+        "prompt_tokens": pt,
+        "completion_tokens": max(0, ct),
+        "base_count": base_count,
+        "base_last_role": role,
+        "base_last_fp": fp,
+    }
+
+
+def restore_usage_anchor(blob: Any) -> Optional[Dict[str, Any]]:
+    """Parse a persisted blob into an in-memory anchor.
+
+    Never carries ``base_last_id``: that value is process-local and a
+    coincidental reuse in a new process must not count as a match.
+    """
+    serialized = serialize_usage_anchor(blob if isinstance(blob, dict) else None)
+    if serialized is None:
+        return None
+    serialized["base_last_id"] = None
+    return serialized
+
+
+def _usage_anchor_base_matches(
+    messages: List[Dict[str, Any]],
+    anchor: Dict[str, Any],
+) -> bool:
+    """True when ``messages`` still has the captured prefix at ``base_count``.
+
+    In-process anchors carry ``base_last_id`` (``id()`` of the last message
+    at capture) — the fast path, fail-closed on new dicts. Restored anchors
+    have ``base_last_id is None`` and match on the content fingerprint.
+    """
+    try:
+        base_count = int(anchor.get("base_count") or 0)
+    except (TypeError, ValueError):
+        return False
+    if base_count <= 0 or len(messages) < base_count:
+        return False
+    base_msg = messages[base_count - 1]
+    stored_id = anchor.get("base_last_id")
+    if stored_id is not None:
+        if id(base_msg) != stored_id:
+            return False
+    else:
+        expected_fp = anchor.get("base_last_fp")
+        if not isinstance(expected_fp, str) or not expected_fp:
+            return False
+        if usage_anchor_message_fingerprint(base_msg) != expected_fp:
+            return False
+    base_role = base_msg.get("role") if isinstance(base_msg, dict) else None
+    if base_role != anchor.get("base_last_role"):
+        return False
+    return True
+
+
+def persist_usage_anchor(agent: Any, anchor: Optional[Dict[str, Any]]) -> None:
+    """Write or clear the session-row usage-anchor blob. Best-effort."""
+    if agent is None or getattr(agent, "_persist_disabled", False):
+        return
+    session_id = getattr(agent, "session_id", None)
+    session_db = getattr(agent, "_session_db", None)
+    patcher = getattr(session_db, "patch_session_model_config", None)
+    if not session_id or not callable(patcher):
+        return
+    blob = serialize_usage_anchor(anchor) if anchor is not None else None
+    try:
+        patcher(session_id, {USAGE_ANCHOR_MODEL_CONFIG_KEY: blob})
+    except Exception:
+        logger.debug("usage anchor persist failed", exc_info=True)
+
+
+def load_persisted_usage_anchor(agent: Any) -> Optional[Dict[str, Any]]:
+    """Read the session-row blob and restore it if the transcript matches.
+
+    Fail closed: missing blob, unreadable store, or a durable transcript
+    that no longer matches the fingerprint (compaction, splice, /new)
+    returns None so preflight estimates.
+    """
+    if agent is None or getattr(agent, "_persist_disabled", False):
+        return None
+    session_id = getattr(agent, "session_id", None)
+    session_db = getattr(agent, "_session_db", None)
+    getter = getattr(session_db, "get_session_model_config_value", None)
+    if not session_id or not callable(getter):
+        return None
+    try:
+        blob = getter(session_id, USAGE_ANCHOR_MODEL_CONFIG_KEY, None)
+    except Exception:
+        logger.debug("usage anchor load failed", exc_info=True)
+        return None
+    restored = restore_usage_anchor(blob)
+    if restored is None:
+        return None
+    msgs_fn = getattr(session_db, "get_messages_as_conversation", None)
+    if callable(msgs_fn):
+        try:
+            msgs = msgs_fn(session_id)
+        except Exception:
+            logger.debug("usage anchor transcript lookup failed", exc_info=True)
+            msgs = None
+        if isinstance(msgs, list) and not _usage_anchor_base_matches(msgs, restored):
+            persist_usage_anchor(agent, None)
+            return None
+    return restored
+
+
+def init_agent_usage_anchor(agent: Any) -> None:
+    """Restore a persisted usage anchor at agent_init, or leave None."""
+    agent._usage_anchor = None
+    restored = load_persisted_usage_anchor(agent)
+    if restored is not None:
+        agent._usage_anchor = restored
 
 
 def anchored_context_tokens(
@@ -3913,15 +4095,9 @@ def anchored_context_tokens(
     """
     if not isinstance(anchor, dict) or not isinstance(messages, list):
         return None
-    base_count = anchor.get("base_count") or 0
-    if base_count <= 0 or len(messages) < base_count:
+    if not _usage_anchor_base_matches(messages, anchor):
         return None
-    base_msg = messages[base_count - 1]
-    if id(base_msg) != anchor.get("base_last_id"):
-        return None
-    base_role = base_msg.get("role") if isinstance(base_msg, dict) else None
-    if base_role != anchor.get("base_last_role"):
-        return None
+    base_count = int(anchor.get("base_count") or 0)
     total = int(anchor["prompt_tokens"]) + int(anchor.get("completion_tokens") or 0)
     delta = messages[base_count:]
     if delta:

--- a/run_agent.py
+++ b/run_agent.py
@@ -810,6 +810,8 @@ class AIAgent:
         # transcript — a fresh/branched/resumed session must fall back to
         # full estimation until its first provider response re-anchors.
         self._usage_anchor = None
+        from agent.model_metadata import persist_usage_anchor
+        persist_usage_anchor(self, None)
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0

--- a/tests/agent/test_usage_anchor.py
+++ b/tests/agent/test_usage_anchor.py
@@ -13,17 +13,27 @@ since. These tests cover:
     id/index check fails closed) and on explicit reset sites;
   * the preflight consumer (_preflight_request_tokens) preferring the
     anchor, plus a sabotage check proving the anchored path (not the
-    heuristic) produces the number.
+    heuristic) produces the number;
+  * persist/restore via a content fingerprint so a restarted agent_init
+    can reuse provider usage when the transcript is unchanged, and reject
+    restore when the last message or history length no longer matches.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from agent.model_metadata import (
+    USAGE_ANCHOR_MODEL_CONFIG_KEY,
     anchored_context_tokens,
     capture_usage_anchor,
     estimate_messages_tokens_rough,
+    init_agent_usage_anchor,
+    persist_usage_anchor,
+    restore_usage_anchor,
+    serialize_usage_anchor,
+    usage_anchor_message_fingerprint,
 )
 from agent.turn_context import _preflight_request_tokens
 
@@ -206,6 +216,175 @@ class TestCompressionTriggerUsesAnchor:
         anchored = anchored_context_tokens(messages, anchor)
         assert heuristic >= threshold  # old behavior: spurious compression
         assert anchored is not None and anchored < threshold
+
+
+def _plain_history():
+    return [
+        _msg("user", "start"),
+        _msg("assistant", "hello"),
+        _msg("user", "do the thing"),
+        _msg("assistant", "done looking"),
+    ]
+
+
+def _namespace_agent(session_id, db):
+    return SimpleNamespace(
+        session_id=session_id,
+        _session_db=db,
+        _persist_disabled=False,
+        _usage_anchor=None,
+    )
+
+
+class TestUsageAnchorPersist:
+    def test_capture_includes_content_fingerprint(self):
+        messages = _plain_history()
+        anchor = capture_usage_anchor(10_000, 20, messages)
+        assert anchor is not None
+        assert isinstance(anchor["base_last_fp"], str)
+        assert len(anchor["base_last_fp"]) == 64
+        assert anchor["base_last_fp"] == usage_anchor_message_fingerprint(messages[-1])
+        assert anchor["base_last_id"] == id(messages[-1])
+
+    def test_serialize_drops_process_local_id(self):
+        messages = _history_with_images(2)
+        captured = capture_usage_anchor(12_000, 100, messages)
+        blob = serialize_usage_anchor(captured)
+        assert blob is not None
+        assert "base_last_id" not in blob
+        assert blob["base_last_fp"] == captured["base_last_fp"]
+        assert blob["prompt_tokens"] == 12_000
+        restored = restore_usage_anchor(blob)
+        assert restored is not None
+        assert restored["base_last_id"] is None
+
+    def test_restore_strips_stale_id_from_blob(self):
+        messages = _plain_history()
+        captured = capture_usage_anchor(8_000, 40, messages)
+        blob = serialize_usage_anchor(captured)
+        blob["base_last_id"] = 123456789
+        restored = restore_usage_anchor(blob)
+        assert restored["base_last_id"] is None
+        rebuilt = [dict(m) for m in messages]
+        assert anchored_context_tokens(rebuilt, restored) == 8_000 + 40
+
+    def test_round_trip_new_objects_returns_provider_total(self):
+        messages = _history_with_images(4)
+        captured = capture_usage_anchor(30_000, 50, messages)
+        restored = restore_usage_anchor(serialize_usage_anchor(captured))
+        rebuilt = [dict(m) for m in messages]
+        assert anchored_context_tokens(rebuilt, restored) == 30_000 + 50
+        # In-process capture still requires id() — compaction-style rebuilds
+        # of the same values must not suppress compression in-process.
+        assert anchored_context_tokens(rebuilt, captured) is None
+
+    def test_restore_rejected_on_last_message_change(self):
+        messages = _history_with_images(4)
+        captured = capture_usage_anchor(30_000, 50, messages)
+        restored = restore_usage_anchor(serialize_usage_anchor(captured))
+        changed = [dict(m) for m in messages]
+        changed[-1] = _msg("assistant", "different last message")
+        assert anchored_context_tokens(changed, restored) is None
+
+    def test_restore_rejected_on_shorter_history(self):
+        messages = _history_with_images(4)
+        captured = capture_usage_anchor(30_000, 50, messages)
+        restored = restore_usage_anchor(serialize_usage_anchor(captured))
+        assert anchored_context_tokens(messages[:2], restored) is None
+
+    def test_sessiondb_round_trip_via_agent_init(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "usage-anchor-roundtrip"
+        messages = _plain_history()
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(sid, messages)
+
+        captured = capture_usage_anchor(40_000, 120, messages)
+        persist_usage_anchor(_namespace_agent(sid, db), captured)
+        stored = json.loads(db.get_session(sid)["model_config"] or "{}")
+        assert USAGE_ANCHOR_MODEL_CONFIG_KEY in stored
+        assert "base_last_id" not in stored[USAGE_ANCHOR_MODEL_CONFIG_KEY]
+
+        resumed = _namespace_agent(sid, db)
+        init_agent_usage_anchor(resumed)
+        rebuilt = [dict(m) for m in messages]
+        rebuilt.append(_msg("user", "next turn"))
+        got = anchored_context_tokens(rebuilt, resumed._usage_anchor)
+        assert got is not None
+        delta = estimate_messages_tokens_rough([rebuilt[-1]])
+        assert got == 40_000 + 120 + delta
+
+    def test_sessiondb_mismatch_last_message_rejected(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "usage-anchor-mismatch"
+        original = _plain_history()
+        db.create_session(sid, source="cli")
+        captured = capture_usage_anchor(10_000, 10, original)
+        persist_usage_anchor(_namespace_agent(sid, db), captured)
+
+        changed = [dict(m) for m in original]
+        changed[-1] = _msg("assistant", "CHANGED")
+        db.append_messages_batch(sid, changed)
+
+        resumed = _namespace_agent(sid, db)
+        init_agent_usage_anchor(resumed)
+        assert resumed._usage_anchor is None
+        stored = json.loads(db.get_session(sid)["model_config"] or "{}")
+        assert USAGE_ANCHOR_MODEL_CONFIG_KEY not in stored
+
+    def test_sessiondb_shorter_history_rejected(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "usage-anchor-short"
+        original = _plain_history()
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(sid, original[:1])
+        captured = capture_usage_anchor(10_000, 10, original)
+        persist_usage_anchor(_namespace_agent(sid, db), captured)
+
+        resumed = _namespace_agent(sid, db)
+        init_agent_usage_anchor(resumed)
+        assert resumed._usage_anchor is None
+
+    def test_fresh_agent_init_restores_anchor(self, tmp_path, monkeypatch):
+        """A new AIAgent for the same session_id restores the persisted blob."""
+        import os
+        from unittest.mock import patch
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "USAGE_ANCHOR_AGENT_INIT"
+        messages = _plain_history()
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(sid, messages)
+        persist_usage_anchor(
+            _namespace_agent(sid, db),
+            capture_usage_anchor(22_000, 80, messages),
+        )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+
+            resumed = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=db,
+                session_id=sid,
+                platform="cli",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        rebuilt = [dict(m) for m in messages]
+        assert anchored_context_tokens(rebuilt, resumed._usage_anchor) == 22_000 + 80
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Desktop group-chat can spawn a fresh `--profile <name> serve` process on every turn. `agent_init` always started with `_usage_anchor = None`, so preflight never saw the previous turn's provider-reported `usage.prompt_tokens` and fell back to `estimate_request_tokens_rough()` (measured ~2.13× over real usage → spurious compaction).

The in-memory anchor was also identity-keyed (`id()` of the last message), which cannot survive a process restart.

This persists a **content fingerprint** of the usage anchor on the existing session-row `model_config` JSON (`_usage_anchor`, same slot as the proactive-prune runway). On `agent_init`, if the durable transcript still matches that fingerprint, the anchor is restored so preflight can use provider totals. Compaction, native Codex compaction, and `reset_session_state` still clear both the in-memory anchor and the blob (fail closed → estimate). In-process `anchored_context_tokens` keeps the `id()` fast path, so same-length rebuilt dicts still fail closed until restore drops `base_last_id`.

## Related Issue

Fixes #99421

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py` — content fingerprint (`base_last_fp`), serialize/restore without `id()`, persist/load helpers on `SessionDB.model_config`
- `agent/agent_init.py` — restore the blob when the durable transcript still matches
- `agent/conversation_loop.py` — persist the anchor after each main-loop capture
- `agent/conversation_compression.py`, `agent/codex_runtime.py`, `run_agent.py` — clear the persisted blob on compaction / session reset
- `tests/agent/test_usage_anchor.py` — round-trip with new dict objects, mismatch rejection, SessionDB + `AIAgent` restore

## How to Test

1. `uv run --extra dev python -m pytest tests/agent/test_usage_anchor.py -q`
2. Capture a usage anchor, persist it, construct a new agent for the same `session_id`: `_usage_anchor` is restored and `anchored_context_tokens` returns the provider total even when messages are fresh dicts with the same values.
3. Change the last message or shorten the history: restore is rejected and preflight estimates.
4. Compaction / `/new` still null `_usage_anchor` in-process and delete the session-row blob, so a rewritten transcript cannot suppress compression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
