### PR TITLE
fix(estop): honor canonical ~/.hermes/ESTOP from profile gateways (salvage #97779)

### DIFF
--- a/agent/estop.py
+++ b/agent/estop.py
@@ -10,9 +10,9 @@
   agent run (``gateway/run.py:_handle_message``).
 
 In-flight work is NEVER killed — this is pause-new-work, not panic/exit.
-The check is a single ``os.stat`` so callers may run it every tick; no
-caching beyond the OS is performed, so engaging/disengaging takes effect on
-the very next check.
+The check is one or two ``os.stat`` calls (process home + fleet root when
+they differ) so callers may run it every tick; no caching beyond the OS is
+performed, so engaging/disengaging takes effect on the very next check.
 
 The sentinel body is optional JSON ``{"reason": ..., "engaged_at": ...}``.
 A corrupt or empty file still counts as engaged (fail safe): the pause must
@@ -79,14 +79,12 @@ def _candidate_sentinel_paths() -> list:
         root = _canonical_root() / SENTINEL_NAME
     except Exception:
         return paths
-    if not isinstance(primary, Path):
-        # Test doubles (e.g. fail-safe stat fixture) are not Path objects.
-        paths.append(root)
-        return paths
     try:
         if root.resolve() != primary.resolve():
             paths.append(root)
     except Exception:
+        # Non-Path test doubles (fail-safe stat fixture) fail .resolve();
+        # the generic comparison below still dedupes plain equal paths.
         if root != primary:
             paths.append(root)
     return paths

--- a/agent/estop.py
+++ b/agent/estop.py
@@ -51,24 +51,62 @@ def _hermes_home() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+def _canonical_root() -> Path:
+    """Fleet-wide Hermes root, even when this process is a profile gateway.
+
+    Profile gateways launch with HERMES_HOME=~/.hermes/profiles/<name>.
+    ``hermes pause`` from an operator seat writes ~/.hermes/ESTOP. If we
+    only inspect the profile home, the emergency stop does not bind
+    (jarvis-os/t_7b65ff88: fleet-analyst kept dispatching through pause).
+    """
+    try:
+        from hermes_constants import get_default_hermes_root
+        return Path(get_default_hermes_root())
+    except Exception:
+        return Path(os.path.expanduser("~/.hermes"))
+
+
 def sentinel_path() -> Path:
-    """Path of the ESTOP sentinel under the active HERMES_HOME."""
+    """Path of the ESTOP sentinel this process would write on `hermes pause`."""
     return _hermes_home() / SENTINEL_NAME
 
 
-def is_engaged() -> bool:
-    """Cheap check (one stat): is the global emergency stop engaged?
-
-    Fail SAFE on stat errors: if we cannot determine whether the sentinel
-    exists (permission error, transient I/O failure on HERMES_HOME), report
-    engaged. The module contract is that the pause must hold even when the
-    sentinel is unreadable — a fail-open here would silently lift an
-    operator's emergency stop exactly when the filesystem is misbehaving.
-    """
+def _candidate_sentinel_paths() -> list:
+    """Profile home first, then the fleet root if it is a different directory."""
+    primary = sentinel_path()
+    paths = [primary]
     try:
-        return sentinel_path().exists()
-    except OSError:
-        return True
+        root = _canonical_root() / SENTINEL_NAME
+    except Exception:
+        return paths
+    if not isinstance(primary, Path):
+        # Test doubles (e.g. fail-safe stat fixture) are not Path objects.
+        paths.append(root)
+        return paths
+    try:
+        if root.resolve() != primary.resolve():
+            paths.append(root)
+    except Exception:
+        if root != primary:
+            paths.append(root)
+    return paths
+
+
+def is_engaged() -> bool:
+    """Cheap check: is the global emergency stop engaged?
+
+    Engaged if ANY candidate sentinel exists: the process HERMES_HOME
+    (profile-local) or the fleet canonical root (~/.hermes). Fail SAFE on
+    stat errors so an unreadable sentinel still holds the pause.
+    """
+    saw_stat_error = False
+    for path in _candidate_sentinel_paths():
+        try:
+            if path.exists():
+                return True
+        except OSError:
+            saw_stat_error = True
+    return saw_stat_error
 
 
 def engage(reason: Optional[str] = None) -> Path:
@@ -91,14 +129,22 @@ def engage(reason: Optional[str] = None) -> Path:
 
 
 def disengage() -> bool:
-    """Remove the ESTOP sentinel. Returns True if a pause was lifted."""
-    try:
-        sentinel_path().unlink()
-        return True
-    except FileNotFoundError:
-        return False
-    except OSError:
-        return False
+    """Remove ESTOP sentinels this process can see.
+
+    Lifts both the process-local sentinel and the fleet-root sentinel so
+    ``hermes resume`` from a profile gateway still clears an operator pause
+    written at ~/.hermes/ESTOP.
+    """
+    lifted = False
+    for path in _candidate_sentinel_paths():
+        try:
+            path.unlink()
+            lifted = True
+        except FileNotFoundError:
+            continue
+        except (OSError, AttributeError):
+            continue
+    return lifted
 
 
 def get_state() -> Optional[dict]:
@@ -107,18 +153,31 @@ def get_state() -> Optional[dict]:
     A sentinel with an unreadable/corrupt body still reports engaged, with
     both fields None — the pause is authoritative, the metadata is not.
     """
-    path = sentinel_path()
-    if not path.exists():
+    if not is_engaged():
         return None
     reason = None
     engaged_at = None
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(raw, dict):
-            reason = raw.get("reason") or None
-            engaged_at = raw.get("engaged_at") or None
-    except (OSError, ValueError):
-        pass
+    found = False
+    for path in _candidate_sentinel_paths():
+        try:
+            exists = path.exists()
+        except OSError:
+            return {"reason": None, "engaged_at": None}
+        except AttributeError:
+            continue
+        if not exists:
+            continue
+        found = True
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                reason = raw.get("reason") or None
+                engaged_at = raw.get("engaged_at") or None
+                break
+        except (OSError, ValueError, AttributeError):
+            continue
+    if not found:
+        return None
     return {"reason": reason, "engaged_at": engaged_at}
 
 

--- a/tests/test_estop.py
+++ b/tests/test_estop.py
@@ -376,3 +376,31 @@ def test_pause_command_registered_for_gateway():
     assert "pause" in GATEWAY_KNOWN_COMMANDS
     # Must be dispatchable while an agent is running (in-band emergency stop).
     assert cmd.busy_policy == "dispatch"
+
+
+def test_profile_gateway_honors_canonical_root_estop(tmp_path, monkeypatch):
+    """fleet-analyst-class: HERMES_HOME is a profile dir; pause lives at root.
+
+    A process launched with HERMES_HOME=~/.hermes/profiles/fleet-analyst must
+    still treat ~/.hermes/ESTOP as engaged. Otherwise `hermes pause` is not
+    a global emergency stop (t_7b65ff88).
+    """
+    root = tmp_path / "hermes-root"
+    profile = root / "profiles" / "fleet-analyst"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    estop._reset_log_state_for_tests()
+
+    assert estop.is_engaged() is False
+    (root / "ESTOP").write_text("{\"reason\": \"thundering herd\"}\n", encoding="utf-8")
+    assert estop.is_engaged() is True
+    assert estop.paused_reply() is not None
+    assert "paused" in estop.paused_reply().lower()
+    # Profile-local engage still works and is independent.
+    estop.engage(reason="local")
+    assert (profile / "ESTOP").exists()
+    assert estop.is_engaged() is True
+    (root / "ESTOP").unlink()
+    assert estop.is_engaged() is True  # still held by profile sentinel
+    estop.disengage()
+    assert estop.is_engaged() is False


### PR DESCRIPTION
## Summary
`hermes pause` written at the fleet root now binds profile gateways: the emergency stop is checked in both the process's own home and the canonical fleet root, so a profile-dispatched gateway can no longer run through an operator's pause.

Salvage of #97779 (@sycamoregroupltd's commits, authorship preserved via rebase-merge) plus one follow-up simplification commit.

## What it does
Profile processes launch with `HERMES_HOME=~/.hermes/profiles/<name>`, so `agent/estop.py` looked only at `~/.hermes/profiles/<name>/ESTOP` and never saw the fleet-root sentinel `hermes pause` actually wrote. The emergency stop silently failed to bind profile gateways while the operator believed the fleet was paused.

- `is_engaged()` — engaged if ANY candidate sentinel exists: process home or fleet root (via `hermes_constants.get_default_hermes_root()`, which correctly strips `profiles/<name>` and handles Docker/custom roots). Fail-safe on stat errors preserved.
- `disengage()` — lifts both sentinels so `hermes resume` from a profile gateway can't leave a stale fleet pause.
- `get_state()` — reads candidates in order, prefers the first parseable body.
- `engage()` — unchanged (still writes the process home; pause stays scoped to the pausing seat).
- Follow-up commit (mine): dropped the redundant `isinstance(primary, Path)` branch (the surrounding `except Exception` covers the fail-safe stat fixture) and fixed the stale "single os.stat" docstring.

## Changes
- `agent/estop.py` (+60/-9 net after follow-up)
- `tests/test_estop.py` — profile-gateway regression (28 lines)

## Validation
- `tests/test_estop.py`: 25 passed (on rebased branch)
- E2E probe (real imports, isolated temp HERMES_HOME): 17/17 — bug repro (root ESTOP + profile HERMES_HOME → engaged), engage/disengage semantics, Docker single-home layout (no duplicate candidates), corrupt sentinel fail-safe, reason preference, `sentinel_path()` unchanged
- Bug confirmed on origin/main pre-fix: same repro returns `is_engaged() == False`
- ruff clean

## Design note (verified during review)
`disengage()` from a profile seat now clears the fleet-root sentinel. This is deliberate per the PR: `hermes resume` is THE documented recovery, and the pre-fix behavior (a profile operator unable to lift a fleet pause at all) was a support trap. The in-process multiplex gap claimed during review was verified as a false positive — `get_default_hermes_root()` strips `profiles/<name>` from the process env, so the fleet root is correct even during ContextVar-scoped turns.

Closes #97779 via salvage.
