### PR TITLE
fix(desktop): resume Bot Chat after a detached runtime

### DIFF
--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -12,7 +12,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const gatewayMocks = vi.hoisted(() => ({
   activeConnectionId: null as null | string,
-  requestGatewayForAgent: vi.fn(async () => ({ routed: true })),
+  requestGatewayForAgent: vi.fn(
+    async (
+      _connectionId?: null | string,
+      _profile?: string,
+      _method?: string,
+      _params?: Record<string, unknown>
+    ): Promise<{ routed?: boolean; session_id?: string }> => ({ routed: true })
+  ),
   requestGatewayForProfile: vi.fn(async () => ({ profiled: true }))
 }))
 

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -1,3 +1,4 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Fail-closed owner resolution for the window's ONE session-scoped RPC
@@ -192,5 +193,67 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
       session_id: 'stored-tg',
       text: 'hi'
     })
+  })
+})
+
+describe('createSessionRpcDispatcher: detached-runtime resume handshake', () => {
+  afterEach(() => {
+    gatewayMocks.requestGatewayForAgent.mockReset()
+    gatewayMocks.requestGatewayForAgent.mockResolvedValue({ routed: true })
+  })
+
+  it('resumes the stored session and retries prompt.submit after a 4001', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockImplementation(async (_conn, _profile, method, params) => {
+      if (method === 'prompt.submit' && params?.session_id === 'rt-omar') {
+        throw new JsonRpcGatewayError("session-scoped RPC rejected: session_id='rt-omar' not in memory", { code: 4001 })
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'rt-fresh' }
+      }
+
+      return { routed: true }
+    })
+
+    const bindings = { current: new Map([['stored-omar', 'rt-omar']]) }
+    const request = createSessionRpcDispatcher({
+      ambientRequest: vi.fn(async () => ({ ambient: true })) as never,
+      runtimeIdByStoredSessionIdRef: bindings,
+      selectedStoredSessionIdRef: { current: null },
+      sessionStateByRuntimeIdRef: { current: new Map() }
+    })
+
+    await expect(request('prompt.submit', { session_id: 'rt-omar', text: 'hi' })).resolves.toEqual({
+      routed: true
+    })
+
+    expect(gatewayMocks.requestGatewayForAgent.mock.calls.map(call => call[2])).toEqual([
+      'prompt.submit',
+      'session.resume',
+      'prompt.submit'
+    ])
+    expect(gatewayMocks.requestGatewayForAgent.mock.calls[1][3]).toMatchObject({
+      omit_messages: true,
+      session_id: 'stored-omar',
+      source: 'desktop'
+    })
+    expect(gatewayMocks.requestGatewayForAgent.mock.calls[2][3]).toMatchObject({
+      session_id: 'rt-fresh',
+      text: 'hi'
+    })
+    expect(bindings.current.get('stored-omar')).toBe('rt-fresh')
+  })
+
+  it('does not auto-resume session.activate (warm path owns that fall-through)', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValue(
+      new JsonRpcGatewayError('session not found', { code: 4001 })
+    )
+
+    await expect(dispatcher().request('session.activate', { session_id: 'rt-omar' })).rejects.toBeInstanceOf(
+      JsonRpcGatewayError
+    )
+    expect(gatewayMocks.requestGatewayForAgent.mock.calls.map(call => call[2])).toEqual(['session.activate'])
   })
 })

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -33,6 +33,8 @@
  */
 import type { MutableRefObject } from 'react'
 
+import { singleFlightSessionResume } from '@/app/session/hooks/use-prompt-actions/single-flight-resume'
+import { isSessionNotFoundError } from '@/app/session/hooks/use-prompt-actions/utils'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
 import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
@@ -41,6 +43,12 @@ import { requestForSessionProfile, type SessionOwnerScope } from '@/store/sessio
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 
 import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
