### PR TITLE
feat(tui): make compact mode a focused layout

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -207,6 +207,8 @@ The Markdown renderer handles headings, lists, block quotes, tables, fenced code
 
 Tool/status activity is shown in a live activity lane. Transcript rows stay focused on user/assistant turns.
 
+`/density on` switches the whole chat surface to a focused presentation: the art-heavy startup panel becomes a four-row session header, capability inventories collapse to aggregate counts, and idle composer spacing is removed. `/density off` restores the classic presentation. The preference is persisted in `display.tui_compact`.
+
 ## Prompt flows
 
 The Python gateway can pause the main loop and request structured input:

--- a/ui-tui/scripts/visual/render.tsx
+++ b/ui-tui/scripts/visual/render.tsx
@@ -22,7 +22,7 @@ import { GatewayProvider } from '../../src/app/gatewayContext.js'
 import { patchOverlayState, resetOverlayState } from '../../src/app/overlayStore.js'
 import { patchUiState, resetUiState } from '../../src/app/uiStore.js'
 import { FloatingOverlays } from '../../src/components/appOverlays.js'
-import { Banner, SessionPanel } from '../../src/components/branding.js'
+import { Banner, CompactSessionPanel, SessionPanel } from '../../src/components/branding.js'
 import { fromSkin, type Theme } from '../../src/theme.js'
 import type { SessionInfo } from '../../src/types.js'
 
@@ -262,6 +262,11 @@ for (const scene of scenes) {
     88
   )
 
