### PR TITLE
fix(api): show reasoning in OpenAI-compatible clients

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3344,6 +3344,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "chat_completions_streaming": True,
                 "responses_api": True,
                 "responses_streaming": True,
+                "reasoning_streaming": True,
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
@@ -5060,6 +5061,8 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        request_reasoning = _request_reasoning_config(body.get("model_options"))
+        reasoning_output_enabled = request_reasoning != {"enabled": False}
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -5203,6 +5206,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put_threadsafe(delta)
 
+            def _on_tool_progress(event_type, name=None, preview=None, args=None, **kwargs):
+                if reasoning_output_enabled and event_type == "reasoning.available" and preview:
+                    _stream_q.put_threadsafe(("__reasoning__", preview))
+
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
             # (e.g. internal/filtered tools) is silently dropped instead of
@@ -5254,11 +5261,9 @@ class APIServerAdapter(BasePlatformAdapter):
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
-            # ``tool_progress_callback`` is intentionally not wired here:
-            # it would duplicate every emit because ``run_agent`` fires it
-            # side-by-side with ``tool_start_callback``/``tool_complete_callback``.
-            # The structured callbacks are strictly richer (they carry
-            # the tool_call id), so they own the chat-completions SSE channel.
+            # Structured callbacks own ordinary tool lifecycle events because
+            # they carry call ids. The progress callback is retained only for
+            # reasoning.available, which has no structured equivalent.
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
@@ -5266,6 +5271,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                tool_progress_callback=_on_tool_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
@@ -5320,6 +5326,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
+        output_start_index = self._response_messages_turn_start_index(
+            history, user_message, result
+        )
+        reasoning_text = (
+            self._extract_result_reasoning(result, start_index=output_start_index)
+            if reasoning_output_enabled
+            else ""
+        )
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
@@ -5384,6 +5398,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "total_tokens": usage.get("total_tokens", 0),
             },
         }
