### PR TITLE
fix(desktop): keep primary SSH session resumes remote (salvage #96895)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,8 +72,10 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  forgetSessionOwnerHintsForSession,
   requestSessionResume,
   sessionMatchesStoredId,
+  sessionOwnerRouteFromRow,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
@@ -992,17 +994,18 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // against whichever cached row is found first — the user clicks a row
     // previewing profile A and the resume dials profile B. Pin the row's own
     // (connection, profile) as the resume owner before navigating; untagged
-    // rows (single-profile installs, legacy pages) keep the id-only path.
+    // rows (single-profile installs and the legacy primary-SSH path) keep the
+    // ambient/id-only path. Clear any stale explicit hint first: older builds
+    // incorrectly persisted those rows as `local`, which made a remote session
+    // click switch to the Mac backend and fail with "session not found".
     onResumeSession: (sessionId, session) => {
-      const rowProfile = session?.profile?.trim()
+      const ownerRoute = sessionOwnerRouteFromRow(session)
 
-      if (rowProfile) {
-        requestSessionResume(sessionId, {
-          connectionId: session?.connection_id?.trim() || 'local',
-          ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
-          profile: rowProfile,
-          targetProfile: rowProfile
-        })
+      if (ownerRoute) {
+        requestSessionResume(sessionId, ownerRoute)
+      } else {
+        forgetSessionOwnerHintsForSession(sessionId)
+        requestSessionResume(sessionId)
       }
 
       openSession(sessionId, navigate)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -31,10 +31,12 @@ import {
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
+  forgetSessionOwnerHintsForSession,
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  getSessionOwnerHints,
   hydrateSessionOwnerHints,
   knownSessionOwner,
   knownSessionProfile,
@@ -42,6 +44,7 @@ import {
   rememberedSessionProfile,
   resolveComposerSessionKey,
   sessionBelongsToProfile,
+  sessionOwnerRouteFromRow,
   sessionPinId,
   setCurrentCwd,
   setCurrentCwdTransient,
@@ -175,6 +178,30 @@ describe('session owner hints', () => {
     hydrateSessionOwnerHints()
     expect(getSessionOwnerHint('stored-a')).toBeUndefined()
     expect(getSessionOwnerHint('stored-c')).toEqual({ connectionId: 'local', profile: 'omar' })
+  })
+
+  it('forgets every route for one session without disturbing other sessions', () => {
+    setSessionOwnerHint('poisoned', { connectionId: 'local', mode: 'local', profile: 'default' })
+    setSessionOwnerHint('poisoned', { connectionId: 'remote-a', mode: 'remote', profile: 'default' })
+    setSessionOwnerHint('healthy', { connectionId: 'remote-a', mode: 'remote', profile: 'default' })
+
+    forgetSessionOwnerHintsForSession('poisoned')
+
+    expect(getSessionOwnerHints('poisoned')).toEqual([])
+    expect(getSessionOwnerHint('healthy')).toMatchObject({ connectionId: 'remote-a' })
+
+    _resetSessionOwnerHintsForTests()
+    hydrateSessionOwnerHints()
+    expect(getSessionOwnerHints('poisoned')).toEqual([])
+    expect(getSessionOwnerHint('healthy')).toMatchObject({ connectionId: 'remote-a' })
+  })
+
+  it('pins only connection-tagged rows and leaves primary SSH rows ambient', () => {
+    expect(
+      sessionOwnerRouteFromRow(session({ connection_id: 'source-a', profile: 'worker' }))
+    ).toEqual({ connectionId: 'source-a', profile: 'worker', targetProfile: 'worker' })
+    expect(sessionOwnerRouteFromRow(session({ profile: 'default' }))).toBeUndefined()
+    expect(sessionOwnerRouteFromRow(session({ connection_id: '  ', profile: 'default' }))).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -867,6 +867,46 @@ export function forgetSessionOwnerHintsForConnection(connectionId: string): void
   }
 }
 
+/** Drop every persisted route for one session. Untagged rows are owned by the
+ * ambient backend that returned them, so a stale explicit hint must not force a
+ * later resume onto a different connection. */
+export function forgetSessionOwnerHintsForSession(sessionId: string): void {
+  const id = sessionId.trim()
+
+  if (!id) {
+    return
+  }
+
+  let changed = false
+
+  for (const [key, entry] of [...sessionOwnerHints]) {
+    if (entry.id === id) {
+      sessionOwnerHints.delete(key)
+      changed = true
+    }
+  }
+
+  if (changed) {
+    persistSessionOwnerHints()
+  }
+}
+
+/** Exact route carried by a connection-tagged row. An untagged row deliberately
+ * returns undefined: it belongs to the ambient backend that supplied the list,
+ * including the legacy primary-SSH path whose rows have no registry id. */
+export function sessionOwnerRouteFromRow(
+  session?: Pick<SessionInfo, 'connection_id' | 'profile'>
+): SessionOwnerRoute | undefined {
+  const connectionId = (session?.connection_id ?? '').trim()
+  const profile = (session?.profile ?? '').trim()
+
+  if (!connectionId || !profile) {
+    return undefined
+  }
+
+  return { connectionId, profile, targetProfile: profile }
+}
+
 /** @internal Tests: forget every in-memory hint (storage untouched unless asked). */
 export function _resetSessionOwnerHintsForTests({ storage = false }: { storage?: boolean } = {}): void {
   sessionOwnerHints.clear()


### PR DESCRIPTION
Salvage of #96895 by @oliver-mee — commit cherry-picked onto current `main` with original authorship preserved. Refs #93888 (stored-session-restore half; the runtime-ID-leak half was fixed by #95080).

## The regression

#95895 (`db127f750`) intended untagged legacy-primary-SSH session rows to keep the ambient/id-only resume path, but its `onResumeSession` click handler in `apps/desktop/src/app/contrib/wiring.tsx` synthesized an explicit local route for every row that carried a profile:

```ts
if (rowProfile) {
  requestSessionResume(sessionId, {
    connectionId: session?.connection_id?.trim() || 'local',
    ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
    profile: rowProfile,
    targetProfile: rowProfile
  })
}
```

`requestSessionResume` persists that route via `setSessionOwnerHint`, so one click on a remote (legacy primary-SSH) session's row permanently recorded it as locally owned. The next resume routed to the local backend → **"Restore failed — Session not found"**, or a bogus **"No inference provider configured"** when Desktop spawns a fresh local backend (dcdanielcoelho's repro on #93888).

## The fix (@oliver-mee)

- **`wiring.tsx`** — `onResumeSession` now uses `sessionOwnerRouteFromRow(session)`: connection-tagged rows keep their exact explicit route (`{connectionId, profile, targetProfile}` — the #92454 twin protection is intact for tagged rows); untagged rows take the ambient/id-only path, which `use-session-actions.resumeSession` already routes via the captured ambient connection.
- **`store/session.ts`** — new `sessionOwnerRouteFromRow` (returns `undefined` for untagged rows) and `forgetSessionOwnerHintsForSession`, which repairs already-poisoned persisted hints on the next click of an untagged row. Cleanup is scoped strictly to the clicked session's id; other sessions' hints are untouched (test-pinned).
- **Tests** — 2 new tests in `src/store/session.test.ts` pinning the untagged→ambient contract and the scoped hint cleanup (including persistence round-trip through `hydrateSessionOwnerHints`).

## Scope

This fixes the **legacy-primary-SSH untagged-row resume sub-case only**. It does NOT address the `connection.json`/`connections.json` registry drift for v1 SSH descriptors (`reconcileRegistryDrift` still skips `mode:'ssh'` configs — mgallmur-glitch's root cause), which is tracked separately on #93888.

**Live repro:** No live SSH remote is available on this box, so the verification surface is vitest + code trace (stated honestly). Before/after on the PR's own tests: on current `main` with only the PR's test file applied, the 2 new tests **fail** (`forgetSessionOwnerHintsForSession is not a function`, `sessionOwnerRouteFromRow is not a function` — and the pinned untagged→ambient contract is violated by the `connectionId:'local'` handler); with the fix cherry-picked, all **91/91 tests pass**. `tsc --noEmit` clean, `eslint` clean on the three changed files.

Credit: @oliver-mee (author, commit authorship preserved). Refs #93888.

## Infographic
![keep-primary-ssh-session-resumes-remote](https://v3b.fal.media/files/b/0aa89478/ihP550snhd5nTPnDkyf8__OxWaR4rh.png)
