### PR TITLE
fix: support configurable IMAP and SMTP TLS modes

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -7,8 +7,12 @@ Uses IMAP to receive and SMTP to send messages.
 Environment variables:
     EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
+    EMAIL_IMAP_SECURITY — IMAP transport: tls, starttls, or plain (default: tls)
+    EMAIL_IMAP_TLS_VERIFY — Verify the IMAP TLS certificate (default: true)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
+    EMAIL_SMTP_SECURITY — SMTP transport: tls, starttls, or plain (port-based default)
+    EMAIL_SMTP_TLS_VERIFY — Verify the SMTP TLS certificate (default: true)
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
@@ -554,8 +558,26 @@ class EmailAdapter(BasePlatformAdapter):
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
+        self._imap_security = (
+            _get_secret("EMAIL_IMAP_SECURITY", "")
+            or extra.get("imap_security", "")
+            or "tls"
+        ).strip().lower()
+        self._imap_tls_verify = _esecret_bool(
+            "EMAIL_IMAP_TLS_VERIFY",
+            is_truthy_value(extra.get("imap_tls_verify"), default=True),
+        )
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
+        self._smtp_security = (
+            _get_secret("EMAIL_SMTP_SECURITY", "")
+            or extra.get("smtp_security", "")
+            or ("tls" if self._smtp_port == 465 else "starttls")
+        ).strip().lower()
+        self._smtp_tls_verify = _esecret_bool(
+            "EMAIL_SMTP_TLS_VERIFY",
+            is_truthy_value(extra.get("smtp_tls_verify"), default=True),
+        )
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
@@ -627,6 +649,40 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    @staticmethod
+    def _tls_context(verify: bool) -> ssl.SSLContext:
+        """Return a verified context unless loopback/custom TLS opts out."""
+        return ssl.create_default_context() if verify else ssl._create_unverified_context()
+
+    def _connect_imap(self) -> imaplib.IMAP4:
+        """Create an IMAP connection using implicit TLS, STARTTLS, or plaintext."""
+        security = self._imap_security.replace("_", "-")
+        valid_modes = {
+            "tls", "ssl", "implicit", "implicit-tls",
+            "starttls", "start-tls",
+            "none", "plain", "plaintext",
+        }
+        if security not in valid_modes:
+            raise ValueError(
+                "Unsupported EMAIL_IMAP_SECURITY value: " + self._imap_security
+            )
+        if security in {"tls", "ssl", "implicit", "implicit-tls"}:
+            return imaplib.IMAP4_SSL(
+                self._imap_host,
+                self._imap_port,
+                timeout=30,
+                ssl_context=self._tls_context(self._imap_tls_verify),
+            )
+
+        imap = imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
+        if security in {"starttls", "start-tls"}:
+            try:
+                imap.starttls(ssl_context=self._tls_context(self._imap_tls_verify))
+            except Exception:
+                _close_imap(imap)
+                raise
+        return imap
+
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
 
