### PR TITLE
fix(update): self-heal broken Git-for-Windows trampoline on Windows (salvage #88136)

### DIFF
--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -59,4 +59,5 @@ jobs:
           uv run --no-sync python -m pytest \
             tests/hermes_cli/test_venv_holder_windows_live.py \
             tests/hermes_cli/test_taskkill_identity_windows_live.py \
+            tests/hermes_cli/test_git_trampoline_windows_live.py \
             -o addopts= -v -p no:cacheprovider

--- a/contributors/emails/852938468@qq.com
+++ b/contributors/emails/852938468@qq.com
@@ -1,0 +1,1 @@
+SayHell0W0rld

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
-from hermes_constants import venv_python_path
+from hermes_constants import get_default_hermes_root, venv_python_path
 
 logger = logging.getLogger(__name__)
 
@@ -7362,6 +7362,26 @@ def _git_is_trampoline(git_cmd: list) -> bool:
     return "fork bomb" in output
 
 
+def _portable_git_candidates() -> list:
+    """PortableGit candidate paths: shared root first, then profile home.
+
+    The Hermes-managed PortableGit tree lives under the SHARED root
+    (``<root>/git/...``), not the profile-scoped HERMES_HOME
+    (``<root>/profiles/<name>``), so a profile-scoped ``hermes update`` must
+    look there (monerostar review, #87876). The profile-home candidate is
+    kept as a fallback for custom layouts that place it there.
+    """
+    candidates = []
+    try:
+        for root in (get_default_hermes_root(), Path(get_hermes_home())):
+            candidates.append(
+                root / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+            )
+    except Exception:
+        pass
+    return candidates
+
+
 def _locate_real_git() -> Optional[Path]:
     """Find a real Git-for-Windows binary that is not a broken trampoline.
 
@@ -7377,18 +7397,7 @@ def _locate_real_git() -> Optional[Path]:
     candidates = [
         Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe"),
         Path(r"C:\Program Files (x86)\Git\mingw64\libexec\git-core\git.exe"),
-    ]
-    try:
-        candidates.append(
-            Path(get_hermes_home())
-            / "git"
-            / "mingw64"
-            / "libexec"
-            / "git-core"
-            / "git.exe"
-        )
-    except Exception:
-        pass
+    ] + _portable_git_candidates()
     for candidate in candidates:
         if not candidate.exists():
             continue

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7338,6 +7338,105 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
             f"  ✓ Restarting {unmapped_relaunched} unmapped Windows gateway process(es)"
         )
 
+def _git_is_trampoline(git_cmd: list) -> bool:
+    """Whether *git_cmd* resolves to a Git-for-Windows trampoline launcher.
+
+    Git for Windows ships two ~46KB shims (``bin\\git.exe``, ``cmd\\git.exe``)
+    that re-exec the real ``mingw64\\libexec\\git-core\\git.exe``. When the
+    shim's re-exec target is missing or PATH resolves to the shim in a
+    context where it cannot find git-core, every git call dies with the
+    launcher's own guard message instead of running — a broken PATH entry,
+    not a network or filesystem problem (#87876). Never raises; unknown
+    states report False so a probe failure can't block an update.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["--version"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=15,
+        )
+    except Exception:
+        return False
+    output = ((result.stdout or "") + (result.stderr or "")).lower()
+    return "fork bomb" in output
+
+
+def _locate_real_git() -> Optional[Path]:
+    """Find a real Git-for-Windows binary that is not a broken trampoline.
+
+    The trampoline symptom is PATH-level: ``bin\\git.exe`` / ``cmd\\git.exe``
+    (both ~46KB shims) fail to re-exec git-core, while the real binary at
+    ``mingw64\\libexec\\git-core\\git.exe`` (≈4.4MB) works when invoked
+    directly (#87876). Check the standard Git for Windows locations plus the
+    Hermes-managed PortableGit copy; accept the first candidate that runs and
+    does NOT print the trampoline guard. Returns None when nothing suitable
+    is found — callers then keep the broken command and let the existing
+    fetch-failure ZIP fallback handle it.
+    """
+    candidates = [
+        Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe"),
+        Path(r"C:\Program Files (x86)\Git\mingw64\libexec\git-core\git.exe"),
+    ]
+    try:
+        candidates.append(
+            Path(get_hermes_home())
+            / "git"
+            / "mingw64"
+            / "libexec"
+            / "git-core"
+            / "git.exe"
+        )
+    except Exception:
+        pass
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            result = subprocess.run(
+                [str(candidate), "--version"],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=15,
+            )
+        except Exception:
+            continue
+        output = ((result.stdout or "") + (result.stderr or "")).lower()
+        if "fork bomb" in output:
+            continue
+        return candidate
+    return None
+
+
+def _ensure_non_trampoline_git(git_cmd: list) -> list:
+    """Swap a broken Git-for-Windows trampoline for a real git binary.
+
+    Runs up front, right after the git command is built. When the resolved
+    ``git`` is a broken trampoline, locate the real binary and rebuild the
+    command with it so fetch/pull/checkout keep working with a real git
+    instead of degrading to the ZIP fallback. When no real binary can be
+    found, leave the command untouched — the existing fetch-failure handler
+    already falls back to the ZIP path on Windows. No-op off Windows (the
+    trampoline is a Git-for-Windows artifact) and when git is healthy.
+    """
+    if sys.platform != "win32":
+        return git_cmd
+    if not _git_is_trampoline(git_cmd):
+        return git_cmd
+    real_git = _locate_real_git()
+    if real_git is None:
+        print(
+            "⚠ Detected a broken git trampoline and could not locate a real "
+            "git binary — the update will fall back to the ZIP path."
+        )
+        return git_cmd
+    print(
+        f"⚠ Detected a broken git trampoline; switching to real git at "
+        f"{real_git}"
+    )
+    return [str(real_git)] + list(git_cmd[1:])
+
+
 def _discard_lockfile_churn(git_cmd, repo_root):
     """Restore tracked ``package-lock.json`` files that npm dirtied locally.
 
@@ -8058,6 +8157,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
     git_cmd = ["git"]
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    # A broken Git-for-Windows trampoline refuses every git call with a
+    # "BUG (fork bomb)" guard instead of running; swap in a real binary up
+    # front so the normal git path survives instead of degrading to ZIP
+    # (#87876).
+    git_cmd = _ensure_non_trampoline_git(git_cmd)
 
     # Discard npm lockfile churn before any stash/branch logic. npm rewrites
     # tracked package-lock.json files non-deterministically at install/build

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1416,3 +1416,96 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestGitTrampolineSelfHeal:
+    """Proactive Git-for-Windows trampoline self-heal (#87876).
+
+    A broken bin\\git.exe / cmd\\git.exe shim (~46KB) refuses every git call
+    with a "BUG (fork bomb)" guard instead of re-execing the real git-core
+    binary. _ensure_non_trampoline_git detects this up front and swaps in a
+    real git binary when one can be located, so the normal git update path
+    survives instead of degrading to the ZIP fallback.
+    """
+
+    @staticmethod
+    def _fake_run_healthy(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command, 0, stdout="git version 2.50.0.windows.1\n", stderr=""
+        )
+
+    @staticmethod
+    def _fake_run_trampoline(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="BUG (fork bomb): tried to spawn itself, check your PATH\n",
+        )
+
+    def test_healthy_git_command_unchanged(self):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_healthy,
+            ),
+            patch("hermes_cli.update_cmd._locate_real_git") as locate,
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        locate.assert_not_called()
+
+    def test_trampoline_swaps_to_real_git(self, capsys):
+        from pathlib import Path
+
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        real = Path(r"C:\Program Files\Git\mingw64\libexec\git-core\git.exe")
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_trampoline,
+            ),
+            patch(
+                "hermes_cli.update_cmd._locate_real_git", return_value=real
+            ),
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == [str(real), "-c", "windows.appendAtomically=false"]
+        out = capsys.readouterr().out
+        assert "switching to real git" in out
+
+    def test_trampoline_no_real_git_keeps_command(self, capsys):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run_trampoline,
+            ),
+            patch("hermes_cli.update_cmd._locate_real_git", return_value=None),
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        out = capsys.readouterr().out
+        assert "ZIP path" in out
+
+    def test_off_windows_noop(self):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git"]
+        with (
+            patch("sys.platform", "linux"),
+            patch("hermes_cli.update_cmd.subprocess.run") as run,
+        ):
+            result = update_cmd._ensure_non_trampoline_git(git_cmd)
+        assert result == git_cmd
+        run.assert_not_called()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1509,3 +1509,24 @@ class TestGitTrampolineSelfHeal:
             result = update_cmd._ensure_non_trampoline_git(git_cmd)
         assert result == git_cmd
         run.assert_not_called()
+
+    def test_portable_git_candidates_check_shared_root_first(self, tmp_path, monkeypatch):
+        # Profile-scoped layout: HERMES_HOME = <root>/profiles/foo, but the
+        # PortableGit tree lives under the SHARED root (monerostar review on
+        # #88136). The candidate list must check get_default_hermes_root()
+        # before the profile home.
+        from hermes_cli import update_cmd
+
+        root = tmp_path / "root"
+        profile_home = root / "profiles" / "foo"
+
+        monkeypatch.setattr(update_cmd, "get_default_hermes_root", lambda: root)
+        monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: profile_home)
+
+        candidates = update_cmd._portable_git_candidates()
+        assert candidates[0] == (
+            root / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+        )
+        assert candidates[1] == (
+            profile_home / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
+        )

--- a/tests/hermes_cli/test_git_trampoline_windows_live.py
+++ b/tests/hermes_cli/test_git_trampoline_windows_live.py
@@ -1,0 +1,95 @@
+"""Live Windows E2E for the Git-for-Windows trampoline self-heal (#87876).
+
+Runs ONLY on a real windows-latest runner (wine2e/** on-demand lane). No
+mocked subprocess anywhere: the probes drive the REAL
+``_git_is_trampoline`` / ``_locate_real_git`` / ``_ensure_non_trampoline_git``
+helpers against the runner's genuine Git-for-Windows install plus a real
+broken-trampoline stand-in (a .bat that reproduces the launcher's
+"BUG (fork bomb)" guard output and refuses to run).
+
+windows-latest ships full Git for Windows at ``C:\\Program Files\\Git`` with
+the real ``mingw64\\libexec\\git-core\\git.exe`` — exactly the layout the
+locator targets — so the swap path is exercised end to end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="live Windows trampoline E2E"
+)
+
+_FORK_BOMB_BAT = (
+    "@echo off\r\n"
+    "echo BUG (fork bomb): tried to spawn itself, check your PATH 1>&2\r\n"
+    "exit /b 1\r\n"
+)
+
+
+def _make_broken_trampoline(tmp_path: Path) -> Path:
+    bat = tmp_path / "git.bat"
+    bat.write_text(_FORK_BOMB_BAT, encoding="utf-8")
+    return bat
+
+
+class TestGitTrampolineLive:
+    def test_runner_git_is_not_a_trampoline(self):
+        from hermes_cli import update_cmd
+
+        # Healthy PATH git on the runner: probe must report False and the
+        # probe itself must actually run git (sanity: git exists here).
+        version = subprocess.run(
+            ["git", "--version"], capture_output=True, text=True, timeout=30
+        )
+        assert version.returncode == 0, version.stderr
+        assert update_cmd._git_is_trampoline(["git"]) is False
+
+    def test_broken_trampoline_detected_live(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        bat = _make_broken_trampoline(tmp_path)
+        assert update_cmd._git_is_trampoline([str(bat)]) is True
+
+    def test_locate_real_git_finds_runner_git_core(self):
+        from hermes_cli import update_cmd
+
+        real = update_cmd._locate_real_git()
+        # windows-latest ships Git for Windows under Program Files with the
+        # canonical git-core layout the locator searches first.
+        assert real is not None, "expected git-core git.exe on windows-latest"
+        assert real.exists()
+        assert real.name == "git.exe"
+        probe = subprocess.run(
+            [str(real), "--version"], capture_output=True, text=True, timeout=30
+        )
+        assert probe.returncode == 0
+        assert "git version" in probe.stdout.lower()
+
+    def test_ensure_non_trampoline_git_swaps_live(self, tmp_path, capsys):
+        from hermes_cli import update_cmd
+
+        bat = _make_broken_trampoline(tmp_path)
+        broken_cmd = [str(bat), "-c", "windows.appendAtomically=false"]
+        healed = update_cmd._ensure_non_trampoline_git(broken_cmd)
+
+        assert healed != broken_cmd, "broken trampoline must be swapped"
+        assert healed[1:] == broken_cmd[1:], "git config args must survive"
+        real = Path(healed[0])
+        assert real.exists() and real.name == "git.exe"
+        # The healed command must actually work.
+        result = subprocess.run(
+            healed[:1] + ["--version"], capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 0
+        assert "switching to real git" in capsys.readouterr().out
+
+    def test_healthy_git_command_untouched_live(self):
+        from hermes_cli import update_cmd
+
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+        assert update_cmd._ensure_non_trampoline_git(git_cmd) == git_cmd


### PR DESCRIPTION
## Summary

Salvage of PR #88136 (@SayHell0W0rld) onto current main — the trampoline leg of #87876 ("Windows update frequently fails"). A broken Git-for-Windows trampoline launcher (the ~46KB `bin\git.exe` / `cmd\git.exe` shim) refuses every git call with a `BUG (fork bomb)` guard instead of re-execing the real `mingw64\libexec\git-core\git.exe`. Today, `hermes update` degrades straight to the ZIP fallback (no `--branch` support, full-archive download) whenever the PATH git is such a shim.

Premise-checked against current main: no trampoline detection/heal exists anywhere in `hermes_cli/update_cmd.py` or the managed-git handling (the only "fork bomb" reference in the tree is an approvals regex). The self-lock (#99525 / `_quarantine_running_hermes_exe`) and venv legs of #87876 are covered by other merged work; this PR completes the third leg.

## What it does

- `_git_is_trampoline(git_cmd)` — probe `git --version` for the trampoline's "fork bomb" guard output. Never raises; unknown states report healthy so a probe failure can't block an update.
- `_locate_real_git()` — search `C:\Program Files\Git` / `(x86)` and the Hermes-managed PortableGit tree for a `git-core\git.exe` that runs cleanly. PortableGit is resolved from `get_default_hermes_root()` (shared root) first, with the profile home as fallback — the profile-scope fix from @monerostar's native Win11 review of #88136, carried over with its regression test.
- `_ensure_non_trampoline_git(git_cmd)` — rebuild `git_cmd` with the real binary when a trampoline is detected; if none is found, leave the command untouched so the existing fetch-failure ZIP fallback still applies. Strict no-op off Windows and when git is healthy.

Both contributor commits are cherry-picked with authorship preserved; `contributors/emails/852938468@qq.com` added via `scripts/add_contributor.py`.

## New in the salvage

- `tests/hermes_cli/test_git_trampoline_windows_live.py` — live windows-latest E2E (wine2e lane, no mocked subprocess): drives the real helpers against the runner's genuine Git-for-Windows install plus a real fork-bomb-guard `.bat` trampoline stand-in. Verifies detect → locate → swap end to end, wired into `.github/workflows/windows-venv-e2e.yml` (on-demand `wine2e/**` lane only, zero cost on normal PRs).

## Verification

- Executed windows-latest run (wine2e lane): all 5 live trampoline probes PASSED — run URL cited in the PR comment below with head-SHA match.
- `TestGitTrampolineSelfHeal` (5 unit tests) pass locally.
- Full `tests/hermes_cli/test_cmd_update.py`: 6 failures are pre-existing — identical failure set reproduced on a clean detached `origin/main` worktree under an isolated `HERMES_HOME` (A/B verified), untouched by this diff.
- `ruff check` clean on all touched files; the new subprocess probes run only inside `_ensure_non_trampoline_git` on `win32`, so no sequenced-mock update-path test sees a new call (verified: no test drives `_cmd_update_impl` under a global win32 patch).

## Risk

- Windows-only; off-Windows strict no-op. Finding no real git degrades to exactly the pre-existing ZIP fallback behavior.

Closes #88136 (salvage). References #87876.

## Infographic

![git-trampoline-self-heal](https://v3b.fal.media/files/b/0aa8948e/ttaT1BcTU2KVu-rOkZ2Ht_0deGLd1Y.png)
