### PR TITLE
fix(compaction): make the summarizer serialization phase cancellable and bounded

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4418,10 +4418,46 @@ class ContextCompressor(ContextEngine):
     _CONTENT_TAIL = 1500      # chars kept from the end
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+    # Cap on the bytes handed to the compaction REDACTOR per message (#99255).
+    # At most _CONTENT_HEAD + _CONTENT_TAIL chars of any body can reach the
+    # summarizer, but redaction historically ran on the whole body and the
+    # truncation was applied to its output — so an MB-scale tool result paid
+    # full strict-redaction cost to produce at most _CONTENT_MAX chars. The
+    # window below is 3x the retained budget, which makes the bound safe:
+    #   * a token bisected by this slice sits 8000 chars past anything the
+    #     later truncation can keep (longest secret pattern is < 200), so it
+    #     cannot reach the output unredacted; and
+    #   * post-redaction shrinkage (media directives, <think> stripping) must
+    #     remove >66% of the window before the retained slice notices.
+    _REDACT_INPUT_HEAD = 12000
+    _REDACT_INPUT_TAIL = 4500
     # Aggregate cap over the whole serialized block, applied AFTER the
     # per-message limits above. Alias of the module-level constant (which
     # carries the full rationale) so subclasses/tests can override per-class.
     _SUMMARY_INPUT_MAX_CHARS = _SUMMARY_INPUT_MAX_CHARS
+
+    def _bound_redaction_input(self, text: Any) -> Any:
+        """Cap the bytes handed to the compaction redactor for one message.
+
+        Head+tail window (see ``_REDACT_INPUT_HEAD`` / ``_REDACT_INPUT_TAIL``),
+        so the strict-redaction cost of a message is bounded by what can
+        actually reach the summarizer instead of by the raw body size.
+        Short bodies — the overwhelming majority — are returned unchanged.
+
+        Non-``str`` values are passed through untouched: ``redact_sensitive_text``
+        already coerces them, and a provider that hands back a dict-shaped
+        ``content`` / ``arguments`` must keep reaching that coercion rather
+        than dying on a slice here.
+        """
+        if not isinstance(text, str):
+            return text
+        if len(text) <= self._REDACT_INPUT_HEAD + self._REDACT_INPUT_TAIL:
+            return text
+        return (
+            text[:self._REDACT_INPUT_HEAD]
+            + "\n...[omitted]...\n"
+            + text[-self._REDACT_INPUT_TAIL:]
+        )
 
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
@@ -4440,6 +4476,18 @@ class ContextCompressor(ContextEngine):
 
         parts = []
         for msg in turns:
+            # #99255: strict-redacting a large compression window is the
+            # CPU-bound phase of compaction, and it runs BEFORE any provider
+            # call — so the host's progress-aware wait sees no progress and
+            # gives up at ``compression.context_timeout_seconds`` while this
+            # loop keeps going. Without a checkpoint here the detached worker
+            # burned hours of GIL-holding CPU on a result the departed host
+            # had already discarded, starving the gateway event loop.
+            # ``AuxiliaryExplicitCancellation`` is a BaseException, so no
+            # broad ``except Exception`` between here and compress_context's
+            # rollback handler can swallow the abort.
+            if self._compression_cancelled():
+                raise AuxiliaryExplicitCancellation()
             role = msg.get("role", "unknown")
             content = msg.get("content")
             if isinstance(content, list):
@@ -4458,7 +4506,9 @@ class ContextCompressor(ContextEngine):
                     elif isinstance(part, str):
                         text_parts.append(part)
                 content = "\n".join(text_parts)
-            content = _redact_compaction_text(content or "")
+            content = _redact_compaction_text(
+                self._bound_redaction_input(content or "")
+            )
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
             # Strip inline reasoning blocks (<think>, <reasoning>, etc.) from
             # assistant content before it reaches the summarizer. Reasoning
