### PR TITLE
feat(agent): escalate repeated transcript-sanitiser heals — counters, one ERROR, one-time user notice (#96870)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3856,6 +3856,13 @@ def _tool_call_id_variants(tc: Any) -> set:
 # consistently whether the empty turn was caught at write time or send time.
 _INTERRUPTED_PLACEHOLDER = "[response interrupted]"
 
+# Repeated heals of the same poisoned transcript used to WARNING on every
+# send (#96870). Escalate once per session window, then stay quiet.
+_EMPTY_HEAL_ESCALATE_AFTER = 5
+_EMPTY_HEAL_WINDOW_S = 600.0
+_empty_heal_log_state: Dict[str, Dict[str, Any]] = {}
+_empty_heal_log_lock = threading.Lock()
+
 
 def _msg_has_payload(msg: Dict[str, Any]) -> bool:
     """True if ``msg`` carries anything the API treats as non-empty content.
@@ -3903,6 +3910,80 @@ def _msg_has_payload(msg: Dict[str, Any]) -> bool:
     if msg.get("codex_message_items") or msg.get("codex_reasoning_items"):
         return True
     return False
+
+
+def fill_empty_non_final_wire_payload(
+    msg: Dict[str, Any], *, is_final: bool
+) -> bool:
+    """Write the interrupted placeholder onto an empty non-final wire copy.
+
+    Used by the send-time projection so ``repair_empty_non_final_messages``
+    does not re-heal the same row on every call (#88955 hidden placeholders,
+    #96870 stream-death / host-fed empties). Pass the per-call copy only —
+    durable history must not be mutated. Returns True when *msg* was filled.
+    """
+    if is_final or not isinstance(msg, dict):
+        return False
+    if msg.get("role") not in ("user", "assistant"):
+        return False
+    if _msg_has_payload(msg):
+        return False
+    msg["content"] = _INTERRUPTED_PLACEHOLDER
+    return True
+
+
+def _session_id_for_heal_log() -> str:
+    try:
+        from hermes_logging import _session_context
+
+        return str(getattr(_session_context, "session_id", None) or "")
+    except Exception:
+        return ""
+
+
+def _log_empty_non_final_heal(healed: int) -> None:
+    """WARNING on the first heals in a window; one ERROR at the threshold.
+
+    Further heals in the same session window stay silent so a poisoned
+    transcript cannot flood ``errors.log`` (dozens of identical WARNINGs
+    per hour with no user-visible signal — #96870).
+    """
+    key = _session_id_for_heal_log() or "-"
+    now = time.monotonic()
+    with _empty_heal_log_lock:
+        state = _empty_heal_log_state.get(key)
+        if state is None or (now - state["window_start"]) > _EMPTY_HEAL_WINDOW_S:
+            state = {"count": 0, "window_start": now, "escalated": False}
+            _empty_heal_log_state[key] = state
+        state["count"] += 1
+        count = state["count"]
+        if count >= _EMPTY_HEAL_ESCALATE_AFTER and not state["escalated"]:
+            state["escalated"] = True
+            level = "error"
+        elif state["escalated"]:
+            level = "silent"
+        else:
+            level = "warning"
+
+    if level == "silent":
+        return
+    if level == "error":
+        _ra().logger.error(
+            "Pre-call sanitizer: healed %d empty non-final message(s) "
+            "(%d heals in this session window). The transcript is being "
+            "repaired on every send; /new drops the poisoned turns.",
+            healed,
+            count,
+        )
+        return
+    _ra().logger.warning(
+        "Pre-call sanitizer: healed %d empty non-final message(s) by "
+        "substituting placeholder content — an empty-content turn was in "
+        "the transcript and would 400 the request ('messages must have "
+        "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
+        "poisoned transcript in memory; no restart needed.",
+        healed,
+    )
 
 
 def repair_empty_non_final_messages(
@@ -3961,14 +4042,7 @@ def repair_empty_non_final_messages(
             repaired.append(msg)
 
     if healed:
-        _ra().logger.warning(
-            "Pre-call sanitizer: healed %d empty non-final message(s) by "
-            "substituting placeholder content — an empty-content turn was in "
-            "the transcript and would 400 the request ('messages must have "
-            "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
-            "poisoned transcript in memory; no restart needed.",
-            healed,
-        )
+        _log_empty_non_final_heal(healed)
         return repaired
     return messages
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3858,10 +3858,22 @@ _INTERRUPTED_PLACEHOLDER = "[response interrupted]"
 
 # Repeated heals of the same poisoned transcript used to WARNING on every
 # send (#96870). Escalate once per session window, then stay quiet.
-_EMPTY_HEAL_ESCALATE_AFTER = 5
+# ``_EMPTY_HEAL_ESCALATE_AFTER`` is the built-in default; deployments tune it
+# via ``agent.sanitizer_heal_escalation_threshold`` in config.yaml (<= 0
+# disables escalation entirely — WARNINGs still fire per window).
+_EMPTY_HEAL_ESCALATE_AFTER = 3
 _EMPTY_HEAL_WINDOW_S = 600.0
 _empty_heal_log_state: Dict[str, Dict[str, Any]] = {}
 _empty_heal_log_lock = threading.Lock()
+# Session keys that already received the one-time user notice. Separate from
+# the windowed log state so a new 10-minute window never re-notifies: the
+# user is told ONCE per session, ever (#96870 — out-of-band, delivery
+# channel only, never injected into conversation context).
+_empty_heal_user_notified: set = set()
+# One-shot pending notices keyed by session, drained by the conversation
+# loop through ``consume_pending_sanitizer_heal_notice`` and delivered via
+# the status/warning callback (the normal delivery channel).
+_empty_heal_pending_notice: Dict[str, str] = {}
 
 
 def _msg_has_payload(msg: Dict[str, Any]) -> bool:
@@ -3941,25 +3953,106 @@ def _session_id_for_heal_log() -> str:
         return ""
 
 
+def _heal_escalation_threshold() -> int:
+    """Resolve the escalation threshold: config override, else the default.
+
+    ``agent.sanitizer_heal_escalation_threshold`` in config.yaml. Fail-safe:
+    any read error falls back to the module default so the sanitiser can
+    never be broken by a bad config file.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        raw = (load_config_readonly().get("agent", {}) or {}).get(
+            "sanitizer_heal_escalation_threshold"
+        )
+        if raw is not None:
+            return int(raw)
+    except Exception:
+        pass
+    return _EMPTY_HEAL_ESCALATE_AFTER
+
+
+def consume_pending_sanitizer_heal_notice() -> Optional[str]:
+    """Drain the one-time user notice for the current session, if any.
+
+    Called by the conversation loop right after the pre-send sanitizer pass;
+    the returned text is delivered through the status/warning callback (the
+    normal out-of-band delivery channel: gateway status message, CLI stderr
+    print). It is NEVER appended to the conversation context, so prompt
+    caching and role alternation are untouched. Returns at most one notice
+    per session for its whole lifetime.
+    """
+    key = _session_id_for_heal_log() or "-"
+    with _empty_heal_log_lock:
+        return _empty_heal_pending_notice.pop(key, None)
+
+
+def get_sanitizer_heal_stats() -> Dict[str, Dict[str, Any]]:
+    """Read-only snapshot of per-session sanitiser heal counters.
+
+    Surfaced by diagnostics (``hermes doctor`` / debug share callers) so
+    repeated silent repairs are visible outside errors.log. Keys are session
+    ids; values carry ``heal_events`` (sanitizer invocations that healed at
+    least one message), ``messages_healed`` (total substituted turns) and
+    ``escalated`` (whether the ERROR + user notice fired).
+    """
+    with _empty_heal_log_lock:
+        return {
+            k: {
+                "heal_events": v.get("total_events", v.get("count", 0)),
+                "messages_healed": v.get("total_healed", 0),
+                "escalated": k in _empty_heal_user_notified,
+            }
+            for k, v in _empty_heal_log_state.items()
+        }
+
+
 def _log_empty_non_final_heal(healed: int) -> None:
     """WARNING on the first heals in a window; one ERROR at the threshold.
 
     Further heals in the same session window stay silent so a poisoned
     transcript cannot flood ``errors.log`` (dozens of identical WARNINGs
-    per hour with no user-visible signal — #96870).
+    per hour with no user-visible signal — #96870). At the threshold the
+    escalation also queues a ONE-TIME out-of-band user notice (drained by
+    ``consume_pending_sanitizer_heal_notice``) pointing at ``/debug share``
+    / ``hermes doctor`` — once per session, never re-armed by a new window.
     """
     key = _session_id_for_heal_log() or "-"
+    threshold = _heal_escalation_threshold()
     now = time.monotonic()
     with _empty_heal_log_lock:
         state = _empty_heal_log_state.get(key)
         if state is None or (now - state["window_start"]) > _EMPTY_HEAL_WINDOW_S:
-            state = {"count": 0, "window_start": now, "escalated": False}
+            prior_events = state.get("total_events", 0) if state else 0
+            prior_healed = state.get("total_healed", 0) if state else 0
+            state = {
+                "count": 0,
+                "window_start": now,
+                "escalated": False,
+                "total_events": prior_events,
+                "total_healed": prior_healed,
+            }
             _empty_heal_log_state[key] = state
         state["count"] += 1
+        state["total_events"] = state.get("total_events", 0) + 1
+        state["total_healed"] = state.get("total_healed", 0) + healed
         count = state["count"]
-        if count >= _EMPTY_HEAL_ESCALATE_AFTER and not state["escalated"]:
+        total_events = state["total_events"]
+        total_healed = state["total_healed"]
+        if threshold > 0 and count >= threshold and not state["escalated"]:
             state["escalated"] = True
             level = "error"
+            if key not in _empty_heal_user_notified:
+                _empty_heal_user_notified.add(key)
+                _empty_heal_pending_notice[key] = (
+                    "⚠️ Your session transcript required repeated repair "
+                    f"({total_events} heal passes so far). Replies keep "
+                    "working, but a corrupted turn is stuck in this "
+                    "session's history — run /debug share or `hermes "
+                    "doctor` to capture diagnostics, or /new to start a "
+                    "clean session."
+                )
         elif state["escalated"]:
             level = "silent"
         else:
@@ -3969,11 +4062,17 @@ def _log_empty_non_final_heal(healed: int) -> None:
         return
     if level == "error":
         _ra().logger.error(
-            "Pre-call sanitizer: healed %d empty non-final message(s) "
-            "(%d heals in this session window). The transcript is being "
-            "repaired on every send; /new drops the poisoned turns.",
+            "Pre-call sanitizer: repeated-heal escalation for session %s — "
+            "healed %d empty non-final message(s) this send; heal pattern: "
+            "%d heal events / %d messages healed this session "
+            "(%d in the current session window, threshold %d). The transcript "
+            "is being repaired on every send; /new drops the poisoned turns.",
+            key,
             healed,
+            total_events,
+            total_healed,
             count,
+            threshold,
         )
         return
     _ra().logger.warning(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2302,7 +2302,10 @@ def run_conversation(
         # repair_message_sequence_with_cursor also recomputes the SessionDB
         # flush cursor (_last_flushed_db_idx) when repair compacts the list,
         # so the turn-end flush doesn't skip the assistant/tool chain (#44837).
-        from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
+        from agent.agent_runtime_helpers import (
+            fill_empty_non_final_wire_payload,
+            repair_message_sequence_with_cursor,
+        )
         repaired_seq = repair_message_sequence_with_cursor(agent, messages)
         if repaired_seq > 0:
             request_logger.info(
@@ -2332,28 +2335,8 @@ def run_conversation(
             # from every outgoing copy so strict OpenAI-compatible backends
             # don't reject the request after a model switch or resumed typed
             # event row enters the live history.
-            _display_kind = api_msg.pop("display_kind", None)
+            api_msg.pop("display_kind", None)
             api_msg.pop("display_metadata", None)
-
-            # Legacy hidden redirect placeholders (#88955): rows persisted
-            # BEFORE the writer-side api_content stamp in
-            # _apply_active_turn_redirect are content="" with no sidecar.
-            # Once display_kind is stripped the pre-call sanitizer
-            # (repair_empty_non_final_messages) would re-heal such a row on
-            # every call forever, since the durable transcript is never
-            # mutated. Give the wire copy the same neutral payload here so
-            # old sessions converge too. Never the interrupt scaffold —
-            # replaying scaffold bytes as assistant text is #81841.
-            if (
-                _display_kind == "hidden"
-                and api_msg.get("role") == "assistant"
-                and not _api_content
-                and not (api_msg.get("content") or "").strip()
-                and not api_msg.get("tool_calls")
-            ):
-                from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
-
-                api_msg["content"] = _INTERRUPTED_PLACEHOLDER
 
             # Durable row identity stamped by _rows_to_conversation so the
             # desktop can address a specific persisted message (reactions).
@@ -2411,6 +2394,16 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
+            # Empty non-final user/assistant turns (#88955 hidden placeholders
+            # and #96870 stream-death / host-fed empties): once display_kind
+            # and api_content are stripped, the pre-call sanitizer would
+            # re-heal the wire copy on every send and flood errors.log.
+            # Fill the WIRE copy here so the sanitizer has nothing to do.
+            # Durable history is not mutated. After reasoning copy so a
+            # thinking-only turn keeps its payload and is not rewritten.
+            fill_empty_non_final_wire_payload(
+                api_msg, is_final=(idx == len(messages) - 1)
+            )
             # _thinking_prefill survives here intentionally: the drop pass below
             # needs it. The transport strips all underscore keys before the wire.
             # Strip length-continuation marks; not every transport drops underscore keys.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2549,6 +2549,24 @@ def run_conversation(
         # manual message manipulation are always caught.
         api_messages = agent._sanitize_api_messages(api_messages)
 
+        # One-time repeated-heal escalation notice (#96870): if the sanitizer
+        # above just crossed the per-session heal threshold, deliver the
+        # queued notice through the status/warning callback — the normal
+        # out-of-band delivery channel (gateway status message / CLI print).
+        # NEVER appended to messages/api_messages: conversation context and
+        # the cached prompt prefix stay byte-identical.
+        try:
+            from agent.agent_runtime_helpers import (
+                consume_pending_sanitizer_heal_notice,
+            )
+
+            _heal_notice = consume_pending_sanitizer_heal_notice()
+            if _heal_notice:
+                agent._emit_warning(_heal_notice)
+        except Exception:
+            # A notice hiccup must never break the send path.
+            logger.debug("sanitizer heal notice delivery failed", exc_info=True)
+
         # Drop thinking-only assistant turns (reasoning but no visible
         # output and no tool_calls) and merge any adjacent user messages
         # left behind. Prevents Anthropic 400s ("The final block in an

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1055,6 +1055,16 @@ agent:
   # the turn (see gateway_timeout). 0 = disable. Default 300.
   # session_stall_timeout: 300
 
+  # Transcript-sanitiser repeated-heal escalation (#96870). The pre-send
+  # sanitiser silently repairs empty non-final turns on the wire copy; after
+  # this many heal passes within a 10-minute session window Hermes logs one
+  # ERROR (with session id + heal pattern) and sends a ONE-TIME out-of-band
+  # notice to the user suggesting /debug share or `hermes doctor`. The notice
+  # goes through the status channel only — conversation context and prompt
+  # caching are untouched. Set 0 to disable escalation (per-window WARNINGs
+  # still fire). Default 3.
+  # sanitizer_heal_escalation_threshold: 3
+
   # Related in-agent compression timeouts (they live under the top-level
   # compression: block, shown here for discoverability next to the stall
   # watchdog they complement — a hung compression is a common stall cause):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -295,6 +295,14 @@ DEFAULT_CONFIG = {
         # from gateway_timeout (which kills the turn) and
         # gateway_notify_interval ("still working" heartbeats). 0 = disable.
         "session_stall_timeout": 300,
+        # Transcript-sanitiser repeated-heal escalation threshold (#96870).
+        # After this many pre-send heal passes within a 10-minute session
+        # window, log one ERROR (session id + heal pattern) and queue a
+        # ONE-TIME out-of-band user notice pointing at /debug share or
+        # `hermes doctor`. Delivered via the status channel only —
+        # conversation context / prompt caching untouched. 0 = disable
+        # escalation (per-window WARNINGs still fire).
+        "sanitizer_heal_escalation_threshold": 3,
         # Long-lived reconnect-loop escalation (seconds). A platform that has
         # been continuously failing/reconnecting for this long gets
         # needs_attention flagged in gateway runtime status (visible in

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -607,6 +607,26 @@ def collect_debug_report(
     if log_snapshots is None:
         log_snapshots = _capture_default_log_snapshots(log_lines)
 
+    # ── Sanitiser heal counters (#96870) ─────────────────────────────────
+    # In-process, in-memory counters: populated when this report is built
+    # inside a process that ran agent turns (gateway /debug share); empty
+    # from a fresh CLI process, where the errors.log tail below carries the
+    # same escalation lines instead.
+    try:
+        from agent.agent_runtime_helpers import get_sanitizer_heal_stats
+
+        heal_stats = get_sanitizer_heal_stats()
+        if heal_stats:
+            buf.write("\n\n--- transcript sanitiser heal counters ---\n")
+            for sess, st in sorted(heal_stats.items()):
+                buf.write(
+                    f"session {sess}: {st['heal_events']} heal events, "
+                    f"{st['messages_healed']} messages healed, "
+                    f"escalated={st['escalated']}\n"
+                )
+    except Exception:
+        pass
+
     # ── Recent log tails (summary only) ──────────────────────────────────
     buf.write("\n\n")
     buf.write(f"--- agent.log (last {log_lines} lines) ---\n")

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -237,6 +237,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("agent", "max_turns"),
         ("agent", "gateway_timeout"),
         ("agent", "session_stall_timeout"),
+        ("agent", "sanitizer_heal_escalation_threshold"),
         ("agent", "tool_use_enforcement"),
         ("agent", "execution_guidance"),
         ("terminal", "backend"),

--- a/tests/run_agent/test_sanitiser_escalation.py
+++ b/tests/run_agent/test_sanitiser_escalation.py
@@ -1,0 +1,211 @@
+"""Empty-transcript sanitizer: stop the per-send heal/WARNING loop (#96870).
+
+``repair_empty_non_final_messages`` is still the single owner of the
+wire-copy substitution. The send-time projection now fills empty non-final
+turns first so the owner heals 0 on the main loop (same pattern as #88955).
+When a caller still hits the owner repeatedly, logging escalates once per
+session window instead of flooding errors.log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent.agent_runtime_helpers import (
+    _INTERRUPTED_PLACEHOLDER,
+    _empty_heal_log_state,
+    fill_empty_non_final_wire_payload,
+    repair_empty_non_final_messages,
+)
+from hermes_logging import clear_session_context, set_session_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_heal_log():
+    _empty_heal_log_state.clear()
+    clear_session_context()
+    yield
+    _empty_heal_log_state.clear()
+    clear_session_context()
+
+
+def _poisoned_rows():
+    return [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "next"},
+    ]
+
+
+class TestFillEmptyNonFinalWirePayload:
+    def test_fills_empty_non_final_assistant(self):
+        msg = {"role": "assistant", "content": ""}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is True
+        assert msg["content"] == _INTERRUPTED_PLACEHOLDER
+
+    def test_fills_empty_non_final_user(self):
+        msg = {"role": "user", "content": None}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is True
+        assert msg["content"] == _INTERRUPTED_PLACEHOLDER
+
+    def test_skips_final_turn(self):
+        msg = {"role": "assistant", "content": ""}
+        assert fill_empty_non_final_wire_payload(msg, is_final=True) is False
+        assert msg["content"] == ""
+
+    def test_skips_tool_call_turn(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "x", "arguments": "{}"}}],
+        }
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == ""
+
+    def test_skips_codex_commentary_carrier(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_message_items": [{"type": "text", "text": "hi"}],
+        }
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == ""
+
+    def test_skips_already_populated_content(self):
+        msg = {"role": "assistant", "content": "hello"}
+        assert fill_empty_non_final_wire_payload(msg, is_final=False) is False
+        assert msg["content"] == "hello"
+
+
+class TestHealLogEscalation:
+    def test_warning_then_one_error_then_silence(self, monkeypatch, caplog):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        set_session_context("sess-heal")
+        durable = _poisoned_rows()
+
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            for _ in range(5):
+                out = repair_empty_non_final_messages(
+                    [dict(m) for m in durable]
+                )
+                assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
+                assert durable[1]["content"] == ""
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(warnings) == 2
+        assert len(errors) == 1
+        assert "healed" in warnings[0].getMessage()
+        assert "session window" in errors[0].getMessage()
+        assert "/new" in errors[0].getMessage()
+
+    def test_sessions_do_not_share_heal_counters(self, monkeypatch, caplog):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            set_session_context("sess-a")
+            repair_empty_non_final_messages([dict(m) for m in _poisoned_rows()])
+            set_session_context("sess-b")
+            repair_empty_non_final_messages([dict(m) for m in _poisoned_rows()])
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(warnings) == 2
+        assert errors == []
+
+    def test_owner_still_heals_wire_copy_only(self):
+        durable = _poisoned_rows()
+        out = repair_empty_non_final_messages(durable)
+        assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert durable[1]["content"] == ""
+        assert out is not durable
+
+
+class TestProjectionStopsReheal:
+    def _loop_agent(self):
+        from unittest.mock import MagicMock, patch
+
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+    def test_unmarked_empty_assistant_is_filled_before_sanitizer(self):
+        """The per-turn WARNING spam IS the bug: projection must fill the
+        unmarked empty row so the sanitizer heals 0 (#96870 / #88955)."""
+        from unittest.mock import patch
+
+        import agent.agent_runtime_helpers as _arh
+        from tests.run_agent.test_run_agent import _mock_response
+
+        agent = self._loop_agent()
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop"),
+        ]
+        sanitizer_healed = []
+        _real_repair = _arh.repair_empty_non_final_messages
+
+        def _spy_repair(messages, *a, **k):
+            empty = [
+                (m.get("role"), m.get("content"))
+                for m in messages
+                if isinstance(m, dict)
+                and m.get("role") in ("user", "assistant")
+                and not (m.get("content") or "").strip()
+                and not m.get("tool_calls")
+            ]
+            sanitizer_healed.append(empty)
+            return _real_repair(messages, *a, **k)
+
+        history = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "continue", "finish_reason": "stop"},
+            {"role": "assistant", "content": "earlier reply", "finish_reason": "stop"},
+        ]
+
+        with (
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(
+                _arh, "repair_empty_non_final_messages", side_effect=_spy_repair
+            ),
+        ):
+            agent.run_conversation("next question", conversation_history=history)
+
+        assert sanitizer_healed, "sanitizer was never invoked — test is vacuous"
+        for empty in sanitizer_healed:
+            assert empty == [], (
+                "sanitizer still received an empty non-final row — "
+                "the re-heal loop is back (#96870)"
+            )
+
+        wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        wire_assistants = [m for m in wire if m.get("role") == "assistant"]
+        assert wire_assistants[0]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert history[1]["content"] == ""
+        assert "api_content" not in history[1]

--- a/tests/run_agent/test_sanitiser_escalation.py
+++ b/tests/run_agent/test_sanitiser_escalation.py
@@ -16,7 +16,11 @@ import pytest
 from agent.agent_runtime_helpers import (
     _INTERRUPTED_PLACEHOLDER,
     _empty_heal_log_state,
+    _empty_heal_pending_notice,
+    _empty_heal_user_notified,
+    consume_pending_sanitizer_heal_notice,
     fill_empty_non_final_wire_payload,
+    get_sanitizer_heal_stats,
     repair_empty_non_final_messages,
 )
 from hermes_logging import clear_session_context, set_session_context
@@ -25,9 +29,13 @@ from hermes_logging import clear_session_context, set_session_context
 @pytest.fixture(autouse=True)
 def _reset_heal_log():
     _empty_heal_log_state.clear()
+    _empty_heal_pending_notice.clear()
+    _empty_heal_user_notified.clear()
     clear_session_context()
     yield
     _empty_heal_log_state.clear()
+    _empty_heal_pending_notice.clear()
+    _empty_heal_user_notified.clear()
     clear_session_context()
 
 
@@ -83,7 +91,7 @@ class TestHealLogEscalation:
     def test_warning_then_one_error_then_silence(self, monkeypatch, caplog):
         import agent.agent_runtime_helpers as arh
 
-        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 3)
         set_session_context("sess-heal")
         durable = _poisoned_rows()
 
@@ -106,7 +114,7 @@ class TestHealLogEscalation:
     def test_sessions_do_not_share_heal_counters(self, monkeypatch, caplog):
         import agent.agent_runtime_helpers as arh
 
-        monkeypatch.setattr(arh, "_EMPTY_HEAL_ESCALATE_AFTER", 3)
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 3)
         with caplog.at_level(logging.WARNING, logger="run_agent"):
             set_session_context("sess-a")
             repair_empty_non_final_messages([dict(m) for m in _poisoned_rows()])
@@ -124,6 +132,132 @@ class TestHealLogEscalation:
         assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
         assert durable[1]["content"] == ""
         assert out is not durable
+
+
+class TestOneTimeUserNotice:
+    def _heal_n(self, n):
+        for _ in range(n):
+            repair_empty_non_final_messages(
+                [dict(m) for m in _poisoned_rows()]
+            )
+
+    def test_notice_queued_once_at_threshold(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 3)
+        set_session_context("sess-notice")
+
+        self._heal_n(2)
+        assert consume_pending_sanitizer_heal_notice() is None
+
+        self._heal_n(1)  # crosses threshold
+        notice = consume_pending_sanitizer_heal_notice()
+        assert notice is not None
+        assert "repeated repair" in notice
+        assert "/debug share" in notice
+        assert "hermes doctor" in notice
+
+        # drained: never delivered twice
+        assert consume_pending_sanitizer_heal_notice() is None
+
+    def test_notice_never_rearms_in_new_window(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 2)
+        set_session_context("sess-rearm")
+
+        self._heal_n(2)
+        assert consume_pending_sanitizer_heal_notice() is not None
+
+        # Simulate window expiry: force a fresh window, cross threshold again.
+        arh._empty_heal_log_state["sess-rearm"]["window_start"] -= (
+            arh._EMPTY_HEAL_WINDOW_S + 1
+        )
+        self._heal_n(2)
+        assert consume_pending_sanitizer_heal_notice() is None
+
+    def test_notice_scoped_to_session(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 2)
+        set_session_context("sess-x")
+        self._heal_n(2)
+        set_session_context("sess-y")
+        # sess-y never escalated; its consume must not steal sess-x's notice
+        assert consume_pending_sanitizer_heal_notice() is None
+        set_session_context("sess-x")
+        assert consume_pending_sanitizer_heal_notice() is not None
+
+    def test_threshold_zero_disables_escalation(self, monkeypatch, caplog):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 0)
+        set_session_context("sess-off")
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            self._heal_n(6)
+        assert consume_pending_sanitizer_heal_notice() is None
+        assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+    def test_threshold_read_from_config(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"agent": {"sanitizer_heal_escalation_threshold": 7}},
+        )
+        assert arh._heal_escalation_threshold() == 7
+
+    def test_threshold_defaults_when_config_unreadable(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        def _boom():
+            raise RuntimeError("no config")
+
+        monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+        assert (
+            arh._heal_escalation_threshold() == arh._EMPTY_HEAL_ESCALATE_AFTER
+        )
+
+
+class TestHealStatsSurface:
+    def test_counters_visible_and_escalation_flagged(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 3)
+        set_session_context("sess-stats")
+        for _ in range(4):
+            repair_empty_non_final_messages(
+                [dict(m) for m in _poisoned_rows()]
+            )
+
+        stats = get_sanitizer_heal_stats()
+        assert stats["sess-stats"]["heal_events"] == 4
+        assert stats["sess-stats"]["messages_healed"] == 4
+        assert stats["sess-stats"]["escalated"] is True
+
+    def test_debug_report_includes_heal_counters(self, monkeypatch):
+        import agent.agent_runtime_helpers as arh
+        from hermes_cli.debug import collect_debug_report, LogSnapshot
+
+        monkeypatch.setattr(arh, "_heal_escalation_threshold", lambda: 2)
+        set_session_context("sess-report")
+        for _ in range(2):
+            repair_empty_non_final_messages(
+                [dict(m) for m in _poisoned_rows()]
+            )
+
+        empty = LogSnapshot(path=None, tail_text="", full_text="")
+        report = collect_debug_report(
+            log_lines=5,
+            dump_text="dump",
+            log_snapshots={
+                k: empty
+                for k in ("agent", "errors", "gateway", "gui", "desktop")
+            },
+        )
+        assert "transcript sanitiser heal counters" in report
+        assert "sess-report: 2 heal events" in report
+        assert "escalated=True" in report
 
 
 class TestProjectionStopsReheal:
@@ -209,3 +343,53 @@ class TestProjectionStopsReheal:
         assert wire_assistants[0]["content"] == _INTERRUPTED_PLACEHOLDER
         assert history[1]["content"] == ""
         assert "api_content" not in history[1]
+
+    def test_pending_notice_delivered_out_of_band_not_in_context(self):
+        """A queued escalation notice is emitted through _emit_warning (the
+        status/delivery channel) and NEVER appears in the wire messages or
+        the durable history — message-flow / caching invariants (#96870)."""
+        from unittest.mock import patch
+
+        import agent.agent_runtime_helpers as _arh
+        from tests.run_agent.test_run_agent import _mock_response
+
+        agent = self._loop_agent()
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop"),
+        ]
+
+        set_session_context("sess-loop-notice")
+        # The turn re-binds the log session context to the agent's own
+        # session id at turn start, so queue the notice under that key —
+        # exactly where the escalation path would have put it mid-session.
+        _live_key = str(getattr(agent, "session_id", None) or "-")
+        with _arh._empty_heal_log_lock:
+            _arh._empty_heal_user_notified.add(_live_key)
+            _arh._empty_heal_pending_notice[_live_key] = (
+                "⚠️ Your session transcript required repeated repair — "
+                "run /debug share or `hermes doctor`."
+            )
+
+        warned = []
+        history = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "earlier", "finish_reason": "stop"},
+        ]
+        with (
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_emit_warning", side_effect=warned.append),
+        ):
+            agent.run_conversation("next", conversation_history=history)
+
+        assert warned and "repeated repair" in warned[0]
+        # one-time: drained after delivery
+        assert _arh._empty_heal_pending_notice == {}
+        # never injected into the wire copy or durable history
+        wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert all("repeated repair" not in str(m.get("content")) for m in wire)
+        assert all(
+            "repeated repair" not in str(m.get("content")) for m in history
+        )


