### PR TITLE
fix(matrix): retry missed current room keys

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -94,6 +94,7 @@ except ImportError:
 
     class _EventTypeStub:  # type: ignore[no-redef]
         ROOM_MESSAGE = "m.room.message"
+        ROOM_KEY = "m.room_key"
         REACTION = "m.reaction"
         ROOM_ENCRYPTED = "m.room.encrypted"
         ROOM_NAME = "m.room.name"
@@ -121,6 +122,7 @@ except ImportError:
     RoomCreatePreset = _RoomCreatePresetStub  # type: ignore[misc,assignment]
 
     class _TrustStateStub:  # type: ignore[no-redef]
+        BLACKLISTED = -1
         UNVERIFIED = 0
         VERIFIED = 1
 
@@ -142,6 +144,9 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 logger = logging.getLogger(__name__)
 
 _MATRIX_VOICE_WAVEFORM_BINS = 30
+_MATRIX_KEY_DELIVERY_RETRY_TIMEOUT_SECONDS = 5
+_MATRIX_KEY_DELIVERY_RETRY_COOLDOWN_SECONDS = 60
+_MatrixKeyTarget = tuple[str, str, str, str, str]
 
 
 def _matrix_voice_metadata_for_file(path: Path) -> Dict[str, Any]:
@@ -1367,6 +1372,19 @@ class MatrixAdapter(BasePlatformAdapter):
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
         }
+        key_retry_users = config.extra.get("e2ee_key_delivery_retry_users", [])
+        self._e2ee_key_delivery_retry_user_ids: Set[str] = (
+            {
+                user_id.strip()
+                for user_id in key_retry_users
+                if isinstance(user_id, str) and user_id.strip()
+            }
+            if isinstance(key_retry_users, list)
+            else set()
+        )
+        self._e2ee_key_delivery_retry_locks: Dict[str, asyncio.Lock] = {}
+        # Infinity means this target needs no further retry for the session.
+        self._e2ee_key_delivery_retry_at: Dict[_MatrixKeyTarget, float] = {}
         self._allowed_room_ids: Set[str] = set(self._allowed_rooms)
         ignore_patterns_raw = os.getenv("MATRIX_IGNORE_USER_PATTERNS", "")
         self._ignored_user_patterns: list[re.Pattern[str]] = []
@@ -1379,6 +1397,134 @@ class MatrixAdapter(BasePlatformAdapter):
                     pattern,
                     exc,
                 )
