### PR TITLE
fix(cron): identify the profile behind cron status results

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -15,9 +15,10 @@ from functools import lru_cache
 
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
-# argparse runs (it sets ``HERMES_HOME`` and strips itself from ``sys.argv``),
-# so it isn't on the parser. Listed here so all "carry over on relaunch"
-# metadata lives in one file.
+# argparse runs (it sets ``HERMES_HOME`` and strips itself from ``sys.argv``).
+# It is also declared on the parser below so the supported selector appears in
+# top-level help. Listed here so all "carry over on relaunch" metadata lives in
+# one file.
 PRE_ARGPARSE_INHERITED_FLAGS: list[tuple[str, bool]] = [
     ("--profile", True),
     ("-p", True),
@@ -39,6 +40,7 @@ _VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset(
         "-s", "--skills",
         "--usage-file",
         "--in",
+        "-p", "--profile",
     }
 )
 _OPTIONAL_VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset({"-c", "--continue"})
@@ -149,6 +151,13 @@ def build_top_level_parser():
 
     parser.add_argument(
         "--version", "-V", action="store_true", help="Show version and exit"
+    )
+    parser.add_argument(
+        "--profile",
+        "-p",
+        metavar="PROFILE",
+        default=argparse.SUPPRESS,
+        help="Run this command against the named profile.",
     )
     parser.add_argument(
         "-z",

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -46,6 +46,15 @@ _VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset(
 _OPTIONAL_VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset({"-c", "--continue"})
 
 
+class _PreparsedProfileAction(argparse.Action):
+    """Expose the bootstrap-only profile selector without accepting it here."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error(
+            f"{option_string or '--profile'} must be processed before argument parsing"
+        )
+
+
 @lru_cache(maxsize=1)
 def top_level_value_flag_sets() -> tuple[frozenset[str], frozenset[str]]:
     """(required-value, optional-value) top-level flags, derived from the
@@ -156,6 +165,7 @@ def build_top_level_parser():
         "--profile",
         "-p",
         metavar="PROFILE",
+        action=_PreparsedProfileAction,
         default=argparse.SUPPRESS,
         help="Run this command against the named profile.",
     )

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -64,6 +64,22 @@ def _active_cron_provider_name() -> str:
         return "builtin"
 
 
+def _cron_profile_name() -> str:
+    """Return the profile whose cron store and gateway are being inspected."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name()
+    except Exception:
+        return "unknown"
+
+
+def _print_cron_profile(profile: Optional[str] = None) -> str:
+    profile = profile or _cron_profile_name()
+    print(color(f"Profile: {profile}", Colors.DIM))
+    return profile
+
+
 def _builtin_gateway_liveness() -> Optional[bool]:
     """Tri-state liveness of the builtin cron scheduler's trigger.
 
@@ -127,7 +143,12 @@ def _warn_if_gateway_not_running() -> None:
     if _builtin_gateway_liveness() is not False:
         return
 
-    print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
+    profile = _cron_profile_name()
+    print(color(
+        f"  ⚠  Gateway for profile '{profile}' is not running — "
+        "jobs won't fire automatically.",
+        Colors.YELLOW,
+    ))
     print(color("     Start it with: hermes gateway install", Colors.DIM))
     print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
     print(color("     Check status:  hermes cron status", Colors.DIM))
@@ -138,6 +159,7 @@ def cron_list(show_all: bool = False):
     from cron.jobs import list_jobs
 
     jobs = list_jobs(include_disabled=show_all)
+    _print_cron_profile()
 
     if not jobs:
         print(color("No scheduled jobs.", Colors.DIM))
@@ -395,6 +417,8 @@ def cron_status():
     from hermes_cli.gateway import find_gateway_pids
 
     print()
+    profile = _print_cron_profile()
+    print()
 
     provider = _active_cron_provider_name()
     if provider != "builtin":
@@ -520,13 +544,21 @@ def cron_status():
                     ))
             print("  Check the gateway log for 'Cron tick error'.")
         else:
-            print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+            print(color(
+                f"✓ Gateway for profile '{profile}' is running — "
+                "cron jobs will fire automatically",
+                Colors.GREEN,
+            ))
             if pids:
                 print(f"  PID: {', '.join(map(str, pids))}")
             if hb_age is not None:
                 print(f"  Ticker heartbeat: {int(hb_age)}s ago")
     else:
