### PR TITLE
fix(cli): explain mixed-install ImportError at chat startup (salvage #96911)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21822,22 +21822,31 @@ def main(
     parsed_skills = _parse_skills_argument(skills)
 
     # Create CLI instance
-    cli = HermesCLI(
-        model=model,
-        toolsets=toolsets_list,
-        provider=provider,
-        reasoning=reasoning,
-        api_key=api_key,
-        base_url=base_url,
-        max_turns=max_turns,
-        run_budget=run_budget,
-        verbose=verbose,
-        compact=compact,
-        resume=resume,
-        checkpoints=checkpoints,
-        pass_session_id=pass_session_id,
-        ignore_rules=ignore_rules,
-    )
+    try:
+        cli = HermesCLI(
+            model=model,
+            toolsets=toolsets_list,
+            provider=provider,
+            reasoning=reasoning,
+            api_key=api_key,
+            base_url=base_url,
+            max_turns=max_turns,
+            run_budget=run_budget,
+            verbose=verbose,
+            compact=compact,
+            resume=resume,
+            checkpoints=checkpoints,
+            pass_session_id=pass_session_id,
+            ignore_rules=ignore_rules,
+        )
+    except ImportError as e:
+        # Direct `python cli.py` / `python -m cli` bypasses cmd_chat's
+        # ImportError handler. Same mixed-tree class as #96900.
+        from hermes_constants import emit_partial_update_hint
+
+        if emit_partial_update_hint(e):
+            sys.exit(1)
+        raise
 
     if parsed_skills:
         # Load the skill payloads in the background: skill_view walks the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3399,9 +3399,6 @@ def cmd_chat(args):
             accept_hooks=getattr(args, "accept_hooks", False),
         )
 
-    # Import and run the CLI
-    from cli import main as cli_main
-
     # --query-file: read the single query from a file (or stdin via '-') so
     # callers never have to shell-quote message bodies. This is the transport
     # the Bot Mode DM protocol uses — interpolating arbitrary text into a
@@ -3453,10 +3450,23 @@ def cmd_chat(args):
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     try:
+        from cli import main as cli_main
+
         cli_main(**kwargs)
     except ValueError as e:
         print(f"Error: {e}")
         sys.exit(1)
+    except ImportError as e:
+        # Mixed-version installs (new cli.py, older hermes_cli.config) crash
+        # here — e.g. missing resolve_turn_limit / split_model_config_default
+        # (#96900). The agent-setup mixin prints this hint too late: HermesCLI
+        # construction already failed. Fast-chat launch also goes through
+        # cmd_chat, so this one catch covers `hermes` / `hermes chat`.
+        from hermes_constants import emit_partial_update_hint
+
+        if emit_partial_update_hint(e):
+            sys.exit(1)
+        raise
 
 
 def cmd_gateway(args):

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1860,3 +1860,19 @@ def partial_update_hint(exc: BaseException) -> list[str]:
         "    hermes update",
         "If that also fails, reinstall: https://hermes-agent.nousresearch.com",
     ]
+
+
+def emit_partial_update_hint(exc: BaseException, *, file=None) -> bool:
+    """Print recovery guidance for a half-updated tree.
+
+    Returns True when guidance was written (caller should then exit), False
+    when *exc* is not a first-party ``ImportError`` (caller should re-raise).
+    """
+    lines = partial_update_hint(exc)
+    if not lines:
+        return False
+    out = sys.stderr if file is None else file
+    print(f"Error: {exc}", file=out)
+    for line in lines:
+        print(line, file=out)
+    return True