+
+/** Methods that must not auto-resume on a detached runtime.
+ *  `session.resume` is the handshake itself; `session.activate` has its own
+ *  warm-cache 4001 → full stored resume fall-through; replay/create are not
+ *  runtime-rebinding calls. */
+const DETACHED_RUNTIME_NO_RETRY = new Set(['session.resume', 'session.activate', 'session.create', 'session.events.since'])
 
 export type AmbientGatewayRequest = <T>(
   method: string,
@@ -97,6 +105,54 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     // backend "session not found" on a backend that never held the runtime.
     assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
 
-    return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    const dispatch = (sessionParams: Record<string, unknown>) =>
+      requestForSessionProfile<T>(owner, ambientRequest, method, sessionParams, timeoutMs, signal)
+
+    try {
+      return await dispatch(params ?? {})
+    } catch (error) {
+      // After sleep/wake the profile serve reaps the in-memory runtime; the
+      // client still holds the dead id. The gateway's 4001 is explicit:
+      // "client should resume the stored session". Do that once here so every
+      // session-scoped RPC (not just prompt.submit) reattaches instead of
+      // spinning on "waking up".
+      if (!paramSessionId || DETACHED_RUNTIME_NO_RETRY.has(method) || !isSessionNotFoundError(error)) {
+        throw error
+      }
+
+      const storedId =
+        sessionStateByRuntimeIdRef.current.get(paramSessionId)?.storedSessionId ??
+        findStoredIdForRuntimeId(runtimeIdByStoredSessionIdRef.current, paramSessionId) ??
+        storedSessionIdForRuntimeId(paramSessionId) ??
+        routingSessionId ??
+        paramSessionId
+
+      if (!storedId) {
+        throw error
+      }
+
+      let liveId = ''
+
+      try {
+        const resumed = await singleFlightSessionResume(storedId, () =>
+          requestForSessionProfile<{ session_id?: string }>(owner, ambientRequest, 'session.resume', {
+            omit_messages: true,
+            session_id: storedId,
+            source: 'desktop'
+          })
+        )
+        liveId = String(resumed?.session_id || '').trim()
+      } catch {
+        throw error
+      }
+
+      if (!liveId || liveId === paramSessionId) {
+        throw error
+      }
+
+      runtimeIdByStoredSessionIdRef.current.set(storedId, liveId)
+
+      return dispatch({ ...(params ?? {}), session_id: liveId })
+    }
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage } from '@assistant-ui/react'
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -144,6 +145,20 @@ describe('session error classifiers', () => {
     expect(isSessionBusyError(new Error('session busy'))).toBe(true)
     expect(isSessionNotFoundError(new Error('other'))).toBe(false)
     expect(isSessionBusyError(new Error('other'))).toBe(false)
+  })
+
+  it('treats gateway 4001 / not-in-memory as a recoverable detached runtime', () => {
+    expect(isSessionNotFoundError(new JsonRpcGatewayError('session not found', { code: 4001 }))).toBe(true)
+    expect(
+      isSessionNotFoundError(
+        new JsonRpcGatewayError("session-scoped RPC rejected: session_id='rt-1' not in memory", { code: 4001 })
+      )
+    ).toBe(true)
+    expect(isSessionNotFoundError(new Error("session_id='rt-1' not in memory"))).toBe(true)
+  })
+
+  it('does not treat 4007 (never existed) as a recoverable detach', () => {
+    expect(isSessionNotFoundError(new JsonRpcGatewayError('session not found', { code: 4007 }))).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage } from '@assistant-ui/react'
+import { JsonRpcGatewayError } from '@hermes/shared'
 
 import { translateNow, type Translations } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -49,9 +50,15 @@ export function inlineErrorMessage(error: unknown, fallback: string): string {
 }
 
 export function isSessionNotFoundError(error: unknown): boolean {
+  // 4001 is the gateway's "runtime not in memory (detached/reaped)" reject;
+  // 4007 is "this id never existed" and must not be treated as recoverable.
+  if (error instanceof JsonRpcGatewayError && typeof error.code === 'number') {
+    return error.code === 4001
+  }
+
   const message = error instanceof Error ? error.message : String(error)
 
-  return /session not found/i.test(message)
+  return /session not found/i.test(message) || message.includes('not in memory')
 }
 
 /**

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1,4 +1,4 @@
-import { registryBackendScopeKey } from '@hermes/shared'
+import { JsonRpcGatewayError, registryBackendScopeKey } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
@@ -2390,6 +2390,51 @@ describe('resumeSession warm-cache mapping integrity', () => {
       expect.objectContaining({ omit_messages: true, session_id: 'rt-A' })
     )
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+
+  it('falls through to a stored session.resume when session.activate 4001s after a detach', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', clientState('stored-A')]])
+    }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        throw new JsonRpcGatewayError("session-scoped RPC rejected: session_id='rt-A' not in memory", { code: 4001 })
+      }
+
+      if (method === 'session.resume') {
+        return {
+          session_id: 'rt-fresh',
+          resumed: 'stored-A',
+          message_count: 0,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(requestGateway).toHaveBeenCalledWith('session.activate', expect.objectContaining({ session_id: 'rt-A' }))
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', expect.objectContaining({ session_id: 'stored-A' }))
+    expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
   })
 
   it('re-arms a pending clarify in place on the warm session.activate path', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,3 +1,5 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
+
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
@@ -1719,9 +1721,13 @@ export function applyStoredSessionPreviewRuntimeInfo(
 // from a transient/wedged backend (ECONNREFUSED, timeout), which must still
 // retry rather than discard the id.
 export function isSessionGoneError(err: unknown): boolean {
+  if (err instanceof JsonRpcGatewayError && typeof err.code === 'number') {
+    return err.code === 4001 || err.code === 4007
+  }
+
   const message = err instanceof Error ? err.message : String(err ?? '')
 
-  return message.includes('404') || /session not found/i.test(message)
+  return message.includes('404') || /session not found/i.test(message) || message.includes('not in memory')
 }
 
 /**

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -74,6 +74,43 @@ import type { GroupChat, RosterRow } from './types'
 
 // ── plugin ───────────────────────────────────────────────────────────────────
 
+/** Re-resume the open Bot Chat after a detached/reaped runtime.
+ *
+ *  Used on `session.reclaimed` (WS still up) and on a gateway closed→open
+ *  edge (sleep/wake missed the reclaim event). `openBotCanonicalChat` is
+ *  overlay-silent when the chat is already on screen. */
+export async function reattachOpenBotChat(): Promise<void> {
+  const claim = $openBotChat.get()
+
+  if (!claim?.openedRegistryId) {
+    return
+  }
+
+  const bot = selectedRosterBot($lastRoster.get(), $selectedRosterKey.get())
+
+  if (!bot) {
+    return
+  }
+
+  const generation = getBotOpenGeneration()
+
+  try {
+    const opened = await openBotCanonicalChat(bot)
+
+    if (!opened || generation !== getBotOpenGeneration()) {
+      return
+    }
+
+    $openBotChat.set({
+      key: claim.key,
+      openedRegistryId: opened.registryId,
+      openedSessionId: opened.openedId
+    })
+  } catch {
+    /* backend still down — next send recovers via the ladder */
+  }
+}
+
 /** One row the composer's `@` popover renders from the roster. */
 interface MentionCompletionItem {
   display: string
@@ -307,7 +344,22 @@ export default {
     // duplicate listener per cycle (same survives-disable class as the face
     // clock before its onDispose hook — these kept firing until app restart).
     const unbindProfileListener = bindProfileSync($focusedBotOwner)
-    const unbindGatewayListener = host.state.gateway.listen(handleSessionsGatewayTransition)
+    // After sleep/wake the profile serve reaps the Bot Chat runtime. Reclaim
+    // events are missed when the WS is already down, so a closed→open gateway
+    // edge must reattach the open Bot Chat the same way `session.reclaimed`
+    // does — otherwise the pane spins on "waking up" until Ctrl+R (#99646).
+    let gatewayWasOpen = host.state.gateway.get() === 'open'
+    const unbindGatewayListener = host.state.gateway.listen(state => {
+      handleSessionsGatewayTransition()
+
+      const isOpen = state === 'open'
+
+      if (isOpen && !gatewayWasOpen) {
+        void reattachOpenBotChat()
+      }
+
+      gatewayWasOpen = isOpen
+    })
 
     // #93492 root fix: the registry pushes a lifecycle event when a
     // connection is removed. The gateway store already disposes the dead
@@ -559,29 +611,7 @@ export default {
                 return
               }
 
-              const bot = selectedRosterBot($lastRoster.get(), $selectedRosterKey.get())
-
-              if (!bot) {
-                return
-              }
-
-              const generation = getBotOpenGeneration()
-              void openBotCanonicalChat(bot)
-                .then(opened => {
-                  // A user action while the re-resume ran owns the center now.
-                  if (!opened || generation !== getBotOpenGeneration()) {
-                    return
-                  }
-
-                  $openBotChat.set({
-                    key: claim.key,
-                    openedRegistryId: opened.registryId,
-                    openedSessionId: opened.openedId
-                  })
-                })
-                .catch(() => {
-                  /* backend still down — next send recovers via the ladder */
-                })
+              void reattachOpenBotChat()
             })
           : null
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -340,8 +340,9 @@ export interface PluginOpenSessionOptions {
    *  (#93604 — Bot Chat shows old messages until app restart). Resume is
    *  cheap and idempotent (the route-resume effect consumes redundant
    *  requests as no-ops), so callers who know the user explicitly navigated
-   *  here set this to guarantee freshness. Only honored with awaitHydration. */
-  forceResume?: boolean
+   *  here set this to guarantee freshness. Honored even without
+   *  awaitHydration so a sleep/wake reattach can handshake without the
+   *  "waking up" overlay. */
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
@@ -948,7 +949,16 @@ export const host = {
       if (options.awaitHydration) {
         // Keep the target-specific overlay visible through transcript hydration,
         // not merely through the gateway/profile activation that precedes it.
-        $gatewaySwapTarget.set(targetProfile)
+        // Skip it when this chat is already on screen (tile or main): a
+        // sleep/wake reattach of the open Bot Chat used to paint "waking up
+        // <bot>" over a usable transcript until the user hit Ctrl+R (#99646).
+        const alreadyVisible =
+          $selectedStoredSessionId.get() === storedSessionId ||
+          $sessionTiles.get().some(tile => tile.storedSessionId === storedSessionId)
+
+        if (!alreadyVisible) {
+          $gatewaySwapTarget.set(targetProfile)
+        }
       }
 
       // Only the HYDRATION half retries. Activation already failed its own
@@ -1005,7 +1015,7 @@ export const host = {
           // an already-mounted tile would paint the idle snapshot and never
           // pull messages that arrived while the panel WS was down (#96183).
           // Refresh the tile transcript in place instead.
-          if (options.awaitHydration && (options.forceResume || !surfaceHealthy)) {
+          if (options.forceResume || (options.awaitHydration && !surfaceHealthy)) {
             const existingTile = $sessionTiles.get().some(tile => tile.storedSessionId === storedSessionId)
             const tileDelegate = existingTile ? sessionTileDelegate() : null
 
@@ -1091,7 +1101,7 @@ export const host = {
 
       throw error
     } finally {
-      if (options.awaitHydration && generation === openSessionGeneration) {
+      if (generation === openSessionGeneration && $gatewaySwapTarget.get() === targetProfile) {
         $gatewaySwapTarget.set(null)
       }
     }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -343,6 +343,7 @@ export interface PluginOpenSessionOptions {
    *  here set this to guarantee freshness. Honored even without
    *  awaitHydration so a sleep/wake reattach can handshake without the
    *  "waking up" overlay. */
+  forceResume?: boolean
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -804,6 +804,32 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('does not show the waking overlay when reattaching an already-visible Bot Chat', async () => {
+    vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
+    setMockAtom($sessionTiles, [{ storedSessionId: 'bot-chat' }] as never)
+    setMockAtom($focusedStoredSessionId, 'bot-chat')
+    setMockAtom($focusedRuntimeId, 'runtime-tile')
+    setMockAtom($focusedSessionState, {
+      messages: [{ id: 'tile-history', parts: [], role: 'assistant' }],
+      storedSessionId: 'bot-chat'
+    } as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect($gatewaySwapTarget.get()).toBeNull()
+
+    await opening
+    expect($gatewaySwapTarget.get()).toBeNull()
+    expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
+  })
+
   it('requests an explicit resume on a cold open where selection has not settled (#89206)', async () => {
     vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 


### PR DESCRIPTION
## What does this PR do?

After sleep/wake (or a WS drop), a profile `serve` backend reaps the in-memory Bot Chat runtime. The desktop still holds the dead runtime id, so the next session-scoped RPC is rejected:

```
session-scoped RPC rejected: session_id='...' not in memory
(detached/reaped runtime; client should resume the stored session)
```

The turn can still land in SQLite, but streaming never reattaches, and the UI hangs on "waking up \<bot\>" until Ctrl+R.

This PR issues the resume handshake the 4001 already asked for:

- The window's session RPC dispatcher resumes the **stored** session once on a 4001 / "not in memory" reject and retries with the fresh runtime id.
- Bot Mode reattaches the open Bot Chat on a gateway closed→open edge (reclaim events are missed when the WS is already down).
- `openSession` no longer paints the waking overlay when that chat is already on screen.

Does not touch multiplex transcript refresh (`use-background-sync.ts`).

## Related Issue

Fixes #99646

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/session-rpc-dispatcher.ts` — on 4001, `session.resume` the stored id (single-flight) and retry the original RPC. Skips `session.activate` so the warm-cache path can still fall through to a full resume.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts` — treat JSON-RPC 4001 and "not in memory" as a recoverable detached runtime; 4007 (never existed) is not.
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts` — same 4001/4007 split for the activate → stored-resume fall-through.
- `apps/desktop/src/sdk/index.ts` — skip `$gatewaySwapTarget` when the session is already visible; honor `forceResume` without requiring the overlay.
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` — reattach the claimed Bot Chat on gateway reconnect as well as `session.reclaimed`.

## How to Test

1. From `apps/desktop`:

```
npx vitest run src/app/contrib/session-rpc-dispatcher.test.ts src/sdk/profile-routing.test.ts src/app/session/hooks/use-prompt-actions/utils.test.ts src/app/session/hooks/use-session-actions.test.tsx src/plugins/hermes-bots/plugin-panes.test.tsx src/plugins/hermes-bots/group-turns.test.ts
```

2. Manual: open a Bot Chat, put the machine to sleep and wake it (or drop the profile WS). Send a prompt. Streaming should attach without Ctrl+R, and the pane should not stick on "waking up \<bot\>".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the vitest commands listed under How to Test (all passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
