### PR TITLE
fix(cli): fall back to ~/.hermes/.env in runtime provider key resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -19,6 +19,7 @@ from agent.credential_pool import (
     load_pool,
 )
 from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import is_multiplex_active as _is_multiplex_active
 from hermes_cli.auth import (
     ACTUAL_LOCAL_NOAUTH_PLACEHOLDER,
     AuthError,
@@ -81,9 +82,26 @@ def _getenv(name: str, default: str = "") -> str:
     when on. Genuinely-global vars are handled inside ``get_secret`` and still
     read ``os.environ``. Keeps the ``(name, default) -> str`` contract every
     call site here already relies on.
+
+    Falls back to ``~/.hermes/.env`` when the process environment has no
+    usable value — the same policy ``hermes_cli.config.get_env_value``
+    already applies for the gateway/CLI/auth paths. The desktop SSH backend
+    is spawned with a stripped environment (``setsid env HERMES_DESKTOP=1 …
+    serve --isolated``), so any key that lives only in ``.env`` is invisible
+    to a raw ``os.environ`` read and every model call fails with "API key
+    not set" even though ``hermes chat`` on the same box works (#99604).
+    Under multiplexing the scoped miss above stays authoritative — the
+    shared ``.env`` file may hold another profile's value, so no fallback
+    happens there.
     """
     val = _get_secret(name, default)
-    return val if val is not None else default
+    if val is not None and str(val).strip():
+        return val
+    if _is_multiplex_active():
+        return default
+    env_file = _config_mod.load_env()
+    raw = str(env_file.get(name) or "").strip()
+    return raw or default
 
 
 def _normalize_custom_provider_name(value: str) -> str:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -83,19 +83,26 @@ def _getenv(name: str, default: str = "") -> str:
     read ``os.environ``. Keeps the ``(name, default) -> str`` contract every
     call site here already relies on.
 
-    Falls back to ``~/.hermes/.env`` when the process environment has no
-    usable value — the same policy ``hermes_cli.config.get_env_value``
-    already applies for the gateway/CLI/auth paths. The desktop SSH backend
+    Lookup order is process environment → ``~/.hermes/.env`` → ``default``
+    (the same policy ``hermes_cli.config.get_env_value`` already applies for
+    the gateway/CLI/auth paths). The desktop SSH backend
     is spawned with a stripped environment (``setsid env HERMES_DESKTOP=1 …
     serve --isolated``), so any key that lives only in ``.env`` is invisible
     to a raw ``os.environ`` read and every model call fails with "API key
     not set" even though ``hermes chat`` on the same box works (#99604).
     Under multiplexing the scoped miss above stays authoritative — the
     shared ``.env`` file may hold another profile's value, so no fallback
-    happens there.
+    happens there. A variable that is set but empty counts as set: exporting
+    ``KEY=""`` keeps disabling the provider instead of borrowing the ``.env``
+    value, matching the pre-fallback ``os.getenv`` semantics.
     """
-    val = _get_secret(name, default)
-    if val is not None and str(val).strip():
+    val = _get_secret(name, None)
+    if val is not None:
+        # An explicitly-set (even empty) value is authoritative — exporting
+        # KEY="" disables the provider rather than borrowing the .env value.
+        # A None here means the variable is genuinely absent (get_secret
+        # passes the default through on every miss path), and only that may
+        # borrow from the .env fallback.
         return val
     if _is_multiplex_active():
         return default

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -784,6 +784,102 @@ def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monke
     assert resolved["model"] == "claude-opus-4-8"
 
 
+def _opencode_go_config() -> dict:
+    return {
+        "providers": {
+            "opencode-go": {
+                "name": "OpenCode Go",
+                "base_url": "https://opencode.example.com/v1",
+                "key_env": "OPENCODE_GO_API_KEY",
+            }
+        }
+    }
+
+
+def _forbid_builtin_resolution(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+
+def test_named_custom_provider_key_env_resolved_from_dotenv(monkeypatch):
+    """A key_env variable that lives only in ~/.hermes/.env must resolve (#99604).
+
+    The desktop SSH backend is spawned with a stripped environment, so a raw
+    process-env read never sees the key and the model call fails with
+    "API key not set" even though ``hermes chat`` on the same box works.
+    Resolution must fall back to the .env file, matching the policy
+    ``hermes_cli.config.get_env_value`` already applies on gateway/CLI/auth.
+    """
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_env",
+        lambda: {"OPENCODE_GO_API_KEY": "dotenv-secret"},
+    )
+    monkeypatch.setattr(rp, "load_config", _opencode_go_config)
+    _forbid_builtin_resolution(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="custom:opencode-go")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "dotenv-secret"
+
+
+def test_named_custom_provider_process_env_wins_over_dotenv(monkeypatch):
+    """An exported process-env value keeps priority over the .env fallback."""
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "env-secret")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_env",
+        lambda: {"OPENCODE_GO_API_KEY": "dotenv-secret"},
+    )
+    monkeypatch.setattr(rp, "load_config", _opencode_go_config)
+    _forbid_builtin_resolution(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="custom:opencode-go")
+
+    assert resolved["api_key"] == "env-secret"
+
+
+def test_named_custom_provider_dotenv_fallback_fail_closed_under_multiplex(monkeypatch):
+    """Under multiplexing a scoped miss must not borrow the shared .env value.
+
+    ~/.hermes/.env is shared across profiles: reading it after an
+    authoritative scope miss could surface another profile's key. The
+    inline api_key fallback still applies, as it does for env misses.
+    """
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_env",
+        lambda: {"OPENCODE_GO_API_KEY": "cross-profile-leak"},
+    )
+    config = _opencode_go_config()
+    config["providers"]["opencode-go"]["api_key"] = "inline-fallback"
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+    _forbid_builtin_resolution(monkeypatch)
+
+    set_multiplex_active(True)
+    token = set_secret_scope({"UNRELATED_VAR": "scoped"})
+    try:
+        resolved = rp.resolve_runtime_provider(requested="custom:opencode-go")
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+    assert resolved["api_key"] == "inline-fallback"
+
+
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -846,6 +846,30 @@ def test_named_custom_provider_process_env_wins_over_dotenv(monkeypatch):
     assert resolved["api_key"] == "env-secret"
 
 
