### PR TITLE
fix(cron): see the shared gateway from a profile-scoped cron list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -64,6 +64,57 @@ def _active_cron_provider_name() -> str:
         return "builtin"
 
 
+def _named_profile_shared_gateway_root() -> Optional[Path]:
+    """Default Hermes root when the current home is ``<root>/profiles/<name>``.
+
+    Named-profile CLI (``hermes -p triage ...``) sets ``HERMES_HOME`` to the
+    profile directory. The shared gateway's lock and pid still live in the
+    default root, which is what actually ticks satellite cron stores (#99631).
+    Returns None when the current home *is* the default (already probed) or
+    is not a named-profile directory.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        home = get_hermes_home().resolve()
+        root = get_default_hermes_root().resolve()
+    except Exception:
+        return None
+    if home == root:
+        return None
+    try:
+        rel = home.relative_to(root / "profiles")
+    except ValueError:
+        return None
+    if len(rel.parts) != 1 or not rel.parts[0]:
+        return None
+    return root
+
+
+def _default_home_gateway_is_live(default_root: Path) -> bool:
+    """True when the default-home runtime lock or pid file shows a live gateway."""
+    try:
+        from gateway.status import (
+            _get_gateway_lock_path,
+            _pid_exists,
+            _pid_from_record,
+            _read_pid_record,
+            is_gateway_runtime_lock_active,
+        )
+
+        default_pid_path = default_root / "gateway.pid"
+        try:
+            if is_gateway_runtime_lock_active(_get_gateway_lock_path(default_pid_path)):
+                return True
+        except Exception:
+            pass
+        rec = _read_pid_record(default_pid_path)
+        pid = _pid_from_record(rec)
+        return bool(pid and _pid_exists(pid))
+    except Exception:
+        return False
+
+
 def _builtin_gateway_liveness() -> Optional[bool]:
     """Tri-state liveness of the builtin cron scheduler's trigger.
 
@@ -102,7 +153,15 @@ def _builtin_gateway_liveness() -> Optional[bool]:
             return True
         # Satellite profile: no local gateway.pid, but the default multiplexer
         # ticks this profile's cron store (#97120).
-        return named_profile_served_by_running_multiplexer()
+        if named_profile_served_by_running_multiplexer():
+            return True
+        # ``hermes -p <profile>`` scopes lock/pid probes to the profile home,
+        # so a healthy shared gateway in the default home still looks dead
+        # when multiplex is off or the default pid file is missing (#99631).
+        shared_root = _named_profile_shared_gateway_root()
+        if shared_root is not None:
+            return _default_home_gateway_is_live(shared_root)
+        return False
     except Exception:
         return None
 
@@ -438,6 +497,21 @@ def cron_status():
                     pids = [lock_pid]
         except Exception:
             pass
+        if not pids and not gateway_alive_via_lock:
+            # Named-profile CLI: lock/pid live in the default home (#99631).
+            try:
+                shared_root = _named_profile_shared_gateway_root()
+                if shared_root is not None and _default_home_gateway_is_live(shared_root):
+                    gateway_alive_via_lock = True
+                    from gateway.status import get_running_pid
+
+                    lock_pid = get_running_pid(
+                        shared_root / "gateway.pid", cleanup_stale=False
+                    )
+                    if lock_pid:
+                        pids = [lock_pid]
+            except Exception:
+                pass
     if pids or gateway_alive_via_lock:
         # The gateway PROCESS is alive — but the cron ticker THREAD inside it
         # can die silently, or stay alive while every tick fails. Check both

