### PR TITLE
fix(api): let OpenAI clients answer approvals and clarification

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1560,6 +1560,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self,
             store_factory=RunIdempotencyStore,
         )
+        # Opt-in OpenAI-compatible streaming interactions. Each request owns
+        # an isolated pending-question map addressed by an opaque interaction
+        # id; the API key is required before an entry can be created.
+        self._interactive_sessions: Dict[str, Dict[str, Any]] = {}
+        self._interactive_sessions_lock = threading.RLock()
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -2246,6 +2251,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/sessions/{session_id}/model", self._handle_session_model_lock),
             ("POST", "/v1/chat/completions", self._handle_chat_completions),
             ("POST", "/v1/responses", self._handle_responses),
+            ("POST", "/v1/interactions/{interaction_id}/response", self._handle_interaction_response),
             ("GET", "/v1/responses/{response_id}", self._handle_get_response),
             ("DELETE", "/v1/responses/{response_id}", self._handle_delete_response),
             # Generic platform HTTP event callback ingress. Authenticated by
@@ -2820,6 +2826,8 @@ class APIServerAdapter(BasePlatformAdapter):
         confirmed_runtime_lock: bool = False,
         room_dispatch: Optional[Dict[str, Any]] = None,
         room_execution_policy: Optional[Dict[str, Any]] = None,
+        interactive: bool = False,
+        clarify_callback=None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -3086,6 +3094,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if interactive and "clarify" not in enabled_toolsets:
+            enabled_toolsets.append("clarify")
+
         max_iterations = _current_max_iterations()
         if room_dispatch is not None:
             from gateway.hosted_room_execution_policy import RoomExecutionPolicy
@@ -3131,6 +3142,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
+            "clarify_callback": clarify_callback if interactive else None,
             "session_db": self._ensure_session_db(),
             "fallback_model": fallback_model,
             "reasoning_config": reasoning_config,
