### PR TITLE
fix(desktop): keep @tanstack/react-query in one runtime chunk (salvage #95684, closes #95560)

### DIFF
--- a/apps/desktop/e2e/launch-packaged-app.spec.ts
+++ b/apps/desktop/e2e/launch-packaged-app.spec.ts
@@ -46,6 +46,27 @@ test('renderer loads and shows DOM content', async () => {
   expect(childCount).toBeGreaterThan(0)
 })
 
+test('boots to the app UI, not the QueryClient error boundary (#95560)', async () => {
+  const page = fixture!.page
+  await page.waitForSelector('#root', { state: 'attached', timeout: 30_000 })
+
+  // Wait until the root has real content (boot overlay fades, app paints) —
+  // the error boundary also paints, so assert on its absence explicitly.
+  await page.waitForFunction(
+    () => (document.getElementById('root')?.textContent ?? '').trim().length > 0,
+    undefined,
+    { timeout: 60_000 },
+  )
+
+  const text = await page.locator('#root').textContent()
+  // The #95560 crash: a duplicate @tanstack/react-query runtime made the
+  // QueryClientProvider's context invisible to useQuery, so the app hit the
+  // error boundary at launch. Neither the boundary headline nor the throw
+  // message may appear on a healthy boot.
+  expect(text).not.toContain('No QueryClient set')
+  expect(text).not.toContain('Something broke in the interface')
+})
+
 test('HUD composer remains fully inside the transparent window', async () => {
   const hudPagePromise = fixture!.app.waitForEvent('window')
 

--- a/apps/desktop/scripts/assert-dist-built.mjs
+++ b/apps/desktop/scripts/assert-dist-built.mjs
@@ -17,6 +17,14 @@ import { isMain } from "./utils.mjs"
 
 const ROUTER_CONTEXT_ERROR = "may be used only in the context of a"
 
+// @tanstack/react-query carries module-level React context (QueryClientContext).
+// The entry's QueryClientProvider and every lazy chunk's useQuery must share ONE
+// runtime instance; if a build ever emits a second copy, the provider's context
+// is invisible to the other copy and useQuery throws "No QueryClient set" — the
+// packaged app error-boundaries on launch (#95560). Same single-instance
+// invariant as the react-router check above, same failure class.
+const QUERY_CLIENT_CONTEXT_ERROR = "No QueryClient set, use QueryClientProvider to set one"
+
 // Pure check — returns { ok: true } or { ok: false, error: "..." }.
 // Kept side-effect-free so it can be unit tested without spawning a process.
 export function checkDistBuilt(distDir) {
@@ -51,6 +59,21 @@ export function checkDistBuilt(distDir) {
     return {
       ok: false,
       error: `react-router context invariant found in multiple JS assets: ${routerContextAssets.join(", ")}`
+    }
+  }
+
+  const queryClientContextAssets = readdirSync(assetsDir)
+    .filter(name => name.endsWith(".js"))
+    .filter(name => readFileSync(join(assetsDir, name), "utf8").includes(QUERY_CLIENT_CONTEXT_ERROR))
+
+  if (queryClientContextAssets.length > 1) {
+    return {
+      ok: false,
+      error:
+        `@tanstack/react-query context invariant found in multiple JS assets: ` +
+        `${queryClientContextAssets.join(", ")} — duplicate react-query runtimes make the ` +
+        `QueryClientProvider's context invisible to useQuery in other chunks (` +
+        `"No QueryClient set" on launch, #95560)`
     }
   }
 

--- a/apps/desktop/scripts/assert-dist-built.test.mjs
+++ b/apps/desktop/scripts/assert-dist-built.test.mjs
@@ -22,6 +22,14 @@ function writeRouterAsset(distDir, name) {
   )
 }
 
+function writeQueryClientAsset(distDir, name) {
+  fs.writeFileSync(
+    path.join(distDir, 'assets', name),
+    `throw new Error('No QueryClient set, use QueryClientProvider to set one')`,
+    'utf8',
+  )
+}
+
 test('checkDistBuilt passes when index.html + an assets JS bundle exist', () => {
   const { tempRoot, distDir } = makeDist(d => {
     fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
@@ -118,6 +126,38 @@ test('checkDistBuilt fails when the Router context invariant is in multiple JS a
     assert.match(result.error, /react-router context invariant found in multiple JS assets/)
     assert.match(result.error, /vendor-react-abc123\.js/)
     assert.match(result.error, /command-def456\.js/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt passes when the QueryClient context invariant is in one JS asset', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    writeQueryClientAsset(d, 'vendor-react-abc123.js')
+    fs.writeFileSync(path.join(d, 'assets', 'command-def456.js'), 'console.log(1)', 'utf8')
+  })
+  try {
+    assert.deepEqual(checkDistBuilt(distDir), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when the QueryClient context invariant is in multiple JS assets (#95560)', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    writeQueryClientAsset(d, 'vendor-react-abc123.js')
+    writeQueryClientAsset(d, 'session-list-density-def456.js')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /@tanstack\/react-query context invariant found in multiple JS assets/)
+    assert.match(result.error, /vendor-react-abc123\.js/)
+    assert.match(result.error, /session-list-density-def456\.js/)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -139,7 +139,17 @@ export default defineConfig(({ command }) => ({
             // the heavy chunk, and the entry then statically imports 19 MB of
             // shiki just to reach react/hast utils — putting the heavy chunk
             // right back on the boot path.
-            { name: 'vendor-react', test: /node_modules[\\/](react|react-dom|scheduler|react-router)[\\/]/ },
+            //
+            // @tanstack/react-query is here for the same reason react-router
+            // is: it carries MODULE-LEVEL context (QueryClientContext) that
+            // the entry's QueryClientProvider and every lazy chunk's useQuery
+            // must share. Left to rolldown's merge heuristics, an unmatched
+            // shared module can be inlined into a lazy chunk — the packaged
+            // app then runs TWO react-query runtimes, the provider's context
+            // is invisible to the other copy, and useQuery throws "No
+            // QueryClient set, use QueryClientProvider to set one" on the
+            // launch path (#95560). Grouping it forces one shared instance.
+            { name: 'vendor-react', test: /node_modules[\\/](react|react-dom|scheduler|react-router|@tanstack[\\/]react-query)[\\/]/ },
             {
               name: 'vendor-md',
               test: /node_modules[\\/](property-information|hast-util-[^\\/]+|mdast-util-[^\\/]+|micromark[^\\/]*|unist-util-[^\\/]+|vfile[^\\/]*|unified|stringify-entities|space-separated-tokens|comma-separated-tokens|zwitch|html-void-elements|devlop|style-to-js|style-to-object|clsx)[\\/]/
@@ -209,7 +219,7 @@ export default defineConfig(({ command }) => ({
       'react/jsx-dev-runtime': path.join(reactDir, 'jsx-dev-runtime.js'),
       'react/jsx-runtime': path.join(reactDir, 'jsx-runtime.js')
     },
-    dedupe: ['react', 'react-dom', 'react-router']
+    dedupe: ['react', 'react-dom', 'react-router', '@tanstack/react-query']
   },
   server: {
     host: '127.0.0.1',


### PR DESCRIPTION
Closes #95560. Salvages PR #95684 by @Finn763 (substantive commit cherry-picked, authorship preserved; contributor email mapping already on main).

## Problem

Desktop crashed at launch with `No QueryClient set, use QueryClientProvider to set one` when the bundler happened to inline a second `@tanstack/react-query` runtime into a lazy chunk — the duplicate copy can't see the provider context created by the copy in the main chunk. `vite.config.ts`'s `vendor-react` advancedChunks group matched only `react|react-dom|scheduler|react-router`, so whether react-query stayed in one chunk was toolchain luck.

## Fix (@Finn763, from #95684)

- `vite.config.ts`: pin `@tanstack/react-query` (and `query-core`) into the `vendor-react` chunk — same proven pattern that already pins react-router for the identical singleton-context reason.
- `scripts/assert-dist-built.mjs`: post-build invariant — build fails if the query runtime appears in more than one asset (extracted `checkDistBuilt` for testability).
- `scripts/assert-dist-built.test.mjs`: 9 guard tests.
- `e2e/launch-packaged-app.spec.ts`: packaged-app smoke asserting no `No QueryClient set` at launch.

## Verification

- Production renderer build on current main toolchain (979 commits newer rolldown than the PR branch): `QueryClientProvider`/QueryClient land solely in `dist/assets/vendor-react-*.js`; `assert-dist-built` passes.
- `npx vitest run scripts/assert-dist-built.test.mjs`: 9/9.
- `tsc -p tsconfig.e2e.json --noEmit` clean.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa891cf/HLZUf21oTn12iOXlMmB3v_4LMkNX7e.png)
