### PR TITLE
fix(kanban): hold young unlinked cards and skip self-dispatch

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -332,6 +332,9 @@ model:
 # Disable this only when every review is performed manually from the dashboard.
 kanban:
   review_dispatch: true
+  # Skip cards assigned to the dispatching process's own profile
+  # (self-supervision). Set false to allow the operator profile to be a worker.
+  no_self_dispatch: true
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2838,6 +2838,10 @@ DEFAULT_CONFIG = {
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.
         "review_dispatch": True,
+        # Do not claim/spawn a card assigned to the dispatching process's
+        # own profile (HERMES_PROFILE / named HERMES_HOME). Prevents the
+        # gateway operator from also being a dispatched worker.
+        "no_self_dispatch": True,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2782,6 +2782,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_self_dispatch": res.skipped_self_dispatch,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2823,6 +2824,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.skipped_self_dispatch:
+        print(
+            f"Skipped (self-dispatch — operator profile): "
+            f"{', '.join(res.skipped_self_dispatch)}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -418,6 +418,14 @@ def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
 # during the launch window.
 DEFAULT_CRASH_GRACE_SECONDS = 30
 
+# Claim-time hold for a brand-new ready/todo card that still has zero
+# parent links. Writers that ``create`` then ``link`` on a later statement
+# used to lose the race: the dispatcher saw a root (the parent-done guard
+# is a no-op when ``task_links`` is empty) and claimed the child before
+# the edges existed. 15s covers the observed ~5s create→link gap without
+# delaying steady-state dispatch of older genuine roots.
+CLAIM_UNLINKED_GRACE_SECONDS = 15
+
 
 # Sentinel exit code a kanban worker uses to signal "I bailed because the
 # provider rate-limited / exhausted quota, not because the task failed."
@@ -4625,6 +4633,46 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+def _unlinked_claim_grace_seconds() -> int:
+    """Seconds a newly created unlinked card is held at the claim gate.
+
+    Reads ``HERMES_KANBAN_UNLINKED_CLAIM_GRACE_SECONDS`` when set (0 restores
+    immediate-claim behaviour for tests that reimport this module). Falls
+    back to :data:`CLAIM_UNLINKED_GRACE_SECONDS`.
+    """
+    raw = os.environ.get("HERMES_KANBAN_UNLINKED_CLAIM_GRACE_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return CLAIM_UNLINKED_GRACE_SECONDS
+
+
+def _is_young_unlinked_root(
+    conn: sqlite3.Connection, task_id: str, now: int,
+) -> bool:
+    """True when *task_id* has no parent links and is still inside the grace."""
+    grace = _unlinked_claim_grace_seconds()
+    if grace <= 0:
+        return False
+    row = conn.execute(
+        "SELECT created_at FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    created_at = int(row["created_at"] or 0)
+    if now - created_at >= grace:
+        return False
+    linked = conn.execute(
+        "SELECT 1 FROM task_links WHERE child_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return linked is None
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4665,6 +4713,12 @@ def claim_task(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
             )
+            return None
+        # Create→link race: a card created ready with parents=[] looks
+        # like a root until the writer inserts task_links. Hold young
+        # unlinked cards for this tick; older unlinked cards are genuine
+        # roots and stay claimable.
+        if _is_young_unlinked_root(conn, task_id, now):
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
@@ -8086,6 +8140,10 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    skipped_self_dispatch: list[str] = field(default_factory=list)
+    """Ready/review task ids skipped because their assignee is the
+    dispatching process's own profile (self-supervision). Gated by
+    ``kanban.no_self_dispatch`` (default True)."""
     memory_pressure: Optional[str] = None
     """System memory pressure observed at spawn time when the memory guard
     restricted this tick (OOF-30/OOF-77): ``"critical"`` — no new workers
@@ -9621,6 +9679,52 @@ def review_dispatch_enabled() -> bool:
         return True
 
 
+def _dispatcher_operator_profile() -> Optional[str]:
+    """Profile identity of the process running the dispatcher, if known.
+
+    Prefers ``HERMES_PROFILE_NAME`` / ``HERMES_PROFILE`` (set on named
+    gateway launches and worker spawns). Falls back to
+    :func:`hermes_cli.profiles.get_active_profile_name` for a named
+    profile inferred from ``HERMES_HOME``. ``default`` / ``custom`` from
+    that fallback are ignored so a default-profile gateway still dispatches
+    cards assigned to ``default``.
+    """
+    for env_name in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
+        value = (os.environ.get(env_name) or "").strip()
+        if value:
+            try:
+                return _canonical_assignee(value)
+            except ValueError:
+                return value.lower()
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        name = (get_active_profile_name() or "").strip()
+    except Exception:
+        return None
+    if not name or name in {"default", "custom"}:
+        return None
+    try:
+        return _canonical_assignee(name)
+    except ValueError:
+        return name.lower()
+
+
+def _self_dispatch_skip_profile() -> Optional[str]:
+    """Assignee the dispatcher must not spawn (self-supervision).
+
+    ``kanban.no_self_dispatch`` defaults True. Returns ``None`` when the
+    gate is off or the operator profile cannot be determined.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = (load_config() or {}).get("kanban", {}) or {}
+        if cfg.get("no_self_dispatch", True) is False:
+            return None
+    except Exception:
+        pass
+    return _dispatcher_operator_profile()
+
+
 # ---------------------------------------------------------------------------
 # Memory-aware dispatch guard (OOF-30 / OOF-77)
 #
@@ -10122,6 +10226,7 @@ def _dispatch_once_locked(
             # bucket it as nonspawnable if the profile genuinely isn't
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
+    _self_profile = _self_dispatch_skip_profile()
     for row in ready_rows:
         if ready_budget is not None and spawned >= ready_budget:
             break
@@ -10169,6 +10274,9 @@ def _dispatch_once_locked(
             else:
                 result.skipped_unassigned.append(row["id"])
                 continue
+        if _self_profile and row_assignee == _self_profile:
+            result.skipped_self_dispatch.append(row["id"])
+            continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a
@@ -10332,6 +10440,9 @@ def _dispatch_once_locked(
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
+            continue
+        if _self_profile and row["assignee"] == _self_profile:
+            result.skipped_self_dispatch.append(row["id"])
             continue
         try:
             from hermes_cli.profiles import profile_exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -481,6 +481,7 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
+    "real_unlinked_claim_grace: opt out of the autouse fixture that zeros kanban unlinked-claim grace",
     "real_agent_prewarm: opt out of the autouse stub that disables the tui_gateway deferred agent pre-warm timer",
     "requires_wal: needs the runtime to actually enable SQLite WAL mode (skipped where Hermes falls back to journal_mode=DELETE)",
     "no_isolate: opt out of per-file subprocess isolation (tests share mutable module-level state)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_KANBAN_RUN_ID",
     "HERMES_KANBAN_CLAIM_LOCK",
     "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+    "HERMES_KANBAN_UNLINKED_CLAIM_GRACE_SECONDS",
     # Pytest is routinely launched from a delegated worker.  The worker
     # lineage marker must not make parent-state tests run as delegated
     # children; tests that exercise child behavior set it explicitly.
@@ -593,6 +594,22 @@ def _neutralize_kanban_memory_guard(request, monkeypatch):
     except Exception:
         return
     monkeypatch.setattr(_kb_mod, "_system_memory_sample", lambda: {}, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _disable_unlinked_claim_grace(request, monkeypatch, _hermetic_environment):
+    """Zero the create→link claim grace so existing tests keep instant claim.
+
+    Production holds a newly created unlinked ready card for
+    ``CLAIM_UNLINKED_GRACE_SECONDS`` so a create-then-link writer can insert
+    ``task_links`` before the dispatcher treats the card as a root. Tests
+    that claim immediately after ``create_task`` were written against the
+    pre-grace behaviour. The env pin survives ``sys.modules`` reimports.
+    Opt out with ``@pytest.mark.real_unlinked_claim_grace``.
+    """
+    if request.node.get_closest_marker("real_unlinked_claim_grace"):
+        return
+    monkeypatch.setenv("HERMES_KANBAN_UNLINKED_CLAIM_GRACE_SECONDS", "0")
 
 
 @pytest.fixture(autouse=True)
@@ -1184,6 +1201,11 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         "real_memory_guard: bypass the autouse fixture that pins the kanban "
         "dispatcher's memory guard to 'no data' — only for tests that "
         "exercise the guard itself with their own patched samples.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_unlinked_claim_grace: opt out of the autouse fixture that "
+        "zeros kanban unlinked-claim grace.",
     )
     # NOTE: linux_only / macos_only / windows_only are declared in
     # pyproject.toml's ``markers`` list, not here — they are part of the

--- a/tests/hermes_cli/test_kanban_unlinked_claim_grace.py
+++ b/tests/hermes_cli/test_kanban_unlinked_claim_grace.py
@@ -1,0 +1,124 @@
+"""Create→link claim race + dispatcher self-supervision.
+
+A card created ``ready`` with no parent links used to be claimable before
+the writer inserted ``task_links``. The claim gate now holds young
+unlinked cards for ``CLAIM_UNLINKED_GRACE_SECONDS``. The dispatcher also
+skips cards assigned to its own operator profile.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def all_assignees_spawnable(monkeypatch):
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+@pytest.mark.real_unlinked_claim_grace
+def test_claim_task_skips_young_unlinked_root(kanban_home, monkeypatch):
+    now = [1_700_000_000]
+    monkeypatch.setattr(kb.time, "time", lambda: now[0])
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="soon-to-be-linked", assignee="scout")
+        assert kb.claim_task(conn, tid) is None
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+
+
+@pytest.mark.real_unlinked_claim_grace
+def test_claim_task_after_grace_claims_unlinked_root(kanban_home, monkeypatch):
+    now = [1_700_000_000]
+    monkeypatch.setattr(kb.time, "time", lambda: now[0])
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="genuine root", assignee="scout")
+        now[0] += kb.CLAIM_UNLINKED_GRACE_SECONDS + 1
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.status == "running"
+        assert claimed.claim_lock is not None
+
+
+@pytest.mark.real_unlinked_claim_grace
+def test_claim_task_young_linked_child_uses_parent_guard(kanban_home, monkeypatch):
+    now = [1_700_000_000]
+    monkeypatch.setattr(kb.time, "time", lambda: now[0])
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="nexus")
+        child = kb.create_task(
+            conn, title="child", assignee="scout", parents=[parent],
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        conn.commit()
+        assert kb.claim_task(conn, child) is None
+        after = kb.get_task(conn, child)
+        assert after is not None
+        assert after.status == "todo"
+        assert after.claim_lock is None
+
+
+def test_dispatch_skips_operator_profile_other_assignees_claim(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_PROFILE", "nexus")
+
+    with kb.connect_closing() as conn:
+        self_id = kb.create_task(conn, title="ops card", assignee="nexus")
+        other_id = kb.create_task(conn, title="worker card", assignee="scout")
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+
+    spawned_ids = [tid for tid, _who, _ws in res.spawned]
+    assert self_id in res.skipped_self_dispatch
+    assert self_id not in spawned_ids
+    assert other_id in spawned_ids
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, self_id).status == "ready"
+        assert kb.get_task(conn, other_id).status == "running"
+
+
+def test_dispatch_skips_operator_profile_on_review_lane(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_PROFILE", "nexus")
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="needs review", assignee="scout")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = kb.get_task(conn, tid).current_run_id
+        assert kb.request_review(
+            conn, tid, summary="done", reviewer="nexus", expected_run_id=run_id,
+        )
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+
+    spawned_ids = [sid for sid, _who, _ws in res.spawned]
+    assert tid in res.skipped_self_dispatch
+    assert tid not in spawned_ids
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "review"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,23 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_accepts_singular_parent(worker_env):
+    """Models often pass ``parent`` instead of ``parents``; fold it into
+    create_task so the child is not born as an unlinked ready root."""
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "child via parent",
+        "assignee": "peer",
+        "parent": worker_env,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["status"] == "todo"
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        assert kb.parent_ids(conn, d["task_id"]) == [worker_env]
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1359,7 +1359,12 @@ def _handle_create(args: dict, **kw) -> str:
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
     body = args.get("body")
-    parents = args.get("parents") or []
+    parents = args.get("parents")
+    if parents is None or parents == []:
+        # Models often pass a singular parent id; fold it into the atomic
+        # create_task(parents=...) path instead of create-then-link.
+        singular = args.get("parent")
+        parents = [singular] if singular else []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
     # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on


### PR DESCRIPTION
## What does this PR do?

Two field-report failures on one dispatcher tick:

1. **Create→link race.** Cards were created `ready` with `parents: []`, then linked a few seconds later. The claim-time parent-done guard is a no-op when `task_links` has no row, so the dispatcher claimed children as roots. `create_task(..., parents=)` and CLI `--parent` already exist; the race is writers who create then link separately, and models that pass a singular `parent` instead of `parents`.
2. **Self-dispatch.** The dispatcher claimed a card assigned to its own operator profile (nexus), which is a self-supervision conflict.

Claim-time now holds a ready/todo card with **zero parent links** that is younger than `CLAIM_UNLINKED_GRACE_SECONDS` (15s). After the grace, an unlinked card is a genuine root and is claimable. Linked children still use the existing parent-done demote. `kanban_create` also folds a singular `parent` into `create_task(parents=...)` so the atomic path is used when the model supplies it.

The ready and review dispatch loops skip cards whose assignee is the dispatching process's own profile (`HERMES_PROFILE` / named `HERMES_HOME`). New config `kanban.no_self_dispatch` defaults true. Default-profile gateways still dispatch cards assigned to `default`.

## Related Issue

Fixes #99281

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: named `CLAIM_UNLINKED_GRACE_SECONDS = 15`; `claim_task` skips young unlinked roots; ready + review loops skip the operator profile; `kanban.no_self_dispatch` (default true).
- `tools/kanban_tools.py`: `kanban_create` accepts singular `parent` and passes it into `create_task`.
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`: `kanban.no_self_dispatch`.
- `tests/hermes_cli/test_kanban_unlinked_claim_grace.py`: monkeypatched-time claim skip / after-grace claim; self-dispatch skip vs other assignees; review-lane skip.
- `tests/tools/test_kanban_tools.py`: singular `parent` creates a `todo` child with the link row.
- `tests/conftest.py`: existing tests keep instant claim via `HERMES_KANBAN_UNLINKED_CLAIM_GRACE_SECONDS=0` (same shape as crash-grace). Opt out with `@pytest.mark.real_unlinked_claim_grace`.

## How to Test

From the worktree, files run separately (CI-style isolation):

```
uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_unlinked_claim_grace.py -q
# 5 passed

uv run --extra dev python -m pytest tests/tools/test_kanban_tools.py::test_create_accepts_singular_parent tests/tools/test_kanban_tools.py::test_create_happy_path -q
# 2 passed

uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_per_profile_cap.py -q
# 4 passed

uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_db.py -q
# 31 passed, 1 skipped

uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q
# 6 passed

uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_core_functionality.py -q
# 43 passed
```

Combined: **91 passed, 1 skipped**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

Focused files above were run with `uv run --extra dev python -m pytest … -q`. Full `pytest tests/ -q` was not run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

`cli-config.yaml.example` documents `kanban.no_self_dispatch`. The 15s grace is an implementation constant, not a user-facing config key. Tool schema still advertises `parents`; the handler also accepts singular `parent`.

## Screenshots / Logs

```
tests/hermes_cli/test_kanban_unlinked_claim_grace.py  5 passed
tests/tools/test_kanban_tools.py (create)             2 passed
tests/hermes_cli/test_kanban_default_assignee.py
  + test_kanban_per_profile_cap.py                    4 passed
tests/hermes_cli/test_kanban_db.py                     31 passed, 1 skipped
tests/hermes_cli/test_kanban_cli.py
  + test_kanban_cli_dispatch_passthrough.py           6 passed
tests/hermes_cli/test_kanban_review_lifecycle.py
  + test_kanban_core_functionality.py                 43 passed
```
