### PR TITLE
fix(telegram): recover Windows CLOSE-WAIT getUpdates reconnect deadlock

### DIFF
--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/retry
         with:
-          command: uv sync --locked --python 3.11 --extra dev
+          command: uv sync --locked --python 3.11 --extra dev --extra messaging
 
       - name: Run venv-holder live E2E
         shell: bash
@@ -59,4 +59,12 @@ jobs:
           uv run --no-sync python -m pytest \
             tests/hermes_cli/test_venv_holder_windows_live.py \
             tests/hermes_cli/test_taskkill_identity_windows_live.py \
+            -o addopts= -v -p no:cacheprovider
+
+      - name: Run Telegram CLOSE-WAIT reconnect live E2E (#87057)
+        shell: bash
+        run: |
+          set -uo pipefail
+          uv run --no-sync python -m pytest \
+            tests/gateway/test_telegram_closewait_windows_live.py \
             -o addopts= -v -p no:cacheprovider

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4594,8 +4594,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     max_keepalive_connections=_base_limits.max_keepalive_connections,
                     keepalive_expiry=_base_limits.keepalive_expiry,
                 )
+                # A long-poll request is continuously active, so keepalive
+                # expiry cannot protect it from a server-side connection close.
+                # Never hand getUpdates a pooled socket from a previous poll;
+                # ordinary Bot API requests retain the shared reusable pool.
+                _updates_limits = _httpx.Limits(
+                    max_connections=request_kwargs["connection_pool_size"],
+                    max_keepalive_connections=0,
+                    keepalive_expiry=_base_limits.keepalive_expiry,
+                )
             else:  # pragma: no cover — httpx always present alongside PTB
                 _pool_limits = None