+  const compactIntro = renderAnsi(
+    <CompactSessionPanel info={info} maxWidth={86} sid="d2a6ecf8" t={scene.theme} />,
+    88
+  )
+
   patchOverlayState({})
 
   const comps = renderAnsi(
@@ -301,6 +306,8 @@ for (const scene of scenes) {
   page += `<div style="background:${scene.bg};color:${scene.fg};padding:14px;border-radius:6px">`
   page += `<div style="font:bold 12px sans-serif;opacity:.6;margin-bottom:8px;color:${scene.fg}">${scene.name}</div>`
   page += `<pre style="margin:0;white-space:pre">${ansiToHtml(intro, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.5;margin:12px 0 6px;color:${scene.fg}">density on</div>`
+  page += `<pre style="margin:0;white-space:pre">${ansiToHtml(compactIntro, scene.fg, scene.bg)}</pre>`
   page += `<pre style="margin:8px 0 0;white-space:pre">${ansiToHtml(comps, scene.fg, scene.bg)}</pre>`
   page += `<pre style="margin:8px 0 0;white-space:pre">${ansiToHtml(statusLine, scene.fg, scene.bg)}</pre>`
   page += `</div>`

--- a/ui-tui/src/__tests__/compactBranding.test.tsx
+++ b/ui-tui/src/__tests__/compactBranding.test.tsx
@@ -1,0 +1,95 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { CompactSessionPanel } from '../components/branding.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { McpServerStatus, SessionInfo } from '../types.js'
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const mcp = (over: Partial<McpServerStatus> & Pick<McpServerStatus, 'name'>): McpServerStatus => ({
+  connected: false,
+  tools: 0,
+  transport: 'http',
+  ...over
+})
+
+const info: SessionInfo = {
+  cwd: '/workspace/hermes-agent',
+  mcp_servers: [
+    mcp({ connected: true, name: 'connected', status: 'connected' }),
+    mcp({ disabled: true, name: 'disabled', status: 'disabled' })
+  ],
+  model: 'provider/opus-4.8-fast',
+  profile_name: 'coder',
+  skills: { development: ['review', 'testing'] },
+  tools: { browser: ['browser_click'], file: ['read_file', 'write_file'] },
+  version: '3.2.1'
+}
+
+async function renderPanel(columns = 88): Promise<string> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let captured = ''
+
+  Object.assign(stdout, { columns, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    captured += chunk.toString()
+  })
+
+  const instance = renderSync(
+    React.createElement(CompactSessionPanel, {
+      info,
+      maxWidth: columns,
+      sid: 'd2a6ecf8',
+      t: DEFAULT_THEME
+    }),
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  try {
+    await delay(20)
+
+    // eslint-disable-next-line no-control-regex
+    return captured.replace(/\u001b\[[0-9;]*m/g, '')
+  } finally {
+    instance.unmount()
+    instance.cleanup()
+  }
+}
+
+describe('compact session branding', () => {
+  it('keeps session identity and aggregate capability counts in a low-chrome header', async () => {
+    const frame = await renderPanel()
+
+    expect(frame).toContain('Hermes Agent')
+    expect(frame).toContain('opus-4.8-fast')
+    expect(frame).toContain('/workspace/hermes-agent')
+    expect(frame).toContain('session d2a6ecf8')
+    expect(frame).toContain('3 tools')
+    expect(frame).toContain('2 skills')
+    expect(frame).toContain('1 MCP')
+    expect(frame).not.toContain('browser_click')
+    expect(frame).not.toContain('disabled')
+  })
+
+  it('progressively hides secondary metadata on narrow terminals', async () => {
+    const frame = await renderPanel(36)
+
+    expect(frame).toContain('Hermes Agent')
+    expect(frame).toContain('3 tools')
+    expect(frame).not.toContain('/workspace/hermes-agent')
+    expect(frame).not.toContain('profile coder')
+  })
+})

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -27,7 +27,7 @@ import { ActiveWidgetSlot, AmbientDock, AmbientRail, useAmbientRailWidth } from 
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
-import { Banner, Panel, SessionPanel } from './branding.js'
+import { Banner, CompactSessionPanel, Panel, SessionPanel } from './branding.js'
 import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
 import { Journey } from './journey.js'
@@ -205,15 +205,28 @@ const TranscriptPane = memo(function TranscriptPane({
 
               {row.msg.kind === 'intro' ? (
                 <Box flexDirection="column" paddingTop={1}>
-                  <Banner maxWidth={Math.max(1, composer.cols - 2)} t={ui.theme} />
+                  {ui.compact ? (
+                    row.msg.info && (
+                      <CompactSessionPanel
+                        info={row.msg.info}
+                        maxWidth={Math.max(1, composer.cols - 2)}
+                        sid={ui.sid}
+                        t={ui.theme}
+                      />
+                    )
+                  ) : (
+                    <>
+                      <Banner maxWidth={Math.max(1, composer.cols - 2)} t={ui.theme} />
 
-                  {row.msg.info && (
-                    <SessionPanel
-                      info={row.msg.info}
-                      maxWidth={Math.max(1, composer.cols - 2)}
-                      sid={ui.sid}
-                      t={ui.theme}
-                    />
+                      {row.msg.info && (
+                        <SessionPanel
+                          info={row.msg.info}
+                          maxWidth={Math.max(1, composer.cols - 2)}
+                          sid={ui.sid}
+                          t={ui.theme}
+                        />
+                      )}
+                    </>
                   )}
                 </Box>
               ) : row.msg.kind === 'panel' && row.msg.panelData ? (
@@ -359,14 +372,14 @@ const ComposerPane = memo(function ComposerPane({
 
           {status.stickyPrompt}
         </Text>
-      ) : (
+      ) : ui.compact ? null : (
         <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag} />
       )}
 
       <StatusRulePane at="top" composer={composer} status={status} />
       <AmbientDock placement="dock-top" />
 
-      <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
+      <Box flexDirection="column" marginTop={ui.statusBar === 'top' || ui.compact ? 0 : 1} position="relative">
         <FloatingOverlays
           cols={composer.cols}
           compIdx={composer.compIdx}

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -209,6 +209,107 @@ const SKELETON_ROWS: readonly (readonly [number, number])[] = [
 const SKILLS_MAX = 8
 const TOOLSETS_MAX = 8
 
+/**
+ * Low-chrome session identity for ``/density on``.
+ *
+ * The classic intro is intentionally expressive and inspectable: logo art,
+ * expandable inventories, and a bordered session card. Compact mode is the
+ * opposite presentation. It keeps the information needed to start working,
+ * leaves the full inventories to /tools and /skills, and spends only four
+ * base rows before any actionable update or install notices.
+ */
+export function CompactSessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
+  const term = useStdout().stdout?.columns ?? 100
+  const cols = Math.max(20, Math.min(term, maxWidth ?? term))
+  const model = info.model.split('/').pop() || info.model
+  const toolsTotal = flat(info.tools).length
+  const skillsTotal = flat(info.skills).length
+  const mcpConnected = (info.mcp_servers ?? []).filter(server => server.connected).length
+
+  const counts = [
+    `${info.lazy && !toolsTotal ? '…' : toolsTotal} tools`,
+    `${info.lazy && !skillsTotal ? '…' : skillsTotal} skills`,
+    ...(mcpConnected ? [`${mcpConnected} MCP`] : [])
+  ].join('  ·  ')
+
+  const sideMeta = [
+    info.profile_name ? `profile ${info.profile_name}` : 'Nous Research',
+    info.version && `v${info.version}`
+  ]
+    .filter(Boolean)
+    .join('  ')
+
+  const sessionMeta = sid ? `session ${sid}` : ''
+  const showSideMeta = cols >= 64
+  const showWorkingDirectory = cols >= 42
+
+  return (
+    <Box flexDirection="column" marginBottom={1} width={cols}>
+      <Box width={cols}>
+        <Box flexGrow={1} flexShrink={1} overflow="hidden">
+          <Text bold color={t.color.primary} wrap="truncate-end">
+            {t.brand.icon} {t.brand.name}
+            <Text bold={false} color={t.color.muted}>
+              {'  ·  '}
+            </Text>
+            <Text bold={false} color={t.color.accent}>
+              {model}
+            </Text>
+          </Text>
+        </Box>
+
+        {showSideMeta && (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {'  '}
+            {sideMeta}
+          </Text>
+        )}
+      </Box>
+
+      {showWorkingDirectory && (
+        <Box width={cols}>
+          <Box flexGrow={1} flexShrink={1} overflow="hidden">
+            <Text color={t.color.muted} wrap="truncate-end">
+              {info.cwd || process.cwd()}
+            </Text>
+          </Box>
+
+          {sessionMeta && (
+            <Text color={t.color.sessionLabel} wrap="truncate-end">
+              {'  '}
+              {sessionMeta}
+            </Text>
+          )}
+        </Box>
+      )}
+
+      <Box width={cols}>
+        <Box flexGrow={1} flexShrink={1} overflow="hidden">
+          <Text color={t.color.text} wrap="truncate-end">
+            {counts}
+          </Text>
+        </Box>
+        <Text color={t.color.muted}>/help</Text>
+      </Box>
+
+      <Text color={t.color.border}>{'─'.repeat(cols)}</Text>
+
+      {typeof info.update_behind === 'number' && info.update_behind > 0 && (
+        <Text color={t.color.warn} wrap="truncate-end">
+          ! update available · {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind ·{' '}
+          {info.update_command || 'hermes update'}
+        </Text>
+      )}
+
+      {info.install_warning && (
+        <Text color={t.color.warn} wrap="wrap">
+          ! {info.install_warning}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
 export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const term = useStdout().stdout?.columns ?? 100
   const cols = Math.max(20, Math.min(term, maxWidth ?? term))


### PR DESCRIPTION
## Summary

- turn the existing density mode into a complete low-chrome TUI presentation
- replace the art-heavy banner and expanded capability card with a four-row session header
- remove idle composer spacer rows in compact mode while preserving the classic layout unchanged
- add dark/light visual-harness coverage and responsive behavior tests

## Why

The density setting previously changed transcript spacing but left the largest pieces of startup chrome intact. This makes density on a genuinely focused alternative without changing the default experience or adding another config key.

## Verification

- npm run typecheck --workspace ui-tui
- 47 focused Vitest regressions passed
- changed TypeScript files pass ESLint with no warnings
- visual harness inspected across default/slate and dark/light terminal scenes

The full TUI suite completed with 1,710 passing tests. Its 12 failures are existing Windows-sensitive editor and terminal-setup expectations, one heap-dump timeout caused by the missing Python launcher, and one timing-sensitive virtual-history assertion; none exercise the changed components.