### PR TITLE
fix(config): recognize global reasoning effort

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -361,6 +361,9 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
 
+        # Global reasoning effort. Empty means use the provider default.
+        "reasoning_effort": "",
+
         # Per-model reasoning effort overrides (spelling-tolerant).
         # Dict mapping model names (any reasonable spelling) to effort levels.
         # Takes precedence over agent.reasoning_effort when the current model

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_agent_reasoning_effort_is_recognized(self, _isolated_hermes_home, capsys):
+        """The global reasoning effort consumed by the runtime is valid config."""
+        set_config_value("agent.reasoning_effort", "high")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "reasoning_effort: high" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)


### PR DESCRIPTION
## Summary
- register the runtime-supported `agent.reasoning_effort` key in `DEFAULT_CONFIG`
- stop `hermes config set agent.reasoning_effort ...` from emitting a false unknown-key warning
- add focused regression coverage for persistence and warning behavior

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config_loader_e2e.py tests/test_hermes_constants.py -q`
  - 152 passed, 5 skipped
- targeted regression test rerun after rebasing onto current `upstream/main`
- CLI E2E with isolated `HERMES_HOME`:
  - `hermes config set agent.reasoning_effort high`
  - `hermes config get agent.reasoning_effort`

Fixes #85741