### PR DESCRIPTION
## Summary

Implements the escalation design for #96870 (silent recovery mode: the transcript sanitiser silently heals a poisoned transcript on every send while the user and gateway see nothing). Salvages and builds on @HexLab98's PR #96916 (projection fill + windowed heal-log escalation — their two commits are cherry-picked with authorship preserved), then adds the observability layer the issue asks for:

- **Per-session heal counters** in `agent/agent_runtime_helpers.py`: heal events + messages healed, tracked per session and preserved across the 10-minute log windows.
- **Threshold escalation**: after N heals in a session window (default **3**, `agent.sanitizer_heal_escalation_threshold` in config.yaml, `0` = off) one `ERROR` is logged with the session id and heal pattern (events / messages healed / window count / threshold), then the log goes quiet — no more per-send WARNING floods.
- **ONE-TIME out-of-band user notice**: at the threshold a notice ("your session transcript required repeated repair … run /debug share or `hermes doctor`, or /new") is queued and delivered by the conversation loop through `_emit_warning` → the status callback (gateway status message / CLI print). It is **never** injected into conversation context or the wire copy — prompt caching, strict role alternation, and durable history stay byte-identical. Once per session, ever; a new heal window does not re-arm it.
- **Counters visible on debug surfaces**: `get_sanitizer_heal_stats()` is rendered as a "transcript sanitiser heal counters" section in the `/debug share` / `hermes debug` report; the config key shows in `hermes dump` overrides; the ERROR line lands in `errors.log` for `hermes logs errors`.

