### PR TITLE
fix(desktop): render /new sessions as siblings not branches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1280,6 +1280,7 @@ export function upsertOptimisticSession(
     model: created.info?.model ?? null,
     output_tokens: 0,
     parent_session_id: parentSessionId,
+    ...(parentSessionId ? { _branched_from: parentSessionId } : {}),
     preview,
     profile: profileKey,
     source: 'tui',

--- a/apps/desktop/src/lib/session-branch-tree.test.ts
+++ b/apps/desktop/src/lib/session-branch-tree.test.ts
@@ -4,16 +4,36 @@ import type { SessionInfo } from '@/types/hermes'
 
 import { makeSessionInfo } from '../test/session-info'
 
-import { flattenSessionsWithBranches } from './session-branch-tree'
+import { flattenSessionsWithBranches, forkParentId } from './session-branch-tree'
 
 const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
   makeSessionInfo({ id, message_count: 1, source: 'cli', title: id, ...overrides })
 
+const fork = (id: string, parentId: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
+  session(id, { _branched_from: parentId, parent_session_id: parentId, ...overrides })
+
+const reset = (id: string, parentId: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
+  session(id, { _reset_from: parentId, parent_session_id: parentId, ...overrides })
+
+describe('forkParentId', () => {
+  it('returns undefined for /new and idle/daily reset lineage', () => {
+    expect(forkParentId(reset('next', 'prev'))).toBeUndefined()
+  })
+
+  it('returns the branch parent for a genuine /branch fork', () => {
+    expect(forkParentId(fork('branch', 'parent'))).toBe('parent')
+  })
+
+  it('falls back to parent_session_id for legacy/optimistic forks without the marker', () => {
+    expect(forkParentId(session('branch', { parent_session_id: 'parent' }))).toBe('parent')
+  })
+})
+
 describe('flattenSessionsWithBranches', () => {
   it('nests branch rows under their parent with tree stems', () => {
     const parent = session('parent', { last_active: 20 })
-    const branchA = session('branch-a', { last_active: 15, parent_session_id: 'parent' })
-    const branchB = session('branch-b', { last_active: 10, parent_session_id: 'parent' })
+    const branchA = fork('branch-a', 'parent', { last_active: 15 })
+    const branchB = fork('branch-b', 'parent', { last_active: 10 })
 
     expect(flattenSessionsWithBranches([parent, branchA, branchB])).toEqual([
       { session: parent },
@@ -24,7 +44,7 @@ describe('flattenSessionsWithBranches', () => {
 
   it('follows a compressed parent via lineage root id', () => {
     const tip = session('tip', { _lineage_root_id: 'root', last_active: 30 })
-    const branch = session('branch', { parent_session_id: 'root', last_active: 10 })
+    const branch = fork('branch', 'root', { last_active: 10 })
 
     expect(flattenSessionsWithBranches([tip, branch])).toEqual([
       { session: tip },
@@ -33,7 +53,7 @@ describe('flattenSessionsWithBranches', () => {
   })
 
   it('keeps orphan branches at the top level when the parent is missing', () => {
-    const branch = session('branch', { parent_session_id: 'missing' })
+    const branch = fork('branch', 'missing')
 
     expect(flattenSessionsWithBranches([branch])).toEqual([{ session: branch }])
   })
@@ -54,7 +74,7 @@ describe('flattenSessionsWithBranches', () => {
   it("preserveOrder keeps the caller's root order even when activity is newer lower down", () => {
     const important = session('important', { last_active: 10 })
     const background = session('background', { last_active: 99 })
-    const branch = session('branch', { last_active: 50, parent_session_id: 'important' })
+    const branch = fork('branch', 'important', { last_active: 50 })
 
     expect(
       flattenSessionsWithBranches([important, background, branch], { preserveOrder: true }).map(e => ({
@@ -65,6 +85,40 @@ describe('flattenSessionsWithBranches', () => {
       { id: 'important', stem: undefined },
       { id: 'branch', stem: '└─ ' },
       { id: 'background', stem: undefined }
+    ])
+  })
+
+  it('renders /new and idle/daily resets as siblings, not nested branches', () => {
+    const first = session('first', { last_active: 10 })
+    const second = reset('second', 'first', { last_active: 20 })
+    const third = reset('third', 'second', { last_active: 30 })
+
+    expect(flattenSessionsWithBranches([first, second, third]).map(e => ({ id: e.session.id, stem: e.branchStem }))).toEqual([
+      { id: 'third', stem: undefined },
+      { id: 'second', stem: undefined },
+      { id: 'first', stem: undefined }
+    ])
+  })
+
+  it('still nests a genuine fork when a reset sibling shares the same parent_session_id', () => {
+    const parent = session('parent', { last_active: 10 })
+    const branch = fork('branch', 'parent', { last_active: 15 })
+    const nextTopic = reset('next', 'parent', { last_active: 20 })
+
+    expect(flattenSessionsWithBranches([parent, branch, nextTopic]).map(e => ({ id: e.session.id, stem: e.branchStem }))).toEqual([
+      { id: 'next', stem: undefined },
+      { id: 'parent', stem: undefined },
+      { id: 'branch', stem: '└─ ' }
+    ])
+  })
+
+  it('nests a parent_session_id-only row (optimistic / legacy fork) when _reset_from is absent', () => {
+    const parent = session('parent', { last_active: 20 })
+    const branch = session('branch', { last_active: 10, parent_session_id: 'parent' })
+
+    expect(flattenSessionsWithBranches([parent, branch])).toEqual([
+      { session: parent },
+      { branchStem: '└─ ', session: branch }
     ])
   })
 })

--- a/apps/desktop/src/lib/session-branch-tree.ts
+++ b/apps/desktop/src/lib/session-branch-tree.ts
@@ -17,6 +17,28 @@ export interface FlattenSessionsOptions {
 
 const recency = (session: SessionInfo): number => session.last_active || session.started_at || 0
 
+/**
+ * Parent id to nest under, or undefined for a top-level sibling.
+ *
+ * `/new` and idle/daily rotation keep `parent_session_id` for durable lineage
+ * but stamp `_reset_from`. Those are new conversations, not nested forks.
+ * Genuine `/branch` writes `_branched_from`. Optimistic desktop branch rows
+ * (and legacy forks minted before the marker) only have `parent_session_id`.
+ */
+export function forkParentId(session: SessionInfo): string | undefined {
+  if (session._reset_from?.trim()) {
+    return undefined
+  }
+
+  const branchedFrom = session._branched_from?.trim()
+
+  if (branchedFrom) {
+    return branchedFrom
+  }
+
+  return session.parent_session_id?.trim() || undefined
+}
+
 /** Flat list with branch/fork sessions nested visually under their parent. */
 export function flattenSessionsWithBranches(
   sessions: readonly SessionInfo[],
@@ -41,7 +63,7 @@ export function flattenSessionsWithBranches(
   const nestedIds = new Set<string>()
 
   for (const session of sessions) {
-    const parentId = session.parent_session_id?.trim()
+    const parentId = forkParentId(session)
 
     if (!parentId) {
       continue

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -505,8 +505,15 @@ export interface SessionInfo {
   message_count: number
   model: null | string
   output_tokens: number
-  /** Parent conversation when this row is a /branch fork. */
+  /** Parent conversation id. Written for genuine /branch forks *and* for
+   *  /new / idle / daily resets (durable lineage). Nesting uses
+   *  {@link _branched_from} vs {@link _reset_from}, not this field alone. */
   parent_session_id?: null | string
+  /** Predecessor of a /new or idle/daily reset. Not a fork — the sidebar
+   *  renders these as siblings of the previous topic. */
+  _reset_from?: null | string
+  /** Parent of a genuine /branch fork. The sidebar nests only these. */
+  _branched_from?: null | string
   /** Durable server-side pin flag (`sessions.pinned`). The list endpoints
    *  back-fill pinned conversations past their LIMIT, so a pinned row is
    *  always present in a page — which makes this authoritative for the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4786,48 +4786,35 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
 
     @staticmethod
-    def _promote_session_lineage_markers(data: Dict[str, Any]) -> None:
-        """Lift ``_reset_from`` / ``_branched_from`` out of ``model_config``.
-
-        ``/new`` and idle/daily rotation write ``parent_session_id`` the same
-        way a genuine ``/branch`` fork does; only these markers tell them
-        apart. List payloads strip ``model_config`` as a heavy field, so the
-        sidebar needs the markers at the top level to nest forks and leave
-        resets as siblings.
-        """
-        if data.get("_reset_from") and data.get("_branched_from"):
-            return
-        raw = data.get("model_config")
-        if not raw:
-            return
-        if isinstance(raw, str):
-            try:
-                cfg = json.loads(raw)
-            except (TypeError, ValueError):
-                return
-        elif isinstance(raw, dict):
-            cfg = raw
-        else:
-            return
-        if not isinstance(cfg, dict):
-            return
-        if not data.get("_reset_from"):
-            value = cfg.get("_reset_from")
-            if isinstance(value, str) and value.strip():
-                data["_reset_from"] = value.strip()
-        if not data.get("_branched_from"):
-            value = cfg.get("_branched_from")
-            if isinstance(value, str) and value.strip():
-                data["_branched_from"] = value.strip()
-
-    @staticmethod
     def _session_row_dict(row: sqlite3.Row) -> Dict[str, Any]:
         data = dict(row)
         if "_system_prompt_resolved" in data:
             resolved = data.pop("_system_prompt_resolved")
             if "system_prompt" in data:
                 data["system_prompt"] = resolved
-        SessionDB._promote_session_lineage_markers(data)
+        # Lift /new vs /branch markers out of model_config so list payloads
+        # (which strip that heavy field) can still tell a reset sibling from
+        # a genuine fork. Keep this a local helper: tests sometimes replace
+        # the SessionDB name with a factory lambda.
+        if not (data.get("_reset_from") and data.get("_branched_from")):
+            raw = data.get("model_config")
+            cfg = None
+            if isinstance(raw, str) and raw:
+                try:
+                    cfg = json.loads(raw)
+                except (TypeError, ValueError):
+                    cfg = None
+            elif isinstance(raw, dict):
+                cfg = raw
+            if isinstance(cfg, dict):
+                if not data.get("_reset_from"):
+                    value = cfg.get("_reset_from")
+                    if isinstance(value, str) and value.strip():
+                        data["_reset_from"] = value.strip()
+                if not data.get("_branched_from"):
+                    value = cfg.get("_branched_from")
+                    if isinstance(value, str) and value.strip():
+                        data["_branched_from"] = value.strip()
         return data
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4786,12 +4786,48 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
 
     @staticmethod
+    def _promote_session_lineage_markers(data: Dict[str, Any]) -> None:
+        """Lift ``_reset_from`` / ``_branched_from`` out of ``model_config``.
+
+        ``/new`` and idle/daily rotation write ``parent_session_id`` the same
+        way a genuine ``/branch`` fork does; only these markers tell them
+        apart. List payloads strip ``model_config`` as a heavy field, so the
+        sidebar needs the markers at the top level to nest forks and leave
+        resets as siblings.
+        """
+        if data.get("_reset_from") and data.get("_branched_from"):
+            return
+        raw = data.get("model_config")
+        if not raw:
+            return
+        if isinstance(raw, str):
+            try:
+                cfg = json.loads(raw)
+            except (TypeError, ValueError):
+                return
+        elif isinstance(raw, dict):
+            cfg = raw
+        else:
+            return
+        if not isinstance(cfg, dict):
+            return
+        if not data.get("_reset_from"):
+            value = cfg.get("_reset_from")
+            if isinstance(value, str) and value.strip():
+                data["_reset_from"] = value.strip()
+        if not data.get("_branched_from"):
+            value = cfg.get("_branched_from")
+            if isinstance(value, str) and value.strip():
+                data["_branched_from"] = value.strip()
+
+    @staticmethod
     def _session_row_dict(row: sqlite3.Row) -> Dict[str, Any]:
         data = dict(row)
         if "_system_prompt_resolved" in data:
             resolved = data.pop("_system_prompt_resolved")
             if "system_prompt" in data:
                 data["system_prompt"] = resolved
+        SessionDB._promote_session_lineage_markers(data)
         return data
 
     @staticmethod

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2610,6 +2610,32 @@ class TestListSessionsRich:
         assert "delegate" not in ids, "Delegate sub-agent should not appear in default list"
         assert "root" in ids
 
+    def test_rich_list_promotes_reset_and_branch_markers(self, db):
+        """List rows expose _reset_from / _branched_from so UIs can tell a
+        /new reset from a genuine /branch without reading model_config."""
+        db.create_session("parent", "cli")
+        db.create_session(
+            "reset_child",
+            "cli",
+            parent_session_id="parent",
+            model_config={"_reset_from": "parent"},
+        )
+        db.create_session(
+            "branch_child",
+            "cli",
+            parent_session_id="parent",
+            model_config={"_branched_from": "parent"},
+        )
+
+        by_id = {row["id"]: row for row in db.list_sessions_rich()}
+        assert by_id["reset_child"]["_reset_from"] == "parent"
+        assert not by_id["reset_child"].get("_branched_from")
+        assert by_id["branch_child"]["_branched_from"] == "parent"
+        assert not by_id["branch_child"].get("_reset_from")
+        compact = {row["id"]: row for row in db.list_sessions_rich(compact_rows=True)}
+        assert compact["reset_child"]["_reset_from"] == "parent"
+        assert compact["branch_child"]["_branched_from"] == "parent"
+
 
 
 class TestCompressionChainProjection:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15206,10 +15206,13 @@ def _project_tree_row(r: dict) -> dict:
     return {
         "id": r.get("id"),
         "_lineage_root_id": r.get("_lineage_root_id"),
-        # The sidebar nests branch/fork sessions under their parent
-        # (flattenSessionsWithBranches keys on this); without it, lane rows can't
-        # draw the └─ connector the flat Recents list shows.
+        # The sidebar nests genuine /branch forks under their parent
+        # (flattenSessionsWithBranches keys on parent_session_id + these
+        # markers). /new and idle/daily resets also write parent_session_id
+        # for durable lineage, but stamp _reset_from so they render as siblings.
         "parent_session_id": r.get("parent_session_id"),
+        "_reset_from": r.get("_reset_from"),
+        "_branched_from": r.get("_branched_from"),
         "title": r.get("title"),
         "preview": r.get("preview"),
         "started_at": r.get("started_at") or 0,


### PR DESCRIPTION
## What does this PR do?

`/new` and idle/daily auto-reset create a fresh, empty conversation, but the desktop sidebar nested it under the previous topic as a branch (`├─` / `└─`). After a few resets, a platform's chats collapsed into one growing fork chain.

The backend already distinguishes the two edges: resets write `parent_session_id` + `model_config._reset_from`; genuine `/branch` forks also write `_branched_from`. The sidebar keyed nesting only off `parent_session_id` and never looked at the markers. List payloads also strip `model_config` as a heavy field, so the UI could not tell them apart.

This PR lifts `_reset_from` / `_branched_from` onto list rows and nests only genuine forks. Reset lineage stays on disk unchanged.

## Related Issue

Fixes #99648

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/session-branch-tree.ts` — nest only when `_branched_from` is set (or a `parent_session_id`-only legacy/optimistic fork). Skip nesting when `_reset_from` is set.
- `apps/desktop/src/types/hermes.ts` — document `_reset_from` / `_branched_from` on `SessionInfo`.
- `hermes_state.py` — promote those markers out of `model_config` on every session row so list UIs still see them after `model_config` is stripped.
- `tui_gateway/server.py` — copy the markers onto project-tree rows (same sidebar flattener).
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts` — stamp `_branched_from` on optimistic desktop `/branch` rows so they nest before the next refresh.
- Tests in `apps/desktop/src/lib/session-branch-tree.test.ts` and `tests/test_hermes_state.py`.

## How to Test

1. From `apps/desktop`: `npx vitest run src/lib/session-branch-tree.test.ts`
2. `scripts/run_tests.sh tests/test_hermes_state.py -k test_rich_list_promotes_reset_and_branch_markers`
3. Manual: run a gateway chat, send `/new` and start an unrelated topic, repeat. Open the desktop sidebar — each new topic should sit at the same level as the previous one, not indented with `├─`/`└─`. A real `/branch` should still nest under its parent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run src/lib/session-branch-tree.test.ts` from `apps/desktop` (11 passed) and `scripts/run_tests.sh tests/test_hermes_state.py -k test_rich_list_promotes_reset_and_branch_markers` (passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