@@ -4491,7 +4541,11 @@ class ContextCompressor(ContextEngine):
                         if isinstance(tc, dict):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
-                            args = _redact_compaction_text(fn.get("arguments", ""))
+                            args = _redact_compaction_text(
+                                self._bound_redaction_input(
+                                    fn.get("arguments", "") or ""
+                                )
+                            )
                             # Truncate long arguments but keep enough for context
                             if len(args) > self._TOOL_ARGS_MAX:
                                 args = args[:self._TOOL_ARGS_HEAD] + "..."

--- a/tests/agent/test_compaction_cancellation_99255.py
+++ b/tests/agent/test_compaction_cancellation_99255.py
@@ -1,0 +1,285 @@
+"""Compaction serialization must be bounded and cancellable (issue #99255).
+
+``_generate_summary`` consults the host-owned cooperative cancellation signal
+once (right before the prompt is built) and again after the auxiliary call
+returns.  Everything between those two points — ``_serialize_for_summary``,
+which strict-redacts every message in the compression window — ran with no
+cancellation checkpoint at all, and handed the redactor each message body *in
+full* before truncating the result to ``_CONTENT_MAX``.
+
+On a large session with MB-scale tool results that combination let a worker
+whose host had already timed out (fence cancelled at
+``compression.context_total_ceiling_seconds``) keep burning CPU for hours,
+holding the GIL and starving the gateway event loop.
+
+These tests pin both halves of the contract:
+
+* the serializer polls the cancellation signal per message and unwinds with
+  ``AuxiliaryExplicitCancellation`` (a ``BaseException``, so no broad
+  ``except Exception`` can swallow it), and
+* the bytes handed to the redactor per message are bounded, so that
+  per-message checkpoint is actually reachable on MB-scale bodies.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+import agent.context_compressor as cc
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.context_compressor import ContextCompressor
+
+SECRET = "sk-proj-" + ("a" * 40)
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100000,
+    ):
+        return ContextCompressor(model="test/model", quiet_mode=True)
+
+
+def _turns(n: int, body: str):
+    out = []
+    for i in range(n):
+        out.append({"role": "user", "content": f"step {i}"})
+        out.append(
+            {"role": "tool", "tool_call_id": f"call_{i}", "content": body}
+        )
+    return out
+
+
+@pytest.fixture
+def fed(monkeypatch):
+    """Count the bytes handed to the compaction redactor."""
+    counter = {"bytes": 0, "calls": 0}
+    real = cc._redact_compaction_text
+
+    def _counting(text):
+        counter["bytes"] += len(text or "")
+        counter["calls"] += 1
+        return real(text)
+
+    monkeypatch.setattr(cc, "_redact_compaction_text", _counting)
+    return counter
+
+
+class TestSerializerIsCancellable:
+    def test_cancelled_host_stops_the_serializer(self):
+        """A fence cancelled mid-serialization must abort the walk."""
+        comp = _compressor()
+        turns = _turns(50, "payload " * 100)
+
+        seen = {"n": 0}
+
+        def _check():
+            seen["n"] += 1
+            # Host gives up after the 5th message.
+            return seen["n"] > 5
+
+        comp._compression_cancelled_check = _check
+
+        with pytest.raises(AuxiliaryExplicitCancellation):
+            comp._serialize_for_summary(turns)
+
+        # It must stop near the cancellation point, not walk all 100 rows.
+        assert seen["n"] <= 10, f"kept walking after cancel: {seen['n']} checks"
+
+    def test_cancellation_is_checked_once_per_message(self):
+        """The checkpoint is inside the loop, not merely at its entry."""
+        comp = _compressor()
+        turns = _turns(20, "payload")
+        seen = {"n": 0}
+
+        def _check():
+            seen["n"] += 1
+            return False
+
+        comp._compression_cancelled_check = _check
+        comp._serialize_for_summary(turns)
+
+        assert seen["n"] >= len(turns), (
+            f"only {seen['n']} checks for {len(turns)} messages — the "
+            "serializer is not polling per message"
+        )
+
+    def test_uncancelled_serialization_is_unaffected(self):
+        """No signal installed → ordinary behavior, no exception."""
+        comp = _compressor()
+        turns = _turns(3, "hello world")
+        out = comp._serialize_for_summary(turns)
+        assert "[TOOL RESULT call_0]" in out
+        assert "hello world" in out
+
+    def test_cancellation_escapes_broad_exception_handlers(self):
+        """AuxiliaryExplicitCancellation must survive `except Exception`."""
+        comp = _compressor()
+        comp._compression_cancelled_check = lambda: True
+
+        with pytest.raises(AuxiliaryExplicitCancellation):
+            try:
+                comp._serialize_for_summary(_turns(5, "x"))
+            except Exception:  # noqa: BLE001 - deliberately broad
+                pytest.fail("cancellation was swallowed by `except Exception`")
+
+
+class TestRedactionInputIsBounded:
+    def test_large_tool_body_does_not_flood_the_redactor(self, fed):
+        """Only ~_CONTENT_MAX chars survive; don't redact a megabyte to get them."""
+        comp = _compressor()
+        big = "A" * 1_000_000 + "=="
+        comp._serialize_for_summary([
+            {"role": "tool", "tool_call_id": "c1", "content": big}
+        ])
+
+        assert fed["bytes"] < 100_000, (
+            f"redactor was handed {fed['bytes']:,} chars to produce at most "
+            f"{comp._CONTENT_MAX:,} — redact-before-truncate is still live"
+        )
+
+    def test_large_tool_args_do_not_flood_the_redactor(self, fed):
+        comp = _compressor()
+        comp._serialize_for_summary([
+            {
+                "role": "assistant",
+                "content": "calling",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "terminal",
+                            "arguments": "B" * 1_000_000 + "==",
+                        }
+                    }
+                ],
+            }
+        ])
+        assert fed["bytes"] < 100_000, (
+            f"tool arguments handed {fed['bytes']:,} chars to the redactor"
+        )
+
+    def test_non_string_content_still_reaches_the_redactor_coercion(self):
+        """Dict/int bodies must not die on a slice in the input bound.
+
+        ``redact_sensitive_text`` coerces non-str values itself; the bound
+        has to pass them through rather than call len()/slice on them.
+        """
+        comp = _compressor()
+        out = comp._serialize_for_summary([
+            {"role": "user", "content": 12345},
+            {"role": "tool", "tool_call_id": "c1", "content": {"a": "b"}},
+            {
+                "role": "assistant",
+                "content": "x",
+                "tool_calls": [
+                    {"function": {"name": "t", "arguments": {"k": "v"}}}
+                ],
+            },
+        ])
+        assert "12345" in out
+        assert "[TOOL RESULT c1]" in out
+
+    def test_bounded_input_keeps_the_serialized_shape(self):
+        """Truncation markers and labels survive the input bound."""
+        comp = _compressor()
+        big = "A" * 1_000_000
+        out = comp._serialize_for_summary([
+            {"role": "tool", "tool_call_id": "c1", "content": big}
+        ])
+        assert out.startswith("[TOOL RESULT c1]: ")
+        assert "...[truncated]..." in out
+        assert len(out) < comp._CONTENT_MAX + 200
+
+    def test_redactor_load_is_independent_of_raw_body_size(self, fed):
+        """Total redactor input scales with message COUNT, not transcript size.
+
+        This is the invariant that decouples compaction prep cost from how
+        big the tool outputs were.  Asserted in bytes rather than seconds so
+        it does not depend on the redactor's own complexity class (the
+        quadratic assignment scan is tracked separately in #99265 / #91672).
+        """
+        comp = _compressor()
+        n = 4
+        small = _turns(n, "A" * 1_000)
+        huge = _turns(n, "A" * 500_000)
+
+        comp._serialize_for_summary(small)
+        small_bytes = fed["bytes"]
+
+        fed["bytes"] = 0
+        comp._serialize_for_summary(huge)
+        huge_bytes = fed["bytes"]
+
+        window = comp._REDACT_INPUT_HEAD + comp._REDACT_INPUT_TAIL
+        # 500x more raw text must not mean 500x more redaction work.
+        assert huge_bytes <= n * (window + 64) + small_bytes, (
+            f"redactor load grew with body size: {small_bytes:,} -> "
+            f"{huge_bytes:,} bytes for a 500x larger transcript"
+        )
+
+    def test_cancellation_latency_is_bounded_by_one_message(self):
+        """After the host cancels, the worker stops within one message."""
+        comp = _compressor()
+        turns = _turns(200, "authorization=Bearer abc\n" + ("A" * 4_000) + "==")
+        calls = {"n": 0}
+
+        def _check():
+            calls["n"] += 1
+            return calls["n"] > 2
+
+        comp._compression_cancelled_check = _check
+        t0 = time.perf_counter()
+        with pytest.raises(AuxiliaryExplicitCancellation):
+            comp._serialize_for_summary(turns)
+        elapsed = time.perf_counter() - t0
+
+        # Without the checkpoint this walks all 400 rows; with it, the walk
+        # ends on the 3rd. Bound the wall clock generously — the point is
+        # "one message", not a performance number.
+        assert calls["n"] <= 4
+        assert elapsed < 60.0, f"cancel took {elapsed:.1f}s to take effect"
+
+
+class TestBoundingNeverLeaksSecrets:
+    """The input bound must never let a secret reach the summarizer prompt."""
+
+    @pytest.fixture(autouse=True)
+    def _redaction_globally_disabled(self, monkeypatch):
+        # force=True at the compaction boundary must still win.
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    def test_secret_at_head_of_huge_body_is_redacted(self):
+        comp = _compressor()
+        body = f"token={SECRET}\n" + ("A" * 1_000_000)
+        out = comp._serialize_for_summary([
+            {"role": "tool", "tool_call_id": "c1", "content": body}
+        ])
+        assert SECRET not in out
+
+    def test_secret_at_tail_of_huge_body_is_redacted(self):
+        comp = _compressor()
+        body = ("A" * 1_000_000) + f"\ntoken={SECRET}"
+        out = comp._serialize_for_summary([
+            {"role": "tool", "tool_call_id": "c1", "content": body}
+        ])
+        assert SECRET not in out
+
+    def test_secret_in_huge_tool_args_is_redacted(self):
+        comp = _compressor()
+        out = comp._serialize_for_summary([
+            {
+                "role": "assistant",
+                "content": "calling",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "terminal",
+                            "arguments": f'{{"cmd":"export token={SECRET}"}}'
+                            + ("A" * 500_000),
+                        }
+                    }
+                ],
+            }
+        ])
+        assert SECRET not in out