@@ -642,22 +698,33 @@ class EmailAdapter(BasePlatformAdapter):
         Returns a connected SMTP object with TLS established — callers
         can proceed directly to ``login()``.
         """
-        ctx = ssl.create_default_context()
+        ctx = self._tls_context(self._smtp_tls_verify)
         host = self._smtp_host
         port = self._smtp_port
+        security = self._smtp_security.replace("_", "-")
+        valid_modes = {
+            "tls", "ssl", "implicit", "implicit-tls",
+            "starttls", "start-tls",
+            "none", "plain", "plaintext",
+        }
+        if security not in valid_modes:
+            raise ValueError(
+                "Unsupported EMAIL_SMTP_SECURITY value: " + self._smtp_security
+            )
 
         def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
             """Attempt one SMTP connection."""
             smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
             smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
-            if port == 465:
+            if security in {"tls", "ssl", "implicit", "implicit-tls"}:
                 return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
             smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
-            try:
-                smtp.starttls(context=ctx)
-            except Exception:
-                smtp.close()
-                raise
+            if security in {"starttls", "start-tls"}:
+                try:
+                    smtp.starttls(context=ctx)
+                except Exception:
+                    smtp.close()
+                    raise
             return smtp
 
         try:
@@ -711,7 +778,7 @@ class EmailAdapter(BasePlatformAdapter):
             # (#79889).
             imap = None
             try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                imap = self._connect_imap()
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
@@ -855,7 +922,7 @@ class EmailAdapter(BasePlatformAdapter):
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -1450,9 +1517,25 @@ async def _standalone_send(
         smtp_port = int(_get_secret("EMAIL_SMTP_PORT", "587") or "587")
     except (ValueError, TypeError):
         smtp_port = 587
+    smtp_security = (
+        _get_secret("EMAIL_SMTP_SECURITY", "")
+        or str(extra.get("smtp_security") or "")
+        or ("tls" if smtp_port == 465 else "starttls")
+    ).strip().lower().replace("_", "-")
+    smtp_tls_verify = _esecret_bool(
+        "EMAIL_SMTP_TLS_VERIFY",
+        is_truthy_value(extra.get("smtp_tls_verify"), default=True),
+    )
+    valid_modes = {
+        "tls", "ssl", "implicit", "implicit-tls",
+        "starttls", "start-tls",
+        "none", "plain", "plaintext",
+    }
 
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
+    if smtp_security not in valid_modes:
+        return {"error": "Unsupported EMAIL_SMTP_SECURITY value: " + smtp_security}
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
@@ -1461,8 +1544,21 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
+        ctx = (
+            _ssl.create_default_context()
+            if smtp_tls_verify
+            else _ssl._create_unverified_context()
+        )
+        if smtp_security in {"tls", "ssl", "implicit", "implicit-tls"}:
+            server = smtplib.SMTP_SSL(smtp_host, smtp_port, context=ctx)
+        else:
+            server = smtplib.SMTP(smtp_host, smtp_port)
+            if smtp_security in {"starttls", "start-tls"}:
+                try:
+                    server.starttls(context=ctx)
+                except Exception:
+                    server.close()
+                    raise
         server.login(address, password)
         server.send_message(msg)
         server.quit()

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -684,10 +684,11 @@ class EmailAdapter(BasePlatformAdapter):
         return imap
 
     def _connect_smtp(self) -> smtplib.SMTP:
-        """Create an SMTP connection, selecting the correct protocol for the port.
+        """Create an SMTP connection using the configured transport mode.
 
-        Port 465 uses implicit TLS (``SMTP_SSL``).  All other ports use
-        ``SMTP`` + ``STARTTLS``.
+        By default port 465 uses implicit TLS (``SMTP_SSL``), while other
+        ports use ``SMTP`` + ``STARTTLS``.  ``EMAIL_SMTP_SECURITY`` can
+        explicitly select implicit TLS, STARTTLS, or plaintext.
 
         When the host resolves to an IPv6 address that is unreachable
         (common on networks without IPv6 routing), the default connection can
@@ -695,8 +696,8 @@ class EmailAdapter(BasePlatformAdapter):
         failures through an IPv4-only socket path, without mutating global
         resolver state.  TLS verification errors are not retried.
 
-        Returns a connected SMTP object with TLS established — callers
-        can proceed directly to ``login()``.
+        Returns a connected SMTP object with the requested transport ready;
+        callers can proceed directly to ``login()``.
         """
         ctx = self._tls_context(self._smtp_tls_verify)
         host = self._smtp_host

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -21,9 +21,29 @@ requires_env:
     prompt: "SMTP host"
     password: false
 optional_env:
+  - name: EMAIL_IMAP_PORT
+    description: "IMAP port (default 993)"
+    prompt: "IMAP port"
+    password: false
+  - name: EMAIL_IMAP_SECURITY
+    description: "IMAP transport: tls, starttls, or plain (default tls)"
+    prompt: "IMAP security mode"
+    password: false
+  - name: EMAIL_IMAP_TLS_VERIFY
+    description: "Verify the IMAP TLS certificate (default true)"
+    prompt: "Verify IMAP TLS certificate"
+    password: false
   - name: EMAIL_SMTP_PORT
     description: "SMTP port (default 587)"
     prompt: "SMTP port"
