### PR TITLE
fix(profiles): hide tombstones from Group Chat and cron targets

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -42,6 +42,7 @@ from hermes_cli.archive_safe import (
 )
 from hermes_constants import (
     clear_named_profile_deleted,
+    live_profile_names,
     mark_named_profile_deleted,
     named_profile_is_deleted,
 )
@@ -436,18 +437,10 @@ def list_profile_names() -> List[str]:
 
     Unlike :func:`list_profiles` this reads NO per-profile config/metadata —
     it is a directory scan, safe to call from hot paths (cron delivery-target
-    listings, create-time validation).
+    listings, create-time validation). Tombstoned named profiles and the
+    reserved ``.deleted`` directory are omitted.
     """
-    names = ["default"]
-    profiles_root = _get_profiles_root()
-    try:
-        if profiles_root.is_dir():
-            for entry in sorted(profiles_root.iterdir()):
-                if entry.is_dir() and entry.name != "default" and _PROFILE_ID_RE.match(entry.name):
-                    names.append(entry.name)
-    except OSError:
-        pass
-    return names
+    return live_profile_names(_get_default_hermes_home())
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -199,21 +199,16 @@ def collect_runtime_inventory() -> UpdatePlan:
         from hermes_cli.profiles import (
             _get_default_hermes_home,
             _get_profiles_root,
-            _PROFILE_ID_RE,
         )
+        from hermes_constants import live_profile_names
 
         default_home = _get_default_hermes_home()
-        if default_home.is_dir():
-            profile_homes.append(("default", default_home))
         root = _get_profiles_root()
-        if root.is_dir():
-            for entry in sorted(root.iterdir()):
-                if (
-                    entry.is_dir()
-                    and entry.name != "default"
-                    and _PROFILE_ID_RE.match(entry.name)
-                ):
-                    profile_homes.append((entry.name, entry))
+        for name in live_profile_names(default_home):
+            home = default_home if name == "default" else root / name
+            if name == "default" and not home.is_dir():
+                continue
+            profile_homes.append((name, home))
         plan.profiles = [name for name, _ in profile_homes]
     except Exception as exc:
         logger.debug("Profile enumeration failed: %s", exc)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import re
 import shutil
 import stat
 import sys
@@ -232,6 +233,10 @@ def get_default_hermes_root() -> Path:
 # erase the fact that the profile was deleted.
 _DELETED_PROFILES_DIR = ".deleted"
 
+# Keep in sync with hermes_cli.profiles._PROFILE_ID_RE. Duplicated here so
+# live_profile_names() can stay import-safe for HostedRoomService.
+_NAMED_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
 # Files whose presence marks a directory as a real Hermes home. A fresh home
 # always gains at least one of these on first use (config save, env backfill,
 # session DB), while arbitrary directories that merely contain a ``profiles``
@@ -300,6 +305,39 @@ def profile_tombstone_path(profile_home: Path) -> Path:
 
 def named_profile_is_deleted(profile_home: str | Path) -> bool:
     return profile_tombstone_path(Path(profile_home)).exists()
+
+
+def live_profile_names(hermes_root: str | Path) -> list[str]:
+    """Cheap name-only listing of live profiles under *hermes_root*.
+
+    Always includes the synthetic ``default`` profile. Named directories
+    under ``<hermes_root>/profiles`` must match the profile-id regex and
+    must not be tombstoned. Reserved directories such as ``.deleted`` are
+    never advertised.
+
+    *hermes_root* is the Hermes home to scan. Callers that serve a
+    specific home (for example HostedRoomService) must pass that home so
+    the scan is not bound to the process-global Hermes root.
+    """
+    names = ["default"]
+    profiles_root = Path(hermes_root) / "profiles"
+    try:
+        if not profiles_root.is_dir():
+            return names
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            name = entry.name
+            if name == "default" or name.startswith("."):
+                continue
+            if not _NAMED_PROFILE_ID_RE.match(name):
+                continue
+            if named_profile_is_deleted(entry):
+                continue
+            names.append(name)
+    except OSError:
+        pass
+    return names
 
 
 def mark_named_profile_deleted(profile_home: str | Path) -> None:

--- a/tests/hermes_cli/test_profile_tombstone_enum.py
+++ b/tests/hermes_cli/test_profile_tombstone_enum.py
@@ -1,0 +1,115 @@
+"""Tombstoned profiles must not appear in Group Chat or cron Bot Chat lists.
+
+``live_profile_names()`` is the shared enumerator for
+``list_profile_names()`` and ``HostedRoomService.local_profiles()``. These
+tests drive both consumers against a real temporary Hermes home.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from cron.scheduler import BOT_CHAT_PLATFORM, cron_delivery_targets
+from hermes_cli.profiles import create_profile, delete_profile, list_profile_names
+from hermes_constants import live_profile_names, mark_named_profile_deleted
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return default_home
+
+
+def _delete(name: str) -> None:
+    with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+        "hermes_cli.profiles._stop_profile_backends"
+    ):
+        delete_profile(name, yes=True)
+
+
+def _server():
+    return SimpleNamespace(
+        _methods={}, _sessions={}, _sessions_lock=threading.Lock()
+    )
+
+
+def _members(*profiles: str) -> list[dict[str, str]]:
+    return [
+        {
+            "member_id": profile,
+            "profile": profile,
+            "handle": "hermes" if profile == "default" else profile,
+        }
+        for profile in profiles
+    ]
+
+
+def test_live_profile_names_is_scoped_to_passed_root(tmp_path):
+    global_home = Path(tmp_path / "process-home")
+    (global_home / "profiles" / "globalone").mkdir(parents=True)
+
+    other = tmp_path / "service-home"
+    (other / "profiles" / "ops").mkdir(parents=True)
+    (other / "profiles" / ".deleted").mkdir()
+    (other / "profiles" / "Not-A-Profile").mkdir()
+    worker = other / "profiles" / "worker"
+    worker.mkdir()
+    mark_named_profile_deleted(worker)
+
+    assert live_profile_names(other) == ["default", "ops"]
+    assert "globalone" not in live_profile_names(other)
+    assert live_profile_names(global_home) == ["default", "globalone"]
+
+
+def test_group_chat_and_cron_hide_tombstones(profile_env):
+    create_profile("ops", no_alias=True, no_skills=True)
+    worker = create_profile("worker", no_alias=True, no_skills=True)
+    service = HostedRoomService(_server(), db_path=profile_env / "state.db")
+
+    before = service.create_room(
+        room_id="room-before",
+        name="Live members",
+        members=_members("default", "ops"),
+    )
+    assert before["room_id"] == "room-before"
+    assert service.local_profiles() == ("default", "ops", "worker")
+    assert list_profile_names() == ["default", "ops", "worker"]
+
+    _delete("worker")
+
+    assert (profile_env / "profiles" / ".deleted").is_dir()
+    assert "worker" not in list_profile_names()
+    assert service.local_profiles() == ("default", "ops")
+    after_delete = service.create_room(
+        room_id="room-after-delete",
+        name="Still live members",
+        members=_members("default", "ops"),
+    )
+    assert after_delete["room_id"] == "room-after-delete"
+
+    worker.mkdir()
+    (worker / "state.db").write_bytes(b"")
+
+    names = list_profile_names()
+    assert names == ["default", "ops"]
+    assert service.local_profiles() == ("default", "ops")
+    target_ids = {target["id"] for target in cron_delivery_targets()}
+    assert f"{BOT_CHAT_PLATFORM}:ops" in target_ids
+    assert f"{BOT_CHAT_PLATFORM}:default" in target_ids
+    assert f"{BOT_CHAT_PLATFORM}:worker" not in target_ids
+
+    after_stale = service.create_room(
+        room_id="room-after-stale",
+        name="Stale shell still hidden",
+        members=_members("default", "ops"),
+    )
+    assert after_stale["room_id"] == "room-after-stale"

