### PR TITLE
fix(gateway): remove stale Windows startup fallback

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -718,6 +718,19 @@ def _install_startup_entry(script_path: Path) -> Path:
     return entry
 
 
+def _remove_startup_entries() -> None:
+    """Remove fallback login entries after a Scheduled Task takes ownership."""
+    for entry in (get_startup_entry_path(), _legacy_startup_entry_path()):
+        try:
+            entry.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            print(f"⚠ Could not remove stale Windows login item {entry}: {exc}")
+        else:
+            print(f"✓ Removed stale Windows login item: {entry}")
+
+
 def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     """Return (hidden_console_python, venv_dir, extra_pythonpath) for detached runs.
 
@@ -1107,6 +1120,7 @@ def install(
 
     ok, detail = _install_scheduled_task(task_name, script_path)
     if ok:
+        _remove_startup_entries()
         print(f"✓ {detail}")
         print(f"  Task script: {script_path}")
         print("ℹ Gateway auto-start installed for Windows login.")
@@ -1457,13 +1471,14 @@ def status(deep: bool = False) -> None:
             for key in ("status", "last run time", "last run result"):
                 if key in info:
                     print(f"  {key.title()}: {info[key]}")
-    elif startup_installed:
+    elif not startup_installed:
+        print("✗ Gateway service not installed")
+
+    if startup_installed:
         entry = get_startup_entry_path()
         if not entry.exists():
             entry = _legacy_startup_entry_path()
         print(f"✓ Windows login item installed: {entry}")
-    else:
-        print("✗ Gateway service not installed")
 
     if pids:
         print(f"✓ Gateway process running (PID: {', '.join(map(str, pids))})")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,6 +314,66 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+@pytest.mark.windows_only
+def test_install_scheduled_task_success_removes_startup_fallback(
+    monkeypatch, tmp_path
+):
+    script_path = tmp_path / "gateway-service" / "Hermes_Gateway_alice.cmd"
+    startup_entry = tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"
+    legacy_entry = startup_entry.with_suffix(".cmd")
+    startup_entry.parent.mkdir(parents=True)
+    startup_entry.write_text("fallback", encoding="utf-8")
+    legacy_entry.write_text("legacy fallback", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_prompt_install_choices",
+        lambda *args, **kwargs: (False, True),
+    )
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda task_name, path: (True, f"Registered Scheduled Task {task_name!r}"),
+    )
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: startup_entry)
+    monkeypatch.setattr(gateway_windows, "_legacy_startup_entry_path", lambda: legacy_entry)
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
+
+    gateway_windows.install(
+        start_now=False,
+        start_on_login=True,
+        elevated_handoff=True,
+    )
+
+    assert not startup_entry.exists()
+    assert not legacy_entry.exists()
+
+
+@pytest.mark.windows_only
+def test_status_reports_scheduled_task_and_startup_fallback_together(
+    monkeypatch, tmp_path, capsys
+):
+    startup_entry = tmp_path / "Startup" / "Hermes_Gateway_alice.vbs"
+    startup_entry.parent.mkdir(parents=True)
+    startup_entry.write_text("fallback", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "query_task_status", lambda: {})
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "get_startup_entry_path", lambda: startup_entry)
+
+    gateway_windows.status()
+
+    output = capsys.readouterr().out
+    assert "Scheduled Task registered: Hermes_Gateway_alice" in output
+    assert f"Windows login item installed: {startup_entry}" in output
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""


### PR DESCRIPTION
## Summary

- remove current and legacy Startup-folder fallbacks after Scheduled Task registration succeeds
- report both Windows auto-start mechanisms when stale entries coexist
- cover the install transition and status output with Windows tests

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -q`

## Related Issue

N/A
