### PR TITLE
mcp: scope the server registry per profile — two profiles naming the same server share one subprocess and its credentials

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25025,7 +25025,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         loop = asyncio.get_running_loop()
         try:
+            import contextvars
+            import functools
+
+            from agent.secret_scope import is_multiplex_active
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+
+            # On a MULTIPLEXED gateway this command arrives inside one
+            # profile's ``_profile_runtime_scope``, and both halves of the
+            # reload must stay inside it:
+            #
+            #  * ``profile_only=True`` so one tenant typing /reload-mcp does
+            #    not tear down (and SIGKILL the stdio children of) every
+            #    OTHER tenant's MCP servers — a cross-tenant outage.
+            #  * ``copy_context()`` because ``run_in_executor`` does NOT
+            #    propagate contextvars, so without it the worker thread
+            #    would lose the HERMES_HOME override and the secret scope
+            #    and re-discover the DEFAULT profile's ``mcp_servers``.
+            #
+            # Single-profile gateways never set multiplex_profiles, so they
+            # keep the historical process-wide reload verbatim.
+            multiplexed = bool(is_multiplex_active())
+
+            def _in_scope(fn, **kwargs):
+                call = functools.partial(fn, **kwargs) if kwargs else fn
+                if not multiplexed:
+                    return call
+                return functools.partial(contextvars.copy_context().run, call)
 
             # Capture old server names before shutdown
             with _lock:
@@ -25033,10 +25059,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Read new config before shutting down, so we know what will be added/removed
             # Shutdown existing connections
-            await loop.run_in_executor(None, shutdown_mcp_servers)
+            await loop.run_in_executor(
+                None, _in_scope(shutdown_mcp_servers, profile_only=multiplexed)
+            )
 
             # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+            new_tools = await loop.run_in_executor(None, _in_scope(discover_mcp_tools))
 
             # Compute what changed
             with _lock:

