### PR TITLE
fix(gateway): prevent macOS gateway startup stalls

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5048,6 +5048,9 @@ def generate_launchd_plist() -> str:
         <string>Aqua</string>
         <string>Background</string>
     </array>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
     
     <key>RunAtLoad</key>
     <true/>

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import plistlib
 import sys
 import time
 from pathlib import Path
@@ -1139,14 +1140,32 @@ class TestRespawnStormBreaker:
 
 
 class TestLaunchdPlistRespawnGovernance:
-    def test_plist_has_throttle_interval(self, tmp_path, monkeypatch):
+    def test_plist_has_runtime_governance(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         from hermes_cli.gateway import generate_launchd_plist
 
         plist = generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
         assert "<key>ThrottleInterval</key>" in plist
         assert "<key>ExitTimeOut</key>" in plist
         assert "<key>KeepAlive</key>" in plist
+        assert parsed["ProcessType"] == "Interactive"
+
+    def test_plist_without_interactive_process_type_is_stale(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli import gateway as gateway_cli
+
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        expected = gateway_cli.generate_launchd_plist()
+        legacy = expected.replace(
+            "    <key>ProcessType</key>\n    <string>Interactive</string>\n", ""
+        )
+        plist_path.write_text(legacy, encoding="utf-8")
+
+        assert gateway_cli.launchd_plist_is_current() is False
 
 
 class TestPermissionErrorOnLockFile:


### PR DESCRIPTION
## What does this PR do?

macOS gateways launched by the generated LaunchAgent can remain unavailable for minutes during startup while Slack profiles and cron scheduling are stalled. The generated gateway plist now requests launchd's Interactive process class so this latency-sensitive messaging and scheduler runtime receives the execution class validated by the issue's controlled service comparison.

### Symptom

`launchctl print` reports `spawn type = daemon (3)`, and an affected multiplex gateway can remain in startup for 4-6 minutes while cron heartbeat age increases and Slack profiles remain disconnected.

### Impact

Affected macOS gateway installations can temporarily lose messaging and scheduled-job availability after a generated-service start or restart.

### Bug Cause

**Trigger:** `hermes_cli/gateway.py:generate_launchd_plist()` generates the macOS gateway LaunchAgent without a `ProcessType` key.

**Causal chain:**
1. A user starts or restarts the generated macOS gateway LaunchAgent.
2. launchd applies its default daemon process class to the gateway and its startup child.
3. On the reported macOS environment, startup can remain blocked for minutes, leaving cron and multiplexed messaging profiles unavailable.

**Why it is wrong:** The gateway is a latency-sensitive interactive messaging and scheduling runtime, but its generated service definition does not request the launchd execution class appropriate for that workload.

**Working sibling / contrast:** The same gateway command started outside launchd reached both Slack profiles and the cron ticker in about eight seconds. The reported LaunchAgent with `ProcessType=Interactive` also connected within seconds.

**Ruled out:** The stderr timestamp wrapper was not the cause because a direct launchd submission reproduced the stall; launching the same Python command outside launchd did not.

### Fix

Add `ProcessType=Interactive` only to the generated gateway LaunchAgent. The existing exact definition comparison now detects installed gateway plists that lack the key, causing the normal start/restart refresh path to replace and reload them. Tests parse the generated plist and verify that a legacy definition is stale.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - request the Interactive launchd process class for the generated gateway LaunchAgent.
- `tests/gateway/test_status.py` - verify the generated value and legacy-plist staleness detection.

## How to Test

1. Generate the macOS gateway plist and parse it with `plistlib`; confirm `ProcessType` is `Interactive`.
2. Remove that key from an installed-definition fixture; confirm `launchd_plist_is_current()` reports it stale.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_status.py -k 'LaunchdPlistRespawnGovernance' -q
```

Local result: 2 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested plist generation and staleness detection on Windows 11; macOS runtime verification is delegated to review

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because the generated service is self-updating
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the change is confined to macOS LaunchAgent generation
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - automated plist parsing and staleness tests cover the committed behavior.
