### PR TITLE
fix(agent): clone plugin context engines via clone_for_agent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -533,6 +533,50 @@ def _refuse_checkpoint_required_on_codex_app_server(
         )
 
 
+def _clone_plugin_context_engine(candidate: Any) -> Any:
+    """Return a per-agent copy of a process-wide plugin context engine.
+
+    Prefers an explicit ``clone_for_agent()`` hook so engines that own
+    unpickleable runtime state (SQLite connections, locks, clients) can
+    construct a fresh instance (#99640). Falls back to ``copy.deepcopy``
+    for engines that do not implement the hook.
+
+    A distinct instance is required so a child agent's ``update_model()``
+    cannot mutate the parent's compressor (#42449). Raises on failure so
+    the caller can fall back to the built-in compressor.
+    """
+    import copy
+
+    clone_fn = getattr(candidate, "clone_for_agent", None)
+    if callable(clone_fn):
+        return clone_fn()
+    return copy.deepcopy(candidate)
+
+
+def _try_clone_plugin_context_engine(
+    candidate: Any, engine_name: str
+) -> tuple[Any | None, bool]:
+    """Clone a plugin context-engine singleton for one agent.
+
+    Returns ``(clone, False)`` on success. On failure logs a warning and
+    returns ``(None, True)`` so the caller can fall back to the built-in
+    compressor without mislabelling the engine as "not found".
+    """
+    try:
+        return _clone_plugin_context_engine(candidate), False
+    except Exception as copy_err:
+        _ra().logger.warning(
+            "Context engine '%s' could not be safely cloned for this "
+            "agent (%s) — falling back to built-in compressor. Plugin "
+            "engines that hold uncopyable state (locks, DB connections) "
+            "should implement clone_for_agent() to construct a fresh "
+            "per-agent runtime.",
+            engine_name,
+            copy_err,
+        )
+        return None, True
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -2710,26 +2754,16 @@ def init_agent(
             except Exception:
                 _candidate = None
             if _candidate is not None and _candidate.name == _engine_name:
-                # Deep-copy the shared plugin singleton so a child agent's
+                # Clone the shared plugin singleton so a child agent's
                 # update_model() can't mutate the parent's compressor (#42449).
-                # Copy can fail for engines holding uncopyable state (locks, DB
-                # connections, clients); in that case fall back to the built-in
-                # compressor with an ACCURATE message rather than silently
-                # mislabelling it "not found".
-                import copy
-                try:
-                    _selected_engine = copy.deepcopy(_candidate)
-                except Exception as _copy_err:
-                    _copy_failed = True
-                    _ra().logger.warning(
-                        "Context engine '%s' could not be safely copied for this "
-                        "agent (%s) — falling back to built-in compressor. Plugin "
-                        "engines that hold uncopyable state (locks, DB connections) "
-                        "should implement __deepcopy__ to copy only mutable budget "
-                        "state.",
-                        _engine_name, _copy_err,
-                    )
-                    _selected_engine = None
+                # Prefer clone_for_agent() when engines hold uncopyable state
+                # (locks, DB connections, clients); otherwise deepcopy.
+                # Failure falls back to the built-in compressor with an
+                # ACCURATE message rather than silently mislabelling it
+                # "not found" (#99640).
+                _selected_engine, _copy_failed = _try_clone_plugin_context_engine(
+                    _candidate, _engine_name
+                )
 
         if _selected_engine is None and not _copy_failed:
             _ra().logger.warning(

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -233,115 +233,181 @@ class TestPluginContextEngineDeepCopy:
 
 
 
-class TestInitAgentDoesNotMutatePluginSingleton:
-    """Regression coverage for #42449: a child agent's init must not mutate the
-    shared plugin context-engine singleton via update_model().
+class TestClonePluginContextEngine:
+    """Per-agent clone of the process-wide plugin context engine.
 
-    Note: ``test_child_init_does_not_corrupt_parent_singleton`` replicates the
-    init_agent selection-block *pattern* (it cannot cheaply spin up a full
-    init_agent), so it documents/verifies the deepcopy approach but does NOT by
-    itself guard a production revert. The real revert guard is
-    ``test_agent_init_source_deepcopies_singleton_not_aliases`` (source-pin),
-    and ``test_unpicklable_engine_falls_back_gracefully`` covers the
-    copy-failure path.
+    #99640: prefer ``clone_for_agent()`` when present, else deepcopy.
+    #42449: the clone must be distinct so ``update_model()`` cannot leak
+    back into the registered singleton.
     """
 
-    def test_child_init_does_not_corrupt_parent_singleton(self, monkeypatch):
-        import hermes_cli.plugins as plugins_mod
-        from hermes_cli.plugins import PluginManager
+    def test_clone_for_agent_used_when_engine_is_unpickleable(self, monkeypatch):
+        """Unpickleable state plus ``clone_for_agent()`` uses the hook, not deepcopy."""
+        import copy as copy_mod
+        import sqlite3
 
-        # Register a "parent" engine as the global plugin singleton, sized for
-        # a 1M-context model (DeepSeek-style), threshold 20% => 200K.
+        from agent.agent_init import _try_clone_plugin_context_engine
+
+        class _UnpickleableClonableEngine(StubEngine):
+            def __init__(self, context_length=1_000_000, threshold_pct=0.20):
+                super().__init__(
+                    context_length=context_length, threshold_pct=threshold_pct
+                )
+                self._conn = sqlite3.connect(":memory:")
+                self.clone_calls = 0
+
+            def clone_for_agent(self):
+                self.clone_calls += 1
+                clone = type(self)(
+                    context_length=self.context_length,
+                    threshold_pct=0.20,
+                )
+                clone.threshold_tokens = self.threshold_tokens
+                return clone
+
+        engine = _UnpickleableClonableEngine()
+        clone = None
+        try:
+            with pytest.raises(TypeError):
+                copy_mod.deepcopy(engine)
+
+            engine_deepcopy_calls = []
+            real_deepcopy = copy_mod.deepcopy
+
+            def _spy(obj, *args, **kwargs):
+                if obj is engine:
+                    engine_deepcopy_calls.append(obj)
+                return real_deepcopy(obj, *args, **kwargs)
+
+            monkeypatch.setattr(copy_mod, "deepcopy", _spy)
+
+            clone, failed = _try_clone_plugin_context_engine(engine, "stub")
+
+            assert failed is False
+            assert clone is not engine
+            assert engine.clone_calls == 1
+            assert engine_deepcopy_calls == []
+            assert clone.context_length == engine.context_length
+
+            clone.update_model(
+                model="MiniMax-M2", context_length=204800, provider="minimax"
+            )
+            assert engine.context_length == 1_000_000
+            assert clone.context_length == 204800
+        finally:
+            engine._conn.close()
+            clone_conn = getattr(clone, "_conn", None) if clone is not None else None
+            if clone_conn is not None:
+                clone_conn.close()
+
+    def test_deepcopy_used_when_clone_for_agent_absent(self, monkeypatch):
+        """Engines without the hook are deep-copied; child mutation stays isolated."""
+        import copy as copy_mod
+
+        import hermes_cli.plugins as plugins_mod
+        from agent.agent_init import _try_clone_plugin_context_engine
+        from hermes_cli.plugins import PluginManager, get_plugin_context_engine
+
         singleton = StubEngine(context_length=1_000_000, threshold_pct=0.20)
+        assert not callable(getattr(singleton, "clone_for_agent", None))
+
+        engine_deepcopy_calls = []
+        real_deepcopy = copy_mod.deepcopy
+
+        def _spy(obj, *args, **kwargs):
+            if obj is singleton:
+                engine_deepcopy_calls.append(obj)
+            return real_deepcopy(obj, *args, **kwargs)
+
+        monkeypatch.setattr(copy_mod, "deepcopy", _spy)
+
         old_mgr = plugins_mod._plugin_manager
         try:
             mgr = PluginManager()
             mgr._context_engine = singleton
             plugins_mod._plugin_manager = mgr
 
-            # Replicate init_agent's fallback selection-block pattern: fetch the
-            # singleton, deepcopy it, then mutate the copy via update_model with
-            # a SMALLER child context (MiniMax-style 204800).
-            import copy
-            from hermes_cli.plugins import get_plugin_context_engine
+            candidate = get_plugin_context_engine()
+            assert candidate is singleton
 
-            _candidate = get_plugin_context_engine()
-            assert _candidate is singleton
-            _selected_engine = copy.deepcopy(_candidate)
-            _selected_engine.update_model(
-                model="MiniMax-M2", context_length=204800, provider="minimax",
-            )
+            clone, failed = _try_clone_plugin_context_engine(candidate, "stub")
 
-            # The child's smaller context must NOT leak back into the parent
-            # singleton (the #42449 corruption).
-            assert singleton.context_length == 1_000_000, (
-                "parent singleton context_length was corrupted by child init"
+            assert failed is False
+            assert engine_deepcopy_calls == [singleton]
+            assert clone is not singleton
+
+            clone.update_model(
+                model="MiniMax-M2", context_length=204800, provider="minimax"
             )
+            assert singleton.context_length == 1_000_000
             assert singleton.threshold_tokens == 200_000
-            # And the child's own engine reflects the child model.
-            assert _selected_engine.context_length == 204800
-            assert _selected_engine is not singleton
+            assert clone.context_length == 204800
         finally:
             plugins_mod._plugin_manager = old_mgr
 
-    def test_unpicklable_engine_falls_back_gracefully(self, monkeypatch):
-        """Copy-failure path: an engine holding uncopyable state (a lock — the
-        plugin docs prescribe locks/DB connections for stateful engines) makes
-        copy.deepcopy raise. init_agent must NOT silently drop it with a
-        misleading 'not found'; it falls back to the built-in compressor and
-        logs an accurate copy-failure warning. Regression for the deepcopy-
-        copy-failure path."""
-        import threading
+    def test_unpickleable_engine_without_hook_falls_back(self, monkeypatch):
+        """Copy failure without ``clone_for_agent()`` falls back and warns."""
+        import copy as copy_mod
+        import sqlite3
+        from unittest.mock import MagicMock
+
+        from agent.agent_init import _try_clone_plugin_context_engine
 
         class _UncopyableEngine(StubEngine):
             def __init__(self):
                 super().__init__(context_length=1_000_000, threshold_pct=0.20)
-                self._lock = threading.RLock()  # RLock can't be deepcopied
+                self._conn = sqlite3.connect(":memory:")
 
         engine = _UncopyableEngine()
-        # Sanity: the engine genuinely defeats deepcopy.
-        import copy
-        with pytest.raises(Exception):
-            copy.deepcopy(engine)
-
-        # Replicate the init_agent fallback block's copy-failure handling.
-        selected = None
-        copy_failed = False
-        try:
-            selected = copy.deepcopy(engine)
-        except Exception:
-            copy_failed = True
-            selected = None
-
-        assert copy_failed is True
-        assert selected is None
-        # The original engine is untouched (no partial mutation).
-        assert engine.context_length == 1_000_000
-
-    def test_agent_init_source_deepcopies_singleton_not_aliases(self):
-        """Source-pin guarding the production fix in agent/agent_init.py:
-        the plugin-singleton fallback MUST deepcopy the candidate, not alias
-        it (`_selected_engine = _candidate`). Full init_agent is too heavy to
-        drive here, so this pins the exact line so a future revert to direct
-        assignment fails CI. Regression for #42449."""
-        import inspect
-        import re
-        import agent.agent_init as _ai
-
-        src = inspect.getsource(_ai)
-        # The candidate fetched from the plugin singleton must be deep-copied
-        # before becoming _selected_engine (which is later mutated by
-        # update_model). A bare `_selected_engine = _candidate` is the bug.
-        assert re.search(
-            r"_selected_engine\s*=\s*(copy|_copy)\.deepcopy\(\s*_candidate\s*\)",
-            src,
-        ), (
-            "agent_init must deepcopy the plugin context-engine singleton "
-            "(`_selected_engine = copy.deepcopy(_candidate)`) — a bare "
-            "`_selected_engine = _candidate` re-introduces #42449 (child "
-            "update_model corrupts the parent's shared singleton)."
+        mock_logger = MagicMock()
+        monkeypatch.setattr(
+            "agent.agent_init._ra", lambda: MagicMock(logger=mock_logger)
         )
-        # And the bug-shape alias must NOT be present on that path.
-        assert not re.search(
-            r"_selected_engine\s*=\s*_candidate\b", src
-        ), "found the #42449 bug-shape alias `_selected_engine = _candidate`"
+        try:
+            with pytest.raises(TypeError):
+                copy_mod.deepcopy(engine)
+
+            clone, failed = _try_clone_plugin_context_engine(engine, "stub")
+
+            assert failed is True
+            assert clone is None
+            assert engine.context_length == 1_000_000
+            mock_logger.warning.assert_called_once()
+            warning = mock_logger.warning.call_args[0][0]
+            assert "could not be safely cloned" in warning
+            assert "falling back to built-in compressor" in warning
+        finally:
+            engine._conn.close()
+
+    def test_clone_for_agent_error_falls_back(self, monkeypatch):
+        """A raising ``clone_for_agent()`` falls back; deepcopy is not a second try."""
+        import copy as copy_mod
+        from unittest.mock import MagicMock
+
+        from agent.agent_init import _try_clone_plugin_context_engine
+
+        class _BrokenCloneEngine(StubEngine):
+            def clone_for_agent(self):
+                raise RuntimeError("clone exploded")
+
+        engine = _BrokenCloneEngine()
+        engine_deepcopy_calls = []
+        real_deepcopy = copy_mod.deepcopy
+
+        def _spy(obj, *args, **kwargs):
+            if obj is engine:
+                engine_deepcopy_calls.append(obj)
+            return real_deepcopy(obj, *args, **kwargs)
+
+        monkeypatch.setattr(copy_mod, "deepcopy", _spy)
+        mock_logger = MagicMock()
+        monkeypatch.setattr(
+            "agent.agent_init._ra", lambda: MagicMock(logger=mock_logger)
+        )
+
+        clone, failed = _try_clone_plugin_context_engine(engine, "stub")
+
+        assert failed is True
+        assert clone is None
+        assert engine_deepcopy_calls == []
+        mock_logger.warning.assert_called_once()

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -411,3 +411,26 @@ class TestClonePluginContextEngine:
         assert clone is None
         assert engine_deepcopy_calls == []
         mock_logger.warning.assert_called_once()
+
+    def test_agent_init_source_routes_plugin_singleton_through_clone_helper(self):
+        """Source-pin for #42449: production init must clone the plugin
+        singleton, not alias it. Full init_agent is too heavy to drive
+        here, so this pins the call site. The helper tests above do not
+        catch `_selected_engine = _candidate`."""
+        import inspect
+        import re
+
+        import agent.agent_init as _ai
+
+        src = inspect.getsource(_ai)
+        assert re.search(
+            r"_try_clone_plugin_context_engine\s*\(\s*_candidate",
+            src,
+        ), (
+            "agent_init must clone the plugin context-engine singleton via "
+            "`_try_clone_plugin_context_engine(_candidate, …)` — a bare "
+            "`_selected_engine = _candidate` re-introduces #42449."
+        )
+        assert not re.search(
+            r"_selected_engine\s*=\s*_candidate\b", src
+        ), "found the #42449 bug-shape alias `_selected_engine = _candidate`"


### PR DESCRIPTION
## What does this PR do?

`init_agent()` always `copy.deepcopy()`'d the process-wide plugin context engine. Engines that own live SQLite connections (for example hermes-lcm) fail pickle, so Hermes logged a warning and silently used the built-in `ContextCompressor` for every child agent that took the general-plugin path.

Prefer a callable `clone_for_agent()` hook when the plugin provides one, otherwise keep `deepcopy`. Isolation for `#42449` is unchanged: the child still gets a distinct instance before `update_model()`. If either strategy fails, keep the graceful fallback warning and use the built-in compressor — do not mislabel the engine as "not found".

## Related Issue

Fixes #99640

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py` — `_clone_plugin_context_engine()` / `_try_clone_plugin_context_engine()`; general-plugin fallback uses `clone_for_agent()` when callable, else `deepcopy`; clone failure still warns and falls back
- `tests/agent/test_context_engine.py` — unpickleable engine with `clone_for_agent()` uses the hook; deepcopy still used when the method is absent; failure still falls back and warns

## How to Test

1. Unpickleable engine (`sqlite3.Connection`) plus `clone_for_agent()` → hook is used, deepcopy is not, clone is distinct, child `update_model()` does not mutate the singleton.
2. Engine without `clone_for_agent()` → deepcopy is used; child mutation stays isolated (`#42449`).
3. Unpickleable engine without the hook, or a raising `clone_for_agent()` → `(None, True)` and the clone-failure warning; no silent "not found".

```
uv run --extra dev python -m pytest tests/agent/test_context_engine.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A