--- a/tests/hermes_cli/test_profile_tombstone_enum.py
+++ b/tests/hermes_cli/test_profile_tombstone_enum.py
@@ -113,3 +113,17 @@ def test_group_chat_and_cron_hide_tombstones(profile_env):
         members=_members("default", "ops"),
     )
     assert after_stale["room_id"] == "room-after-stale"
+
+
+def test_update_inventory_hides_tombstones(profile_env):
+    create_profile("ops", no_alias=True, no_skills=True)
+    create_profile("gone", no_alias=True, no_skills=True)
+    _delete("gone")
+
+    from hermes_cli.update_inventory import collect_runtime_inventory
+
+    plan = collect_runtime_inventory()
+    assert "ops" in plan.profiles
+    assert "default" in plan.profiles
+    assert "gone" not in plan.profiles
+    assert ".deleted" not in plan.profiles

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -149,13 +149,9 @@ class HostedRoomService:
         return self.db_path.parent
 
     def local_profiles(self) -> tuple[str, ...]:
-        profiles = {"default"}
-        profiles_dir = self.root / "profiles"
-        if profiles_dir.is_dir():
-            profiles.update(
-                path.name for path in profiles_dir.iterdir() if path.is_dir()
-            )
-        return tuple(sorted(profiles))
+        from hermes_constants import live_profile_names
+
+        return tuple(live_profile_names(self.root))
 
     def bindings(self) -> tuple[HostedRoomBinding, ...]:
         local_gateway_id = hosted_rooms.local_authority_gateway_id()


### PR DESCRIPTION
## What does this PR do?

Deleting a named profile leaves the reserved `profiles/.deleted/` directory (and, if a stale process remakes the directory, a tombstoned shell). Two hot-path enumerators treated those entries as live profiles:

- `HostedRoomService.local_profiles()` advertised every child of `profiles/`, so roster validation failed with `5111 invalid local profile` on every later `groups.create` — even when the selected members were all live.
- `list_profile_names()` kept profile-id validation but skipped `named_profile_is_deleted()`, so `cron_delivery_targets()` could re-expose `bot-chat:<deleted>`.

This adds one root-scoped enumerator, `live_profile_names(hermes_root)`, used by both paths. It keeps profile-id validation, skips `.deleted` / reserved dot-directories, and skips tombstoned shells. `HostedRoomService` passes its own Hermes root so the scan is not bound to the process-global home.

## Related Issue

Fixes #99226

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `live_profile_names(hermes_root)` in `hermes_constants.py` next to the existing tombstone helpers.
- `hermes_cli/profiles.py` `list_profile_names()` now returns that enumerator over the default Hermes home.
- `tui_gateway/hosted_room_service.py` `HostedRoomService.local_profiles()` uses the same helper with `self.root`.
- Add `tests/hermes_cli/test_profile_tombstone_enum.py`: enumerator is scoped to the passed root; live Group Chat create after deleting a sibling profile; stale recreated shells stay out of names and Bot Chat targets.

## How to Test

1. `uv run --extra dev python -m pytest tests/hermes_cli/test_profile_tombstone_enum.py -q`
2. Create named profiles `ops` and `worker`, then create a Group Chat with only `default` and `ops` — it succeeds.
3. Delete `worker` (`profiles/.deleted/worker` exists). Create the same Group Chat again — it still succeeds; `.deleted` is not advertised as a local profile.
4. Recreate an empty `profiles/worker` while the tombstone remains. `list_profile_names()` and `cron_delivery_targets()` must not include `worker` / `bot-chat:worker`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A