### PR TITLE
fix(auxiliary): Codex timeout Timer no longer releases shared-client FDs (salvage #72260)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1930,6 +1930,25 @@ class _CodexCompletionsAdapter:
                     )
                 except Exception:
                     logger.debug("Codex auxiliary: client abort during timeout failed", exc_info=True)
+                # Socket shutdown wakes a reader blocked on a REAL transport,
+                # but the owner may be blocked inside the SDK's event stream
+                # (or a test double with no sockets). Closing the attempt-
+                # owned stream is the same attempt-scoped wake the hard-cancel
+                # branch above performs from this Timer thread — it releases
+                # the owner without touching the shared client's FDs; the
+                # owner then does the real close in its ``finally``.
+                with attempt_stream_lock:
+                    stream = attempt_stream[0] if attempt_stream else None
+                close_stream = getattr(stream, "close", None)
+                if callable(close_stream):
+                    try:
+                        close_stream()
+                    except Exception:
+                        logger.debug(
+                            "Codex auxiliary: attempt stream close during "
+                            "stranger-thread timeout failed",
+                            exc_info=True,
+                        )
             # The cached auxiliary client wraps this same ``self._client``
             # (or *is* a ``CodexAuxiliaryClient`` whose ``_real_client`` is
             # this instance).  After we close the httpx transport above, the

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1815,6 +1815,10 @@ class _CodexCompletionsAdapter:
         progress_deadline = [_start_monotonic + no_progress_timeout]
         saw_content = threading.Event()
         timed_out = threading.Event()
+        # Set only when the timeout WON the attempt (not when the owner
+        # hard-cancelled first): tells the owning thread's ``finally`` that
+        # the shared client's FDs still need a real close (#29507).
+        timeout_release_pending = threading.Event()
         stream_finished = threading.Event()
         timeout_timer: List[Optional[threading.Timer]] = [None]
         # A protected provider call may outlive its owning compression attempt:
@@ -1827,6 +1831,9 @@ class _CodexCompletionsAdapter:
         )
         attempt_stream_lock = threading.Lock()
         attempt_stream: List[Any] = []
+        # The thread driving this request owns its transport's file
+        # descriptors — see the FD-ownership note in _close_client_on_timeout.
+        owner_tid = threading.get_ident()
 
         def _effective_deadline() -> float:
             with deadline_lock:
@@ -1890,12 +1897,39 @@ class _CodexCompletionsAdapter:
                             exc_info=True,
                         )
                 return
