### PR TITLE
fix(update): require complete runtime restart proof

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10231,6 +10231,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 restarted_services,
                 killed_pids,
             )
+            _expected_fleet_profiles = _planned_gateway_profiles(_pre_update_plan)
             # A brief settle window: freshly restarted/resumed gateways need
             # a moment to rewrite gateway_state.json with their new identity.
             # Skipped when the restart phase touched nothing (no gateways
@@ -10262,8 +10263,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # resumed gateway has published (no "down" rows remain)
                     # or the deadline passes, so a slow second gateway can't
                     # be misread as down and re-trigger the retry loop.
-                    if _fleet_snapshot and not any(
-                        row.get("state") == "down" for row in _fleet_snapshot
+                    _seen_fleet_profiles = {
+                        str(row.get("profile"))
+                        for row in _fleet_snapshot
+                        if row.get("profile")
+                    }
+                    if (
+                        _fleet_snapshot
+                        and not any(
+                            row.get("state") == "down" for row in _fleet_snapshot
+                        )
+                        and _expected_fleet_profiles <= _seen_fleet_profiles
                     ):
                         break
                     if _time.monotonic() >= _fleet_deadline:
@@ -10272,7 +10282,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _fleet_snapshot = collect_fleet_versions(
                     pre_restart_pids=_pre_restart_gateway_pids
                 )
+            _seen_fleet_profiles = {
+                str(row.get("profile"))
+                for row in _fleet_snapshot
+                if row.get("profile")
+            }
+            _missing_fleet_profiles = (
+                _expected_fleet_profiles - _seen_fleet_profiles
+            )
             if print_fleet_version_matrix(_fleet_snapshot):
+                gateway_fleet_restart_incomplete = True
+            elif _missing_fleet_profiles:
+                print(
+                    "\n⚠ Fleet version check missed planned gateway profile(s): "
+                    + ", ".join(sorted(_missing_fleet_profiles))
+                )
                 gateway_fleet_restart_incomplete = True
             elif not _fleet_snapshot and _fleet_rows_expected:
                 # Fleet probe returned zero rows even though at least one
@@ -10433,7 +10457,7 @@ def _fleet_probe_expected_runtimes(
     * ``pre_restart_pids`` non-empty, or ``None`` (pre-state unreadable —
       cannot prove nothing was running; same contract as
       ``_restart_phase_failure_is_incomplete``, #78574).
-    * the pre-update plan inventoried ≥1 runtime.
+    * the pre-update plan inventoried ≥1 gateway runtime.
 
     ``windows_resume_token`` is deliberately EXCLUDED (#93406 residual). The
     pause/resume token is bookkeeping for ``_pause_windows_gateways_for_update``
@@ -10468,12 +10492,20 @@ def _fleet_probe_expected_runtimes(
         return True
     if pre_restart_pids is None or pre_restart_pids:
         return True
+    return bool(_planned_gateway_profiles(pre_update_plan))
+
+
+def _planned_gateway_profiles(pre_update_plan) -> set[str]:
+    """Profiles whose pre-update gateways must appear in the fleet proof."""
     try:
-        if pre_update_plan is not None and pre_update_plan.runtimes:
-            return True
+        return {
+            str(runtime.profile)
+            for runtime in pre_update_plan.runtimes
+            if getattr(runtime, "kind", None) == "gateway"
+            and getattr(runtime, "profile", None)
+        }
     except Exception:
-        pass
-    return False
+        return set()
 
 
 def _print_items(items, label, key, fallback_key=None):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1152,7 +1152,7 @@ def _reload_process_scan_modules() -> None:
 
 def _finish_dashboard_update_cleanup(
     node_failures: list[str], already_restarted_units: "set[str] | None" = None
-) -> None:
+) -> dict[str, list]:
     """Refresh managed dashboards or stop stale manual ones after an update.
 
     *already_restarted_units* forwards the systemd unit names (no
@@ -1164,7 +1164,7 @@ def _finish_dashboard_update_cleanup(
         print()
         print("  ℹ Leaving running dashboard process(es) untouched because the")
         print("    Node.js dependency refresh did not complete.")
-        return
+        return {"matched": [], "killed": [], "failed": [], "unrecovered": []}
 
     # The scan path lazy-imports symbols from _subprocess_compat; make sure
     # both modules reflect the freshly-updated source before touching them.
@@ -1173,16 +1173,16 @@ def _finish_dashboard_update_cleanup(
     stop_result = _m()._kill_stale_dashboard_processes(
         restart_managed=True, already_restarted_units=already_restarted_units
     )
-    if not stop_result.get("unrecovered"):
-        return
+    if stop_result.get("unrecovered"):
+        print()
+        print(
+            "⚠ A web dashboard/serve process was stopped during update and could "
+            "not be auto-restarted."
+        )
+        print("  Re-launch it when you want the web UI back:")
+        print("    hermes dashboard --port <port>")
+    return stop_result
 
-    print()
-    print(
-        "⚠ A web dashboard/serve process was stopped during update and could "
-        "not be auto-restarted."
-    )
-    print("  Re-launch it when you want the web UI back:")
-    print("    hermes dashboard --port <port>")
 
 def _atomic_replace_dir(src: str, dst: str) -> None:
     """Replace directory *dst* with *src* without leaving *dst* half-deleted.
@@ -10197,8 +10197,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Forward the systemd units restarted above (includes hermes-serve*,
         # #83438) so a Serve-only install's freshly restarted process isn't
         # found and restarted again below (review on #83595).
-        _finish_dashboard_update_cleanup(
+        _dashboard_cleanup = _finish_dashboard_update_cleanup(
             node_failures, already_restarted_units=set(restarted_services)
+        ) or {}
+        _dashboard_restarted_pids = set(_dashboard_cleanup.get("killed") or [])
+        _dashboard_restarted_pids.difference_update(
+            _dashboard_cleanup.get("unrecovered") or []
         )
 
         print()
@@ -10310,6 +10314,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     externally_supervised_profiles=externally_supervised_profiles,
                     killed_pids=killed_pids,
                     failed_units=failed_or_stale_units,
+                    restarted_runtime_pids=_dashboard_restarted_pids,
                 )
                 if report_unaccounted_runtimes(_runtime_outcomes):
                     gateway_fleet_restart_incomplete = True

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -428,6 +428,7 @@ def match_runtime_outcomes(
     externally_supervised_profiles: list,
     killed_pids: set,
     failed_units: list,
+    restarted_runtime_pids: set | None = None,
 ) -> list[dict[str, Any]]:
     """Reconcile the plan's runtimes against what the restart phase DID.
 
@@ -439,12 +440,13 @@ def match_runtime_outcomes(
 
         {"kind", "profile", "pid", "mechanism", "outcome"}
 
-    outcome: ``restarted`` (service restarted / profile relaunched /
-    handed to external supervisor), ``stopped`` (pid killed, watcher or
-    operator relaunches), ``failed`` (in the phase's failed/stale list) or
-    ``unaccounted`` — the plan saw it and NO bookkeeping mentions it: the
-    blind-spot tripwire (same philosophy as the fleet matrix's DOWN row).
-    Never raises; on any probe error returns what it has.
+    outcome: ``restarted`` (service restarted / profile relaunched / handed
+    to an external supervisor / exact dashboard cleanup PID recovered),
+    ``stopped`` (pid killed, watcher or operator relaunches), ``failed`` (in
+    the phase's failed/stale list) or ``unaccounted`` — the plan saw it and
+    NO bookkeeping mentions it: the blind-spot tripwire (same philosophy as
+    the fleet matrix's DOWN row). Never raises; on any probe error returns
+    what it has.
     """
     outcomes: list[dict[str, Any]] = []
     try:
@@ -453,22 +455,27 @@ def match_runtime_outcomes(
         relaunched = set(relaunched_profiles or [])
         external = set(externally_supervised_profiles or [])
         killed = {int(p) for p in (killed_pids or set())}
+        restarted_pids = {int(p) for p in (restarted_runtime_pids or set())}
 
         for runtime in plan.runtimes:
             r = runtime if isinstance(runtime, RuntimeRecord) else None
             if r is None:
                 continue
             outcome = "unaccounted"
-            if r.profile in relaunched or r.profile in external:
+            if r.pid is not None and r.pid in restarted_pids:
+                outcome = "restarted"
+            elif r.kind == "gateway" and (
+                r.profile in relaunched or r.profile in external
+            ):
                 outcome = "restarted"
             elif r.pid is not None and r.pid in killed:
                 outcome = "stopped"
-            elif any(
+            elif r.kind == "gateway" and any(
                 r.profile in unit or (r.profile == "default" and "hermes-gateway" in unit)
                 for unit in failed_set
             ):
                 outcome = "failed"
-            elif any(
+            elif r.kind == "gateway" and any(
                 r.profile in svc or (r.profile == "default" and "hermes-gateway" in svc)
                 for svc in restarted_set
             ):

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -159,6 +159,39 @@ def test_external_supervisor_counts_as_restarted():
     assert outcomes[0]["outcome"] == "restarted"
 
 
+def test_dashboard_cleanup_pid_counts_as_restarted():
+    runtime = RuntimeRecord(
+        kind="dashboard",
+        profile="default",
+        pid=650,
+        supervisor="manual-serve",
+        restart_via="respawn-argv",
+    )
+    outcomes = match_runtime_outcomes(
+        _plan(runtime),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+        restarted_runtime_pids={650},
+    )
+    assert outcomes[0]["outcome"] == "restarted"
+
+
+def test_gateway_profile_restart_does_not_cover_dashboard():
+    runtime = RuntimeRecord(
+        kind="serve",
+        profile="default",
+        pid=651,
+        supervisor="desktop",
+        restart_via="desktop",
+    )
+    outcomes = match_runtime_outcomes(
+        _plan(runtime),
+        restarted_services=[], relaunched_profiles=["default"],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "unaccounted"
+
+
 def test_mixed_fleet_only_the_missed_one_escalates(capsys):
     outcomes = match_runtime_outcomes(
         _plan(

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -25,6 +25,7 @@ import inspect
 import types
 
 from hermes_cli.main import _fleet_probe_expected_runtimes
+from hermes_cli.update_cmd import _planned_gateway_profiles
 
 
 def _plan(runtimes):
@@ -40,7 +41,7 @@ class TestEmptySnapshotFailClosed:
         # externally-supervised gateway). Zero rows must fail closed.
         assert (
             _fleet_probe_expected_runtimes(
-                _plan([object()]),
+                _plan([types.SimpleNamespace(kind="gateway", profile="work")]),
                 [],  # pre_restart_pids: probe saw nothing
                 None,  # no Windows resume token
                 [],  # restarted_services
@@ -48,6 +49,18 @@ class TestEmptySnapshotFailClosed:
             )
             is True
         )
+
+    def test_non_gateway_plan_does_not_demand_gateway_rows(self):
+        plan = _plan([types.SimpleNamespace(kind="serve", profile="default")])
+        assert _fleet_probe_expected_runtimes(plan, [], None, [], set()) is False
+
+    def test_planned_gateway_profiles_are_exact(self):
+        plan = _plan([
+            types.SimpleNamespace(kind="gateway", profile="personal"),
+            types.SimpleNamespace(kind="gateway", profile="ops"),
+            types.SimpleNamespace(kind="serve", profile="default"),
+        ])
+        assert _planned_gateway_profiles(plan) == {"personal", "ops"}
 
     def test_windows_resume_token_alone_is_not_expected(self):
         # (c) The Windows pause/resume token is EXCLUDED from the expectation
@@ -147,3 +160,8 @@ class TestCallSiteWiring:
             "elif not _fleet_snapshot and (restarted_services or killed_pids):"
             not in src
         )
+
+    def test_nonempty_snapshot_must_cover_planned_profiles(self):
+        src = self._impl_source()
+        assert "_expected_fleet_profiles <= _seen_fleet_profiles" in src
+        assert "elif _missing_fleet_profiles:" in src

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -862,11 +862,14 @@ class TestPostUpdateStaleModuleReload:
             side_effect=lambda: order.append("reload"),
         ), patch(
             "hermes_cli.main._kill_stale_dashboard_processes",
-            side_effect=lambda **kw: order.append("kill") or {"unrecovered": []},
+            side_effect=lambda **kw: order.append("kill") or {
+                "matched": [41], "killed": [41], "failed": [], "unrecovered": [],
+            },
         ):
-            update_cmd._finish_dashboard_update_cleanup([])
+            result = update_cmd._finish_dashboard_update_cleanup([])
 
         assert order == ["reload", "kill"]
+        assert result["killed"] == [41]
 
     def test_node_failures_skip_reload_and_kill(self):
         """A failed Node refresh leaves the running dashboard untouched —
@@ -875,10 +878,11 @@ class TestPostUpdateStaleModuleReload:
 
         with patch.object(update_cmd, "_reload_process_scan_modules") as mock_reload, \
              patch("hermes_cli.main._kill_stale_dashboard_processes") as mock_kill:
-            update_cmd._finish_dashboard_update_cleanup(["dashboard"])
+            result = update_cmd._finish_dashboard_update_cleanup(["dashboard"])
 
         mock_reload.assert_not_called()
         mock_kill.assert_not_called()
+        assert result["killed"] == []
 
     def test_reload_restores_missing_symbol(self):
         """Simulate the stale-module state: strip ``bounded_probe_run`` off


### PR DESCRIPTION
Summary:
- carry successful dashboard cleanup PIDs into runtime reconciliation
- prevent gateway profile bookkeeping from falsely covering non-gateway runtimes
- wait for every planned gateway profile to appear in the post-update fleet proof
- fail closed when a non-empty fleet snapshot is still missing a planned gateway

Why:
The updater already stopped and relaunched serve/dashboard processes but discarded that bookkeeping, so healthy replacements were reported unaccounted. After that was fixed, a non-empty 2-of-4 gateway snapshot could still be accepted as success because missing profiles were not compared with the pre-update plan.

Validation:
- 80 passed, 2 platform-specific skipped across fleet coverage, restart reconciliation, dashboard cleanup, and serve inventory
- ruff and git diff checks passed
- supervised local canary: receipt success, 7 of 7 runtime outcomes restarted, 4 of 4 planned gateways current