--- a/tests/tools/test_mcp_profile_isolation.py
+++ b/tests/tools/test_mcp_profile_isolation.py
@@ -1,0 +1,435 @@
+"""Cross-profile isolation contract for the MCP server registry.
+
+A multiplexing gateway serves many profiles from ONE process. Every
+inbound turn runs inside ``gateway.run._profile_runtime_scope``, which
+installs that profile's ``HERMES_HOME`` override and its ``.env`` secret
+scope. The MCP registry, however, used to be keyed by the *bare* server
+name, so two profiles that each configure a server called ``github``
+shared one subprocess -- started with whichever profile connected first,
+holding that profile's credentials. Profile B's turns then reached
+profile A's GitHub account.
+
+These tests pin the fix: every module-level MCP registry structure is
+partitioned by the active profile, derived from the SAME scope the rest
+of the multiplexed path uses (``get_hermes_home_override()`` gated on
+``agent.secret_scope.is_multiplex_active()``), and collapses to exactly
+one partition -- today's behaviour -- when multiplexing is off.
+"""
+
+import contextlib
+
+import pytest
+
+import agent.secret_scope as secret_scope
+import tools.mcp_tool as mcp
+from hermes_constants import (
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+
+# The module-level registries that must be profile-partitioned. Kept as a
+# list so a newly added registry is caught by the sweep test below.
+_SCOPED_REGISTRY_NAMES = [
+    "_servers",
+    "_server_connecting",
+    "_server_connect_errors",
+    "_lazy_server_configs",
+    "_lazy_server_fingerprints",
+    "_lazy_server_tool_names",
+    "_server_connect_retry_after",
+    "_server_connect_failures",
+    "_server_error_counts",
+    "_server_breaker_opened_at",
+    "_server_trust_levels",
+    "_tool_read_only_hints",
+    "_parallel_safe_servers",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_mcp_registries():
+    """Snapshot every scoped registry and restore it afterwards."""
+    saved = {}
+    for name in _SCOPED_REGISTRY_NAMES:
+        container = getattr(mcp, name)
+        saved[name] = _snapshot(container)
+        _wipe(container)
+    was_multiplex = secret_scope.is_multiplex_active()
+    yield
+    secret_scope.set_multiplex_active(was_multiplex)
+    for name in _SCOPED_REGISTRY_NAMES:
+        container = getattr(mcp, name)
+        _wipe(container)
+        _restore(container, saved[name])
+
+
+def _partitions(container):
+    getter = getattr(container, "partitions", None)
+    return getter() if callable(getter) else {"": container}
+
+
+def _snapshot(container):
+    return {
+        key: (dict(part) if hasattr(part, "items") else set(part))
+        for key, part in _partitions(container).items()
+    }
+
+
+def _wipe(container):
+    for part in list(_partitions(container).values()):
+        part.clear()
+
+
+def _restore(container, snapshot):
+    parts = _partitions(container)
+    for key, value in snapshot.items():
+        part = parts.get(key)
+        if part is None:
+            continue
+        part.update(value)
+
+
+@contextlib.contextmanager
+def _profile(home):
+    """Mimic ``gateway.run._profile_runtime_scope`` for one profile.
+
+    Installs the same two seams the multiplexed inbound path installs: the
+    context-local HERMES_HOME override and the profile's secret scope.
+    """
+    home_token = set_hermes_home_override(str(home))
+    secret_token = secret_scope.set_secret_scope(
+        {"GITHUB_TOKEN": f"token-for-{home.name}"}
+    )
+    try:
+        yield
+    finally:
+        secret_scope.reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+class _FakeServer:
+    """Stand-in for a connected ``MCPServerTask`` (no subprocess, no I/O)."""
+
+    def __init__(self, name, token):
+        self.name = name
+        self.token = token
+        self.session = object()
+        self._registered_tool_names = [f"mcp__{name}__do_thing"]
+        self._tools = []
+        self._sampling = None
+        self.shutdown_calls = 0
+
+    def _is_recycled_stdio(self):
+        return False
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+        self.session = None
+
+
+@pytest.fixture
+def homes(tmp_path):
+    a = tmp_path / "profile-a"
+    b = tmp_path / "profile-b"
+    a.mkdir()
+    b.mkdir()
+    return a, b
+
+
+# ── the leak ────────────────────────────────────────────────────────────
+
+
+def test_two_profiles_same_server_name_do_not_share_a_connection(homes):
+    """Profile B must never be handed profile A's live MCP server."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    server_a = _FakeServer("github", token="token-A")
+    with _profile(home_a):
+        mcp._servers["github"] = server_a
+        assert mcp._get_connected_server_for_call("github") is server_a
+
+    with _profile(home_b):
+        leaked = mcp._get_connected_server_for_call("github")
+
+    assert leaked is not server_a, (
+        "profile B was handed profile A's 'github' MCP connection -- that "
+        "subprocess holds profile A's credentials"
+    )
+    assert leaked is None
+
+
+def test_lazy_config_cache_does_not_hand_b_profile_as_credentials(homes):
+    """``_lazy_server_configs`` holds ALREADY-INTERPOLATED secrets.
+
+    ``_load_mcp_config`` expands ``${GITHUB_TOKEN}`` through the active
+    profile's secret scope before the config is cached, so a bare-name
+    lazy cache literally stores profile A's token and would spawn profile
+    B's first ``github`` call with it.
+    """
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._lazy_server_configs["github"] = {
+            "command": "npx",
+            "env": {"GITHUB_TOKEN": "token-A"},
+        }
+
+    with _profile(home_b):
+        leaked = mcp._lazy_server_configs.get("github")
+
+    assert leaked is None, (
+        "profile B's lazy start would spawn 'github' with profile A's "
+        f"credentials: {leaked}"
+    )
+
+
+def test_registration_gate_does_not_skip_a_second_profile(homes):
+    """``register_mcp_servers`` skips names already in the registry.
+
+    With a bare-name registry that skip fires for profile B, so B never
+    gets its own connection at all -- it just inherits A's.
+    """
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._servers["github"] = _FakeServer("github", token="token-A")
+        mcp._server_connecting.add("slack")
+        mcp._lazy_server_configs["linear"] = {"command": "npx"}
+
+    with _profile(home_b):
+        assert "github" not in mcp._servers
+        assert "slack" not in mcp._server_connecting
+        assert "linear" not in mcp._lazy_server_configs
+
+
+def test_connect_error_and_cooldown_state_is_per_profile(homes):
+    """A failure in profile A must not blank out / block profile B."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._server_connect_errors["github"] = "bad token"
+        mcp._record_connect_failure("github")
+        assert mcp._connect_cooldown_active("github")
+
+    with _profile(home_b):
+        assert mcp._server_connect_errors.get("github") is None
+        assert not mcp._connect_cooldown_active("github")
+
+
+def test_trust_tier_is_per_profile(homes):
+    """Profile A marking a server ``trust: full`` must not un-gate B's."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._server_trust_levels["github"] = mcp._TRUST_FULL
+        mcp._tool_read_only_hints["github"] = {"mcp__github__push": True}
+
+    with _profile(home_b):
+        # B has not classified 'github' yet: it must NOT inherit A's
+        # "full trust" tier or A's readOnlyHint exemptions, both of which
+        # short-circuit the dangerous-call approval gate.
+        assert mcp._server_trust_levels.get("github") is None
+        assert mcp._tool_read_only_hints.get("github") is None
+        mcp._server_trust_levels["github"] = mcp._TRUST_UNTRUSTED
+
+    with _profile(home_a):
+        assert mcp._server_trust_levels["github"] == mcp._TRUST_FULL
+
+
+def test_circuit_breaker_counts_are_per_profile(homes):
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        for _ in range(mcp._CIRCUIT_BREAKER_THRESHOLD):
+            mcp._bump_server_error("github")
+
+    with _profile(home_b):
+        assert mcp._server_error_counts.get("github", 0) == 0
+
+
+def test_parallel_safe_flag_is_per_profile(homes):
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._parallel_safe_servers.add("github")
+        assert "github" in mcp._parallel_safe_servers
+
+    with _profile(home_b):
+        assert "github" not in mcp._parallel_safe_servers
+
+
+# ── single-profile behaviour must not change ────────────────────────────
+
+
+def test_single_profile_gateway_is_unpartitioned(homes):
+    """Multiplexing OFF: one partition, exactly today's behaviour.
+
+    Even a HERMES_HOME override (plugins, ``mcp_startup`` discovery
+    threads, ``bot_mode_probe``, the desktop backend) must NOT split the
+    registry when the process is not a multiplexer -- otherwise a server
+    started under an override would be looked up under a different key
+    and silently orphaned.
+    """
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(False)
+
+    server = _FakeServer("github", token="token-A")
+    with _profile(home_a):
+        mcp._servers["github"] = server
+        mcp._lazy_server_configs["linear"] = {"command": "npx"}
+
+    with _profile(home_b):
+        assert mcp._get_connected_server_for_call("github") is server
+        assert mcp._lazy_server_configs.get("linear") == {"command": "npx"}
+
+    # And with no scope at all.
+    assert mcp._servers.get("github") is server
+    # Exactly one populated partition -- the legacy root one.
+    populated = [k for k, v in _partitions(mcp._servers).items() if v]
+    assert populated == [mcp._ROOT_PROFILE_KEY]
+
+
+def test_unscoped_multiplex_read_does_not_alias_a_profile(homes):
+    """Fail-closed: an unscoped read under multiplexing gets its own slot.
+
+    ``agent.secret_scope.get_secret`` raises on an unscoped read while
+    multiplexing is on. The registry cannot raise (it is consulted from
+    status/banner paths), so it does the next-safest thing: an unscoped
+    caller gets a dedicated partition that can never alias a real
+    profile's servers.
+    """
+    home_a, _ = homes
+    secret_scope.set_multiplex_active(True)
+
+    server = _FakeServer("github", token="token-A")
+    with _profile(home_a):
+        mcp._servers["github"] = server
+
+    assert mcp._servers.get("github") is None
+
+
+# ── teardown ────────────────────────────────────────────────────────────
+
+
+def test_profile_teardown_leaves_other_profiles_running(homes):
+    """``shutdown_mcp_servers(profile_only=True)`` reaps only this profile."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    server_a = _FakeServer("github", token="token-A")
+    server_b = _FakeServer("github", token="token-B")
+    with _profile(home_a):
+        mcp._servers["github"] = server_a
+    with _profile(home_b):
+        mcp._servers["github"] = server_b
+
+    mcp._ensure_mcp_loop()
+    try:
+        with _profile(home_b):
+            mcp.shutdown_mcp_servers(profile_only=True)
+            assert mcp._servers.get("github") is None
+
+        assert server_b.shutdown_calls == 1
+        assert server_a.shutdown_calls == 0
+        with _profile(home_a):
+            assert mcp._servers.get("github") is server_a
+    finally:
+        mcp._stop_mcp_loop()
+
+
+def test_full_shutdown_reaps_every_profile(homes):
+    """The process-exit path stays process-wide (unchanged default)."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    server_a = _FakeServer("github", token="token-A")
+    server_b = _FakeServer("github", token="token-B")
+    with _profile(home_a):
+        mcp._servers["github"] = server_a
+    with _profile(home_b):
+        mcp._servers["github"] = server_b
+
+    mcp._ensure_mcp_loop()
+    mcp.shutdown_mcp_servers()
+
+    assert server_a.shutdown_calls == 1
+    assert server_b.shutdown_calls == 1
+    with _profile(home_a):
+        assert mcp._servers.get("github") is None
+    with _profile(home_b):
+        assert mcp._servers.get("github") is None
+
+
+def test_idle_loop_check_sees_every_profile(homes):
+    """Another profile's live server must keep the shared MCP loop alive."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._servers["github"] = _FakeServer("github", token="token-A")
+
+    mcp._ensure_mcp_loop()
+    try:
+        with _profile(home_b):
+            assert mcp._stop_mcp_loop_if_idle() is False
+            assert mcp._mcp_loop is not None
+    finally:
+        with _profile(home_a):
+            mcp._servers.clear()
+        mcp._stop_mcp_loop()
+
+
+# ── lifecycle keys stay consistent ──────────────────────────────────────
+
+
+def test_reconnect_targets_only_the_calling_profile(homes):
+    """``reconnect_mcp_server`` must not reach into another profile."""
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        mcp._servers["github"] = _FakeServer("github", token="token-A")
+
+    with _profile(home_b):
+        assert mcp.reconnect_mcp_server("github") is False
+
+
+def test_server_task_remembers_its_owning_profile(homes):
+    """A long-lived server task addresses the partition it was born in.
+
+    ``MCPServerTask.run()`` re-enters the registry to self-evict and to
+    republish tools after a reconnect. It must always mean ITS OWN
+    profile, never whatever context the loop task happens to carry.
+    """
+    from hermes_constants import hermes_home_key
+
+    home_a, home_b = homes
+    secret_scope.set_multiplex_active(True)
+
+    with _profile(home_a):
+        task_a = mcp.MCPServerTask("github")
+    with _profile(home_b):
+        task_b = mcp.MCPServerTask("github")
+
+    assert task_a._profile_key == hermes_home_key(home_a)
+    assert task_b._profile_key == hermes_home_key(home_b)
+    assert task_a._profile_key != task_b._profile_key
+
+
+def test_server_task_profile_key_is_root_without_multiplexing(homes):
+    """Single-profile: the owning key is the one legacy partition."""
+    home_a, _ = homes
+    secret_scope.set_multiplex_active(False)
+
+    with _profile(home_a):
+        task = mcp.MCPServerTask("github")
+
+    assert task._profile_key == mcp._ROOT_PROFILE_KEY

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -110,11 +110,12 @@ import shutil
 import sys
 import threading
 import time
+from collections.abc import MutableMapping, MutableSet
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, TypeVar
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -2396,11 +2397,18 @@ class MCPServerTask:
         "_reconnect_retries", "_session_proven", "_was_parked",
         "_inflight_tasks", "_reconnecting", "_suspect_reason",
         "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
-        "_ever_connected",
+        "_ever_connected", "_profile_key",
     )
 
     def __init__(self, name: str):
         self.name = name
+        # Profile that owns this server, captured at construction (i.e.
+        # inside the connecting profile's ``_profile_runtime_scope``).
+        # Held explicitly rather than re-read from the ambient context:
+        # ``run()`` is a long-lived task that re-enters the registry for
+        # self-eviction and post-reconnect tool publication, and it must
+        # address ITS OWN partition even if the contextvar were ever lost.
+        self._profile_key: str = _mcp_profile_key()
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
         self._task: Optional[asyncio.Task] = None
@@ -3918,7 +3926,7 @@ class MCPServerTask:
             return
         if not self._ready.is_set():
             with _lock:
-                if _servers.get(self.name) is not self:
+                if _partition_for(_servers, self._profile_key).get(self.name) is not self:
                     return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config
@@ -3927,8 +3935,10 @@ class MCPServerTask:
         # recovered: drop its stale connect error so status surfaces stop
         # reporting it as failed.
         with _lock:
-            if _servers.get(self.name) is self:
-                _server_connect_errors.pop(self.name, None)
+            if _partition_for(_servers, self._profile_key).get(self.name) is self:
+                _partition_for(_server_connect_errors, self._profile_key).pop(
+                    self.name, None
+                )
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -4477,16 +4487,267 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 # Module-level state
 # ---------------------------------------------------------------------------
+#
+# PROFILE PARTITIONING (cross-tenant isolation)
+# ---------------------------------------------
+# Every registry below used to be a plain dict keyed by the BARE server
+# name. That is safe in the single-profile deployment Hermes ships by
+# default, but a multiplexing gateway (``gateway.multiplex_profiles``)
+# serves many profiles from ONE process: two profiles that each configure
+# a server called ``github`` would share ONE subprocess, started with
+# whichever profile connected first and holding that profile's
+# credentials. Profile B's turns then reached profile A's GitHub account.
+#
+# The registries are therefore partitioned by profile. The partition key
+# comes from the SAME scope the rest of the multiplexed path uses — the
+# context-local HERMES_HOME override installed by
+# ``gateway.run._profile_runtime_scope`` alongside
+# ``agent.secret_scope.set_secret_scope`` — so there is exactly one notion
+# of "who is this" in the process. See ``_mcp_profile_key``.
+#
+# Single-profile behaviour is bit-for-bit unchanged: the key is the empty
+# string whenever the process is not a multiplexer, so every access lands
+# in one partition, exactly as before.
 
-_servers: Dict[str, MCPServerTask] = {}
-_server_connecting: set[str] = set()
-_server_connect_errors: Dict[str, str] = {}
+# Partition key for a process that is not a multiplexer: one partition,
+# legacy behaviour.
+_ROOT_PROFILE_KEY = ""
+
+# Partition key for a read that happens under multiplexing with NO profile
+# scope installed. ``agent.secret_scope.get_secret`` fails closed (raises)
+# in that situation; a registry cannot raise (status/banner paths consult
+# it), so it does the next-safest thing and hands the caller a dedicated
+# partition that can never alias a real profile's servers. The NUL prefix
+# keeps it disjoint from every ``hermes_home_key`` (a normcased path).
+_UNSCOPED_PROFILE_KEY = "\x00unscoped"
+
+# Value type of a profile-partitioned mapping (keys are always server names).
+_VT = TypeVar("_VT")
+
+# Memoized module handles for ``_mcp_profile_key``. It runs on every
+# registry access — including per-tool ``check_fn`` evaluation on every
+# turn — so the two lazy imports (kept lazy to avoid an import cycle
+# through ``agent.secret_scope`` → ``hermes_cli.config``) are resolved
+# once. The MODULE is cached, not the functions, so tests that
+# monkeypatch ``is_multiplex_active`` still take effect.
+_secret_scope_mod = None
+_hermes_constants_mod = None
+
+
+def _mcp_profile_key() -> str:
+    """Return the partition key for the profile owning the current context.
+
+    Mirrors ``tools.registry.check_fn_cache_scope`` — the established
+    idiom for "which multiplex profile is this?" in this codebase:
+
+    * Multiplexing OFF (the default deployment, and every CLI/TUI/test
+      process): always :data:`_ROOT_PROFILE_KEY`. A HERMES_HOME override
+      is used by plenty of single-profile paths (``hermes_cli.plugins``,
+      ``hermes_cli.mcp_startup``'s discovery thread, ``bot_mode_probe``,
+      the desktop backend) and partitioning on it there would strand a
+      server started under an override behind a key nothing looks up.
+    * Multiplexing ON with a profile scope installed: the canonical
+      ``hermes_home_key`` of that profile's home — the same identity
+      ``_profile_runtime_scope`` installs, resolved and normcased so two
+      spellings of one home cannot fork a profile's registry in half.
+    * Multiplexing ON with no scope: :data:`_UNSCOPED_PROFILE_KEY`.
+
+    Never raises: an unresolvable identity degrades to the isolated
+    unscoped partition rather than aliasing somebody else's credentials.
+    """
+    global _secret_scope_mod, _hermes_constants_mod
+    try:
+        mod = _secret_scope_mod
+        if mod is None:
+            import agent.secret_scope as mod
+            _secret_scope_mod = mod
+        if not mod.is_multiplex_active():
+            return _ROOT_PROFILE_KEY
+    except Exception:
+        # secret_scope unavailable ⇒ not a multiplexer.
+        return _ROOT_PROFILE_KEY
+    try:
+        consts = _hermes_constants_mod
+        if consts is None:
+            import hermes_constants as consts
+            _hermes_constants_mod = consts
+        override = consts.get_hermes_home_override()
+        if not override:
+            return _UNSCOPED_PROFILE_KEY
+        return consts.hermes_home_key(override)
+    except Exception:
+        logger.debug("Could not resolve MCP profile key", exc_info=True)
+        return _UNSCOPED_PROFILE_KEY
+
+
+class _ProfileScopedDict(MutableMapping[str, _VT]):
+    """A dict whose contents are private to the active profile.
+
+    Presents the full ``MutableMapping`` surface so the ~90 existing call
+    sites (``_servers.get(name)``, ``_servers[name] = srv``,
+    ``dict(_servers)``, ``_lazy_server_configs.pop(name, None)``, …) and
+    the test suite's ``monkeypatch``-style save/restore fixtures keep
+    working verbatim.
+
+    ``partitions()`` is the deliberate escape hatch for the handful of
+    genuinely PROCESS-global operations — full shutdown, the shared MCP
+    event loop's idle check — which must see every profile's entries.
+    """
+
+    __slots__ = ("_partitions",)
+
+    def __init__(self):
+        self._partitions: Dict[str, Dict[str, _VT]] = {}
+
+    # -- partition plumbing ------------------------------------------------
+    def partitions(self) -> Dict[str, Dict[str, _VT]]:
+        """Return the raw ``{profile_key: dict}`` map (do not mutate keys)."""
+        return self._partitions
+
+    def for_key(self, key: str) -> Dict[str, _VT]:
+        """Return (creating if needed) the partition for an explicit key.
+
+        Used where the profile identity must be carried explicitly rather
+        than read from the ambient context — a long-lived server task, or
+        a coroutine handed to the MCP loop by
+        ``asyncio.run_coroutine_threadsafe`` (which does NOT copy the
+        caller's context).
+        """
+        part = self._partitions.get(key)
+        if part is None:
+            part = self._partitions[key] = {}
+        return part
+
+    def _current(self) -> Dict[str, _VT]:
+        return self.for_key(_mcp_profile_key())
+
+    # -- MutableMapping ----------------------------------------------------
+    def __getitem__(self, key):
+        return self._current()[key]
+
+    def __setitem__(self, key, value):
+        self._current()[key] = value
+
+    def __delitem__(self, key):
+        del self._current()[key]
+
+    def __iter__(self):
+        return iter(self._current())
+
+    def __len__(self):
+        return len(self._current())
+
+    def __contains__(self, key):
+        return key in self._current()
+
+    def __repr__(self):
+        return repr(self._current())
+
+
+class _ProfileScopedSet(MutableSet[str]):
+    """A set whose contents are private to the active profile.
+
+    Same rationale as :class:`_ProfileScopedDict`. Implements the concrete
+    ``set`` methods the call sites use (``add``/``discard``/``update``/
+    ``difference_update``/``clear``) on top of ``MutableSet``.
+    """
+
+    __slots__ = ("_partitions",)
+
+    def __init__(self):
+        self._partitions: Dict[str, Set[str]] = {}
+
+    def partitions(self) -> Dict[str, Set[str]]:
+        return self._partitions
+
+    def for_key(self, key: str) -> Set[str]:
+        part = self._partitions.get(key)
+        if part is None:
+            part = self._partitions[key] = set()
+        return part
+
+    def _current(self) -> Set[str]:
+        return self.for_key(_mcp_profile_key())
+
+    def __contains__(self, value):
+        return value in self._current()
+
+    def __iter__(self):
+        return iter(self._current())
+
+    def __len__(self):
+        return len(self._current())
+
+    def add(self, value):
+        self._current().add(value)
+
+    def discard(self, value):
+        self._current().discard(value)
+
+    def update(self, other):
+        self._current().update(other)
+
+    def difference_update(self, other):
+        self._current().difference_update(other)
+
+    def clear(self):
+        self._current().clear()
+
+    def __repr__(self):
+        return repr(self._current())
+
+
+def _all_partitions(container):
+    """Every partition of a scoped container (or the container itself).
+
+    Tolerates a plain ``dict``/``set`` so a test that monkeypatches one of
+    these module globals with a bare container still works.
+    """
+    getter = getattr(container, "partitions", None)
+    if callable(getter):
+        return list(getter().values())
+    return [container]
+
+
+def _all_partition_values(container) -> list:
+    values: list = []
+    for part in _all_partitions(container):
+        values.extend(part.values() if hasattr(part, "values") else part)
+    return values
+
+
+def _clear_all_partitions(container) -> None:
+    for part in _all_partitions(container):
+        part.clear()
+
+
+def _any_partition_populated(container) -> bool:
+    return any(bool(part) for part in _all_partitions(container))
+
+
+def _partition_for(container, key: str):
+    """The partition for an explicit profile key (plain containers pass through)."""
+    getter = getattr(container, "for_key", None)
+    if callable(getter):
+        return getter(key)
+    return container
+
+
+_servers: "_ProfileScopedDict[MCPServerTask]" = _ProfileScopedDict()
+_server_connecting: _ProfileScopedSet = _ProfileScopedSet()
+_server_connect_errors: "_ProfileScopedDict[str]" = _ProfileScopedDict()
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
-_lazy_server_configs: Dict[str, dict] = {}
-_lazy_server_fingerprints: Dict[str, str] = {}
-_lazy_server_tool_names: Dict[str, List[str]] = {}
+#
+# Profile-partitioned for the same reason as ``_servers``, and arguably
+# more urgently: ``_load_mcp_config`` interpolates ``${VAR}`` refs through
+# the ACTIVE profile's secret scope before the config is cached here, so
+# an entry holds that profile's resolved credentials verbatim. A bare-name
+# cache would spawn another profile's first call with them.
+_lazy_server_configs: "_ProfileScopedDict[dict]" = _ProfileScopedDict()
+_lazy_server_fingerprints: "_ProfileScopedDict[str]" = _ProfileScopedDict()
+_lazy_server_tool_names: "_ProfileScopedDict[List[str]]" = _ProfileScopedDict()
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -4514,8 +4775,8 @@ _connect_server_claim: contextvars.ContextVar[
 # server is retried on a backoff schedule instead of on every worker
 # session -- isolating it from the rest of the bridge. A successful
 # connection clears the state.
-_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
-_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
+_server_connect_retry_after: "_ProfileScopedDict[float]" = _ProfileScopedDict()  # name -> deadline
+_server_connect_failures: "_ProfileScopedDict[int]" = _ProfileScopedDict()       # name -> failures
 _CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
 _CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
 
@@ -4549,6 +4810,23 @@ def _connect_cooldown_active(server_name: str) -> bool:
     deadline = _server_connect_retry_after.get(server_name)
     return deadline is not None and time.monotonic() < deadline
 
+
+def _clear_connect_state(profile_key: str, profile_only: bool) -> None:
+    """Drop connect-backoff state for one profile, or for every profile.
+
+    Call under ``_lock``. ``profile_only`` mirrors ``shutdown_mcp_servers``:
+    a profile-scoped teardown must not clear another tenant's backoff (that
+    would re-arm the #50394 restart storm for a profile that never asked for
+    a restart), while the process-wide default keeps the historical
+    "wipe everything" behaviour.
+    """
+    if profile_only:
+        _partition_for(_server_connect_retry_after, profile_key).clear()
+        _partition_for(_server_connect_failures, profile_key).clear()
+    else:
+        _clear_all_partitions(_server_connect_retry_after)
+        _clear_all_partitions(_server_connect_failures)
+
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
 # a "server unreachable" message that tells the model to stop retrying,
@@ -4566,8 +4844,8 @@ def _connect_cooldown_active(server_name: str) -> bool:
 # the breaker most recently transitioned into the open state. Use the
 # ``_bump_server_error`` / ``_reset_server_error`` helpers to mutate
 # this state — they keep the count and timestamp in sync.
-_server_error_counts: Dict[str, int] = {}
-_server_breaker_opened_at: Dict[str, float] = {}
+_server_error_counts: "_ProfileScopedDict[int]" = _ProfileScopedDict()
+_server_breaker_opened_at: "_ProfileScopedDict[float]" = _ProfileScopedDict()
 _CIRCUIT_BREAKER_THRESHOLD = 3
 _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 
@@ -4598,8 +4876,8 @@ _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 # Classification happens at CALL TIME from data captured at DISCOVERY —
 # no toolset or schema mutation, so the conversation's toolset stays
 # byte-stable and prompt caching is preserved.
-_server_trust_levels: Dict[str, str] = {}
-_tool_read_only_hints: Dict[str, Dict[str, bool]] = {}
+_server_trust_levels: "_ProfileScopedDict[str]" = _ProfileScopedDict()
+_tool_read_only_hints: "_ProfileScopedDict[Dict[str, bool]]" = _ProfileScopedDict()
 
 _TRUST_FULL = "full"
 _TRUST_UNTRUSTED = "untrusted"
@@ -5237,7 +5515,7 @@ def _handle_session_expired_and_retry(
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
-_parallel_safe_servers: set = set()
+_parallel_safe_servers: _ProfileScopedSet = _ProfileScopedSet()
 
 # Exact MCP tool-name provenance. The generated registry name is lossy because
 # provider-safe normalization maps punctuation to ``_``. Keep the raw server
@@ -8350,15 +8628,35 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
     return staged_engine_names
 
 
-def shutdown_mcp_servers():
-    """Close all MCP server connections and stop the background loop.
+def shutdown_mcp_servers(*, profile_only: bool = False):
+    """Close MCP server connections and stop the background loop.
 
     Each server Task is signalled to exit its ``async with`` block so that
     the anyio cancel-scope cleanup happens in the same Task that opened it.
     All servers are shut down in parallel via ``asyncio.gather``.
+
+    ``profile_only=False`` (the default, and every existing caller —
+    process exit in ``hermes_cli.main`` / ``cli.py``, ``/reload-mcp``)
+    keeps the historical PROCESS-wide semantics: every profile's servers
+    are reaped and the shared loop is stopped. In a single-profile process
+    there is exactly one partition, so this is bit-for-bit what it always
+    did.
+
+    ``profile_only=True`` reaps only the ACTIVE profile's servers and
+    leaves other profiles' subprocesses running on the shared loop (which
+    is stopped only if it goes idle). That is the teardown a multiplexing
+    gateway needs when it stops serving one profile; tearing down all of
+    them would be a cross-tenant outage.
     """
+    # Captured on the CALLER's context. ``asyncio.run_coroutine_threadsafe``
+    # below does not copy it onto the MCP loop, so the inner coroutine must
+    # address partitions by this explicit key, never by ambient lookup.
+    profile_key = _mcp_profile_key()
     with _lock:
-        servers_snapshot = list(_servers.values())
+        if profile_only:
+            servers_snapshot = list(_partition_for(_servers, profile_key).values())
+        else:
+            servers_snapshot = _all_partition_values(_servers)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -8368,9 +8666,8 @@ def shutdown_mcp_servers():
     # configured server immediately.
     if not servers_snapshot:
         with _lock:
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
-        _stop_mcp_loop()
+            _clear_connect_state(profile_key, profile_only)
+        _stop_mcp_loop(only_if_idle=profile_only)
         return
 
     async def _shutdown():
@@ -8384,12 +8681,14 @@ def shutdown_mcp_servers():
                     "Error closing MCP server '%s': %s", server.name, result,
                 )
         with _lock:
-            _servers.clear()
+            if profile_only:
+                _partition_for(_servers, profile_key).clear()
+            else:
+                _clear_all_partitions(_servers)
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+            _clear_connect_state(profile_key, profile_only)
 
     with _lock:
         loop = _mcp_loop
@@ -8411,10 +8710,9 @@ def shutdown_mcp_servers():
     # shutdown must leave no stale connect-cooldown state behind — the
     # next start should re-attempt every server immediately (#50394).
     with _lock:
-        _server_connect_retry_after.clear()
-        _server_connect_failures.clear()
+        _clear_connect_state(profile_key, profile_only)
 
-    _stop_mcp_loop()
+    _stop_mcp_loop(only_if_idle=profile_only)
 
 
 def _kill_orphaned_mcp_children(
@@ -8613,7 +8911,14 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
-        if only_if_idle and (_servers or _server_connecting):
+        if only_if_idle and (
+            # The event loop is process-GLOBAL and shared by every profile,
+            # so idleness is a question about all partitions. Asking only
+            # the active profile would tear the loop out from under another
+            # tenant's live servers.
+            _any_partition_populated(_servers)
+            or _any_partition_populated(_server_connecting)
+        ):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
         loop = _mcp_loop


### PR DESCRIPTION
## The problem

The multiplexing gateway scopes config, memory and secrets per profile: `_profile_runtime_scope` installs a `HERMES_HOME` override alongside `set_secret_scope`, and `agent/secret_scope.py` is deliberately fail-closed so an un-migrated call site raises rather than silently reading another profile's value.

The MCP layer never joined that scheme. Thirteen module-level structures in `tools/mcp_tool.py` are keyed by bare server name, so **two profiles that each configure a server called `github` share one subprocess** — started by whichever arrived first, holding that profile's credentials.

A test written against unmodified code shows it directly:

```
test_two_profiles_same_server_name_do_not_share_a_connection
>       assert leaked is not server_a
E       AssertionError: profile B was handed profile A's 'github' MCP connection
```

Two things make it worse than a shared connection:

- **`_lazy_server_configs` caches a config whose `${TOKEN}` placeholders are already expanded.** `_load_mcp_config` interpolates through the active secret scope *before* caching, so the cached dict literally holds the first profile's credential and would spawn the second profile's first call with it.
- **The trust maps leak too.** Inheriting another profile's `trust: full` or its `readOnlyHint` exemptions silently un-gates the dangerous-call approval path.

## The fix

`_mcp_profile_key()` partitions every one of those structures:

- not a multiplexer → `""`, one partition, today's behaviour;
- multiplexing + scope → `hermes_home_key(get_hermes_home_override())`, the same override `_profile_runtime_scope` installs;
- multiplexing, no scope → a dedicated partition that cannot alias a profile (registries can't raise the way `get_secret` does).

This mirrors `tools/registry.py::check_fn_cache_scope` and `hermes_cli/plugins.py::_plugin_home_key` rather than introducing a second notion of identity. Gating on `is_multiplex_active()` rather than on "an override is set" is load-bearing: plugins, discovery, the bot-mode probe and the desktop backend all set overrides in single-profile processes, and partitioning on those would strand a server behind a key nothing looks up.

`_ProfileScopedDict`/`_ProfileScopedSet` implement the full `MutableMapping`/`MutableSet` protocols, so the ~90 existing call sites and test fixtures are unchanged; `partitions()`/`for_key()` are the escape hatch for genuinely process-global work.

**Lifecycle.** `MCPServerTask` captures its key at construction, because the long-lived `run()` task must address its own partition. `shutdown_mcp_servers` captures on the caller's context — `run_coroutine_threadsafe` does not copy contextvars onto the MCP loop. `_stop_mcp_loop(only_if_idle=True)` deliberately asks **all** partitions: the loop is process-global, and a per-profile check would let one profile's probe tear it out from under another's live servers.

**Also fixed:** `gateway/run.py::_execute_mcp_reload` ran `shutdown_mcp_servers` process-wide from inside one profile's scope, so one tenant typing `/reload-mcp` tore down every other tenant's stdio children — and, contextvars not propagating through `run_in_executor`, then re-discovered the *default* profile's `mcp_servers`.

## Single-profile behaviour is unchanged

Three ways: by construction (the key is `""` in any non-multiplexed process, so there is exactly one partition and every default is preserved); by explicit test (`test_single_profile_gateway_is_unpartitioned` asserts one partition even under a `HERMES_HOME` override); and by baseline diff — the same suites on the base commit and on this branch:

| suite | baseline | with fix |
|---|---|---|
| 76 MCP test files | 845 passed, 7 failed | 857 passed, 7 failed (+12 new) |
| gateway + cli + hermes_cli | 15571 passed, 20 failed, 172 skipped | 15571 passed, 20 failed, 172 skipped |

Same failing files, same counts, both sides; those failures are pre-existing and platform-specific (macOS).

## Known siblings, deliberately not fixed here

Reported rather than swept in, so this stays reviewable:

1. **MCP tools are registered without `scope=`**, so they land in the process-global `_tools` rather than `_scoped_tools`. Execution is profile-correct after this change (handlers re-resolve by name), but advertised **schemas, names and descriptions** still cross profiles. `_scoped_tools` already does this for plugins — the natural follow-up.
2. `_mcp_stderr_log_fh` resolves once under whichever profile calls first, then becomes every profile's stdio child's stderr.
3. `hermes_cli/mcp_startup.py`'s `_mcp_discovery_started` is a once-per-process gate, so profiles 2..N get no MCP tools. Same shape in `tui_gateway/entry.py`.
4. `_mcp_tool_server_names` is left unpartitioned on purpose — it is meaningless apart from the global registry, and partitioning it alone would make `has_registered_mcp_tools()` lie. Fix with (1).
5. `_MCP_DISCOVERY_LOCK_PATH`; 6. `mcp_oauth.py::_reserved_sockets` (a global FIFO cap of 8, so one profile's OAuth burst can evict another's parked callback socket); 7. `model_tools.py::_last_resolved_tool_names`.

Happy to split any of those out if you'd rather see them separately.

## Notes for review

- The `_profile_key` on `MCPServerTask` costs a `__slots__` entry. Deliberate — trusting contextvar inheritance into the long-lived `run()` task is the kind of thing that breaks silently later.
- `_mcp_profile_key()` runs on every registry access including per-tool `check_fn` evaluation, so the two lazy imports are memoized at module level — the module is cached, not the functions, so monkeypatching `is_multiplex_active` still takes effect.
- Container annotations are generic over the value type so the advisory `ty` diff stays quiet; the blocking `ruff` rules are untouched.