### PR TITLE
feat(gateway): add audio-only replies for voice turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4571,6 +4571,16 @@ def _reconnect_needs_attention(info: dict, now: float) -> bool:
     return (now - queued_at) >= _RECONNECT_ATTENTION_AFTER_SECONDS
 
 
+def _voice_turn_suppresses_text(message_type: Any, user_config: Any) -> bool:
+    """Return whether this inbound voice turn opted out of text delivery."""
+    if getattr(message_type, "value", message_type) != MessageType.VOICE.value:
+        return False
+    if not isinstance(user_config, dict):
+        return False
+    voice_config = user_config.get("voice")
+    return isinstance(voice_config, dict) and voice_config.get("suppress_text") is True
+
+
 class TurnRunner:
     """Per-turn collaborator carrying the tool-progress callbacks that used to
     be nested closures inside ``GatewayRunner._run_agent_inner``.
@@ -5774,6 +5784,8 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        if _voice_turn_suppresses_text(ctx.message_type, ctx.user_config):
+            _streaming_enabled = False
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
@@ -29966,6 +29978,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,
+            message_type=message_type,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -96,6 +96,9 @@ class TurnContext:
     # "internal_notification" for async-delegation/background notifications
     # (#82888). DB-only presentation metadata; never sent to the provider.
     persist_user_display_kind: Optional[str] = None
+    # Inbound type is needed before the agent starts so delivery policy can
+    # disable text streaming for an opt-in voice turn.
+    message_type: Any = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1950,6 +1950,8 @@ DEFAULT_CONFIG = {
         "submit_mode": "direct",       # TUI: direct submits immediately; draft leaves an editable transcript
         "max_recording_seconds": 120,
         "auto_tts": False,
+        # Voice input: deliver auto-TTS audio without a separate text stream.
+        "suppress_text": False,
         # Desktop remote clients call the profile's STT/TTS providers
         # DIRECTLY (config + key fetched over the authenticated REST channel
         # at voice-session start) instead of relaying audio through the

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -94,8 +94,7 @@ async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
     adapter._keep_typing = _hold_typing()
     adapter._should_auto_tts_for_chat = lambda _chat_id: True
     adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
-    long_reply = "x" * 2000  # avoid the telegram caption-collapse path
-    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result=long_reply))
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
     event = _make_voice_event(platform)
     requested = []
 
@@ -141,3 +140,15 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     adapter.play_tts.assert_not_awaited()
     # Text reply still goes out.
     assert adapter.sent and adapter.sent[0]["content"] == "reply text"
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_caption_suppresses_separate_text():
+    """A successful short Telegram voice reply is delivered as one audio bubble."""
+    adapter = _DummyAdapter(Platform.TELEGRAM)
+    requested, adapter = await _run_auto_tts(adapter, Platform.TELEGRAM)
+
+    assert requested and requested[0].endswith(".ogg")
+    adapter.play_tts.assert_awaited_once()
+    assert adapter.play_tts.await_args.kwargs["caption"] == "reply text"
+    assert adapter.sent == []

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
 from gateway.turn_context import TurnContext
 
@@ -47,6 +48,33 @@ class TestTurnContext:
         ctx = TurnContext(last_progress_msg=last_progress_msg)
         ctx.last_progress_msg[0] = "🔍 web_search"
         assert last_progress_msg[0] == "🔍 web_search"
+
+    def test_message_type_defaults_to_none(self):
+        assert TurnContext().message_type is None
+
+
+class TestVoiceTextSuppression:
+    def test_enabled_for_voice_turn(self):
+        from gateway.run import _voice_turn_suppresses_text
+
+        assert _voice_turn_suppresses_text(
+            MessageType.VOICE, {"voice": {"suppress_text": True}}
+        )
+
+    @pytest.mark.parametrize(
+        ("message_type", "config"),
+        [
+            (MessageType.TEXT, {"voice": {"suppress_text": True}}),
+            (MessageType.VOICE, {"voice": {"suppress_text": False}}),
+            (MessageType.VOICE, {}),
+            (MessageType.VOICE, {"voice": "invalid"}),
+            (None, {"voice": {"suppress_text": True}}),
+        ],
+    )
+    def test_disabled_for_non_matching_turns(self, message_type, config):
+        from gateway.run import _voice_turn_suppresses_text
+
+        assert not _voice_turn_suppresses_text(message_type, config)
 
 
 class TestTurnRunner:

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -111,6 +111,10 @@ class TestVoiceSubmitModeValidation:
         )
 
 
+def test_voice_text_suppression_is_opt_in():
+    assert DEFAULT_CONFIG["voice"]["suppress_text"] is False
+
+
 class TestUnknownTopLevelKeys:
     """Arbitrary top-level keys must NOT warn — they are bridged to os.environ.
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `voice.suppress_text` setting for audio-only replies to inbound voice messages. When enabled alongside auto-TTS, voice turns no longer stream a duplicate text bubble before the audio reply; text turns and the default configuration remain unchanged, and failed TTS still falls back to text delivery.

## Related Issue

Closes #99619

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` - disable platform text streaming only for opted-in inbound voice turns.
- `gateway/turn_context.py` - carry the inbound message type into per-turn delivery policy.
- `hermes_cli/config_defaults.py` - add the backward-compatible `voice.suppress_text: false` default.
- `tests/gateway/` - cover voice-only gating, successful caption delivery, and existing TTS failure fallback.
- `tests/hermes_cli/test_config_validation.py` - verify the setting remains opt-in by default.

## How to Test

1. Set `voice.auto_tts: true` and `voice.suppress_text: true`, then send a Telegram voice note. Verify one audio reply carries the text caption and no separate streamed text bubble is sent.
2. Force TTS synthesis to fail and verify the final text reply is still sent.
3. Send a text message, or leave `voice.suppress_text` unset, and verify existing text streaming behavior remains unchanged.
4. Run:

```bash
scripts/run_tests.sh tests/gateway/test_turn_context.py tests/gateway/test_base_auto_tts_output_format.py tests/hermes_cli/test_config_validation.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant configuration defaults and inline documentation are updated
- [x] `cli-config.yaml.example` is N/A because the repository has no matching voice section there
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change architecture or workflows
- [x] I've considered cross-platform impact; the gate uses platform-independent turn metadata
- [x] Tool descriptions and schemas are N/A because no model tool changed

## Screenshots / Logs

N/A - automated behavior tests cover the delivery gate and fallback paths.