-        print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
+        print(color(
+            f"✗ Gateway for profile '{profile}' is not running — "
+            "cron jobs will NOT fire",
+            Colors.RED,
+        ))
         print()
         print("  To enable automatic execution:")
         print("    hermes gateway install    # Install as a user service")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -145,7 +145,7 @@ def _warn_if_gateway_not_running() -> None:
 
     profile = _cron_profile_name()
     print(color(
-        f"  ⚠  Gateway for profile '{profile}' is not running — "
+        f"  ⚠  Gateway is not running for profile '{profile}' — "
         "jobs won't fire automatically.",
         Colors.YELLOW,
     ))
@@ -416,7 +416,6 @@ def cron_status():
     from cron.jobs import list_jobs
     from hermes_cli.gateway import find_gateway_pids
 
-    print()
     profile = _print_cron_profile()
     print()
 
@@ -545,7 +544,7 @@ def cron_status():
             print("  Check the gateway log for 'Cron tick error'.")
         else:
             print(color(
-                f"✓ Gateway for profile '{profile}' is running — "
+                f"✓ Gateway is running for profile '{profile}' — "
                 "cron jobs will fire automatically",
                 Colors.GREEN,
             ))
@@ -555,7 +554,7 @@ def cron_status():
                 print(f"  Ticker heartbeat: {int(hb_age)}s ago")
     else:
         print(color(
-            f"✗ Gateway for profile '{profile}' is not running — "
+            f"✗ Gateway is not running for profile '{profile}' — "
             "cron jobs will NOT fire",
             Colors.RED,
         ))

--- a/tests/hermes_cli/test_cron_profile_scope.py
+++ b/tests/hermes_cli/test_cron_profile_scope.py
@@ -1,0 +1,43 @@
+"""Regression coverage for profile-scoped cron CLI diagnostics (#99579)."""
+
+from unittest.mock import patch
+
+
+def test_cron_list_names_inspected_profile_when_empty(capsys):
+    import hermes_cli.cron as cron_cli
+
+    with (
+        patch("cron.jobs.list_jobs", return_value=[]),
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="otto-projektleiter"),
+    ):
+        cron_cli.cron_list()
+
+    output = capsys.readouterr().out
+    assert "Profile: otto-projektleiter" in output
+    assert "No scheduled jobs." in output
+
+
+def test_cron_status_scopes_negative_gateway_claim_to_profile(capsys):
+    import hermes_cli.cron as cron_cli
+
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="default"),
+        patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+        patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+        patch("gateway.status.is_gateway_runtime_lock_active", return_value=False),
+        patch("cron.jobs.list_jobs", return_value=[]),
+    ):
+        cron_cli.cron_status()
+
+    output = capsys.readouterr().out
+    assert "Profile: default" in output
+    assert "Gateway for profile 'default' is not running" in output
+    assert "Gateway is not running — cron jobs will NOT fire" not in output
+
+
+def test_top_level_help_documents_profile_selector():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    assert "--profile PROFILE" in parser.format_help()

--- a/tests/hermes_cli/test_cron_profile_scope.py
+++ b/tests/hermes_cli/test_cron_profile_scope.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 
 def test_cron_list_names_inspected_profile_when_empty(capsys):
     import hermes_cli.cron as cron_cli
@@ -44,3 +46,14 @@ def test_top_level_help_documents_profile_selector():
     assert "--profile PROFILE" in parser.format_help()
     assert {"--profile", "-p"} <= required
     assert {"--profile", "-p"}.isdisjoint(optional)
+
+
+def test_top_level_parser_rejects_unconsumed_profile_selector():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--profile", "bad:name"])
+
+    assert exc_info.value.code == 2

--- a/tests/hermes_cli/test_cron_profile_scope.py
+++ b/tests/hermes_cli/test_cron_profile_scope.py
@@ -31,13 +31,16 @@ def test_cron_status_scopes_negative_gateway_claim_to_profile(capsys):
 
     output = capsys.readouterr().out
     assert "Profile: default" in output
-    assert "Gateway for profile 'default' is not running" in output
+    assert "Gateway is not running for profile 'default'" in output
     assert "Gateway is not running — cron jobs will NOT fire" not in output
 
 
 def test_top_level_help_documents_profile_selector():
-    from hermes_cli._parser import build_top_level_parser
+    from hermes_cli._parser import build_top_level_parser, top_level_value_flag_sets
 
     parser, _subparsers, _chat_parser = build_top_level_parser()
