### PR TITLE
fix(skills): dedupe background-review pending patches by target

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -153,8 +153,167 @@ _SKILL = (
 
 
 # ---------------------------------------------------------------------------
-# Pending store CRUD
+# Pending store CRUD — skill-target dedupe (#99661)
 # ---------------------------------------------------------------------------
+
+
+def _patch_payload(name, file_path, old, new):
+    return {
+        "action": "patch",
+        "name": name,
+        "file_path": file_path,
+        "old_string": old,
+        "new_string": new,
+    }
+
+
+def test_skill_stage_same_target_does_not_grow_queue(hermes_home):
+    """A second patch to the same skill/file must not add another pending item.
+
+    Background-review firings are isolated: each rediscovers the same file
+    with a reworded body. Same-target identity, not byte-identical content,
+    is what stops the flood.
+    """
+    from tools import write_approval as wa
+
+    first = wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("agent-github-identity-setup", "SKILL.md",
+                       "Do X.", "Do X, then Y."),
+        summary="patch 1",
+        origin="background_review",
+    )
+    second = wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("agent-github-identity-setup", "SKILL.md",
+                       "Do X.", "Do X, then Y, and also Z."),
+        summary="patch 2 (reworded)",
+        origin="background_review",
+    )
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert len(wa.list_pending(wa.SKILLS)) == 1
+    assert second["id"] == first["id"]
+    assert second.get("deduped") is True
+    # First payload stays on disk — skip, not supersede.
+    assert wa.list_pending(wa.SKILLS)[0]["payload"]["new_string"] == "Do X, then Y."
+
+
+def test_skill_stage_different_file_still_stages(hermes_home):
+    """A patch to a different file of the same skill is a new pending item."""
+    from tools import write_approval as wa
+
+    wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("agent-github-identity-setup", "SKILL.md",
+                       "Do X.", "Do X, then Y."),
+        summary="patch skill.md",
+        origin="background_review",
+    )
+    other = wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("agent-github-identity-setup", "references/github.md",
+                       "token", "app password"),
+        summary="patch references",
+        origin="background_review",
+    )
+    assert wa.pending_count(wa.SKILLS) == 2
+    assert other.get("deduped") is not True
+    files = {
+        r["payload"].get("file_path") for r in wa.list_pending(wa.SKILLS)
+    }
+    assert files == {"SKILL.md", "references/github.md"}
+
+
+def test_skill_stage_normalizes_same_file_path(hermes_home):
+    """./SKILL.md and SKILL.md are the same target."""
+    from tools import write_approval as wa
+
+    wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("demo", "SKILL.md", "a", "b"),
+        summary="plain",
+        origin="background_review",
+    )
+    dup = wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("demo", "./SKILL.md", "a", "c"),
+        summary="dotted",
+        origin="background_review",
+    )
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert dup.get("deduped") is True
+
+
+def test_gated_skill_manage_same_target_does_not_grow_queue(hermes_home):
+    """Production path: skill_manage stages through the approval gate."""
+    from tools.skill_manager_tool import skill_manage
+    from tools import write_approval as wa
+
+    _set_approval("skills", True)
+    r1 = json.loads(skill_manage(
+        action="patch", name="held-skill", file_path="SKILL.md",
+        old_string="step 1", new_string="step 1 (held)",
+    ))
+    r2 = json.loads(skill_manage(
+        action="patch", name="held-skill", file_path="SKILL.md",
+        old_string="step 1", new_string="step 1 (held, again)",
+    ))
+    assert r1.get("staged") is True and r1.get("pending_id")
+    assert r2.get("staged") is True
+    assert r2.get("deduped") is True
+    assert r2["pending_id"] == r1["pending_id"]
+    assert wa.pending_count(wa.SKILLS) == 1
+
+
+def test_skill_stage_batch_same_target_does_not_grow_queue(hermes_home):
+    """A later batch that retouches an already-pending file must not add a row."""
+    from tools import write_approval as wa
+
+    wa.stage_write(
+        wa.SKILLS,
+        _patch_payload("demo", "SKILL.md", "a", "b"),
+        summary="single",
+        origin="background_review",
+    )
+    skipped = wa.stage_write(
+        wa.SKILLS,
+        {
+            "action": "batch",
+            "operations": [
+                {
+                    "action": "patch",
+                    "name": "demo",
+                    "file_path": "SKILL.md",
+                    "old_string": "a",
+                    "new_string": "c",
+                },
+            ],
+        },
+        summary="batch",
+        origin="background_review",
+    )
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert skipped.get("deduped") is True
+
+
+def test_gated_skill_manage_different_file_still_stages(hermes_home):
+    from tools.skill_manager_tool import skill_manage
+    from tools import write_approval as wa
+
+    _set_approval("skills", True)
+    r1 = json.loads(skill_manage(
+        action="write_file", name="held-skill",
+        file_path="references/a.md", file_content="a",
+    ))
+    r2 = json.loads(skill_manage(
+        action="write_file", name="held-skill",
+        file_path="references/b.md", file_content="b",
+    ))
+    assert r1.get("staged") is True
+    assert r2.get("staged") is True
+    assert r2.get("deduped") is not True
+    assert r1["pending_id"] != r2["pending_id"]
+    assert wa.pending_count(wa.SKILLS) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1516,6 +1516,26 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 )
 
 
+def _staged_skill_tool_result(record, gist, decision_message) -> str:
+    """JSON tool result for a newly staged — or duplicate-skipped — skill write."""
+    payload = {
+        "success": True,
+        "staged": True,
+        "pending_id": record["id"],
+        "gist": gist,
+        "message": decision_message,
+    }
+    if record.get("deduped"):
+        payload["deduped"] = True
+        payload["message"] = (
+            f"Already staged for approval as {record['id']} "
+            "(same skill/file). Not duplicating — review with /skills pending."
+        )
+        if record.get("summary"):
+            payload["gist"] = record["summary"]
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def _apply_skill_write_gate(action, name, **payload_kwargs):
     """Evaluate the skill write gate. Returns a JSON tool-result string when the
     write should NOT proceed (blocked or staged), or None to perform the real
@@ -1548,11 +1568,7 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         new_string=payload_kwargs.get("new_string") or "",
     )
     record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
-    return json.dumps(
-        {"success": True, "staged": True, "pending_id": record["id"],
-         "gist": gist, "message": decision.message},
-        ensure_ascii=False,
-    )
+    return _staged_skill_tool_result(record, gist, decision.message)
 
 
 def apply_skill_pending(payload: Dict[str, Any]) -> str:
@@ -1714,11 +1730,7 @@ def _skill_manage_batch(
                 record = wa.stage_write(
                     wa.SKILLS, payload, summary=gist, origin=wa.current_origin()
                 )
-                return json.dumps(
-                    {"success": True, "staged": True, "pending_id": record["id"],
-                     "gist": gist, "message": decision.message},
-                    ensure_ascii=False,
-                )
+                return _staged_skill_tool_result(record, gist, decision.message)
 
     # --- snapshot every touched skill for rollback ---
     snap_root = Path(tempfile.mkdtemp(prefix="skill_batch_"))

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -45,10 +45,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import posixpath
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 
@@ -128,7 +129,25 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     Returns a dict with ``id`` and metadata. Best-effort: on disk failure it
     logs and still returns a record (the write is simply lost, which is the
     safe failure for an approval gate — nothing is silently committed).
+
+    Skills pending items are deduped by target: if an existing record already
+    mutates the same skill/file, this returns that record with ``deduped=True``
+    and does not grow the queue. Isolated background-review firings otherwise
+    restage near-duplicate patches to the same file every
+    ``skills.creation_nudge_interval`` iterations.
     """