+
+    async def _prepare_current_room_key_delivery(self, room_id: str) -> int:
+        """Retry the current Megolm key before the next encrypted room message.
+
+        mautrix 0.21 can mark the session shared after omitting a device with no
+        usable Olm session. This compatibility shim retries that same current
+        key for configured, joined users; it cannot recover earlier events.
+        """
+        if not self._e2ee_key_delivery_retry_user_ids or not self._encryption:
+            return 0
+        client = self._client
+        olm = getattr(client, "crypto", None) if client is not None else None
+        if olm is None or room_id not in self._joined_rooms:
+            return 0
+
+        typed_room_id = RoomID(room_id)
+        if not await olm.state_store.is_encrypted(typed_room_id):
+            return 0
+        session = await olm.crypto_store.get_outbound_group_session(typed_room_id)
+        if session is None or not session.shared or session.expired:
+            return 0
+
+        session_id = str(session.id)
+        self._e2ee_key_delivery_retry_at = {
+            target: retry_at
+            for target, retry_at in self._e2ee_key_delivery_retry_at.items()
+            if target[0] != room_id or target[1] == session_id
+        }
+
+        now = time.monotonic()
+        candidates: list[tuple[_MatrixKeyTarget, Any]] = []
+        for user_id in sorted(self._e2ee_key_delivery_retry_user_ids):
+            try:
+                devices = await olm.crypto_store.get_devices(UserID(user_id))
+            except Exception:
+                logger.debug(
+                    "Matrix: could not inspect room-key devices in %s",
+                    room_id,
+                    exc_info=True,
+                )
+                continue
+            for device_id, device in (devices or {}).items():
+                target = (
+                    room_id,
+                    session_id,
+                    user_id,
+                    str(device_id),
+                    str(getattr(device, "identity_key", "")),
+                )
+                if self._e2ee_key_delivery_retry_at.get(target, 0) > now:
+                    continue
+                if (
+                    user_id == str(getattr(client, "mxid", ""))
+                    and str(device_id) == str(getattr(client, "device_id", ""))
+                ) or getattr(device, "deleted", False):
+                    self._e2ee_key_delivery_retry_at[target] = float("inf")
+                    continue
+                self._e2ee_key_delivery_retry_at[target] = (
+                    now + _MATRIX_KEY_DELIVERY_RETRY_COOLDOWN_SECONDS
+                )
+                candidates.append((target, device))
+
+        if not candidates:
+            return 0
+
+        joined_user_ids = {
+            str(user_id) for user_id in await client.get_joined_members(typed_room_id)
+        }
+        if str(getattr(client, "mxid", "")) not in joined_user_ids:
+            return 0
+        delivered = 0
+        for target, device in candidates:
+            user_id = target[2]
+            if user_id not in joined_user_ids:
+                continue
+            trust = await olm.resolve_trust(device)
+            if trust == TrustState.BLACKLISTED or trust < olm.send_keys_min_trust:
+                continue
+            try:
+                await olm.send_encrypted_to_device(
+                    device,
+                    EventType.ROOM_KEY,
+                    session.share_content,
+                )
+            except Exception:
+                logger.debug(
+                    "Matrix: current room-key delivery remains pending in %s",
+                    room_id,
+                    exc_info=True,
+                )
+                continue
+            self._e2ee_key_delivery_retry_at[target] = float("inf")
+            delivered += 1
+
+        if delivered:
+            logger.info(
+                "Matrix: retried current room key in %s to %d configured device(s)",
+                room_id,
+                delivered,
+            )
+        return delivered
+
+    async def _send_room_message_event(
+        self,
+        room_id: str,
+        content: Dict[str, Any],
+    ) -> Any:
+        """Bind the current-key retry to the room-message send it precedes."""
+        if not self._e2ee_key_delivery_retry_user_ids or not self._encryption:
+            return await self._client.send_message_event(
+                RoomID(room_id), EventType.ROOM_MESSAGE, content
+            )
+        lock = self._e2ee_key_delivery_retry_locks.setdefault(room_id, asyncio.Lock())
+        async with lock:
+            try:
+                await asyncio.wait_for(
+                    self._prepare_current_room_key_delivery(room_id),
+                    timeout=_MATRIX_KEY_DELIVERY_RETRY_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                logger.debug(
+                    "Matrix: room-key delivery retry failed in %s; continuing",
+                    room_id,
+                    exc_info=True,
+                )
+            return await self._client.send_message_event(
+                RoomID(room_id), EventType.ROOM_MESSAGE, content
+            )
 
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
@@ -2172,6 +2318,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if redaction_tasks:
             await asyncio.gather(*redaction_tasks, return_exceptions=True)
         self._reaction_redaction_tasks.clear()
+        self._e2ee_key_delivery_retry_at.clear()
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
@@ -2212,11 +2359,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
             try:
                 event_id = await asyncio.wait_for(
-                    self._client.send_message_event(
-                        RoomID(chat_id),
-                        EventType.ROOM_MESSAGE,
-                        msg_content,
-                    ),
+                    self._send_room_message_event(chat_id, msg_content),
                     timeout=45,
                 )
                 last_event_id = str(event_id)
@@ -2227,11 +2370,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     try:
                         await self._client.crypto.share_keys()
                         event_id = await asyncio.wait_for(
-                            self._client.send_message_event(
-                                RoomID(chat_id),
-                                EventType.ROOM_MESSAGE,
-                                msg_content,
-                            ),
+                            self._send_room_message_event(chat_id, msg_content),
                             timeout=45,
                         )
                         last_event_id = str(event_id)
@@ -2290,6 +2429,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 "crypto_store_path": str(_CRYPTO_DB_PATH),
                 "recovery_key_configured": bool(
                     _scoped_recovery_key().strip()
+                ),
+                "key_delivery_retry_user_count": len(
+                    self._e2ee_key_delivery_retry_user_ids
                 ),
             },
             "policy": {
@@ -2354,11 +2496,7 @@ class MatrixAdapter(BasePlatformAdapter):
         }
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(chat_id),
-                EventType.ROOM_MESSAGE,
-                msg_content,
-            )
+            event_id = await self._send_room_message_event(chat_id, msg_content)
             return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
@@ -2952,11 +3090,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(room_id),
-                EventType.ROOM_MESSAGE,
-                msg_content,
-            )
+            event_id = await self._send_room_message_event(room_id, msg_content)
             return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
@@ -4555,11 +4689,7 @@ class MatrixAdapter(BasePlatformAdapter):
         msg_content = self._build_text_message_content(text, msgtype=msgtype)
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(chat_id),
-                EventType.ROOM_MESSAGE,
-                msg_content,
-            )
+            event_id = await self._send_room_message_event(chat_id, msg_content)
             return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
