### PR TITLE
fix(agent): thinking-only length truncations no longer wedge continuations

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1826,8 +1826,43 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _consume_ephemeral_reasoning_off(agent) -> bool:
+    """Consume the one-shot "answer without thinking" continuation flag.
+
+    Set by the length-continuation path when a request returned reasoning
+    but NO visible content — the thinking phase consumed the entire output
+    cap (GLM-5.3 on ollama-cloud with reasoning_effort=high: reported live as
+    finish_reason="length", content="", completion_tokens == max_tokens).
+
+    Continuation turns never replay the prior reasoning, so re-running with
+    thinking ON re-derives — and re-burns — the whole thinking budget from
+    scratch instead of writing the answer (observed: 4 futile continuations
+    then "Response remained truncated after 4 continuation attempts").
+    When True is returned the caller must override the wire reasoning_config
+    with ``{"enabled": False, "effort": "none"}`` for exactly the next call.
+    """
+    if getattr(agent, "_ephemeral_reasoning_off", False):
+        agent._ephemeral_reasoning_off = False
+        return True
+    return False
+
+
+def _reasoning_config_for_wire(agent):
+    """``agent.reasoning_config`` with the one-shot reasoning-off override applied."""
+    if _consume_ephemeral_reasoning_off(agent):
+        return {
+            **(agent.reasoning_config or {}),
+            "enabled": False,
+            "effort": "none",
+        }
+    return agent.reasoning_config
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    # One-shot continuation override — consumed exactly once, on the FIRST
+    # request this call builds (only one api_mode branch runs per invocation).
+    _wire_reasoning_config = _reasoning_config_for_wire(agent)
     if tools_for_api is None:
         tools_for_api = agent.tools
 
@@ -1844,7 +1879,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -1936,7 +1971,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
             base_url=agent.base_url,
@@ -2093,7 +2128,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
@@ -2126,7 +2161,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=_wire_reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         cache_scope_id=_cache_scope_id,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4118,29 +4118,46 @@ def run_conversation(
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
-                            # An EMPTY partial-stream stub (stream dropped
-                            # mid tool-call before any text was delivered)
-                            # must not be appended as an interim assistant
-                            # message: it would serialize as
-                            # {"role": "assistant", "content": ""}, and
+                            # An interim assistant message with NO visible
+                            # content must not be appended — whichever way it
+                            # got that way.  An empty partial-stream stub
+                            # (stream dropped before any text was delivered)
+                            # and a response whose whole output budget went to
+                            # reasoning delivered in a separate field (GLM-5.3
+                            # on ollama-cloud with reasoning_effort=high:
+                            # finish_reason="length", content="",
+                            # completion_tokens == max_tokens) both serialize
+                            # as {"role": "assistant", "content": ""}, and
                             # strict providers (Moonshot/Kimi via OpenRouter)
                             # reject empty assistant content with HTTP 400
                             # ("message ... with role 'assistant' must not be
                             # empty") on the very next replay — permanently
-                            # poisoning the session history.  There is no
-                            # partial text to continue from anyway, so only
-                            # the continuation user-message is appended.
+                            # poisoning the session history until the pre-call
+                            # sanitizer "heals" the hole (observed 3+ healings
+                            # per turn).  There is no partial text to continue
+                            # from anyway, so only the continuation
+                            # user-message is appended.
+                            _interim_content = getattr(assistant_message, "content", None)
                             _is_empty_partial_stub = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
-                                and not getattr(assistant_message, "content", None)
+                                and not _interim_content
                             )
-                            if not _is_empty_partial_stub:
+                            if not _interim_content and not _is_empty_partial_stub:
+                                # Thinking-only truncation: the model spent the
+                                # entire output cap on reasoning and produced no
+                                # visible text.  A continuation with thinking
+                                # ON would re-think the whole context from
+                                # scratch (continuations never replay prior
+                                # reasoning) and re-burn the same budget, so
+                                # the next call drops thinking for one request
+                                # — the answer must be written, not re-derived.
+                                agent._ephemeral_reasoning_off = True
+                            if _interim_content:
                                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                                 # Marked so the ceiling exit can drop the fragment trail.
                                 interim_msg["_length_continuation_fragment"] = True
                                 append_message(messages, interim_msg)
