### PR TITLE
fix(gateway): compare Responses transcripts semantically to stop history doubling

### DIFF
--- a/contributors/emails/frendo.wu@gmail.com
+++ b/contributors/emails/frendo.wu@gmail.com
@@ -1,0 +1,1 @@
+FrendoWu

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7047,8 +7047,51 @@ class APIServerAdapter(BasePlatformAdapter):
         full_history.append({"role": "assistant", "content": final_response})
         return full_history
 
-    @staticmethod
+    # Fields the agent stamps onto live messages, or that survive only on one
+    # side of the store round-trip. None of them change what a message *says*,
+    # so none of them may decide whether a transcript already contains the
+    # prior history -- see _messages_semantically_equal.
+    _TRANSCRIPT_BOOKKEEPING_FIELDS = frozenset({
+        "_db_persisted",
+        "_row_id",
+        "timestamp",
+        "reasoning",
+        "reasoning_content",
+        "finish_reason",
+    })
+
+    @classmethod
+    def _messages_semantically_equal(cls, left: Any, right: Any) -> bool:
+        """Compare two transcript messages ignoring bookkeeping-only differences."""
+        if not isinstance(left, dict) or not isinstance(right, dict):
+            return left == right
+
+        lhs = {k: v for k, v in left.items() if k not in cls._TRANSCRIPT_BOOKKEEPING_FIELDS}
+        rhs = {k: v for k, v in right.items() if k not in cls._TRANSCRIPT_BOOKKEEPING_FIELDS}
+
+        # ``name`` is present on live tool messages but is dropped on the store
+        # round-trip, so the same message can carry "terminal" on one side and
+        # nothing on the other. Compare it only when both sides still have it;
+        # ``tool_call_id`` already disambiguates tool results.
+        left_name = lhs.pop("name", None)
+        right_name = rhs.pop("name", None)
+        if left_name is not None and right_name is not None and left_name != right_name:
+            return False
+
+        return lhs == rhs
+
+    @classmethod
+    def _messages_prefix_matches(cls, messages: List[Any], prefix: List[Any]) -> bool:
+        if len(messages) < len(prefix):
+            return False
+        return all(
+            cls._messages_semantically_equal(message, expected)
+            for message, expected in zip(messages, prefix)
+        )
+
+    @classmethod
     def _response_messages_turn_start_index(
+        cls,
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
         result: Dict[str, Any],
@@ -7061,9 +7104,9 @@ class APIServerAdapter(BasePlatformAdapter):
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
         expected_prefix = prior + [current_user]
-        if agent_messages[:len(expected_prefix)] == expected_prefix:
+        if cls._messages_prefix_matches(agent_messages, expected_prefix):
             return len(expected_prefix)
-        if prior and agent_messages[:len(prior)] == prior:
+        if prior and cls._messages_prefix_matches(agent_messages, prior):
             return len(prior)
         return 0
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3085,3 +3085,101 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="s2", gateway_session_key="ch")
         assert captured[1]["model"] == "anthropic/claude-opus-4.6"
