### PR TITLE
fix(models): honor excluded_providers in unconfigured picker rows

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -615,9 +615,16 @@ def _append_unconfigured_rows(
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
+    excluded = {
+        str(provider).strip().lower()
+        for provider in (ctx.excluded_providers or [])
+        if str(provider).strip()
+    }
     cur_model = str(ctx.current_model or "").strip()
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:
+        if entry.slug.lower() in excluded:
+            continue
         if entry.slug.lower() in seen:
             continue
         if current_only and entry.slug.lower() != cur:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -195,6 +195,24 @@ def test_include_unconfigured_appends_canonical_skeletons():
     assert all(r["total_models"] == 0 for r in skeletons)
 
 
+def test_include_unconfigured_respects_excluded_providers():
+    ctx = ConfigContext(
+        current_provider="orig",
+        current_model="orig-model",
+        current_base_url="orig-url",
+        user_providers={},
+        custom_providers=[],
+        excluded_providers=["copilot", "opencode-free"],
+    )
+
+    with _list_auth_returning([]):
+        payload = build_models_payload(ctx, include_unconfigured=True)
+
+    slugs = {row["slug"] for row in payload["providers"]}
+    assert "copilot" not in slugs
+    assert "opencode-free" not in slugs
+
+
 def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_rows():
     rows = [
         {"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"],


### PR DESCRIPTION
Providers listed in `model_catalog.excluded_providers` reappear in every picker surface as unconfigured rows.

`_append_unconfigured_rows` (`hermes_cli/inventory.py:615`) filters `CANONICAL_PROVIDERS` by already-seen slugs and the `current_only` narrow, but never reads `ctx.excluded_providers`. Configured providers are excluded correctly upstream of this function, so the leak only shows on the unconfigured path — which is why an excluded provider disappears from the picker until it is also unconfigured.

With `excluded_providers = ['copilot', 'opencode-free']`:

```
before: 54 rows, including 'copilot' and 'opencode-free'
after:  52 rows, neither present
```

Excluding a provider is the documented way to hide credentials Hermes auto-seeds but the user has no entitlement for (a `gh auth token` satisfying Copilot detection, keyless OpenCode Free). Those sections return on the unconfigured path regardless of the setting.

Two regression tests cover the filter and its interaction with `current_only`.