-                                if assistant_message.content:
-                                    truncated_response_parts.append(assistant_message.content)
+                                truncated_response_parts.append(_interim_content)
 
                             if length_continue_retries < 4:
                                 _is_partial_stream_stub = (
@@ -4184,12 +4201,42 @@ def run_conversation(
                                 break
 
                             partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
+                            # The pending one-shot reasoning-off override must
+                            # not leak into the next turn when the 4th
+                            # truncation goes straight to the ceiling exit
+                            # without scheduling a continuation call to
+                            # consume it.
+                            agent._ephemeral_reasoning_off = False
                             if partial_response:
                                 agent._vprint(
                                     f"{agent.log_prefix}⚠️  Response still truncated "
-                                    f"after 4 continuation attempts — keeping the "
+                                    f"after {length_continue_retries} continuation attempts — keeping the "
                                     f"partial response received so far.",
                                     force=True,
+                                )
+                                _ceiling_final = partial_response
+                            else:
+                                # Every fragment was empty — e.g. a thinking
+                                # model that spent each attempt's whole cap on
+                                # reasoning (GLM-5.3 on ollama-cloud).  Return
+                                # an actionable message instead of an invisible
+                                # None result, which only surfaces as a bare
+                                # error card.
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  Response still truncated "
+                                    f"after {length_continue_retries} continuation attempts — no visible "
+                                    f"text was produced.",
+                                    force=True,
+                                )
+                                _ceiling_final = (
+                                    "⚠️ **No visible answer was produced.** The "
+                                    "model hit its output-token limit on every "
+                                    "continuation attempt — its reasoning "
+                                    "consumed the entire budget each time.\n\n"
+                                    "To fix this:\n"
+                                    "→ Lower reasoning effort: `/thinkon low` "
+                                    "or `/thinkoff`\n"
+                                    "→ Or raise max_tokens for this model"
                                 )
                             # Unanswered continue nudges made every later turn re-truncate.
                             _turn_start = (
@@ -4218,7 +4265,7 @@ def run_conversation(
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
-                                "final_response": partial_response or None,
+                                "final_response": _ceiling_final,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -1,0 +1,228 @@
+"""Regression tests for thinking-only length truncations.
+
+GLM-5.3-flash on ollama-cloud with reasoning_effort=high can burn the ENTIRE
+output cap on reasoning delivered in a separate field and return
+finish_reason="length" with NO visible content (verified live: max_tokens=4096
+→ completion_tokens=4096, reasoning ~18.5KB, content empty).
+
+The old continuation flow handled this badly:
+  1. the empty response was appended as an interim assistant fragment,
+     poisoning the transcript until the pre-call sanitizer "healed" it
+     (observed 3+ healings per turn);
+  2. every continuation re-ran with thinking ON, re-deriving — and re-burning
+     — the whole thinking budget against a growing context, so 4 attempts
+     still produced nothing and the turn died with
+     "Response remained truncated after 4 continuation attempts".
+
+The fix: skip empty interim fragments, and issue the continuation with a
+one-shot reasoning-off override so the budget goes to writing the answer.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import FINISH_REASON_LENGTH
+
+
+class _AgentStandIn:
+    """Minimal agent surface _reasoning_config_for_wire needs."""
+
+    def __init__(self, reasoning_config):
+        self.reasoning_config = reasoning_config
+
+
+class TestReasoningOffOneShotOverride:
+    def test_flag_consumed_exactly_once(self):
+        from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+        agent = _AgentStandIn({"enabled": True, "effort": "high"})
+        # Without the flag the reasoning config passes through untouched.
+        assert _reasoning_config_for_wire(agent) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+        agent._ephemeral_reasoning_off = True
+        cfg = _reasoning_config_for_wire(agent)
+        assert cfg["enabled"] is False
+        assert cfg["effort"] == "none"
+        assert agent._ephemeral_reasoning_off is False, (
+            "The one-shot override must be consumed by the first call."
+        )
+
+        # Subsequent calls keep the user's own reasoning config.
+        assert _reasoning_config_for_wire(agent) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_flag_with_no_user_reasoning_config(self):
+        from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+        agent = _AgentStandIn(None)
+        agent._ephemeral_reasoning_off = True
+        cfg = _reasoning_config_for_wire(agent)
+        assert cfg == {"enabled": False, "effort": "none"}
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _thinking_only_length_response():
+    """finish_reason='length' with reasoning but zero visible content — the
+    live GLM-5.3-flash-on-ollama-cloud shape (normal response id, NOT the
+    partial-stream stub)."""
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id="chatcmpl-thinking-exhausted",
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=""),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _full_response(content):
+    from tests.run_agent.test_run_agent import _mock_response
+
+    return _mock_response(content=content, finish_reason="stop")
+
+
+def _truncated_text_response(content):
+    from tests.run_agent.test_run_agent import _mock_response
+
+    return _mock_response(content=content, finish_reason=FINISH_REASON_LENGTH)
+
+
+def _run(agent, message, history=None):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(message, conversation_history=history)
+
+
+def _no_empty_assistant_rows(messages):
+    return [
+        m for m in messages
+        if m.get("role") == "assistant"
+        and not (m.get("content") or "").strip()
+        and not m.get("tool_calls")
+    ]
+
+
+class TestThinkingOnlyTruncation:
+    def test_retry_after_thinking_only_truncation_completes(self, loop_agent):
+        """One thinking-only truncation, then a normal answer: the retry must
+        drop thinking (one-shot), boost the output cap, and finish the turn."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _full_response("Here is the full answer."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        assert "full answer" in (result["final_response"] or "")
+        assert _no_empty_assistant_rows(result["messages"]) == [], (
+            "An empty (thinking-only) truncated response must never be "
+            "appended to the transcript."
+        )
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 2
+        # Continuation retry boosts the output cap (2^1 × 4096 base floor).
+        assert calls[1].kwargs.get("max_tokens") == 8192, (
+            "The continuation retry must request a larger output budget than "
+            "the request that truncated."
+        )
+        assert loop_agent._ephemeral_reasoning_off is False, (
+            "The one-shot reasoning-off override must be consumed by the "
+            "continuation call."
+        )
+
+    def test_thinking_only_truncation_sets_reasoning_off(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _mock_response(
+                content="done", finish_reason=FINISH_REASON_LENGTH
+            ),
+            _full_response("finally complete."),
+        ]
+        _run(loop_agent, "write me a long report")
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 3
+        # The thinking-only fragment set the flag; it was consumed by the
+        # next call, and the SECOND truncated fragment (which had visible
+        # text) does not set it again — so the third call sees thinking ON.
+        assert loop_agent._ephemeral_reasoning_off is False
+
+    def test_full_ceiling_with_empty_fragments_still_settles(self, loop_agent):
+        """All four attempts thinking-only: the turn must exit through the
+        ceiling with an actionable final_response, no poisoned transcript,
+        and no leaked reasoning-off flag."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response() for _ in range(4)
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "truncated after 4 continuation attempts" in (result.get("error") or "")
+        assert result["final_response"], (
+            "An all-empty ceiling exit must still surface a user-facing "
+            "message instead of an invisible None."
+        )
+        assert "reasoning" in (result["final_response"] or "").lower()
+        assert _no_empty_assistant_rows(result["messages"]) == []
+        assert loop_agent._ephemeral_reasoning_off is False, (
+            "The ceiling exit must clear the pending one-shot override so the "
+            "next turn does not silently lose thinking."
+        )
+
+    def test_mixed_fragments_keep_visible_text(self, loop_agent):
+        """A visible fragment followed by a thinking-only one: the visible
+        text must be stitched, the empty one skipped."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _truncated_text_response("visible part one. "),
+            _thinking_only_length_response(),
+            _full_response("and the ending."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        assert "visible part one." in (result["final_response"] or "")
+        assert "and the ending." in (result["final_response"] or "")
+        assert _no_empty_assistant_rows(result["messages"]) == []


### PR DESCRIPTION
## What does this PR do?

Fixes a non-convergent length-continuation loop for the "thinking-only truncation" response shape: the model spends its **entire output budget on reasoning** (delivered in a separate field — `reasoning_content` / `reasoning`) and returns `finish_reason="length"` with **no visible content**.

Live verification against Ollama Cloud `glm-5.3-flash` (a reasoning model) with `reasoning_effort: high`:

| request | result |
|---|---|
| `max_tokens=4096`, effort `high` | `finish_reason=length`, `completion_tokens=4096`, reasoning ≈18.5 KB, **`content` empty** |
| `max_tokens=8192`, effort `high` | `finish_reason=stop`, 8 035 tokens — thinking just barely fits |
| `max_tokens=12000`, `reasoning_effort=none` | `finish_reason=stop`, 7 739 tokens, full 36 KB answer |

The old flow then made things worse, twice:

1. The empty response was appended to the transcript as an interim assistant fragment. Strict providers (`messages must have non-empty content`) would 400 the next replay — on the reporting machine this surfaced as repeated `Pre-call sanitizer: healed N empty non-final message(s)` warnings (3+ per turn).
2. Every continuation re-ran with **thinking still on**. Continuations never replay prior reasoning, so each retry re-derived — and re-burned — the whole thinking budget against a growing context. Four attempts produced nothing, and the turn died with `Response remained truncated after 4 continuation attempts` (the reported user-facing failure; also observed live: 4× `Response truncated (finish_reason='length')` in `desktop.log` over ~6 minutes, then the error card).

The budget boost at the `restart_with_length_continuation` site cannot fix this shape by itself: the thinking phase scales with the context, so a bigger cap can still be consumed entirely by reasoning before any text is emitted.

## What changed

- `agent/conversation_loop.py`
  - An interim assistant fragment with **no visible content is never appended**, whichever way it got empty (previously only the empty *partial-stream stub* was skipped — a completed thinking-only response was still appended, poisoning the transcript).
  - A thinking-only truncation sets a one-shot `agent._ephemeral_reasoning_off` override, so the continuation request is issued **without thinking**: the answer must be written, not re-derived. This is the convergence fix — with reasoning off, the continuation completes (see the third row in the table above).
  - The ceiling exit clears a pending one-shot override (it must not leak into the next turn) and, when every fragment was empty, returns an actionable user-facing `final_response` instead of an invisible `None` (previously the gateway/desktop only showed a bare error card).
- `agent/chat_completion_helpers.py` — `_consume_ephemeral_reasoning_off()` / `_reasoning_config_for_wire()` apply the one-shot override at all four `build_api_kwargs` call sites (anthropic_messages, codex_responses, provider-profile path, legacy path). When the flag is set, the wire `reasoning_config` becomes `{"enabled": False, "effort": "none"}`, which existing provider profiles already translate to their transport's thinking-off form (e.g. `reasoning_effort: "none"` for Ollama Cloud, `think: false` for Ollama URLs).
- Visible-content truncations keep the existing behavior (fragment stitched + nudge + progressive budget boost). Tool-call truncations are untouched.

## Related Issue

Fixes #83915 — the loop now converges on reasoning-only output: the empty fragment is not appended and the retry drops thinking, so the budget goes to the answer instead of a from-scratch re-think.

Fixes #90422 — same failure on opencode-go with `reasoning_effort: ultra`: the first thinking-only truncation now triggers a reasoning-off continuation that completes the turn.

Also resolves the downstream waste described in #73336 (empty assistant append + futile retries) via the continuation path rather than by extending the think-tag detector, which stays unchanged; and complements the false-positive detection work in #98406 / #73223 — when the truncation is *real*, the continuation should still converge, which it now does.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — skip empty interim fragments in the length-continuation branch; set one-shot reasoning-off override on thinking-only truncations; clear pending override + return actionable `final_response` at the continuation ceiling.
- `agent/chat_completion_helpers.py` — one-shot `_ephemeral_reasoning_off` consumption (`_reasoning_config_for_wire`) wired through all four `build_api_kwargs` call sites.
- `tests/run_agent/test_length_continuation_thinking_exhaustion.py` — 6 new tests: one-shot override consumed exactly once; thinking-only truncation completes on retry; boost present on the retry request; mixed visible/empty fragments stitched correctly; all-empty ceiling exits clean (no leaked flag, no empty assistant rows).

## How to Test

Live reproduction (Ollama Cloud, any reasoning model — used `glm-5.3-flash`):

1. `model: { provider: ollama-cloud, default: glm-5.3-flash, base_url: https://ollama.com/v1, max_tokens: 4096 }`, `agent: { reasoning_effort: high }`.
2. Ask for a long answer (e.g. "write a 300-item list"). Before: 4× `finish_reason=length` with empty content → `Response remained truncated after 4 continuation attempts` error card, plus repeated `Pre-call sanitizer: healed N empty non-final message(s)` in the logs.
3. After: first truncation is thinking-only → the continuation is sent with `reasoning_effort: none` + a doubled output cap → the answer is delivered and the turn completes. No empty assistant rows are written to the session.

Unit tests:

```
pytest tests/run_agent/test_length_continuation_thinking_exhaustion.py tests/run_agent/test_continuation_ceiling_wedge.py -q
pytest tests/agent/transports/test_chat_completions.py tests/plugins/model_providers/ -q
```

All green (165 tests across the targeted suites: new tests, ceiling wedge, partial-stream finish reasons, stream-interrupt retry, continuation repetition guard, transports, provider profiles, reasoning-effort wire translation, compressor provenance).

I also ran the full `tests/run_agent` + `tests/agent` directories (7 461 passed). The remaining failures on this Windows machine are **pre-existing**: I reran the identical failing set against a pristine `origin/main` checkout on the same platform and got the **same 155-test failure set** — zero regressions from this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites (165, all green) plus the full `tests/run_agent` + `tests/agent` directories; residual failures verified pre-existing on pristine upstream main (identical 155-test set, zero regressions); full-repo parity via `scripts/run_tests.sh` left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13, desktop-managed checkout)

### Documentation & Housekeeping

- [x] N/A — behavior comments live next to the changed code; no config keys, tools, or architecture seams touched

## Screenshots / Logs

Live probe of the failing shape (Ollama Cloud, `glm-5.3-flash`):

```
T1 effort=none  max=12000: finish=stop   completion_tokens=7739  reasoning_len=0      content_len=35998
T2 effort=high max=8192:  finish=stop    completion_tokens=8035  reasoning_len=20191  content_len=17626
T3 effort=high max=4096:  finish=length  completion_tokens=4096  reasoning_len=18578  content_len=0
```

T3 is the exact failure this PR fixes. Desktop log of the reported incident (before the fix): four truncations over six minutes, then the error card:

```
16:15:46 ⚠️ Response truncated (finish_reason='length') - model hit max output tokens
16:18:29 ⚠️ Response truncated (finish_reason='length') - model hit max output tokens
16:19:47 ⚠️ Response truncated (finish_reason='length') - model hit max output tokens
16:21:32 ⚠️ Response truncated (finish_reason='length') - model hit max output tokens
→ error: "Response remained truncated after 4 continuation attempts"
```

And the transcript poisoning the old flow produced on that machine:

```
WARNING run_agent: Pre-call sanitizer: healed 3 empty non-final message(s) by substituting
placeholder content — an empty-content turn was in the transcript and would 400 the request
('messages must have non-empty content' / INVALID_REQUEST_BODY).
```