### PR TITLE
fix(api-server): report cache-exclusive input_tokens and cached_tokens in run usage

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7361,7 +7361,14 @@ class APIServerAdapter(BasePlatformAdapter):
                         task_id=effective_task_id,
                     )
                     usage = {
-                        "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                        # #99554: input_tokens is cache-EXCLUSIVE fresh input,
+                        # cached_tokens exposes the provider-cache reads, and
+                        # prompt_tokens keeps the legacy cache-INCLUSIVE total
+                        # (input + cache_read + cache_write per
+                        # CanonicalUsage) so existing readers see no change.
+                        "input_tokens": getattr(agent, "session_input_tokens", 0) or 0,
+                        "cached_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                        "prompt_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                     }

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -852,7 +852,18 @@ async def _handle_runs(
                                 except Exception:
                                     pass
                     u = {
-                        "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                        # cache-exclusive fresh input + the cached-read
+                        # count, so a client can tell a prompt served from
+                        # the provider cache from one billed as fresh
+                        # (#99554). session_prompt_tokens is cache-
+                        # INCLUSIVE (input + cache_read + cache_write per
+                        # CanonicalUsage); reporting it as "input_tokens"
+                        # made the two indistinguishable.
+                        "input_tokens": getattr(agent, "session_input_tokens", 0) or 0,
+                        "cached_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                        # Legacy cache-inclusive totals kept for existing
+                        # readers (sum of the two above plus cache writes).
+                        "prompt_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                     }

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -360,9 +360,11 @@ class TestAgentExecution:
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
         mock_agent.run_conversation.return_value = {"final_response": "ok"}
-        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_input_tokens = 1      # cache-exclusive fresh input
+        mock_agent.session_cache_read_tokens = 4  # served from provider cache
+        mock_agent.session_prompt_tokens = 6     # cache-INCLUSIVE legacy total
         mock_agent.session_completion_tokens = 2
-        mock_agent.session_total_tokens = 3
+        mock_agent.session_total_tokens = 8
 
         model_options = {"reasoning": {"enabled": False}, "fast": False}
         with patch.object(adapter, "_create_agent", return_value=mock_agent) as mock_create_agent:
@@ -381,7 +383,16 @@ class TestAgentExecution:
         # here doesn't set an explicit session_id string so the guard skips
         # the annotation — header will fall back to the provided session_id.
         assert result["final_response"] == "ok"
-        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        # #99554: input_tokens is cache-EXCLUSIVE, cached_tokens exposes the
+        # cached-read count, prompt_tokens keeps the legacy cache-inclusive
+        # total so existing readers see no regression.
+        assert usage == {
+            "input_tokens": 1,
+            "cached_tokens": 4,
+            "prompt_tokens": 6,
+            "output_tokens": 2,
+            "total_tokens": 8,
+        }
         create_kwargs = mock_create_agent.call_args.kwargs
         assert create_kwargs["requested_model"] == "MiniMax-M3"
         assert create_kwargs["requested_provider"] == "minimax"
@@ -2407,6 +2418,8 @@ class TestSessionKeyHeader:
             captured_kwargs.update(kwargs)
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_input_tokens = 0
+            mock_agent.session_cache_read_tokens = 0
             mock_agent.session_prompt_tokens = 0
             mock_agent.session_completion_tokens = 0
             mock_agent.session_total_tokens = 0

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -172,6 +172,8 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
     observed = {}
 
     class FakeAgent:
+        session_input_tokens = 0
+        session_cache_read_tokens = 0
         session_prompt_tokens = 0
         session_completion_tokens = 0
         session_total_tokens = 0
@@ -201,7 +203,15 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
     )
 
     assert result["session_id"] == "request-session"
-    assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    # #99554: cache-exclusive input + cached_reads exposed alongside the
+    # legacy cache-inclusive prompt_tokens.
+    assert usage == {
+        "input_tokens": 0,
+        "cached_tokens": 0,
+        "prompt_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+    }
     assert observed == {"registered": True, "task_id": "request-session"}
     assert "run_steer_test" not in adapter._active_run_agents
 


### PR DESCRIPTION
Fixes #99554

## Problem

The terminal usage payload for a run reported `session_prompt_tokens` as `input_tokens` — the **cache-inclusive** count (`input_tokens + cache_read_tokens + cache_write_tokens` per `CanonicalUsage`). A client reading the payload could not distinguish a prompt served almost entirely from the provider's cache from one billed as fully fresh input — the two looked identical.

The cache-exclusive counter (`session_input_tokens`) and the cached-read counter (`session_cache_read_tokens`) were both maintained right beside it (initialized together in `run_agent.py`) but never reached the payload.

## Fix

Both payload sites fixed (the runs path in `api_server_runs.py` **and** the chat-completions path in `api_server.py` — the pre-split location the reporter noted carries the same code):

- `input_tokens` → cache-**exclusive** fresh input (`session_input_tokens`)
- `cached_tokens` → provider-cache reads (`session_cache_read_tokens`, matching the OpenAI `prompt_tokens_details.cached_tokens` convention)
- `prompt_tokens` → the legacy cache-inclusive total, kept so existing readers see no regression
- `output_tokens` / `total_tokens` unchanged

The payload rides `run.completed` SSE, the stored run status, and `GET /v1/runs/{id}` — all three now expose the distinction.

## Verification

- `test_run_agent_uses_session_id_as_task_id` extended: mock agent with distinct values for all five counters asserts the full new payload shape
- Steering + multimodal + session-api suites: **138/138 pass** across `test_api_server.py`, `test_session_api.py`, `test_api_server_multimodal.py` (two exact-equality assertions updated to the new 5-key shape)