### PR TITLE
docs(skills): Dual Gate TDD — plan names cases, Coder writes RED files

### DIFF
--- a/optional-skills/software-development/subagent-driven-development/SKILL.md
+++ b/optional-skills/software-development/subagent-driven-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent-driven-development
 description: "Execute plans via delegate_task subagents (2-stage review)."
-version: 1.1.0
+version: 1.2.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
 platforms: [linux, macos, windows]
@@ -77,7 +77,7 @@ delegate_task(
     3. Write minimal implementation
     4. Run: pytest tests/models/test_user.py -v (verify PASS)
     5. Run: pytest tests/ -q (verify no regressions)
-    6. Commit: git add -A && git commit -m "feat: add User model with password hashing"
+    Do not commit. Git is Orchestrator-owned.
 
     PROJECT CONTEXT:
     - Python 3.11, Flask app in src/app.py
@@ -174,22 +174,20 @@ delegate_task(
 )
 ```
 
-### 4. Verify and Commit
+### 4. Verify (no Coder commits)
 
 ```bash
 # Run full test suite
 pytest tests/ -q
 
-# Review all changes
+# Review all changes — Orchestrator owns git
 git diff --stat
-
-# Final commit if needed
-git add -A && git commit -m "feat: complete [feature name] implementation"
 ```
 
 ## Task Granularity
 
-**Each task = 2-5 minutes of focused work.**
+**Each task is a reviewable deliverable, not a 2-5 minute keystroke.**
+A one-line toggle is ONE task. Do not invent five TDD micro-steps.
 
 **Too big:**
 - "Implement user authentication system"
@@ -198,8 +196,6 @@ git add -A && git commit -m "feat: complete [feature name] implementation"
 - "Create User model with email and password fields"
 - "Add password hashing function"
 - "Create login endpoint"
-- "Add JWT token generation"
-- "Create registration endpoint"
 
 ## Red Flags — Never Do These
 

--- a/skills/software-development/test-driven-development/SKILL.md
+++ b/skills/software-development/test-driven-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-driven-development
 description: "TDD: enforce RED-GREEN-REFACTOR, tests before code."
-version: 1.1.0
+version: 1.2.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
 platforms: [linux, macos, windows]
@@ -20,6 +20,24 @@ Write the test first. Watch it fail. Write minimal code to pass.
 **Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
 
 **Violating the letter of the rules is violating the spirit of the rules.**
+
+## TDD Starts at the Design Phase (binding)
+
+TDD does not begin when coding begins -- it begins when the PLAN is written.
+Size the artifact to the class (XS skip / 40 lines, S 120, M 400, L/XL 900).
+
+- **A plan, design, or explanation of intended behavior is INCOMPLETE without
+  its tests.** "Tests: will be written" is not a plan section.
+- The plan names the exact failing cases and commands. Coder writes those
+  test files in RED before production code. Planner writes test files into
+  the target repo only for M+ public contracts when the Orchestrator brief
+  explicitly asks. XS mechanical work updates the narrowest existing test
+  or records "no new test: reason".
+- The prose describes the behavior; the named cases pin it. Implementation
+  makes those cases green. A plan that says "tests will be written later"
+  is not saved as a plan.
+- If you cannot name the failing case while writing the plan, the design is
+  not concrete enough -- fix the design, not the process.
 
 ## When to Use
 
@@ -330,7 +348,7 @@ delegate_task(
     3. Write minimal code to pass
     4. Run test to verify it passes
     5. Refactor if needed
-    6. Commit
+    Do not commit. Git is Orchestrator-owned.
 
     Project test command: pytest tests/ -q
     Project structure: [describe relevant files]

--- a/tests/skills/test_subagent_driven_development_skill.py
+++ b/tests/skills/test_subagent_driven_development_skill.py
@@ -1,0 +1,46 @@
+"""Dual Gate contracts for the optional subagent-driven-development skill.
+
+Leaf implementers do not commit. Task size is a reviewable deliverable,
+not a 2-5 minute keystroke. This skill must not re-teach the factory
+plan-skill anti-pattern the Dual Gate removed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "software-development"
+    / "subagent-driven-development"
+    / "SKILL.md"
+)
+
+
+def _frontmatter_and_body() -> tuple[dict, str]:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "frontmatter must close with ---"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file()
+
+
+def test_does_not_teach_two_to_five_minute_keystroke_tasks():
+    _, body = _frontmatter_and_body()
+    assert "Each task = 2-5 minutes of focused work." not in body
+
+
+def test_implementer_example_does_not_tell_the_child_to_commit():
+    _, body = _frontmatter_and_body()
+    assert "6. Commit" not in body
+    assert "git commit" not in body

--- a/tests/skills/test_test_driven_development_skill.py
+++ b/tests/skills/test_test_driven_development_skill.py
@@ -1,0 +1,67 @@
+"""Dual Gate contracts for the bundled test-driven-development skill.
+
+TDD starts at the design phase: the plan names cases; Coder writes the
+test files in RED; Planner writes test files into the target repo only
+for M+ public contracts when the brief asks. A plan that defers tests is
+not a plan. These tests pin that section so a factory copy-paste of the
+pre-Dual-Gate skill cannot silently return.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT / "skills" / "software-development" / "test-driven-development" / "SKILL.md"
+)
+
+
+def _frontmatter_and_body() -> tuple[dict, str]:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "frontmatter must close with ---"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file()
+
+
+def test_design_phase_section_is_present():
+    _, body = _frontmatter_and_body()
+    assert "## TDD Starts at the Design Phase" in body
+
+
+def test_plan_names_cases_coder_writes_files():
+    _, body = _frontmatter_and_body()
+    assert "Coder writes those" in body and "test files" in body
+    assert "Planner writes test files into" in body
+    assert "no new test: reason" in body
+
+
+def test_deferred_tests_are_not_a_plan():
+    _, body = _frontmatter_and_body()
+    assert "tests will be written later" in body
+
+
+def test_does_not_require_test_files_to_exist_when_the_plan_is_saved():
+    """AGENTS.md once claimed the RED files exist at plan-save time.
+
+    Dual Gate forbids that: the plan names cases; Coder writes the files.
+    The bundled TDD skill must not reintroduce the sabotaging sentence.
+    """
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "when the plan is saved, the test files exist" not in content
+    assert "test files exist in this repo" not in content
+
+
+def test_delegate_example_does_not_tell_the_child_to_commit():
+    _, body = _frontmatter_and_body()
+    # Git is Orchestrator-owned; a leaf Coder example must not teach commits.
+    assert "6. Commit" not in body

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development.md
@@ -16,7 +16,7 @@ TDD: enforce RED-GREEN-REFACTOR, tests before code.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/software-development\test-driven-development` |
-| Version | `1.1.0` |
+| Version | `1.2.0` |
 | Author | Hermes Agent (adapted from obra/superpowers) |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -38,6 +38,24 @@ Write the test first. Watch it fail. Write minimal code to pass.
 **Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
 
 **Violating the letter of the rules is violating the spirit of the rules.**
+
+## TDD Starts at the Design Phase (binding)
+
+TDD does not begin when coding begins -- it begins when the PLAN is written.
+Size the artifact to the class (XS skip / 40 lines, S 120, M 400, L/XL 900).
+
+- **A plan, design, or explanation of intended behavior is INCOMPLETE without
+  its tests.** "Tests: will be written" is not a plan section.
+- The plan names the exact failing cases and commands. Coder writes those
+  test files in RED before production code. Planner writes test files into
+  the target repo only for M+ public contracts when the Orchestrator brief
+  explicitly asks. XS mechanical work updates the narrowest existing test
+  or records "no new test: reason".
+- The prose describes the behavior; the named cases pin it. Implementation
+  makes those cases green. A plan that says "tests will be written later"
+  is not saved as a plan.
+- If you cannot name the failing case while writing the plan, the design is
+  not concrete enough -- fix the design, not the process.
 
 ## When to Use
 
@@ -348,7 +366,7 @@ delegate_task(
     3. Write minimal code to pass
     4. Run test to verify it passes
     5. Refactor if needed
-    6. Commit
+    Do not commit. Git is Orchestrator-owned.
 
     Project test command: pytest tests/ -q
     Project structure: [describe relevant files]

--- a/website/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development.md
@@ -16,7 +16,7 @@ Execute plans via delegate_task subagents (2-stage review).
 |---|---|
 | Source | Optional — install with `hermes skills install official/software-development/subagent-driven-development` |
 | Path | `optional-skills/software-development\subagent-driven-development` |
-| Version | `1.1.0` |
+| Version | `1.2.0` |
 | Author | Hermes Agent (adapted from obra/superpowers) |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -95,7 +95,7 @@ delegate_task(
     3. Write minimal implementation
     4. Run: pytest tests/models/test_user.py -v (verify PASS)
     5. Run: pytest tests/ -q (verify no regressions)
-    6. Commit: git add -A && git commit -m "feat: add User model with password hashing"
+    Do not commit. Git is Orchestrator-owned.
 
     PROJECT CONTEXT:
     - Python 3.11, Flask app in src/app.py
@@ -192,22 +192,20 @@ delegate_task(
 )
 ```
 
-### 4. Verify and Commit
+### 4. Verify (no Coder commits)
 
 ```bash
 # Run full test suite
 pytest tests/ -q
 
-# Review all changes
+# Review all changes — Orchestrator owns git
 git diff --stat
-
-# Final commit if needed
-git add -A && git commit -m "feat: complete [feature name] implementation"
 ```
 
 ## Task Granularity
 
-**Each task = 2-5 minutes of focused work.**
+**Each task is a reviewable deliverable, not a 2-5 minute keystroke.**
+A one-line toggle is ONE task. Do not invent five TDD micro-steps.
 
 **Too big:**
 - "Implement user authentication system"
@@ -216,8 +214,6 @@ git add -A && git commit -m "feat: complete [feature name] implementation"
 - "Create User model with email and password fields"
 - "Add password hashing function"
 - "Create login endpoint"
-- "Add JWT token generation"
-- "Create registration endpoint"
 
 ## Red Flags — Never Do These
 


### PR DESCRIPTION
## Summary

TDD starts at the **design phase**: the plan names failing cases; Coder writes those test files in RED. Planner writes test files into the repo only for M+ public contracts when the brief asks. Leaf implementers do not commit.

This PR updates the bundled `test-driven-development` skill and the optional `subagent-driven-development` skill so they cannot re-teach the factory anti-patterns Dual Gate removed:

- no `Each task = 2-5 minutes of focused work`
- no `6. Commit` / `git commit` in leaf-implementer examples

`AGENTS.md` is **not** edited (approval-gated instruction surface). A pending one-step paste for the Testing chapter lives outside this repo.

## Test plan

- [x] `scripts/run_tests.sh tests/skills/test_test_driven_development_skill.py tests/skills/test_subagent_driven_development_skill.py tests/skills/test_authoring_standards.py` — 1181 passed
- [ ] Reverse-mutation: restoring `Each task = 2-5 minutes of focused work.` must fail `test_does_not_teach_two_to_five_minute_keystroke_tasks`
