### PR TITLE
fix(redact): keep dotted config-key scans linear past the keyword pre-gate

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -204,7 +204,14 @@ _ENV_LOOKUP_VALUE_RE = re.compile(
 # ``(?:[A-Za-z0-9_\-]+\.)+`` (exponential backtracking on long dotted runs).
 # The ``*`` runs bordering {_SECRET_CFG_NAMES} must stay backtrackable
 # (secret words are matchable by the class, e.g. ``app.api.key=…``).
+# The lookbehind anchors each attempt to the start of a key run: without it,
+# ``re.sub`` retries the backtrackable ``*`` prefix at every byte of a long
+# non-matching dotted run, making the sub quadratic whenever the text contains
+# a secret keyword anywhere (the ``_CFG_SECRET_WORD_RE`` pre-gate only skips
+# secret-free text). Match set is unchanged — any match starting mid-run
+# implies a leftmost match starting at the run start (#99255).
 _CFG_DOTTED_RE = re.compile(
+    rf"(?<![A-Za-z0-9_.\-])"
     rf"([A-Za-z0-9_\-]++\.[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*+"
     rf"|[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]++)"
     rf"={_CFG_VALUE}",

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -690,6 +690,23 @@ class TestConfigKeyRedosResistance:
         assert redact_sensitive_text(text, force=True) == text
         assert time.perf_counter() - t0 < 2.0
 
+    def test_dotted_cfg_scan_stays_linear_with_keyword_elsewhere(self):
+        """_CFG_DOTTED_RE must stay linear once the pre-gate passes.
+
+        The ``_CFG_SECRET_WORD_RE`` pre-gate only skips secret-FREE text, so a
+        payload that contains a real secret assignment AND a long opaque
+        dotted run still reaches the backtrackable ``*`` prefix. Without the
+        run-start lookbehind the sub retries that prefix from every byte of
+        the run (quadratic while holding the GIL).
+        """
+        import time
+
+        text = "password=hunter2\n" + "a." * 15_000 + "=value"
+        t0 = time.perf_counter()
+        result = redact_sensitive_text(text, force=True)
+        assert "hunter2" not in result
+        assert time.perf_counter() - t0 < 2.0
+
     def test_yaml_assign_redos_resistance(self):
         """_YAML_ASSIGN_RE must not backtrack excessively on long inputs."""
         import time


### PR DESCRIPTION
## Summary
`_CFG_DOTTED_RE` redaction stays linear once the secret-keyword pre-gate passes, closing the residual quadratic-scan path the #99265 fix left open.

## What it does
`redact_sensitive_text(force=True)` skips the `_CFG_*_RE` subs only when the text contains NO secret keyword (`_CFG_SECRET_WORD_RE` pre-gate). A compaction payload containing one real secret assignment **plus** a long opaque dotted run (base64/hex blob ending in `=value`) still reaches `_CFG_DOTTED_RE`'s backtrackable `[A-Za-z0-9_.\-]*` prefix, which `re.sub` retries from every byte of the run — quadratic while holding the GIL, same class as #99255.

Anchor each attempt to the start of a key run with a negative lookbehind (same technique main just merged for `_ENV_ASSIGN_LOWER_RE` in #99265).

## Changes
- `agent/redact.py` — add `(?<![A-Za-z0-9_.\-])` run-start anchor to `_CFG_DOTTED_RE` + comment explaining the residual path
- `tests/agent/test_redact.py` — `test_dotted_cfg_scan_stays_linear_with_keyword_elsewhere`: secret + 30k dotted run must complete < 2s with the secret masked

## Validation
| Shape | Pre-fix (origin/main) | With fix |
|---|---|---|
| 30k-char dotted run + secret keyword elsewhere | 102.5s | 0.015s |
| Match set (20-case dotted-config corpus, old vs new regex) | — | 20/20 identical |
| Mutation check (lookbehind removed) | new test FAILS (88s) | passes (0.7s) |
| tests/agent/test_redact.py | — | 99 passed |

Match-set preservation argument: any match starting mid-run implies a leftmost match starting at the run start (the prefix class `[A-Za-z0-9_.\-]*` is a superset of every suffix of itself), so `re.sub`'s leftmost scan reports the same matches either way — verified empirically over the corpus above.

This is the sibling-site widening for #99265 (already merged by maintainer) — found during that PR's review per the fix-the-whole-bug-class rule. Credit to @fangliquanflq for the original lookbehind technique.
