### PR TITLE
fix(gateway): anchor merged message bursts on the newest message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2824,6 +2824,25 @@ def _invalidate_pending_stt_cache(event: MessageEvent) -> None:
             delattr(event, attr)
 
 
+def _advance_merged_reply_anchor(existing: MessageEvent, event: MessageEvent) -> None:
+    """Point a merged pending event at the newest message in the burst.
+
+    ``merge_pending_message_event`` folds the incoming event's text/media into
+    the queued one, but the queued event keeps the *first* message's
+    ``message_id``.  That id is what ``_reply_anchor_for_event`` hands to the
+    adapters as ``reply_to``, so a three-message burst produced a reply quoting
+    message #1 while its content answered message #3 -- the wrong-quote symptom
+    in WhatsApp/Telegram group chats.
+
+    The newest message is the right anchor: it is the last thing the user
+    typed, and the merged turn answers all of it.  Events with no id of their
+    own (synthetic/proactive sends) leave the existing anchor alone rather than
+    clearing it, since dropping the anchor loses reply threading outright.
+    """
+    if event.message_id is not None:
+        existing.message_id = event.message_id
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -2866,6 +2885,7 @@ def merge_pending_message_event(
             existing.media_text_inlined.extend(incoming_inline_flags)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+            _advance_merged_reply_anchor(existing, event)
             _invalidate_pending_stt_cache(existing)
             return
 
@@ -2886,6 +2906,7 @@ def merge_pending_message_event(
                 and event.message_type != MessageType.TEXT
             ):
                 existing.message_type = event.message_type
+            _advance_merged_reply_anchor(existing, event)
             _invalidate_pending_stt_cache(existing)
             return
 
@@ -2896,6 +2917,7 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            _advance_merged_reply_anchor(existing, event)
             return
 
     pending_messages[session_key] = event

--- a/tests/gateway/test_merge_pending_reply_anchor.py
+++ b/tests/gateway/test_merge_pending_reply_anchor.py
@@ -1,0 +1,84 @@
+"""Merged message bursts must quote the newest message, not the first.
+
+``merge_pending_message_event`` folds a rapid burst of user messages into the
+single queued event that the next turn consumes.  The queued event's
+``message_id`` is what ``_reply_anchor_for_event`` hands to adapters as
+``reply_to``, so keeping the first message's id made the agent answer message #3
+while visibly quoting message #1.
+"""
+
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    _reply_anchor_for_event,
+    merge_pending_message_event,
+)
+
+
+def _event(text, message_id, message_type=MessageType.TEXT, media=()):
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        message_id=message_id,
+        media_urls=list(media),
+        media_types=["image/jpeg"] * len(media),
+    )
+
+
+def test_text_burst_anchors_on_last_message():
+    pending = {}
+    for text, message_id in (("first", "M1"), ("second", "M2"), ("third", "M3")):
+        merge_pending_message_event(
+            pending, "sess", _event(text, message_id), merge_text=True
+        )
+
+    merged = pending["sess"]
+    assert merged.text == "first\nsecond\nthird"
+    assert merged.message_id == "M3"
+    assert _reply_anchor_for_event(merged) == "M3"
+
+
+def test_photo_burst_anchors_on_last_message():
+    pending = {}
+    merge_pending_message_event(
+        pending, "sess", _event("", "P1", MessageType.PHOTO, ["a.jpg"])
+    )
+    merge_pending_message_event(
+        pending, "sess", _event("caption", "P2", MessageType.PHOTO, ["b.jpg"])
+    )
+
+    merged = pending["sess"]
+    assert merged.media_urls == ["a.jpg", "b.jpg"]
+    assert merged.message_id == "P2"
+
+
+def test_text_then_media_anchors_on_last_message():
+    pending = {}
+    merge_pending_message_event(pending, "sess", _event("look at this", "T1"))
+    merge_pending_message_event(
+        pending, "sess", _event("", "P9", MessageType.PHOTO, ["c.jpg"])
+    )
+
+    merged = pending["sess"]
+    assert merged.message_id == "P9"
+    assert merged.message_type == MessageType.PHOTO
+
+
+def test_anchorless_followup_keeps_previous_anchor():
+    """Synthetic events carry no id; clearing the anchor would drop threading."""
+    pending = {}
+    merge_pending_message_event(pending, "sess", _event("real message", "T1"))
+    merge_pending_message_event(
+        pending, "sess", _event("synthetic", None), merge_text=True
+    )
+
+    assert pending["sess"].message_id == "T1"
+
+
+def test_first_event_is_stored_unchanged():
+    pending = {}
+    event = _event("solo", "S1")
+    merge_pending_message_event(pending, "sess", event)
+
+    assert pending["sess"] is event
+    assert pending["sess"].message_id == "S1"


### PR DESCRIPTION
## Problem

When a user sends several messages in quick succession, `merge_pending_message_event()` folds them into the single queued event that the next turn consumes. It merges the **text and media** of every message in the burst, but leaves the queued event's `message_id` pointing at the **first** message.

`_reply_anchor_for_event()` hands that id to adapters as `reply_to`. The result: a three-message burst produces a reply whose content answers message #3 while visibly quoting message #1. On WhatsApp and Telegram group chats this reads as the agent replying to the wrong message.

All three merge branches were affected — photo burst, media merge, and the `merge_text` text burst.

## Reproduction

Before this change:

```
Case 1 — text burst (merge_text=True)
  merged text : 'first\nsecond\nthird'
  message_id  : MSG_1      <-- expected MSG_3
  reply anchor: MSG_1

Case 2 — photo burst
  media_urls  : ['a.jpg', 'b.jpg']
  message_id  : IMG_1      <-- expected IMG_2

Case 3 — text then media
  message_id  : TXT_1      <-- expected IMG_9
```

After: `MSG_3`, `IMG_2`, `IMG_9` respectively.

## Fix

A small `_advance_merged_reply_anchor()` helper, called from each of the three merge branches, advances the anchor to the newest message in the burst. The newest message is the correct anchor — it is the last thing the user typed, and the merged turn answers all of it.

The helper deliberately no-ops when the incoming event carries no `message_id` of its own. Synthetic and proactive sends have no id, and clearing the anchor would lose reply threading entirely rather than merely misplacing it.

## Testing

New `tests/gateway/test_merge_pending_reply_anchor.py` — 5 tests covering the three merge paths plus two guard cases (anchorless follow-up preserves the previous anchor; a first event is stored unmodified).

Verified the three bug tests **fail without the source change** and pass with it; the two guard tests pass either way.

Regression sweep on `tests/gateway` (filtered to `reply|anchor|pending|merge|burst|whatsapp|telegram`): **1223 passed, 6 skipped**.

One unrelated failure, `test_api_server_runs.py::TestSteerRun::test_pending_steer_preserved_on_run_completed`, reproduces identically on a clean `main` checkout and is pre-existing.

Platform tested: Linux (Ubuntu, WSL2), Python 3.12.
