### PR TITLE
fix(kanban): keep manually parked cards blocked

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4441,16 +4441,17 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` was explicitly parked in ``blocked``.
 
     A ``blocked`` status can come from two very different sources:
 
-    * **Worker- or operator-initiated** — a worker called
+    * **Creator-, worker-, or operator-initiated** — the creator requested
+      ``initial_status="blocked"``, a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
       ``hermes kanban block <id>``).  This is a deliberate handoff that
-      should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
+      should stay blocked until an operator unblocks it.  Creation records
+      the requested status in the ``"created"`` payload; the block tool emits
+      a ``"blocked"`` event row in ``task_events``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
@@ -4459,10 +4460,9 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    explicit block-state event for the task.  A ``"blocked"`` event or a
+    ``"created"`` event whose payload records ``status="blocked"`` is sticky;
+    a later ``"unblocked"`` event clears it.
 
     Returns ``False`` when there is no such event at all (e.g. the task
     was set to ``status='blocked'`` by the circuit breaker or by direct
@@ -4470,12 +4470,20 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     for that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('created', 'blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row or row["kind"] == "unblocked":
+        return False
+    if row["kind"] == "blocked":
+        return True
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else {}
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(payload, dict) and payload.get("status") == "blocked"
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4528,9 +4528,9 @@ def recompute_ready(
     blocked purely by a parent dependency unblocks itself when the
     parent completes), *except* in two cases:
 
-    1. The most recent block event was a worker-initiated
-       ``kanban_block`` — those stay blocked until an explicit
-       ``kanban_unblock`` (#28712).
+    1. The creator requested ``initial_status="blocked"`` or the most
+       recent explicit block event was ``blocked`` — those stay parked
+       until an explicit ``kanban_unblock`` (#28712).
 
     2. The task's ``consecutive_failures`` has reached the effective
        failure limit.  This prevents infinite retry loops when a task
@@ -4559,10 +4559,9 @@ def recompute_ready(
             task_id = row["id"]
             cur_status = row["status"]
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for explicit human intervention — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
+                # Creator / worker / operator explicitly parked the task — do not
+                # silently auto-recover.  ``unblock_task`` is the only legitimate
+                # exit (it emits ``"unblocked"`` which flips this predicate back).
                 continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -13,6 +13,7 @@ These tests pin down:
 
 * Worker / operator-initiated blocks are sticky and survive
   ``recompute_ready``.
+* Tasks created with ``initial_status="blocked"`` are equally sticky.
 * Circuit-breaker blocks (``gave_up`` event, status flipped via
   ``_record_task_failure``) still auto-recover — the original intent
   of #40c1decb3 is preserved.
@@ -74,6 +75,22 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             promoted = kb.recompute_ready(conn)
             assert promoted == 0, "worker-blocked task must not auto-promote"
             assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_initial_blocked_is_sticky_until_explicit_unblock(kanban_home: Path) -> None:
+    """An explicitly parked task must not be treated as dependency-blocked."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="awaiting human ops",
+            initial_status="blocked",
+        )
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Cards created with `--initial-status blocked` now remain blocked until an explicit unblock. Previously, the dispatcher promoted these deliberately parked cards to `ready` on its next tick, allowing work intended to wait for human operations to be dispatched automatically.

### Symptom

`hermes kanban create --initial-status blocked` initially reports and stores `blocked`, but `recompute_ready()` changes a parentless card to `ready` on the next dispatcher tick.

### Impact

Human-gated cards can be dispatched without the explicit operator action their creator required.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:recompute_ready` when it examines a task created with `initial_status="blocked"`.

**Causal chain:**
1. `create_task()` records `status="blocked"` only in the `created` event payload.
2. `_has_sticky_block()` recognizes only later `blocked` and `unblocked` event kinds, so it treats the newly created card as a recoverable dependency or circuit-breaker block.
3. With no unfinished parents, `recompute_ready()` promotes the card to `ready`.

**Why it is wrong:** The explicit creation status is a durable operator gate, not a transient dependency state.

**Working sibling / contrast:** Cards blocked later through `kanban_block()` already stay blocked because that path emits a dedicated `blocked` event.

**Ruled out:** `create_task()` does honor the CLI flag and stores the requested status; the loss occurs only when dispatcher dependency recomputation runs.

### Fix

Treat a `created` event whose payload records `status="blocked"` as the same sticky state as an explicit `blocked` event. A later `unblocked` event still clears the gate, while circuit-breaker blocks without an explicit event retain their existing auto-recovery behavior.

## Related Issue

Fixes #99576

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - recognize explicitly blocked creation events in sticky-block detection.
- `tests/hermes_cli/test_kanban_blocked_sticky.py` - cover dispatcher ticks and explicit unblock for initially blocked cards.

## How to Test

1. Create a task with `initial_status="blocked"`.
2. Run `recompute_ready()` and confirm the task remains blocked.
3. Explicitly unblock it and confirm it becomes ready.
4. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k recompute_ready -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant docstrings are updated; user documentation is N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no workflow changed
- [x] Cross-platform impact was considered; the change uses SQLite events and Python JSON handling
- [x] Tool descriptions and schemas are N/A because no tool schema changed

## Screenshots / Logs

N/A - the automated regression reproduces the dispatcher transition directly.
