### PR TITLE
fix(relay): preserve streamed response fidelity

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4144,25 +4144,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             last_chunk_time["t"] = time.time()
             return True
 
-        def _relay_final_response() -> dict[str, Any]:
-            tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
-            return {
-                "model": model_name,
-                "choices": [
-                    {
-                        "message": {
-                            "role": role,
-                            "content": "".join(content_parts) or None,
-                            "reasoning_content": "".join(reasoning_parts) or None,
-                            "tool_calls": tool_calls or None,
-                        },
-                        "finish_reason": finish_reason or "stop",
-                    }
-                ],
-                "usage": usage_obj,
-            }
-
         from agent import relay_llm
+        relay_accumulator = relay_llm.OpenAIChatStreamAccumulator()
 
         stream = _set_managed_stream(
             relay_llm.stream(
@@ -4171,8 +4154,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 session_id=str(getattr(agent, "session_id", "") or ""),
                 name=str(getattr(agent, "provider", "") or "provider"),
                 model_name=str(getattr(agent, "model", "") or ""),
-                finalizer=_relay_final_response,
+                finalizer=relay_accumulator.finalize,
                 on_stream_created=_stream_created,
+                on_chunk=relay_accumulator.observe,
                 accept_chunk=_accept_stream_chunk,
                 completed_response_predicate=lambda value: hasattr(value, "choices"),
                 metadata={

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -833,6 +833,144 @@ class ManagedLlmStream(Iterator[Any]):
         self._close(logical_outcome="cancelled")
 
 
+class OpenAIChatStreamAccumulator:
+    """Rebuild a Chat Completions response from post-intercept chunks.
+
+    Relay may drain the provider stream before Hermes' synchronous consumer
+    processes the replayed chunks. The Relay finalizer must therefore observe
+    the post-intercept chunks directly instead of reading consumer-owned
+    accumulation state.
+    """
+
+    def __init__(self) -> None:
+        self._model: Any = None
+        self._role = "assistant"
+        self._content_parts: list[str] = []
+        self._reasoning_parts: list[str] = []
+        self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._last_id_at_index: dict[Any, str] = {}
+        self._active_slot_by_index: dict[Any, int] = {}
+        self._finish_reason: Any = None
+        self._usage: Any = None
+
+    def observe(self, chunk: Any) -> None:
+        payload = _jsonable(chunk)
+        if not isinstance(payload, dict):
+            return
+        if payload.get("model"):
+            self._model = payload["model"]
+        if payload.get("usage"):
+            self._usage = payload["usage"]
+
+        choices = payload.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return
+        choice = choices[0]
+        if not isinstance(choice, dict):
+            return
+        if choice.get("finish_reason"):
+            self._finish_reason = choice["finish_reason"]
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            return
+        if delta.get("role"):
+            self._role = str(delta["role"])
+
+        from agent.message_content import flatten_message_text
+        from agent.reasoning_summaries import separate_glued_reasoning_blocks
+
+        content = flatten_message_text(delta.get("content"), sep="")
+        if content:
+            self._content_parts.append(content)
+        reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+        if isinstance(reasoning, str) and reasoning:
+            reasoning = separate_glued_reasoning_blocks(
+                self._reasoning_parts[-1] if self._reasoning_parts else "",
+                reasoning,
+            )
+            self._reasoning_parts.append(reasoning)
+
+        tool_calls = delta.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            return
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            raw_index = tool_call.get("index")
+            raw_index = raw_index if raw_index is not None else 0
+            tool_call_id = tool_call.get("id")
+            tool_call_id = str(tool_call_id) if tool_call_id is not None else ""
+            if raw_index not in self._active_slot_by_index:
+                numeric_index = (
+                    raw_index
+                    if isinstance(raw_index, int)
+                    else int(raw_index)
+                    if isinstance(raw_index, str) and raw_index.isdigit()
+                    else max(self._tool_calls, default=-1) + 1
+                )
+                if numeric_index in self._tool_calls:
+                    numeric_index = max(self._tool_calls, default=-1) + 1
+                self._active_slot_by_index[raw_index] = numeric_index
+            if (
+                tool_call_id
+                and raw_index in self._last_id_at_index
+                and tool_call_id != self._last_id_at_index[raw_index]
+            ):
+                self._active_slot_by_index[raw_index] = (
+                    max(self._tool_calls, default=-1) + 1
+                )
+            if tool_call_id:
+                self._last_id_at_index[raw_index] = tool_call_id
+            index = self._active_slot_by_index[raw_index]
+            accumulated = self._tool_calls.setdefault(
+                index,
+                {
+                    "id": "",
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                    "extra_content": None,
+                },
+            )
+            if tool_call_id:
+                accumulated["id"] = tool_call_id
+            if tool_call.get("type"):
+                accumulated["type"] = tool_call["type"]
+            function = tool_call.get("function")
+            if isinstance(function, dict):
+                if function.get("name"):
+                    accumulated["function"]["name"] = function["name"]
+                arguments = function.get("arguments")
+                if isinstance(arguments, str) and arguments:
+                    accumulated["function"]["arguments"] += arguments
+            extra_content = tool_call.get("extra_content")
+            if extra_content is None and isinstance(
+                tool_call.get("model_extra"), dict
+            ):
+                extra_content = tool_call["model_extra"].get("extra_content")
+            if extra_content is not None:
+                accumulated["extra_content"] = extra_content
+
+    def finalize(self) -> dict[str, Any]:
+        tool_calls = [
+            self._tool_calls[index] for index in sorted(self._tool_calls)
+        ]
+        return {
+            "model": self._model,
+            "choices": [
+                {
+                    "message": {
+                        "role": self._role,
+                        "content": "".join(self._content_parts) or None,
+                        "reasoning_content": "".join(self._reasoning_parts) or None,
+                        "tool_calls": tool_calls or None,
+                    },
+                    "finish_reason": self._finish_reason or "stop",
+                }
+            ],
+            "usage": self._usage,
+        }
+
+
 class AnthropicStreamAccumulator:
     """Rebuild an Anthropic Message from post-intercept SSE events."""
 

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -406,6 +406,227 @@ def test_live_stream_defers_runtime_shutdown_until_exhaustion(
 
 
 
+def test_openai_chat_stream_accumulator_rebuilds_text_tools_and_usage():
+    accumulator = relay_llm.OpenAIChatStreamAccumulator()
+    for chunk in (
+        {
+            "model": "test-model",
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "check ",
+                        "content": [{"type": "text", "text": "done"}],
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "search_files",
+                                    "arguments": '{"pat',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "test-model",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "search_files",
+                                    "arguments": 'tern":"x"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4},
+        },
+    ):
+        accumulator.observe(chunk)
+
+    assert accumulator.finalize() == {
+        "model": "test-model",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "done",
+                    "reasoning_content": "check ",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "search_files",
+                                "arguments": '{"pattern":"x"}',
+                            },
+                            "extra_content": None,
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 4},
+    }
+
+
+def test_openai_chat_accumulator_preserves_reused_indices_and_terminal_fields():
+    accumulator = relay_llm.OpenAIChatStreamAccumulator()
+    accumulator.observe(
+        {
+            "model": "test-model",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": "shared",
+                                "id": "call-1",
+                                "function": {
+                                    "name": "first",
+                                    "arguments": '{"a":',
+                                },
+                                "model_extra": {
+                                    "extra_content": {"signature": "sig-1"}
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+        }
+    )
+    accumulator.observe(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": "shared",
+                                "id": "call-2",
+                                "function": {
+                                    "name": "second",
+                                    "arguments": '{"b":',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "",
+                }
+            ],
+        }
+    )
+    accumulator.observe(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": "shared",
+                                "id": "",
+                                "function": {"arguments": "2}"},
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+    accumulator.observe(
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+        }
+    )
+    accumulator.observe({"choices": [], "usage": {}})
+
+    response = accumulator.finalize()
+    assert response["choices"][0]["finish_reason"] == "tool_calls"
+    assert response["usage"] == {"prompt_tokens": 11, "completion_tokens": 7}
+    assert response["choices"][0]["message"]["tool_calls"] == [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "first", "arguments": '{"a":'},
+            "extra_content": {"signature": "sig-1"},
+        },
+        {
+            "id": "call-2",
+            "type": "function",
+            "function": {"name": "second", "arguments": '{"b":2}'},
+            "extra_content": None,
+        },
+    ]
+
+
+def test_openai_chat_finalizer_is_complete_before_python_consumer_drains(
+    relay_turn, monkeypatch
+):
+    relay, _turn = relay_turn
+    captured = {}
+    chunks = [
+        {
+            "model": "test-model",
+            "choices": [{"delta": {"content": "hello "}, "finish_reason": None}],
+        },
+        {
+            "model": "test-model",
+            "choices": [{"delta": {"content": "world"}, "finish_reason": "stop"}],
+        },
+    ]
+
+    async def drain_before_returning_stream(
+        _name, request, callback, observe_chunk, finalizer, **_kwargs
+    ):
+        upstream = callback(request)
+        drained = []
+        async for chunk in upstream:
+            observe_chunk(chunk)
+            drained.append(chunk)
+        captured["final"] = finalizer()
+
+        async def replay():
+            for chunk in drained:
+                yield chunk
+
+        return replay()
+
+    monkeypatch.setattr(
+        relay.llm, "stream_execute", drain_before_returning_stream
+    )
+    accumulator = relay_llm.OpenAIChatStreamAccumulator()
+    stream = relay_llm.stream(
+        {"model": "test-model", "messages": []},
+        lambda _request: iter(chunks),
+        session_id="session-1",
+        name="test-provider",
+        model_name="test-model",
+        finalizer=accumulator.finalize,
+        on_chunk=accumulator.observe,
+        metadata={"api_mode": "custom"},
+    )
+
+    assert captured["final"]["choices"][0]["message"]["content"] == "hello world"
+    assert list(stream) == chunks
+
+
 def test_anthropic_stream_accumulator_merges_plain_provider_object():
     accumulator = relay_llm.AnthropicStreamAccumulator()
     accumulator.observe({

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -98,6 +98,81 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_relay_finalizer_observes_chunks_before_host_replay(
+        self, mock_close, mock_create
+    ):
+        """Relay finalization does not depend on Hermes consuming the replay."""
+        from agent import relay_llm
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="Hello"),
+            _make_stream_chunk(
+                content=" world",
+                finish_reason="stop",
+                model="test-model",
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+        captured = {}
+
+        def drain_before_replay(
+            request,
+            stream_factory,
+            *,
+            finalizer,
+            on_chunk,
+            on_stream_created,
+            **_kwargs,
+        ):
+            upstream = stream_factory(request)
+            on_stream_created(upstream)
+            drained = list(upstream)
+            for chunk in drained:
+                on_chunk(chunk)
+            captured["final"] = finalizer()
+
+            class ReplayStream:
+                final_response = None
+                output_modified = False
+
+                def __init__(self):
+                    self._chunks = iter(drained)
+
+                def __iter__(self):
+                    return self
+
+                def __next__(self):
+                    return next(self._chunks)
+
+                def close(self):
+                    return None
+
+            return ReplayStream()
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with patch.object(relay_llm, "stream", side_effect=drain_before_replay):
+            response = agent._interruptible_streaming_api_call({})
+
+        assert captured["final"]["choices"][0]["message"]["content"] == (
+            "Hello world"
+        )
+        assert response.choices[0].message.content == "Hello world"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_sparse_delta_allows_missing_optional_fields(self, mock_close, mock_create):
         """Managed stream deltas may omit both content and tool_calls."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Problem

Hermes hands Relay an asynchronous provider stream, then consumes Relay's replayed chunks synchronously. Relay can finish draining the provider and invoke the response finalizer before Hermes has accumulated those replayed chunks.

The existing finalizer read Hermes's consumer-owned buffers. In that valid ordering, the terminal output shown by Hermes could be complete while Relay recorded an empty or truncated final response in ATIF.

## Before

```text
provider -> Relay drains chunks -> finalizer reads Hermes buffers
                                      (not consumed yet)
         -> Hermes consumes replayed chunks -> complete terminal output
```

## After

```text
provider -> Relay observes post-intercept chunks -> Relay-owned accumulator
         -> finalizer records complete response
         -> Hermes consumes the same replayed chunks unchanged
```

The new accumulator mirrors Hermes's existing Chat Completions aggregation for scalar and multipart text, reasoning, fragmented tool calls, repeated tool names, providers that reuse tool indexes, terminal finish reasons, extra tool metadata, and usage-only chunks. It remains tolerant of sparse or unsupported chunks so observability cannot replace a provider error.

This does not change the provider request, the chunks returned to Hermes, or Hermes's user-visible response. It does not change Relay's public API or Python binding.

## Scope boundaries

- This PR fixes ownership and ordering for successful post-intercept Chat Completions streams.
- It does not change how failed, cancelled, empty, or truncated streams are classified after Hermes validates the replay.
- It does not select a winning response across application-level retries.
- It is independent of #96633. That Relay 0.8.1 upgrade can merge current `main` after this lands.

## Validation

- `tests/agent/test_relay_llm.py`: 40 passed against Relay 0.7.2.
- `tests/run_agent/test_streaming.py`: 40 passed against Relay 0.8.1, including the host-level regression where finalization happens before replay consumption.
- Adjacent retry and auxiliary Relay tests: 9 passed.
- Changed-file Ruff checks and `git diff --check`: passed.

The regression tests cover post-intercept chunk observation, tool-call fragmentation and reused indexes, valid usage followed by an empty usage object, and a complete Relay finalizer before Hermes begins replay consumption.