+    if subsystem == SKILLS:
+        existing = _existing_skill_pending(payload)
+        if existing is not None:
+            skipped = dict(existing)
+            skipped["deduped"] = True
+            logger.info(
+                "Skipping duplicate pending skills write for %s (existing id=%s)",
+                _format_skill_targets(_skill_write_targets(payload)),
+                existing.get("id"),
+            )
+            return skipped
+
     pid = uuid.uuid4().hex[:8]
     record = {
         "id": pid,
@@ -149,6 +168,101 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record
+
+
+# Whole-skill delete conflicts with any pending write to that skill. Other
+# actions key on (skill name, normalized relative file).
+_SKILL_DELETE_FILE = "*"
+
+
+def _normalize_skill_relpath(file_path: Any) -> str:
+    """Return the skill-relative file a pending write would mutate."""
+    raw = file_path.strip() if isinstance(file_path, str) else ""
+    if not raw:
+        return "SKILL.md"
+    # Skills use posix relative paths; collapse ./, //, and leading slashes
+    # so SKILL.md, ./SKILL.md, and /SKILL.md hash to the same target.
+    normalized = posixpath.normpath(raw.replace("\\", "/").lstrip("/"))
+    return normalized if normalized not in {"", "."} else "SKILL.md"
+
+
+def _op_skill_target(
+    op: Dict[str, Any], default_name: str = ""
+) -> Optional[Tuple[str, str]]:
+    name = (op.get("name") or default_name or "").strip()
+    if not name:
+        return None
+    action = op.get("action") or ""
+    # skill_manage full-rewrite patch (content set) always hits SKILL.md
+    # and ignores file_path — same as create/edit.
+    if action == "delete":
+        return (name, _SKILL_DELETE_FILE)
+    if action in {"create", "edit"} or (action == "patch" and op.get("content")):
+        return (name, "SKILL.md")
+    return (name, _normalize_skill_relpath(op.get("file_path")))
+
+
+def _skill_write_targets(payload: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """Return (skill_name, relative_file) pairs a pending payload would mutate."""
+    if not isinstance(payload, dict):
+        return []
+    default_name = (payload.get("name") or "").strip()
+    if payload.get("action") == "batch":
+        targets: List[Tuple[str, str]] = []
+        seen: Set[Tuple[str, str]] = set()
+        for op in payload.get("operations") or []:
+            if not isinstance(op, dict):
+                continue
+            target = _op_skill_target(op, default_name)
+            if target is None or target in seen:
+                continue
+            seen.add(target)
+            targets.append(target)
+        return targets
+    target = _op_skill_target(payload, default_name)
+    return [target] if target is not None else []
+
+
+def _skill_targets_overlap(
+    left: List[Tuple[str, str]], right: List[Tuple[str, str]]
+) -> bool:
+    if not left or not right:
+        return False
+    by_name: Dict[str, Set[str]] = {}
+    for name, rel in left:
+        by_name.setdefault(name, set()).add(rel)
+    for name, rel in right:
+        files = by_name.get(name)
+        if not files:
+            continue
+        if rel == _SKILL_DELETE_FILE or _SKILL_DELETE_FILE in files or rel in files:
+            return True
+    return False
+
+
+def _format_skill_targets(targets: List[Tuple[str, str]]) -> str:
+    if not targets:
+        return "(unknown)"
+    return ", ".join(f"{name}:{rel}" for name, rel in targets)
+
+
+def _existing_skill_pending(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return an existing skills pending record for the same skill/file.
+
+    Two writes to the same target overlap by construction: isolated
+    background-review firings restage near-duplicate patches with
+    reworded bodies, so content-equality is the wrong predicate.
+    """
+    targets = _skill_write_targets(payload)
+    if not targets:
+        return None
+    for record in list_pending(SKILLS):
+        existing_payload = record.get("payload")
+        if not isinstance(existing_payload, dict):
+            continue
+        if _skill_targets_overlap(targets, _skill_write_targets(existing_payload)):
+            return record
+    return None
 
 
 def list_pending(subsystem: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## What does this PR do?

`agent/background_review.py` + `agent/turn_finalizer.py` fire a skill-review nudge every `skills.creation_nudge_interval` iterations. Each firing is an isolated fork that never inspects `~/.hermes/pending/skills/*.json`, so a long session restages near-duplicate patches to the same file (29 pending writes to one skill in #99661).

Before staging a new skills pending item, skip if an existing record already targets the same skill/file (path-normalized; a whole-skill delete conflicts with any file of that skill). Reworded rediscoveries do not grow the queue. A different file still stages. The interval gate is unchanged — this is not a session-end curator.

Skip, not supersede: the first pending payload stays on disk so later isolated reviews cannot overwrite a held proposal.

## Related Issue

Fixes #99661

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/write_approval.py` — `stage_write` skips a skills item whose (skill, file) already has a pending record; returns that record with `deduped=True`
- `tools/skill_manager_tool.py` — gated `skill_manage` / batch staging report the skip instead of a new pending id
- `tests/tools/test_write_approval.py` — same target does not grow the queue; a different file still stages; `./SKILL.md` normalizes; gated `skill_manage` and batch paths

## How to Test

1. Stage a patch for `skill/SKILL.md`, then a reworded patch to the same file → `pending_count == 1`, second result `deduped`.
2. Stage a patch for `skill/references/other.md` → queue grows to 2.
3. `skill_manage` with `skills.write_approval` on follows the same rules.

```
uv run --extra dev python -m pytest tests/tools/test_write_approval.py tests/tools/test_skill_manage_batch.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A