### PR TITLE
fix(cli): validate cron scripts at creation, name profile in cron output, add kanban show --all

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4234,6 +4234,79 @@ def _windows_cron_bootstrap_argv(
     return [python_exe, "-c", bootstrap, script_path]
 
 
+def _resolve_script_path(
+    script_path: str,
+) -> tuple[bool, str, Optional[Path]]:
+    """Resolve and validate a cron ``script``/``monitor_script`` value.
+
+    Shared by the fire-time runner (``_run_job_script``) and the CLI's
+    creation-time check (``hermes_cli.cron.cron_create``) so a job whose
+    script cannot be found fails *today at creation*, not at 07:00 tomorrow
+    (#99583).
+
+    Resolution contract (identical for both callers):
+
+    * relative paths resolve against ``HERMES_HOME/scripts/`` (profile-scoped
+      — ``_get_hermes_home()``, so the owning profile's scripts dir);
+    * absolute and ``~``-prefixed paths are resolved and must stay inside
+      the scripts dir (path-traversal / symlink-escape guard);
+    * the target must exist and be a regular file.
+
+    Returns ``(True, '', path)`` on success; on failure
+    ``(False, message, None)`` — the message is safe to show to a user or
+    report back to an LLM.
+    """
+    scripts_dir = _get_hermes_home() / "scripts"
+    from cron.jobs import _ensure_cron_dir
+
+    _ensure_cron_dir(scripts_dir)
+    scripts_dir_resolved = scripts_dir.resolve()
+
+    # Same ingestion contract as cron.lifecycle_guard._expand_candidate_path:
+    # a NUL-bearing value can never name a real script, and on Windows the
+    # Path operations raise ValueError *after* expanduser (expanduser never
+    # expands "~user" there, so the try below never fires) — reject eagerly
+    # so both platforms fail cleanly instead of crashing the scheduler.
+    # str() first so the guard itself can never raise TypeError on a
+    # non-str script_path (e.g. a Path passed by a future caller) — the
+    # guard must be crash-proof even though every current call site
+    # passes a plain str (#86832 review).
+    if "\x00" in str(script_path):
+        return False, f"Blocked: script path contains a NUL byte: {script_path!r}", None
+
+    try:
+        raw = Path(script_path).expanduser()
+    except (ValueError, RuntimeError, OSError):
+        # Same ingestion contract as cron.lifecycle_guard: a NUL-bearing
+        # value (ValueError) or an unexpandable ``~`` (RuntimeError with no
+        # resolvable HOME) can never name a real script. The creation-time
+        # guard tolerates such values as "nothing to scan", so they can
+        # reach fire time — fail the run with a report instead of crashing
+        # the scheduler with an unhandled exception.
+        return False, f"Blocked: script path is not a valid filesystem path: {script_path!r}", None
+    if raw.is_absolute():
+        path = raw.resolve()
+    else:
+        path = (scripts_dir / raw).resolve()
+
+    # Guard against path traversal, absolute path injection, and symlink
+    # escape — scripts MUST reside within HERMES_HOME/scripts/.
+    try:
+        path.relative_to(scripts_dir_resolved)
+    except ValueError:
+        return False, (
+            f"Blocked: script path resolves outside the scripts directory "
+            f"({scripts_dir_resolved}): {script_path!r}"
+        ), None
+
+    if not path.exists():
+        return False, f"Script not found: {path}", None
+    if not path.is_file():
+        return False, f"Script path is not a file: {path}", None
+
+    return True, "", path
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
@@ -4275,51 +4348,9 @@ def _run_job_script(
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
-    scripts_dir = _get_hermes_home() / "scripts"
-    _ensure_cron_dir(scripts_dir)
-    scripts_dir_resolved = scripts_dir.resolve()
-
-    # Same ingestion contract as cron.lifecycle_guard._expand_candidate_path:
-    # a NUL-bearing value can never name a real script, and on Windows the
-    # Path operations raise ValueError *after* expanduser (expanduser never
-    # expands "~user" there, so the try below never fires) — reject eagerly
-    # so both platforms fail cleanly instead of crashing the scheduler.
-    # str() first so the guard itself can never raise TypeError on a
-    # non-str script_path (e.g. a Path passed by a future caller) — the
-    # guard must be crash-proof even though every current call site
-    # passes a plain str (#86832 review).
-    if "\x00" in str(script_path):
-        return False, f"Blocked: script path contains a NUL byte: {script_path!r}"
-
-    try:
-        raw = Path(script_path).expanduser()
-    except (ValueError, RuntimeError, OSError):
-        # Same ingestion contract as cron.lifecycle_guard: a NUL-bearing
-        # value (ValueError) or an unexpandable ``~`` (RuntimeError with no
-        # resolvable HOME) can never name a real script. The creation-time
-        # guard tolerates such values as "nothing to scan", so they can
-        # reach fire time — fail the run with a report instead of crashing
-        # the scheduler with an unhandled exception.
-        return False, f"Blocked: script path is not a valid filesystem path: {script_path!r}"
-    if raw.is_absolute():
-        path = raw.resolve()
-    else:
-        path = (scripts_dir / raw).resolve()
-
-    # Guard against path traversal, absolute path injection, and symlink
-    # escape — scripts MUST reside within HERMES_HOME/scripts/.
-    try:
-        path.relative_to(scripts_dir_resolved)
-    except ValueError:
-        return False, (
-            f"Blocked: script path resolves outside the scripts directory "
-            f"({scripts_dir_resolved}): {script_path!r}"
-        )
-
-    if not path.exists():
-        return False, f"Script not found: {path}"
-    if not path.is_file():
-        return False, f"Script path is not a file: {path}"
+    ok, message, path = _resolve_script_path(script_path)
+    if not ok:
+        return False, message
 
     script_timeout = _get_script_timeout()
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -107,6 +107,23 @@ def _builtin_gateway_liveness() -> Optional[bool]:
         return None
 
 
+def _active_profile_label() -> str:
+    """Human label for the profile being inspected, e.g. ``"default"``.
+
+    CLI commands that read profile-scoped state (cron jobs, gateway pid) must
+    name the profile in their output — otherwise a user inspecting profile B
+    while the gateway runs under profile A sees "Gateway is not running" as a
+    confusing false negative (#99579).
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        name = get_active_profile_name() or "default"
+    except Exception:
+        name = "default"
+    return name
+
+
 def _warn_if_gateway_not_running() -> None:
     """Warn that scheduled jobs won't fire unless the gateway is running.
 
@@ -127,7 +144,11 @@ def _warn_if_gateway_not_running() -> None:
     if _builtin_gateway_liveness() is not False:
         return
 
-    print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
+    print(color(
+        f"  ⚠  Gateway is not running for profile '{_active_profile_label()}' "
+        "— jobs won't fire automatically.",
+        Colors.YELLOW,
+    ))
     print(color("     Start it with: hermes gateway install", Colors.DIM))
     print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
     print(color("     Check status:  hermes cron status", Colors.DIM))
@@ -140,13 +161,17 @@ def cron_list(show_all: bool = False):
     jobs = list_jobs(include_disabled=show_all)
 
     if not jobs:
-        print(color("No scheduled jobs.", Colors.DIM))
+        print(color(
+            f"No scheduled jobs in profile '{_active_profile_label()}'.",
+            Colors.DIM,
+        ))
         print(color("Create one with 'hermes cron create ...' or the /cron command in chat.", Colors.DIM))
         return
 
+    profile = _active_profile_label()
     print()
     print(color("┌─────────────────────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│                         Scheduled Jobs                                  │", Colors.CYAN))
+    print(color(f"│              Scheduled Jobs  (profile: {profile})          │".ljust(75) + "│", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────────────────────┘", Colors.CYAN))
     print()
 
@@ -520,13 +545,24 @@ def cron_status():
                     ))
             print("  Check the gateway log for 'Cron tick error'.")
         else:
-            print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+            print(color(
+                f"✓ Gateway is running for profile '{_active_profile_label()}' — "
+                "cron jobs will fire automatically",
+                Colors.GREEN,
+            ))
             if pids:
                 print(f"  PID: {', '.join(map(str, pids))}")
             if hb_age is not None:
                 print(f"  Ticker heartbeat: {int(hb_age)}s ago")
     else:
-        print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
+        print(color(
+            f"✗ Gateway is not running for profile '{_active_profile_label()}' "
+            "— cron jobs will NOT fire",
+            Colors.RED,
+        ))
+        print()
+        print("  If the gateway runs under a different profile, check that profile:")
+        print("    hermes --profile <name> cron status")
         print()
         print("  To enable automatic execution:")
         print("    hermes gateway install    # Install as a user service")
@@ -684,6 +720,30 @@ def cron_create(args):
     # raises GatewayLifecycleBlocked, the `cronjob` tool wrapper catches it and
     # returns it as result["error"], and the `if not result.get("success")`
     # branch below prints it in red and exits 1 — same UX as before.
+    resolved_script_path = None
+    script_value = getattr(args, "script", None)
+    monitor_value = getattr(args, "monitor_script", None)
+    for label, raw in (("script", script_value), ("monitor-script", monitor_value)):
+        if not raw:
+            continue
+        try:
+            from cron.scheduler import _resolve_script_path
+
+            ok, message, path = _resolve_script_path(raw)
+        except Exception as exc:  # pragma: no cover - defensive
+            ok, message, path = False, f"could not validate {label}: {exc}", None
+        if not ok:
+            print(color(f"Failed to create job: {label} {raw!r} is not usable.", Colors.RED))
+            print(color(f"  {message}", Colors.RED))
+            print(color(
+                "  Place the script in the ACTIVE profile's scripts directory "
+                f"(resolved via HERMES_HOME, which is profile-scoped). "
+                f"Found it? Run the create again.",
+                Colors.YELLOW,
+            ))
+            return 1
+        if label == "script":
+            resolved_script_path = path
     result = _cron_api(
         action="create",
         schedule=args.schedule,
@@ -693,12 +753,12 @@ def cron_create(args):
         repeat=getattr(args, "repeat", None),
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
-        script=getattr(args, "script", None),
+        script=script_value,
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", False) or None,
-        monitor_script=getattr(args, "monitor_script", None),
+        monitor_script=monitor_value,
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
@@ -709,10 +769,13 @@ def cron_create(args):
     print(color(f"Created job: {result['job_id']}", Colors.GREEN))
     print(f"  Name: {result['name']}")
     print(f"  Schedule: {result['schedule']}")
-    if result.get("skills"):
+    if resolved_script_path is not None:
+        print(f"  Script: {script_value}")
+        print(color(f"  Resolved: {resolved_script_path} (HERMES_HOME is profile-scoped)", Colors.DIM))
+    elif result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
     job_data = result.get("job", {})
-    if job_data.get("script"):
+    if job_data.get("script") and resolved_script_path is None:
         print(f"  Script: {job_data['script']}")
     if job_data.get("monitor_script"):
         print(f"  Monitor: {job_data['monitor_script']} (agent runs only on output change)")

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -510,6 +510,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         metavar="VALUE",
         help="With --state-type: keep runs whose column equals this value",
     )
+    p_show.add_argument(
+        "--all",
+        action="store_true",
+        help="Show every event, not just the most recent 20",
+    )
 
     # --- assign ---
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
@@ -1935,11 +1940,17 @@ def _cmd_show(args: argparse.Namespace) -> int:
             print(f"  [{_fmt_ts(c.created_at)}] {c.author}: {c.body}")
     if events:
         print()
+        shown = events if getattr(args, "all", False) else events[-20:]
         print(f"Events ({len(events)}):")
-        for e in events[-20:]:
+        for e in shown:
             pl = f" {e.payload}" if e.payload else ""
             run_tag = f" [run {e.run_id}]" if e.run_id else ""
             print(f"  [{_fmt_ts(e.created_at)}]{run_tag} {e.kind}{pl}")
+        if len(events) > len(shown):
+            print(
+                f"  … {len(events) - len(shown)} earlier event(s) not shown "
+                f"(re-run with --all to see them)"
+            )
     if runs:
         print()
         print(f"Runs ({len(runs)}):")

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -52,7 +52,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_create.add_argument(
         "--script",
         help=(
-            "Path to a script under ~/.hermes/scripts/. Default mode: "
+            "Path to a script under the ACTIVE profile's scripts dir "
+            "(~/.hermes/scripts/ for the default profile; "
+            "~/.hermes/profiles/<name>/scripts/ when --profile is set). "
+            "Must already exist — creation fails otherwise. Default mode: "
             "script stdout is injected into the agent's prompt each run. "
             "With --no-agent: the script IS the job and its stdout is "
             "delivered verbatim. .sh/.bash files run via bash, everything "
@@ -74,8 +77,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--monitor-script",
         dest="monitor_script",
         help=(
-            "Monitor mode: path to a cheap source script under "
-            "~/.hermes/scripts/ that runs each tick BEFORE the agent. "
+            "Monitor mode: path to a cheap source script under the ACTIVE "
+            "profile's scripts dir (~/.hermes/scripts/ for the default "
+            "profile; ~/.hermes/profiles/<name>/scripts/ when --profile is "
+            "set) that runs each tick BEFORE the agent. "
             "Unchanged output (exact-bytes hash) suppresses the agent run "
             "entirely; changed output injects a MONITOR CHANGE DETECTED "
             "diff into the prompt. Script output must be stable (no "
@@ -169,7 +174,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--script",
         help=(
-            "Path to a script under ~/.hermes/scripts/. Pass empty string to clear. "
+            "Path to a script under the ACTIVE profile's scripts dir "
+            "(~/.hermes/scripts/ for the default profile; "
+            "~/.hermes/profiles/<name>/scripts/ when --profile is set). "
+            "Pass empty string to clear. "
             "With --no-agent the script IS the job; otherwise its stdout is "
             "injected into the agent's prompt each run."
         ),

--- a/tests/cron/test_99583_99578_99579.py
+++ b/tests/cron/test_99583_99578_99579.py
@@ -1,0 +1,187 @@
+"""Tests for issue fixes:
+
+* #99583 — ``hermes cron create --script`` validates the script exists at
+  creation (profile-scoped HERMES_HOME) and prints the resolved path.
+* #99578 — ``hermes kanban show`` names the number of truncated events and
+  offers ``--all``.
+* #99579 — ``cron list``/``cron status`` name the profile being inspected.
+"""
+
+import argparse
+import importlib
+import json
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    (home / "cron").mkdir()
+    (home / "cron" / "output").mkdir()
+    (home / "scripts" / "watch.sh").write_text("#!/bin/bash\necho alert\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+
+    import hermes_constants
+
+    importlib.reload(hermes_constants)
+    yield home
+
+
+class _Args(argparse.Namespace):
+    """Minimal args object with the attributes cron_create reads."""
+
+    def __init__(self, **kw):
+        defaults = dict(
+            schedule="every 5m",
+            prompt="do a thing",
+            name=None,
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script=None,
+            workdir=None,
+            model=None,
+            model_provider=None,
+            no_agent=False,
+            monitor_script=None,
+            monitor_url=None,
+            continuity=None,
+            reasoning_effort=None,
+        )
+        defaults.update(kw)
+        super().__init__(**defaults)
+
+
+# ---------------------------------------------------------------- #99583
+
+
+def test_cron_create_rejects_missing_script(hermes_env, capsys):
+    from hermes_cli.cron import cron_create
+
+    rc = cron_create(_Args(script="does_not_exist.py"))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Failed to create job" in out
+    assert "does_not_exist.py" in out
+    assert "Script not found" in out
+
+
+def test_cron_create_rejects_out_of_tree_absolute_script(hermes_env, capsys):
+    from hermes_cli.cron import cron_create
+
+    outside = hermes_env.parent / "outside.py"
+    outside.write_text("print('hi')\n")
+    rc = cron_create(_Args(script=str(outside)))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "outside the scripts directory" in out
+
+
+def test_cron_create_accepts_existing_script_and_prints_resolved(hermes_env, capsys, monkeypatch):
+    from hermes_cli.cron import cron_create
+
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    rc = cron_create(_Args(script="watch.sh"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Created job" in out
+    m = re.search(r"Resolved: (\S+watch\.sh)", out)
+    assert m, f"expected Resolved line in output:\n{out}"
+    assert Path(m.group(1)).resolve() == (hermes_env / "scripts" / "watch.sh").resolve()
+
+
+def test_cron_create_rejects_missing_monitor_script(hermes_env, capsys):
+    from hermes_cli.cron import cron_create
+
+    rc = cron_create(_Args(monitor_script="no_monitor.py"))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "monitor-script" in out
+
+
+# ---------------------------------------------------------------- #99578
+
+
+def _make_kanban_task_with_events(tmp_path, n_events: int):
+    from hermes_cli import kanban_db as kb
+
+    db = tmp_path / "kb.db"
+    with kb.connect_closing(db) as conn:
+        task_id = kb.create_task(conn, title="t")
+    with kb.connect_closing(db) as conn:
+        now = int(time.time())
+        for i in range(n_events):
+            conn.execute(
+                "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (task_id, None, f"evt{i}", None, now + i),
+            )
+    return db, task_id
+
+
+def test_kanban_show_truncation_notice(tmp_path, capsys, monkeypatch):
+    from hermes_cli.kanban import _cmd_show
+
+    db, task_id = _make_kanban_task_with_events(tmp_path, 25)
+    args = _Args(task_id=task_id, json=False, all=False)
+    monkeypatch.setattr("hermes_cli.kanban_db.kanban_db_path", lambda board=None: db)
+
+    rc = _cmd_show(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Events (26):" in out
+    assert "6 earlier event(s) not shown" in out
+    assert "--all" in out
+
+    rc = _cmd_show(_Args(task_id=task_id, json=False, all=True))
+    out2 = capsys.readouterr().out
+    assert rc == 0
+    assert "Events (26):" in out2
+    assert "earlier event(s) not shown" not in out2
+    assert "evt0" in out2
+
+
+# ---------------------------------------------------------------- #99579
+
+
+def test_cron_list_names_profile(hermes_env, capsys):
+    from hermes_cli.cron import cron_list
+
+    cron_list(show_all=False)
+    out = capsys.readouterr().out
+    assert "profile" in out.lower()
+    # With no jobs the label names the profile explicitly.
+    assert re.search(r"profile '[^']+'", out)
+
+
+def test_cron_status_names_profile(hermes_env, capsys, monkeypatch):
+    from hermes_cli import gateway
+    from hermes_cli.cron import cron_status
+
+    # Force the liveness probe to "not running" so the ✗ branch prints.
+    monkeypatch.setattr(
+        "hermes_cli.cron._builtin_gateway_liveness",
+        lambda: False,
+    )
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        "hermes_cli.cron._active_cron_provider_name",
+        lambda: "builtin",
+    )
+    from cron import jobs as cron_jobs
+
+    monkeypatch.setattr(cron_jobs, "get_ticker_heartbeat_age", lambda: None)
+    monkeypatch.setattr(cron_jobs, "get_ticker_success_age", lambda: None)
+    monkeypatch.setattr(cron_jobs, "get_ticker_last_error", lambda: None)
+    cron_status()
+    out = capsys.readouterr().out
+    assert "profile" in out.lower()


### PR DESCRIPTION
Fixes #99583, #99579, #99578 — three small CLI fixes surfaced by the fresh-issues scan.

## #99583 — `cron create --script` accepts scripts that can never run
- **Validate at creation**: `hermes cron create --script X` now resolves X against the ACTIVE profile's scripts dir (HERMES_HOME is profile-scoped) and refuses with a clear message if the script does not exist or escapes the scripts dir. Previously the failure only surfaced at fire time — for a `0 7 * * *` watchdog, many hours later.
- **Shared resolution**: extracted `cron.scheduler._resolve_script_path()` from the fire-time runner so CLI and scheduler use identical rules (relative → `HERMES_HOME/scripts/`, absolute/`~` must stay inside, must exist, must be a file).
- **Help text**: `--script`/`--monitor-script` now documented as profile-scoped (`~/.hermes/profiles/<name>/scripts/` when `--profile` is set), not `~/.hermes/scripts/` as universal.
- **Resolved path** printed on successful create so the user sees exactly where the script was resolved.

## #99579 — `cron list`/`cron status` don't name the profile being inspected
Both commands now print the profile name in the header, the empty-list message, and every gateway-not-running warning. A user inspecting profile B while the gateway runs under profile A no longer sees a bare "Gateway is not running" — they get the profile name plus a hint to check `hermes --profile <name> cron status`.

## #99578 — `kanban show` silently truncates events
`kanban show` printed `Events (N):` but only rendered the last 20. It now prints how many earlier events were truncated and how to see them (`--all`); `--all` shows every event.

## Tests
`tests/cron/test_99583_99578_99579.py` — 7 tests covering: missing/out-of-tree/monitor script rejection, successful create with resolved path printed, truncation notice + `--all`, and profile naming in `cron list`/`cron status`.

Full cron suite: 999 passed, 1 skipped.