### PR TITLE
chore: AUTHOR_MAP entries for fangliquanflq (99265) and sycamoregroupltd (97779)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -254,6 +254,8 @@ LEGACY_AUTHOR_MAP = {
     "dale@dalenguyen.me": "dalenguyen",  # PR #53678 salvage (strip VIRTUAL_ENV/CONDA_PREFIX from terminal subprocess env; #23473)
     "prashantjain25@gmail.com": "prashantjain25",  # PR #80740 salvage (custom-endpoint /v1/models disk cache; #72762)
     "liruixinch@outlook.com": "HexLab98",  # PR #53863 salvage (env-only proxy policy for auxiliary OpenAI clients on macOS; #53702)
+    "fangliquan@qq.com": "fangliquanflq",  # PR #99265 (linear lowercase env-assignment redaction; #99255) - merged directly by maintainer
+    "devops@sycamore.group": "sycamoregroupltd",  # PR #97779 salvage (estop fleet-root sentinel for profile gateways)
     "blaryx@gmail.com": "Blaryxoff",  # PR #32602 salvage (deep-merge PUT /api/config to preserve unrelated sections; #13396)
     "diamondeyesfox@gmail.com": "DiamondEyesFox",  # PR #53351 salvage (rebaseline in-place compression flushes to prevent duplicate compacted rows; #9096)
     "piyrw9754@gmail.com": "rlaope",  # PR #35075 salvage (align cron invisible-unicode set with install-time scanner; #35075)


### PR DESCRIPTION
## Summary
Adds two AUTHOR_MAP entries so check-attribution passes and release notes credit the right accounts for this session's salvages.

## Changes
- `scripts/release.py` — map `fangliquan@qq.com` → `fangliquanflq` (PR #99265, merged directly by maintainer with the email still unmapped) and `devops@sycamore.group` → `sycamoregroupltd` (PR #97779, estop fleet-root sentinel salvage).

## Validation
- `python -m py_compile scripts/release.py` passes.
- Both logins verified against the GitHub API (`gh api users/<login>`): fangliquanflq id=280272527, sycamoregroupltd id=58149681.