--- a/tests/hermes_cli/test_cli_partial_update_hint_96900.py
+++ b/tests/hermes_cli/test_cli_partial_update_hint_96900.py
@@ -1,0 +1,135 @@
+"""Chat startup must explain a mixed-version ImportError (#96900).
+
+A half-updated install can ship a newer ``cli.py`` that imports
+``resolve_turn_limit`` / ``split_model_config_default`` from
+``hermes_cli.config`` while the older ``config.py`` does not export them.
+Construction of ``HermesCLI`` then dies before the agent-setup mixin can
+print ``partial_update_hint``. ``cmd_chat`` is the load-bearing catch:
+bare ``hermes`` and ``hermes chat`` (including the fast-chat launch path)
+all go through it.
+"""
+
+from argparse import Namespace
+import io
+import sys
+import types
+
+import pytest
+
+from hermes_constants import emit_partial_update_hint, partial_update_hint
+
+
+def _chat_args(**overrides):
+    base = {
+        "continue_last": None,
+        "model": None,
+        "provider": None,
+        "resume": None,
+        "no_restore_cwd": False,
+        "toolsets": None,
+        "skills": None,
+        "tui": False,
+        "tui_dev": False,
+        "cli": True,
+        "verbose": None,
+        "quiet": True,
+        "query": "hello",
+        "image": None,
+        "worktree": False,
+        "checkpoints": False,
+        "pass_session_id": False,
+        "max_turns": None,
+        "ignore_rules": False,
+        "ignore_user_config": False,
+        "safe_mode": False,
+        "compact": False,
+        "source": None,
+        "yolo": False,
+        "accept_hooks": False,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def _missing_config_name_error(name: str = "resolve_turn_limit") -> ImportError:
+    exc = ImportError(
+        f"cannot import name '{name}' from 'hermes_cli.config'"
+    )
+    exc.name = "hermes_cli.config"
+    return exc
+
+
+@pytest.fixture
+def main_mod(monkeypatch):
+    import hermes_cli.main as mod
+
+    monkeypatch.setattr(mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(mod, "_termux_should_prefetch_update_check", lambda: False)
+    monkeypatch.setattr(mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(mod, "_resolve_session_by_name_or_id", lambda val: val)
+    return mod
+
+
+def test_emit_hint_for_missing_resolve_turn_limit():
+    exc = _missing_config_name_error("resolve_turn_limit")
+    buf = io.StringIO()
+
+    assert emit_partial_update_hint(exc, file=buf) is True
+    text = buf.getvalue()
+    assert "resolve_turn_limit" in text
+    assert "hermes update" in text
+    assert "partially-updated" in text
+
+
+def test_emit_hint_for_missing_split_model_config_default():
+    exc = _missing_config_name_error("split_model_config_default")
+    assert partial_update_hint(exc)
+    buf = io.StringIO()
+    assert emit_partial_update_hint(exc, file=buf) is True
+    assert "hermes update" in buf.getvalue()
+
+
+def test_emit_hint_stays_silent_for_third_party_import_error():
+    exc = ImportError("cannot import name 'dumps' from 'requests'")
+    exc.name = "requests"
+    buf = io.StringIO()
+    assert emit_partial_update_hint(exc, file=buf) is False
+    assert buf.getvalue() == ""
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["resolve_turn_limit", "split_model_config_default"],
+)
+def test_cmd_chat_prints_update_hint_when_config_helper_is_missing(
+    main_mod, monkeypatch, capsys, name
+):
+    def boom(**_kwargs):
+        raise _missing_config_name_error(name)
+
+    monkeypatch.setitem(sys.modules, "cli", types.SimpleNamespace(main=boom))
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.cmd_chat(_chat_args())
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert name in err
+    assert "hermes update" in err
+    assert "partially-updated" in err
+
+
+def test_cmd_chat_still_reraises_unrelated_import_errors(main_mod, monkeypatch):
+    exc = ImportError("cannot import name 'dumps' from 'requests'")
+    exc.name = "requests"
+
+    def boom(**_kwargs):
+        raise exc
+
+    monkeypatch.setitem(sys.modules, "cli", types.SimpleNamespace(main=boom))
+
+    with pytest.raises(ImportError) as excinfo:
+        main_mod.cmd_chat(_chat_args())
+
+    assert excinfo.value is exc

--- a/tests/hermes_cli/test_update_import_guard.py
+++ b/tests/hermes_cli/test_update_import_guard.py
@@ -336,7 +336,7 @@ def test_hint_does_not_claim_partial_update_for_lookalike_third_party(modname):
 
 
 @pytest.mark.parametrize("modname", ["tools.todo_tool", "agent.context_compressor",
-                                     "hermes_constants", "cli"])
+                                     "hermes_constants", "hermes_cli.config", "cli"])
 def test_hint_fires_for_each_first_party_root(modname):
     exc = ImportError("cannot import name 'X'")
     exc.name = modname


### PR DESCRIPTION
## Summary
A half-updated install that crashes `hermes chat` startup with a first-party ImportError now prints recovery guidance (`hermes update`) instead of a bare traceback.

Salvage of #96911 (@HexLab98's commits, authorship preserved via rebase-merge).

## What it does
Issue #96900's crash (`cannot import name 'split_model_config_default' from 'hermes_cli.config'`) is a mixed-version tree: a newer `cli.py` importing helpers an older `hermes_cli/config.py` doesn't export. Construction of `HermesCLI` dies before the agent-setup mixin can print the existing partial-update hint.

- `hermes_cli/main.py cmd_chat` — catch first-party ImportError around `cli_main(**kwargs)`, print the hint, exit 1. Covers `hermes`, `hermes chat`, and the fast-chat launch path. The `from cli import main` import moves inside the try (an import-time failure in `cli.py` is the same mixed-tree class).
- `cli.py main` — same guard around `HermesCLI(...)` construction for direct `python cli.py` / `python -m cli` invocations.
- `hermes_constants.emit_partial_update_hint(exc)` — shared helper: prints `partial_update_hint()` lines, returns True when guidance was written (caller exits) / False for third-party ImportErrors (caller re-raises). Third-party errors pass through untouched.
- `tests/hermes_cli/test_update_import_guard.py` — adds `hermes_cli.config` to the first-party root list parametrization.

## Changes
- `cli.py` (+22/-11)
- `hermes_cli/main.py` (+14/-4)
- `hermes_constants.py` (+16)
- `tests/hermes_cli/test_cli_partial_update_hint_96900.py` (new, 135 lines)
- `tests/hermes_cli/test_update_import_guard.py` (+1/-1)

## Validation
- Targeted: `tests/hermes_cli/test_cli_partial_update_hint_96900.py` + `test_update_import_guard.py` → 37 passed (rebased branch)
- E2E probes (real subprocess, real imports): (A) `cmd_chat` with a mixed-tree-shaped ImportError (`.name` set as `from X import Y` does) → hint on stderr, `SystemExit(1)`; (B) real mixed tree — copy of `hermes_cli/config.py` with `split_model_config_default` stripped → import raises, `emit_partial_update_hint` returns True and prints the guidance; (C) `cli.main()` with `HermesCLI` construction raising → hint + exit 1; (D) third-party ImportError (`requests`) → returns False, nothing written, re-raised
- ruff clean on all touched files

## Note
Issue #96900 was closed as not-a-code-bug (mixed-version install, both helpers exist on a consistent tree) — this PR is the "make the failure self-explaining" UX improvement noted as the remaining actionable piece in that close.

Closes #96911 via salvage.