+                _updates_limits = None
 
             def _with_limits(httpx_kwargs: Optional[dict] = None) -> dict:
                 """Merge tuned keepalive limits into httpx client kwargs.
@@ -4673,6 +4683,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 if _pool_limits is not None:
                     _transport_kwargs["limits"] = _pool_limits
                 _transport_kwargs["socket_options"] = tcp_keepalive_socket_options()
+                _updates_transport_kwargs = dict(_transport_kwargs)
+                if _updates_limits is not None:
+                    _updates_transport_kwargs["limits"] = _updates_limits
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={
@@ -4685,7 +4698,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs,
                     httpx_kwargs={
                         "transport": TelegramFallbackTransport(
-                            fallback_ips, **_transport_kwargs
+                            fallback_ips,
+                            **_updates_transport_kwargs,
                         )
                     },
                 )
@@ -4695,14 +4709,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs={"limits": _updates_limits},
                 )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs, httpx_kwargs=_with_limits())
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, httpx_kwargs=_with_limits()
+                    **request_kwargs, httpx_kwargs={"limits": _updates_limits}
                 )
 
             get_updates_request = self._instrument_polling_request(get_updates_request)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -242,6 +242,7 @@ from plugins.platforms.telegram.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
     parse_fallback_ip_env,
+    tcp_keepalive_socket_options,
 )
 from utils import atomic_replace, env_float, env_int
 
@@ -2494,6 +2495,7 @@ class TelegramAdapter(BasePlatformAdapter):
             polling_req = self._app.bot._request[0]  # noqa: SLF001
         except Exception:
             return
+        shutdown_ok = False
         try:
             # Bounded: a wedged CLOSE-WAIT socket can make this close hang
             # forever and freeze the reconnect ladder (#66377). The wall-clock
@@ -2504,11 +2506,19 @@ class TelegramAdapter(BasePlatformAdapter):
             await _await_with_thread_deadline(
                 polling_req.shutdown(), timeout=_DRAIN_TIMEOUT
             )
+            shutdown_ok = True
         except Exception:
             logger.debug(
                 "[%s] Polling request shutdown failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
+        if not shutdown_ok:
+            # HTTPXRequest.initialize() rebuilds the client only when
+            # ``client.is_closed``. An abandoned aclose() leaves that flag
+            # false, so initialize() is a no-op and start_polling reuses the
+            # CLOSE-WAIT getUpdates socket — the gateway stays alive but
+            # deaf (#87057). Swap in a fresh client before initialize().
+            self._orphan_and_rebuild_polling_client(polling_req)
         try:
             await _await_with_thread_deadline(
                 polling_req.initialize(), timeout=_DRAIN_TIMEOUT
@@ -2521,6 +2531,64 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Polling request re-initialize failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
+            self._orphan_and_rebuild_polling_client(polling_req)
+
+    def _orphan_and_rebuild_polling_client(self, polling_req) -> None:
+        """Replace a wedged HTTPXRequest client after a hung aclose().
+
+        PTB's ``HTTPXRequest.initialize()`` only calls ``_build_client()``
+        when the current client reports ``is_closed``. If ``shutdown()`` was
+        abandoned on a CLOSE-WAIT socket, that flag stays false and the next
+        ``start_polling()`` reuses the dead getUpdates connection (#87057).
+        Swap in a fresh client and close the old one in a detached, bounded
+        background task so it cannot block the reconnect ladder.
+        """
+        old = getattr(polling_req, "_client", None)
+        build = getattr(polling_req, "_build_client", None)
+        if old is None or not callable(build):
+            return
+        if getattr(old, "is_closed", True):
+            return
+        try:
+            polling_req._client = build()  # noqa: SLF001
+        except Exception:
+            logger.debug(
+                "[%s] Failed to rebuild polling HTTP client after hung drain",
+                self.name, exc_info=True,
+            )
+            return
+        logger.warning(
+            "[%s] Replaced wedged getUpdates HTTP client after drain timeout "
+            "(likely CLOSE-WAIT socket)",
+            self.name,
+        )
+
+        async def _orphan_aclose() -> None:
+            try:
+                aclose = getattr(old, "aclose", None)
+                if not callable(aclose):
+                    return
+                # The stale client can be wedged in the same cancellation-
+                # swallowing httpcore scope as shutdown(). Use the wall-clock
+                # thread deadline — not asyncio.wait_for — so this cleanup
+                # task cannot itself hang forever and accumulate one leaked
+                # task per reconnect attempt (#87265 review).
+                await _await_with_thread_deadline(
+                    aclose(), timeout=_DRAIN_TIMEOUT
+                )
+            except Exception:
+                logger.debug(
+                    "[%s] Orphan polling client aclose failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
+
+        try:
+            task = asyncio.ensure_future(_orphan_aclose())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(_consume_abandoned_task)
+        except Exception:
+            pass
 
     def _begin_polling_generation(self) -> tuple[int, asyncio.Event]:
         """Start accepting progress for a new getUpdates polling generation."""
@@ -4604,6 +4672,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
                     _transport_kwargs["limits"] = _pool_limits
+                _transport_kwargs["socket_options"] = tcp_keepalive_socket_options()
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -21,6 +21,37 @@ logger = logging.getLogger(__name__)
 
 _TELEGRAM_API_HOST = "api.telegram.org"
 
+# TCP keepalive so a half-open or CLOSE-WAIT long-poll errors out instead of
+# blocking getUpdates indefinitely. Windows does not enable SO_KEEPALIVE on
+# new sockets by default, so a dead api.telegram.org peer can hang forever
+# (#87057). Idle/interval knobs are best-effort — not every Python/OS combo
+# exposes TCP_KEEPIDLE / TCP_KEEPALIVE.
+_TCP_KEEPALIVE_IDLE_S = 30
+_TCP_KEEPALIVE_INTERVAL_S = 10
+_TCP_KEEPALIVE_COUNT = 3
+
+
+def tcp_keepalive_socket_options() -> list[tuple[int, int, int]]:
+    """Return ``setsockopt`` tuples that enable TCP keepalive on new sockets.
+
+    Pure data for httpx/httpcore ``socket_options``. Safe on every host: the
+    list always includes ``SO_KEEPALIVE`` and adds idle/interval/count only
+    when the running interpreter exposes those option names.
+    """
+    options: list[tuple[int, int, int]] = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    ]
+    idle = getattr(socket, "TCP_KEEPIDLE", None) or getattr(socket, "TCP_KEEPALIVE", None)
+    if idle is not None:
+        options.append((socket.IPPROTO_TCP, idle, _TCP_KEEPALIVE_IDLE_S))
+    interval = getattr(socket, "TCP_KEEPINTVL", None)
+    if interval is not None:
+        options.append((socket.IPPROTO_TCP, interval, _TCP_KEEPALIVE_INTERVAL_S))
+    count = getattr(socket, "TCP_KEEPCNT", None)
+    if count is not None:
+        options.append((socket.IPPROTO_TCP, count, _TCP_KEEPALIVE_COUNT))
+    return options
+
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
 _DOH_TIMEOUT = 4.0  # seconds — bounded so connect() isn't noticeably delayed
@@ -73,6 +104,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
         transport_kwargs.setdefault("limits", self._POOL_LIMITS)
+        transport_kwargs.setdefault("socket_options", tcp_keepalive_socket_options())
         self._transport_kwargs = transport_kwargs
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._primary_lock = asyncio.Lock()

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -135,12 +135,21 @@ def _assert_keepalive_tight(instances):
         assert limits.max_connections is not None and limits.max_connections > 0
 
 
+def _assert_updates_pool_never_reuses(instance):
+    """The long-poll pool must not reuse server-closed connections (#87057)."""
+    limits = instance.kwargs.get("httpx_kwargs", {}).get("limits")
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_keepalive_connections == 0
+    assert limits.max_connections == 512
+
+
 def test_proxy_branch_general_pool_has_tight_keepalive(monkeypatch):
     """The proxy path the #31599 reporter hit must wire tuned limits."""
     instances = _drive_connect(monkeypatch, proxy_url="http://127.0.0.1:9/")
     # Both the general request pool and the get_updates pool are built here.
     assert len(instances) >= 2
-    _assert_keepalive_tight(instances)
+    _assert_keepalive_tight(instances[:1])
+    _assert_updates_pool_never_reuses(instances[1])
     # Sanity: the proxy was actually threaded through (we're on the proxy branch).
     assert any(inst.kwargs.get("proxy") == "http://127.0.0.1:9/" for inst in instances)
 
@@ -156,7 +165,7 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
     )
 
     assert len(instances) >= 2
-    for instance in instances:
+    for index, instance in enumerate(instances):
         transport = instance.kwargs["httpx_kwargs"]["transport"]
         assert isinstance(transport, tg_adapter.TelegramFallbackTransport)
         limits = transport._transport_kwargs["limits"]
@@ -172,6 +181,10 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
             and opt[2] == 1
             for opt in sock_opts
         )