## Live repro (before / after)

Real repair path (`repair_empty_non_final_messages`) + real `AIAgent.run_conversation` turns against a transcript carrying an empty mid-turn assistant row (stream death shape from the issue), only the HTTP client stubbed:

**Before (origin/main d10ef89ee5), 10 sends:**
```
log records by level: {'WARNING': 10}
ERROR records: 0
user-visible notices: NONE — user sees nothing
heal stats surface: NONE
```

**After (this branch), 5 real conversation turns:**
```
sanitizer log records over 5 real turns: {'WARNING': 2, 'ERROR': 1}
ERROR line: Pre-call sanitizer: repeated-heal escalation for session 20260831_115029_2baece — … heal pattern: 3 heal events / 3 messages healed this session (3 in the current session window, threshold 3) …
out-of-band user notices delivered: 1
  -> ⚠️ Your session transcript required repeated repair (3 heal passes so far)… run /debug share or `hermes doctor` … or /new …
invariants: notice NOT in wire messages; durable history untouched  ✔
heal stats: {'…': {'heal_events': 5, 'messages_healed': 5, 'escalated': True}}
```

## Tests

`tests/run_agent/test_sanitiser_escalation.py` — 19 tests: projection fill guards (#96916), WARN→ERROR→silence windowing, per-session counter isolation, one-time notice (threshold crossing, drain-once, no re-arm on new window, session scoping), threshold=0 disable, config read + fail-safe default, heal-stats snapshot, debug-report section, and a full-loop E2E asserting the notice goes out via `_emit_warning` and never appears in wire messages or durable history.

Local: 19/19 new; `tests/run_agent` 1982 passed (1 failure pre-existing on pristine origin/main: `test_codex_app_server_integration.py::…fail_closed`); `tests/hermes_cli/test_debug.py`, steer/thinking-only/partial-stream sanitizer suites, `tests/hermes_cli/test_config.py`, `tests/run_agent/test_streaming.py` all green. ruff + Windows-footgun checker clean.

Closes #96870.

## Infographic

![sanitiser heal escalation](https://v3b.fal.media/files/b/0aa894c9/rCgkXRcoFuzwbCyMMRgSV_PdI8Ar7W.png)
