### PR TITLE
fix(telegram): throttle typing keep-alives per chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5452,6 +5452,16 @@ class BasePlatformAdapter(ABC):
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:
+                    # Stamp happens inside the claim, before the await. If
+                    # this send never actually delivers, restore the previous
+                    # stamp so a sibling session can take the next tick
+                    # instead of a wedged winner blacking out the chat.
+                    clock = getattr(self, "_typing_clock", None)
+                    if clock is None:
+                        self._typing_clock = {}
+                        clock = self._typing_clock
+                    key = str(chat_id)
+                    prev = clock.get(key, 0.0)
                     if self._claim_typing_tick(chat_id, interval):
                         try:
                             await asyncio.wait_for(
@@ -5461,10 +5471,11 @@ class BasePlatformAdapter(ABC):
                         except asyncio.TimeoutError:
                             # Slow network — abandon this tick, keep the loop
                             # on schedule so the next send_typing fires fresh.
-                            pass
+                            clock[key] = prev
                         except asyncio.CancelledError:
                             raise
                         except Exception as typing_err:
+                            clock[key] = prev
                             logger.debug(
                                 "[%s] send_typing error (non-fatal): %s",
                                 self.name, typing_err,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3260,6 +3260,14 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Shared per-chat typing keep-alive clock (chat_id -> monotonic ts).
+        # Telegram rate-limits sendChatAction per CHAT, but _keep_typing runs
+        # per SESSION. DM topics share one chat_id, so N concurrent sessions
+        # would otherwise each refresh every 2s (N x 0.5 calls/s against a
+        # ~1 msg/s envelope) until Telegram flood-bans the chat (#99643).
+        # Same class of gate as progress edits: one tick per chat per
+        # interval, regardless of how many sessions are active in it.
+        self._typing_clock: Dict[str, float] = {}
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
         # by adapters whose typing indicator renders text (Slack's
@@ -5365,6 +5373,45 @@ class BasePlatformAdapter(ABC):
 
         return paths, cleaned
 
+    def _claim_typing_tick(
+        self,
+        chat_id: str,
+        interval: float,
+        *,
+        now: float | None = None,
+    ) -> bool:
+        """Claim the shared per-chat typing keep-alive slot.
+
+        Telegram rate-limits sendChatAction per CHAT, but ``_keep_typing``
+        runs per SESSION. DM topics share one chat_id, so N concurrent
+        sessions would each refresh every ``interval`` seconds (N x 0.5
+        calls/s against a ~1 msg/s envelope) until Telegram flood-bans
+        the chat (#99643).
+
+        Same class of gate as progress edits: one tick per chat per
+        interval, regardless of how many sessions are active in it.
+
+        Returns True if this caller owns the tick and should ``send_typing``.
+        asyncio is single-threaded, so stamping the clock *before* awaiting
+        send_typing makes the claim atomic against sibling loops.
+        """
+        clock = getattr(self, "_typing_clock", None)
+        if clock is None:
+            self._typing_clock = {}
+            clock = self._typing_clock
+        key = str(chat_id)
+        if now is None:
+            now = time.monotonic()
+        last = clock.get(key, 0.0)
+        try:
+            gap = float(interval)
+        except (TypeError, ValueError):
+            gap = 2.0
+        if gap > 0.0 and (now - last) < gap:
+            return False
+        clock[key] = now
+        return True
+
     async def _keep_typing(
         self,
         chat_id: str,
@@ -5377,6 +5424,10 @@ class BasePlatformAdapter(ABC):
         
         Telegram/Discord typing status expires after ~5 seconds, so we refresh every 2
         to recover quickly after progress messages interrupt it.
+
+        Typing refreshes are gated on a shared per-chat clock so concurrent
+        sessions in the same chat (Telegram DM topics share one chat_id) do
+        not multiply sendChatAction traffic past the platform flood envelope.
         
         Skips send_typing when the chat is in ``_typing_paused`` (e.g. while
         the agent is waiting for dangerous-command approval).  This is critical
@@ -5401,22 +5452,23 @@ class BasePlatformAdapter(ABC):
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:
-                    try:
-                        await asyncio.wait_for(
-                            self.send_typing(chat_id, metadata=metadata),
-                            timeout=_send_typing_timeout,
-                        )
-                    except asyncio.TimeoutError:
-                        # Slow network — abandon this tick, keep the loop
-                        # on schedule so the next send_typing fires fresh.
-                        pass
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as typing_err:
-                        logger.debug(
-                            "[%s] send_typing error (non-fatal): %s",
-                            self.name, typing_err,
-                        )
+                    if self._claim_typing_tick(chat_id, interval):
+                        try:
+                            await asyncio.wait_for(
+                                self.send_typing(chat_id, metadata=metadata),
+                                timeout=_send_typing_timeout,
+                            )
+                        except asyncio.TimeoutError:
+                            # Slow network — abandon this tick, keep the loop
+                            # on schedule so the next send_typing fires fresh.
+                            pass
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as typing_err:
+                            logger.debug(
+                                "[%s] send_typing error (non-fatal): %s",
+                                self.name, typing_err,
+                            )
                 if stop_event is None:
                     await asyncio.sleep(interval)
                     continue

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8548,9 +8548,33 @@ class TelegramAdapter(BasePlatformAdapter):
         self._telegram_typing_cooldown_until.pop(str(chat_id), None)
         return False
 
+    def _send_in_cooldown(self, chat_id: str) -> bool:
+        """True when this chat is inside the per-chat send cooldown (#66722).
+
+        Typing must not hammer sendChatAction while send()/edit is already
+        flood-limited. getattr-guard: the dict is populated by send() when
+        that gate is present; tests (and older adapters) may set it directly.
+        Stamped with ``time.monotonic()``.
+        """
+        until_map = getattr(self, "_send_cooldown_until", None)
+        if not until_map:
+            return False
+        until = until_map.get(str(chat_id))
+        if until is None:
+            return False
+        try:
+            until_ts = float(until)
+        except (TypeError, ValueError):
+            return False
+        return time.monotonic() < until_ts
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """Send typing indicator."""
-        if not self._bot or self._typing_in_cooldown(chat_id):
+        """Send typing indicator.
+
+        No-ops while the chat is in the per-chat send cooldown so a known
+        flood window quiesces typing traffic instead of extending it.
+        """
+        if not self._bot or self._typing_in_cooldown(chat_id) or self._send_in_cooldown(chat_id):
             return
 
         _is_dm_topic: bool = False

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -308,3 +308,33 @@ class TestKeepTypingPerChatClock:
         await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=1.0)
 
         assert sorted(calls) == ["dm-a", "dm-b"]
+
+    @pytest.mark.asyncio
+    async def test_failed_tick_releases_slot_for_sibling(self, monkeypatch):
+        """A winner whose send_typing errors must not starve the chat (#99676)."""
+        adapter = _StubAdapter()
+        calls = []
+
+        async def failing_then_ok(chat_id, metadata=None):
+            calls.append(chat_id)
+            if len(calls) == 1:
+                raise RuntimeError("transport down")
+
+        monkeypatch.setattr(adapter, "send_typing", failing_then_ok)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        task_a = asyncio.create_task(
+            adapter._keep_typing("shared-dm", interval=10.0, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.02)
+        task_b = asyncio.create_task(
+            adapter._keep_typing("shared-dm", interval=10.0, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=1.0)
+
+        assert calls == ["shared-dm", "shared-dm"], (
+            f"sibling must pick up the next tick after a failed send, got {calls!r}"
+        )

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -234,3 +234,77 @@ class TestKeepTypingTimeoutPerTick:
             ("discord-chat", True),
         ]
         assert "discord-chat" not in adapter._typing_paused
+
+
+class TestKeepTypingPerChatClock:
+    """Telegram rate-limits sendChatAction per CHAT, but _keep_typing runs
+    per SESSION. DM topics share one chat_id; without a shared clock, N
+    concurrent sessions multiply the refresh rate until Telegram flood-bans
+    the chat (#99643).
+    """
+
+    def test_claim_typing_tick_is_per_chat_not_per_session(self):
+        adapter = _StubAdapter()
+        assert adapter._claim_typing_tick("chat-1", 2.0, now=10.0) is True
+        # Sibling session in the same chat must not double the rate.
+        assert adapter._claim_typing_tick("chat-1", 2.0, now=10.5) is False
+        assert adapter._claim_typing_tick("chat-1", 2.0, now=11.9) is False
+        # A different chat has its own slot.
+        assert adapter._claim_typing_tick("chat-2", 2.0, now=10.5) is True
+        # After the interval the original chat can fire again.
+        assert adapter._claim_typing_tick("chat-1", 2.0, now=12.0) is True
+
+    @pytest.mark.asyncio
+    async def test_two_sessions_same_chat_do_not_double_rate(self, monkeypatch):
+        adapter = _StubAdapter()
+        calls = []
+
+        async def recording_send_typing(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        # Interval longer than the observation window so each loop fires
+        # only its first tick. Without the per-chat clock that is 2 sends.
+        task_a = asyncio.create_task(
+            adapter._keep_typing("shared-dm", interval=10.0, stop_event=stop_event)
+        )
+        task_b = asyncio.create_task(
+            adapter._keep_typing("shared-dm", interval=10.0, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=1.0)
+
+        assert calls == ["shared-dm"], (
+            f"two sessions in the same chat must share one typing tick, "
+            f"got {calls!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_sessions_different_chats_keep_independent_clocks(
+        self, monkeypatch
+    ):
+        adapter = _StubAdapter()
+        calls = []
+
+        async def recording_send_typing(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        task_a = asyncio.create_task(
+            adapter._keep_typing("dm-a", interval=10.0, stop_event=stop_event)
+        )
+        task_b = asyncio.create_task(
+            adapter._keep_typing("dm-b", interval=10.0, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=1.0)
+
+        assert sorted(calls) == ["dm-a", "dm-b"]

--- a/tests/gateway/test_telegram_typing_backoff.py
+++ b/tests/gateway/test_telegram_typing_backoff.py
@@ -1,6 +1,7 @@
 """Telegram typing indicator transient backoff tests."""
 
 import sys
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -84,3 +85,29 @@ async def test_typing_bad_thread_failure_does_not_cool_down(monkeypatch):
 
     assert adapter._bot.send_chat_action.await_count == 2
     assert "123" not in adapter._telegram_typing_cooldown_until
+
+
+@pytest.mark.asyncio
+async def test_send_typing_noops_during_send_cooldown():
+    """sendChatAction must not fire while the chat is in send cooldown.
+
+    The per-chat send cooldown (#66722) gates send()/edit. Typing used to
+    walk past it and keep hammering a flood-limited chat (#99643).
+    """
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(return_value=None)
+    adapter._send_cooldown_until = {"123": time.monotonic() + 30.0}
+
+    await adapter.send_typing("123")
+
+    adapter._bot.send_chat_action.assert_not_called()
+
+    # A different chat is not blocked.
+    await adapter.send_typing("456")
+    adapter._bot.send_chat_action.assert_called_once()
+
+    # After the cooldown expires, typing resumes.
+    adapter._send_cooldown_until["123"] = time.monotonic() - 0.1
+    adapter._bot.send_chat_action.reset_mock()
+    await adapter.send_typing("123")
+    adapter._bot.send_chat_action.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Telegram rate-limits `sendChatAction` per **chat**, but `_keep_typing` refreshed typing every 2s per **session**. DM topics all share one `chat_id`, so N concurrent topics produced N × 0.5 calls/s into a single private chat against a ~1 msg/s envelope and could flood-ban the chat with almost no edit volume.

This adds a shared per-chat keep-alive clock on the adapter (one tick per `chat_id` per interval, regardless of how many sessions are active). Sibling loops still run; they skip `send_typing` when another session already claimed the slot.

`TelegramAdapter.send_typing` also no-ops while `_send_cooldown_until` is active, so a known flood window quiesces typing instead of extending it. That dict is getattr-guarded: send() stamps it when the #66722 gate is present; tests can set it directly.

## Related Issue

Fixes #99643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — `_typing_clock` keyed by `chat_id`; `_claim_typing_tick()` stamps the clock before awaiting `send_typing` so sibling session loops cannot double the rate
- `plugins/platforms/telegram/adapter.py` — `send_typing` skips `sendChatAction` while `_send_cooldown_until` is in the future for that chat
- `tests/gateway/test_keep_typing_timeout.py` — two sessions on the same `chat_id` produce one tick; different chats stay independent
- `tests/gateway/test_telegram_typing_backoff.py` — `send_typing` no-ops during send cooldown and resumes after it expires

## How to Test

1. `uv run --extra dev python -m pytest tests/gateway/test_keep_typing_timeout.py tests/gateway/test_telegram_typing_backoff.py -q`
2. Two `_keep_typing` loops on the same `chat_id` must not double `send_typing` in the first interval.
3. Set `_send_cooldown_until[chat_id]` in the future and call `TelegramAdapter.send_typing` — `send_chat_action` must not fire.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A