### PR TITLE
fix(desktop): isolate scroll to the hovered tile

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -25,7 +25,7 @@ import { sessionBlockingPrompt } from '@/store/prompts'
 import { toggleReview } from '@/store/review'
 import { $gatewayState } from '@/store/session'
 import { $botChatSessionIds, $sessionStates, $sessionTiles, isBotChatSession } from '@/store/session-states'
-import { $threadScrolledUp } from '@/store/thread-scroll'
+import { threadScrolledUpStore } from '@/store/thread-scroll'
 import { $autoSpeakReplies } from '@/store/voice-prefs'
 import { useTheme } from '@/themes'
 
@@ -74,7 +74,7 @@ import {
   normalizeComposerEditorDom,
   RICH_INPUT_SLOT
 } from './rich-editor'
-import { useComposerScope } from './scope'
+import { useComposerScope, useComposerSurfaceId } from './scope'
 import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
 import { SuggestionPills } from './suggestion-pills'
@@ -161,7 +161,7 @@ export function ChatBar({
   const scope = useComposerScope()
   const attachments = useStore(scope.attachments.$attachments)
   const compacting = useStore(useMemo(() => sessionCompacting(sessionId ?? null), [sessionId]))
-  const scrolledUp = useStore($threadScrolledUp)
+  const scrolledUp = useStore(threadScrolledUpStore(useComposerSurfaceId() ?? ''))
   const autoSpeak = useStore($autoSpeakReplies)
   // The turn is parked on the user (clarify / approval / sudo / secret). Esc must
   // not interrupt it — there's nothing actively running to stop, and stopping

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 
 import { blurComposerInput } from '@/app/chat/composer/focus'
+import { useComposerSurfaceId } from '@/app/chat/composer/scope'
 import { AGENTS_ROUTE } from '@/app/routes'
 import { BillingBanner } from '@/components/billing-banner'
 import { composerDockCard } from '@/components/chat/composer-dock'
@@ -27,7 +28,7 @@ import {
 } from '@/store/composer-status'
 import { refreshSessionGoal } from '@/store/goals'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
-import { $threadScrolledUp } from '@/store/thread-scroll'
+import { threadScrolledUpStore } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
 import { PreviewStatusRow } from './preview-row'
@@ -97,7 +98,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   // items actually changed.
   const items = useSessionSlice($statusItemsBySession, sessionId)
   const previews = useSessionSlice($previewStatusBySession, sessionId)
-  const scrolledUp = useStore($threadScrolledUp)
+  const scrolledUp = useStore(threadScrolledUpStore(useComposerSurfaceId() ?? ''))
   const billing = useStore($billingBlock)
 
   const groups = useMemo(() => groupStatusItems(items), [items])

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -664,6 +664,7 @@ const ChatViewContent = memo(function ChatViewContent({
             onCancel={haltRun}
             onDismissError={onDismissError}
             onRestoreToMessage={onRestoreToMessage}
+            scrollScope={composerSurfaceId ?? ''}
             sessionId={activeSessionId}
             sessionKey={threadKey}
           />

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -1,12 +1,13 @@
 import { useStore } from '@nanostores/react'
 import { useRef } from 'react'
 
+import { useComposerSurfaceId } from '@/app/chat/composer/scope'
 import { Codicon } from '@/components/ui/codicon'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { $approvalRequest } from '@/store/prompts'
-import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-scroll'
+import { requestScrollToBottom, threadJumpButtonVisibleStore } from '@/store/thread-scroll'
 
 /**
  * Floating "jump to bottom" control. Sits centered just above the composer,
@@ -30,7 +31,8 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
  */
 export function ScrollToBottomButton() {
   const { t } = useI18n()
-  const visible = useStore($threadJumpButtonVisible)
+  const scrollScope = useComposerSurfaceId() ?? ''
+  const visible = useStore(threadJumpButtonVisibleStore(scrollScope))
   const request = useStore($approvalRequest)
   // Scrolled away while an approval is pending → the inline Run/Reject bar is
   // below the fold. Relabel so the user knows the session needs them, not just
@@ -59,7 +61,7 @@ export function ScrollToBottomButton() {
       data-state={state}
       onClick={() => {
         triggerHaptic('selection')
-        requestScrollToBottom()
+        requestScrollToBottom(scrollScope)
       }}
       style={{
         bottom: 'calc(var(--composer-measured-height) + 0.625rem)'

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -53,7 +53,7 @@ describe('clarify.request stream hydration', () => {
   beforeEach(() => {
     clearClarifyRequest()
     scrollToBottom.mockClear()
-    stopScrollListener = onScrollToBottomRequest(scrollToBottom)
+    stopScrollListener = onScrollToBottomRequest(scrollToBottom, SID)
   })
 
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -94,7 +94,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 
@@ -142,7 +142,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -43,6 +43,8 @@ interface ThreadProps {
   onCancel?: () => Promise<void> | void
   onDismissError?: (messageId: string) => void
   onRestoreToMessage?: (messageId: string, target?: RestoreMessageTarget) => Promise<void> | void
+  /** Per-ChatView scroll identity. See `useComposerSurfaceId`. */
+  scrollScope?: string
   sessionId?: string | null
   sessionKey?: string | null
 }
@@ -64,6 +66,7 @@ export const Thread = memo(function Thread({
   onCancel,
   onDismissError,
   onRestoreToMessage,
+  scrollScope = '',
   sessionId = null,
   sessionKey
 }: ThreadProps) {
@@ -175,6 +178,8 @@ export const Thread = memo(function Thread({
           components={messageComponents}
           emptyPlaceholder={emptyPlaceholder}
           loadingIndicator={loadingIndicator}
+          scrollScope={scrollScope}
+          sessionId={sessionId}
           sessionKey={sessionKey}
         />
         {loading === 'session' && <CenteredThreadSpinner />}

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -20,6 +20,7 @@ import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
+import { isolateTileWheel } from '@/lib/tile-scroll'
 import { cn } from '@/lib/utils'
 import {
   onScrollToBottomRequest,
@@ -186,6 +187,10 @@ interface ThreadMessageListProps {
   components: ThreadMessageComponents
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
+  /** Per-ChatView identity for transcript scroll. Empty is the unscoped
+   *  legacy slot used by tests / a lone pane. */
+  scrollScope?: string
+  sessionId?: string | null
   sessionKey?: string | null
 }
 
@@ -375,6 +380,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   components,
   emptyPlaceholder,
   loadingIndicator,
+  scrollScope = '',
+  sessionId = null,
   sessionKey
 }) => {
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
@@ -575,11 +582,22 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
-  useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
-  useEffect(() => () => resetThreadScroll(), [])
+  useEffect(() => setThreadAtBottom(isAtBottom, scrollScope), [isAtBottom, scrollScope])
+  useEffect(() => () => resetThreadScroll(scrollScope), [scrollScope])
 
   // Floating jump button (outside this subtree) → return to the bottom.
-  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+  // Register under this ChatView's surface id AND the live runtime id so a
+  // gateway-driven jump (clarify hydration) hits only this transcript.
+  useEffect(() => {
+    const jump = () => void scrollToBottom()
+    const stopSurface = onScrollToBottomRequest(jump, scrollScope)
+    const stopSession = sessionId ? onScrollToBottomRequest(jump, sessionId) : undefined
+
+    return () => {
+      stopSurface()
+      stopSession?.()
+    }
+  }, [scrollScope, scrollToBottom, sessionId])
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
   // the same to any window): rAF and ResizeObserver may have been frozen, so
@@ -617,8 +635,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     el.setAttribute('data-editing', 'true')
   }, [endEditHold, scrollRef, stopScroll])
 
-  useEffect(() => onThreadEditOpen(beginEditHold), [beginEditHold])
-  useEffect(() => onThreadEditClose(endEditHold), [endEditHold])
+  useEffect(() => onThreadEditOpen(beginEditHold, scrollScope), [beginEditHold, scrollScope])
+  useEffect(() => onThreadEditClose(endEditHold, scrollScope), [endEditHold, scrollScope])
   useEffect(() => () => endEditHold(), [endEditHold])
   // New run → snap to the latest turn.
   useAuiEvent('thread.runStart', () => void scrollToBottom())
@@ -772,6 +790,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
         className="size-full overflow-x-hidden overflow-y-auto overscroll-contain"
         data-following={isAtBottom ? 'true' : 'false'}
         data-slot="aui_thread-viewport"
+        onWheel={isolateTileWheel}
         ref={scrollRef as React.RefCallback<HTMLDivElement>}
       >
         {renderEmpty ? (

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -44,6 +44,7 @@ import {
   replaceBeforeCaret,
   RICH_INPUT_SLOT
 } from '@/app/chat/composer/rich-editor'
+import { useComposerSurfaceId } from '@/app/chat/composer/scope'
 import { detectTrigger, openDirectiveScope, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import { isRedoShortcut, isUndoShortcut } from '@/app/chat/composer/undo-history'
@@ -87,6 +88,7 @@ interface UserEditComposerProps {
 export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
+  const scrollScope = useComposerSurfaceId() ?? ''
   const aui = useAui()
   const draft = useAuiState(s => s.composer.text)
   const rootRef = useRef<HTMLDivElement | null>(null)
@@ -148,7 +150,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // and a sibling unmount-only effect would only be a second place to forget.
   useEffect(
     () => () => {
-      notifyThreadEditClose()
+      notifyThreadEditClose(scrollScope)
       releaseActiveComposer('edit')
 
       for (const id of pendingTimeoutsRef.current) {
@@ -157,7 +159,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       pendingTimeoutsRef.current.clear()
     },
-    []
+    [scrollScope]
   )
 
   const focusEditor = useCallback(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -1,6 +1,7 @@
 import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
+import { useComposerSurfaceId } from '@/app/chat/composer/scope'
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
@@ -266,6 +267,7 @@ export const UserMessage: FC<{
 }> = ({ onCancel, onRequestRestoreConfirm }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
+  const scrollScope = useComposerSurfaceId() ?? ''
   const messageId = useAuiState(s => s.message.id)
   const content = useAuiState(s => s.message.content)
   const messageText = messageContentText(content)
@@ -519,7 +521,7 @@ export const UserMessage: FC<{
                           return
                         }
 
-                        notifyThreadEditOpen()
+                        notifyThreadEditOpen(scrollScope)
                       }}
                       type="button"
                     >

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -29,6 +29,7 @@ import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
+import { isolateTileWheel } from '@/lib/tile-scroll'
 import { cn } from '@/lib/utils'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
 
@@ -684,8 +685,12 @@ export function TreeGroup({
               return (
                 <div
                   aria-hidden={!isActive || undefined}
-                  className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible')}
+                  className={cn(
+                    'absolute inset-0 overflow-auto overscroll-contain',
+                    !isActive && 'pointer-events-none invisible'
+                  )}
                   key={paneId}
+                  onWheel={isolateTileWheel}
                   {...hiddenPaneProps(!isActive)}
                 >
                   {pane?.render ? (

--- a/apps/desktop/src/lib/tile-scroll.test.ts
+++ b/apps/desktop/src/lib/tile-scroll.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isolateTileWheel } from './tile-scroll'
+
+describe('isolateTileWheel', () => {
+  it('stops the wheel from reaching sibling tile scrollers', () => {
+    const event = { stopPropagation: vi.fn() }
+
+    isolateTileWheel(event)
+
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/lib/tile-scroll.ts
+++ b/apps/desktop/src/lib/tile-scroll.ts
@@ -1,0 +1,10 @@
+/**
+ * Keep a wheel/trackpad gesture inside the tile it started on.
+ *
+ * Multi-tile layouts stack several overflow surfaces under one layout tree.
+ * Without stopping the event at the hovered scroller, the same delta chains
+ * into sibling tiles (or a parent of all of them) and every pane moves.
+ */
+export function isolateTileWheel(event: { stopPropagation: () => void }): void {
+  event.stopPropagation()
+}

--- a/apps/desktop/src/store/thread-scroll.test.ts
+++ b/apps/desktop/src/store/thread-scroll.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  notifyThreadEditOpen,
+  onScrollToBottomRequest,
+  onThreadEditOpen,
+  requestScrollToBottom,
+  resetThreadScroll,
+  setThreadAtBottom,
+  threadJumpButtonVisibleStore,
+  threadScrolledUpStore
+} from './thread-scroll'
+
+afterEach(() => {
+  resetThreadScroll('tile-a')
+  resetThreadScroll('tile-b')
+  resetThreadScroll()
+})
+
+describe('thread scroll isolation', () => {
+  it('requestScrollToBottom only fires the handler for that surface id', () => {
+    const tileA = vi.fn()
+    const tileB = vi.fn()
+    const stopA = onScrollToBottomRequest(tileA, 'tile-a')
+    const stopB = onScrollToBottomRequest(tileB, 'tile-b')
+
+    requestScrollToBottom('tile-a')
+
+    expect(tileA).toHaveBeenCalledOnce()
+    expect(tileB).not.toHaveBeenCalled()
+
+    requestScrollToBottom('tile-b')
+
+    expect(tileA).toHaveBeenCalledOnce()
+    expect(tileB).toHaveBeenCalledOnce()
+
+    stopA()
+    stopB()
+  })
+
+  it('keeps scrolled-up state per surface so one tile cannot dim another', () => {
+    setThreadAtBottom(false, 'tile-a')
+
+    expect(threadScrolledUpStore('tile-a').get()).toBe(true)
+    expect(threadJumpButtonVisibleStore('tile-a').get()).toBe(true)
+    expect(threadScrolledUpStore('tile-b').get()).toBe(false)
+    expect(threadJumpButtonVisibleStore('tile-b').get()).toBe(false)
+  })
+
+  it('does not broadcast an inline-edit hold to other tiles', () => {
+    const tileA = vi.fn()
+    const tileB = vi.fn()
+    const stopA = onThreadEditOpen(tileA, 'tile-a')
+    const stopB = onThreadEditOpen(tileB, 'tile-b')
+
+    notifyThreadEditOpen('tile-a')
+
+    expect(tileA).toHaveBeenCalledOnce()
+    expect(tileB).not.toHaveBeenCalled()
+
+    stopA()
+    stopB()
+  })
+})

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -5,60 +5,107 @@ import { atom, type WritableAtom } from 'nanostores'
 // subtree, so ThreadMessageList mirrors it into these atoms for the composer,
 // status stack, and floating jump button — all of which render OUTSIDE the thread.
 //
-// `$threadScrolledUp` dims the composer / status stack; `$threadJumpButtonVisible`
-// shows the floating jump control. Both track `!isAtBottom` today, but stay
-// separate so their thresholds can diverge again without touching consumers.
-export const $threadScrolledUp = atom(false)
-export const $threadJumpButtonVisible = atom(false)
+// Identity is per ChatView surface (`useComposerSurfaceId`), never process-global:
+// each tiled session has its own composer + jump button + transcript scroller,
+// and a shared atom/handler set would dim, jump, and scroll every visible tile
+// when only one of them moved (#99271).
+//
+// `$threadScrolledUp` / `$threadJumpButtonVisible` remain the unscoped (legacy
+// single-pane / test) slot. Surfaces that know their id use the scoped stores.
 
-// Skip no-op writes so subscribers don't churn on every scroll tick.
-const setter = (target: WritableAtom<boolean>) => (value: boolean) => {
+const DEFAULT_SCOPE = ''
+
+function scopedBooleanAtom(
+  slots: Map<string, WritableAtom<boolean>>,
+  scope: string,
+  initial: boolean
+): WritableAtom<boolean> {
+  let slot = slots.get(scope)
+
+  if (!slot) {
+    slot = atom(initial)
+    slots.set(scope, slot)
+  }
+
+  return slot
+}
+
+const scrolledUpSlots = new Map<string, WritableAtom<boolean>>()
+const jumpVisibleSlots = new Map<string, WritableAtom<boolean>>()
+
+export function threadScrolledUpStore(scope: string = DEFAULT_SCOPE): WritableAtom<boolean> {
+  return scopedBooleanAtom(scrolledUpSlots, scope, false)
+}
+
+export function threadJumpButtonVisibleStore(scope: string = DEFAULT_SCOPE): WritableAtom<boolean> {
+  return scopedBooleanAtom(jumpVisibleSlots, scope, false)
+}
+
+export const $threadScrolledUp = threadScrolledUpStore()
+export const $threadJumpButtonVisible = threadJumpButtonVisibleStore()
+
+const setScoped = (target: WritableAtom<boolean>, value: boolean) => {
   if (target.get() !== value) {
     target.set(value)
   }
 }
 
-const setScrolledUp = setter($threadScrolledUp)
-const setJumpButtonVisible = setter($threadJumpButtonVisible)
+export const setThreadAtBottom = (isAtBottom: boolean, scope: string = DEFAULT_SCOPE) => {
+  const scrolledUp = !isAtBottom
 
-export const setThreadAtBottom = (isAtBottom: boolean) => {
-  setScrolledUp(!isAtBottom)
-  setJumpButtonVisible(!isAtBottom)
+  setScoped(threadScrolledUpStore(scope), scrolledUp)
+  setScoped(threadJumpButtonVisibleStore(scope), scrolledUp)
 }
 
-export const resetThreadScroll = () => setThreadAtBottom(true)
+export const resetThreadScroll = (scope: string = DEFAULT_SCOPE) => setThreadAtBottom(true, scope)
+
+type HandlerMap = Map<string, Set<() => void>>
+
+function addHandler(map: HandlerMap, handler: () => void, scope: string): () => void {
+  let handlers = map.get(scope)
+
+  if (!handlers) {
+    handlers = new Set()
+    map.set(scope, handlers)
+  }
+
+  handlers.add(handler)
+
+  return () => {
+    handlers!.delete(handler)
+
+    if (handlers!.size === 0) {
+      map.delete(scope)
+    }
+  }
+}
+
+function fireHandlers(map: HandlerMap, scope: string) {
+  map.get(scope)?.forEach(handler => handler())
+}
 
 // Cross-component bridge: the jump button lives by the composer, the viewport's
 // `scrollToBottom` lives inside the thread. The bridge registers a handler; the
 // button fires it. Mirrors the composer focus/insert emitter pattern.
-const handlers = new Set<() => void>()
+const scrollToBottomHandlers: HandlerMap = new Map()
 
-export const onScrollToBottomRequest = (handler: () => void) => {
-  handlers.add(handler)
+export const onScrollToBottomRequest = (handler: () => void, scope: string = DEFAULT_SCOPE) =>
+  addHandler(scrollToBottomHandlers, handler, scope)
 
-  return () => void handlers.delete(handler)
-}
-
-export const requestScrollToBottom = () => handlers.forEach(handler => handler())
+export const requestScrollToBottom = (scope: string = DEFAULT_SCOPE) => fireHandlers(scrollToBottomHandlers, scope)
 
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when
 // the inline composer unmounts.
-const editOpenHandlers = new Set<() => void>()
-const editCloseHandlers = new Set<() => void>()
+const editOpenHandlers: HandlerMap = new Map()
+const editCloseHandlers: HandlerMap = new Map()
 
-export const onThreadEditOpen = (handler: () => void) => {
-  editOpenHandlers.add(handler)
+export const onThreadEditOpen = (handler: () => void, scope: string = DEFAULT_SCOPE) =>
+  addHandler(editOpenHandlers, handler, scope)
 
-  return () => void editOpenHandlers.delete(handler)
-}
+export const notifyThreadEditOpen = (scope: string = DEFAULT_SCOPE) => fireHandlers(editOpenHandlers, scope)
 
-export const notifyThreadEditOpen = () => editOpenHandlers.forEach(handler => handler())
+export const onThreadEditClose = (handler: () => void, scope: string = DEFAULT_SCOPE) =>
+  addHandler(editCloseHandlers, handler, scope)
 
-export const onThreadEditClose = (handler: () => void) => {
-  editCloseHandlers.add(handler)
-
-  return () => void editCloseHandlers.delete(handler)
-}
-
-export const notifyThreadEditClose = () => editCloseHandlers.forEach(handler => handler())
+export const notifyThreadEditClose = (scope: string = DEFAULT_SCOPE) => fireHandlers(editCloseHandlers, scope)


### PR DESCRIPTION
## What does this PR do?

In a multi-tile Desktop layout, scrolling one chat pane also moved the others. Transcript stick-to-bottom, the jump-to-bottom button, and composer "scrolled up" styling all shared one process-global handler set / atom. Every mounted tile registered `scrollToBottom` on that set, so a jump (or a resize follow triggered by the shared scrolled-up flag) applied to every visible transcript.

This keys scroll state and handlers by ChatView surface id (`useComposerSurfaceId`). Wheel events stop at the hovered tile scroller, and the pane body uses `overscroll-contain` so leftover deltas cannot chain into a sibling.

## Related Issue

Fixes #99271

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/thread-scroll.ts` — per-surface atoms and handler maps. `requestScrollToBottom(scope)` only fires that tile's transcript.
- `apps/desktop/src/components/assistant-ui/thread/list.tsx` — register jump/edit handlers under the ChatView surface id (and the live runtime id for gateway-driven jumps). Stop wheel propagation on the transcript scroller.
- `apps/desktop/src/app/chat/{index,scroll-to-bottom-button,composer}.tsx` — jump button and composer dimming read the scoped stores.
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx` — `overscroll-contain` + wheel isolation on the pane body.
- `apps/desktop/src/lib/tile-scroll.ts` — small `isolateTileWheel` helper.
- Tests: `thread-scroll.test.ts` (handler/atom isolation by id) and `tile-scroll.test.ts`.

## How to Test

1. From `apps/desktop`:
   ```bash
   npx vitest run src/store/thread-scroll.test.ts src/lib/tile-scroll.test.ts src/app/chat/scroll-to-bottom-button.test.tsx src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx src/components/assistant-ui/thread/list.test.ts src/components/assistant-ui/thread/user-message-edit.test.tsx src/components/assistant-ui/thread/user-message-edit-gesture.test.tsx src/components/assistant-ui/thread/edit-context.test.tsx src/components/pane-shell/tree/renderer/tree-group.test.tsx src/components/assistant-ui/thread/streaming.test.tsx src/app/chat/surface-vars.test.ts
   ```
   All 90 tests in those files passed (64 + 26).
2. Open Desktop with two or more chat tiles visible. Place the pointer over one transcript and scroll. Only that tile should move; the other tiles keep their positions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  (N/A — Desktop-only TypeScript; ran the vitest files listed above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (vitest in `apps/desktop`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — isolation is covered by unit tests (`requestScrollToBottom('tile-a')` does not fire `tile-b`; `isolateTileWheel` stops propagation).
