### PR TITLE
fix(windows): drop Startup shim after Scheduled Task install

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -15,9 +15,12 @@ Design notes
 * We write a shared ``gateway.cmd`` wrapper plus a console-less ``gateway.vbs``
   launcher. Scheduled Task and Startup-folder persistence both route through
   VBS/wscript; immediate manual starts route through direct ``subprocess`` spawn.
-* Status = merge of "is the schtasks entry registered?" + "is the startup
-  login item present?" + "is there a gateway process running?" so the status
-  command keeps working regardless of which install path was taken.
+* Status lists every persistence mechanism that is actually present: the
+  schtasks entry, the Startup-folder shim, and any live gateway PID. When
+  both autostart paths exist, both are printed; status must not hide a
+  leftover shim behind a registered Scheduled Task.
+* A successful Scheduled Task install removes any leftover Startup-folder
+  shim for the same profile so both mechanisms do not fire at logon.
 * Quoting is tricky: schtasks parses ``/TR`` itself and cmd.exe parses the
   generated ``gateway.cmd``. Those are DIFFERENT parsers. We keep two
   separate quote helpers (same pattern OpenClaw uses) and never cross them.
@@ -354,6 +357,40 @@ def get_startup_entry_path() -> Path:
 def _legacy_startup_entry_path() -> Path:
     _assert_windows()
     return _startup_dir() / f"{_sanitize_filename(get_task_name())}.cmd"
+
+
+def _startup_shim_targets() -> tuple[tuple[Path, str], ...]:
+    """Current and legacy Startup-folder launchers for this profile."""
+    return (
+        (get_startup_entry_path(), "Windows login item"),
+        (_legacy_startup_entry_path(), "legacy Windows login item"),
+    )
+
+
+def _present_startup_entries() -> list[tuple[Path, str]]:
+    """Startup-folder shims that currently exist for this profile."""
+    return [(path, label) for path, label in _startup_shim_targets() if path.exists()]
+
+
+def _remove_startup_shims() -> list[tuple[Path, str]]:
+    """Unlink Startup-folder fallbacks for this profile.
+
+    A later elevated ``hermes gateway install`` must not leave a previously
+    written UAC-fallback shim in place; both would fire at logon (#99638).
+    Missing files are ignored. Other unlink errors are reported and skipped
+    so a leftover file cannot abort a successful Scheduled Task install.
+    """
+    removed: list[tuple[Path, str]] = []
+    for path, label in _startup_shim_targets():
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            print(f"⚠ Could not remove {label}: {path} ({exc})")
+            continue
+        removed.append((path, label))
+    return removed
 
 
 # ---------------------------------------------------------------------------