@@ -3158,6 +3170,226 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
+
+    def _interactive_request_mode(self, body: Dict[str, Any], stream: bool):
+        """Resolve the opt-in interaction flag and its fail-closed preflight."""
+        hermes_options = body.get("hermes")
+        interactive = bool(
+            isinstance(hermes_options, dict)
+            and _coerce_request_bool(hermes_options.get("interactive"), default=False)
+        )
+        if interactive and not stream:
+            return interactive, web.json_response(
+                _openai_error(
+                    "Hermes interactive requests require stream=true.",
+                    code="interactive_requires_stream",
+                ),
+                status=400,
+            )
+        if interactive and not self._api_key:
+            return interactive, web.json_response(
+                _openai_error(
+                    "Hermes interactive requests require a configured API server key.",
+                    err_type="gateway_auth_error",
+                    code="interactive_auth_required",
+                ),
+                status=403,
+            )
+        return interactive, None
+
+    def _begin_interactive_session(self, interaction_id: str, stream_q) -> Any:
+        """Register one isolated streaming interaction and return its clarify callback."""
+        from gateway.run import _load_gateway_config
+        from tools.clarify_gateway import resolve_clarify_timeout
+
+        state: Dict[str, Any] = {
+            "stream_q": stream_q,
+            "pending": {},
+            "approval_session_key": f"interaction:{interaction_id}",
+            "request_profile": _api_request_profile.get(),
+            "clarify_timeout": resolve_clarify_timeout(_load_gateway_config()),
+        }
+        with self._interactive_sessions_lock:
+            self._interactive_sessions[interaction_id] = state
+
+        def _clarify(question, choices, multi_select=False, questions=None):
+            from tools.clarify_tool import TIMEOUT_RESPONSE
+
+            request_id = f"clarify_{uuid.uuid4().hex}"
+            pending = {
+                "event": threading.Event(),
+                "kind": "clarify",
+                "result": None,
+                "batch": bool(questions),
+            }
+            with self._interactive_sessions_lock:
+                current = self._interactive_sessions.get(interaction_id)
+                if current is not state:
+                    return TIMEOUT_RESPONSE
+                state["pending"][request_id] = pending
+
+            payload = {
+                "type": "hermes.clarify.request",
+                "interaction_id": interaction_id,
+                "request_id": request_id,
+                "question": question or "",
+                "choices": choices,
+                "multi_select": bool(multi_select),
+            }
+            if questions:
+                payload["questions"] = questions
+            stream_q.put_threadsafe(("__interaction__", payload))
+
+            timeout = state["clarify_timeout"]
+            deadline = None if timeout is None or float(timeout) <= 0 else time.monotonic() + float(timeout)
+            try:
+                from tools.environments.base import touch_activity_if_due
+            except Exception:  # pragma: no cover - optional environment helper
+                touch_activity_if_due = None
+            activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
+            while True:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    break
+                if pending["event"].wait(timeout=1.0 if remaining is None else min(1.0, remaining)):
+                    break
+                if touch_activity_if_due is not None:
+                    touch_activity_if_due(activity_state, "waiting for API clarify response")
+            with self._interactive_sessions_lock:
+                state["pending"].pop(request_id, None)
+            if not pending["event"].is_set():
+                return TIMEOUT_RESPONSE
+            return pending["result"]
+
+        return _clarify
+
+    def _interaction_approval_notify(self, interaction_id: str, stream_q):
+        """Build the approval-core notifier for one interactive stream."""
+        def _notify(approval_data: Dict[str, Any]) -> None:
+            event = dict(approval_data or {})
+            if "command" in event:
+                from gateway.run import _redact_approval_command
+
+                event["command"] = _redact_approval_command(event.get("command"))
+            request_id = str(event.get("request_id") or f"approval_{uuid.uuid4().hex}")
+            choices = _approval_event_choices(
+                smart_denied=bool(event.get("smart_denied")),
+                allow_session=event.get("allow_session") is not False,
+                allow_permanent=event.get("allow_permanent") is not False,
+            )
+            with self._interactive_sessions_lock:
+                state = self._interactive_sessions.get(interaction_id)
+                if state is None:
+                    return
+                state["pending"][request_id] = {
+                    "kind": "approval",
+                    "choices": choices,
+                }
+            event.update({
+                "type": "hermes.approval.request",
+                "interaction_id": interaction_id,
+                "request_id": request_id,
+                "choices": choices,
+            })
+            stream_q.put_threadsafe(("__interaction__", event))
+
+        return _notify
+
+    def _close_interactive_session(self, interaction_id: Optional[str]) -> None:
+        if not interaction_id:
+            return
+        with self._interactive_sessions_lock:
+            state = self._interactive_sessions.pop(interaction_id, None)
+            pending = list((state or {}).get("pending", {}).values())
+        approval_session_key = (state or {}).get("approval_session_key")
+        if approval_session_key:
+            from tools.approval import unregister_gateway_notify
+
+            unregister_gateway_notify(approval_session_key)
+        for entry in pending:
+            event = entry.get("event")
+            if event is not None:
+                if entry.get("kind") == "clarify" and entry.get("result") is None:
+                    from tools.clarify_tool import TIMEOUT_RESPONSE
+
+                    entry["result"] = TIMEOUT_RESPONSE
+                event.set()
+
+    async def _handle_interaction_response(self, request: "web.Request") -> "web.Response":
+        """Resolve one pending prompt from an opt-in OpenAI-compatible stream."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        interaction_id = request.match_info["interaction_id"]
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        response_type = str(body.get("type") or "")
+        if response_type not in {"approval", "clarify"}:
+            return web.json_response(
+                _openai_error("Unsupported interaction response type.", code="invalid_interaction_type"),
+                status=400,
+            )
+        request_id = str(body.get("request_id") or "").strip()
+        with self._interactive_sessions_lock:
+            state = self._interactive_sessions.get(interaction_id)
+            if state is not None and state.get("request_profile") != _api_request_profile.get():
+                state = None
+            pending = (state or {}).get("pending", {}).get(request_id)
+            if pending is None or pending.get("kind") != response_type:
+                return web.json_response(
+                    _openai_error("Interaction request is not pending.", code="interaction_not_pending"),
+                    status=409 if state is not None else 404,
+                )
+            if response_type == "approval":
+                raw_choice = str(body.get("choice") or "").strip().lower()
+                choice = {"approve": "once", "approved": "once", "allow": "once"}.get(
+                    raw_choice, raw_choice
+                )
+                if choice not in pending["choices"]:
+                    return web.json_response(
+                        _openai_error("Approval choice was not offered.", code="invalid_approval_choice"),
+                        status=400,
+                    )
+                from tools.approval import resolve_gateway_approval
+
+                resolved = resolve_gateway_approval(
+                    state["approval_session_key"],
+                    choice,
+                    request_id=request_id,
+                )
+                if resolved <= 0:
+                    return web.json_response(
+                        _openai_error("Approval is no longer pending.", code="interaction_not_pending"),
+                        status=409,
+                    )
+                state["pending"].pop(request_id, None)
+                return web.json_response({
+                    "object": "hermes.interaction.response",
+                    "interaction_id": interaction_id,
+                    "request_id": request_id,
+                    "accepted": True,
+                    "choice": choice,
+                })
+            if pending["event"].is_set():
+                return web.json_response(
+                    _openai_error("Interaction request is not pending.", code="interaction_not_pending"),
+                    status=409,
+                )
+            if pending.get("batch"):
+                pending["result"] = {
+                    "answers": body.get("answers") if isinstance(body.get("answers"), dict) else {},
+                    "timed_out": _coerce_request_bool(body.get("timed_out"), default=False),
+                }
+            else:
+                pending["result"] = body.get("response", "")
+            pending["event"].set()
+        return web.json_response({
+            "object": "hermes.interaction.response",
+            "interaction_id": interaction_id,
+            "request_id": request_id,
+            "accepted": True,
+        })
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
@@ -3355,6 +3587,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "openai_stream_interactions": True,
                 "session_resources": True,
                 "model_options": True,
                 "session_chat": True,
@@ -3404,6 +3637,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "model_options": {"method": "GET", "path": "/api/model/options"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
+                "interaction_response": {
+                    "method": "POST",
+                    "path": "/v1/interactions/{interaction_id}/response",
+                },
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
@@ -5063,6 +5300,9 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        interactive, interaction_error = self._interactive_request_mode(body, stream)
+        if interaction_error is not None:
+            return interaction_error
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -5192,6 +5432,18 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
+            interaction_id = f"int_{uuid.uuid4().hex}" if interactive else None
+            clarify_callback = (
+                self._begin_interactive_session(interaction_id, _stream_q)
+                if interaction_id
+                else None
+            )
+            approval_session_key = f"interaction:{interaction_id}" if interaction_id else None
+            approval_notify_callback = (
+                self._interaction_approval_notify(interaction_id, _stream_q)
+                if interaction_id
+                else None
+            )
 
             def _on_delta(delta):
                 # Filter out None — the agent fires stream_delta_callback(None)
@@ -5273,6 +5525,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                interactive=interactive,
+                clarify_callback=clarify_callback,
+                approval_session_key=approval_session_key,
+                approval_notify_callback=approval_notify_callback,
                 **agent_overrides,
                 route=route,
             ))
@@ -5280,11 +5536,14 @@ class APIServerAdapter(BasePlatformAdapter):
             # agent_task.done(), which can race with queue timeout checks.
             agent_task.add_done_callback(lambda _fut: _stream_q.put_nowait(None))
 
-            return await self._write_sse_chat_completion(
-                request, completion_id, model_name, created, _stream_q,
-                agent_task, agent_ref, session_id=session_id,
-                gateway_session_key=gateway_session_key,
-            )
+            try:
+                return await self._write_sse_chat_completion(
+                    request, completion_id, model_name, created, _stream_q,
+                    agent_task, agent_ref, session_id=session_id,
+                    gateway_session_key=gateway_session_key,
+                )
+            finally:
+                self._close_interactive_session(interaction_id)
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
         async def _compute_completion():
@@ -5474,6 +5733,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__interaction__":
+                    payload = item[1]
+                    await response.write(
+                        _sse_frame(
+                            payload,
+                            event=str(payload.get("type") or "hermes.interaction"),
+                        )
+                    )
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
@@ -5945,6 +6212,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__interaction__":
+                        await _write_event(
+                            str(payload.get("type") or "hermes.interaction"),
+                            payload,
+                        )
                 elif isinstance(it, str):
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
@@ -6334,6 +6606,9 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = stored_session_id or str(uuid.uuid4())
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        interactive, interaction_error = self._interactive_request_mode(body, stream)
+        if interaction_error is not None:
+            return interaction_error
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(
             body,
@@ -6354,6 +6629,18 @@ class APIServerAdapter(BasePlatformAdapter):
             # agent runs so frontends can render text deltas and tool
             # calls in real time.  See _write_sse_responses for details.
             _stream_q = ThreadSafeAsyncQueue()
+            interaction_id = f"int_{uuid.uuid4().hex}"
+            clarify_callback = (
+                self._begin_interactive_session(interaction_id, _stream_q)
+                if interactive
+                else None
+            )
+            approval_session_key = f"interaction:{interaction_id}" if interactive else None
+            approval_notify_callback = (
+                self._interaction_approval_notify(interaction_id, _stream_q)
+                if interactive
+                else None
+            )
 
             def _on_delta(delta):
                 # None from the agent is a CLI box-close signal, not EOS.
@@ -6402,6 +6689,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                interactive=interactive,
+                clarify_callback=clarify_callback,
+                approval_session_key=approval_session_key,
+                approval_notify_callback=approval_notify_callback,
                 **agent_overrides,
                 route=route,
             ))
@@ -6413,22 +6704,25 @@ class APIServerAdapter(BasePlatformAdapter):
             model_name = body.get("model", self._model_name)
             created_at = int(time.time())
 
-            return await self._write_sse_responses(
-                request=request,
-                response_id=response_id,
-                model=model_name,
-                created_at=created_at,
-                stream_q=_stream_q,
-                agent_task=agent_task,
-                agent_ref=agent_ref,
-                conversation_history=conversation_history,
-                user_message=user_message,
-                instructions=instructions,
-                conversation=conversation,
-                store=store,
-                session_id=session_id,
-                gateway_session_key=gateway_session_key,
-            )
+            try:
+                return await self._write_sse_responses(
+                    request=request,
+                    response_id=response_id,
+                    model=model_name,
+                    created_at=created_at,
+                    stream_q=_stream_q,
+                    agent_task=agent_task,
+                    agent_ref=agent_ref,
+                    conversation_history=conversation_history,
+                    user_message=user_message,
+                    instructions=instructions,
+                    conversation=conversation,
+                    store=store,
+                    session_id=session_id,
+                    gateway_session_key=gateway_session_key,
+                )
+            finally:
+                self._close_interactive_session(interaction_id if interactive else None)
 
         async def _compute_response():
             return await self._run_agent(
@@ -7265,6 +7559,10 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        interactive: bool = False,
+        clarify_callback=None,
+        approval_session_key: Optional[str] = None,
+        approval_notify_callback=None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -7309,6 +7607,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         def _run():
             from gateway.session_context import clear_session_vars
+            from tools.approval import (
+                register_gateway_notify,
+                reset_current_session_key,
+                set_current_session_key,
+                unregister_gateway_notify,
+            )
 
             with self._profile_scope(request_profile):
                 tokens = self._bind_api_server_session(
@@ -7321,7 +7625,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                 )
                 agent = None
+                approval_token = None
                 try:
+                    if approval_session_key and approval_notify_callback:
+                        approval_token = set_current_session_key(approval_session_key)
+                        register_gateway_notify(approval_session_key, approval_notify_callback)
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -7336,6 +7644,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
+                        interactive=interactive,
+                        clarify_callback=clarify_callback,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
@@ -7477,6 +7787,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
                 finally:
+                    if approval_session_key and approval_notify_callback:
+                        unregister_gateway_notify(approval_session_key)
+                    if approval_token is not None:
+                        reset_current_session_key(approval_token)
                     # Turn finished (success, auth failure, or crash) — clear
                     # ownership markers so a disconnect landing after this
                     # point can't reap background work this turn left

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
+    ThreadSafeAsyncQueue,
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
@@ -39,6 +40,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from tools import approval as approval_mod
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +228,47 @@ class TestAdapterInit:
         assert captured["checkpoint_max_total_size_mb"] == 321
         assert captured["checkpoint_max_file_size_mb"] == 4
 
+    def test_create_agent_enables_clarify_only_for_interactive_request(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "api_key": "test-key",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "test/model")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", lambda: None)
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", lambda _model: {})
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_: {"terminal"},
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        clarify_callback = MagicMock()
+
+        adapter._create_agent(
+            session_id="api-session",
+            interactive=True,
+            clarify_callback=clarify_callback,
+        )
+
+        assert "clarify" in captured["enabled_toolsets"]
+        assert captured["clarify_callback"] is clarify_callback
+
 
 # ---------------------------------------------------------------------------
 # Auth checking
@@ -316,6 +359,10 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post(
+        "/v1/interactions/{interaction_id}/response",
+        adapter._handle_interaction_response,
+    )
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
     app.router.add_post(
@@ -323,6 +370,19 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
         adapter._handle_platform_event_callback,
     )
     return app
+
+
+async def _read_sse_event(resp, expected_event: str) -> dict:
+    """Read a bounded SSE stream until one named event arrives."""
+    for _ in range(100):
+        raw = await asyncio.wait_for(resp.content.readline(), timeout=2.0)
+        if not raw:
+            break
+        if raw.decode().strip() != f"event: {expected_event}":
+            continue
+        data_line = await asyncio.wait_for(resp.content.readline(), timeout=2.0)
+        return json.loads(data_line.decode().removeprefix("data: "))
+    raise AssertionError(f"SSE event {expected_event!r} was not emitted")
 
 
 class _FakeGoogleChatAdapter:
@@ -356,6 +416,57 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_run_agent_bridges_approval_core_to_interactive_notifier(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        captured = {}
+        approval_session_key = "interaction:test"
+
+        def _notify(data):
+            captured.update(data)
+            approval_mod.resolve_gateway_approval(
+                approval_session_key,
+                "once",
+                request_id=data["request_id"],
+            )
+
+        def _run_conversation(**_kwargs):
+            with patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={
+                    "approvals": {"mode": "manual", "timeout": 2},
+                    "security": {"tirith_enabled": False},
+                },
+            ), patch(
+                "tools.approval.detect_dangerous_command",
+                return_value=(True, "recursive delete", "recursive-delete"),
+            ):
+                captured["decision"] = approval_mod.check_all_command_guards(
+                    "rm -rf build",
+                    "local",
+                )
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = _run_conversation
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="clean",
+                conversation_history=[],
+                session_id="session-approval",
+                interactive=True,
+                approval_session_key=approval_session_key,
+                approval_notify_callback=_notify,
+            )
+
+        assert captured["decision"]["approved"] is True, captured
+        assert captured["command"] == "rm -rf build"
+        with approval_mod._lock:
+            assert approval_session_key not in approval_mod._gateway_queues
+            assert approval_session_key not in approval_mod._gateway_notify_cbs
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
@@ -878,9 +989,14 @@ class TestCapabilitiesEndpoint:
                 "durable": True,
                 "retention_seconds": 86400,
             }
+            assert data["features"]["openai_stream_interactions"] is True
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
+            assert data["endpoints"]["interaction_response"] == {
+                "method": "POST",
+                "path": "/v1/interactions/{interaction_id}/response",
+            }
             assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
@@ -978,6 +1094,208 @@ class TestToolsetsEndpoint:
 
 
 class TestChatCompletionsEndpoint:
+    @pytest.mark.asyncio
+    async def test_interactive_requires_streaming(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "hermes": {"interactive": True},
+                },
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["code"] == "interactive_requires_stream"
+
+    @pytest.mark.asyncio
+    async def test_interactive_requires_configured_api_key(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": True,
+                    "hermes": {"interactive": True},
+                },
+            )
+            data = await resp.json()
+
+        assert resp.status == 403
+        assert data["error"]["code"] == "interactive_auth_required"
+
+    @pytest.mark.asyncio
+    async def test_interactive_disconnect_returns_clarify_timeout(self, auth_adapter):
+        from tools.clarify_tool import TIMEOUT_RESPONSE
+
+        stream_q = ThreadSafeAsyncQueue()
+        callback = auth_adapter._begin_interactive_session("int_disconnect", stream_q)
+        pending = asyncio.create_task(
+            asyncio.to_thread(callback, "Continue?", ["yes", "no"])
+        )
+
+        tag, _payload = await asyncio.wait_for(stream_q.get(), timeout=1.0)
+        assert tag == "__interaction__"
+        auth_adapter._close_interactive_session("int_disconnect")
+
+        assert await asyncio.wait_for(pending, timeout=1.0) == TIMEOUT_RESPONSE
+        assert auth_adapter._interactive_sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_interactive_responses_are_isolated_per_stream(self, auth_adapter):
+        queues = [ThreadSafeAsyncQueue(), ThreadSafeAsyncQueue()]
+        callbacks = [
+            auth_adapter._begin_interactive_session("int_one", queues[0]),
+            auth_adapter._begin_interactive_session("int_two", queues[1]),
+        ]
+        pending = [
+            asyncio.create_task(asyncio.to_thread(callbacks[0], "First?", None)),
+            asyncio.create_task(asyncio.to_thread(callbacks[1], "Second?", None)),
+        ]
+        first = (await asyncio.wait_for(queues[0].get(), timeout=1.0))[1]
+        second = (await asyncio.wait_for(queues[1].get(), timeout=1.0))[1]
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            crossed = await cli.post(
+                "/v1/interactions/int_one/response",
+                json={
+                    "type": "clarify",
+                    "request_id": second["request_id"],
+                    "response": "wrong stream",
+                },
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert crossed.status == 409
+
+            for interaction_id, payload, answer in (
+                ("int_one", first, "one"),
+                ("int_two", second, "two"),
+            ):
+                accepted = await cli.post(
+                    f"/v1/interactions/{interaction_id}/response",
+                    json={
+                        "type": "clarify",
+                        "request_id": payload["request_id"],
+                        "response": answer,
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert accepted.status == 200
+
+        assert await asyncio.gather(*pending) == ["one", "two"]
+        auth_adapter._close_interactive_session("int_one")
+        auth_adapter._close_interactive_session("int_two")
+        assert auth_adapter._interactive_sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_interactive_clarify_round_trip_over_sse(self, auth_adapter):
+        app = _create_app(auth_adapter)
+
+        async def _mock_run_agent(**kwargs):
+            answer = await asyncio.to_thread(
+                kwargs["clarify_callback"],
+                "Which environment?",
+                ["staging", "production"],
+                multi_select=False,
+            )
+            kwargs["stream_delta_callback"](f"selected:{answer}")
+            return (
+                {"final_response": f"selected:{answer}", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "deploy"}],
+                        "stream": True,
+                        "hermes": {"interactive": True},
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+
+                event_data = await _read_sse_event(resp, "hermes.clarify.request")
+
+                answer_resp = await cli.post(
+                    f"/v1/interactions/{event_data['interaction_id']}/response",
+                    json={
+                        "type": "clarify",
+                        "request_id": event_data["request_id"],
+                        "response": "staging",
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert answer_resp.status == 200
+                stream_body = (await resp.text())
+
+        assert "selected:staging" in stream_body
+        assert auth_adapter._interactive_sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_interactive_approval_round_trip_over_sse(self, auth_adapter):
+        app = _create_app(auth_adapter)
+
+        async def _mock_run_agent(**kwargs):
+            request_id = "approval-test-request"
+            entry = approval_mod._ApprovalEntry({
+                "request_id": request_id,
+                "command": "rm -rf build",
+                "description": "recursive delete",
+                "pattern_keys": ["recursive-delete"],
+            })
+            with approval_mod._lock:
+                approval_mod._gateway_queues[kwargs["approval_session_key"]] = [entry]
+            kwargs["approval_notify_callback"](entry.data)
+            assert await asyncio.to_thread(entry.event.wait, 5.0)
+            kwargs["stream_delta_callback"](f"decision:{entry.result}")
+            return (
+                {"final_response": f"decision:{entry.result}", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "clean build"}],
+                        "stream": True,
+                        "hermes": {"interactive": True},
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+
+                event_data = await _read_sse_event(resp, "hermes.approval.request")
+                assert event_data["choices"] == ["once", "session", "always", "deny"]
+
+                approval_resp = await cli.post(
+                    f"/v1/interactions/{event_data['interaction_id']}/response",
+                    json={
+                        "type": "approval",
+                        "request_id": event_data["request_id"],
+                        "choice": "once",
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert approval_resp.status == 200
+                stream_body = await resp.text()
+
+        assert "decision:once" in stream_body
+        assert auth_adapter._interactive_sessions == {}
+
     @pytest.mark.asyncio
     async def test_invalid_json_returns_400(self, adapter):
         app = _create_app(adapter)
@@ -1334,6 +1652,53 @@ class TestDeriveChatSessionId:
 
 
 class TestResponsesEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_stream_interactive_clarify_round_trip(self, auth_adapter):
+        app = _create_app(auth_adapter)
+
+        async def _mock_run_agent(**kwargs):
+            answer = await asyncio.to_thread(
+                kwargs["clarify_callback"],
+                "Which region?",
+                ["us-east", "eu-west"],
+                multi_select=False,
+            )
+            kwargs["stream_delta_callback"](f"region:{answer}")
+            return (
+                {"final_response": f"region:{answer}", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "test",
+                        "input": "deploy",
+                        "stream": True,
+                        "hermes": {"interactive": True},
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                event_data = await _read_sse_event(resp, "hermes.clarify.request")
+
+                answer_resp = await cli.post(
+                    f"/v1/interactions/{event_data['interaction_id']}/response",
+                    json={
+                        "type": "clarify",
+                        "request_id": event_data["request_id"],
+                        "response": "eu-west",
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert answer_resp.status == 200
+                stream_body = await resp.text()
+
+        assert "region:eu-west" in stream_body
+        assert auth_adapter._interactive_sessions == {}
 
 
     @pytest.mark.asyncio

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -282,13 +282,26 @@ _UNATTENDED_APPROVAL_PLATFORMS = frozenset({
 def _is_unattended_platform_approval_context() -> bool:
     """True when the session platform is a programmatic/unattended surface.
 