### PR DESCRIPTION
## What does this PR do?

Makes the compaction **serialization phase** cancellable and bounds the bytes it hands to the redactor, so a manual `/compress` on a large session can no longer keep a detached worker burning CPU for hours after its host gave up (#99255).

This is a **containment** fix. It does not make redaction faster — that is the quadratic assignment scan owned by #91672 and #99265. It makes the phase *stoppable* and *bounded* whether or not those land.

## Related Issue

Fixes #99255.

Adjacent, deliberately **not** touched here (different layer, different owners):
- #91672 / #99265 — `agent/redact.py` regex linearity (both open, both owned by others)
- #83087 — manual `/compress` RPC timeout
- #48564 — RFC: prevent event-loop starvation

---

## The failure, end to end

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["User sends /compress - 1000 msgs, MB-scale tool output"] --> B["Gateway offloads to executor"]
    B --> C["Worker admitted to pool - thread compress-ctx-timeout_N"]
    C --> D["Checkpoint 1: _compression_cancelled - passes"]
    D --> E["_serialize_for_summary - NO checkpoint in the loop"]
    E --> F["Redact full MB body THEN truncate to 6000 chars"]
    F --> G["Host idle budget expires - context_timeout_seconds"]
    G --> H["Fence cancelled, host returns, worker DETACHED"]
    H --> I["Worker keeps grinding for hours holding the GIL"]
    I --> J["Event loop starved - getUpdates stalls, bot dead"]
    J --> K["Container restart is the only exit"]
    style I fill:#8b0000,stroke:#ff0038,stroke-width:3px
    style K fill:#3b0008,stroke:#ff0038,stroke-width:2px
```

### Cause — line by line

`ContextCompressor` already has a complete cooperative-cancellation channel, installed by the host for the duration of a fenced call:

| Piece | Location |
|---|---|
| Host installs `lambda: commit_fence.is_cancelled` | `agent/conversation_compression.py` — `_install_compression_cancelled_check` |
| Compressor reads it | `ContextCompressor._compression_cancelled()` |
| Cleared under a generation guard | `_clear_compression_cancelled_check_if_owner` |

That channel is consulted in exactly **two** places: once in `_generate_summary` immediately *before* the prompt is built, and once *after* the auxiliary call returns.

Between those two points sits `_serialize_for_summary`, which strict-redacts every message in the compression window. **It never consults the signal.** So the worker passes its only pre-flight checkpoint, enters the CPU-bound phase, and from that moment nothing can stop it.

Two properties of that loop turn "slow" into a multi-hour outage:

1. **No checkpoint.** The host's progress-aware wait is inactivity-based, and this phase runs *before* any provider call — so it produces no `touch_progress` events. The host times out at `compression.context_timeout_seconds`, fence-cancels, and returns. The worker is a daemon thread on a shared pool: it is detached, never cancelled, and runs to completion on a result the departed host has already discarded.
2. **Redact-before-truncate.** The body was handed to the redactor *in full*, and the `_CONTENT_MAX` truncation was applied to the redactor's **output**. A 1 MB tool result therefore paid full strict-redaction cost to produce at most 6000 chars. The `force=True` compaction boundary means `security.redact_secrets: false` cannot opt out, and the ENV-assignment pre-gate is only `"=" in text` — base64 padding alone arms it.

### Consequence

Because the redaction of a *single* message could run for many minutes inside one uninterruptible `re.sub`, a per-message checkpoint alone would not even have been reachable. The two defects compound: (2) makes each step unbounded, (1) means nothing can interrupt it. Result: ~106% CPU for 5+ hours, the GIL held by a pure-Python regex loop, every other coroutine in the gateway starved — one session's `/compress` takes down every chat in the process.

### Measured on `main` before the fix

Serializing one tool message whose payload contains `=` and a secret keyword:

| payload | bytes fed to redactor | bytes kept | elapsed |
|---:|---:|---:|---:|
| 2,005 | 2,005 | 2,037 | 0.385 s |
| 4,021 | 4,021 | 4,053 | 1.397 s |
| 8,005 | 8,005 | **5,561** | 5.361 s |
| 16,021 | 16,021 | **5,561** | 20.827 s |
| 32,005 | 32,005 | **5,561** | 93.408 s |

Doubling the input quadruples the time, and from 8 KB on **every additional byte is redacted and then thrown away**. A 20-message x 200 KB session did not finish serialization within a 300 s bound at all.

---

## The fix

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph LR
    A["Next message"] --> B{"_compression_cancelled"}
    B -->|cancelled| C["raise AuxiliaryExplicitCancellation - BaseException"]
    C --> D["Existing compress_context rollback - lease released, transcript restored"]
    B -->|live| E["_bound_redaction_input - head 12000 + tail 4500"]
    E --> F["Strict redact - bounded input"]
    F --> G["Existing truncation to _CONTENT_MAX"]
    G --> A
    style C fill:#8b0000,stroke:#ff0038,stroke-width:3px
    style E fill:#3b0008,stroke:#ff0038,stroke-width:2px
```

**1. A checkpoint per message.** `_serialize_for_summary` polls the existing `_compression_cancelled()` once per message and raises `AuxiliaryExplicitCancellation`. That class is already a `BaseException`, so no broad `except Exception` between here and the rollback handler can swallow it, and it lands on the `except AuxiliaryExplicitCancellation` path `compress_context` already has — the same unwind an in-flight `/stop` uses today. **No new rollback path is introduced.**

**2. A bound on redaction input.** `_bound_redaction_input` caps what the redactor sees per message at a head+tail window (12000 + 4500) — three times the retained budget — so redaction cost tracks what can actually reach the summarizer rather than the raw body size. This is what makes the checkpoint in (1) reachable.

### Why the bound cannot leak a secret

Only `_CONTENT_HEAD` (4000) + `_CONTENT_TAIL` (1500) chars of a body can ever reach the prompt. The slice keeps 12000 head chars, so **a token bisected by the slice sits 8000 chars past anything the later truncation can retain** — the longest secret pattern is under 200 chars. Everything that reaches the output has been redacted. Three tests pin this directly (secret at head, at tail, and inside huge tool arguments), each with `security.redact_secrets: false` to prove the `force=True` boundary still wins.

### Behavior change worth flagging

The retained slice is now taken from raw offsets rather than post-redaction offsets. For an assistant message that is **more than 66% inline `<think>` text**, the summarizer may see slightly less tail context than before. Never a correctness or security difference — and native `reasoning` fields are already excluded from serialization, so only inlined think-tags reach this path.

## Changes Made

- `agent/context_compressor.py`
  - `_serialize_for_summary`: consult `_compression_cancelled()` per message; raise `AuxiliaryExplicitCancellation`.
  - `_bound_redaction_input` plus `_REDACT_INPUT_HEAD` / `_REDACT_INPUT_TAIL`: cap redactor input per message; non-`str` values pass through to `redact_sensitive_text`'s own coercion (a dict-shaped `content` / `arguments` must not die on a slice).
  - Both redaction call sites (message body, tool-call arguments) routed through the bound.
- `tests/agent/test_compaction_cancellation_99255.py`: new regression suite (13 tests).

Net: **+56 / -2** in one source file.

## How to Test

```bash
python -m pytest tests/agent/test_compaction_cancellation_99255.py -q
```

Coverage:
- cancelled host stops the walk; checkpoint fires once per message; cancellation survives a deliberately broad `except Exception`; uncancelled behavior unchanged
- redactor is not flooded by a 1 MB body or 1 MB tool arguments; total redactor load scales with message **count**, not transcript size; cancellation latency bounded to one message
- serialized shape (labels, truncation marker) preserved; non-str content/arguments still coerced
- three secret-leak guards with global redaction disabled

## Verification

- New suite: **13 passed** (41 s), run in a clean worktree off `origin/main`.
- `tests/agent/test_compaction_redaction_boundaries.py`, `test_compressor_media_stripping.py`, `test_compression_small_ctx_threshold_floor.py`, `test_compaction_anti_thrash.py`, `test_compressed_summary_metadata.py`, `test_compression_fallback_budget.py`: **42 passed**.
- `tests/agent/test_redact.py`, `test_tool_call_arg_no_redaction.py`, `tests/test_redaction_registry.py`: **117 passed**.
- `tests/agent/test_compress_context_progress_timeout.py`: 10 failures — **pre-existing**, verified identical with this change stashed on clean `main` (10 failed / 7 passed both ways). Untouched by this PR.
- `ruff check` clean; `py_compile` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #91672 and #99265 both own `agent/redact.py` regex linearity and are deliberately not touched here
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the compaction/redaction suites listed above; a full-suite run was not attempted locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings and inline rationale), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A — no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKrRS7LVgyHf2WQkEahSwu