@@ -1110,6 +1147,8 @@ def install(
         print(f"✓ {detail}")
         print(f"  Task script: {script_path}")
         print("ℹ Gateway auto-start installed for Windows login.")
+        for path, label in _remove_startup_shims():
+            print(f"✓ Removed leftover {label}: {path}")
         if start_now:
             running_pids = _gateway_pids()
             if running_pids:
@@ -1220,8 +1259,6 @@ def uninstall() -> None:
     task_name = get_task_name()
     script_path = get_task_script_path()
     vbs_script_path = script_path.with_suffix(".vbs")
-    startup_entry = get_startup_entry_path()
-    legacy_startup_entry = _legacy_startup_entry_path()
 
     scheduled_task_removed = False
     if is_task_registered():
@@ -1246,9 +1283,10 @@ def uninstall() -> None:
         else:
             print(f"⚠ schtasks /Delete returned code {code}: {detail}")
 
+    for path, label in _remove_startup_shims():
+        print(f"✓ Removed {label}: {path}")
+
     for path, label in [
-        (startup_entry, "Windows login item"),
-        (legacy_startup_entry, "legacy Windows login item"),
         (script_path, "Task script"),
         (vbs_script_path, "Task launcher"),
     ]:
@@ -1272,7 +1310,7 @@ def is_task_registered() -> bool:
 
 
 def is_startup_entry_installed() -> bool:
-    return get_startup_entry_path().exists() or _legacy_startup_entry_path().exists()
+    return bool(_present_startup_entries())
 
 
 def is_installed() -> bool:
@@ -1447,7 +1485,7 @@ def status(deep: bool = False) -> None:
     _assert_windows()
     task_name = get_task_name()
     task_installed = is_task_registered()
-    startup_installed = is_startup_entry_installed()
+    startup_entries = _present_startup_entries()
     pids = _gateway_pids()
 
     if task_installed:
@@ -1457,12 +1495,12 @@ def status(deep: bool = False) -> None:
             for key in ("status", "last run time", "last run result"):
                 if key in info:
                     print(f"  {key.title()}: {info[key]}")
-    elif startup_installed:
-        entry = get_startup_entry_path()
-        if not entry.exists():
-            entry = _legacy_startup_entry_path()
-        print(f"✓ Windows login item installed: {entry}")
-    else:
+    for path, label in startup_entries:
+        if task_installed:
+            print(f"⚠ Leftover {label} still installed: {path}")
+        else:
+            print(f"✓ {label} installed: {path}")
+    if not task_installed and not startup_entries:
         print("✗ Gateway service not installed")
 
     if pids:
@@ -1479,7 +1517,7 @@ def status(deep: bool = False) -> None:
         # is lying when the high-level summary disagrees with reality.
         _print_deep_probes()
 
-    if not task_installed and not startup_installed and not pids:
+    if not task_installed and not startup_entries and not pids:
         print()
         print("To install:")
         print("  hermes gateway install")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -340,6 +340,109 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+def _mock_startup_dir(monkeypatch, tmp_path, *, task_name="Hermes_Gateway_alice"):
+    """Point Startup-folder helpers at a temp dir; skip the Windows host guard."""
+    startup_dir = tmp_path / "Startup"
+    startup_dir.mkdir()
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_startup_dir", lambda: startup_dir)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: task_name)
+    return startup_dir
+
+
+def test_install_scheduled_task_removes_startup_shim(monkeypatch, tmp_path, capsys):
+    """A later elevated install must drop the UAC-fallback shim (#99638)."""
+    startup_dir = _mock_startup_dir(monkeypatch, tmp_path)
+    shim = startup_dir / "Hermes_Gateway_alice.vbs"
+    legacy = startup_dir / "Hermes_Gateway_alice.cmd"
+    other = startup_dir / "Hermes_Gateway_bob.vbs"
+    shim.write_text("' leftover shim", encoding="utf-8")
+    legacy.write_text("rem leftover", encoding="utf-8")
+    other.write_text("' other profile", encoding="utf-8")
+    script_path = tmp_path / "gateway-service" / "Hermes_Gateway_alice.cmd"
+
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda task_name, path: (True, f"Created Scheduled Task {task_name!r}"),
+    )
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
+
+    gateway_windows.install(force=True, start_now=False, start_on_login=True)
+
+    assert not shim.exists()
+    assert not legacy.exists()
+    assert other.exists()
+    out = capsys.readouterr().out
+    assert "Created Scheduled Task 'Hermes_Gateway_alice'" in out
+    assert "Removed leftover Windows login item" in out
+    assert str(shim) in out
+    assert "Removed leftover legacy Windows login item" in out
+
+
+def test_status_reports_leftover_startup_shim_alongside_scheduled_task(
+    monkeypatch, tmp_path, capsys
+):
+    """Status must list both autostart paths when a leftover shim remains."""
+    startup_dir = _mock_startup_dir(monkeypatch, tmp_path)
+    shim = startup_dir / "Hermes_Gateway_alice.vbs"
+    shim.write_text("' leftover shim", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "query_task_status", lambda: {"status": "Ready"}
+    )
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+
+    gateway_windows.status()
+    out = capsys.readouterr().out
+    assert "Scheduled Task registered: Hermes_Gateway_alice" in out
+    assert "Leftover Windows login item still installed" in out
+    assert str(shim) in out
+    assert "Gateway service not installed" not in out
+
+
+def test_status_reports_startup_shim_when_scheduled_task_is_absent(
+    monkeypatch, tmp_path, capsys
+):
+    """Startup-only installs still surface as the active login item."""
+    startup_dir = _mock_startup_dir(monkeypatch, tmp_path)
+    shim = startup_dir / "Hermes_Gateway_alice.vbs"
+    shim.write_text("' fallback shim", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+
+    gateway_windows.status()
+    out = capsys.readouterr().out
+    assert "Windows login item installed" in out
+    assert str(shim) in out
+    assert "Leftover" not in out
+    assert "Scheduled Task registered" not in out
+
+
+def test_status_omits_startup_shim_when_only_scheduled_task_is_present(
+    monkeypatch, tmp_path, capsys
+):
+    """A clean Scheduled Task install must not invent a leftover shim line."""
+    _mock_startup_dir(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "query_task_status", lambda: {"status": "Ready"}
+    )
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+
+    gateway_windows.status()
+    out = capsys.readouterr().out
+    assert "Scheduled Task registered: Hermes_Gateway_alice" in out
+    assert "Windows login item" not in out
+    assert "Leftover" not in out
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes gateway install` on Windows falls back to a Startup-folder VBS shim when UAC is declined. Re-running later with elevation registers a Scheduled Task but left that shim in place, so both autostart paths fired at logon against the same launcher.

The single-instance guard already rejects the second process, so this is leftover state: `gateway status` reported only the task while the Startup entry survived reinstalls.

After a successful Scheduled Task install, remove the current and legacy Startup-folder shims for that profile. `gateway status` now lists both mechanisms when both still exist (leftover shim is called out instead of being hidden behind the task).

## Related Issue

Fixes #99638

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway_windows.py` — `_remove_startup_shims()` after successful `_install_scheduled_task`; uninstall reuses the same helper; `status()` prints every present autostart mechanism instead of `elif` hiding the shim
- `tests/hermes_cli/test_gateway_windows.py` — mocked Startup dir: successful task install deletes this profile's `.vbs`/`.cmd` shims and leaves another profile's file; status reports leftover shim beside a registered task, reports a Startup-only install, and omits a leftover line when only the task is present

## How to Test

1. Mock a profile Startup dir with leftover `.vbs` and `.cmd` shims, succeed at Scheduled Task install → both shims are gone; a differently named profile file remains.
2. Status with a registered task and leftover `.vbs` → both the task and leftover login item are printed.
3. Status with only the shim, or only the task → reports that one mechanism, not leftover noise.

```
uv run --extra dev python -m pytest tests/hermes_cli/test_gateway_windows.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A