### PR TITLE
fix(skills): resolve the frontmatter name _find_skill ignores

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -71,6 +71,20 @@ description: Use when deploying multi-region Kubernetes clusters with custom CNI
 Step 1.
 """
 
+# Directory name deliberately differs from the frontmatter name — the
+# mismatch scenario from #99609. Nothing at creation time forces the two
+# to agree, and skills_list displays the frontmatter name.
+MISMATCHED_NAME_CONTENT = """\
+---
+name: keeta-eng-conduct
+description: Frontmatter name differs from the directory name.
+---
+
+# Mismatched Name Skill
+
+Step 1: Do the thing under the other name.
+"""
+
 
 # ---------------------------------------------------------------------------
 # _validate_name
@@ -165,6 +179,16 @@ class TestCreateSkill:
         assert result["success"] is False
         assert "already exists" in result["error"]
 
+    def test_create_rejects_name_colliding_with_existing_frontmatter_name(self, tmp_path):
+        """A new skill's directory name must not collide with an existing
+        skill's displayed (frontmatter) name — skills_list dedups by that
+        name, so the new skill would be silently hidden."""
+        with _skill_dir(tmp_path):
+            _create_skill("eng-conduct", MISMATCHED_NAME_CONTENT)
+            result = _create_skill("keeta-eng-conduct", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+        assert "already exists" in result["error"]
+
     def test_create_rejects_category_traversal(self, tmp_path):
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
@@ -232,6 +256,53 @@ class TestEditSkill:
             found = _find_skill("my-skill")
         assert found is not None
         assert found["path"] == tmp_path / "mlops" / "my-skill"
+
+    def test_find_skill_accepts_frontmatter_name(self, tmp_path):
+        """The name ``skills list`` displays must resolve in skill_manage.
+
+        skills_list shows the frontmatter ``name:`` when it diverges from
+        the directory name, but ``_find_skill`` matched only the directory
+        name — so every mutating action called with the displayed name
+        failed with a misleading "not found in active profile" error while
+        the skill sat visibly enabled in the correct profile (#99609).
+        """
+        with _skill_dir(tmp_path):
+            _create_skill(
+                "eng-conduct", MISMATCHED_NAME_CONTENT, category="example-category"
+            )
+            found = _find_skill("keeta-eng-conduct")
+        assert found is not None
+        assert found["path"] == tmp_path / "example-category" / "eng-conduct"
+
+    def test_edit_existing_skill_by_frontmatter_name(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill(
+                "eng-conduct", MISMATCHED_NAME_CONTENT, category="example-category"
+            )
+            result = _edit_skill("keeta-eng-conduct", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True, result.get("error")
+        content = (tmp_path / "example-category" / "eng-conduct" / "SKILL.md").read_text()
+        assert "Updated description" in content
+
+    def test_find_skill_directory_name_wins_over_foreign_frontmatter(self, tmp_path):
+        """One skill's frontmatter name must not shadow another skill's dir.
+
+        The conflicting pair is written directly to disk: _create_skill's
+        duplicate check now also consults the frontmatter fallback, so it
+        refuses to create a skill whose directory name collides with an
+        existing skill's frontmatter name — the same collision
+        skills_list's seen-names dedup would silently hide.
+        """
+        claiming = tmp_path / "real-target"
+        claiming.mkdir()
+        (claiming / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        claimed = tmp_path / "test-skill"
+        claimed.mkdir()
+        (claimed / "SKILL.md").write_text(MISMATCHED_NAME_CONTENT)
+        with _skill_dir(tmp_path):
+            found = _find_skill("test-skill")
+        assert found is not None
+        assert found["path"] == claimed
 
     def test_edit_invalid_content_rejected(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -676,6 +676,28 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
     return _skills_dir() / name
 
 
+def _read_frontmatter_name(skill_md: Path) -> Optional[str]:
+    """Read a SKILL.md's frontmatter ``name:`` — the name skills_list displays.
+
+    Fail-quiet on unreadable files: the fallback lookup in ``_find_skill``
+    must never break the directory-name match, and an unreadable SKILL.md
+    simply has no second name to offer. The value is truncated with the
+    same ``MAX_NAME_LENGTH`` budget skills_list applies when displaying it.
+    """
+    try:
+        from agent.skill_utils import parse_frontmatter
+
+        content = skill_md.read_text(encoding="utf-8-sig", errors="replace")[:4000]
+        frontmatter, _ = parse_frontmatter(content)
+    except OSError:
+        logger.debug("frontmatter read failed for %s", skill_md, exc_info=True)
+        return None
+    name = frontmatter.get("name")
+    if isinstance(name, str):
+        return name[:MAX_NAME_LENGTH]
+    return None
+
+
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
     Find a skill by name across all skill directories.
@@ -690,6 +712,14 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     the caller to use. The bare-name match compares the skill's own
     directory name (``parent.name``), so bare lookups keep working for
     category-nested skills.
+
+    As a last resort the frontmatter ``name:`` is matched too, so the name
+    ``skills list`` displays (frontmatter name wins over the directory
+    name there) resolves everywhere instead of failing with a misleading
+    "not found in active profile" error when the two names diverge.
+    Directory-name matches keep priority; a frontmatter match is only
+    returned after the whole scan found no directory/categorized match,
+    so one skill's frontmatter cannot shadow another skill's directory.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
 
@@ -711,6 +741,8 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
                 _resolved_root = _skills_dir()
         return _resolved_root
 
+    frontmatter_match: Optional[Path] = None
+
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
@@ -727,9 +759,14 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
                 try:
                     rel = skill_md.parent.resolve().relative_to(_local_root())
                 except ValueError:
-                    continue
-                if rel.as_posix() == name:
+                    rel = None
+                if rel is not None and rel.as_posix() == name:
                     return {"path": skill_md.parent}
+            if frontmatter_match is None:
+                if _read_frontmatter_name(skill_md) == name:
+                    frontmatter_match = skill_md.parent
+    if frontmatter_match is not None:
+        return {"path": frontmatter_match}
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

`skills list` displays a skill's **frontmatter `name:`** (`tools/skills_tool.py`: `name = frontmatter.get("name", skill_dir.name)`). But `_find_skill` in `tools/skill_manager_tool.py` matched **only the directory name** (`skill_md.parent.name == name`), never reading frontmatter. When the two names diverge (nothing at creation time forces them to agree), every mutating skill action — patch/edit/delete/write_file/remove_file, and the `/skills approve` replay (`apply_skill_pending` → `skill_manage` → `_find_skill`) — called with the name `skills list` just showed failed with:

```
Skill 'keeta-eng-conduct' not found in active profile 'default'.
```

That error actively misdiagnoses the failure as profile scoping while the skill sits visibly enabled in the correct active profile.

The fix adds a frontmatter-name fallback to `_find_skill`: after the existing directory-name/categorized-path scan finds no match, a skill whose frontmatter `name:` equals the query resolves to its directory. Two safety properties:

- **Directory-name matches keep priority** — a frontmatter match is only remembered during the scan and returned after it completes without a directory/categorized hit, so one skill's frontmatter cannot shadow another skill's directory name.
- **Same name budget as the display** — the fallback name is truncated with the same `MAX_NAME_LENGTH` (64) that `skills_list` applies when displaying it, so lookups match exactly what the user saw.

A side effect worth noting: `_create_skill`'s duplicate check calls `_find_skill`, so it now also refuses a new skill whose directory name collides with an existing skill's frontmatter name — a collision `skills_list`'s seen-names dedup would silently hide anyway.

## Related Issue

Fixes #99609
Fixes #61172 — same root cause via the Dashboard skill-editor surface (supersedes my earlier #61177)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: added `_read_frontmatter_name()` helper (reads the frontmatter `name:` with the same first-4000-chars + `MAX_NAME_LENGTH` budget as `skills_list`, fail-quiet on unreadable files); `_find_skill()` now records a frontmatter match during the scan and returns it only when no directory-name/categorized match exists
- `tests/tools/test_skill_manager_tool.py`: regression tests — frontmatter-name lookup resolves (incl. category-nested), `_edit_skill` works by the displayed name, directory name wins over a foreign frontmatter claim, and `_create_skill` rejects a directory name colliding with an existing skill's frontmatter name

## How to Test

1. Create a skill whose directory name differs from its frontmatter `name:` (e.g. dir `eng-conduct`, frontmatter `name: keeta-eng-conduct`) — `_create_skill` allows this today, which is how the mismatch arises
2. `hermes skills list` shows `keeta-eng-conduct` as enabled; before the fix, `skill_manage(action='edit', name='keeta-eng-conduct', ...)` (and `/skills approve` of a staged write against it) failed with "not found in active profile"
3. After the fix, the same call resolves to the `eng-conduct` directory and succeeds — verified by `tests/tools/test_skill_manager_tool.py`:

```
67 passed
```

Plus the surrounding skill suites (`test_skills_tool.py`, `test_skill_manage_batch.py`, `test_skills_sync*.py`, `test_web_server_skill*.py`, `test_cli_*skills*.py`, ...): 374 passed, 0 failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior docstring on `_find_skill` updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (frontmatter read uses `utf-8-sig` like the existing scan paths; no path handling changed)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change; lookup now accepts the name skills_list already displays)

## For New Skills

N/A — no new skill.