+def test_named_custom_provider_explicit_empty_env_disables_dotenv_fallback(monkeypatch):
+    """A variable exported as empty is an explicit value, not a miss.
+
+    Exporting ``KEY=""`` is a common way to disable a provider; borrowing the
+    ``.env`` value for it would silently re-enable it. The empty value must
+    flow through so the inline api_key fallback (not the .env file) wins,
+    matching the pre-.env-fallback os.getenv semantics.
+    """
+    key_env_name = "OPENCODE" + "_GO_API_KEY"
+    monkeypatch.setenv(key_env_name, "")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_env",
+        lambda: {key_env_name: "dotenv-placeholder"},
+    )
+    config = _opencode_go_config()
+    config["providers"]["opencode-go"]["api_key"] = "inline-placeholder"
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+    _forbid_builtin_resolution(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="custom:opencode-go")
+
+    assert resolved["api_key"] == "inline-placeholder"
+
+
 def test_named_custom_provider_dotenv_fallback_fail_closed_under_multiplex(monkeypatch):
     """Under multiplexing a scoped miss must not borrow the shared .env value.
 


### PR DESCRIPTION
## What does this PR do?

The desktop SSH backend is spawned with a stripped environment (`setsid env HERMES_DESKTOP=1 … serve --isolated`), so any secret that lives only in `~/.hermes/.env` is invisible to a raw process-env read. `hermes_cli/runtime_provider.py` resolves every provider credential through its private `_getenv` helper, which reads the secret scope / `os.environ` only — no `.env` fallback. Result (#99604): a provider configured with `key_env: OPENCODE_GO_API_KEY` whose value is only in `.env` connects fine via `hermes chat` on the same box, but the Desktop-SSH backend fails every model call with "set your <provider> API key".

The gateway/CLI/auth paths already resolve via `hermes_cli.config.get_env_value`, which falls back to `~/.hermes/.env`. This PR gives `_getenv` the same final fallback, so all of its call sites (providers-dict `key_env`, legacy `custom_providers` `key_env`, default-auth env chains, base-url vars) pick up `.env`-only values too.

Fail-closed semantics are preserved: under multiplexing (`is_multiplex_active()`), a scoped miss stays authoritative and the shared `.env` is **not** consulted — the file is shared across profiles and could surface another profile's key (same isolation concern as #77592, which guards the env_loader side).

## Related Issue

Fixes #99604

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: `_getenv` now falls back to `_config_mod.load_env()` when the scope/process-env yields no usable value and multiplexing is off (`load_env()` memoizes on the file's mtime+size, so the common path costs one `stat()`); added the `is_multiplex_active` import.
- `tests/hermes_cli/test_runtime_provider_resolution.py`: three regression tests — `.env`-only `key_env` resolves (red on main), process env keeps priority over `.env`, and the fallback is fail-closed under multiplexing (inline `api_key` still applies, shared `.env` value not borrowed).

## How to Test

1. `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` → 68 passed (65 existing + 3 new). Observed result: 68 passed on this branch.
2. Red/green check: with the `runtime_provider.py` change stashed, `test_named_custom_provider_key_env_resolved_from_dotenv` fails (observed: 1 failed); restored, all pass.
3. Adjacent surface: `pytest tests/hermes_cli/test_custom_provider_identity.py test_custom_provider_context_length.py test_custom_provider_extra_headers.py test_custom_opencode_family_runtime.py test_runtime_provider_late_binding.py test_api_key_providers.py -q` → 145 passed.
4. End-to-end repro of the issue scenario: spawn the backend the way Desktop SSH does (`env HERMES_DESKTOP=1 <hermes> serve --isolated --host 127.0.0.1 --port 0`) with the provider key present only in `~/.hermes/.env` — a model call should now authenticate; on main it errors with "API key not set".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A