### PR TITLE
fix(desktop): recover incomplete transcript turns (salvage #88127)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -272,11 +272,10 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     // mutates the per-runtime cache entry, and syncSessionStateToView
     // guards the view publish to the active session, so this is safe.
     if (runningChanged && sessionId) {
-      // Set when THIS event released a turn that ended without ever
-      // producing an assistant payload, so the catch-up side effects below
-      // run on that edge only. The updater is invoked exactly once,
+      // Set when THIS event releases a confirmed live turn whose terminal
+      // message never arrived. The updater is invoked exactly once,
       // synchronously, by updateSessionState.
-      let recoveredWithoutPayload = false
+      let recoveredIncompleteTurn = false
 
       const nextState = updateSessionState(
         sessionId,
@@ -348,15 +347,14 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           }
 
           // Past that gate the turn DID start and the backend now reports it
-          // finished. When no assistant payload ever arrived (gateway crash
-          // mid-stream, provider error before the first delta, agent-build
-          // failure) message.complete never fires, so this is the only event
-          // that can release the session. Bailing here instead left
+          // finished. When message.complete never fires (gateway crash
+          // mid-stream, provider error, reconnect gap), this is the only
+          // event that can release the session. Bailing here instead left
           // awaitingResponse/busy latched until app restart (#46517): the
           // per-session busy flag is authoritative for isTargetSessionBusy,
           // so submitPrompt and the slash dispatcher silently returned false
           // and the session accepted no further input.
-          recoveredWithoutPayload = state.awaitingResponse && !state.sawAssistantPayload
+          recoveredIncompleteTurn = state.turnLive
 
           return {
             ...state,
@@ -381,13 +379,13 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
         payload?.stored_session_id || undefined
       )
 
-      if (recoveredWithoutPayload) {
+      if (recoveredIncompleteTurn) {
         // Stays unscoped, like the settle above: a background session's
         // sidebar row has to drop its working dot without the user opening
-        // it. This fires on the recovery edge only — once awaitingResponse
-        // is false the `state.busy === busy` guard above short-circuits
-        // every later heartbeat — so it costs one coalesced refresh per
-        // broken turn, not one per tick.
+        // it. This fires on the recovery edge only — once turnLive is false
+        // the `state.busy === busy` guard above short-circuits every later
+        // heartbeat — so it costs one coalesced refresh per broken turn,
+        // not one per tick.
         scheduleSessionsRefresh()
 
         // The transcript catch-up IS scoped. The stream died, but the turn

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -744,7 +744,13 @@ export function useMessageStream({
         shouldHydrate =
           !completionError &&
           !hasInlineError &&
-          !unresolvedUserTail &&
+          // A visible user message with no reply after the terminal frame
+          // means this window never rendered the turn's output. When the
+          // frame also carries no text, the reply only exists in stored
+          // history — hydrate to catch up instead of leaving the transcript
+          // blank until restart (#88036). A non-empty frame still settles
+          // locally, so the user-tail guard keeps applying there.
+          (!unresolvedUserTail || !finalText) &&
           !(localVisibleText && !finalText) &&
           (state.adoptedRunningTurn || !state.sawAssistantPayload || !finalText)
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -2,7 +2,8 @@ import { act, cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
-import { chatMessageText } from '@/lib/chat-messages'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionTodos } from '@/store/todos'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -77,6 +78,31 @@ describe('useMessageStream interim text sealing', () => {
     const texts = assistantMessages()
     expect(texts).toContain('awaaaaa clean!! tsc zero errors')
     expect(texts).toContain('All checks passed.')
+  })
+
+  it('hydrates an empty completion when the live transcript still ends with the user message', async () => {
+    // #88036: the terminal frame arrived empty while this window never
+    // rendered any assistant output — the reply exists only in stored
+    // history, so the settle must hydrate instead of leaving the
+    // transcript ending on the user's message until restart.
+    const hydrateFromStoredSession = vi.fn<() => Promise<void>>(async () => undefined)
+
+    stream = renderMessageStream(SID, {
+      hydrateFromStoredSession,
+      states: new Map([
+        [
+          SID,
+          createClientSessionState('stored-session-1', [
+            { id: 'user-1', parts: [textPart('finish the task')], role: 'user' }
+          ])
+        ]
+      ])
+    })
+    await start()
+
+    await complete('')
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, 'stored-session-1', SID)
   })
 
   it('marks sealed interim bubbles interim and leaves the final reply unmarked', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -120,7 +120,7 @@ describe('session.info model-options invalidation gating', () => {
   })
 })
 
-describe('session.info settles a turn that produced no assistant payload', () => {
+describe('session.info settles an incomplete live turn', () => {
   // #46517: a turn that ends without ever emitting an assistant payload (gateway
   // crash mid-stream, provider error before the first delta, agent-build
   // failure) never reaches message.complete, so session.info running=false is
@@ -261,6 +261,25 @@ describe('session.info settles a turn that produced no assistant payload', () =>
 
     expect(hydrateFromStoredSession).toHaveBeenCalledTimes(1)
     expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates a live turn that settles after an interim without message.complete', async () => {
+    mountStream()
+
+    startTurn(ACTIVE_SID)
+    act(() =>
+      stream.handleEvent({
+        payload: { already_streamed: true, text: 'Now checking the details before answering.' },
+        session_id: ACTIVE_SID,
+        type: 'message.interim'
+      })
+    )
+
+    expect(sessionStates!.get(ACTIVE_SID)?.sawAssistantPayload).toBe(true)
+
+    sessionInfo(ACTIVE_SID, { running: false })
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, null, ACTIVE_SID)
   })
 })
 


### PR DESCRIPTION
Salvages #88127 by @szzhoujiarui — cherry-picked onto current main with original authorship preserved. Refs #88036.

## What this fixes

The desktop transcript could stop rendering new assistant output while the turn completed fine in the backend/state.db — the UI stayed blank until app restart (#88036). Two terminal-event gaps in the renderer left the transcript stranded:

1. **Empty `message.complete` while the live transcript still ends with the user message** — the settle path skipped hydration (`unresolvedUserTail` guard), so the reply that exists only in stored history never reached the screen. Now an empty terminal frame with an unresolved user tail hydrates durable history.
2. **`session.info running=false` after interim assistant output, with no `message.complete`** — the recovery edge only fired for turns with *no* assistant payload (`awaitingResponse && !sawAssistantPayload`), so a turn that streamed an interim and then lost its terminal frame settled the busy flag but never hydrated. The discriminator is now `state.turnLive` (backend-confirmed live turn whose terminal message never arrived): settle the pending bubble, release the composer, refresh the sidebar, and hydrate the active session.

## Staleness resolved during salvage

The PR predates two main-side refactors; the cherry-pick was reconciled onto them:

- `gateway-event.ts` was split into `gateway-event/` per-family modules (0553a06728) — the session.info recovery change now lands in `gateway-event/session-info.ts`.
- The use-message-stream tests moved onto the shared `renderMessageStream` harness — both new tests were ported to the harness API (seeded `states` map + `hydrateFromStoredSession` override) instead of the PR's hand-rolled `Harness` component.
- Main's newer #95514 guard (`!(localVisibleText && !finalText)`) is preserved alongside the PR's relaxed user-tail condition (`!unresolvedUserTail || !finalText`); the two compose — the empty-frame hydration only fires when this window has no visible assistant text.

## Verification

**Live repro:** A/B vitest proof on this box — with main's unfixed `session-info.ts`/`index.ts` restored, both new recovery-sequence tests FAIL (`hydrates an empty completion when the live transcript still ends with the user message`, `hydrates a live turn that settles after an interim without message.complete`); with the salvage applied, the full use-message-stream suite passes 23 files / 141 tests. Desktop typecheck (`tsc -p .`, electron, e2e configs) and eslint on all changed files are clean. A live Electron rendering-recovery drive was not possible in this session (Playwright e2e lane disabled per #76627; no xvfb on this box) — vitest integration of the exact recovery event sequences is the verification surface, honestly stated.

## Infographic
![transcript-recovery](https://v3b.fal.media/files/b/0aa89460/MRgJglXCybQRfU5d9K3DJ_XbJLnT6v.png)