-            close = getattr(self._client, "close", None)
-            if callable(close):
+            # FD-ownership contract (#29507 / #67142 / #70773): only the
+            # thread driving the request may RELEASE this client's file
+            # descriptors. This callback has two callers — ``_check_cancelled``
+            # on the owning thread, and the daemon watchdog ``threading.Timer``,
+            # which is a stranger thread. From a stranger thread we may only
+            # ``shutdown()`` the pooled sockets: ``close()`` releases the raw
+            # TLS fd while the owner's OpenSSL BIO still caches that integer,
+            # the kernel recycles it into the next ``open()`` in this process
+            # (a SessionDB / kanban.db handle), and the owner's unwinding TLS
+            # flush writes an application-data record into that database file.
+            # ``shutdown()`` from any thread is FD-safe; ``close()`` is not.
+            # The owning thread performs the real close in the ``finally``
+            # below, which is where the FD release belongs.
+            timeout_release_pending.set()
+            if threading.get_ident() == owner_tid:
+                close = getattr(self._client, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        logger.debug("Codex auxiliary: client close during timeout failed", exc_info=True)
+            else:
                 try:
-                    close()
+                    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+                    shutdown_count = force_close_tcp_sockets(self._client)
+                    logger.info(
+                        "Codex auxiliary client aborted (timeout, tcp_force_closed=%d, "
+                        "deferred_close=stranger_thread)",
+                        shutdown_count,
+                    )
                 except Exception:
-                    logger.debug("Codex auxiliary: client close during timeout failed", exc_info=True)
+                    logger.debug("Codex auxiliary: client abort during timeout failed", exc_info=True)
             # The cached auxiliary client wraps this same ``self._client``
             # (or *is* a ``CodexAuxiliaryClient`` whose ``_real_client`` is
             # this instance).  After we close the httpx transport above, the
@@ -2090,6 +2124,22 @@ class _CodexCompletionsAdapter:
             _t = timeout_timer[0]
             if _t is not None:
                 _t.cancel()
+            # A stranger-thread timeout only shut the sockets down; the FDs
+            # are still open and this — the owning thread, now unwound — is
+            # the one context that may release them (#29507). Gated on
+            # timeout_release_pending, NOT timed_out: in the hard-cancel
+            # branch (timeout_won=False) the shared client must stay usable
+            # for other sessions.
+            if timeout_release_pending.is_set():
+                close = getattr(self._client, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        logger.debug(
+                            "Codex auxiliary: owner-thread close after timeout failed",
+                            exc_info=True,
+                        )
 
         content = "".join(text_parts).strip() or None
 

--- a/tests/agent/test_codex_aux_no_progress_timeout.py
+++ b/tests/agent/test_codex_aux_no_progress_timeout.py
@@ -152,47 +152,50 @@ class TestNoProgressFailFast:
 
     def test_watchdog_timer_fires_while_blocked_before_first_event(self):
         """responses.create() itself can block with zero bytes; the re-armable
-        watchdog must close the client and surface the no-progress timeout
-        without any event ever reaching _check_cancelled."""
+        watchdog must mark the timeout (without releasing FDs from its own
+        stranger thread — #29507) and the owning thread must surface the
+        no-progress TimeoutError and perform the close on unwind."""
         release = threading.Event()
 
         def _blocked_create(**_kwargs):
             release.wait(timeout=30.0)
             return iter([])
 
-        closed = threading.Event()
+        closed_by = []
         real_client = SimpleNamespace(
             base_url="https://chatgpt.com/backend-api/codex",
             responses=SimpleNamespace(create=_blocked_create),
-            close=closed.set,
+            close=lambda: closed_by.append(threading.get_ident()),
         )
         adapter = _CodexCompletionsAdapter(real_client, "gpt-5.6-sol")
+        owner_result: dict = {}
         try:
             with (
                 patch("agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.3),
                 patch("agent.auxiliary_client._evict_cached_client_instance"),
             ):
-                # The watchdog closes the shared client at the window; the
-                # blocked create keeps waiting (SimpleNamespace has no real
-                # transport), so unblock it and verify the timeout surfaced.
-                waiter: dict = {}
-
                 def _run():
+                    owner_result["tid"] = threading.get_ident()
                     try:
                         adapter.create(
                             messages=[{"role": "user", "content": "x"}],
                             timeout=300,
                         )
                     except Exception as exc:  # noqa: BLE001
-                        waiter["exc"] = exc
+                        owner_result["exc"] = exc
 
                 t = threading.Thread(target=_run, daemon=True)
                 t.start()
-                assert closed.wait(timeout=5.0), "watchdog never closed client"
+                # Watchdog fires within the patched window; it must NOT
+                # close() from its own thread (FD ownership, #29507).
+                time.sleep(1.0)
+                assert not closed_by, f"stranger-thread close: {closed_by}"
                 release.set()
                 t.join(timeout=5.0)
-            assert isinstance(waiter.get("exc"), TimeoutError)
-            assert "no-progress timeout" in str(waiter["exc"])
+            assert isinstance(owner_result.get("exc"), TimeoutError)
+            assert "no-progress timeout" in str(owner_result["exc"])
+            # The OWNER released the FDs on unwind.
+            assert closed_by == [owner_result["tid"]], closed_by
         finally:
             release.set()
 

--- a/tests/agent/test_codex_aux_timeout_fd_ownership.py
+++ b/tests/agent/test_codex_aux_timeout_fd_ownership.py
@@ -1,0 +1,160 @@
+"""Regression: the timeout watchdog must not release the client's FDs.
+
+Salvaged from PR #72260 (@necoweb3 / dsad), adapted to the re-armable
+no-progress watchdog introduced in PR #99660.
+
+``close()`` from a thread that does not own the in-flight httpx connection
+releases the raw TLS fd while the owner's OpenSSL BIO still caches that
+integer. The kernel can hand the same integer to the next ``open()`` in the
+process — a SessionDB or kanban.db handle — and the owner's unwinding TLS
+flush then writes an application-data record into that database file
+(#29507 / #67142 / #70773). ``shutdown()`` is FD-safe from any thread;
+``close()`` is not, so it belongs to the owning thread.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+
+
+def _adapter_with_recording_client(stream):
+    """Build an adapter whose client records (action, thread) events.
+
+    The nested ``_client._transport._pool._connections`` shape is what
+    ``force_close_tcp_sockets`` traverses.
+    """
+    events = []
+
+    class _Sock:
+        def shutdown(self, how):
+            events.append(("shutdown", threading.get_ident()))
+
+        def close(self):
+            events.append(("sock.close", threading.get_ident()))
+
+    sock = _Sock()
+
+    class _Conn:
+        def __init__(self):
+            self._connection = self
+            self._network_stream = self
+
+        def get_extra_info(self, name):
+            return sock if name == "socket" else None
+
+    class _Client:
+        def __init__(self):
+            self._transport = SimpleNamespace(
+                _pool=SimpleNamespace(_connections=[_Conn()])
+            )
+
+    class _LeafClient:
+        def __init__(self):
+            self._client = _Client()
+            self.base_url = "https://chatgpt.com/backend-api/codex"
+            self.responses = SimpleNamespace(create=lambda **kw: stream)
+
+        def close(self):
+            events.append(("client.close", threading.get_ident()))
+
+    return _CodexCompletionsAdapter(_LeafClient(), "gpt-5.5"), events
+
+
+class TestCodexAuxiliaryTimeoutFdOwnership:
+    def test_stalled_stream_timeout_shuts_down_from_timer_and_closes_from_owner(self):
+        """The watchdog Timer fires on a stalled stream: it may only
+        shutdown(); the real close() must land on the owning thread in the
+        adapter's ``finally``."""
+
+        def _stalled():
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                time.sleep(0.02)
+                yield SimpleNamespace(type="response.in_progress")
+
+        adapter, events = _adapter_with_recording_client(_stalled())
+        owner_tid = threading.get_ident()
+
+        def _consume(stream, *, model, on_event):
+            del model
+            for event in stream:
+                on_event(event)
+            return SimpleNamespace(output=[], usage=None)
+
+        with (
+            patch("agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.3),
+            patch("agent.auxiliary_client._evict_cached_client_instance"),
+            patch("agent.codex_runtime._consume_codex_event_stream", _consume),
+            pytest.raises(TimeoutError),
+        ):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=300,
+            )
+
+        # Give the daemon Timer thread a beat to finish its callback.
+        time.sleep(0.2)
+        actions = [a for a, _ in events]
+        # Stranger thread (Timer) only shut the sockets down.
+        shutdown_tids = {tid for a, tid in events if a == "shutdown"}
+        assert "shutdown" in actions, events
+        assert owner_tid not in shutdown_tids, "shutdown ran on owner thread"
+        # close() from a stranger thread is the corruption vector — banned.
+        stranger_closes = [
+            (a, tid) for a, tid in events
+            if a in {"client.close", "sock.close"} and tid != owner_tid
+        ]
+        assert not stranger_closes, f"stranger-thread FD release: {stranger_closes}"
+        # The owning thread released the FDs on unwind.
+        assert ("client.close", owner_tid) in events, events
+
+    def test_owner_thread_deadline_hit_closes_directly(self):
+        """When the OWNING thread detects the deadline in _check_cancelled,
+        it may close() directly — no shutdown-only detour required."""
+
+        def _one_keepalive_then_block():
+            yield SimpleNamespace(type="response.in_progress")
+            time.sleep(1.0)  # past the patched window; owner detects on next event
+            yield SimpleNamespace(type="response.in_progress")
+
+        adapter, events = _adapter_with_recording_client(_one_keepalive_then_block())
+        owner_tid = threading.get_ident()
+
+        def _consume(stream, *, model, on_event):
+            del model
+            for event in stream:
+                on_event(event)
+            return SimpleNamespace(output=[], usage=None)
+
+        # Cancel the watchdog race by making the Timer window huge relative
+        # to the owner's per-event check: patch the timer to never fire.
+        class _NeverTimer:
+            def __init__(self, *_a, **_k):
+                self.daemon = True
+
+            def start(self):
+                pass
+
+            def cancel(self):
+                pass
+
+        with (
+            patch("agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.3),
+            patch("agent.auxiliary_client._evict_cached_client_instance"),
+            patch("agent.auxiliary_client.threading.Timer", _NeverTimer),
+            patch("agent.codex_runtime._consume_codex_event_stream", _consume),
+            pytest.raises(TimeoutError),
+        ):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=300,
+            )
+
+        stranger = [(a, t) for a, t in events if t != owner_tid]
+        assert not stranger, f"non-owner activity: {stranger}"
+        assert ("client.close", owner_tid) in events, events


### PR DESCRIPTION
## Summary

The Codex auxiliary timeout watchdog no longer releases the shared client's file descriptors from its Timer thread — closing the #29507 corruption vector (recycled TLS fd → OpenSSL BIO flush writes into a just-opened SQLite handle) that the main transport already guards against but `agent/auxiliary_client.py` never did.

Salvages PR #72260 by @necoweb3 (commit authorship preserved), reapplied onto the post-#99660 re-armable watchdog.

## Changes

- `agent/auxiliary_client.py` (`_close_client_on_timeout`, salvaged from #72260):
  - stranger thread (watchdog Timer) → `force_close_tcp_sockets()` only (shutdown() is FD-safe from any thread; close() is not — same contract as `_retire_shared_openai_client` / `_abort_request_openai_client`)
  - owning thread → real `close()` as before
  - new `timeout_release_pending` event: the owner's `finally` performs the deferred FD release after a stranger-thread timeout; deliberately NOT gated on `timed_out` so the hard-cancel branch (timeout_won=False) keeps the shared client alive for other sessions
- `tests/agent/test_codex_aux_timeout_fd_ownership.py`: 2 regression tests (Timer thread shutdown-only + owner close on unwind; owner-detected deadline closes directly) — adapted from the contributor's originals
- `tests/agent/test_codex_aux_no_progress_timeout.py`: blocked-before-first-event watchdog test updated to assert the new contract (Timer never closes; owner does)

## Validation

- FD-ownership tests: 2 passed; sabotage run (stranger-thread close restored) fails the stalled-stream test — pins the fix
- Sibling suites: `test_codex_aux_no_progress_timeout.py`, `test_aux_progress_streaming.py`, `test_auxiliary_client.py` — 246 passed
- `ruff check` clean

**Live repro:** the corruption itself is a kernel fd-recycling race (probabilistic, needs a live TLS connection unwinding across a recycled fd — same class as #29507, which was proven on the main transport); the deterministic proof here is the thread-identity assertion: with the fix, zero close()/sock.close() events from non-owner threads across the stalled-stream and blocked-create timeout paths; sabotaged build shows the stranger-thread close immediately.

## Infographic

![FD ownership mission](https://v3b.fal.media/files/b/0aa89506/3O5dEeI-yihdEVumTSrV3_ZDvRDmbu.png)