+        if index == 0:
+            assert limits.max_keepalive_connections >= 1
+        else:
+            assert limits.max_keepalive_connections == 0
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -26,6 +26,7 @@ client-level limits when a custom transport is supplied.
 """
 
 import asyncio
+import socket
 from unittest.mock import MagicMock
 
 import httpx
@@ -163,6 +164,14 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
         assert limits.keepalive_expiry is not None
         assert limits.keepalive_expiry < 5.0
         assert limits.max_connections == 512
+        sock_opts = transport._transport_kwargs.get("socket_options")
+        assert sock_opts, "fallback transport must enable TCP keepalive (#87057)"
+        assert any(
+            opt[0] == socket.SOL_SOCKET
+            and opt[1] == socket.SO_KEEPALIVE
+            and opt[2] == 1
+            for opt in sock_opts
+        )
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_closewait_windows_live.py
+++ b/tests/gateway/test_telegram_closewait_windows_live.py
@@ -1,0 +1,289 @@
+"""Windows live E2E probes for the CLOSE-WAIT getUpdates reconnect fix (#87057).
+
+These probes run ONLY on a real Windows runner (the on-demand
+``windows-venv-e2e.yml`` lane, fired by pushes to ``wine2e/**`` branches).
+They exercise the REAL PTB ``HTTPXRequest`` transport against a live local
+HTTP server whose sockets are genuinely half-closed by the server side, so
+the client's pooled connection sits in CLOSE-WAIT exactly the way a dropped
+``api.telegram.org`` long-poll does on Windows (selector/proactor overlapped
+I/O never surfaces the peer close).
+
+Scenario pinned by #87057: after a transient network error the reconnect
+ladder calls ``_drain_polling_connections()``. On Windows the close of the
+CLOSE-WAIT socket can wedge; PTB's ``HTTPXRequest.initialize()`` only builds
+a fresh client when ``client.is_closed`` is true, so an abandoned close left
+``start_polling()`` on the same dead socket and the gateway went silently
+deaf. The fix swaps in a fresh HTTP client when the drain times out.
+
+Probes:
+1. ``test_drain_recovers_after_server_half_close_live`` — a real pooled
+   keep-alive connection is half-closed by the server (CLOSE-WAIT on the
+   client). The drain must complete within its bound and the next real
+   request must succeed on a NEW TCP connection.
+2. ``test_drain_bounded_and_functional_when_close_wedges_live`` — the real
+   request's ``shutdown()`` is replaced with one that hangs forever
+   (deterministic stand-in for the observed proactor CLOSE-WAIT close hang).
+   The drain must return within the wall-clock bound, replace the wedged
+   client, and the replacement must complete a real HTTP round-trip.
+"""
+
+import asyncio
+import json
+import sys
+import time
+
+import pytest
+
+# The gateway conftest installs a MagicMock ``telegram`` package when the
+# real library has not been imported yet. This probe exercises the REAL PTB
+# HTTPXRequest against a live socket server, so evict any mock before the
+# real import. The lane installs the messaging extra, so real PTB is present.
+# Gated to win32: on other platforms these tests are skipped and evicting the
+# shared mock here would poison later test modules in the same session.
+if sys.platform == "win32":
+    _tg = sys.modules.get("telegram")
+    if _tg is not None and not hasattr(_tg, "__file__"):
+        for _name in [
+            m for m in list(sys.modules) if m == "telegram" or m.startswith("telegram.")
+        ]:
+            del sys.modules[_name]
+        # The adapter module may have bound mock names at import time — reload
+        # it against the real library.
+        for _name in [
+            m for m in list(sys.modules) if m.startswith("plugins.platforms.telegram")
+        ]:
+            del sys.modules[_name]
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="Windows-only live probe: CLOSE-WAIT reconnect behavior (#87057)",
+    ),
+]
+
+
+class _LiveBotApiServer:
+    """Minimal live HTTP/1.1 server that can half-close its connections.
+
+    Speaks just enough HTTP for PTB's ``HTTPXRequest.do_request`` POSTs.
+    Every accepted TCP connection is tracked so probes can assert whether a
+    request arrived on a fresh connection or reused a pooled one, and the
+    server can actively half-close (FIN) all live connections to park the
+    client side in CLOSE-WAIT.
+    """
+
+    def __init__(self):
+        self.server = None
+        self.port = None
+        self.connections_accepted = 0
+        self.requests_served = 0
+        self._writers = []
+
+    async def start(self):
+        self.server = await asyncio.start_server(
+            self._handle, host="127.0.0.1", port=0
+        )
+        self.port = self.server.sockets[0].getsockname()[1]
+
+    async def stop(self):
+        for w in self._writers:
+            try:
+                w.close()
+            except Exception:
+                pass
+        if self.server is not None:
+            self.server.close()
+            await self.server.wait_closed()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/botTEST/getUpdates"
+
+    async def half_close_all(self):
+        """Send FIN on every live connection -> client side goes CLOSE-WAIT."""
+        for w in self._writers:
+            try:
+                w.write_eof()
+            except Exception:
+                pass
+        # Give the client's TCP stack a moment to process the FIN.
+        await asyncio.sleep(0.2)
+
+    async def _handle(self, reader, writer):
+        self.connections_accepted += 1
+        self._writers.append(writer)
+        try:
+            while True:
+                # Read request head.
+                head = await reader.readuntil(b"\r\n\r\n")
+                headers = head.decode("latin1").lower()
+                length = 0
+                for line in headers.split("\r\n"):
+                    if line.startswith("content-length:"):
+                        length = int(line.split(":", 1)[1].strip())
+                if length:
+                    await reader.readexactly(length)
+                self.requests_served += 1
+                body = json.dumps({"ok": True, "result": []}).encode()
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                    b"Connection: keep-alive\r\n"
+                    b"\r\n" + body
+                )
+                await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionError, OSError):
+            pass
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+
+def _make_adapter():
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    return TelegramAdapter(PlatformConfig(enabled=True, token="123456:TEST"))
+
+
+def _diag(server, label, extra=""):
+    print(
+        f"[closewait-probe] {label}: connections={server.connections_accepted} "
+        f"requests={server.requests_served} platform={sys.platform} {extra}",
+        flush=True,
+    )
+
+
+async def test_drain_recovers_after_server_half_close_live(monkeypatch):
+    """Drain must retire a real CLOSE-WAIT pooled connection within bound."""
+    from telegram.request import HTTPXRequest
+    from unittest.mock import MagicMock
+
+    import plugins.platforms.telegram.adapter as tg_adapter
+
+    server = _LiveBotApiServer()
+    await server.start()
+    try:
+        polling_req = HTTPXRequest(
+            connection_pool_size=1,
+            read_timeout=5.0,
+            connect_timeout=5.0,
+            pool_timeout=5.0,
+        )
+        await polling_req.initialize()
+
+        # Real round-trip 1: connection enters the keep-alive pool.
+        code, payload = await polling_req.do_request(server.url, "POST")
+        assert code == 200 and b'"ok"' in payload
+        assert server.connections_accepted == 1
+        _diag(server, "after first round-trip")
+
+        # Server half-closes: the pooled client connection is now CLOSE-WAIT.
+        await server.half_close_all()
+        _diag(server, "after server half-close (client socket CLOSE-WAIT)")
+
+        adapter = _make_adapter()
+        mock_app = MagicMock()
+        mock_app.bot._request = (polling_req, MagicMock())
+        adapter._app = mock_app
+
+        monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 5.0)
+        started = time.monotonic()
+        await adapter._drain_polling_connections()
+        elapsed = time.monotonic() - started
+        _diag(server, "after drain", f"elapsed={elapsed:.2f}s")
+        assert elapsed < 12.0, (
+            f"drain must be bounded even with a CLOSE-WAIT socket, took {elapsed:.2f}s"
+        )
+
+        # The reconnect path must be LIVE: a new real request succeeds on a
+        # fresh TCP connection, not the dead pooled one.
+        before = server.connections_accepted
+        code, payload = await polling_req.do_request(server.url, "POST")
+        assert code == 200 and b'"ok"' in payload
+        assert server.connections_accepted > before, (
+            "post-drain getUpdates must use a NEW connection, not the "
+            "CLOSE-WAIT one"
+        )
+        _diag(server, "after post-drain round-trip")
+        await polling_req.shutdown()
+    finally:
+        await server.stop()
+
+
+async def test_drain_bounded_and_functional_when_close_wedges_live(monkeypatch):
+    """A wedged close must not hang the drain; the swapped client must work.
+
+    Deterministic stand-in for the Windows proactor hang: the real
+    HTTPXRequest's shutdown() is replaced with a coroutine that never
+    returns (what a CLOSE-WAIT close did in #87057). The drain must
+    (a) return within the wall-clock bound, (b) swap in a fresh client
+    because initialize() would otherwise no-op on is_closed=False, and
+    (c) leave the polling request able to complete a REAL round-trip.
+    """
+    from telegram.request import HTTPXRequest
+    from unittest.mock import MagicMock
+
+    import plugins.platforms.telegram.adapter as tg_adapter
+
+    server = _LiveBotApiServer()
+    await server.start()
+    try:
+        polling_req = HTTPXRequest(
+            connection_pool_size=1,
+            read_timeout=5.0,
+            connect_timeout=5.0,
+            pool_timeout=5.0,
+        )
+        await polling_req.initialize()
+        code, _ = await polling_req.do_request(server.url, "POST")
+        assert code == 200
+        old_client = polling_req._client  # noqa: SLF001
+        _diag(server, "wedge-probe: after first round-trip")
+
+        async def _wedged_shutdown():
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(polling_req, "shutdown", _wedged_shutdown)
+        monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 1.0)
+
+        adapter = _make_adapter()
+        mock_app = MagicMock()
+        mock_app.bot._request = (polling_req, MagicMock())
+        adapter._app = mock_app
+
+        started = time.monotonic()
+        await asyncio.wait_for(adapter._drain_polling_connections(), timeout=30.0)
+        elapsed = time.monotonic() - started
+        _diag(server, "wedge-probe: after drain", f"elapsed={elapsed:.2f}s")
+        assert elapsed < 10.0, (
+            f"drain with a wedged shutdown must stay bounded, took {elapsed:.2f}s"
+        )
+
+        new_client = polling_req._client  # noqa: SLF001
+        assert new_client is not old_client, (
+            "drain must swap in a fresh HTTP client when shutdown wedges "
+            "(initialize() no-ops while is_closed is False)"
+        )
+
+        # The replacement client must be genuinely functional: real request,
+        # real socket, live server.
+        before = server.connections_accepted
+        code, payload = await polling_req.do_request(server.url, "POST")
+        assert code == 200 and b'"ok"' in payload
+        assert server.connections_accepted > before
+        _diag(server, "wedge-probe: after post-swap round-trip")
+
+        # Bounded cleanup of the orphaned client must not linger forever.
+        deadline = time.monotonic() + 10.0
+        while adapter._background_tasks and time.monotonic() < deadline:
+            await asyncio.sleep(0.2)
+        assert not adapter._background_tasks, (
+            "orphaned-client cleanup task must complete/abandon within bound"
+        )
+    finally:
+        await server.stop()

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -18,6 +18,7 @@ and "stick" to whichever path works.
 
 import httpx
 import pytest
+import socket
 
 import plugins.platforms.telegram.telegram_network as tnet
 
@@ -353,6 +354,13 @@ class TestFallbackTransportInit:
             assert "limits" in kw
             # Caller-supplied limits must win over the setdefault default.
             assert kw["limits"] is custom_limits
+            assert "socket_options" in kw
+            assert any(
+                opt[0] == socket.SOL_SOCKET
+                and opt[1] == socket.SO_KEEPALIVE
+                and opt[2] == 1
+                for opt in kw["socket_options"]
+            )
 
 
 class TestFallbackTransportClose:
@@ -566,4 +574,15 @@ class TestDiscoverFallbackIps:
 
         assert ips == ["149.154.167.220"]
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
+
+
+def test_tcp_keepalive_socket_options_enables_so_keepalive():
+    """Windows long-polls need SO_KEEPALIVE or a dead peer hangs forever (#87057)."""
+    options = tnet.tcp_keepalive_socket_options()
+    assert any(
+        level == socket.SOL_SOCKET
+        and opt == socket.SO_KEEPALIVE
+        and value == 1
+        for level, opt, value in options
+    )
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -959,3 +959,123 @@ class TestConnectTimeoutClassifier:
 
     def test_generic_negative(self):
         assert TelegramAdapter._looks_like_connect_timeout(Exception("Timed out")) is False
+
+
+@pytest.mark.asyncio
+async def test_drain_rebuilds_http_client_when_shutdown_hangs(monkeypatch):
+    """Hung aclose() must not leave initialize() as a no-op (#87057).
+
+    PTB's HTTPXRequest.initialize() only rebuilds when client.is_closed.
+    If shutdown() is abandoned on a CLOSE-WAIT socket, that flag stays
+    false and start_polling would reuse the dead getUpdates connection.
+    Drain must swap in a fresh client so the reconnect ladder is live.
+    """
+    adapter = _make_adapter()
+
+    class _FakeClient:
+        def __init__(self):
+            self.is_closed = False
+
+        async def aclose(self):
+            await asyncio.Event().wait()
+
+    class _FakePollingReq:
+        def __init__(self):
+            self._client = _FakeClient()
+            self.built = []
+
+        def _build_client(self):
+            client = _FakeClient()
+            self.built.append(client)
+            return client
+
+        async def shutdown(self):
+            await asyncio.Event().wait()
+
+        async def initialize(self):
+            if self._client.is_closed:
+                self._client = self._build_client()
+
+    polling_req = _FakePollingReq()
+    original = polling_req._client
+    mock_app = MagicMock()
+    mock_app.bot._request = (polling_req, MagicMock())
+    adapter._app = mock_app
+
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.05)
+    await asyncio.wait_for(adapter._drain_polling_connections(), timeout=2.0)
+
+    assert polling_req.built, "drain must rebuild the HTTP client after hung aclose"
+    assert polling_req._client is not original
+    assert polling_req._client is polling_req.built[-1]
+
+
+@pytest.mark.asyncio
+async def test_drain_rebuild_does_not_block_loop_or_leak_cleanup_task(monkeypatch):
+    """The orphaned aclose() must be bounded and must not pin the event loop.
+
+    The stale client can absorb cancellation inside httpcore's shielded
+    scopes; the detached cleanup uses the wall-clock thread deadline so a
+    wedged close is abandoned instead of accumulating one leaked background
+    task per reconnect attempt (#87057 / #87265 review).
+    """
+    adapter = _make_adapter()
+
+    class _Client:
+        is_closed = False
+
+        async def aclose(self):
+            # Simulate httpcore cleanup that absorbs cancellation for a while.
+            for _ in range(20):
+                try:
+                    await asyncio.sleep(0.01)
+                except asyncio.CancelledError:
+                    continue
+
+    class _PollingRequest:
+        def __init__(self):
+            self._client = _Client()
+            self.rebuilt = []
+
+        def _build_client(self):
+            client = _Client()
+            self.rebuilt.append(client)
+            return client
+
+        async def shutdown(self):
+            await asyncio.Event().wait()
+
+        async def initialize(self):
+            if self._client.is_closed:
+                self._client = self._build_client()
+
+    request = _PollingRequest()
+    original_client = request._client
+    app = MagicMock()
+    app.bot._request = (request, MagicMock())
+    adapter._app = app
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.02)
+
+    ticks = 0
+
+    async def _ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker = asyncio.create_task(_ticker())
+    await adapter._drain_polling_connections()
+    ticker.cancel()
+    await asyncio.gather(ticker, return_exceptions=True)
+
+    assert request.rebuilt, "stale polling client must be replaced"
+    assert request._client is request.rebuilt[-1]
+    assert request._client is not original_client
+    assert ticks >= 2, "a wedged close must not block the asyncio event loop"
+
+    await asyncio.sleep(0.35)
+    assert not adapter._background_tasks, (
+        "stale-client cleanup must finish or abandon its own wedged close "
+        "without accumulating a background task"
+    )

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -1026,6 +1026,7 @@ async def test_drain_rebuild_does_not_block_loop_or_leak_cleanup_task(monkeypatc
 
         async def aclose(self):
             # Simulate httpcore cleanup that absorbs cancellation for a while.
+            # The detached cleanup must not stay registered forever.
             for _ in range(20):
                 try:
                     await asyncio.sleep(0.01)
@@ -1046,6 +1047,7 @@ async def test_drain_rebuild_does_not_block_loop_or_leak_cleanup_task(monkeypatc
             await asyncio.Event().wait()
 
         async def initialize(self):
+            # Mirrors PTB: initialize() does nothing while is_closed is false.
             if self._client.is_closed:
                 self._client = self._build_client()
 


### PR DESCRIPTION
Fixes #87057 — on Windows, a network blip left the Telegram `getUpdates` long-poll socket in CLOSE-WAIT; the reconnect ladder's drain would time out closing it, and PTB's `HTTPXRequest.initialize()` (which only rebuilds when `client.is_closed`) then no-opped — so `start_polling()` reused the dead pooled socket and the gateway stayed alive (PID, cron, heartbeat) but permanently deaf.

## What this does — bounded socket teardown on reconnect

Salvages and merges the two strong PR attempts, with follow-up hardening:

- **Drain rebuilds the HTTP client when shutdown wedges** (`_orphan_and_rebuild_polling_client`): if the bounded `shutdown()` (wall-clock thread deadline, same primitive as the general-pool drain) times out, swap in a fresh client via PTB's own `_build_client()` factory before `initialize()`, so the next polling generation never reuses the CLOSE-WAIT socket. The orphaned client's `aclose()` runs in a detached background task, itself bounded by `_await_with_thread_deadline` and tracked in `_background_tasks` — a wedged close can neither hang the ladder nor leak one task per reconnect attempt.
- **getUpdates pool never keeps idle connections** (`max_keepalive_connections=0` on the dedicated polling request only): a long-poll is continuously active, so keepalive expiry can't protect it from server-side closes; ordinary Bot API requests keep the shared reusable pool. Kills the CLOSE-WAIT reuse class at the transport layer too.
- **TCP keepalive on all Telegram transports** (`tcp_keepalive_socket_options()` in `telegram_network.py`, wired into the fallback-IP transport and the direct branch): Windows doesn't enable SO_KEEPALIVE by default, so a dead `api.telegram.org` peer (e.g. `149.154.166.110:443`) could hang a read forever.
- **Conflict-retry ladder untouched** — no changes to the 409/conflict paths (#82327 territory); all 717 telegram gateway tests pass.
- **No duplicate watchdog**: main already has the #92991 progress-based stall watchdog (150s); #87111's proposed second 90s liveness probe was dropped in salvage to avoid two overlapping steady-state watchdogs with different thresholds.

## Credit

- **@HexLab98** (PR #87111, submitted first) — client-rebuild-on-hung-drain mechanism, TCP keepalive socket options, and the drain/liveness test suite. Both commits cherry-picked with authorship preserved.
- **@JoaoMarcos44** (PR #87265) — no-keepalive getUpdates limits, bounded orphan-close analysis (the "one leaked cleanup task per reconnect" finding), and the loop-liveness regression test. Commit cherry-picked with authorship preserved.

## Windows proof (live, windows-latest)

New live probe suite `tests/gateway/test_telegram_closewait_windows_live.py` (skipif non-win32) runs the **real PTB `HTTPXRequest`** against a **real local HTTP server that half-closes its connections** (client socket genuinely in CLOSE-WAIT):

1. after a server half-close, the drain completes within bound and the next real request succeeds on a **new** TCP connection;
2. with a wedged `shutdown()` (the observed proactor hang), the drain returns within bound, swaps the client, the replacement completes a real round-trip, and the orphan cleanup task drains.

Executed on the on-demand `windows-venv-e2e` lane (wine2e/** push):
**Run: https://github.com/NousResearch/hermes-agent/actions/runs/33427923818 — `2 passed` on `windows-latest`, head SHA `6f758b1a341ddc4b4bd22c66ec844d42de8c279a` (this branch's HEAD).**

Premise check: the wedge probe **fails against unfixed origin/main** (drain returns but the next poll reuses the stale client) and passes with this branch — the bug was live on main before this PR.

## Tests

- `tests/gateway/` `-k telegram`: **717 passed, 3 skipped** (includes conflict-ladder, stall-watchdog, polling-progress neighborhoods)
- ruff clean on all touched files

## Superseded

- Closes #87111 (salvaged, both commits cherry-picked, authorship preserved)
- Closes #87265 (salvaged, commit cherry-picked, authorship preserved)

## Infographic

![closewait-recovery](https://v3b.fal.media/files/b/0aa894b2/VcvDcrqzO42GiWf0zgFYW_OCKEA2oi.png)
