### PR TITLE
feat(cli): opt-in 'cost' status-bar field showing live session spend

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6624,6 +6624,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        # Running estimated session cost (USD) — consumed by the opt-in
+        # "cost" status-bar field. Mirrors what /usage and state.db report.
+        snapshot["session_estimated_cost_usd"] = getattr(agent, "session_estimated_cost_usd", 0) or 0
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -7594,6 +7597,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             total_tokens = snapshot.get("session_total_tokens", 0)
             if total_tokens and field_set is not None and "total_tokens" in field_set:
                 parts.append(f"Σ{format_token_count_compact(total_tokens)}")
+            # Session cost ($) — same opt-in contract as total_tokens.
+            # Deferred import keeps the render path exception-isolated and the
+            # module import graph unchanged. Reuses format_cost_label so the
+            # sub-cent honesty rules from #79220 apply verbatim here.
+            if field_set is not None and "cost" in field_set:
+                try:
+                    from agent.usage_pricing import format_cost_label as _fcl
+                    from decimal import Decimal as _D
+                    parts.append(_fcl(_D(str(snapshot.get("session_estimated_cost_usd", 0) or 0))))
+                except Exception:
+                    pass
             if not parts:
                 parts = [f"⚕ {snapshot['model_short']}"]
             return self._right_align_status_title(" │ ".join(parts), session_title, width)
@@ -7760,6 +7774,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     total_tokens = snapshot.get("session_total_tokens", 0)
                     if total_tokens and field_set is not None and "total_tokens" in field_set:
                         _append(frags, " │ ", ("class:status-bar-dim", f"Σ{format_token_count_compact(total_tokens)}"))
+                    # Session cost ($) — same opt-in contract as total_tokens.
+                    if field_set is not None and "cost" in field_set:
+                        try:
+                            from agent.usage_pricing import format_cost_label as _fcl
+                            from decimal import Decimal as _D
+                            _cost_lbl = _fcl(_D(str(snapshot.get("session_estimated_cost_usd", 0) or 0)))
+                            _append(frags, " │ ", ("class:status-bar-dim", _cost_lbl))
+                        except Exception:
+                            pass
                     if not frags:
                         frags = [
                             ("class:status-bar", " ⚕ "),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1634,9 +1634,9 @@ DEFAULT_CONFIG = {
         # default set. Available: model, context_detail, context_pct,
         # cache_hit, latency, tps, compressions, bg_tasks, bg_processes,
         # bg_subagents, goal, duration, prompt_elapsed, idle_since, focus,
-        # yolo, stash, battery, title, total_tokens.
-        # total_tokens (session Σ) is opt-in only — it never shows unless
-        # listed here. Narrow terminals still drop wide-mode-only fields
+        # yolo, stash, battery, title, total_tokens, cost.
+        # total_tokens (session Σ) and cost (session $) are opt-in only —
+        # they never show unless listed here. Narrow terminals still drop wide-mode-only fields
         # (context_detail, prompt_elapsed, idle_since) regardless of config.
         "status_bar": {
             "fields": [],  # empty = built-in defaults (all fields)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -453,6 +453,89 @@ class TestStatusBarFieldConfig:
             text = cli_obj._build_status_bar_text(width=120)
         assert "Σ" not in text
 
+    def test_cost_when_explicitly_requested(self):
+        """cost field renders a $ label from session_estimated_cost_usd."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=7,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 0.0046
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "cost"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "$0.0046" in text
+        assert "claude-sonnet-4-20250514" in text
+
+    def test_cost_zero_renders_dollar_zero(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=7,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 0.0
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "cost"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "$0.00" in text
+
+    def test_cost_sub_cent_under_threshold_shows_floor_label(self):
+        """A positive cost that rounds to $0.0000 at 4dp must not read as zero."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=7,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 0.00001
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "cost"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "~$<0.0001" in text
+
+    def test_cost_normal_amount_two_dp(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=7,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 1.234
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "cost"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "$1.23" in text
+
+    def test_cost_hidden_by_default(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=7,
+        )
+        cli_obj.agent.session_estimated_cost_usd = 0.0046
+        with patch.object(cli_mod, "CLI_CONFIG", {}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "$0.0046" not in text
+
     def test_narrow_terminal_drops_context_detail(self):
         """Narrow terminal (<76) ignores context_detail even if configured."""
         text = self._cli_with_fields(["model", "context_detail", "duration"], width=60)


### PR DESCRIPTION
## Summary
Adds a `cost` field to the CLI/TUI status bar's `display.status_bar.fields` config. When explicitly listed, the bar renders the running session spend from `agent.session_estimated_cost_usd` via `format_cost_label`, so it inherits the sub-cent honesty rules from #79220:

- `$0.00` for zero
- `~$0.0046` (4 dp) for sub-cent amounts
- `~$<0.0001` when a positive amount would round to zero at 4 dp
- `~$1.23` (2 dp) for normal magnitudes

Follows the exact opt-in contract of `total_tokens` (Σ): **default bars never widen** — the field only appears when listed:

```yaml
display:
  status_bar:
    fields: [model, context_detail, context_pct, cache_hit, latency, tps, duration, cost]
```

Both renderers are supported: the plain-text path (`_build_status_bar_text`) and the prompt_toolkit fragment path (`_get_status_bar_fragments`). The available-fields documentation in `config_defaults.py` now lists `cost` alongside `total_tokens`.

## Motivation
The per-session cost is already tracked (`session_estimated_cost_usd`, persisted to `state.db` and surfaced by `/usage`), but there was no way to see it at a glance while working. This puts live spend in the existing telemetry bar without changing anything for users who don't ask for it.

## Test plan
- 5 new tests in `TestStatusBarFieldConfig` (`tests/cli/test_cli_status_bar.py`): opt-in render, zero, sub-cent floor label, 2 dp normal, hidden-by-default
- Full `TestStatusBarFieldConfig` + `TestCLIStatusBar` suites pass (53/53)
- Verified the remaining `tests/cli` failures on this machine (worktree, bang-shell, PTY/terminal-compat tests) reproduce identically on clean `origin/main` — pre-existing Windows-PTY issues, unrelated to this change