### PR TITLE
feat(compression): compact active sessions without blocking turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -20,6 +20,7 @@ preserved.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -2305,6 +2306,20 @@ def init_agent(
     compression_micro_compact = is_truthy_value(
         _compression_cfg.get("micro_compact"), default=False
     )
+    compression_background_compact = is_truthy_value(
+        _compression_cfg.get("background_compact"), default=False
+    )
+    try:
+        compression_background_start_ratio = float(
+            _compression_cfg.get("background_compact_start_ratio", 0.80)
+        )
+        if not math.isfinite(compression_background_start_ratio):
+            raise ValueError("non-finite background compaction ratio")
+    except (TypeError, ValueError):
+        compression_background_start_ratio = 0.80
+    compression_background_start_ratio = min(
+        0.99, max(0.10, compression_background_start_ratio)
+    )
     # How often a pass runs, in completed turns. Each pass rewrites
     # already-sent history and costs one prompt-cache break, so this is the
     # dial for how often that cost is paid: 1 = every turn (most aggressive
@@ -2831,6 +2846,9 @@ def init_agent(
         _cc._micro_compact_defrag_threshold_tokens = (
             compression_micro_compact_defrag_tokens
         )
+    agent._background_compression_enabled = compression_background_compact
+    agent._background_compression_start_ratio = compression_background_start_ratio
+    agent._background_compression_job = None
     agent.compression_checkpoint_required = compression_checkpoint_required
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.codex_responses_native_compaction = codex_responses_native_compaction

--- a/agent/background_compression.py
+++ b/agent/background_compression.py
@@ -17,6 +17,13 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+_POST_COMPACTION_STATE_FIELDS = (
+    "last_compression_rough_tokens",
+    "last_prompt_tokens",
+    "last_completion_tokens",
+    "awaiting_real_usage_after_compression",
+)
+
 
 @dataclass
 class BackgroundCompressionJob:
@@ -28,6 +35,11 @@ class BackgroundCompressionJob:
 
 
 def _background_pressure_tokens(compressor: Any) -> int:
+    if (
+        getattr(compressor, "awaiting_real_usage_after_compression", False) is True
+        or getattr(compressor, "last_prompt_tokens", 0) == -1
+    ):
+        return 0
     for name in ("last_prompt_tokens", "last_real_prompt_tokens", "last_compression_rough_tokens"):
         value = getattr(compressor, name, 0)
         if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
@@ -66,6 +78,11 @@ def _run_background_compression(
             job.compressor_state = _snapshot_compressor_attempt_state(
                 worker.context_compressor
             )
+            for name in _POST_COMPACTION_STATE_FIELDS:
+                if hasattr(worker.context_compressor, name):
+                    job.compressor_state[name] = copy.deepcopy(
+                        getattr(worker.context_compressor, name)
+                    )
     except BaseException as exc:
         job.error = exc
         logger.warning(
@@ -193,6 +210,10 @@ def adopt_completed_background_compression(
     agent._db_flush_scan_prefix = None
     agent._flushed_db_message_ids = set()
     agent._session_messages = adopted
+    # The worker crossed the same full compaction boundary as a foreground
+    # rewrite. Its transferred token sentinels suppress another background
+    # launch until real provider usage calibrates the adopted transcript.
+    agent._usage_anchor = None
     # Gateway transcript writers must re-baseline exactly as they do for a
     # foreground in-place boundary. Without this flag they may concatenate the
     # stale pre-compaction SessionEntry history in front of the adopted result.

--- a/agent/background_compression.py
+++ b/agent/background_compression.py
@@ -32,6 +32,39 @@ class BackgroundCompressionJob:
     error: Optional[BaseException] = None
     committed: bool = False
     compressor_state: dict[str, Any] = field(default_factory=dict)
+    agent_state: dict[str, Any] = field(default_factory=dict)
+    boundary_messages: list[dict[str, Any]] = field(default_factory=list)
+
+
+class _BackgroundMemoryManagerView:
+    """Keep prompt reads available while suppressing live lifecycle writes."""
+
+    def __init__(self, manager: Any) -> None:
+        self._manager = manager
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._manager, name)
+
+    def on_session_end(self, _messages: list[dict[str, Any]]) -> None:
+        return None
+
+    def on_session_switch(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _has_external_memory_provider(agent: Any) -> bool:
+    manager = getattr(agent, "_memory_manager", None)
+    if manager is None:
+        return False
+    try:
+        return any(
+            getattr(provider, "name", "") != "builtin"
+            for provider in manager.providers
+        )
+    except Exception:
+        # An unknown manager cannot promise that its lifecycle state is safe to
+        # share with a concurrent compression worker.
+        return True
 
 
 def _background_pressure_tokens(compressor: Any) -> int:
@@ -57,13 +90,24 @@ def _run_background_compression(
     try:
         worker = copy.copy(agent)
         worker.context_compressor = copy.copy(agent.context_compressor)
+        # Tool refresh mutates several containers together. Isolate every one
+        # before the compaction boundary so the worker cannot half-publish onto
+        # the live agent while a foreground turn is still running.
+        worker.tools = copy.deepcopy(getattr(agent, "tools", None))
+        worker.valid_tool_names = set(getattr(agent, "valid_tool_names", set()))
+        worker._context_engine_tool_names = set(
+            getattr(agent, "_context_engine_tool_names", set())
+        )
+        manager = getattr(agent, "_memory_manager", None)
+        if manager is not None:
+            worker._memory_manager = _BackgroundMemoryManagerView(manager)
         worker._background_compression_enabled = False
         worker.status_callback = None
         worker._emit_status = lambda *_args, **_kwargs: None
         worker._emit_warning = lambda *_args, **_kwargs: None
         worker._session_messages = snapshot
 
-        compressed, _system_prompt = worker._compress_context(
+        compressed, system_prompt = worker._compress_context(
             snapshot,
             system_message,
             approx_tokens=approx_tokens,
@@ -83,6 +127,23 @@ def _run_background_compression(
                     job.compressor_state[name] = copy.deepcopy(
                         getattr(worker.context_compressor, name)
                     )
+            job.agent_state = {
+                "_cached_system_prompt": system_prompt,
+                "_cached_system_prompt_static": getattr(
+                    worker, "_cached_system_prompt_static", None
+                ),
+                "tools": copy.deepcopy(getattr(worker, "tools", None)),
+                "valid_tool_names": set(
+                    getattr(worker, "valid_tool_names", set())
+                ),
+                "_context_engine_tool_names": set(
+                    getattr(worker, "_context_engine_tool_names", set())
+                ),
+                "_tool_snapshot_generation": getattr(
+                    worker, "_tool_snapshot_generation", -1
+                ),
+            }
+            job.boundary_messages = copy.deepcopy(snapshot)
     except BaseException as exc:
         job.error = exc
         logger.warning(
@@ -112,6 +173,13 @@ def maybe_start_background_compression(
     if getattr(agent, "_persist_disabled", False):
         return False
     if not getattr(agent, "_session_db", None) or not getattr(agent, "session_id", None):
+        return False
+    # Stateful external providers own mutable turn buffers. A shallow worker
+    # cannot safely deliver compression lifecycle callbacks while foreground
+    # turns continue, and adopting later would include post-snapshot turns in
+    # the wrong boundary. Keep the feature disabled until MemoryManager grows
+    # a watermark-aware boundary contract.
+    if _has_external_memory_provider(agent):
         return False
     if not isinstance(messages, list) or len(messages) < 2:
         return False
@@ -158,7 +226,19 @@ def maybe_start_background_compression(
         name=f"hermes-bg-compress-{str(agent.session_id)[:16]}",
         daemon=True,
     )
-    thread.start()
+    try:
+        thread.start()
+    except Exception as exc:
+        job.error = exc
+        job.done.set()
+        if getattr(agent, "_background_compression_job", None) is job:
+            agent._background_compression_job = None
+        logger.warning(
+            "Background compression thread failed to start for session %s: %s",
+            agent.session_id,
+            exc,
+        )
+        return False
     logger.info(
         "Background compression started: session=%s tokens=%s trigger=%s",
         agent.session_id,
@@ -177,16 +257,17 @@ def adopt_completed_background_compression(
     if not isinstance(job, BackgroundCompressionJob) or not job.done.is_set():
         return conversation_history
 
-    agent._background_compression_job = None
     if (
         job.error is not None
         or not job.committed
         or job.session_id != str(getattr(agent, "session_id", ""))
     ):
+        agent._background_compression_job = None
         return conversation_history
 
     session_db = getattr(agent, "_session_db", None)
     if session_db is None:
+        agent._background_compression_job = None
         return conversation_history
     try:
         adopted = session_db.get_messages_as_conversation(job.session_id)
@@ -198,18 +279,31 @@ def adopt_completed_background_compression(
         )
         return conversation_history
     if not isinstance(adopted, list) or not adopted:
+        logger.warning(
+            "Background compression adoption reload returned no messages for session %s; "
+            "will retry at the next turn boundary",
+            job.session_id,
+        )
         return conversation_history
 
     compressor = getattr(agent, "context_compressor", None)
-    if compressor is not None:
-        for name, value in job.compressor_state.items():
-            try:
+    try:
+        if compressor is not None:
+            for name, value in job.compressor_state.items():
                 setattr(compressor, name, copy.deepcopy(value))
-            except Exception:
-                pass
-    agent._db_flush_scan_prefix = None
-    agent._flushed_db_message_ids = set()
-    agent._session_messages = adopted
+        for name, value in job.agent_state.items():
+            setattr(agent, name, copy.deepcopy(value))
+        agent._db_flush_scan_prefix = None
+        agent._flushed_db_message_ids = set()
+        agent._session_messages = adopted
+    except Exception:
+        logger.warning(
+            "Background compression live-state publication failed for session %s; "
+            "will retry at the next turn boundary",
+            job.session_id,
+            exc_info=True,
+        )
+        return conversation_history
     # The worker crossed the same full compaction boundary as a foreground
     # rewrite. Its transferred token sentinels suppress another background
     # launch until real provider usage calibrates the adopted transcript.
@@ -220,6 +314,21 @@ def adopt_completed_background_compression(
     agent._last_compaction_in_place = True
     agent._last_compression_attempt_recorded = True
     agent._last_compression_attempt_in_place = True
+    manager = getattr(agent, "_memory_manager", None)
+    if manager is not None:
+        try:
+            manager.commit_session_boundary_async(
+                job.boundary_messages,
+                new_session_id=job.session_id,
+                parent_session_id=job.session_id,
+                reason="compression",
+            )
+        except Exception:
+            logger.debug(
+                "memory manager background-compression boundary enqueue failed",
+                exc_info=True,
+            )
+    agent._background_compression_job = None
     logger.info(
         "Background compression adopted: session=%s messages=%d",
         job.session_id,

--- a/agent/background_compression.py
+++ b/agent/background_compression.py
@@ -28,11 +28,11 @@ _POST_COMPACTION_STATE_FIELDS = (
 @dataclass
 class BackgroundCompressionJob:
     session_id: str
+    system_message: str = ""
     done: threading.Event = field(default_factory=threading.Event)
     error: Optional[BaseException] = None
     committed: bool = False
     compressor_state: dict[str, Any] = field(default_factory=dict)
-    agent_state: dict[str, Any] = field(default_factory=dict)
     boundary_messages: list[dict[str, Any]] = field(default_factory=list)
 
 
@@ -107,7 +107,7 @@ def _run_background_compression(
         worker._emit_warning = lambda *_args, **_kwargs: None
         worker._session_messages = snapshot
 
-        compressed, system_prompt = worker._compress_context(
+        compressed, _system_prompt = worker._compress_context(
             snapshot,
             system_message,
             approx_tokens=approx_tokens,
@@ -127,22 +127,6 @@ def _run_background_compression(
                     job.compressor_state[name] = copy.deepcopy(
                         getattr(worker.context_compressor, name)
                     )
-            job.agent_state = {
-                "_cached_system_prompt": system_prompt,
-                "_cached_system_prompt_static": getattr(
-                    worker, "_cached_system_prompt_static", None
-                ),
-                "tools": copy.deepcopy(getattr(worker, "tools", None)),
-                "valid_tool_names": set(
-                    getattr(worker, "valid_tool_names", set())
-                ),
-                "_context_engine_tool_names": set(
-                    getattr(worker, "_context_engine_tool_names", set())
-                ),
-                "_tool_snapshot_generation": getattr(
-                    worker, "_tool_snapshot_generation", -1
-                ),
-            }
             job.boundary_messages = copy.deepcopy(snapshot)
     except BaseException as exc:
         job.error = exc
@@ -218,7 +202,10 @@ def maybe_start_background_compression(
             return False
 
     snapshot = copy.deepcopy(messages)
-    job = BackgroundCompressionJob(session_id=str(agent.session_id))
+    job = BackgroundCompressionJob(
+        session_id=str(agent.session_id),
+        system_message=system_message or "",
+    )
     agent._background_compression_job = job
     thread = threading.Thread(
         target=_run_background_compression,
@@ -291,8 +278,25 @@ def adopt_completed_background_compression(
         if compressor is not None:
             for name, value in job.compressor_state.items():
                 setattr(compressor, name, copy.deepcopy(value))
-        for name, value in job.agent_state.items():
-            setattr(agent, name, copy.deepcopy(value))
+
+        # Rebuild prompt/tool state from the live runtime rather than publishing
+        # the shallow worker's snapshot. A model switch can complete while the
+        # summary is in flight; restoring the worker's model-A prompt and tools
+        # onto model B would make the next request use a torn runtime. The shared
+        # refresh helper publishes the complete tool tuple under its generation
+        # guard, and rebuilding here preserves the normal compaction-boundary
+        # refresh without allowing the background worker to win a stale race.
+        from agent.conversation_compression import _refresh_agent_tool_definitions
+
+        previous_prompt = getattr(agent, "_cached_system_prompt", None)
+        _refresh_agent_tool_definitions(agent)
+        agent._invalidate_system_prompt()
+        rebuilt_prompt = agent._build_system_prompt(job.system_message)
+        if previous_prompt is not None and rebuilt_prompt == previous_prompt:
+            agent._cached_system_prompt = previous_prompt
+        else:
+            agent._cached_system_prompt = rebuilt_prompt
+        session_db.update_system_prompt(job.session_id, agent._cached_system_prompt)
         agent._db_flush_scan_prefix = None
         agent._flushed_db_message_ids = set()
         agent._session_messages = adopted

--- a/agent/background_compression.py
+++ b/agent/background_compression.py
@@ -28,7 +28,7 @@ _POST_COMPACTION_STATE_FIELDS = (
 @dataclass
 class BackgroundCompressionJob:
     session_id: str
-    system_message: str = ""
+    system_message: Optional[str] = None
     done: threading.Event = field(default_factory=threading.Event)
     error: Optional[BaseException] = None
     committed: bool = False
@@ -84,7 +84,7 @@ def _run_background_compression(
     agent: Any,
     job: BackgroundCompressionJob,
     snapshot: list[dict[str, Any]],
-    system_message: str,
+    system_message: Optional[str],
     approx_tokens: int,
 ) -> None:
     try:
@@ -143,7 +143,7 @@ def _run_background_compression(
 def maybe_start_background_compression(
     agent: Any,
     messages: list[dict[str, Any]],
-    system_message: str = "",
+    system_message: Optional[str] = None,
 ) -> bool:
     """Start one eligible background compaction without blocking the caller."""
     if getattr(agent, "_background_compression_enabled", False) is not True:
@@ -204,12 +204,12 @@ def maybe_start_background_compression(
     snapshot = copy.deepcopy(messages)
     job = BackgroundCompressionJob(
         session_id=str(agent.session_id),
-        system_message=system_message or "",
+        system_message=system_message,
     )
     agent._background_compression_job = job
     thread = threading.Thread(
         target=_run_background_compression,
-        args=(agent, job, snapshot, system_message or "", pressure),
+        args=(agent, job, snapshot, system_message, pressure),
         name=f"hermes-bg-compress-{str(agent.session_id)[:16]}",
         daemon=True,
     )

--- a/agent/background_compression.py
+++ b/agent/background_compression.py
@@ -1,0 +1,207 @@
+"""Background context compaction with durable splice-merge adoption.
+
+A job summarizes a stable transcript snapshot on a daemon thread. The existing
+in-place compression transaction publishes that snapshot with a start watermark,
+so rows appended while the summary is running are cloned after the compacted
+handoff atomically. The live agent adopts the committed transcript at the next
+turn boundary; it never waits for an in-flight job.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackgroundCompressionJob:
+    session_id: str
+    done: threading.Event = field(default_factory=threading.Event)
+    error: Optional[BaseException] = None
+    committed: bool = False
+    compressor_state: dict[str, Any] = field(default_factory=dict)
+
+
+def _background_pressure_tokens(compressor: Any) -> int:
+    for name in ("last_prompt_tokens", "last_real_prompt_tokens", "last_compression_rough_tokens"):
+        value = getattr(compressor, name, 0)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+            return int(value)
+    return 0
+
+
+def _run_background_compression(
+    agent: Any,
+    job: BackgroundCompressionJob,
+    snapshot: list[dict[str, Any]],
+    system_message: str,
+    approx_tokens: int,
+) -> None:
+    try:
+        worker = copy.copy(agent)
+        worker.context_compressor = copy.copy(agent.context_compressor)
+        worker._background_compression_enabled = False
+        worker.status_callback = None
+        worker._emit_status = lambda *_args, **_kwargs: None
+        worker._emit_warning = lambda *_args, **_kwargs: None
+        worker._session_messages = snapshot
+
+        compressed, _system_prompt = worker._compress_context(
+            snapshot,
+            system_message,
+            approx_tokens=approx_tokens,
+        )
+        job.committed = bool(
+            getattr(worker, "_last_compaction_in_place", False)
+            and compressed is not snapshot
+        )
+        if job.committed:
+            from agent.conversation_compression import _snapshot_compressor_attempt_state
+
+            job.compressor_state = _snapshot_compressor_attempt_state(
+                worker.context_compressor
+            )
+    except BaseException as exc:
+        job.error = exc
+        logger.warning(
+            "Background compression failed for session %s: %s",
+            job.session_id,
+            exc,
+            exc_info=True,
+        )
+    finally:
+        job.done.set()
+
+
+def maybe_start_background_compression(
+    agent: Any,
+    messages: list[dict[str, Any]],
+    system_message: str = "",
+) -> bool:
+    """Start one eligible background compaction without blocking the caller."""
+    if getattr(agent, "_background_compression_enabled", False) is not True:
+        return False
+    if getattr(agent, "compression_enabled", True) is not True:
+        return False
+    if getattr(agent, "compression_in_place", True) is not True:
+        return False
+    if getattr(agent, "compression_checkpoint_required", False) is True:
+        return False
+    if getattr(agent, "_persist_disabled", False):
+        return False
+    if not getattr(agent, "_session_db", None) or not getattr(agent, "session_id", None):
+        return False
+    if not isinstance(messages, list) or len(messages) < 2:
+        return False
+
+    existing = getattr(agent, "_background_compression_job", None)
+    if isinstance(existing, BackgroundCompressionJob):
+        return False
+
+    compressor = getattr(agent, "context_compressor", None)
+    # External context engines own their state and threading model. Background
+    # splice-merge is deliberately a built-in-compressor capability until the
+    # ContextEngine contract grows an explicit snapshot/commit interface.
+    from agent.context_compressor import ContextCompressor
+
+    if not isinstance(compressor, ContextCompressor):
+        return False
+    threshold = getattr(compressor, "threshold_tokens", 0)
+    if not isinstance(threshold, (int, float)) or isinstance(threshold, bool) or threshold <= 0:
+        return False
+    pressure = _background_pressure_tokens(compressor)
+    try:
+        start_ratio = float(getattr(agent, "_background_compression_start_ratio", 0.8))
+    except (TypeError, ValueError):
+        start_ratio = 0.8
+    start_ratio = min(0.99, max(0.1, start_ratio))
+    if pressure < int(threshold * start_ratio):
+        return False
+
+    has_content = getattr(compressor, "has_content_to_compress", None)
+    if callable(has_content):
+        try:
+            if has_content(messages) is False:
+                return False
+        except Exception:
+            logger.debug("Background compression eligibility probe failed", exc_info=True)
+            return False
+
+    snapshot = copy.deepcopy(messages)
+    job = BackgroundCompressionJob(session_id=str(agent.session_id))
+    agent._background_compression_job = job
+    thread = threading.Thread(
+        target=_run_background_compression,
+        args=(agent, job, snapshot, system_message or "", pressure),
+        name=f"hermes-bg-compress-{str(agent.session_id)[:16]}",
+        daemon=True,
+    )
+    thread.start()
+    logger.info(
+        "Background compression started: session=%s tokens=%s trigger=%s",
+        agent.session_id,
+        pressure,
+        int(threshold * start_ratio),
+    )
+    return True
+
+
+def adopt_completed_background_compression(
+    agent: Any,
+    conversation_history: Optional[list[dict[str, Any]]],
+) -> Optional[list[dict[str, Any]]]:
+    """Adopt a committed background result, or preserve the caller's history."""
+    job = getattr(agent, "_background_compression_job", None)
+    if not isinstance(job, BackgroundCompressionJob) or not job.done.is_set():
+        return conversation_history
+
+    agent._background_compression_job = None
+    if (
+        job.error is not None
+        or not job.committed
+        or job.session_id != str(getattr(agent, "session_id", ""))
+    ):
+        return conversation_history
+
+    session_db = getattr(agent, "_session_db", None)
+    if session_db is None:
+        return conversation_history
+    try:
+        adopted = session_db.get_messages_as_conversation(job.session_id)
+    except Exception:
+        logger.warning(
+            "Background compression committed but adoption reload failed for session %s",
+            job.session_id,
+            exc_info=True,
+        )
+        return conversation_history
+    if not isinstance(adopted, list) or not adopted:
+        return conversation_history
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        for name, value in job.compressor_state.items():
+            try:
+                setattr(compressor, name, copy.deepcopy(value))
+            except Exception:
+                pass
+    agent._db_flush_scan_prefix = None
+    agent._flushed_db_message_ids = set()
+    agent._session_messages = adopted
+    # Gateway transcript writers must re-baseline exactly as they do for a
+    # foreground in-place boundary. Without this flag they may concatenate the
+    # stale pre-compaction SessionEntry history in front of the adopted result.
+    agent._last_compaction_in_place = True
+    agent._last_compression_attempt_recorded = True
+    agent._last_compression_attempt_in_place = True
+    logger.info(
+        "Background compression adopted: session=%s messages=%d",
+        job.session_id,
+        len(adopted),
+    )
+    return adopted

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8840,6 +8840,7 @@ def run_conversation(
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
+        system_message=system_message,
     )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1957,6 +1957,23 @@ def run_conversation(
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
 
+    # A completed background compaction has already atomically published its
+    # stable snapshot plus every durable row appended after the start watermark.
+    # Adopt only at this turn boundary: an in-flight job never delays the user,
+    # and no live provider request sees its transcript mutate underneath it.
+    # This runs after the per-turn reset so adoption can raise the in-place
+    # boundary signal consumed by gateway transcript re-baselining.
+    try:
+        from agent.background_compression import (
+            adopt_completed_background_compression,
+        )
+
+        conversation_history = adopt_completed_background_compression(
+            agent, conversation_history
+        )
+    except Exception:
+        logger.warning("Background compression adoption failed", exc_info=True)
+
     # Adopt any ~/.hermes/.env credential/base-url edits made since the last
     # turn — a Settings save updates .env but not this worker's client, which
     # was built at agent init (#67821). No-op when .env is unchanged.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -462,6 +462,25 @@ def finalize_turn(
                 logger.info("Micro-compaction failed: %s", _mc_err)
 
         agent._persist_session(messages, conversation_history)
+
+        # Schedule after the finalized assistant row is durable. The worker
+        # receives a private snapshot and returns immediately; SessionDB's
+        # compression watermark preserves later turns for splice adoption.
+        if not interrupted and not failed and final_response:
+            try:
+                from agent.background_compression import (
+                    maybe_start_background_compression,
+                )
+
+                maybe_start_background_compression(
+                    agent,
+                    messages,
+                    getattr(agent, "_cached_system_prompt", "") or "",
+                )
+            except Exception:
+                logger.warning(
+                    "Background compression scheduling failed", exc_info=True
+                )
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")
         logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -143,6 +143,7 @@ def finalize_turn(
     _turn_exit_reason,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
+    system_message=None,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -475,7 +476,7 @@ def finalize_turn(
                 maybe_start_background_compression(
                     agent,
                     messages,
-                    getattr(agent, "_cached_system_prompt", "") or "",
+                    system_message,
                 )
             except Exception:
                 logger.warning(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -688,6 +688,18 @@ compression:
   # summarization on a short idle thread. Example: 1800 = compact after 30 min idle.
   idle_compact_after_seconds: 0
 
+  # Background splice-merge compaction (default: false). When enabled for the
+  # built-in in-place compressor, start a full summary on a stable transcript
+  # snapshot before the foreground threshold. User turns continue immediately;
+  # rows appended while the summary runs are spliced after the compacted handoff
+  # atomically, and the live agent adopts it at the next turn boundary.
+  # Suppressed for legacy rotation and checkpoint-required configurations.
+  background_compact: false
+
+  # Fraction of the normal compression threshold at which background work
+  # starts (default: 0.80, clamped to 0.10 - 0.99).
+  background_compact_start_ratio: 0.80
+
   # Proactive tool-result prune (default: 0 = disabled). Opt-in token trigger
   # for a deterministic, no-LLM prune of OLD tool-result payloads, run
   # independently of `threshold` above. On large-window models (512K/1M) the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -876,6 +876,15 @@ DEFAULT_CONFIG = {
                                       # for a full trigger-sized token runway to
                                       # regrow before rearming. Keeps prompt-cache
                                       # breaks episodic. 0 = no minimum-savings gate.
+        "background_compact": False,  # opt-in: begin full compaction on a stable
+                                      # snapshot before the foreground threshold,
+                                      # then atomically splice in rows appended while
+                                      # the summary ran. The next turn adopts the
+                                      # committed transcript without waiting.
+        "background_compact_start_ratio": 0.80,  # fraction of the normal compression
+                                      # threshold at which background work starts;
+                                      # clamped to 0.10..0.99. Ignored unless
+                                      # background_compact is true.
         "micro_compact": False,       # opt-in: after each completed turn, fold the
                                       # oldest un-absorbed exchange into a rolling
                                       # summary, amortizing compression cost instead

--- a/tests/agent/test_background_compression.py
+++ b/tests/agent/test_background_compression.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def _agent_with_blocking_compressor(
+    db: SessionDB,
+    session_id: str,
+    started: threading.Event,
+    release: threading.Event,
+):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = agent.context_compressor
+
+    def _compress(messages, **_kwargs):
+        started.set()
+        assert release.wait(2.0)
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            dict(messages[-1]),
+        ]
+
+    compressor.compress = MagicMock(side_effect=_compress)
+    compressor.has_content_to_compress = lambda _messages: True
+    compressor.compression_count = 0
+    compressor.last_prompt_tokens = 80
+    compressor.last_completion_tokens = 0
+    compressor.context_length = 200
+    compressor.threshold_tokens = 100
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._background_compression_enabled = True
+    agent._background_compression_start_ratio = 0.75
+    from agent.context_compressor import ContextCompressor
+
+    assert isinstance(agent.context_compressor, ContextCompressor)
+    assert agent.context_compressor.threshold_tokens == 100
+    assert agent.context_compressor.last_prompt_tokens == 80
+    return agent
+
+
+def test_background_compaction_splices_durable_tail_without_blocking(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_SPLICE"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "current question"},
+        {"role": "assistant", "content": "current answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(1.0)
+
+    concurrent_tail = {"role": "user", "content": "arrived while summarizing"}
+    db.append_messages_batch(session_id, [concurrent_tail])
+    release.set()
+
+    job = agent._background_compression_job
+    assert job.done.wait(3.0)
+    assert job.error is None
+
+    adopted = adopt_completed_background_compression(agent, history + [concurrent_tail])
+
+    assert [message["content"] for message in adopted] == [
+        "[CONTEXT COMPACTION] summary",
+        "current answer",
+        "arrived while summarizing",
+    ]
+    assert agent._last_compaction_in_place is True
+    assert agent._last_compression_attempt_in_place is True
+    assert db.get_messages_as_conversation(session_id) == adopted
+
+
+def test_inflight_job_is_never_adopted_or_started_twice(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_INFLIGHT"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(1.0)
+    assert maybe_start_background_compression(agent, history, "system") is False
+    assert adopt_completed_background_compression(agent, history) is history
+
+    release.set()
+    assert agent._background_compression_job.done.wait(3.0)
+
+
+def test_failed_background_compaction_preserves_original_transcript(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_FAILURE"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    def _fail(*_args, **_kwargs):
+        started.set()
+        assert release.wait(2.0)
+        raise RuntimeError("summary failed")
+
+    agent.context_compressor.compress.side_effect = _fail
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(1.0)
+    release.set()
+    assert agent._background_compression_job.done.wait(3.0)
+
+    adopted = adopt_completed_background_compression(agent, history)
+
+    assert adopted is history
+    durable = db.get_messages_as_conversation(session_id)
+    assert [(m["role"], m["content"]) for m in durable] == [
+        ("user", "question"),
+        ("assistant", "answer"),
+    ]
+
+
+def test_completed_job_from_previous_session_is_not_adopted(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_OLD_SESSION"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(1.0)
+    release.set()
+    assert agent._background_compression_job.done.wait(3.0)
+    agent.session_id = "NEW_SESSION"
+
+    assert adopt_completed_background_compression(agent, history) is history
+
+
+def test_background_compaction_respects_opt_in_and_pressure_threshold(tmp_path: Path) -> None:
+    from agent.background_compression import maybe_start_background_compression
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_GATES"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    agent._background_compression_enabled = False
+    assert maybe_start_background_compression(agent, history, "system") is False
+
+    agent._background_compression_enabled = True
+    agent.context_compressor.last_prompt_tokens = 74
+    assert maybe_start_background_compression(agent, history, "system") is False
+    assert not started.is_set()

--- a/tests/agent/test_background_compression.py
+++ b/tests/agent/test_background_compression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from hermes_state import SessionDB
@@ -264,3 +265,128 @@ def test_background_compaction_respects_opt_in_and_pressure_threshold(tmp_path: 
     agent.context_compressor.last_prompt_tokens = 74
     assert maybe_start_background_compression(agent, history, "system") is False
     assert not started.is_set()
+
+
+def test_adoption_publishes_prompt_rebuilt_by_background_worker(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_PROMPT_REBUILD"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+    agent._cached_system_prompt = "OLD PROMPT"
+    agent._cached_system_prompt_static = "OLD STATIC"
+
+    def _rebuild_prompt(worker, _system_message):
+        worker._cached_system_prompt_static = "NEW STATIC"
+        return "NEW PROMPT"
+
+    with patch.object(type(agent), "_build_system_prompt", _rebuild_prompt):
+        assert maybe_start_background_compression(agent, history, "system") is True
+        assert started.wait(3.0)
+        release.set()
+        assert agent._background_compression_job.done.wait(3.0)
+
+    # Worker state stays private until the next foreground turn boundary.
+    assert agent._cached_system_prompt == "OLD PROMPT"
+    assert agent._cached_system_prompt_static == "OLD STATIC"
+
+    adopted = adopt_completed_background_compression(agent, history)
+
+    assert adopted is not history
+    assert agent._cached_system_prompt == "NEW PROMPT"
+    assert agent._cached_system_prompt_static == "NEW STATIC"
+
+
+def test_external_memory_provider_disables_background_compaction(tmp_path: Path) -> None:
+    from agent.background_compression import maybe_start_background_compression
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_EXTERNAL_MEMORY_GATE"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+    provider = SimpleNamespace(name="external")
+    agent._memory_manager = SimpleNamespace(providers=[provider])
+
+    assert maybe_start_background_compression(agent, history, "system") is False
+    assert agent._background_compression_job is None
+    assert not started.is_set()
+
+
+def test_adoption_retries_after_transient_history_reload_failure(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_ADOPTION_RETRY"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(3.0)
+    release.set()
+    job = agent._background_compression_job
+    assert job.done.wait(3.0)
+    durable = db.get_messages_as_conversation(session_id)
+
+    with patch.object(
+        db,
+        "get_messages_as_conversation",
+        side_effect=[RuntimeError("transient read failure"), durable],
+    ):
+        assert adopt_completed_background_compression(agent, history) is history
+        assert agent._background_compression_job is job
+        adopted = adopt_completed_background_compression(agent, history)
+
+    assert adopted == durable
+    assert agent._background_compression_job is None
+    assert agent._last_compaction_in_place is True
+
+
+def test_thread_start_failure_restores_scheduling_retryability(tmp_path: Path) -> None:
+    from agent.background_compression import maybe_start_background_compression
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_THREAD_START_RETRY"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+
+    with patch("agent.background_compression.threading.Thread.start", side_effect=RuntimeError("no thread")):
+        assert maybe_start_background_compression(agent, history, "system") is False
+
+    assert agent._background_compression_job is None
+    release.set()
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert agent._background_compression_job.done.wait(3.0)

--- a/tests/agent/test_background_compression.py
+++ b/tests/agent/test_background_compression.py
@@ -106,6 +106,50 @@ def test_background_compaction_splices_durable_tail_without_blocking(tmp_path: P
     assert db.get_messages_as_conversation(session_id) == adopted
 
 
+def test_adoption_suppresses_reschedule_until_fresh_real_usage(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_USAGE_REBASE"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "current question"},
+        {"role": "assistant", "content": "current answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+    agent._usage_anchor = object()
+
+    assert maybe_start_background_compression(agent, history, "system") is True
+    assert started.wait(1.0)
+    release.set()
+    assert agent._background_compression_job.done.wait(3.0)
+
+    adopted = adopt_completed_background_compression(agent, history)
+
+    assert agent.context_compressor.last_compression_rough_tokens > 0
+    assert agent.context_compressor.last_prompt_tokens == -1
+    assert agent.context_compressor.last_completion_tokens == 0
+    assert agent.context_compressor.awaiting_real_usage_after_compression is True
+    assert agent._usage_anchor is None
+    assert maybe_start_background_compression(agent, adopted, "system") is False
+
+    agent.context_compressor.update_from_response(
+        {"prompt_tokens": 80, "completion_tokens": 5}
+    )
+
+    assert agent.context_compressor.awaiting_real_usage_after_compression is False
+    assert maybe_start_background_compression(agent, adopted, "system") is True
+    assert agent._background_compression_job.done.wait(3.0)
+
+
 def test_inflight_job_is_never_adopted_or_started_twice(tmp_path: Path) -> None:
     from agent.background_compression import (
         adopt_completed_background_compression,

--- a/tests/agent/test_background_compression.py
+++ b/tests/agent/test_background_compression.py
@@ -85,7 +85,7 @@ def test_background_compaction_splices_durable_tail_without_blocking(tmp_path: P
     agent = _agent_with_blocking_compressor(db, session_id, started, release)
 
     assert maybe_start_background_compression(agent, history, "system") is True
-    assert started.wait(1.0)
+    assert started.wait(3.0)
 
     concurrent_tail = {"role": "user", "content": "arrived while summarizing"}
     db.append_messages_batch(session_id, [concurrent_tail])
@@ -129,7 +129,7 @@ def test_adoption_suppresses_reschedule_until_fresh_real_usage(tmp_path: Path) -
     agent._usage_anchor = object()
 
     assert maybe_start_background_compression(agent, history, "system") is True
-    assert started.wait(1.0)
+    assert started.wait(3.0)
     release.set()
     assert agent._background_compression_job.done.wait(3.0)
 
@@ -170,7 +170,7 @@ def test_inflight_job_is_never_adopted_or_started_twice(tmp_path: Path) -> None:
     agent = _agent_with_blocking_compressor(db, session_id, started, release)
 
     assert maybe_start_background_compression(agent, history, "system") is True
-    assert started.wait(1.0)
+    assert started.wait(3.0)
     assert maybe_start_background_compression(agent, history, "system") is False
     assert adopt_completed_background_compression(agent, history) is history
 
@@ -203,7 +203,7 @@ def test_failed_background_compaction_preserves_original_transcript(tmp_path: Pa
 
     agent.context_compressor.compress.side_effect = _fail
     assert maybe_start_background_compression(agent, history, "system") is True
-    assert started.wait(1.0)
+    assert started.wait(3.0)
     release.set()
     assert agent._background_compression_job.done.wait(3.0)
 
@@ -236,7 +236,7 @@ def test_completed_job_from_previous_session_is_not_adopted(tmp_path: Path) -> N
     agent = _agent_with_blocking_compressor(db, session_id, started, release)
 
     assert maybe_start_background_compression(agent, history, "system") is True
-    assert started.wait(1.0)
+    assert started.wait(3.0)
     release.set()
     assert agent._background_compression_job.done.wait(3.0)
     agent.session_id = "NEW_SESSION"
@@ -297,15 +297,77 @@ def test_adoption_publishes_prompt_rebuilt_by_background_worker(tmp_path: Path) 
         release.set()
         assert agent._background_compression_job.done.wait(3.0)
 
-    # Worker state stays private until the next foreground turn boundary.
-    assert agent._cached_system_prompt == "OLD PROMPT"
-    assert agent._cached_system_prompt_static == "OLD STATIC"
+        # Worker state stays private until the next foreground turn boundary.
+        assert agent._cached_system_prompt == "OLD PROMPT"
+        assert agent._cached_system_prompt_static == "OLD STATIC"
 
-    adopted = adopt_completed_background_compression(agent, history)
+        adopted = adopt_completed_background_compression(agent, history)
 
     assert adopted is not history
     assert agent._cached_system_prompt == "NEW PROMPT"
     assert agent._cached_system_prompt_static == "NEW STATIC"
+
+
+def test_adoption_rebuilds_prompt_and_tools_from_live_runtime_after_model_switch(
+    tmp_path: Path,
+) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_MODEL_SWITCH"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+    agent.model = "model-a"
+
+    def _rebuild_prompt(target, _system_message):
+        target._cached_system_prompt_static = f"STATIC:{target.model}"
+        return f"PROMPT:{target.model}"
+
+    def _refresh_tools(target):
+        name = f"tool-{target.model}"
+        target.tools = [
+            {
+                "type": "function",
+                "function": {"name": name, "description": "", "parameters": {}},
+            }
+        ]
+        target.valid_tool_names = {name}
+        target._context_engine_tool_names = set()
+        target._tool_snapshot_generation += 1
+        return True
+
+    with (
+        patch.object(type(agent), "_build_system_prompt", _rebuild_prompt),
+        patch(
+            "agent.conversation_compression._refresh_agent_tool_definitions",
+            side_effect=_refresh_tools,
+        ),
+    ):
+        assert maybe_start_background_compression(agent, history, "system") is True
+        assert started.wait(3.0)
+        agent.model = "model-b"
+        agent._cached_system_prompt = None
+        release.set()
+        assert agent._background_compression_job.done.wait(3.0)
+
+        adopted = adopt_completed_background_compression(agent, history)
+
+    assert adopted is not history
+    assert agent._cached_system_prompt == "PROMPT:model-b"
+    assert agent._cached_system_prompt_static == "STATIC:model-b"
+    assert agent.valid_tool_names == {"tool-model-b"}
+    assert agent.tools[0]["function"]["name"] == "tool-model-b"
+    assert db.get_session(session_id)["system_prompt"] == "PROMPT:model-b"
 
 
 def test_external_memory_provider_disables_background_compaction(tmp_path: Path) -> None:

--- a/tests/agent/test_background_compression.py
+++ b/tests/agent/test_background_compression.py
@@ -370,6 +370,41 @@ def test_adoption_rebuilds_prompt_and_tools_from_live_runtime_after_model_switch
     assert db.get_session(session_id)["system_prompt"] == "PROMPT:model-b"
 
 
+def test_adoption_does_not_embed_rendered_prompt_in_real_builder(tmp_path: Path) -> None:
+    from agent.background_compression import (
+        adopt_completed_background_compression,
+        maybe_start_background_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "BACKGROUND_REAL_PROMPT_REBUILD"
+    db.create_session(session_id, source="test")
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    db.append_messages_batch(session_id, history)
+    started = threading.Event()
+    release = threading.Event()
+    agent = _agent_with_blocking_compressor(db, session_id, started, release)
+    previous_prompt = agent._build_system_prompt("UNIQUE RAW CALLER CONTEXT")
+    agent._cached_system_prompt = previous_prompt
+
+    assert maybe_start_background_compression(agent, history, None) is True
+    assert started.wait(3.0)
+    release.set()
+    assert agent._background_compression_job.done.wait(3.0)
+
+    adopted = adopt_completed_background_compression(agent, history)
+    rebuilt_prompt = agent._cached_system_prompt
+
+    assert adopted is not history
+    assert "UNIQUE RAW CALLER CONTEXT" not in rebuilt_prompt
+    assert previous_prompt not in rebuilt_prompt
+    assert rebuilt_prompt.count("You are Hermes Agent") == 1
+    assert len(rebuilt_prompt) < len(previous_prompt) * 1.5
+
+
 def test_external_memory_provider_disables_background_compaction(tmp_path: Path) -> None:
     from agent.background_compression import maybe_start_background_compression
 

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -8,6 +8,8 @@ for must still be returned.  Previously any of those raised straight out of
 traceback and lost the whole turn.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from agent.turn_finalizer import finalize_turn
@@ -106,6 +108,7 @@ def _run(
     final_response=None,
     api_call_count=3,
     turn_exit_reason="unknown",
+    system_message=None,
 ):
     messages = [
         {"role": "user", "content": "do a thing"},
@@ -132,6 +135,7 @@ def _run(
         original_user_message="do a thing",
         _should_review_memory=False,
         _turn_exit_reason=turn_exit_reason,
+        system_message=system_message,
     )
 
 
@@ -162,5 +166,23 @@ def test_clean_turn_has_no_cleanup_errors_key():
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
     assert result["completed"] is False
     assert "cleanup_errors" not in result
+
+
+def test_background_compression_receives_raw_system_message():
+    agent = _StubAgent(raise_in=())
+    agent._cached_system_prompt = "fully rendered cached prompt"
+
+    with patch(
+        "agent.background_compression.maybe_start_background_compression"
+    ) as schedule:
+        _run(
+            agent,
+            final_response="done",
+            api_call_count=1,
+            turn_exit_reason="completed",
+            system_message="raw caller context",
+        )
+
+    assert schedule.call_args.args[2] == "raw caller context"
 
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -89,6 +89,8 @@ compression:
   tail_mode: lean            # Tail retention policy: lean | legacy (default: lean)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
   min_tail_user_messages: 1  # Real user messages guaranteed in the tail (default: 1)
+  background_compact: false  # Summarize a stable snapshot before the foreground threshold
+  background_compact_start_ratio: 0.80  # Start at 80% of the normal trigger
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
   codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
   codex_app_server_auto: native  # native|hermes|off for Codex app-server thread compaction
@@ -116,6 +118,8 @@ auxiliary:
 | `min_tail_user_messages` | `1` | ≥1 | Minimum number of REAL (actionable) user messages guaranteed to survive in the uncompressed tail. `1` = the existing single last-user anchor (behavior-preserving default). Raise to e.g. `3` to keep the last 3 real user turns verbatim even when bulky tool outputs fill the tail token budget. Blank platform echoes, compaction handoffs, and synthetic continuation rows never count toward N. The guarantee wins over the tail token budget — the tail may exceed the budget when the anchor pulls the cut back |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `idle_compact_after_seconds` | `0` | ≥0 seconds | Opt-in: compact up front when a session resumes after this many seconds idle (0 = disabled). Skips when context ≤ threshold × target_ratio; honors cooldown/anti-thrash/lock guards |
+| `background_compact` | `false` | bool | Opt in to full compaction on a daemon worker while foreground turns continue. Available for the built-in in-place compressor; disabled for legacy rotation, checkpoint-required, persistence-isolated, and external-engine paths |
+| `background_compact_start_ratio` | `0.80` | 0.10-0.99 | Start background work when prompt usage reaches this fraction of the resolved foreground compression threshold |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
 | `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |
@@ -133,6 +137,27 @@ Consumers observe the mode rather than diffing session ids:
 - The gateway re-baselines transcript handling from the agent's rotation-independent `_last_compaction_in_place` flag, not from an id-change diff.
 
 Set `in_place: false` to restore the legacy rotating path, where each compaction commits a new session id linked to the previous one via `parent_session_id`.
+
+### Background splice-merge compaction
+
+With `compression.background_compact: true`, Hermes starts a full compaction
+after a successful turn once prompt usage reaches
+`background_compact_start_ratio × threshold_tokens`. The worker owns a deep
+snapshot of the finalized transcript, so the next user turn can continue on the
+existing context without waiting for the summary request.
+
+Publication reuses the in-place compressor's SessionDB watermark transaction.
+Rows appended after the snapshot watermark are cloned byte-for-byte after the
+compacted handoff in the same transaction; failure or lost lock ownership leaves
+the old active transcript untouched. A live agent adopts the committed active
+rows only at the next turn boundary, then raises the normal in-place compaction
+signal so gateway transcript caches re-baseline instead of concatenating stale
+history. An unfinished job is never awaited by a user turn, and a completed job
+for a session that was reset or switched is not adopted into the new session.
+
+The feature is opt-in because it may spend an auxiliary-model request on a
+conversation that does not continue. It requires `compression.in_place: true`
+and is suppressed when `compression.checkpoint_required` is enabled.
 
 ### Per-model threshold overrides
 


### PR DESCRIPTION
## What does this PR do?

Adds opt-in background context compaction for active sessions. Hermes can summarize a stable transcript snapshot before the foreground compression threshold while user turns continue, then atomically publish the compacted handoff with every message appended during the summary.

### Motivation

Long compression requests can pause an active conversation for minutes. The requested splice-merge model moves that auxiliary-model latency off the foreground path without dropping turns that arrive during the summary.

### Behavior

With `compression.background_compact: true`, Hermes starts background work at `background_compact_start_ratio` of the normal compression threshold. An in-flight job is never awaited by a user turn. Once committed, the live agent adopts the new active transcript at the next turn boundary.

The feature is intentionally opt-in and limited to the built-in in-place compressor. Legacy rotation, checkpoint-required configurations, persistence-isolated agents, and external context engines keep their existing behavior.

### Implementation

- A daemon worker owns a deep snapshot and a shallow-isolated agent/compressor state copy.
- Existing SessionDB compression locks and the start watermark protect publication.
- `archive_and_compact` atomically publishes the compressed snapshot and byte-exact clones of durable rows appended after the watermark.
- Adoption reloads the committed active transcript only for the same session and raises the existing in-place boundary signal so gateway transcript caches re-baseline.
- Failure, lock loss, session reset, and session switch preserve the caller's current history.

## Related Issue

Closes #99524

## Type of Change

- [x] New feature

## Changes Made

- `agent/background_compression.py` - coordinates non-blocking jobs and turn-boundary adoption.
- `agent/turn_finalizer.py` - schedules eligible jobs after the finalized turn is durable.
- `agent/conversation_loop.py` - adopts completed jobs before the next turn context is built.
- `agent/agent_init.py` and `hermes_cli/config_defaults.py` - load safe opt-in settings.
- `tests/agent/test_background_compression.py` - covers concurrent tail splice, non-blocking behavior, failure, reset, duplicate scheduling, and threshold gates.
- `cli-config.yaml.example` and compression documentation - document configuration and safety boundaries.

## How to Test

1. Enable `compression.background_compact: true` and set a low `background_compact_start_ratio` in an isolated configuration.
2. Continue sending turns while the auxiliary summary is blocked; verify the foreground turn proceeds and the later active transcript contains both the compacted handoff and the concurrent tail.
3. Run the automated coverage:

```bash
scripts/run_tests.sh tests/agent/test_background_compression.py tests/agent/test_compress_context_progress_timeout.py tests/agent/test_turn_finalizer_final_response_persistence.py tests/gateway/test_compression_concurrent_sessions.py -q
```

Result: 30 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test wrapper on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are not applicable
- [x] I've considered cross-platform impact; the worker uses only Python threading and existing SessionDB primitives
- [x] Tool descriptions and schemas are not applicable
