### PR TITLE
fix(agent_init): reserve Gemini's default maxOutputTokens in the compressor when max_tokens is unset (#57275)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2777,6 +2777,34 @@ def init_agent(
         if not agent.quiet_mode:
             _ra().logger.info("Using context engine: %s", _selected_engine.name)
     else:
+        # Native Gemini output reservation (#57275 claim 4): when
+        # model.max_tokens is unset, the native generateContent adapter does
+        # NOT run uncapped — it sends maxOutputTokens=65,535
+        # (GEMINI_DEFAULT_MAX_OUTPUT_TOKENS, see
+        # _effective_gemini_max_output_tokens). The compressor's threshold is
+        # pct×(window − max_tokens); passing None here meant it reserved 0
+        # while the wire reserved 65,535, so on a 128K window the trigger
+        # landed at ~96K against a real safe input budget of ~65K and the
+        # provider 400'd before compaction fired. Mirror the adapter's
+        # default so the reservation matches what is actually sent. The
+        # generic provider-default gap is #63839; this wires only the native
+        # Gemini path, where the default is a documented constant.
+        _compressor_max_tokens = agent.max_tokens
+        if _compressor_max_tokens is None:
+            try:
+                from agent.gemini_native_adapter import (
+                    GEMINI_DEFAULT_MAX_OUTPUT_TOKENS,
+                    is_native_gemini_base_url,
+                )
+                _gemini_provider = str(
+                    getattr(agent, "provider", "") or ""
+                ).strip().lower() in {
+                    "gemini", "google", "google-gemini", "google-ai-studio",
+                }
+                if _gemini_provider or is_native_gemini_base_url(agent.base_url):
+                    _compressor_max_tokens = GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+            except Exception:
+                pass
         agent.context_compressor = ContextCompressor(
             model=agent.model,
             threshold_percent=compression_threshold,
@@ -2791,7 +2819,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
-            max_tokens=agent.max_tokens,
+            max_tokens=_compressor_max_tokens,
             model_thresholds=compression_model_thresholds,
             threshold_tokens_cap=compression_threshold_tokens,
             proactive_prune_tokens=compression_proactive_prune_tokens,

--- a/tests/run_agent/test_gemini_native_reservation.py
+++ b/tests/run_agent/test_gemini_native_reservation.py
@@ -1,0 +1,96 @@
+"""Native Gemini output-token reservation at agent init (#57275 claim 4).
+
+When ``model.max_tokens`` is unset, the native generateContent adapter still
+sends ``maxOutputTokens=65,535`` (GEMINI_DEFAULT_MAX_OUTPUT_TOKENS) — Gemini
+treats an omitted cap as a low internal default, not "unlimited", so the
+adapter always sends an explicit cap.  The compressor's trigger is
+``pct × (window − max_tokens)``; constructing it with ``max_tokens=None``
+reserved 0 while the wire reserved 65,535: on a 128K window the trigger
+landed at ~96K against a real safe input budget of ~65K, and the provider
+400'd before compaction ever fired.
+
+These tests assert the compressor's reservation mirrors the adapter default
+on the native Gemini path, and ONLY there.
+"""
+
+
+
+
+from unittest.mock import patch
+
+
+
+import agent.context_compressor as cc_mod
+from agent.gemini_native_adapter import GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+CFG = {"agent": {}}
+
+
+def _build_agent(model, base_url, provider="", max_tokens=None, window=131072):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=CFG),
+        patch("hermes_cli.config.load_config_readonly", return_value=CFG),
+        patch(
+            "agent.model_metadata.get_model_context_length", return_value=window,
+        ),
+        patch.object(cc_mod, "get_model_context_length", return_value=window),
+    ):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            provider=provider,
+            max_tokens=max_tokens,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_native_gemini_unset_max_tokens_reserves_adapter_default():
+    agent = _build_agent(
+        "gemma-3-27b-it",
+        "https://generativelanguage.googleapis.com/v1beta",
+    )
+    cc = agent.context_compressor
+    assert cc.max_tokens == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+    # Trigger must sit at/below the real safe input budget the wire leaves.
+    assert cc.threshold_tokens <= cc.context_length - GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_gemini_provider_name_also_reserves_default():
+    agent = _build_agent(
+        "gemini-3.7-flash", "https://example-proxy.invalid/v1", provider="google",
+    )
+    assert agent.context_compressor.max_tokens == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_explicit_max_tokens_wins_over_adapter_default():
+    agent = _build_agent(
+        "gemma-3-27b-it",
+        "https://generativelanguage.googleapis.com/v1beta",
+        max_tokens=8192,
+    )
+    assert agent.context_compressor.max_tokens == 8192
+
+
+def test_non_gemini_paths_keep_no_reservation():
+    agent = _build_agent(
+        "openai/gpt-4.1", "https://openrouter.ai/api/v1",
+    )
+    assert agent.context_compressor.max_tokens is None
+
+
+def test_gemini_openai_compat_endpoint_not_treated_as_native():
+    # The /openai compatibility endpoint does not use the native adapter.
+    agent = _build_agent(
+        "gemma-3-27b-it",
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+    assert agent.context_compressor.max_tokens is None


### PR DESCRIPTION
## Summary

On the native Gemini path the adapter never runs uncapped: when `model.max_tokens` is unset, `_effective_gemini_max_output_tokens()` sends `maxOutputTokens=65,535` (`GEMINI_DEFAULT_MAX_OUTPUT_TOKENS`) because Gemini treats an omitted cap as a low internal default. But the compressor was constructed with `max_tokens=None`, which `_compute_threshold_tokens()` documents as "assume no reservation". Result on a 128K Gemma window: compaction trigger at **98,304** while the real safe input budget was **65,537** — the provider 400'd before compaction ever fired.

Fix: at compressor construction, when `max_tokens` is unset and the runtime is native Gemini (provider name or `is_native_gemini_base_url()`; the `/openai` compat endpoint is excluded), reserve the adapter's documented default so the threshold math matches what the wire actually sends.

Kept deliberately Gemini-wiring-scoped: the *generic* provider-default reservation gap (every provider profile with a `default_max_tokens`) is tracked in #63839 and its `_resolve_output_reservation()` design; this PR only wires the one path where the default is a documented adapter constant and the mismatch is currently reproducible.

Reported by @Artemonim in #57275 (residual claim 4).

## Changes

- `agent/agent_init.py` — resolve `_compressor_max_tokens` before `ContextCompressor(...)`: fall back to `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS` when `agent.max_tokens is None` and the runtime is native Gemini.
- `tests/run_agent/test_gemini_native_reservation.py` — new: native base_url reserves the default; provider-name variant; explicit `max_tokens` wins; non-Gemini paths keep `None`; `/openai` compat endpoint excluded.

## Validation

**Live repro:** real-import harness (temp `HERMES_HOME`, native Gemini base_url, window=131,072, `max_tokens` unset) — before (origin/main): `compressor.max_tokens=None`, `threshold_tokens=98,304`, wire `maxOutputTokens=65,535` → trigger **above** the 65,537 safe input budget; after: `compressor.max_tokens=65,535`, `threshold_tokens=64,000` → below it.

- `pytest tests/run_agent/test_gemini_native_reservation.py tests/run_agent/test_compression_feasibility.py -x -q` → 15 passed (memory-capped).
- `ruff check` clean on touched files.

## Infographic

![Reserve the output](https://v3b.fal.media/files/b/0aa894cc/ftWldbUR1OxS6tncSGFCt_sNZC2Yj1.png)