--- a/tests/hermes_cli/test_cron_shared_gateway_liveness.py
+++ b/tests/hermes_cli/test_cron_shared_gateway_liveness.py
@@ -1,0 +1,102 @@
+"""Named-profile cron list must see a live shared/default-home gateway (#99631).
+
+``hermes -p triage cron list`` sets HERMES_HOME to the profile directory.
+Current-home lock/pid probes therefore miss the gateway process that lives
+in the default home and actually ticks that profile's cron store.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_constants
+from hermes_cli import cron as cron_cli
+
+
+@pytest.fixture()
+def named_profile_home(tmp_path, monkeypatch):
+    """``hermes -p triage`` layout: HERMES_HOME is the profile dir, not the root."""
+    default = tmp_path / ".hermes"
+    profile = default / "profiles" / "triage"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda *a, **k: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    hermes_constants._default_hermes_root_memo = None
+    yield SimpleNamespace(root=tmp_path, default=default, profile=profile)
+    hermes_constants._default_hermes_root_memo = None
+
+
+def _patch_current_home_dead(monkeypatch) -> None:
+    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(
+        "hermes_cli.gateway.named_profile_served_by_running_multiplexer",
+        lambda: False,
+    )
+
+
+def _path_aware_lock(default_home: Path, *, default_live: bool):
+    def _lock_active(lock_path=None):
+        from gateway.status import _get_gateway_lock_path
+
+        if lock_path is None:
+            return False
+        default_lock = _get_gateway_lock_path(default_home / "gateway.pid")
+        try:
+            return default_live and Path(lock_path).resolve() == default_lock.resolve()
+        except OSError:
+            return False
+
+    return _lock_active
+
+
+class TestNamedProfileSeesSharedGateway:
+    def test_default_home_lock_live_is_not_false(
+        self, named_profile_home, monkeypatch, capsys
+    ):
+        assert not (named_profile_home.profile / "gateway.pid").exists()
+        _patch_current_home_dead(monkeypatch)
+        monkeypatch.setattr(
+            "gateway.status.is_gateway_runtime_lock_active",
+            _path_aware_lock(named_profile_home.default, default_live=True),
+        )
+
+        assert cron_cli._builtin_gateway_liveness() is not False
+        cron_cli._warn_if_gateway_not_running()
+        assert "Gateway is not running" not in capsys.readouterr().out
+
+    def test_default_home_pid_live_is_not_false(
+        self, named_profile_home, monkeypatch, capsys
+    ):
+        assert not (named_profile_home.profile / "gateway.pid").exists()
+        (named_profile_home.default / "gateway.pid").write_text(
+            str(os.getpid()), encoding="utf-8"
+        )
+        _patch_current_home_dead(monkeypatch)
+        monkeypatch.setattr(
+            "gateway.status.is_gateway_runtime_lock_active",
+            _path_aware_lock(named_profile_home.default, default_live=False),
+        )
+
+        assert cron_cli._builtin_gateway_liveness() is not False
+        cron_cli._warn_if_gateway_not_running()
+        assert "Gateway is not running" not in capsys.readouterr().out
+
+    def test_neither_default_nor_profile_live_warns(
+        self, named_profile_home, monkeypatch, capsys
+    ):
+        assert not (named_profile_home.profile / "gateway.pid").exists()
+        assert not (named_profile_home.default / "gateway.pid").exists()
+        _patch_current_home_dead(monkeypatch)
+        monkeypatch.setattr(
+            "gateway.status.is_gateway_runtime_lock_active",
+            _path_aware_lock(named_profile_home.default, default_live=False),
+        )
+
+        assert cron_cli._builtin_gateway_liveness() is False
+        cron_cli._warn_if_gateway_not_running()
+        assert "Gateway is not running" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

`hermes -p <profile> cron list` warned that the gateway was not running even when the shared/default-home gateway was healthy and that profile's jobs were already firing.

`_builtin_gateway_liveness()` already checks the current-home runtime lock, `find_gateway_pids()`, and `named_profile_served_by_running_multiplexer()` (#97120 / #99441). Those first two probes still look at the *profile* `HERMES_HOME` (`~/.hermes/profiles/triage/gateway.lock` / `gateway.pid`), which the shared process never writes. The multiplexer helper only counts as live when default-home `gateway.pid` exists *and* `gateway.multiplex_profiles` is on, so Bot Mode / desktop-shared tickers and lock-held-but-pid-missing default gateways still false-alarmed.

For a named-profile CLI, after the current-home probes miss, treat the gateway as live when the default-home runtime lock or pid is active. The multiplexer helper remains a second signal. `hermes cron status` uses the same default-home fallback so it does not independently claim the gateway is down.

This does not change list/status copy (no competition with #99615, which labels the inspected profile).

## Related Issue

Fixes #99631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cron.py` — `_named_profile_shared_gateway_root()` / `_default_home_gateway_is_live()`; `_builtin_gateway_liveness()` and `cron_status()` consult default-home lock/pid when the current home is `<root>/profiles/<name>`
- `tests/hermes_cli/test_cron_shared_gateway_liveness.py` — named-profile `HERMES_HOME`, no local `gateway.pid`, default-home lock or pid live → liveness is not False and `_warn_if_gateway_not_running` is silent; neither default nor profile live → warn

## How to Test

1. Isolated named-profile home with no local `gateway.pid`, default-home lock mocked live → `_builtin_gateway_liveness()` is not False; `_warn_if_gateway_not_running()` prints nothing.
2. Same layout with a live default-home pid file and inactive lock → same (no warning).
3. Same layout with neither default nor profile live → warning prints.
4. Existing builtin-liveness / multiplexer / cron list tests still pass.

```
uv run --extra dev python -m pytest tests/hermes_cli/test_cron_shared_gateway_liveness.py tests/cron/test_87033_cronjob_gateway_liveness.py tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_status_profile_isolation.py tests/gateway/test_multiplex_lifecycle.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