+    password: false
+  - name: EMAIL_SMTP_SECURITY
+    description: "SMTP transport: tls, starttls, or plain (default depends on port)"
+    prompt: "SMTP security mode"
+    password: false
+  - name: EMAIL_SMTP_TLS_VERIFY
+    description: "Verify the SMTP TLS certificate (default true)"
+    prompt: "Verify SMTP TLS certificate"
     password: false
   - name: EMAIL_IMAP_HOST
     description: "IMAP host for inbound polling (e.g. imap.gmail.com)"

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -85,7 +85,7 @@ class TestMailSecurityModes(unittest.TestCase):
         "EMAIL_SMTP_PORT": "1025",
         "EMAIL_SMTP_SECURITY": "starttls",
         "EMAIL_SMTP_TLS_VERIFY": "false",
-    })
+    }, clear=True)
     def test_starttls_uses_plain_clients_and_unverified_contexts(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.email.adapter import EmailAdapter
@@ -126,7 +126,7 @@ class TestMailSecurityModes(unittest.TestCase):
         "EMAIL_SMTP_PORT": "1025",
         "EMAIL_SMTP_SECURITY": "starttls",
         "EMAIL_SMTP_TLS_VERIFY": "false",
-    })
+    }, clear=True)
     def test_standalone_sender_honors_starttls_without_delivery(self):
         from plugins.platforms.email.adapter import _standalone_send
 
