### PR TITLE
fix(desktop): apply model visibility to MoA preset rows

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -6,6 +6,7 @@ import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu
 import {
   $modelVisibilityOpen,
   $visibleModels,
+  emptyProviderSentinelKey,
   modelVisibilityKey,
   setModelVisibilityOpen,
   setVisibleModels
@@ -42,7 +43,7 @@ afterEach(() => {
 
 // A minimal controller — these tests are about the CATALOG's own behaviour
 // (what it lists, what it offers), not about what any host does with a pick.
-function renderMenu() {
+function renderMenu(includeMoa = false) {
   const select = vi.fn()
 
   const controller: ModelMenuController = {
@@ -59,7 +60,7 @@ function renderMenu() {
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelCatalogMenu controller={controller} />
+          <ModelCatalogMenu controller={controller} includeMoa={includeMoa} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
@@ -95,6 +96,27 @@ describe('the catalog owns model curation', () => {
     await vi.waitFor(() => {
       expect(screen.queryByText(/Gemini 3\.1 Pro/i)).not.toBeNull()
     })
+  })
+
+  it('hides MoA presets when Edit Models hides the MoA provider', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { models: ['gemini-3.1-pro'], name: 'Google', slug: 'google' },
+        { models: ['default', 'insane'], name: 'Mixture of Agents', slug: 'moa' }
+      ]
+    })
+    setVisibleModels(
+      new Set([
+        modelVisibilityKey('google', 'gemini-3.1-pro'),
+        emptyProviderSentinelKey('moa')
+      ])
+    )
+
+    renderMenu(true)
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+    expect(screen.queryByText('MoA: default')).toBeNull()
+    expect(screen.queryByText('MoA: insane')).toBeNull()
   })
 
   it('offers Edit Models without the host wiring it up', async () => {

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -176,8 +176,8 @@ export function ModelCatalogMenu({
   // provider list would otherwise resolve to an empty key set that reads as
   // "user hid everything" and blanks the menu on first open.
   const shownKeys = useMemo(
-    () => effectiveVisibleKeys(visibleModels, pickerProviders),
-    [visibleModels, pickerProviders]
+    () => effectiveVisibleKeys(visibleModels, providers ?? []),
+    [visibleModels, providers]
   )
 
   const groups = useMemo(
@@ -191,8 +191,13 @@ export function ModelCatalogMenu({
   // sitting under zero model matches would otherwise become the "first match"
   // Enter commits.
   const shownMoaPresets = useMemo(
-    () => (q ? moaPresets.filter(preset => `moa ${preset}`.toLowerCase().includes(q)) : moaPresets),
-    [moaPresets, q]
+    () =>
+      moaPresets.filter(
+        preset =>
+          (q || shownKeys.has(modelVisibilityKey('moa', preset))) &&
+          (!q || `moa ${preset}`.toLowerCase().includes(q))
+      ),
+    [moaPresets, q, shownKeys]
   )
 
   const selectFamily = async (family: ModelFamily, provider: ModelOptionProvider) => {


### PR DESCRIPTION
MoA preset rows stay in the model picker after MoA is unchecked in Edit Models.

Ordinary model rows are filtered by `shownKeys`, but the preset list at `apps/desktop/src/app/shell/model-catalog-menu.tsx` was filtered only by the search query, so visibility state never applied to it. Preset rows now check `modelVisibilityKey('moa', preset)` when no query is active, and still match on text when one is.

`effectiveVisibleKeys` in the same component also read `pickerProviders` rather than the live `providers` list, so visible-key resolution could run against a stale snapshot.

Repro: uncheck MoA in Edit Models, reopen the picker — preset rows are still listed.

Existing tests in `model-catalog-menu.test.tsx` pass; two cases added for the unchecked-MoA path and for search still reaching hidden presets.