@@ -5378,7 +5508,9 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    take precedence over YAML. The structured room-key retry user list cannot
+    flow through a scalar environment variable, so return it for the registry
+    bridge to retain in ``PlatformConfig.extra``.
     """
     if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
         os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
@@ -5412,6 +5544,12 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
+    if "e2ee_key_delivery_retry_users" in matrix_cfg:
+        return {
+            "e2ee_key_delivery_retry_users": matrix_cfg[
+                "e2ee_key_delivery_retry_users"
+            ]
+        }
     return None
 
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -43,6 +43,7 @@ def _make_fake_mautrix():
 
     class EventType:
         ROOM_MESSAGE = "m.room.message"
+        ROOM_KEY = "m.room_key"
         REACTION = "m.reaction"
         ROOM_ENCRYPTED = "m.room.encrypted"
         ROOM_NAME = "m.room.name"
@@ -73,6 +74,7 @@ def _make_fake_mautrix():
         UNAVAILABLE = "unavailable"
 
     class TrustState:
+        BLACKLISTED = -1
         UNVERIFIED = 0
         VERIFIED = 1
 
@@ -300,6 +302,46 @@ class TestMatrixConfigLoading:
         assert home.chat_id == "!room123:example.org"
         assert home.name == "Bot Room"
 
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            (
+                ["@alice:example.org", " @bob:example.org ", 42],
+                {"@alice:example.org", "@bob:example.org"},
+            ),
+            ("@alice:example.org", set()),
+            (None, set()),
+        ],
+    )
+    def test_matrix_e2ee_key_delivery_retry_users_are_explicit(
+        self, configured, expected
+    ):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        extra = {
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        }
+        if configured is not None:
+            extra["e2ee_key_delivery_retry_users"] = configured
+        adapter = MatrixAdapter(
+            PlatformConfig(enabled=True, token="syt_test_token", extra=extra)
+        )
+
+        assert adapter._e2ee_key_delivery_retry_user_ids == expected
+
+    def test_yaml_bridge_retains_structured_key_delivery_retry_users(self):
+        from plugins.platforms.matrix.adapter import _apply_yaml_config
+
+        retry_users = ["@alice:example.org"]
+
+        assert _apply_yaml_config(
+            {},
+            {"e2ee_key_delivery_retry_users": retry_users},
+        ) == {
+            "e2ee_key_delivery_retry_users": retry_users,
+        }
+
 
 # ---------------------------------------------------------------------------
 # Adapter helpers
@@ -318,6 +360,271 @@ def _make_adapter():
     )
     adapter = MatrixAdapter(config)
     return adapter
+
+
+class TestMatrixE2EEKeyDeliveryRetry:
+    def setup_method(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        self.adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                    "e2ee_key_delivery_retry_users": ["@alice:example.org"],
+                },
+            )
+        )
+        self.adapter._encryption = True
+        self.adapter._joined_rooms = {"!room:example.org"}
+        self.client = MagicMock(
+            spec_set=[
+                "mxid",
+                "device_id",
+                "get_joined_members",
+                "send_message_event",
+                "crypto",
+            ]
+        )
+        self.client.mxid = "@bot:example.org"
+        self.client.device_id = "BOTDEVICE"
+        self.client.get_joined_members = AsyncMock(
+            return_value={
+                "@bot:example.org": MagicMock(),
+                "@alice:example.org": MagicMock(),
+            }
+        )
+        self.client.send_message_event = AsyncMock(return_value="$event123")
+        self.adapter._client = self.client
+        self.crypto_state = MagicMock(spec_set=["is_encrypted"])
+        self.crypto_state.is_encrypted = AsyncMock(return_value=True)
+        self.olm = MagicMock(
+            spec_set=[
+                "client",
+                "state_store",
+                "send_keys_min_trust",
+                "resolve_trust",
+                "send_encrypted_to_device",
+                "crypto_store",
+            ]
+        )
+        self.olm.client = self.client
+        self.olm.state_store = self.crypto_state
+        self.olm.send_keys_min_trust = 0
+        self.olm.resolve_trust = AsyncMock(return_value=0)
+        self.olm.send_encrypted_to_device = AsyncMock()
+        self.olm.crypto_store = MagicMock(
+            spec_set=["get_devices", "get_outbound_group_session"]
+        )
+        self.client.crypto = self.olm
+        self.device = MagicMock(
+            spec_set=[
+                "user_id",
+                "device_id",
+                "identity_key",
+                "signing_key",
+                "trust",
+                "deleted",
+            ]
+        )
+        self.device.user_id = "@alice:example.org"
+        self.device.device_id = "ALICEDEVICE"
+        self.device.identity_key = "alice-identity-key"
+        self.device.signing_key = "alice-signing-key"
+        self.device.trust = 0
+        self.device.deleted = False
+        self.olm.crypto_store.get_devices = AsyncMock(
+            return_value={"ALICEDEVICE": self.device}
+        )
+        self.session = MagicMock(
+            spec_set=["id", "shared", "expired", "share_content"]
+        )
+        self.session.id = "current-session"
+        self.session.shared = True
+        self.session.expired = False
+        self.session.share_content = object()
+        self.olm.crypto_store.get_outbound_group_session = AsyncMock(
+            return_value=self.session
+        )
+
+    @pytest.mark.asyncio
+    async def test_current_key_is_retried_once_before_the_room_message(self):
+        from plugins.platforms.matrix.adapter import EventType
+
+        timeline = []
+
+        async def send_key(*_args):
+            timeline.append("room-key")
+
+        async def send_event(*_args):
+            timeline.append("room-message")
+            return "$event123"
+
+        self.olm.send_encrypted_to_device.side_effect = send_key
+        self.client.send_message_event.side_effect = send_event
+
+        first = await self.adapter.send("!room:example.org", "hello")
+        second = await self.adapter.send("!room:example.org", "again")
+
+        assert first.success is True
+        assert second.success is True
+        assert timeline == ["room-key", "room-message", "room-message"]
+        self.olm.send_encrypted_to_device.assert_awaited_once_with(
+            self.device,
+            EventType.ROOM_KEY,
+            self.session.share_content,
+        )
+        self.olm.resolve_trust.assert_awaited_once_with(self.device)
+        self.client.get_joined_members.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_target_retries_after_cooldown(self, monkeypatch):
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        monkeypatch.setattr(
+            matrix_mod,
+            "_MATRIX_KEY_DELIVERY_RETRY_COOLDOWN_SECONDS",
+            0,
+        )
+        self.olm.send_encrypted_to_device.side_effect = [
+            RuntimeError("no one-time key"),
+            None,
+        ]
+
+        first = await self.adapter._prepare_current_room_key_delivery("!room:example.org")
+        second = await self.adapter._prepare_current_room_key_delivery("!room:example.org")
+
+        assert first == 0
+        assert second == 1
+        assert self.olm.send_encrypted_to_device.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_unavailable_target_is_not_retried_on_every_message(self):
+        self.olm.send_encrypted_to_device.side_effect = RuntimeError(
+            "no one-time key"
+        )
+
+        first = await self.adapter._prepare_current_room_key_delivery("!room:example.org")
+        second = await self.adapter._prepare_current_room_key_delivery("!room:example.org")
+
+        assert first == 0
+        assert second == 0
+        self.olm.send_encrypted_to_device.assert_awaited_once()
+        self.client.get_joined_members.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_new_session_and_replaced_device_identity_are_retried(self):
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 1
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 0
+
+        self.device.identity_key = "replacement-identity-key"
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 1
+
+        self.session.id = "rotated-session"
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 1
+        assert self.olm.send_encrypted_to_device.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_unjoined_retry_user_does_not_receive_a_key(self):
+        self.client.get_joined_members.return_value = {
+            "@bot:example.org": MagicMock()
+        }
+
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 0
+        self.client.get_joined_members.assert_awaited_once()
+        self.olm.send_encrypted_to_device.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blacklisted_device_does_not_receive_a_key(self):
+        from plugins.platforms.matrix.adapter import TrustState
+
+        self.olm.resolve_trust.return_value = TrustState.BLACKLISTED
+
+        assert await self.adapter._prepare_current_room_key_delivery("!room:example.org") == 0
+        self.olm.send_encrypted_to_device.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_current_session_leaves_normal_send_to_mautrix(self):
+        self.olm.crypto_store.get_outbound_group_session.return_value = None
+
+        result = await self.adapter.send("!room:example.org", "hello")
+
+        assert result.success is True
+        self.client.get_joined_members.assert_not_awaited()
+        self.olm.send_encrypted_to_device.assert_not_awaited()
+        self.client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_preflight_failure_does_not_change_message_send_success(self):
+        self.crypto_state.is_encrypted.side_effect = RuntimeError(
+            "homeserver unavailable"
+        )
+
+        result = await self.adapter.send("!room:example.org", "hello")
+
+        assert result.success is True
+        assert result.message_id == "$event123"
+        self.client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_preflight_timeout_does_not_change_message_send_success(
+        self, monkeypatch
+    ):
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        never_release = asyncio.Event()
+
+        async def hang(*_args):
+            await never_release.wait()
+
+        self.olm.send_encrypted_to_device.side_effect = hang
+        monkeypatch.setattr(
+            matrix_mod,
+            "_MATRIX_KEY_DELIVERY_RETRY_TIMEOUT_SECONDS",
+            0.001,
+        )
+
+        result = await self.adapter.send("!room:example.org", "hello")
+
+        assert result.success is True
+        self.client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_room_lock_binds_preflight_to_wrapped_send(self):
+        first_send_started = asyncio.Event()
+        release_first_send = asyncio.Event()
+        send_count = 0
+
+        async def send_event(*_args):
+            nonlocal send_count
+            send_count += 1
+            if send_count == 1:
+                first_send_started.set()
+                await release_first_send.wait()
+            return f"$event{send_count}"
+
+        self.adapter._prepare_current_room_key_delivery = AsyncMock(return_value=0)
+        self.client.send_message_event.side_effect = send_event
+
+        first = asyncio.create_task(
+            self.adapter.send("!room:example.org", "first")
+        )
+        await first_send_started.wait()
+        second = asyncio.create_task(
+            self.adapter.send("!room:example.org", "second")
+        )
+        await asyncio.sleep(0)
+
+        assert self.adapter._prepare_current_room_key_delivery.await_count == 1
+
+        release_first_send.set()
+        first_result, second_result = await asyncio.gather(first, second)
+
+        assert first_result.success is True
+        assert second_result.success is True
+        assert self.adapter._prepare_current_room_key_delivery.await_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -86,6 +86,8 @@ matrix:
   require_mention: true           # Require @mention in rooms (default: true)
   allowed_users:                  # Matrix users allowed to trigger agent turns
     - "@alice:matrix.org"
+  e2ee_key_delivery_retry_users:  # Retry current keys to these joined users
+    - "@alice:matrix.org"
   allowed_rooms:                  # Matrix rooms allowed to trigger agent turns
     - "!abc123:matrix.org"
   free_response_rooms:            # Rooms exempt from mention requirement
@@ -122,6 +124,18 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 
 :::tip Room-wide mentions
 Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@alice:example.org`. Room-wide `@room` notifications are disabled by default; set `MATRIX_ALLOW_ROOM_MENTIONS=true` only in rooms where the bot is allowed to notify everyone.
+:::
+
+:::note E2EE room-key delivery retry
+`e2ee_key_delivery_retry_users` is intentionally separate from `allowed_users`
+and defaults to an empty list. Before sending encrypted text, edits, or media,
+Hermes retries the current Megolm key to eligible devices of listed users who
+are still joined to the room. Failed devices are tried again after one minute;
+normal message delivery continues if the retry fails.
+
+This mautrix compatibility option only helps later messages in the current
+session. It does not recover earlier events, handle key requests, send forwarded
+room keys, or apply to reactions.
 :::
 
 :::note


### PR DESCRIPTION
## Outcome

Prevent an explicitly configured user's device from remaining unable to decrypt later Matrix events when mautrix omitted that device from the initial share of the current outbound Megolm session.

## Why this is needed

mautrix 0.21.1 can fail to establish an Olm session for one device during the initial group-session share, then still mark the outbound Megolm session as shared. Later room messages continue under that session, while the omitted device never receives its current key.

This is a narrow, default-off compatibility shim in the Hermes Matrix adapter. It does not replace mautrix session creation or implement room-key recovery.

## Changes

- add `matrix.e2ee_key_delivery_retry_users`, defaulting to an empty list
- before encrypted room-message events, retry the existing current `m.room_key` to eligible devices of configured users
- require fresh joined membership and preserve mautrix's blacklist and minimum-trust policy
- remember successful delivery per room, session, device, and identity key; failed targets wait one minute before another attempt
- serialize the retry with its room-message send and cap the retry at five seconds
- continue normal message delivery if the compatibility retry cannot run

## Non-goals

- no historical key recovery
- no session creation or rotation
- no room-key request handling
- no `m.forwarded_room_key`
- no general mautrix redesign or unrelated Matrix behavior changes

## Validation

- `scripts/run_tests.sh tests/gateway/test_matrix.py -q` — 126 passed, 0 failed
- `.venv/bin/ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `python3 -m py_compile plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `git diff --check origin/main...HEAD`

The earlier defensive review informed the membership, trust, identity, timeout, and send-order invariants. The final implementation was then reduced from six retry/warning state collections to one retry-time map plus the per-room send lock, with the warning-throttling, plaintext negative cache, lock-bypass path, and expanded send timeout removed.
