### PR TITLE
fix(cli): keep the venv interpreter symlink unresolved in the Linux desktop entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -77,12 +77,17 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly — as-is: a venv interpreter
+            # is usually a symlink, and CPython locates pyvenv.cfg and the
+            # venv site-packages through the UNRESOLVED path. Resolving it
+            # escapes to the base interpreter, which lacks the venv's
+            # packages (#99581).
+            argv = [sys.executable, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        # Unresolved for the same venv-symlink reason as above.
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -107,10 +108,43 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # As-is, not resolved: the venv interpreter path must survive unchanged
+    # (see the symlinked-venv regression test below).
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+# #99581: uv (and standard) venvs make sys.executable a symlink into the
+# base interpreter install. CPython finds pyvenv.cfg and the venv
+# site-packages through the UNRESOLVED path, so resolving the symlink when
+# building Exec= wrote the base interpreter into the entry — it lacks the
+# venv's packages, and the launch dies on the first third-party import
+# (ModuleNotFoundError), silently (Terminal=false).
+@pytest.mark.skipif(sys.platform == "win32", reason="needs symlink creation privileges on Windows")
+def test_exec_keeps_venv_symlink_interpreter_unresolved(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    base = tmp_path / "uv" / "python" / "bin" / "python3"
+    base.parent.mkdir(parents=True)
+    base.write_text("", encoding="utf-8")
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base) not in exec_line
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux `hermes.desktop` entry written by `hermes_cli/linux_desktop_entry.py` launching an interpreter that cannot import Hermes' dependencies. `resolve_exec_command()` built `Exec=` with `str(Path(sys.executable).resolve())`. In a uv (or standard) venv, `bin/python` is a symlink into the base interpreter install, and CPython locates `pyvenv.cfg` and the venv's `site-packages` through the **unresolved** path — so `.resolve()` wrote the base interpreter into the entry. Launched from the menu, that interpreter has no venv packages and dies on the first third-party import (`ModuleNotFoundError: No module named 'dotenv'`), completely silently since `Terminal=false`. Using `sys.executable` as-is keeps the venv symlink semantics in both the interpreter-prefix branch (from #90292) and the module-fallback branch.

## Related Issue

Fixes #99581

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/linux_desktop_entry.py`: `resolve_exec_command()` now uses `sys.executable` as-is instead of `Path(sys.executable).resolve()` in both branches, with a comment explaining why a venv interpreter symlink must stay unresolved.
- `tests/hermes_cli/test_linux_desktop_entry.py`: the #90292 regression test now asserts the prefix equals `sys.executable` unresolved; added a new regression test that simulates a uv-style venv (symlinked `sys.executable`) and asserts the `Exec=` interpreter is the symlink path, never the base interpreter it points at.

## How to Test

1. `python -m pytest tests/hermes_cli/test_linux_desktop_entry.py -q` — Observed result: 17 passed, 1 skipped (Windows-only test skipped on non-Windows hosts), 0 failures.
2. New regression test `test_exec_keeps_venv_symlink_interpreter_unresolved` fails on the previous code (Exec= contains the symlink target / base interpreter) and passes after the fix.
3. Manual repro from the issue (uv venv on Linux): before the fix, the generated `~/.local/share/applications/hermes.desktop` had `Exec=~/.local/share/uv/python/.../bin/python3 ...` and clicking the menu entry died silently with `ModuleNotFoundError: dotenv`; after the fix it has `Exec=<venv>/bin/python ...` and launches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the entry itself is Linux-only and covered by the platform-guarded tests

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
