### PR TITLE
fix(cron): bind generated session id into task context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5825,6 +5825,7 @@ def run_job(
         platform="",
         chat_id="",
         chat_name="",
+        session_id=_cron_session_id,
         # A cron job cannot receive a completion after its turn ends. We clear the
         # HERMES_SESSION_* routing keys just below, so an async delegation's
         # completion event carries session_key="" — _enrich_async_delegation_routing

--- a/tests/cron/test_scheduler_cron_session_isolation.py
+++ b/tests/cron/test_scheduler_cron_session_isolation.py
@@ -45,6 +45,8 @@ class _FakeCronAgent:
         assert result["approved"] is False
         assert result["outcome"] == "blocked"
         assert get_session_env("HERMES_CRON_SESSION") == "1"
+        session_id = get_session_env("HERMES_SESSION_ID")
+        assert session_id.startswith("cron_ctx-isolation_")
         return {
             "completed": True,
             "failed": False,


### PR DESCRIPTION
## Summary

- bind each scheduler-generated cron session ID into the task-local Hermes session context
- preserve the existing cron marker and routing isolation
- add a regression assertion that cron agents observe the generated `cron_<job>_<timestamp>` session ID

## Problem

The scheduler generated `_cron_session_id` for persistence, but did not pass it to `set_session_vars()`. Integrations that validate genuine scheduler authority from both `HERMES_CRON_SESSION=1` and the scheduler-shaped `HERMES_SESSION_ID` therefore rejected legitimate cron runs.

## Verification

```text
python -m pytest tests/cron/test_scheduler_cron_session_isolation.py tests/tools/test_cron_approval_mode.py tests/gateway/test_session_env.py -q -o 'addopts='
40 passed
```

## Risk

Low. This sets the already-generated session identifier in the existing task-local ContextVar scope; cleanup remains handled by the existing token reset path.
