### PR TITLE
fix(update): guard the ledger, orphan, and manual-serve reap rungs against killing an ancestor gateway

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7912,6 +7912,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # archaeology, no hand-off contract required.
             _ledger_backends = _m()._ledger_reapable_backend_pids(_venv_holders)
             if _ledger_backends:
+                if _refuse_gateway_ancestor_tree_kill(
+                    _ledger_backends, gateway_mode=gateway_mode
+                ):
+                    _m()._resume_windows_gateways_after_update(
+                        _windows_gateway_resume
+                    )
+                    sys.exit(2)
                 print(
                     f"  ⚠ {len(_ledger_backends)} ledger-identified orphaned "
                     "Hermes backend process(es) hold the venv; stopping their trees"
@@ -7932,6 +7939,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # is still alive never reach here (_orphaned_desktop_
                 # backend_pids returns None for them) — that path keeps the
                 # refusal, because the app would just respawn what we kill.
+                # _orphaned_desktop_backend_pids returns (pid, create_time)
+                # identity pairs, not bare pids -- unwrap before handing them
+                # to the ancestor check, which still takes plain pids. Same
+                # int-or-tuple tolerance as _stop_process_trees() below.
+                if _refuse_gateway_ancestor_tree_kill(
+                    [
+                        entry[0] if isinstance(entry, tuple) else int(entry)
+                        for entry in _orphan_backends
+                    ],
+                    gateway_mode=gateway_mode,
+                ):
+                    _m()._resume_windows_gateways_after_update(
+                        _windows_gateway_resume
+                    )
+                    sys.exit(2)
                 print(
                     f"  ⚠ {len(_orphan_backends)} orphaned Desktop backend "
                     "process(es) still hold the venv; stopping their trees"
@@ -7953,14 +7975,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # back on the SAME bind after the update — success or failure.
             _serve_entries = _m()._ledger_manual_serve_holders(_venv_holders)
             if _serve_entries:
+                _serve_pids = [int(e["pid"]) for e in _serve_entries]
+                if _refuse_gateway_ancestor_tree_kill(
+                    _serve_pids, gateway_mode=gateway_mode
+                ):
+                    _m()._resume_windows_gateways_after_update(
+                        _windows_gateway_resume
+                    )
+                    sys.exit(2)
                 print(
                     f"  ⚠ {len(_serve_entries)} manual serve/dashboard "
                     "backend(s) hold the venv; stopping them for the update "
                     "(they will be relaunched on their recorded endpoints)"
                 )
-                _m()._stop_process_trees(
-                    [int(e["pid"]) for e in _serve_entries]
-                )
+                _m()._stop_process_trees(_serve_pids)
                 _serve_resume_token = {
                     "pending": True,
                     "entries": _serve_entries,
@@ -8011,6 +8039,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if _handoff and _no_live_shim:
                 _handoff_backends = _m()._handoff_reapable_backend_pids(_venv_holders)
                 if _handoff_backends:
+                    # No ancestor-refusal guard here: this rung only runs
+                    # when `_handoff` is True, which requires
+                    # `args.gateway` -- and the real caller
+                    # (hermes_cli/main.py) always derives `gateway_mode`
+                    # from that same `args.gateway`, so `gateway_mode` is
+                    # already True on every path that reaches this print.
+                    # _refuse_gateway_ancestor_tree_kill() itself exempts
+                    # gateway_mode unconditionally (the supported
+                    # `--gateway` hand-off), so adding the same call here
+                    # would be unreachable dead code, unlike the three
+                    # rungs above (all reachable with gateway_mode=False).
                     print(
                         f"  ⚠ {len(_handoff_backends)} Hermes backend process(es) "
                         "still hold the venv after the Desktop hand-off; "

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -1103,6 +1103,159 @@ def test_update_impl_refuses_before_terminating_gateway_ancestor(
     assert "`/update`" in output
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_refuses_before_reaping_ledger_backend_ancestor(
+    _winp, monkeypatch, capsys
+):
+    """#98814-class residual gap: the class fix above only wired the
+    ancestor-refusal guard into the pausable-gateway rung. The
+    ledger-identified-orphan rung two steps below it -- reachable even when
+    every holder isn't a pausable gateway, since "gateway" is itself a
+    REAPABLE_PURPOSES entry -- called _stop_process_trees() unconditionally
+    and could still taskkill /T its own ancestor gateway."""
+    import hermes_cli.gateway as gateway_cli
+
+    holder = (
+        300,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: pid == 300,
+    )
+
+    with patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_run_pre_update_backup", return_value=None
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=[holder]
+    ), patch.object(
+        cli_main, "_leftover_pausable_gateway_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_reapable_backend_pids", return_value=[300]
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ) as resume, patch.object(
+        cli_main, "_stop_process_trees"
+    ) as stop_trees:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    stop_trees.assert_not_called()
+    resume.assert_called_once_with(None)
+    output = capsys.readouterr().out
+    assert "taskkill /T" in output
+    assert "`/update`" in output
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_refuses_before_reaping_orphan_backend_ancestor(
+    _winp, monkeypatch, capsys
+):
+    """Same residual gap as the ledger rung, one step further down the
+    cascade: the orphaned-Desktop-backend rung also called
+    _stop_process_trees() unconditionally."""
+    import hermes_cli.gateway as gateway_cli
+
+    holder = (
+        300,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: pid == 300,
+    )
+
+    with patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_run_pre_update_backup", return_value=None
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=[holder]
+    ), patch.object(
+        cli_main, "_leftover_pausable_gateway_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_reapable_backend_pids", return_value=None
+    ), patch.object(
+        cli_main, "_orphaned_desktop_backend_pids", return_value=[(300, 10000)]
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ) as resume, patch.object(
+        cli_main, "_stop_process_trees"
+    ) as stop_trees:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    stop_trees.assert_not_called()
+    resume.assert_called_once_with(None)
+    output = capsys.readouterr().out
+    assert "taskkill /T" in output
+    assert "`/update`" in output
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_refuses_before_reaping_manual_serve_ancestor(
+    _winp, monkeypatch, capsys
+):
+    """Same residual gap, at the manual serve/dashboard rung (#63206):
+    _stop_process_trees() was called unconditionally on the ledger-derived
+    serve-holder PIDs."""
+    import hermes_cli.gateway as gateway_cli
+
+    holder = (
+        300,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_is_pid_ancestor_of_current_process",
+        lambda pid: pid == 300,
+    )
+
+    with patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(
+        cli_main, "_run_pre_update_backup", return_value=None
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=[holder]
+    ), patch.object(
+        cli_main, "_leftover_pausable_gateway_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_reapable_backend_pids", return_value=None
+    ), patch.object(
+        cli_main, "_orphaned_desktop_backend_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_manual_serve_holders", return_value=[{"pid": 300}]
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ) as resume, patch.object(
+        cli_main, "_stop_process_trees"
+    ) as stop_trees:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    stop_trees.assert_not_called()
+    resume.assert_called_once_with(None)
+    output = capsys.readouterr().out
+    assert "taskkill /T" in output
+    assert "`/update`" in output
+
+
 def test_stop_service_refuses_pid_reuse_before_sc_stop(monkeypatch):
     import hermes_cli.update_cmd as update_cmd
 


### PR DESCRIPTION
## Problem

#99558 (merged earlier today) added `_refuse_gateway_ancestor_tree_kill()` and wired it into the leftover-pausable-gateway rung, so a chat-platform-launched `hermes update` refuses to taskkill `/T` its own ancestor gateway (#98814): killing the process tree it's running inside would kill the updater before it could mutate the checkout.

That guard was only wired into **one** of the venv-holder recovery cascade's rungs. Three more rungs in the same cascade call `_stop_process_trees()` — `taskkill /T /F` — unconditionally, with no ancestry check at all:

- **`_ledger_reapable_backend_pids()`** — positively identifies orphaned Hermes backends via the spawn ledger. `"gateway"` is itself a `REAPABLE_PURPOSES` entry (`hermes_cli/process_identity.py`), and this rung fires whenever `_leftover_pausable_gateway_pids()` returns `None` (mixed holders — e.g. a stray REPL or Desktop backend alongside the gateway) even though *its own* entry in the ledger is a gateway. When that gateway's own recorded spawner is dead (a detached/login-launched gateway, common), this rung reaps it — including when it's the updater's own ancestor.
- **`_orphaned_desktop_backend_pids()`** — reaps orphaned Desktop `serve` backends.
- **`_ledger_manual_serve_holders()`** — reaps manual `hermes serve --host <ip>` backends (#63206).

Each of these is reachable with `gateway_mode=False` (a terminal-launched, non-`--gateway` update) — the exact topology #98814 was filed against — so the same self-kill symptom can still occur through any of these three rungs even after today's fix, if the gateway holding the venv happens to classify as ledger/orphan/manual-serve reapable instead of "pausable gateway."

Confirmed via a standalone dynamic repro against the real functions (mocked psutil/ledger): a mixed holder set makes `_leftover_pausable_gateway_pids()` return `None`, and the SAME holder list then reaches `_ledger_reapable_backend_pids()` -> `[ancestor_pid]` with no refusal in between.

**Not guarded here:** the fourth rung, `_handoff_reapable_backend_pids()` (the GUI-updater hand-off path). It only runs when `_handoff` is `True`, which requires `args.gateway` — and the real caller (`hermes_cli/main.py`) always derives `gateway_mode` from that same `args.gateway`, so `gateway_mode` is already `True` on every path that reaches it. `_refuse_gateway_ancestor_tree_kill()` itself exempts `gateway_mode` unconditionally (the supported `--gateway` hand-off), so adding the same call there would be unreachable dead code.

## Fix

Add the same `_refuse_gateway_ancestor_tree_kill()` check immediately before each of the three reachable `_stop_process_trees()` calls, refusing (exit 2, resuming any paused Windows gateway services first) exactly like the existing leftover-pausable-gateway rung does.

`_orphaned_desktop_backend_pids()` returns `(pid, create_time)` identity pairs (added by #99558's fail-closed process-identity work), not bare pids, so its rung unwraps them before the ancestor check — tolerating both int and tuple entries the same way `_stop_process_trees()` itself already does.

## Testing

Added 3 regression tests to `tests/hermes_cli/test_update_concurrent_quarantine.py`, mirroring the existing `test_update_impl_refuses_before_terminating_gateway_ancestor` (#98814) pattern: each drives `_cmd_update_impl()` through `_detect_venv_python_processes` -> the target rung's holder-detection function (mocked to return the process's own ancestor pid) and asserts `sys.exit(2)`, `_stop_process_trees` never called, and the refusal message printed.

Mutation-verified: stashed `hermes_cli/update_cmd.py` only (kept the new tests), confirmed all 3 fail against the pre-fix code (`_stop_process_trees` IS called with the ancestor pid); restored and confirmed all pass.

```
tests/hermes_cli/test_update_concurrent_quarantine.py, test_update_venv_health.py,
test_update_handoff_backend_reap.py, test_update_orphan_backend_reap.py,
test_taskkill_identity_windows_live.py, test_serve_runtime_inventory.py,
test_process_identity.py, test_mcp_helper_ledger.py: 108 passed, 9 skipped
(windows_only markers, expected in this sandbox)
```

## Checklist

- [x] Mutation-verified each new test fails against the pre-fix code and passes with the fix.
- [x] Ran the full set of tests covering every function this PR touches, not just the directly-relevant file.
- [x] Fresh competitor-PR search (`_refuse_gateway_ancestor_tree_kill`, ledger/orphan/serve function names) turned up nothing open against this specific gap.