+        if reasoning_text:
+            response_data["choices"][0]["message"]["reasoning_content"] = reasoning_text
         if is_partial or is_failed or not completed:
             response_data["hermes"] = {
                 "completed": completed,
@@ -5445,14 +5461,25 @@ class APIServerAdapter(BasePlatformAdapter):
                 """Write a single queue item to the SSE stream.
 
                 Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
+                Tagged tuples carry either reasoning or tool progress. Tool
+                progress is sent as a custom ``event: hermes.tool.progress`` so
                 frontends can display them without storing the markers in
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    reasoning_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{
+                            "index": 0,
+                            "delta": {"reasoning_content": item[1]},
+                            "finish_reason": None,
+                        }],
+                    }
+                    await response.write(_sse_frame(reasoning_chunk))
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
@@ -5609,6 +5636,7 @@ class APIServerAdapter(BasePlatformAdapter):
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        reasoning_enabled: bool = True,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -5676,6 +5704,11 @@ class APIServerAdapter(BasePlatformAdapter):
         message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
         message_output_index: Optional[int] = None
         message_opened = False
+        reasoning_item_id = f"rs_{uuid.uuid4().hex[:24]}"
+        reasoning_output_index: Optional[int] = None
+        reasoning_opened = False
+        reasoning_parts: List[str] = []
+        reasoning_item: Optional[Dict[str, Any]] = None
 
         async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
             nonlocal sequence_number
@@ -5796,6 +5829,71 @@ class APIServerAdapter(BasePlatformAdapter):
                     "content_index": 0,
                     "delta": delta_text,
                     "logprobs": [],
+                })
+
+            async def _open_reasoning_item() -> None:
+                nonlocal reasoning_opened, reasoning_output_index, reasoning_item, output_index
+                if reasoning_opened:
+                    return
+                reasoning_opened = True
+                reasoning_output_index = output_index
+                output_index += 1
+                reasoning_item = {
+                    "id": reasoning_item_id,
+                    "type": "reasoning",
+                    "status": "in_progress",
+                    "summary": [],
+                }
+                emitted_items.append(reasoning_item)
+                await _write_event("response.output_item.added", {
+                    "type": "response.output_item.added",
+                    "output_index": reasoning_output_index,
+                    "item": dict(reasoning_item),
+                })
+                await _write_event("response.reasoning_summary_part.added", {
+                    "type": "response.reasoning_summary_part.added",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "summary_index": 0,
+                    "part": {"type": "summary_text", "text": ""},
+                })
+
+            async def _emit_reasoning_delta(delta_text: str) -> None:
+                await _open_reasoning_item()
+                reasoning_parts.append(delta_text)
+                await _write_event("response.reasoning_summary_text.delta", {
+                    "type": "response.reasoning_summary_text.delta",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "summary_index": 0,
+                    "delta": delta_text,
+                })
+
+            async def _close_reasoning_item() -> None:
+                if not reasoning_opened:
+                    return
+                reasoning_text = "".join(reasoning_parts)
+                summary_part = {"type": "summary_text", "text": reasoning_text}
+                await _write_event("response.reasoning_summary_text.done", {
+                    "type": "response.reasoning_summary_text.done",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "summary_index": 0,
+                    "text": reasoning_text,
+                })
+                await _write_event("response.reasoning_summary_part.done", {
+                    "type": "response.reasoning_summary_part.done",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "summary_index": 0,
+                    "part": summary_part,
+                })
+                reasoning_item["status"] = "completed"
+                reasoning_item["summary"] = [summary_part]
+                await _write_event("response.output_item.done", {
+                    "type": "response.output_item.done",
+                    "output_index": reasoning_output_index,
+                    "item": dict(reasoning_item),
                 })
 
             async def _emit_tool_started(payload: Dict[str, Any]) -> str:
@@ -5924,6 +6022,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__reasoning__" and isinstance(payload, str) and payload:
+                        await _emit_reasoning_delta(payload)
                 elif isinstance(it, str):
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
@@ -6012,6 +6112,25 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
+
+            result_reasoning = (
+                self._extract_result_reasoning(
+                    result,
+                    start_index=self._response_messages_turn_start_index(
+                        conversation_history, user_message, result
+                    ) if isinstance(result, dict) else 0,
+                )
+                if reasoning_enabled
+                else ""
+            )
+            streamed_reasoning = "".join(reasoning_parts)
+            if result_reasoning and not streamed_reasoning:
+                await _emit_reasoning_delta(result_reasoning)
+            elif result_reasoning.startswith(streamed_reasoning):
+                reasoning_suffix = result_reasoning[len(streamed_reasoning):]
+                if reasoning_suffix:
+                    await _emit_reasoning_delta(reasoning_suffix)
+            await _close_reasoning_item()
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
@@ -6313,6 +6432,8 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = stored_session_id or str(uuid.uuid4())
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        request_reasoning = _request_reasoning_config(body.get("model_options"))
+        reasoning_output_enabled = request_reasoning != {"enabled": False}
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(
             body,
@@ -6344,13 +6465,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     _stream_q.put_threadsafe(delta)
 
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Queue non-start tool progress events if needed in future.
-
-                The structured Responses stream uses ``tool_start_callback``
-                and ``tool_complete_callback`` for exact call-id correlation,
-                so progress events are currently ignored here.
-                """
-                return
+                """Queue reasoning; structured callbacks own tool lifecycle."""
+                if reasoning_output_enabled and event_type == "reasoning.available" and preview:
+                    _stream_q.put_threadsafe(("__reasoning__", preview))
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
@@ -6407,6 +6524,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                reasoning_enabled=reasoning_output_enabled,
             )
 
         async def _compute_response():
@@ -6487,7 +6605,11 @@ class APIServerAdapter(BasePlatformAdapter):
             user_message,
             result,
         )
