### PR TITLE
fix(web): fail keyless ring over on masked-throttle response-shape errors

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -46,6 +46,30 @@ def _is_rate_limitish(message: str) -> bool:
     return any(marker in (message or "").lower() for marker in _RATE_LIMIT_MARKERS)
 
 
+_SHAPE_FAILURE_MARKERS = (
+    "unrecognized mcp response shape",
+    "malformed mcp response",
+    "invalid mcp response",
+)
+
+
+def _is_vendor_retryable(message: str) -> bool:
+    """Heuristic: should the ring try the next vendor for this error?
+
+    True for rate-limit-shaped errors and for unparseable MCP response
+    shapes: anonymous endpoints occasionally answer HTTP 200 with an HTML
+    or non-JSON-RPC error page while throttling, which fails response
+    parsing and carries none of the classic rate-limit markers (observed
+    live 2026-08-31: Exa returning masked 429s as "Unrecognized MCP
+    response shape"). Anything else — auth failures, bad input — fails
+    fast: it would fail identically on every vendor.
+    """
+    lowered = (message or "").lower()
+    return _is_rate_limitish(message) or any(
+        marker in lowered for marker in _SHAPE_FAILURE_MARKERS
+    )
+
+
 def _fail_msg(vendor: str, kind: str, exc: Any, *, other_backends: bool = True) -> str:
     label, env_key, site = _VENDOR_HINTS[vendor]
     alt = " or another web backend via `hermes tools`" if other_backends else ""
@@ -355,12 +379,13 @@ def _walk_ring(name: str, kind: str, call, throttled) -> tuple:
 
 
 def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any]:
-    """Rate-limit-shaped errors advance to the next vendor, other errors stop the walk
-    (a malformed query fails everywhere). ``data.served_by`` is set when the serving
-    vendor differs from *name*."""
+    """Vendor-retryable errors (rate-limit-shaped or masked-throttle response-shape
+    failures) advance to the next vendor, other errors stop the walk (a malformed
+    query fails everywhere). ``data.served_by`` is set when the serving vendor
+    differs from *name*."""
 
     def _throttled(result: Dict[str, Any]) -> bool:
-        return not result.get("success") and _is_rate_limitish(result.get("error", ""))
+        return not result.get("success") and _is_vendor_retryable(result.get("error", ""))
 
     order, vendor, result, exhausted = _walk_ring(name, "search", lambda v: _KEYLESS_SEARCHERS[v](query, limit), _throttled)
     if not order:
@@ -373,13 +398,43 @@ def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any
 
 
 def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
-    """Fails over only when EVERY url in a batch is rate-limit-shaped (partial failures
-    are page problems, returned as-is)."""
+    """Per-URL vendor failover: each URL is retried on the next ring vendor while its
+    error is vendor-retryable (rate-limit-shaped or a masked-throttle response-shape
+    failure); successes and hard failures (auth, bad input, page-level problems) are
+    final, so a mixed batch only re-fetches the URLs that need another vendor. Results
+    keep input order and length; URLs served by a fallback vendor are tagged
+    ``served_by``."""
 
-    def _all_throttled(results: List[Dict[str, Any]]) -> bool:
-        return bool(results) and all(r.get("error", "") and _is_rate_limitish(r.get("error", "")) for r in results)
+    def _per_url_throttled(result: Dict[str, Any]) -> bool:
+        return bool(result.get("error")) and _is_vendor_retryable(result.get("error", ""))
 
-    order, _vendor, results, _exhausted = _walk_ring(name, "extract", lambda v: _KEYLESS_EXTRACTORS[v](list(urls)), _all_throttled)
+    order = _ring_order(name)
     if not order:
         return [_page_error(u, _ALL_PAID_MSG) for u in urls]
