### PR TITLE
fix(update): cold-start every autostart-installed profile gateway after update (#91675 resume half)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5158,6 +5158,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_warn_pending_fleet_restart_on_startup",
         "_web_build_toolchain_ready",
         "_web_toolchain_roots",
+        "_windows_autostart_profile_homes",
         "_write_fleet_restart_pending_marker",
         "_write_lazy_refresh_incomplete_marker",
         "_write_marker_file",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6447,8 +6447,56 @@ def _pause_windows_gateways_for_update() -> dict | None:
         raise RuntimeError(detail) from exc
 
 
+def _windows_autostart_profile_homes() -> list[tuple[str, Path]]:
+    """Enumerate profiles whose Windows gateway autostart entry is installed.
+
+    Returns ``(profile_name, hermes_home)`` pairs for every profile —
+    default and named — that has a Scheduled Task or Startup-folder entry
+    installed (``gateway_windows.is_installed()``), i.e. every profile the
+    user asked to have a gateway.
+
+    ``gateway_windows`` helpers are profile-implicit: task name, script
+    path, and Startup entry all resolve through ``get_hermes_home()``.
+    Scoping each probe with ``set_hermes_home_override`` retargets them at
+    the profile being inspected without touching ``os.environ`` (#91675).
+
+    Best-effort per profile: one unreadable profile must not hide the
+    others. Enumeration failures degrade to an empty list — the caller
+    falls back to the active profile, the pre-#91675 behavior.
+    """
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    try:
+        from hermes_cli import gateway_windows
+        from hermes_cli.profiles import list_profiles
+
+        profiles = list_profiles()
+    except Exception as exc:
+        logger.debug("Could not enumerate profiles for gateway cold-start: %s", exc)
+        return []
+
+    installed: list[tuple[str, Path]] = []
+    for profile in profiles:
+        override = set_hermes_home_override(str(profile.path))
+        try:
+            if gateway_windows.is_installed():
+                installed.append((str(profile.name), Path(profile.path)))
+        except Exception as exc:
+            logger.debug(
+                "Could not check gateway autostart for profile %s: %s",
+                profile.name,
+                exc,
+            )
+        finally:
+            reset_hermes_home_override(override)
+    return installed
+
+
 def _cold_start_windows_gateway_after_update() -> bool:
-    """Start a fresh detached gateway after update when one is installed but down.
+    """Start fresh detached gateways after update when installed but down.
 
     Invoked from ``_resume_windows_gateways_after_update`` for the
     ``cold_start_if_installed`` case: no gateway was running when the update
@@ -6458,16 +6506,28 @@ def _cold_start_windows_gateway_after_update() -> bool:
     fresh spawn via the same hidden-console + breakaway path that
     ``hermes gateway start`` uses (``gateway_windows._spawn_detached``).
 
-    Best-effort and idempotent: re-checks that nothing is running first so a
-    concurrent start (e.g. the autostart entry firing) can't produce a
-    duplicate gateway.
+    Covers EVERY profile with an installed autostart entry, not just the
+    active one (#91675): ``_spawn_detached`` builds its argv through the
+    profile-implicit ``_build_gateway_argv()``, so each spawn is scoped with
+    ``set_hermes_home_override`` to the profile being started. The liveness
+    re-check is likewise per profile — the old global
+    ``find_gateway_pids(all_profiles=True)`` guard meant a sibling profile's
+    gateway coming up first (watchdog task, login) suppressed the cold start
+    entirely, so "one of N" was really "zero or one, whichever the race
+    decided".
+
+    Best-effort and idempotent per profile: each profile re-checks that its
+    own gateway is not already running first, so a concurrent start (e.g.
+    the autostart entry firing) can't produce a duplicate gateway.
 
     A successful ``Popen`` only proves the process was created, not that it
     survived (e.g. a Windows job object denying breakaway kills it before it
     logs anything — #84185). So the success line is gated on the same
     post-spawn liveness poll every other ``_spawn_detached`` caller uses
     (``gateway_windows._report_gateway_start``), instead of being printed
-    unconditionally from the returned PID.
+    unconditionally from the returned PID. One profile's failure does not
+    stop the remaining profiles from being started; failures are aggregated
+    and raised at the end.
     """
     if not _m()._is_windows():
         return True
@@ -6477,17 +6537,6 @@ def _cold_start_windows_gateway_after_update() -> bool:
     except Exception as exc:
         raise RuntimeError(
             f"Could not load Windows gateway cold-start helpers: {exc}"
-        ) from exc
-
-    # Re-check liveness right before spawning — between pause and resume the
-    # autostart entry may have already brought a gateway up, or a leftover
-    # process may have re-registered. Don't double-start.
-    try:
-        if list(find_gateway_pids(all_profiles=True)):
-            return True
-    except Exception as exc:
-        raise RuntimeError(
-            f"Could not re-check gateway liveness before cold-start: {exc}"
         ) from exc
 
     try:
@@ -6502,23 +6551,68 @@ def _cold_start_windows_gateway_after_update() -> bool:
             f"{exc}"
         ) from exc
 
-    try:
-        pid = gateway_windows._spawn_detached()
-    except Exception as exc:
-        raise RuntimeError(f"Could not cold-start Windows gateway after update: {exc}") from exc
+    targets = _m()._windows_autostart_profile_homes()
+    if not targets:
+        # Enumeration found nothing (or failed): fall back to the active
+        # profile. The pause phase only set ``cold_start_if_installed`` after
+        # seeing an installed autostart entry for this home, so an empty
+        # enumeration here is a probe gap, not proof there is nothing to do.
+        targets = [(None, None)]
 
-    if not pid:
-        raise RuntimeError("Windows gateway cold-start did not return a process ID")
-    ready_pids = gateway_windows._wait_for_gateway_ready()
-    if not ready_pids:
-        raise RuntimeError(
-            f"Windows gateway cold-start PID {pid} did not become ready"
-        )
-    print()
-    print(
-        "✓ Gateway started via cold-start after update "
-        f"(PID: {', '.join(map(str, ready_pids))})"
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
     )
+
+    failures: list[str] = []
+    for profile_name, profile_home in targets:
+        label = profile_name or "active profile"
+        override = (
+            set_hermes_home_override(str(profile_home))
+            if profile_home is not None
+            else None
+        )
+        try:
+            # Re-check liveness right before spawning — between pause and
+            # resume the autostart entry may have already brought this
+            # profile's gateway up, or a leftover process may have
+            # re-registered. Don't double-start. Scoped to THIS profile: a
+            # live sibling must not suppress this profile's start.
+            try:
+                if list(find_gateway_pids()):
+                    continue
+            except Exception as exc:
+                raise RuntimeError(
+                    f"could not re-check gateway liveness before cold-start: {exc}"
+                ) from exc
+
+            try:
+                pid = gateway_windows._spawn_detached()
+            except Exception as exc:
+                raise RuntimeError(f"could not cold-start gateway: {exc}") from exc
+
+            if not pid:
+                raise RuntimeError("gateway cold-start did not return a process ID")
+            ready_pids = gateway_windows._wait_for_gateway_ready()
+            if not ready_pids:
+                raise RuntimeError(
+                    f"gateway cold-start PID {pid} did not become ready"
+                )
+            print()
+            print(
+                "✓ Gateway started via cold-start after update "
+                f"[{label}] (PID: {', '.join(map(str, ready_pids))})"
+            )
+        except Exception as exc:
+            failures.append(f"{label}: {exc}")
+        finally:
+            if override is not None:
+                reset_hermes_home_override(override)
+
+    if failures:
+        raise RuntimeError(
+            "Windows gateway cold-start failed for: " + "; ".join(failures)
+        )
     return True
 
 

--- a/tests/hermes_cli/test_update_cold_start_all_profiles.py
+++ b/tests/hermes_cli/test_update_cold_start_all_profiles.py
@@ -1,0 +1,176 @@
+"""#91675 (resume half): post-update cold-start must resume EVERY profile
+with an installed gateway autostart entry, not just the active profile.
+
+``_cold_start_windows_gateway_after_update`` called
+``gateway_windows._spawn_detached()`` exactly once; ``_build_gateway_argv``
+derives its profile from ``get_hermes_home()``, so only the updater's own
+(active) profile ever came back. Worse, the idempotency guard was
+``find_gateway_pids(all_profiles=True)`` while the spawn was single-profile:
+if a sibling profile's gateway came up first (watchdog task, login), the
+guard saw a live PID and NOTHING was cold-started — "one of N" was really
+"zero or one, whichever the race decided".
+
+These tests use a REAL temp HERMES_HOME with two profiles and REAL
+Startup-folder autostart entries (fake APPDATA); only the OS boundary
+(platform gate, schtasks, spawn, liveness poll) is stubbed.
+"""
+
+from __future__ import annotations
+
+import hermes_constants
+from hermes_cli import gateway as hermes_gateway
+from hermes_cli import gateway_windows
+from hermes_cli import main as cli_main
+from hermes_cli import update_cmd
+
+
+def _setup_two_profiles(tmp_path, monkeypatch):
+    """Two-profile HERMES_HOME (default + beta), both with autostart installed."""
+    root = tmp_path / "hermes-home"
+    startup = (
+        tmp_path
+        / "appdata"
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+    )
+    startup.mkdir(parents=True)
+    root.mkdir()
+    (root / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    beta = root / "profiles" / "beta"
+    beta.mkdir(parents=True)
+    (beta / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    # REAL Startup-folder entries for BOTH profiles — the enumeration under
+    # test must find these via per-profile get_startup_entry_path().
+    (startup / "Hermes_Gateway.vbs").write_text("' default\n", encoding="utf-8")
+    (startup / "Hermes_Gateway_beta.vbs").write_text("' beta\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    # No schtasks off-Windows: "task not found" exercises the REAL
+    # Startup-folder fallback of is_installed().
+    monkeypatch.setattr(
+        gateway_windows, "_exec_schtasks", lambda args: (1, "", "no such task")
+    )
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: False)
+    return root, beta
+
+
+def test_cold_start_spawns_one_gateway_per_autostart_profile(
+    tmp_path, monkeypatch, capsys
+):
+    root, beta = _setup_two_profiles(tmp_path, monkeypatch)
+
+    spawned_homes: list[str] = []
+
+    def fake_spawn(script_path=None):
+        spawned_homes.append(str(hermes_constants.get_hermes_home()))
+        return 40000 + len(spawned_homes)
+
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", fake_spawn)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: [4242]
+    )
+
+    assert update_cmd._cold_start_windows_gateway_after_update() is True
+
+    # BOTH profiles' homes got a spawn, each scoped to its own HERMES_HOME.
+    assert sorted(spawned_homes) == sorted([str(root), str(beta)])
+    out = capsys.readouterr().out
+    assert "[default]" in out
+    assert "[beta]" in out
+
+
+def test_live_sibling_does_not_suppress_other_profiles(
+    tmp_path, monkeypatch, capsys
+):
+    """The old ``all_profiles=True`` guard skipped EVERYTHING when any one
+    gateway was alive. Per-profile guard: a live beta gateway must only skip
+    beta — default still cold-starts."""
+    root, beta = _setup_two_profiles(tmp_path, monkeypatch)
+
+    spawned_homes: list[str] = []
+
+    def fake_spawn(script_path=None):
+        spawned_homes.append(str(hermes_constants.get_hermes_home()))
+        return 50000 + len(spawned_homes)
+
+    def fake_find_gateway_pids(*args, **kwargs):
+        # beta's gateway already came back (e.g. its watchdog task fired).
+        if str(hermes_constants.get_hermes_home()) == str(beta):
+            return [7777]
+        return []
+
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", fake_spawn)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", fake_find_gateway_pids)
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: [5001]
+    )
+
+    assert update_cmd._cold_start_windows_gateway_after_update() is True
+
+    assert spawned_homes == [str(root)]  # default spawned, beta skipped
+
+
+def test_enumeration_failure_falls_back_to_active_profile(
+    tmp_path, monkeypatch, capsys
+):
+    """If profile enumeration yields nothing, keep the pre-#91675 behavior:
+    a single active-profile spawn (the pause phase already proved an
+    autostart entry exists for this home)."""
+    root, _beta = _setup_two_profiles(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        cli_main, "_windows_autostart_profile_homes", lambda: [], raising=False
+    )
+
+    spawned_homes: list[str] = []
+
+    def fake_spawn(script_path=None):
+        spawned_homes.append(str(hermes_constants.get_hermes_home()))
+        return 60001
+
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", fake_spawn)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: [6001]
+    )
+
+    assert update_cmd._cold_start_windows_gateway_after_update() is True
+    assert spawned_homes == [str(root)]
+
+
+def test_one_profile_failure_does_not_stop_the_rest(tmp_path, monkeypatch, capsys):
+    """A dead spawn for one profile is aggregated and raised at the end —
+    after every other profile got its start attempt."""
+    import pytest
+
+    root, beta = _setup_two_profiles(tmp_path, monkeypatch)
+
+    spawned_homes: list[str] = []
+
+    def fake_spawn(script_path=None):
+        spawned_homes.append(str(hermes_constants.get_hermes_home()))
+        return 70000 + len(spawned_homes)
+
+    def fake_ready(*args, **kwargs):
+        # default's spawn dies (job object denies breakaway); beta survives.
+        if str(hermes_constants.get_hermes_home()) == str(root):
+            return []
+        return [7002]
+
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", fake_spawn)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", fake_ready)
+
+    with pytest.raises(RuntimeError, match="cold-start failed for: default"):
+        update_cmd._cold_start_windows_gateway_after_update()
+
+    # beta was still attempted and succeeded despite default's failure.
+    assert sorted(spawned_homes) == sorted([str(root), str(beta)])
+    assert "[beta]" in capsys.readouterr().out

--- a/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
+++ b/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
@@ -21,12 +21,18 @@ from hermes_cli import update_cmd
 def _run_cold_start(monkeypatch, capsys, *, surviving_pids):
     monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
 
-    # The pre-spawn re-check (``all_profiles=True``) must find nothing
-    # running so the cold-start path proceeds and actually spawns.
+    # The per-profile pre-spawn re-check must find nothing running so the
+    # cold-start path proceeds and actually spawns (#91675: the guard is
+    # per profile now, not the old global ``all_profiles=True`` scan).
     monkeypatch.setattr(
         hermes_gateway,
         "find_gateway_pids",
-        lambda all_profiles=False: [] if all_profiles else surviving_pids,
+        lambda *a, **k: [],
+    )
+    # Profile enumeration is exercised elsewhere
+    # (test_update_cold_start_all_profiles); pin the single-target fallback.
+    monkeypatch.setattr(
+        cli_main, "_windows_autostart_profile_homes", lambda: [], raising=False
     )
     monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 4242)
     # Avoid the real 6s/0.4s poll loop in _report_gateway_start.


### PR DESCRIPTION
## Summary

Fixes the **post-update cold-start / resume half** of #91675: after a `hermes update`, the resume logic only ever brought back the **active** profile's gateway. Every other profile with an installed autostart entry stayed down until the next login.

Scope note: this PR deliberately covers ONLY the cross-platform resume/enumeration logic. The Windows-only "✓ then dies after the 6s liveness poll" half of #91675 (Job-Object breakaway spawn path) is owned by #84409 and is untouched here. The sibling launcher-refresh hole is owned by #91956.

## Root cause (traced on current `origin/main`)

`_cold_start_windows_gateway_after_update()` (`hermes_cli/update_cmd.py`) called `gateway_windows._spawn_detached()` exactly **once**. `_spawn_detached` builds its argv through `_build_gateway_argv()`, which takes no profile and derives one from `get_hermes_home()` — so exactly one gateway could ever be cold-started: the updater's own (active) profile.

Worse (as @jackulau traced on the issue), the idempotency guard was inverted relative to the spawn:

```python
if list(find_gateway_pids(all_profiles=True)):   # guard: ALL profiles
    return
pid = gateway_windows._spawn_detached()          # spawn: ONE profile
```

If a sibling profile's gateway happened to come up first (watchdog task, login), the global guard saw a live PID and returned — and **nothing** was cold-started. "One of N" was really "zero or one, whichever the race decided."

## Fix

- New `_windows_autostart_profile_homes()`: enumerates every profile (default + named, via `list_profiles()`) whose gateway autostart entry is installed, probing `gateway_windows.is_installed()` per profile under `set_hermes_home_override(profile.path)` — the context-local primitive `hermes_constants` already ships, so no `gateway_windows` signature changes and no `os.environ` mutation.
- `_cold_start_windows_gateway_after_update()` now loops over those profiles: per-profile liveness re-check (`find_gateway_pids()` scoped to that profile's home — a live sibling no longer suppresses other profiles), per-profile `_spawn_detached()`, per-profile `_wait_for_gateway_ready()` gate (#84185 honesty preserved), success line labeled `[<profile>]`.
- One profile's failure no longer stops the rest: failures are aggregated and raised at the end.
- Empty/failed enumeration falls back to the previous single active-profile spawn (the pause phase only sets `cold_start_if_installed` after seeing an installed entry for that home).

**Live repro:** real-import harness of the actual `_pause_windows_gateways_for_update()` → `_resume_windows_gateways_after_update()` pipeline against an isolated temp `HERMES_HOME` with two profiles (`default` + `beta`), both with real Startup-folder autostart entries on disk; only OS-boundary primitives (win32 gate, schtasks, spawn, liveness poll) stubbed — before (main `d10ef89ee5`): `SPAWNED GATEWAY HOMES: [<root>]` — only the active profile resumed, beta stayed down; after (this branch): both homes spawned, `✓ Gateway started via cold-start after update [default] ... [beta]`.

## Tests

- New `tests/hermes_cli/test_update_cold_start_all_profiles.py` (4 tests, real temp HERMES_HOME + real Startup entries):
  - one spawn per autostart profile, each scoped to its own home
  - a live sibling gateway only skips *its own* profile (the race-guard fix)
  - enumeration failure falls back to the single active-profile spawn
  - one profile's dead spawn is aggregated, the rest still start
- Sabotage-verified: with the fix stashed, the two core tests fail (`spawns_one_gateway_per_autostart_profile`, `one_profile_failure_does_not_stop_the_rest`); with it applied, 13/13 green across the cold-start test files.
- Updated `test_update_cold_start_gateway_liveness.py` to the per-profile guard semantics (#84185 assertions unchanged).
- Targeted run: 91 passed, 2 skipped across the update/gateway cold-start suite. `ruff check` clean; Windows-footguns checker clean.

Part of the #91277 fleet-update reliability campaign (per-profile restart correctness). Refs #91675.

## Infographic

![resume-all-profiles](https://v3b.fal.media/files/b/0aa8949e/neGy_hCHADDwh2tlp_4AW_LVvBQUov.png)