-    Webhook, msgraph_webhook, and api_server sessions bind
+    Webhook, msgraph_webhook, and ordinary api_server sessions bind
     ``HERMES_SESSION_PLATFORM`` like chat gateways do, but there is no human
     who can resolve a pending approval. Treating them as gateway approval
     contexts blocks the session for the full approval timeout (60-300s) and
-    then fails closed anyway — the deadlock in #37284/#87509.
+    then fails closed anyway — the deadlock in #37284/#87509. An api_server
+    request with an authenticated, session-scoped notifier is the exception.
     """
-    return _get_session_platform() in _UNATTENDED_APPROVAL_PLATFORMS
+    platform = _get_session_platform()
+    if platform not in _UNATTENDED_APPROVAL_PLATFORMS:
+        return False
+    # An OpenAI-compatible API stream can explicitly attach an authenticated
+    # approval notifier for this one request. The notifier is session-scoped,
+    # so its presence is the authoritative proof that a human-capable client
+    # can answer; ordinary API/webhook requests remain unattended and retain
+    # the configured fail-closed policy.
+    if platform != "api_server":
+        return True
+    session_key = get_current_session_key(default="")
+    with _lock:
+        return not bool(session_key and _gateway_notify_cbs.get(session_key))
 
 
 def _is_single_query_approval_context() -> bool:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,6 +112,33 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
+#### Interactive approvals and clarification
+
+Hermes-aware clients can opt into interactive prompts on either OpenAI-compatible endpoint by sending `"stream": true` and `"hermes": {"interactive": true}`. This mode requires a configured API server key; non-streaming interactive requests return `400`, and interactive requests to a server without a key return `403`. Requests without this opt-in keep the existing unattended approval behavior and do not expose the `clarify` tool.
+
+An interactive stream may emit either of these custom SSE events:
+
+- `event: hermes.approval.request` — includes `interaction_id`, `request_id`, the redacted command and description, and the permitted `choices` (`once`, `session`, `always`, or `deny` as allowed by the command guard).
+- `event: hermes.clarify.request` — includes `interaction_id`, `request_id`, the question, choices, `multi_select`, and optional batched `questions`.
+
+Answer the prompt with the same Bearer authentication used for the stream:
+
+```http
+POST /v1/interactions/{interaction_id}/response
+Authorization: Bearer <API_SERVER_KEY>
+Content-Type: application/json
+```
+
+```json
+{"type": "approval", "request_id": "approval_...", "choice": "once"}
+```
+
+```json
+{"type": "clarify", "request_id": "clarify_...", "response": "staging"}
+```
+
+For batched clarification, send `"answers": {"q0": "...", "q1": ["..."]}` instead of `response`. Approval and clarify waits retain their configured timeouts. Timeout, disconnect, hardline blocklist, and deny rules remain fail-closed; this protocol does not bypass or weaken command guards.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.


### PR DESCRIPTION
## What does this PR do?

OpenAI-compatible clients can now opt into authenticated, structured approval and clarification round trips on streaming `/v1/chat/completions` and `/v1/responses` requests. Without this change, dangerous commands are denied by the unattended policy and `clarify` is unavailable, leaving clients with no safe way to answer the agent. The new protocol is request-isolated and preserves timeout, deny, disconnect, and hardline protections.

### Symptom

API clients cannot receive pending approval or clarification events through the OpenAI-compatible endpoints. The default unattended approval policy denies dangerous commands, while changing it to automatic approval removes the human decision boundary.

### Impact

Clients such as OpenCode that use the OpenAI-compatible streaming APIs cannot complete agent turns that require a user decision without weakening approval policy globally.

### Bug Cause

**Trigger:** `gateway/platforms/api_server.py` streaming handlers create API agents without an approval notifier or clarification callback.

**Causal chain:**
1. An OpenAI-compatible request reaches a dangerous command or calls `clarify`.
2. The API agent has no authenticated interaction transport, and the API toolset omits `clarify`.
3. Approval falls through to the unattended deny policy, or structured clarification cannot be requested.

**Why it is wrong:** The API surface exposes agent tools but does not expose the decision channel required by those tools.

**Working sibling / contrast:** Native `/v1/runs` requests already expose structured approval state and a decision endpoint.

**Ruled out:** Changing `approvals.unattended_mode` is not a safe fix because automatic approval would weaken the default security boundary for every unattended API request.

### Fix

- Add an explicit `hermes.interactive` streaming opt-in for both OpenAI-compatible endpoints.
- Emit structured `hermes.approval.request` and `hermes.clarify.request` SSE events and accept authenticated responses through `/v1/interactions/{interaction_id}/response`.
- Scope pending prompts and approval callbacks to an opaque per-request interaction ID.
- Keep non-interactive requests unchanged and fail closed on invalid choices, timeout, disconnect, or missing authentication.

## Related Issue

Closes #99553

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` - add the opt-in interaction broker, SSE events, response route, and stream lifecycle cleanup.
- `tools/approval.py` - treat only API requests with a registered per-request notifier as interactive approval contexts.
- `tests/gateway/test_api_server.py` - cover authentication, stream-only enforcement, approval and clarification round trips, disconnect cleanup, and request isolation.
- `website/docs/user-guide/features/api-server.md` - document the request and response protocol.

## How to Test

1. Send a streaming request with `"hermes": {"interactive": true}` and valid Bearer authentication.
2. Answer the emitted approval or clarification event through its interaction response endpoint.
3. Run the focused gateway suites:

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_approval_prompt_redaction.py -q
```

Result: 126 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no workflow changed
- [x] I've considered cross-platform impact; the protocol and synchronization primitives are platform-neutral
- [x] Tool descriptions and schemas are N/A because no existing tool contract changed

## Screenshots / Logs

Focused automated coverage validates both OpenAI-compatible streaming formats and the authenticated interaction callback.