+
+
+class TestResponsesTranscriptPrefixDetection:
+    """Regression tests for stored /v1/responses history doubling.
+
+    ``_response_messages_turn_start_index`` used to compare whole message dicts.
+    The agent stamps live messages with bookkeeping fields (``_db_persisted``,
+    ``_row_id``, ``timestamp``, reasoning traces) that the API-layer history does
+    not carry, so the prefix check failed on every chained turn and
+    ``_build_response_conversation_history`` prepended history the transcript
+    already contained -- doubling the stored context each turn.
+    """
+
+    @staticmethod
+    def _turn_start(prior, user_message, agent_messages):
+        return APIServerAdapter._response_messages_turn_start_index(
+            prior, user_message, {"messages": agent_messages}
+        )
+
+    def test_bookkeeping_fields_do_not_break_prefix_detection(self):
+        prior = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent_messages = [
+            {"role": "user", "content": "hi", "_db_persisted": True, "_row_id": 41,
+             "timestamp": "2026-08-31T23:51:23"},
+            {"role": "assistant", "content": "hello", "_db_persisted": True, "_row_id": 42,
+             "timestamp": "2026-08-31T23:51:24", "reasoning": "...",
+             "reasoning_content": "...", "finish_reason": "stop"},
+            {"role": "user", "content": "and now?"},
+            {"role": "assistant", "content": "sure"},
+        ]
+        assert self._turn_start(prior, "and now?", agent_messages) == len(prior) + 1
+
+    def test_tool_name_dropped_on_round_trip_still_matches(self):
+        # Live tool messages carry ``name``; the stored copy loses it.
+        prior = [
+            {"role": "user", "content": "list them"},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"output": "a\\nb"}'},
+        ]
+        agent_messages = [
+            {"role": "user", "content": "list them", "_row_id": 7},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"output": "a\\nb"}',
+             "name": "terminal", "_row_id": 8},
+            {"role": "user", "content": "thanks"},
+        ]
+        assert self._turn_start(prior, "thanks", agent_messages) == len(prior) + 1
+
+    def test_conflicting_tool_names_are_not_treated_as_equal(self):
+        prior = [{"role": "tool", "tool_call_id": "call_1", "content": "x", "name": "terminal"}]
+        agent_messages = [
+            {"role": "tool", "tool_call_id": "call_1", "content": "x", "name": "read_file"},
+            {"role": "user", "content": "next"},
+        ]
+        assert self._turn_start(prior, "next", agent_messages) == 0
+
+    def test_differing_content_is_still_not_a_prefix(self):
+        prior = [{"role": "user", "content": "hi"}]
+        agent_messages = [
+            {"role": "user", "content": "something else", "_row_id": 1},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert self._turn_start(prior, "next", agent_messages) == 0
+
+    def test_stored_history_grows_linearly_across_chained_turns(self):
+        """Four chained turns must not double the stored transcript."""
+        history: list = []
+        row_id = 0
+        for turn in range(4):
+            user_message = f"question {turn}"
+            # The agent returns the authoritative full transcript, bookkeeping
+            # fields and all.
+            transcript = []
+            for message in history:
+                row_id += 1
+                transcript.append({**message, "_db_persisted": True, "_row_id": row_id,
+                                   "timestamp": f"t{row_id}"})
+            transcript.append({"role": "user", "content": user_message})
+            transcript.append({"role": "assistant", "content": f"answer {turn}"})
+
+            history = APIServerAdapter._build_response_conversation_history(
+                history, user_message, {"messages": transcript}, f"answer {turn}"
+            )
+            # Strip bookkeeping the way the store round-trip does.
+            history = [
+                {k: v for k, v in m.items()
+                 if k not in {"_db_persisted", "_row_id", "timestamp"}}
+                for m in history
+            ]
+
+        assert len(history) == 8, [m["content"] for m in history]
+        assert [m["content"] for m in history] == [
+            "question 0", "answer 0",
+            "question 1", "answer 1",
+            "question 2", "answer 2",
+            "question 3", "answer 3",
+        ]


### PR DESCRIPTION
## What does this PR do?

Stops stored `/v1/responses` `conversation_history` from **doubling on every chained turn**.

`_response_messages_turn_start_index` decides whether the agent transcript already contains the prior history by comparing whole message dicts. It does not, because the two sides are shaped differently:

- the agent stamps live messages with `_db_persisted`, `_row_id`, `timestamp`, `reasoning`, `reasoning_content`, `finish_reason`;
- `name` is present on the live tool message but **lost on the store round-trip** — the same message reads `"name": "terminal"` in one copy and has no `name` in another.

So the prefix check returns `0` on every turn and `_build_response_conversation_history` falls through to

```python
full_history = prior
full_history.append(current_user)
full_history.extend(agent_messages)   # agent_messages already contains prior
```

`N → 2N + 2`, every turn, deterministically.

### Observed in production

An ESP32 badge talking to a local gateway over `/v1/responses`, 11 short turns, no long inputs. Per-turn `history=` from `agent.log`, three separate conversations:

```
b7f65549:  0  3  8  33  28   66  131  260  517  1030  2055
0cdac661:  0 29 60 128 256  254  511 1020 1016  2037
83002d6a:  0  3  8  17  34   32   67  132  128
```

Prompt tokens followed: `24k → 30k → 43k → 69k → 122k → 228k → 439k → 637k`. In the stored snapshot, **841 user messages for 52 distinct utterances** — one short question stored 192 times. At 637k tokens the session crossed the compression threshold, compression streamed for its full 600 s ceiling with zero progress, and the client (300 s budget) had already given up.

## Related Issue

No issue filed. There are three open PRs on this bug; this one is deliberately narrow and I could not find one that covers the field set observed above:

- **#85678** — same diagnosis, ignores `_db_persisted` and `_row_id` only. Applying its predicate to the message shapes above still returns `False`, because `timestamp` and `name` also diverge.
- **#75289** — `_transcript_mode="full"`, targets `repair_message_sequence` merging.
- **#70695** — larger rework that also introduces semantic prefix identity.

Happy to fold this into any of them instead if a maintainer prefers; the evidence above is the part worth keeping.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/api_server.py`: add `_TRANSCRIPT_BOOKKEEPING_FIELDS`, `_messages_semantically_equal`, `_messages_prefix_matches`; `_response_messages_turn_start_index` becomes a `classmethod` and uses them. `role`, `content`, `tool_calls` and `tool_call_id` are still compared exactly; `name` is compared only when both sides carry one.
- `tests/gateway/test_api_server.py`: 5 regression tests, including a four-turn chain asserting the stored transcript stays linear (8 messages, not 30).

## How to Test

Reproduce the bug on `main`:

```python
from gateway.platforms.api_server import APIServerAdapter as A
prior = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
agent = [
    {"role": "user", "content": "hi", "_db_persisted": True, "_row_id": 41, "timestamp": "t"},
    {"role": "assistant", "content": "hello", "_db_persisted": True, "_row_id": 42,
     "timestamp": "t", "reasoning": "..", "finish_reason": "stop"},
    {"role": "user", "content": "and now?"},
    {"role": "assistant", "content": "sure"},
]
print(A._response_messages_turn_start_index(prior, "and now?", {"messages": agent}))       # main: 0
print(len(A._build_response_conversation_history(prior, "and now?", {"messages": agent}, "sure")))  # main: 7, expected 4
```

With this branch: `3` and `4`.

Then `pytest tests/gateway/test_api_server.py -q` → **115 passed** (110 existing + 5 new).

## Platforms tested

macOS 15 (arm64), Python 3.11, against a live gateway on the `/v1/responses` path.

Note on the full suite: `pytest tests/gateway/ -q` shows 22 pre-existing failures in this environment (telegram / wecom / teams / systemd media-timeout and socket tests). They reproduce identically on unmodified `origin/main` here, so they are unrelated to this change.
