### PR TITLE
fix(config): support literal dots in config key paths (set/get/unset)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1090,6 +1090,50 @@ def _split_key_path(key: str) -> list[str]:
     return parts
 
 
+def _greedy_literal_match(container: dict, parts: list) -> Optional[Tuple[str, int]]:
+    """Return ``(literal_key, n_consumed)`` for the longest dotted literal match.
+
+    Dots in config key names are the norm, not the exception — model IDs
+    (``grok-4.6``, ``glm-5.3``), Matrix room IDs (``!room:chat.example.cc``),
+    and versioned provider names all embed dots. Users typing
+    ``providers.myprov.models.grok-4.6.context_length`` do not know the
+    escape syntax exists, so when navigating an EXISTING mapping we prefer an
+    existing literal key equal to the dot-join of the next N path segments
+    (longest match wins) over blindly splitting. See #84064 / #80006 /
+    #91095 / #91607 / #99124.
+
+    Backward compatible: when no multi-segment literal key exists, the single
+    segment ``parts[0]`` is the only candidate, which is exactly the historic
+    plain-split behavior. Returns ``None`` when nothing matches.
+    """
+    if not isinstance(container, dict) or not parts:
+        return None
+    for n in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:n])
+        if candidate in container:
+            return candidate, n
+    return None
+
+
+def _phantom_sibling(container: dict, part: str) -> Optional[str]:
+    """Return an existing sibling key that ``part`` would shadow, if any.
+
+    Called when a write is about to CREATE a new intermediate mapping named
+    ``part``. If the mapping already holds a literal dotted key that starts
+    with ``part + "."`` (e.g. creating ``grok-4`` beside an existing
+    ``grok-4.5``), the split almost certainly chopped a dotted leaf name and
+    the write would produce a phantom sibling the runtime never reads.
+    Fail loudly instead of silently corrupting (#84064 discussion).
+    """
+    if not isinstance(container, dict):
+        return None
+    prefix = part + "."
+    for k in container:
+        if isinstance(k, str) and k.startswith(prefix):
+            return k
+    return None
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1111,11 +1155,27 @@ def _set_nested(config, dotted_key: str, value):
     replaced any non-dict value (including lists) with ``{}``, silently
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
+
+    Dotted key names (#84064 family): when navigating an existing mapping,
+    an existing literal key equal to the dot-join of the next N segments is
+    preferred over blind splitting (see ``_greedy_literal_match``), so
+    ``models.grok-4.6.supports_vision`` lands on the real ``grok-4.6`` entry.
+    And when a write WOULD create a new intermediate mapping that shadows an
+    existing dotted sibling (``grok-4`` beside ``grok-4.5``), it raises
+    ``ValueError`` instead of silently writing a phantom the runtime never
+    reads.
     """
     parts = _split_key_path(dotted_key)
     current = config
-    for part in parts[:-1]:
+    i = 0
+    while i < len(parts):
+        remaining = parts[i:]
+        at_leaf = len(remaining) == 1
         if isinstance(current, list):
+            part = remaining[0]
+            if at_leaf:
+                current[int(part)] = value
+                return
             try:
                 idx = int(part)
             except (TypeError, ValueError):
@@ -1124,21 +1184,43 @@ def _set_nested(config, dotted_key: str, value):
                     f"segment {part!r} is not a numeric index"
                 )
             current = current[idx]
+            i += 1
         elif isinstance(current, dict):
-            existing = current.get(part)
-            # Preserve dicts and lists; replace missing/scalar with a fresh dict.
-            if part not in current or not isinstance(existing, (dict, list)):
-                current[part] = {}
+            match = _greedy_literal_match(current, remaining)
+            if match is not None:
+                key, consumed = match
+                if i + consumed == len(parts):
+                    current[key] = value
+                    return
+                existing = current.get(key)
+                # Preserve dicts and lists; replace scalar with a fresh dict.
+                if not isinstance(existing, (dict, list)):
+                    current[key] = {}
+                current = current[key]
+                i += consumed
+                continue
+            part = remaining[0]
+            if at_leaf:
+                current[part] = value
+                return
+            # About to CREATE an intermediate mapping. Refuse when that would
+            # write a phantom sibling of an existing dotted literal key.
+            shadowed = _phantom_sibling(current, part)
+            if shadowed is not None:
+                escaped = shadowed.replace(".", "\\.")
+                raise ValueError(
+                    f"Refusing to create nested key {part!r} in {dotted_key!r}: "
+                    f"the mapping already contains a literal key {shadowed!r} "
+                    f"that contains a dot. If you meant that key, escape its "
+                    f"dots with a backslash (e.g. {escaped})."
+                )
+            current[part] = {}
             current = current[part]
+            i += 1
         else:
             raise TypeError(
                 f"Cannot navigate into {type(current).__name__} at key {dotted_key!r}"
             )
-    last = parts[-1]
-    if isinstance(current, list):
-        current[int(last)] = value
-    else:
-        current[last] = value
 
 
 def clear_model_endpoint_credentials(
@@ -1172,59 +1254,84 @@ _MISSING = object()
 
 
 def _get_nested(config, dotted_key: str):
-    """Return a dotted-path value from nested dict/list config data."""
+    """Return a dotted-path value from nested dict/list config data.
+
+    Mirrors ``_set_nested``'s navigation: honors backslash-escaped dots and
+    prefers an existing literal dotted key over blind splitting, so
+    ``config get providers.p.models.grok-4.6.context_length`` reads the real
+    ``grok-4.6`` entry instead of reporting the key unset (#84064).
+    """
+    parts = _split_key_path(dotted_key)
     current = config
-    for part in _split_key_path(dotted_key):
+    i = 0
+    while i < len(parts):
+        remaining = parts[i:]
         if isinstance(current, list):
             try:
-                current = current[int(part)]
+                current = current[int(remaining[0])]
             except (TypeError, ValueError, IndexError):
                 return _MISSING
+            i += 1
         elif isinstance(current, dict):
-            if part not in current:
+            match = _greedy_literal_match(current, remaining)
+            if match is None:
                 return _MISSING
-            current = current[part]
+            key, consumed = match
+            current = current[key]
+            i += consumed
         else:
             return _MISSING
     return current
 
 
 def _unset_nested(config, dotted_key: str) -> bool:
-    """Remove a dotted-path value from nested dict/list config data."""
+    """Remove a dotted-path value from nested dict/list config data.
+
+    Same escape-aware, greedy-literal navigation as ``_set_nested`` /
+    ``_get_nested`` (#84064): unsetting an unescaped dotted key removes the
+    real literal entry rather than a phantom sibling.
+    """
     parts = _split_key_path(dotted_key)
     if not parts:
         return False
 
     parents = []
     current = config
-    for part in parts[:-1]:
-        parents.append((current, part))
+    removed = False
+    i = 0
+    while i < len(parts):
+        remaining = parts[i:]
         if isinstance(current, list):
+            part = remaining[0]
+            if len(remaining) == 1:
+                try:
+                    current.pop(int(part))
+                    removed = True
+                    break
+                except (TypeError, ValueError, IndexError):
+                    return False
+            parents.append((current, part))
             try:
                 current = current[int(part)]
             except (TypeError, ValueError, IndexError):
                 return False
+            i += 1
         elif isinstance(current, dict):
-            if part not in current:
+            match = _greedy_literal_match(current, remaining)
+            if match is None:
                 return False
-            current = current[part]
+            key, consumed = match
+            if i + consumed == len(parts):
+                del current[key]
+                removed = True
+                break
+            parents.append((current, key))
+            current = current[key]
+            i += consumed
         else:
             return False
 
-    last = parts[-1]
-    removed = False
-    if isinstance(current, list):
-        try:
-            current.pop(int(last))
-            removed = True
-        except (TypeError, ValueError, IndexError):
-            return False
-    elif isinstance(current, dict):
-        if last not in current:
-            return False
-        del current[last]
-        removed = True
-    else:
+    if not removed:
         return False
 
     # Drop empty dict containers left behind by the deletion while preserving
@@ -5641,7 +5748,7 @@ def set_config_value(key: str, value: str, force: bool = False):
         print(f"✗ Invalid config key: {key!r} (empty or surrounding whitespace).",
               file=sys.stderr)
         sys.exit(1)
-    if any(seg == "" for seg in key.split(".")):
+    if any(seg == "" for seg in _split_key_path(key)):
         print(
             f"✗ Invalid config key: {key!r} — contains an empty path segment "
             "(leading, trailing, or doubled '.').",
@@ -5821,7 +5928,11 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
-    _set_nested(user_config, key, value)
+    try:
+        _set_nested(user_config, key, value)
+    except ValueError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        sys.exit(1)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
     # key the runtime resolver actually reads, instead of being silently

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1056,6 +1056,40 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+def _split_key_path(key: str) -> list[str]:
+    """Split a dotted config-key path, honoring backslash-escaped dots.
+
+    ``hermes config set`` uses ``.`` as the nesting separator, so a key that
+    itself contains a literal dot (e.g. provider names like
+    ``qwen3.5-397b-wafer``) was silently split into bogus nested segments
+    (#84064).  A backslash escapes a dot::
+
+        _split_key_path("providers.qwen3\\.5-397b.api_key")
+            -> ["providers", "qwen3.5-397b", "api_key"]
+
+    Backslashes before any other character are preserved verbatim.  Keys
+    without escapes behave exactly as ``key.split(".")``.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    i = 0
+    while i < len(key):
+        ch = key[i]
+        if ch == "\\" and i + 1 < len(key) and key[i + 1] == ".":
+            current.append(".")
+            i += 2
+            continue
+        if ch == ".":
+            parts.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    parts.append("".join(current))
+    return parts
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1078,7 +1112,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _split_key_path(dotted_key)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -1140,7 +1174,7 @@ _MISSING = object()
 def _get_nested(config, dotted_key: str):
     """Return a dotted-path value from nested dict/list config data."""
     current = config
-    for part in dotted_key.split("."):
+    for part in _split_key_path(dotted_key):
         if isinstance(current, list):
             try:
                 current = current[int(part)]
@@ -1157,7 +1191,7 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
-    parts = dotted_key.split(".")
+    parts = _split_key_path(dotted_key)
     if not parts:
         return False
 
@@ -5324,7 +5358,7 @@ def _default_value_for_key(dotted_key: str):
     best-effort coercion used by ``config set``.
     """
     node = DEFAULT_CONFIG
-    for part in dotted_key.split("."):
+    for part in _split_key_path(dotted_key):
         if not isinstance(node, dict) or part not in node:
             return None
         node = node[part]
@@ -5436,7 +5470,7 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     if not key:
         return False, None
 
-    segments = key.split(".")
+    segments = _split_key_path(key)
     top = segments[0]
 
     # ── Underscore-prefixed keys are internal/test markers ───────────

--- a/tests/hermes_cli/test_config_dotted_key_names.py
+++ b/tests/hermes_cli/test_config_dotted_key_names.py
@@ -1,0 +1,359 @@
+"""Regression tests for dotted config key names (#84064 bug class).
+
+Every issue in the family has a distinct repro shape, all rooted in the same
+unescaped ``key.split(".")``:
+
+* #84064 — ``providers.<name>.models.<model-with-dot>`` phantom siblings,
+  plus read-path (``config get``) and unset-path breakage.
+* #80006 — Matrix room IDs with dots under ``matrix.channel_prompts``.
+* #91095 — creation targets under a ``custom_providers`` list index where the
+  dotted model key already exists (``custom_providers.0.models.qwen3.5:4b``).
+* #91607 — ``model_overrides.zai.glm-5.3`` via
+  ``utils.py::atomic_roundtrip_yaml_update`` (a second split site).
+* #99124 — dotted leaf keys (``glm-5.3-flash``) across set/get/unset.
+
+Two complementary behaviors are covered:
+
+1. Backslash escaping via ``_split_key_path`` (carrier PR #84152).
+2. Greedy literal-key matching + loud phantom-sibling refusal, because dotted
+   model IDs are the norm and users won't know the escape syntax exists.
+"""
+
+import argparse
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import (
+    _MISSING,
+    _get_nested,
+    _greedy_literal_match,
+    _phantom_sibling,
+    _set_nested,
+    _unset_nested,
+    config_command,
+    set_config_value,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    """Point HERMES_HOME at a temp dir so tests never touch real config."""
+    env_file = tmp_path / ".env"
+    env_file.touch()
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+def _write_config(tmp_path, data: dict):
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(data, sort_keys=False))
+
+
+def _read_config(tmp_path):
+    return yaml.safe_load((tmp_path / "config.yaml").read_text())
+
+
+PROVIDER_CONFIG = {
+    "providers": {
+        "myprov": {
+            "name": "My Provider",
+            "base_url": "https://example.invalid/v1",
+            "default_model": "grok-4.6",
+            "models": {
+                "grok-4.6": {"context_length": 500000},
+                "grok-4.5": {"context_length": 500000},
+            },
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Unit level: helpers
+# ---------------------------------------------------------------------------
+
+class TestGreedyLiteralMatch:
+    def test_longest_match_wins(self):
+        d = {"grok-4.6": 1, "grok-4": 2}
+        assert _greedy_literal_match(d, ["grok-4", "6"]) == ("grok-4.6", 2)
+
+    def test_single_segment_fallback(self):
+        assert _greedy_literal_match({"a": 1}, ["a", "b"]) == ("a", 1)
+
+    def test_no_match(self):
+        assert _greedy_literal_match({"a": 1}, ["x", "y"]) is None
+
+    def test_phantom_sibling_detection(self):
+        assert _phantom_sibling({"grok-4.6": {}}, "grok-4") == "grok-4.6"
+        assert _phantom_sibling({"grok-4.6": {}}, "other") is None
+        assert _phantom_sibling({"plain": {}}, "plain") is None
+
+
+# ---------------------------------------------------------------------------
+# #84064 — provider model keys with dots: set / get / unset all address the
+# real literal key WITHOUT any escaping (the common unescaped command).
+# ---------------------------------------------------------------------------
+
+class TestUnescapedDottedModelKeys:
+    def test_set_hits_existing_literal_key_no_phantom(self, _isolated_hermes_home):
+        _write_config(_isolated_hermes_home, PROVIDER_CONFIG)
+        set_config_value("providers.myprov.models.grok-4.6.supports_vision", "true")
+        saved = _read_config(_isolated_hermes_home)
+        models = saved["providers"]["myprov"]["models"]
+        assert models["grok-4.6"]["supports_vision"] is True
+        assert "grok-4" not in models  # no phantom sibling
+
+    def test_get_reads_real_dotted_key(self, _isolated_hermes_home, capsys):
+        _write_config(_isolated_hermes_home, PROVIDER_CONFIG)
+        args = argparse.Namespace(
+            config_command="get",
+            key="providers.myprov.models.grok-4.6.context_length",
+            json=False,
+        )
+        config_command(args)
+        assert capsys.readouterr().out.strip() == "500000"
+
+    def test_unset_removes_real_dotted_key_field(self, _isolated_hermes_home):
+        cfg = {
+            "providers": {
+                "myprov": {
+                    "models": {
+                        "grok-4.6": {
+                            "context_length": 500000,
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            }
+        }
+        _write_config(_isolated_hermes_home, cfg)
+        args = argparse.Namespace(
+            config_command="unset",
+            key="providers.myprov.models.grok-4.6.supports_vision",
+        )
+        config_command(args)
+        saved = _read_config(_isolated_hermes_home)
+        target = saved["providers"]["myprov"]["models"]["grok-4.6"]
+        assert "supports_vision" not in target
+        assert target["context_length"] == 500000
+
+    def test_set_refuses_phantom_when_dotted_sibling_exists(
+        self, _isolated_hermes_home, capsys
+    ):
+        """Soju06's suggestion on #84064: creating a NEW nested mapping that
+        shadows an existing dotted literal key fails loudly instead of
+        silently writing a phantom."""
+        _write_config(_isolated_hermes_home, PROVIDER_CONFIG)
+        with pytest.raises(SystemExit):
+            set_config_value("providers.myprov.models.grok-4.7.context_length", "128000")
+        err = capsys.readouterr().err
+        assert "Refusing to create nested key" in err
+        assert "grok-4" in err
+        # Config untouched.
+        saved = _read_config(_isolated_hermes_home)
+        assert "grok-4" not in saved["providers"]["myprov"]["models"]
+
+    def test_escaped_form_creates_new_dotted_key(self, _isolated_hermes_home):
+        _write_config(_isolated_hermes_home, PROVIDER_CONFIG)
+        set_config_value(
+            "providers.myprov.models.grok-4\\.7.context_length", "128000"
+        )
+        saved = _read_config(_isolated_hermes_home)
+        assert saved["providers"]["myprov"]["models"]["grok-4.7"] == {
+            "context_length": 128000
+        }
+
+
+# ---------------------------------------------------------------------------
+# #80006 — Matrix room IDs with dots
+# ---------------------------------------------------------------------------
+
+class TestMatrixRoomIds:
+    def test_set_existing_room_id_key(self, _isolated_hermes_home):
+        _write_config(
+            _isolated_hermes_home,
+            {"matrix": {"channel_prompts": {"!TestRoom:example.org": "old"}}},
+        )
+        set_config_value("matrix.channel_prompts.!TestRoom:example.org", "be brief")
+        saved = _read_config(_isolated_hermes_home)
+        prompts = saved["matrix"]["channel_prompts"]
+        assert prompts["!TestRoom:example.org"] == "be brief"
+        assert "!TestRoom:example" not in prompts
+
+    def test_escaped_creates_new_room_id_key(self, _isolated_hermes_home):
+        _write_config(_isolated_hermes_home, {"matrix": {"channel_prompts": {}}})
+        set_config_value(
+            "matrix.channel_prompts.!TestRoom:example\\.org", "be brief"
+        )
+        saved = _read_config(_isolated_hermes_home)
+        assert saved["matrix"]["channel_prompts"]["!TestRoom:example.org"] == "be brief"
+
+
+# ---------------------------------------------------------------------------
+# #91095 — dotted model key under a custom_providers LIST index
+# ---------------------------------------------------------------------------
+
+class TestCustomProvidersListIndex:
+    def test_set_updates_existing_dotted_model_under_list_index(
+        self, _isolated_hermes_home
+    ):
+        _write_config(
+            _isolated_hermes_home,
+            {
+                "custom_providers": [
+                    {
+                        "name": "Local Ollama",
+                        "models": {"qwen3.5:4b": {"context_length": 16384}},
+                    }
+                ]
+            },
+        )
+        set_config_value(
+            "custom_providers.0.models.qwen3.5:4b.context_length", "65536"
+        )
+        saved = _read_config(_isolated_hermes_home)
+        models = saved["custom_providers"][0]["models"]
+        assert models["qwen3.5:4b"]["context_length"] == 65536
+        assert "qwen3" not in models
+
+    def test_escaped_creates_absent_dotted_model_under_list_index(
+        self, _isolated_hermes_home
+    ):
+        """#91095 follow-up: creation of a NOT-yet-existing dotted key must be
+        possible via escaping, even under a list index."""
+        _write_config(
+            _isolated_hermes_home,
+            {"custom_providers": [{"name": "Local Ollama", "models": {}}]},
+        )
+        set_config_value(
+            "custom_providers.0.models.qwen3\\.5:4b.context_length", "65536"
+        )
+        saved = _read_config(_isolated_hermes_home)
+        assert saved["custom_providers"][0]["models"]["qwen3.5:4b"] == {
+            "context_length": 65536
+        }
+
+
+# ---------------------------------------------------------------------------
+# #91607 — model_overrides via utils.atomic_roundtrip_yaml_update
+# ---------------------------------------------------------------------------
+
+class TestAtomicRoundtripYamlUpdate:
+    def test_existing_dotted_model_id_not_split(self, tmp_path):
+        from utils import atomic_roundtrip_yaml_update
+
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "model_overrides:\n"
+            "  zai:\n"
+            "    glm-5.3:\n"
+            "      supports_reasoning: false\n"
+        )
+        atomic_roundtrip_yaml_update(
+            path, "model_overrides.zai.glm-5.3.supports_reasoning", True
+        )
+        saved = yaml.safe_load(path.read_text())
+        overrides = saved["model_overrides"]["zai"]
+        assert overrides["glm-5.3"]["supports_reasoning"] is True
+        assert "glm-5" not in overrides
+
+    def test_escaped_dotted_key_created(self, tmp_path):
+        from utils import atomic_roundtrip_yaml_update
+
+        path = tmp_path / "config.yaml"
+        path.write_text("model_overrides: {}\n")
+        atomic_roundtrip_yaml_update(
+            path, "model_overrides.zai.glm-5\\.3.supports_reasoning", True
+        )
+        saved = yaml.safe_load(path.read_text())
+        assert saved["model_overrides"]["zai"]["glm-5.3"]["supports_reasoning"] is True
+
+    def test_plain_paths_unchanged(self, tmp_path):
+        from utils import atomic_roundtrip_yaml_update
+
+        path = tmp_path / "config.yaml"
+        path.write_text("# keep this comment\ndisplay:\n  personality: default\n")
+        atomic_roundtrip_yaml_update(path, "display.personality", "hacker")
+        text = path.read_text()
+        assert "# keep this comment" in text
+        saved = yaml.safe_load(text)
+        assert saved["display"]["personality"] == "hacker"
+
+
+# ---------------------------------------------------------------------------
+# #99124 — dotted LEAF keys (glm-5.3-flash) round-trip through set/get/unset
+# ---------------------------------------------------------------------------
+
+class TestDottedLeafKeys:
+    CFG = {
+        "providers": {
+            "Bai": {"models": {"glm-5.3-flash": {"context_length": 128000}}}
+        }
+    }
+
+    def test_set_leaf_parent_is_dotted(self, _isolated_hermes_home):
+        _write_config(_isolated_hermes_home, self.CFG)
+        set_config_value("providers.Bai.models.glm-5.3-flash.context_length", "1000000")
+        saved = _read_config(_isolated_hermes_home)
+        models = saved["providers"]["Bai"]["models"]
+        assert models["glm-5.3-flash"]["context_length"] == 1000000
+        assert "glm-5" not in models
+
+    def test_get_dotted_leaf_mapping(self, _isolated_hermes_home, capsys):
+        _write_config(_isolated_hermes_home, self.CFG)
+        args = argparse.Namespace(
+            config_command="get", key="providers.Bai.models.glm-5.3-flash", json=True
+        )
+        config_command(args)
+        assert "128000" in capsys.readouterr().out
+
+    def test_unset_dotted_leaf(self, _isolated_hermes_home):
+        _write_config(_isolated_hermes_home, self.CFG)
+        args = argparse.Namespace(
+            config_command="unset", key="providers.Bai.models.glm-5.3-flash"
+        )
+        config_command(args)
+        saved = _read_config(_isolated_hermes_home)
+        assert "glm-5.3-flash" not in saved.get("providers", {}).get("Bai", {}).get(
+            "models", {}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: plain dotted paths with no dotted-key collision
+# split exactly as before.
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    def test_plain_nested_set(self, _isolated_hermes_home):
+        set_config_value("terminal.backend", "docker")
+        saved = _read_config(_isolated_hermes_home)
+        assert saved["terminal"]["backend"] == "docker"
+
+    def test_plain_nested_get_and_unset_helpers(self):
+        cfg = {"a": {"b": {"c": 1}}}
+        assert _get_nested(cfg, "a.b.c") == 1
+        assert _unset_nested(cfg, "a.b.c") is True
+        assert _get_nested(cfg, "a.b.c") is _MISSING
+
+    def test_list_index_navigation_unchanged(self):
+        cfg = {"custom_providers": [{"name": "p1"}]}
+        _set_nested(cfg, "custom_providers.0.name", "p2")
+        assert cfg["custom_providers"][0]["name"] == "p2"
+
+    def test_deep_creation_without_siblings_unchanged(self, _isolated_hermes_home):
+        set_config_value("agent.max_iterations", "50")
+        saved = _read_config(_isolated_hermes_home)
+        assert saved["agent"]["max_iterations"] == 50
+
+    def test_greedy_never_beats_exact_nested_structure(self):
+        """A literal dotted key never shadows the plain-split path when the
+        plain path ALSO fully exists — longest literal match only consumes
+        segments when the literal dotted key is present; nested dicts still
+        resolve segment-by-segment."""
+        cfg = {"a": {"b": {"c": 1}}}
+        assert _get_nested(cfg, "a.b.c") == 1
+        _set_nested(cfg, "a.b.c", 2)
+        assert cfg == {"a": {"b": {"c": 2}}}

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -491,27 +491,8 @@ class TestSecretRedactionInDisplay:
 
 
 # ---------------------------------------------------------------------------
-# `config get` redacts resolved credentials (issue #84106)
+# #34067: Schema validation for unknown keys
 # ---------------------------------------------------------------------------
-
-_MCP_SECRETS_CONFIG = """\
-config_version: 34
-security:
-  redact_secrets: true
-mcp_servers:
-  demo_url:
-    url: "https://example.invalid/mcp?apikey=${FMP_API_KEY}"
-  demo_env:
-    command: demo
-    env:
-      COINGECKO_PRO_API_KEY: "${COINGECKO_PRO_API_KEY}"
-  demo_header:
-    url: "https://example.invalid/mcp"
-    headers:
-      Authorization: "Bearer ${TEST_BEARER_TOKEN}"
-"""
-
-
 
 class TestSchemaValidation:
     """#34067: ``hermes config set`` must not report bare success for
@@ -849,7 +830,9 @@ class TestLiteralDotKeyEscaping:
         assert "qwen3" not in providers
         target = providers["qwen3.5-397b-wafer-non-zdr"]
         assert target["api"] == "https://pass.wafer.ai/v1"
-        assert target["extra_headers"] == '{"Wafer-ZDR": "required"}'
+        # Current main coerces structured-looking values to real mappings
+        # (_looks_structured_value), so the JSON string lands as a dict.
+        assert target["extra_headers"] == {"Wafer-ZDR": "required"}
         # Sibling provider untouched.
         assert providers["openrouter"] == {"api_key": "or-keep"}
         # Escaped key is schema-known (providers.* is an open dict) — no warning.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -489,8 +489,29 @@ class TestSecretRedactionInDisplay:
         captured = capsys.readouterr()
         assert "Set model.reasoning_effort = high" in captured.out
 
-# #34067: Schema validation for unknown keys
+
 # ---------------------------------------------------------------------------
+# `config get` redacts resolved credentials (issue #84106)
+# ---------------------------------------------------------------------------
+
+_MCP_SECRETS_CONFIG = """\
+config_version: 34
+security:
+  redact_secrets: true
+mcp_servers:
+  demo_url:
+    url: "https://example.invalid/mcp?apikey=${FMP_API_KEY}"
+  demo_env:
+    command: demo
+    env:
+      COINGECKO_PRO_API_KEY: "${COINGECKO_PRO_API_KEY}"
+  demo_header:
+    url: "https://example.invalid/mcp"
+    headers:
+      Authorization: "Bearer ${TEST_BEARER_TOKEN}"
+"""
+
+
 
 class TestSchemaValidation:
     """#34067: ``hermes config set`` must not report bare success for
@@ -776,3 +797,124 @@ class TestMalformedYAMLConfigPreservation:
         assert "Failed to parse" in combined or "not valid YAML" in combined
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Literal dots in key paths — regression tests for #84064
+# ---------------------------------------------------------------------------
+
+class TestLiteralDotKeyEscaping:
+    """``hermes config set/unset/get`` must not split a key segment on a
+    literal dot.  Provider names routinely embed version numbers
+    (``qwen3.5-397b-wafer``), and before the backslash-escape (#84064)
+    ``providers.qwen3.5-397b-wafer.api_key`` silently created a bogus nested
+    ``qwen3`` -> ``5-397b-wafer`` structure while reporting success.
+    """
+
+    def _write_config(self, tmp_path, data: dict):
+        import yaml as _yaml
+        (tmp_path / "config.yaml").write_text(_yaml.safe_dump(data, sort_keys=False))
+
+    def test_split_key_path_escaped_dot(self):
+        from hermes_cli.config import _split_key_path
+
+        assert _split_key_path("providers.qwen3\\.5-397b.api_key") == [
+            "providers", "qwen3.5-397b", "api_key",
+        ]
+        assert _split_key_path("qwen3\\.5") == ["qwen3.5"]
+        assert _split_key_path("a\\.b\\.c") == ["a.b.c"]
+        # Unescaped keys keep plain dot-splitting semantics.
+        assert _split_key_path("terminal.backend") == ["terminal", "backend"]
+        assert _split_key_path("model") == ["model"]
+        # Backslash before a non-dot char is preserved verbatim.
+        assert _split_key_path("win\\path.key") == ["win\\path", "key"]
+
+    def test_set_preserves_literal_dot_in_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
+                "openrouter": {"api_key": "or-keep"},
+            }
+        })
+
+        set_config_value(
+            "providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
+            '{"Wafer-ZDR": "required"}',
+        )
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        providers = saved["providers"]
+        # No bogus ``qwen3`` nesting was created; the existing entry was updated.
+        assert "qwen3" not in providers
+        target = providers["qwen3.5-397b-wafer-non-zdr"]
+        assert target["api"] == "https://pass.wafer.ai/v1"
+        assert target["extra_headers"] == '{"Wafer-ZDR": "required"}'
+        # Sibling provider untouched.
+        assert providers["openrouter"] == {"api_key": "or-keep"}
+        # Escaped key is schema-known (providers.* is an open dict) — no warning.
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    def test_unset_removes_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
+                "openrouter": {"api_key": "or-keep"},
+            }
+        })
+
+        args = argparse.Namespace(
+            config_command="unset",
+            key="providers.qwen3\\.5-397b-wafer-non-zdr",
+        )
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert "qwen3.5-397b-wafer-non-zdr" not in saved["providers"]
+        assert saved["providers"]["openrouter"] == {"api_key": "or-keep"}
+        assert "Unset providers.qwen3\\.5-397b-wafer-non-zdr" in capsys.readouterr().out
+
+    def test_unset_nested_field_under_literal_dot_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {
+                    "api": "https://pass.wafer.ai/v1",
+                    "extra_headers": '{"K": "V"}',
+                },
+            }
+        })
+
+        args = argparse.Namespace(
+            config_command="unset",
+            key="providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
+        )
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        target = saved["providers"]["qwen3.5-397b-wafer-non-zdr"]
+        assert "extra_headers" not in target
+        assert target["api"] == "https://pass.wafer.ai/v1"
+
+    def test_get_reads_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {"qwen3.5-397b": {"api": "https://pass.wafer.ai/v1"}},
+        })
+
+        args = argparse.Namespace(
+            config_command="get",
+            key="providers.qwen3\\.5-397b.api",
+            json=False,
+        )
+        config_command(args)
+
+        assert capsys.readouterr().out.strip() == "https://pass.wafer.ai/v1"
+
+    def test_unescaped_dotted_path_unchanged(self, _isolated_hermes_home):
+        """Nesting semantics for plain dotted keys are untouched."""
+        set_config_value("terminal.backend", "docker")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["backend"] == "docker"

--- a/utils.py
+++ b/utils.py
@@ -587,14 +587,30 @@ def atomic_roundtrip_yaml_update(
         config = CommentedMap(config)
 
     current = config
-    keys = key_path.split(".")
-    for key in keys[:-1]:
-        next_value = current.get(key)
+    # Honor escaped dots and prefer existing literal dotted keys (e.g. model
+    # IDs like ``glm-5.3``) over blind splitting — same navigation as
+    # ``hermes config set``'s ``_set_nested`` (#91607: /model + TUI
+    # persistence route through here and used to write ``glm-5: {'3': ...}``
+    # phantom siblings while the runtime kept reading the literal key).
+    from hermes_cli.config import _greedy_literal_match, _split_key_path
+
+    keys = _split_key_path(key_path)
+    i = 0
+    while True:
+        remaining = keys[i:]
+        seg, consumed = remaining[0], 1
+        match = _greedy_literal_match(dict(current), remaining)
+        if match is not None:
+            seg, consumed = match
+        if i + consumed == len(keys):
+            current[seg] = value
+            break
+        next_value = current.get(seg)
         if not isinstance(next_value, CommentedMap):
             next_value = CommentedMap()
-            current[key] = next_value
+            current[seg] = next_value
         current = next_value
-    current[keys[-1]] = value
+        i += consumed
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1158,6 +1158,27 @@ Subcommands:
 | `check` | Check for missing or stale config. |
 | `migrate` | Add newly introduced options interactively. |
 
+### Dots inside key names
+
+`hermes config set/get/unset` use `.` as the nesting separator, but many real
+key names contain literal dots — model IDs (`grok-4.6`, `glm-5.3-flash`),
+Matrix room IDs (`!room:example.org`), versioned provider names. Two rules
+make these addressable:
+
+- **Existing keys just work.** When navigating an existing mapping, an
+  existing literal key that matches the dotted remainder is preferred over
+  splitting. `hermes config set providers.p.models.grok-4.6.supports_vision true`
+  updates the real `grok-4.6` entry (and `get`/`unset` resolve the same way).
+- **Creating a new dotted key requires escaping.** Escape literal dots with a
+  backslash: `hermes config set 'providers.p.models.grok-4\.7.context_length' 128000`
+  creates the literal `grok-4.7` key. (Quote the key so your shell keeps the
+  backslash.)
+
+If an unescaped write would create a nested mapping that shadows an existing
+dotted sibling (e.g. creating `grok-4` next to an existing `grok-4.6`), the
+command fails with an error instead of silently writing a phantom entry the
+runtime would never read.
+
 ## `hermes pairing`
 
 ```bash


### PR DESCRIPTION
## What

`hermes config set/get/unset` (and the `/model` + TUI persistence path through `utils.py::atomic_roundtrip_yaml_update`) split key paths on every `.` with no escaping. Model IDs (`grok-4.6`, `glm-5.3-flash`), Matrix room IDs, and versioned provider names legitimately contain dots, so all three verbs silently addressed the wrong path: `set` wrote a phantom nested sibling the runtime never reads, `get` reported real keys unset (or read back the phantom, a false positive), and `unset` removed only the phantom. All three printed `✓` success.

This PR salvages **#84152** (webtecnica) — the escape-aware `_split_key_path()` routed through `_set_nested` / `_get_nested` / `_unset_nested` / `_default_value_for_key` / `_validate_config_key`, plus its regression tests — cherry-picked onto current main with authorship preserved, and layers on top the two behaviors the issue threads converged on:

1. **Greedy literal-key matching** (earliest proposed in #80253 by RelaxJonh): when navigating an *existing* mapping, an existing literal key equal to the dot-join of the next N path segments (longest match wins) is preferred over blind splitting. Dotted model IDs are the norm — users won't know escape syntax exists — so the common unescaped command now hits the real key across **set, get, and unset**. Plain dotted paths with no dotted-key collision split exactly as before.
2. **Loud failure instead of silent phantoms** (Soju06's suggestion on #84064): when a write would *create* a new intermediate mapping that shadows an existing dotted literal sibling (creating `grok-4` beside an existing `grok-4.6`), `config set` refuses with a clear error that shows the escaped spelling to use.
3. **Second split site covered** (#91607): `utils.py::atomic_roundtrip_yaml_update` — used by `cli.py` runtime persistence (`/model`, TUI) and `hermes_cli/personality.py` — now uses the same escape-aware split + greedy literal matching.
4. The CFG-04 empty-segment guard in `set_config_value` also splits escape-aware so escaped keys aren't misclassified.
5. Docs: new "Dots inside key names" section in `website/docs/reference/cli-commands.md`.

Split call sites audited on current main: `hermes_cli/config.py` lines using `_split_key_path` (set/get/unset/default-value/validate/empty-segment guard) and `utils.py::atomic_roundtrip_yaml_update`. The `skills.config.<logical_key>` walker (`config.py`, `_strip_dotted_keys`, `plugins.py` settings keys) intentionally keeps raw splitting — there a dot means nesting by design.

## Live repro (before → after)

Real CLI (`python -m hermes_cli.main`) against a temp `HERMES_HOME` seeded with the exact config from #84064:

**Before (current main d10ef89ee5):**
```console
$ hermes config set providers.myprov.models.grok-4.6.supports_vision true
✓ Set providers.myprov.models.grok-4.6.supports_vision = True ...
# config.yaml now contains a phantom:
#     grok-4:
#       '6':
#         supports_vision: true
$ hermes config get providers.myprov.models.grok-4.6.context_length
Config key not set: providers.myprov.models.grok-4.6.context_length   # key IS present
$ hermes config unset providers.myprov.models.grok-4.6.supports_vision
✓ Unset ...   # removed only the phantom
```

**After (this branch):**
```console
$ hermes config set providers.myprov.models.grok-4.6.supports_vision true
✓ Set ...
# lands on the REAL entry:
#     grok-4.6:
#       context_length: 500000
#       supports_vision: true      ← no phantom created
$ hermes config get providers.myprov.models.grok-4.6.context_length
500000
$ hermes config unset providers.myprov.models.grok-4.6.supports_vision
✓ Unset ...                        # removes the real field
$ hermes config set providers.myprov.models.grok-4.7.context_length 128000
✗ Refusing to create nested key 'grok-4' ... already contains a literal key 'grok-4.6' ...
  escape its dots with a backslash (e.g. grok-4\.6).
$ hermes config set 'providers.myprov.models.grok-4\.7.context_length' 128000
✓ Set ...                          # escaped creation of a NEW dotted key works
$ hermes config set terminal.backend docker
✓ Set ...                          # plain paths unchanged
```

## Tests

- New `tests/hermes_cli/test_config_dotted_key_names.py` (24 tests) covering every issue's repro shape: #84064 provider model keys (set/get/unset + loud-failure + escaped creation), #80006 Matrix room IDs, #91095 dotted models under a `custom_providers` list index incl. escaped creation-when-absent, #91607 `model_overrides` via `atomic_roundtrip_yaml_update` (incl. comment preservation), #99124 dotted leaf keys, plus backward-compat guards.
- Carrier's `TestLiteralDotKeyEscaping` suite preserved; one stale assertion updated (structured-value coercion landed on main after #84152 branched) and its dead `_MCP_SECRETS_CONFIG` fixture (flagged in the #84152 review) removed.
- `pytest tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config_dotted_key_names.py` → **116 passed**. `pytest tests/hermes_cli/ -k config` shows 27 failures, byte-identical to the failure set on clean `origin/main` in the same environment (pre-existing test pollution, zero delta). `ruff check` clean on all touched files.

## Credits

- **@webtecnica** — carrier PR #84152 (escape-aware splitter + tests), cherry-picked with authorship preserved in git log.
- **@RelaxJonh** — #80253, earliest fix in the family; its greedy longest-prefix-match idea is implemented here across all three verbs.
- **@aniruddhaadak80** (#93883, quoted segments + greedy matching) and **@JohnXR** (#99126, backslash escape + tests) — independent fixes for the same class; superseded by this salvage.
- Reporters: **@changwt** (#80006, earliest report), **@Soju06** (read-path/unset findings + the fail-loudly design on #84064), **@pitimon**, **@JerryLiu369**, **@sky0eyes**, and the #91095/#99124 reporters.

Fixes #84064, fixes #80006, fixes #91095, fixes #91607, fixes #99124

## Infographic

![config-dotted-keys](https://v3b.fal.media/files/b/0aa894d1/mPyhlCQNKwZNrqbZkQ2a1_ekkWXXUl.png)