-    return results
+    final: List[Optional[Dict[str, Any]]] = [None] * len(urls)
+    pending: List[tuple] = list(enumerate(urls))
+    last_result: Dict[int, Dict[str, Any]] = {}
+    for i, vendor in enumerate(order):
+        if not pending:
+            break
+        batch = [u for _idx, u in pending]
+        results = _KEYLESS_EXTRACTORS[vendor](batch)
+        still_pending: List[tuple] = []
+        for (idx, u), r in zip(pending, results):
+            last_result[idx] = r
+            if _per_url_throttled(r):
+                still_pending.append((idx, u))
+                continue
+            if vendor != name and not r.get("error"):
+                r.setdefault("served_by", vendor)
+            final[idx] = r
+        if still_pending and i + 1 < len(order):
+            logger.info(
+                "keyless %s extract: %d URL(s) vendor-retryable; failing over to %s",
+                vendor, len(still_pending), order[i + 1],
+            )
+        pending = still_pending
+    for idx, u in pending:  # ring exhausted with URLs still retryable
+        fallback = last_result.get(idx)
+        final[idx] = fallback if fallback is not None else _page_error(u, "extract failed on all keyless vendors")
+    return [r for r in final if r is not None]

--- a/tests/plugins/web/test_keyless_failover_classifier.py
+++ b/tests/plugins/web/test_keyless_failover_classifier.py
@@ -1,0 +1,220 @@
+"""Regression tests for the keyless ring failover classifier.
+
+Covers the 2026-08-31 live failure: Exa's anonymous MCP endpoint sometimes
+answers HTTP 200 with a body that doesn't parse as JSON-RPC (rate-limit
+pages, HTML error pages). The vendor wrapper turns that into the error
+string "Keyless Exa search failed: Unrecognized MCP response shape. ...",
+which carries none of the classic rate-limit markers — so the ring used to
+treat it as a hard, vendor-independent failure and never tried the next
+free provider. These tests pin the fix: shape failures are *retryable
+vendor failures*, so the walk advances; auth/config errors keep failing
+fast.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+
+# Load by file path: the runtime env's editable-install finder claims the
+# top-level "plugins" name, so `from plugins.web import keyless_mcp` is
+# unreliable under pytest. Direct loading sidesteps package resolution.
+_spec = importlib.util.spec_from_file_location(
+    "keyless_mcp_under_test", REPO / "plugins" / "web" / "keyless_mcp.py"
+)
+assert _spec is not None and _spec.loader is not None
+km = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(km)
+
+
+def _make_ring(monkeypatch, behavior):
+    """Replace both vendor registries with scripted fakes.
+
+    *behavior*: {vendor: callable(arg) -> result} keyed by vendor name;
+    unscripted vendors return success. Returns the call log — every vendor
+    invocation is recorded in wrapper order.
+    """
+    calls: list = []
+
+    def fake_searcher(vendor):
+        def _search(query, limit=5):
+            calls.append(vendor)
+            fn = behavior.get(vendor)
+            if fn is None:
+                return {"success": True, "data": {"web": []}}
+            return fn(query)
+
+        return _search
+
+    def fake_extractor(vendor):
+        def _extract(urls):
+            calls.append(vendor)
+            fn = behavior.get(vendor)
+            if fn is None:
+                return [{"url": u, "title": "t", "content": "c"} for u in urls]
+            return fn(urls)
+
+        return _extract
+
+    searchers = {v: fake_searcher(v) for v in km._KEYLESS_RING}
+    extractors = {v: fake_extractor(v) for v in km._KEYLESS_RING}
+    monkeypatch.setattr(km, "_KEYLESS_SEARCHERS", searchers)
+    monkeypatch.setattr(km, "_KEYLESS_EXTRACTORS", extractors)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _stable_ring(monkeypatch):
+    """Pin the walk to ring order starting at exa; keep config out."""
+    monkeypatch.setattr(km, "_ring_order", lambda name=None: list(km._KEYLESS_RING))
+    yield
+
+
+SHAPE_ERROR = (
+    "Keyless Exa search failed: Unrecognized MCP response shape. "
+    "Set EXA_API_KEY (https://exa.ai) or another web backend via "
+    "`hermes tools` for reliable service."
+)
+
+
+class TestSearchFailover:
+    def test_masked_429_shape_failure_advances_to_next_vendor(self, monkeypatch):
+        """THE regression: exa returns a masked rate-limit (shape failure);
+        the ring must move on to parallel instead of returning the error."""
+        def exa_fail(query):
+            return {"success": False, "error": SHAPE_ERROR}
+
+        def parallel_ok(query):
+            return {"success": True, "data": {"web": [{"url": "https://x", "title": "t"}]}}
+
+        calls = _make_ring(monkeypatch, {"exa": exa_fail, "parallel": parallel_ok})
+
+        result = km.search_with_failover("exa", "obscura rust cdp")
+
+        assert calls == ["exa", "parallel"], "ring did not advance past exa"
+        assert result["success"] is True
+        assert result["data"]["served_by"] == "parallel"
+
+    def test_explicit_rate_limit_still_fails_over(self, monkeypatch):
+        """Classic 429s advance the ring; if every vendor throttles, the
+        walk exhausts with the aggregate error."""
+        def throttled(query):
+            return {"success": False, "error": "search failed: HTTP 429: slow down"}
+
+        calls = _make_ring(monkeypatch, {v: throttled for v in km._KEYLESS_RING})
+
+        result = km.search_with_failover("exa", "q")
+
+        assert calls == list(km._KEYLESS_RING), "walk did not cover the ring"
+        assert result["success"] is False
+        assert "all keyless vendors throttled" in result["error"]
+
+    def test_rate_limit_failover_serves_from_next_vendor(self, monkeypatch):
+        def exa_429(query):
+            return {"success": False, "error": "Keyless Exa search failed: HTTP 429: slow down"}
+
+        calls = _make_ring(monkeypatch, {"exa": exa_429})
+
+        result = km.search_with_failover("exa", "q")
+
+        assert calls == ["exa", "parallel"]
+        assert result["success"] is True
+        assert result["data"]["served_by"] == "parallel"
+
+    def test_auth_error_still_fails_fast(self, monkeypatch):
+        def exa_auth(query):
+            return {"success": False, "error": "Keyless Exa search failed: HTTP 401: unauthorized"}
+
+        calls = _make_ring(monkeypatch, {"exa": exa_auth})
+
+        result = km.search_with_failover("exa", "q")
+
+        assert calls == ["exa"], "auth error must not advance the ring"
+        assert result["success"] is False
+        assert "401" in result["error"]
+
+
+class TestExtractFailover:
+    def test_masked_429_shape_failure_batch_advances(self, monkeypatch):
+        def exa_fail(urls):
+            return [
+                {"url": u, "title": "", "content": "", "error": SHAPE_ERROR}
+                for u in urls
+            ]
+
+        def parallel_ok(urls):
+            return [{"url": u, "title": "t", "content": "c"} for u in urls]
+
+        calls = _make_ring(monkeypatch, {"exa": exa_fail, "parallel": parallel_ok})
+
+        results = km.extract_with_failover(
+            "exa", ["https://raw.githubusercontent.com/x/y/main/README.md"]
+        )
+
+        assert calls == ["exa", "parallel"], "extract ring did not advance"
+        assert all(r.get("error") is None for r in results)
+
+    def test_extract_mixed_batch_retries_only_retryable_urls(self, monkeypatch):
+        """THE second blind spot (live 2026-08-31): a mixed batch where one
+        URL masked-throttles and another succeeds must re-fetch ONLY the
+        retryable URL on the next vendor, and return results in input
+        order with the hard error preserved verbatim."""
+        shape_url = "https://raw.githubusercontent.com/x/y/main/README.md"
+        ok_url = "https://example.com"
+
+        def exa_mixed(urls):
+            out = []
+            for u in urls:
+                if u == shape_url:
+                    out.append({"url": u, "title": "", "content": "", "error": SHAPE_ERROR})
+                else:
+                    out.append({"url": u, "title": "Example", "content": "body"})
+            return out
+
+        def parallel_rescues(urls):
+            assert urls == [shape_url], "only the retryable URL should be re-fetched"
+            return [{"url": u, "title": "README", "content": "x" * 50} for u in urls]
+
+        calls = _make_ring(monkeypatch, {"exa": exa_mixed, "parallel": parallel_rescues})
+
+        results = km.extract_with_failover("exa", [shape_url, ok_url])
+
+        assert calls == ["exa", "parallel"]
+        assert len(results) == 2 and results[0]["url"] == shape_url  # order kept
+        assert results[0].get("error") is None and results[0]["served_by"] == "parallel"
+        assert results[1]["content"] == "body" and "served_by" not in results[1]
+
+    def test_extract_retryable_url_exhausting_all_vendors_keeps_last_error(self, monkeypatch):
+        def throttled(urls):
+            return [{"url": u, "title": "", "content": "", "error": "HTTP 429: slow down"} for u in urls]
+
+        calls = _make_ring(monkeypatch, {v: throttled for v in km._KEYLESS_RING})
+
+        results = km.extract_with_failover("exa", ["https://a.example"])
+
+        assert calls == list(km._KEYLESS_RING)
+        assert len(results) == 1 and results[0]["error"] == "HTTP 429: slow down"
+
+    def test_extract_notes_served_by_on_failover(self, monkeypatch):
+        """Observability: search results carry served_by on failover; extract
+        results must too, or the fallback is silent."""
+
+        def exa_fail(urls):
+            return [
+                {"url": u, "title": "", "content": "", "error": SHAPE_ERROR}
+                for u in urls
+            ]
+
+        def parallel_ok(urls):
+            return [{"url": u, "title": "t", "content": "c"} for u in urls]
+
+        _make_ring(monkeypatch, {"exa": exa_fail, "parallel": parallel_ok})
+
+        results = km.extract_with_failover("exa", ["https://example.com"])
+
+        assert results and all(r.get("served_by") == "parallel" for r in results)

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -25,7 +25,7 @@ from plugins.web.parallel.provider import ParallelWebSearchProvider
 def _no_web_env(monkeypatch):
     """Blank every web credential and neutralize config lookups."""
     for var in (
-        "EXA_API_KEY", "PARALLEL_API_KEY", "KEENABLE_API_KEY", "TAVILY_API_KEY",
+        "EXA_API_KEY", "PARALLEL_API_KEY", "KEENABLE_API_KEY",
         "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "BRAVE_SEARCH_API_KEY",
         "SEARXNG_URL", "TOOL_GATEWAY_USER_TOKEN",
     ):
@@ -289,7 +289,7 @@ class TestResolutionOrder:
 
     def test_keyless_ring_rotates_and_covers_all_vendors(self, fresh_registry, monkeypatch):
         monkeypatch.setattr(registry, "_read_config_key", lambda *p: None)
-        # The ring order always contains all four vendors, starting at the
+        # The ring order always contains all five vendors, starting at the
         # current cursor and wrapping.
         order = registry._keyless_preference()
         assert sorted(order) == sorted(keyless_mcp._KEYLESS_RING)
@@ -302,15 +302,6 @@ class TestResolutionOrder:
         monkeypatch.setattr(keyless_mcp, "_vendor_pinned", lambda name: name == "keenable")
         assert keyless_mcp._ring_order("keenable")[0] == "keenable"
         assert keyless_mcp._ring_order("keenable")[0] == "keenable"
-
-    def test_tavily_is_not_a_ring_member(self):
-        """Tavily is opt-in keyless; zero-config rotation must not include it."""
-        from plugins.web import keyless_mcp
-
-        assert "tavily" not in keyless_mcp._KEYLESS_RING
-        assert "tavily" not in keyless_mcp._KEYLESS_SEARCHERS
-        assert "tavily" not in keyless_mcp._KEYLESS_EXTRACTORS
-        assert "tavily" not in registry._KEYLESS_PREFERENCE
 
     def test_registry_keyless_disabled_returns_none(self, fresh_registry, monkeypatch):
         monkeypatch.setattr(registry, "_read_config_key", lambda *p: None)
@@ -458,11 +449,12 @@ class TestKeylessFailover:
         assert out["success"] is True
         assert out["data"]["served_by"] == "parallel"
 
-    def test_search_no_failover_on_non_throttle_error(self, monkeypatch):
+    def test_search_no_failover_on_auth_error(self, monkeypatch):
+        """Hard auth failures are vendor-independent: the ring stays put."""
         self._pin(monkeypatch, "exa")
         monkeypatch.setitem(
             keyless_mcp._KEYLESS_SEARCHERS, "exa",
-            lambda q, l: {"success": False, "error": "Unrecognized MCP response shape"},
+            lambda q, l: {"success": False, "error": "Keyless Exa search failed: HTTP 401: unauthorized"},
         )
         called = []
         monkeypatch.setitem(
@@ -472,6 +464,23 @@ class TestKeylessFailover:
         out = keyless_mcp.search_with_failover("exa", "q")
         assert out["success"] is False
         assert not called  # peer never tried
+
+    def test_search_fails_over_on_masked_throttle_shape_error(self, monkeypatch):
+        """Anonymous endpoints sometimes wrap 429s in unparseable bodies:
+        the resulting shape error carries no rate-limit markers but is a
+        vendor failure that must advance the ring (observed live on Exa's
+        keyless MCP endpoint, 2026-08-31)."""
+        self._pin(monkeypatch, "exa")
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_SEARCHERS, "exa",
+            lambda q, l: {"success": False, "error": "Unrecognized MCP response shape"},
+        )
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_SEARCHERS, "parallel", lambda q, l: self._ok("parallel"),
+        )
+        out = keyless_mcp.search_with_failover("exa", "q")
+        assert out["success"] is True
+        assert out["data"]["served_by"] == "parallel"
 
     def test_search_all_throttled_reports_ring(self, monkeypatch):
         self._pin(monkeypatch, "exa")
@@ -537,18 +546,24 @@ class TestKeylessFailover:
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
         assert out == good
 
-    def test_extract_partial_failure_stays_on_primary(self, monkeypatch):
+    def test_extract_partial_batch_retries_only_retryable_urls(self, monkeypatch):
+        """Per-URL failover: a partial batch re-fetches ONLY the URLs whose
+        errors are vendor-retryable; successes pass through untouched and
+        input order is preserved."""
         self._pin(monkeypatch, "exa")
         partial = [
             {"url": "https://a", "title": "A", "content": "x"},
             {"url": "https://b", "title": "", "content": "", "error": "rate limit"},
         ]
-        called = []
+        seen = []
         monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda urls: partial)
         monkeypatch.setitem(
             keyless_mcp._KEYLESS_EXTRACTORS, "parallel",
-            lambda urls: called.append(1) or [],
+            lambda urls: seen.append(list(urls))
+            or [{"url": "https://b", "title": "B", "content": "y"}],
         )
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
-        assert out == partial
-        assert not called
+        assert seen == [["https://b"]]  # only the retryable URL re-fetched
+        assert out[0] == partial[0]  # success untouched
+        assert out[1]["content"] == "y"
+        assert out[1]["served_by"] == "parallel"


### PR DESCRIPTION
## What does this PR do?

Fixes #99500 — the keyless ring (exa → parallel → firecrawl → keenable) never advances on **masked-throttle response-shape failures**: Exa's anonymous MCP endpoint sometimes answers HTTP 200 with an unparseable body while throttling, which surfaces as `KeylessMCPError("Unrecognized MCP response shape")` — a string carrying none of the classic rate-limit markers, so `_is_rate_limitish()` treats it as vendor-independent and the walk stops at the first vendor even though the other free providers are healthy. Observed live on 2026-08-31 (details + probes in the issue).

While fixing this, a second gap in the same function produced the same user-visible symptom: `extract_with_failover()` only advanced when **every** URL in a batch was throttled, so a mixed batch (one throttled URL + one succeeding URL) returned the throttled URL's error as-is. The fix therefore:

1. Adds `_is_vendor_retryable()` = rate-limit-shaped **or** response-shape failure → advance the ring. Auth failures, invalid input, and other hard errors keep failing fast (a 401 would fail identically on every vendor).
2. Makes `extract_with_failover()` fail over **per URL**: in a mixed batch, only URLs with vendor-retryable errors are re-fetched on the next vendor; successes pass through untouched (no wasted re-fetches). Results keep input order and length, and entries served by a fallback vendor are tagged `served_by` (search already did this; extract now matches).

## Related Issue

Fixes #99500

### Relation to other open PRs (disclosed for review)

- #97142 implements per-URL rescue for errors that are *already classified* as rate-limit-shaped. It does **not** touch the classifier, so masked-throttle shape failures — the case in #99500 — still never trigger rescue under it. This PR's classifier change is complementary; if maintainers prefer #97142's approach for the per-URL mechanics, the classifier half of this PR (`_is_vendor_retryable()` + tests) lands cleanly on top of it.
- #94019 exposes resolved-provider attribution in tool results; the `served_by` tagging here is the ring-level piece of the same observability concern.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/keyless_mcp.py`
  - new `_SHAPE_FAILURE_MARKERS` + `_is_vendor_retryable()`; search and extract gates now use it
  - `extract_with_failover()`: per-URL failover loop (pending set, per-vendor batch re-fetch, input order/length preserved, `served_by` tagging, ring-exhaustion keeps the last error per URL)
  - docstrings updated to the new semantics
- `tests/plugins/web/test_keyless_failover_classifier.py` (new): regression suite — masked-429 advances the ring; explicit 429 exhaustion reports the whole ring; rate-limit failover serves from the next vendor (`served_by`); auth errors fail fast; mixed batch re-fetches only the retryable URL in input order; retryable URL exhausting all vendors keeps its last error
- `tests/tools/test_web_keyless_fallback.py`: two tests pinned the old semantics — `test_search_no_failover_on_non_throttle_error` used the exact #99500 shape error as its "non-throttle" example (its premise is falsified by the live evidence; fail-fast intent preserved with a genuine 401 case) and `test_extract_partial_failure_stays_on_primary` pinned per-batch no-retry (rewritten to pin per-URL rescue: only the retryable URL re-fetched, success untouched, `served_by` tagged)

## How to Test

1. `pytest tests/plugins/web/test_keyless_failover_classifier.py tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py -q` — all green (64 tests)
2. Simulate the live failure: patch `keyless_mcp._KEYLESS_SEARCHERS["exa"]` to return `{"success": False, "error": "Unrecognized MCP response shape"}` and any other vendor to succeed → `search_with_failover("exa", ...)` now returns success with `data.served_by` set to the rescuing vendor (previously returned the error)
3. Live repro from the issue (rate-limit dependent): with `web.provider_tier.exa: free`, once Exa starts masking 429s, `web_extract` on a failing URL is served by the next vendor instead of erroring — verified live: the same URL that failed through the ring was fetched (4,991 chars) by the parallel keyless endpoint under this patch, while an unaffected URL in the same batch stayed on the primary with no re-fetch

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (overlap with #97142 / #94019 disclosed above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `pytest tests/tools tests/plugins -q`: 78 passed (subset incl. all keyless suites); full-suite result attached in comments
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python string/flow logic, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (tool schemas unchanged; behavior now matches documented ring semantics)