+    required, optional = top_level_value_flag_sets()
 
     assert "--profile PROFILE" in parser.format_help()
+    assert {"--profile", "-p"} <= required
+    assert {"--profile", "-p"}.isdisjoint(optional)

--- a/tests/hermes_cli/test_cron_status_profile_isolation.py
+++ b/tests/hermes_cli/test_cron_status_profile_isolation.py
@@ -75,7 +75,10 @@ class TestCronStatusHeartbeatGuard:
             cron_mod.cron_status()
 
         stdout = capsys.readouterr().out
-        assert "✓ Gateway is running — cron jobs will fire automatically" in stdout
+        assert (
+            "✓ Gateway for profile 'default' is running — "
+            "cron jobs will fire automatically"
+        ) in stdout
         assert "⚠" not in stdout
 
 

--- a/tests/hermes_cli/test_cron_status_profile_isolation.py
+++ b/tests/hermes_cli/test_cron_status_profile_isolation.py
@@ -76,7 +76,7 @@ class TestCronStatusHeartbeatGuard:
 
         stdout = capsys.readouterr().out
         assert (
-            "✓ Gateway for profile 'default' is running — "
+            "✓ Gateway is running for profile 'default' — "
             "cron jobs will fire automatically"
         ) in stdout
         assert "⚠" not in stdout


### PR DESCRIPTION
## What does this PR do?

Cron list and status output now identifies the profile whose cron store and gateway state are being inspected. Negative and positive gateway claims are explicitly scoped to that profile, and the supported top-level `--profile` selector now appears in `hermes --help`, preventing an empty default profile from being mistaken for another profile's missing jobs.

### Symptom

Running `hermes cron list` or `hermes cron status` from the wrong profile reports no jobs and says the gateway is not running without naming the inspected profile. The `--profile` selector that resolves the mismatch works, but is absent from top-level help.

### Impact

Operators can mistake a profile-scope mismatch for missing schedules or a stopped gateway and create duplicate jobs in the wrong profile.

### Bug Cause

**Trigger:** `hermes_cli/cron.py` / `cron_list()` and `cron_status()` output, plus `hermes_cli/_parser.py` / `build_top_level_parser()`.

**Causal chain:**
1. A user runs a cron inspection command without selecting the profile that owns the jobs.
2. Cron storage and gateway discovery correctly use the active `HERMES_HOME`, but the output omits that scope and phrases gateway state as a system-wide claim.
3. The user sees "No scheduled jobs" or "Gateway is not running" and has no visible path in top-level help to inspect the intended profile.

**Why it is wrong:** Correctly scoped internals produced misleading unscoped diagnostics, while the pre-argparse profile selector was intentionally stripped before parser dispatch and therefore never appeared in parser-generated help.

**Working sibling / contrast:** `hermes --profile <name> cron status` already selects the named profile correctly because the bootstrap resolves `HERMES_HOME` before importing profile-scoped modules.

**Ruled out:** Gateway PID discovery was not globally mixing profiles. `find_gateway_pids()` already defaults to the current profile; the defect was missing scope in user-facing output and help.

### Fix

- Print the inspected profile for both empty and populated cron listings and for every status path.
- Scope gateway-running and gateway-not-running messages to that profile.
- Declare the pre-parsed `-p` / `--profile` selector on the top-level parser for help and parser-introspection parity.
- Add red-to-green behavior tests for empty list output, negative status output, and top-level help.

## Related Issue

Fixes #99579

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cron.py` - label cron output with the inspected profile and scope gateway claims.
- `hermes_cli/_parser.py` - document the pre-parsed profile selector in top-level help.
- `tests/hermes_cli/test_cron_profile_scope.py` - cover profile labels, scoped status wording, and help discovery.

## How to Test

1. Run `hermes cron list` and confirm it prints `Profile: <active-profile>` before job results.
2. Run `hermes --profile <name> cron status` and confirm both the profile label and gateway claim name that profile.
3. Run `hermes --help` and confirm `--profile PROFILE, -p PROFILE` appears.
4. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_cron_profile_scope.py tests/cron/test_87033_cronjob_gateway_liveness.py tests/hermes_cli/test_top_level_value_flags_parity.py tests/hermes_cli/test_startup_plugin_gating.py -q
```

Result: 28 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; top-level CLI help is generated from the parser declaration
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