-        output_items = self._extract_output_items(result, start_index=output_start_index)
+        output_items = self._extract_output_items(
+            result,
+            start_index=output_start_index,
+            include_reasoning=reasoning_output_enabled,
+        )
 
         response_data = {
             "id": response_id,
@@ -7066,7 +7188,48 @@ class APIServerAdapter(BasePlatformAdapter):
         return out
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
+    def _message_reasoning_text(message: Dict[str, Any]) -> str:
+        """Return the displayable reasoning summary carried by one message."""
+        for key in ("reasoning_content", "reasoning"):
+            value = message.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        parts: List[str] = []
+        for detail in message.get("reasoning_details") or []:
+            if not isinstance(detail, dict):
+                continue
+            for key in ("summary", "text"):
+                value = detail.get(key)
+                if isinstance(value, str) and value.strip():
+                    parts.append(value.strip())
+                    break
+        return "\n\n".join(parts)
+
+    @classmethod
+    def _extract_result_reasoning(
+        cls, result: Dict[str, Any], start_index: int = 0
+    ) -> str:
+        """Collect this turn's assistant reasoning without replaying history."""
+        messages = result.get("messages", []) if isinstance(result, dict) else []
+        if start_index > 0:
+            messages = messages[start_index:]
+        parts: List[str] = []
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            text = cls._message_reasoning_text(message)
+            if text and text not in parts:
+                parts.append(text)
+        return "\n\n".join(parts)
+
+    @classmethod
+    def _extract_output_items(
+        cls,
+        result: Dict[str, Any],
+        start_index: int = 0,
+        include_reasoning: bool = True,
+    ) -> List[Dict[str, Any]]:
         """
         Build the output item array from the agent's messages.
 
@@ -7079,6 +7242,19 @@ class APIServerAdapter(BasePlatformAdapter):
         messages = result.get("messages", [])
         if start_index > 0:
             messages = messages[start_index:]
+
+        reasoning = (
+            cls._extract_result_reasoning(result, start_index=start_index)
+            if include_reasoning
+            else ""
+        )
+        if reasoning:
+            items.append({
+                "id": f"rs_{uuid.uuid4().hex[:24]}",
+                "type": "reasoning",
+                "status": "completed",
+                "summary": [{"type": "summary_text", "text": reasoning}],
+            })
 
         for msg in messages:
             role = msg.get("role")

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -868,6 +868,7 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["reasoning_streaming"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["model_options"] is True
@@ -1019,6 +1020,50 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+
+    @pytest.mark.asyncio
+    async def test_stream_exposes_reasoning_as_reasoning_content(self, adapter):
+        async def _mock_run_agent(**kwargs):
+            kwargs["tool_progress_callback"](
+                "reasoning.available", "_thinking", "Check the premise.", None
+            )
+            kwargs["stream_delta_callback"]("The premise holds.")
+            return (
+                {
+                    "final_response": "The premise holds.",
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": "The premise holds.",
+                            "reasoning": "Check the premise.",
+                        }
+                    ],
+                },
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Check it"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                events = [
+                    json.loads(line.removeprefix("data: "))
+                    for line in (await resp.text()).splitlines()
+                    if line.startswith("data: {")
+                ]
+
+        deltas = [event["choices"][0]["delta"] for event in events]
+        assert {"reasoning_content": "Check the premise."} in deltas
+        assert {"content": "The premise holds."} in deltas
 
 
     @pytest.mark.asyncio
@@ -1292,6 +1337,43 @@ class TestChatCompletionsEndpoint:
             assert '"status": "completed"' not in body
 
 
+    @pytest.mark.asyncio
+    async def test_non_streaming_exposes_reasoning_on_message(self, adapter):
+        result = {
+            "final_response": "The premise holds.",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "The premise holds.",
+                    "reasoning_content": "Check the premise.",
+                }
+            ],
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new=AsyncMock(
+                    return_value=(
+                        result,
+                        {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                    )
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Check it"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["choices"][0]["message"]["reasoning_content"] == "Check the premise."
+
+
 # ---------------------------------------------------------------------------
 # _derive_chat_session_id unit tests
 # ---------------------------------------------------------------------------
@@ -1349,6 +1431,44 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_includes_reasoning_output_item(self, adapter):
+        result = {
+            "final_response": "The premise holds.",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "The premise holds.",
+                    "reasoning": "Check the premise.",
+                }
+            ],
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new=AsyncMock(
+                    return_value=(
+                        result,
+                        {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                    )
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "test", "input": "Check it"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        reasoning = next(item for item in data["output"] if item["type"] == "reasoning")
+        assert reasoning["status"] == "completed"
+        assert reasoning["summary"] == [
+            {"type": "summary_text", "text": "Check the premise."}
+        ]
 
 
     @pytest.mark.asyncio
@@ -1598,6 +1718,67 @@ class TestResponsesEndpoint:
 
 
 class TestResponsesStreaming:
+
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_reasoning_summary_with_monotonic_sequence(self, adapter):
+        async def _mock_run_agent(**kwargs):
+            kwargs["tool_progress_callback"](
+                "reasoning.available", "_thinking", "Check the premise.", None
+            )
+            kwargs["tool_start_callback"]("call_1", "terminal", {"command": "pwd"})
+            kwargs["tool_complete_callback"](
+                "call_1", "terminal", {"command": "pwd"}, "C:/workspace"
+            )
+            kwargs["stream_delta_callback"]("The premise holds.")
+            return (
+                {
+                    "final_response": "The premise holds.",
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": "The premise holds.",
+                            "reasoning": "Check the premise.",
+                        }
+                    ],
+                },
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "test", "input": "Check it", "stream": True},
+                )
+                assert resp.status == 200
+                events = [
+                    json.loads(line.removeprefix("data: "))
+                    for line in (await resp.text()).splitlines()
+                    if line.startswith("data: {")
+                ]
+
+        event_types = [event["type"] for event in events]
+        assert "response.reasoning_summary_part.added" in event_types
+        assert "response.reasoning_summary_text.delta" in event_types
+        assert "response.reasoning_summary_text.done" in event_types
+        assert "response.reasoning_summary_part.done" in event_types
+        sequence_numbers = [event["sequence_number"] for event in events]
+        assert sequence_numbers == list(range(len(sequence_numbers)))
+        completed = next(event for event in events if event["type"] == "response.completed")
+        assert [item["type"] for item in completed["response"]["output"]] == [
+            "reasoning",
+            "function_call",
+            "function_call_output",
+            "message",
+        ]
+        reasoning = next(
+            item for item in completed["response"]["output"] if item["type"] == "reasoning"
+        )
+        assert reasoning["summary"] == [
+            {"type": "summary_text", "text": "Check the premise."}
+        ]
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

OpenAI-compatible clients currently receive no visible reasoning while Hermes is thinking, even though the agent emits reasoning progress internally. This change exposes reasoning on both `/v1/chat/completions` and `/v1/responses`, including streaming and non-streaming responses, so clients such as Open WebUI, opencode, and LibreChat no longer sit silent during reasoning.

### Symptom

Chat Completions streams contain only `delta.content`, and Responses streams contain only text and tool events. Non-streaming responses also omit reasoning that is present in the agent result.

### Impact

API-server clients cannot render a thinking section and can appear stalled during long reasoning phases. Hermes native surfaces do not have this gap because they already consume `reasoning.available` progress.

### Bug Cause

**Trigger:** `gateway/platforms/api_server.py:5206` and `gateway/platforms/api_server.py:6467` when an API-server agent emits `reasoning.available`.

**Causal chain:**
1. The agent produces reasoning and invokes its tool-progress callback.
2. Chat Completions did not wire that callback, while the Responses callback explicitly discarded progress events; batch response builders projected only final text.
3. OpenAI-compatible clients receive text and tool activity but no reasoning payload.

**Why it is wrong:** the compatibility writers drop an already-available model output channel at the transport boundary.

**Working sibling / contrast:** `/v1/runs` already maps `reasoning.available` into its SSE event stream, and native TUI and messaging surfaces can display reasoning.

**Ruled out:** reasoning request parsing is not the failure. `model_options.reasoning` and `reasoning_effort` already reach agent construction; endpoint tests reproduce the loss after the callback fires.

### Fix

Wire reasoning progress into Chat Completions as `delta.reasoning_content`. Add native Responses reasoning output items plus summary part/text events, include reasoning in terminal and non-streaming payloads, preserve monotonically increasing `sequence_number` values across interleaved reasoning, tool, and text events, honor explicit reasoning opt-out, and advertise `reasoning_streaming` in capabilities.

## Related Issue

Closes #99552

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` - project agent reasoning into Chat Completions and Responses API streaming and batch formats.
- `tests/gateway/test_api_server.py` - cover both protocols, terminal output items, capabilities, interleaved output ordering, and sequence monotonicity.

## How to Test

1. Send a streaming Chat Completions request to a reasoning-enabled model and verify a chunk contains `choices[0].delta.reasoning_content` before normal content.
2. Send a streaming Responses request and verify reasoning summary events, tool/text events, and a reasoning item in `response.completed.output`.
3. Run the endpoint suite:

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py -q
```

Result: 113 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant endpoint suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant API behavior is documented by endpoint docstrings and capability output; user docs N/A
- [x] `cli-config.yaml.example` N/A - no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` N/A - no workflow architecture changed
- [x] Cross-platform impact considered - protocol serialization is platform-independent
- [x] Tool descriptions/schemas N/A - no model tool changed

## Screenshots / Logs

N/A - automated endpoint tests verify the serialized HTTP and SSE payloads.