@@ -148,6 +148,60 @@ class TestMailSecurityModes(unittest.TestCase):
             ssl.CERT_NONE,
         )
         smtp.send_message.assert_called_once()
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "127.0.0.1",
+        "EMAIL_IMAP_SECURITY": "plain",
+        "EMAIL_SMTP_HOST": "127.0.0.1",
+        "EMAIL_SMTP_SECURITY": "plain",
+    }, clear=True)
+    def test_plain_mode_skips_tls_for_imap_and_smtp(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        imap = MagicMock()
+        smtp = MagicMock()
+        with patch("imaplib.IMAP4", return_value=imap), \
+             patch("imaplib.IMAP4_SSL") as imap_ssl_cls, \
+             patch("smtplib.SMTP", return_value=smtp), \
+             patch("smtplib.SMTP_SSL") as smtp_ssl_cls:
+            self.assertIs(adapter._connect_imap(), imap)
+            self.assertIs(adapter._connect_smtp(), smtp)
+
+        imap_ssl_cls.assert_not_called()
+        imap.starttls.assert_not_called()
+        smtp_ssl_cls.assert_not_called()
+        smtp.starttls.assert_not_called()
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "127.0.0.1",
+        "EMAIL_IMAP_SECURITY": "invalid",
+        "EMAIL_SMTP_HOST": "127.0.0.1",
+        "EMAIL_SMTP_SECURITY": "invalid",
+    }, clear=True)
+    def test_invalid_modes_fail_before_opening_connections(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        with patch("imaplib.IMAP4") as imap_cls, \
+             patch("imaplib.IMAP4_SSL") as imap_ssl_cls, \
+             patch("smtplib.SMTP") as smtp_cls, \
+             patch("smtplib.SMTP_SSL") as smtp_ssl_cls:
+            with self.assertRaisesRegex(ValueError, "EMAIL_IMAP_SECURITY"):
+                adapter._connect_imap()
+            with self.assertRaisesRegex(ValueError, "EMAIL_SMTP_SECURITY"):
+                adapter._connect_smtp()
+
+        imap_cls.assert_not_called()
+        imap_ssl_cls.assert_not_called()
+        smtp_cls.assert_not_called()
+        smtp_ssl_cls.assert_not_called()
 
 
 class TestMessageIdDomain(unittest.TestCase):

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -6,10 +6,13 @@ Validates that:
 - Message-ID generation handles a missing '@' in EMAIL_ADDRESS
 """
 
+import asyncio
 import os
+import ssl
 import unittest
 import uuid
 from email.mime.text import MIMEText
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -66,6 +69,85 @@ class TestImapResponseGuard(unittest.TestCase):
     def test_none_element_skipped(self):
         results = self._fetch_with([("OK", [None])])
         self.assertEqual(results, [])
+
+
+class TestMailSecurityModes(unittest.TestCase):
+    """Explicit bridge TLS settings are honored by IMAP and SMTP paths."""
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "127.0.0.1",
+        "EMAIL_IMAP_PORT": "1143",
+        "EMAIL_IMAP_SECURITY": "starttls",
+        "EMAIL_IMAP_TLS_VERIFY": "false",
+        "EMAIL_SMTP_HOST": "127.0.0.1",
+        "EMAIL_SMTP_PORT": "1025",
+        "EMAIL_SMTP_SECURITY": "starttls",
+        "EMAIL_SMTP_TLS_VERIFY": "false",
+    })
+    def test_starttls_uses_plain_clients_and_unverified_contexts(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        imap = MagicMock()
+        smtp = MagicMock()
+        with patch("imaplib.IMAP4", return_value=imap) as imap_cls, \
+             patch("imaplib.IMAP4_SSL") as imap_ssl_cls, \
+             patch("smtplib.SMTP", return_value=smtp) as smtp_cls, \
+             patch("smtplib.SMTP_SSL") as smtp_ssl_cls:
+            self.assertIs(adapter._connect_imap(), imap)
+            self.assertIs(adapter._connect_smtp(), smtp)
+
+        imap_cls.assert_called_once_with("127.0.0.1", 1143, timeout=30)
+        imap_ssl_cls.assert_not_called()
+        imap.starttls.assert_called_once()
+        self.assertIsInstance(
+            imap.starttls.call_args.kwargs["ssl_context"], ssl.SSLContext
+        )
+        self.assertEqual(
+            imap.starttls.call_args.kwargs["ssl_context"].verify_mode,
+            ssl.CERT_NONE,
+        )
+        smtp_cls.assert_called_once()
+        smtp_ssl_cls.assert_not_called()
+        smtp.starttls.assert_called_once()
+        self.assertEqual(
+            smtp.starttls.call_args.kwargs["context"].verify_mode,
+            ssl.CERT_NONE,
+        )
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "127.0.0.1",
+        "EMAIL_SMTP_PORT": "1025",
+        "EMAIL_SMTP_SECURITY": "starttls",
+        "EMAIL_SMTP_TLS_VERIFY": "false",
+    })
+    def test_standalone_sender_honors_starttls_without_delivery(self):
+        from plugins.platforms.email.adapter import _standalone_send
+
+        smtp = MagicMock()
+        with patch("smtplib.SMTP", return_value=smtp) as smtp_cls, \
+             patch("smtplib.SMTP_SSL") as smtp_ssl_cls:
+            result = asyncio.run(_standalone_send(
+                SimpleNamespace(extra={}),
+                "nobody@example.invalid",
+                "test",
+            ))
+
+        self.assertEqual(result["success"], True)
+        smtp_cls.assert_called_once_with("127.0.0.1", 1025)
+        smtp_ssl_cls.assert_not_called()
+        smtp.starttls.assert_called_once()
+        self.assertEqual(
+            smtp.starttls.call_args.kwargs["context"].verify_mode,
+            ssl.CERT_NONE,
+        )
+        smtp.send_message.assert_called_once()
 
 
 class TestMessageIdDomain(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add explicit `tls`, `starttls`, and `plain` transport modes for IMAP and SMTP
- honor `EMAIL_IMAP_TLS_VERIFY` and `EMAIL_SMTP_TLS_VERIFY`, including profile config fallbacks
- use the same SMTP transport settings in standalone/cron delivery
- expose the new connection settings in the email plugin manifest

## Problem

The email adapter always opened IMAP with `IMAP4_SSL`, regardless of the server's transport mode. Local mail bridges and other servers that expose plaintext IMAP followed by STARTTLS therefore fail with `SSL: WRONG_VERSION_NUMBER` even when STARTTLS is configured.

SMTP certificate verification was also always enabled, and the standalone sender did not share configurable transport behavior.

Defaults preserve the existing behavior: implicit TLS for IMAP, implicit TLS on SMTP port 465, and STARTTLS on other SMTP ports. Certificate verification remains enabled unless explicitly disabled.

## Test plan

- `python -m unittest tests.gateway.test_email_robustness tests.gateway.test_email`
  - 46 tests passed
- security-mode tests also pass with conflicting `EMAIL_*` values in the outer environment
- `git diff --check`
- plugin manifest parsed and checked for duplicate/new optional environment entries

No live email was sent by the tests; SMTP clients are mocked.
