### PR TITLE
fix(matrix): restore voice bubbles — send_voice rejected is_voice, dr…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7221,6 +7221,21 @@ class TurnRunner:
                 if has_voice_directive:
                     unique_tags.insert(0, "[[audio_as_voice]]")
                 final_response = final_response + "\n" + "\n".join(unique_tags)
+        elif "[[audio_as_voice]]" not in final_response:
+            # The agent wrote its own MEDIA: tag, which skips the whole
+            # auto-append above -- including the [[audio_as_voice]] directive
+            # a TTS tool asked for THIS turn. Losing it means the adapter
+            # delivers a file card instead of a voice bubble, so recover the
+            # directive on its own. The MEDIA: tags themselves are deliberately
+            # not appended here: the agent already supplied them, and adding
+            # them again would deliver the same file twice.
+            _, has_voice_directive = _collect_auto_append_media_tags(
+                result.get("messages", []),
+                history_offset=len(agent_history),
+                history_media_paths=_history_media_paths,
+            )
+            if has_voice_directive:
+                final_response = "[[audio_as_voice]]\n" + final_response
 
         # Auto-titling runs at TURN START (agent/turn_context.py) from the
         # user's message alone, so it no longer waits on final_response — a

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2584,6 +2584,8 @@ class MatrixAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = True,
+        **kwargs: Any,
     ) -> SendResult:
         """Upload an audio file as a voice message (MSC3245 native voice).
 
@@ -2594,10 +2596,26 @@ class MatrixAdapter(BasePlatformAdapter):
         transcode non-Ogg input to Ogg/Opus (best-effort — if ffmpeg is
         unavailable the original file is sent unchanged, preserving the
         previous behaviour).
+
+        Ogg/Opus input is forced to ``is_voice=True``: it is exactly the
+        container MSC3245 voice messages use, and without the flag Element X
+        draws a file card instead of a player. The caller cannot be relied on
+        here — gateway media delivery derives ``is_voice`` from an
+        ``[[audio_as_voice]]`` directive in the response text, and the gateway
+        only auto-appends that directive from tool results when the agent did
+        not write its own ``MEDIA:`` tag (see ``gateway/run.py``). An agent
+        that synthesises audio itself (e.g. ``terminal`` + ``synth_voice.py``)
+        and emits its own ``MEDIA:`` tag therefore never gets the directive,
+        so the decision is made here, in code, rather than depending on the
+        model remembering a marker. Non-Ogg input still honours the caller's
+        flag, so a plain ``.mp3`` attachment is not turned into a voice note.
         """
+        already_ogg = str(audio_path).lower().endswith((".ogg", ".oga", ".opus"))
+        if already_ogg:
+            is_voice = True
         converted_path: Optional[str] = None
         send_path = audio_path
-        if not str(audio_path).lower().endswith((".ogg", ".oga", ".opus")):
+        if not already_ogg:
             converted_path = await asyncio.to_thread(
                 _matrix_transcode_voice_to_ogg, audio_path
             )
@@ -2618,7 +2636,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     else None
                 ),
                 metadata=metadata,
-                is_voice=True,
+                is_voice=is_voice,
             )
         finally:
             if converted_path:

--- a/tests/gateway/test_matrix_voice_bubble_msc3245.py
+++ b/tests/gateway/test_matrix_voice_bubble_msc3245.py
@@ -1,0 +1,154 @@
+"""Regression tests for Element voice bubbles on Matrix (MSC3245).
+
+Element only draws an inline audio player for an ``m.audio`` event carrying
+the MSC3245 ``org.matrix.msc3245.voice`` flag. That flag is set only when
+``is_voice=True`` reaches ``MatrixAdapter._upload_and_send``, and ``is_voice``
+is derived from an ``[[audio_as_voice]]`` directive in the agent's response
+text.
+
+An agent that synthesises its own audio and emits its own ``MEDIA:`` tag never
+got that directive (``GatewayRunner`` only auto-appends it when the response
+does *not* already contain a ``MEDIA:`` tag), so its voice notes arrived as
+file cards. Ogg/Opus is exactly the container MSC3245 voice messages use, so
+the adapter no longer depends on the caller having inferred intent.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def adapter():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    return MatrixAdapter.__new__(MatrixAdapter)
+
+
+@pytest.mark.parametrize(
+    "audio_path,caller_is_voice,expected_is_voice",
+    [
+        # The regression: the gateway could not infer intent, but the
+        # container is unambiguous, so the flag must still be set.
+        ("/tmp/agent_reply.ogg", False, True),
+        ("/tmp/agent_reply.oga", False, True),
+        ("/tmp/agent_reply.opus", False, True),
+        ("/tmp/AGENT_REPLY.OGG", False, True),        # case-insensitive
+        # Explicit intent is preserved.
+        ("/tmp/tts_reply.ogg", True, True),
+        # Non-Ogg input still honours the caller, so a plain audio attachment
+        # is not silently turned into a voice note.
+        ("/tmp/song.mp3", False, False),
+        ("/tmp/song.wav", False, False),
+    ],
+)
+def test_ogg_audio_is_flagged_as_voice(
+    adapter, monkeypatch, audio_path, caller_is_voice, expected_is_voice
+):
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    captured = {}
+
+    async def fake_send_local_file(
+        self, chat_id, path, msgtype, caption=None, reply_to=None,
+        file_name=None, metadata=None, is_voice=False, **kwargs
+    ):
+        captured["msgtype"] = msgtype
+        captured["is_voice"] = is_voice
+        return SimpleNamespace(success=True, error=None)
+
+    monkeypatch.setattr(MatrixAdapter, "_send_local_file", fake_send_local_file)
+    # Non-Ogg input would otherwise shell out to ffmpeg to transcode.
+    monkeypatch.setattr(
+        "plugins.platforms.matrix.adapter._matrix_transcode_voice_to_ogg",
+        lambda _path: None,
+    )
+
+    asyncio.run(
+        adapter.send_voice(
+            chat_id="!room:example.org",
+            audio_path=audio_path,
+            is_voice=caller_is_voice,
+        )
+    )
+
+    assert captured["msgtype"] == "m.audio"
+    assert captured["is_voice"] is expected_is_voice
+
+
+@pytest.mark.parametrize("is_voice,expect_flag", [(True, True), (False, False)])
+def test_msc3245_flag_tracks_is_voice(adapter, is_voice, expect_flag):
+    """The emitted event carries the voice flag iff is_voice is set.
+
+    Pinned in both directions: without the flag Element renders a file card,
+    and if it were emitted unconditionally every audio attachment would become
+    a voice note.
+    """
+    sent = {}
+
+    class _FakeClient:
+        crypto = None
+        state_store = None
+
+        async def upload_media(self, *args, **kwargs):
+            return "mxc://example.org/abc123"
+
+        async def send_message_event(self, room_id, event_type, content, **kwargs):
+            sent["content"] = content
+            return "$event123"
+
+    adapter._client = _FakeClient()
+    adapter._encryption = False
+    adapter._max_media_bytes = 10 * 1024 * 1024
+    adapter._apply_relation_metadata = lambda content, reply_to=None, metadata=None: None
+
+    asyncio.run(
+        adapter._upload_and_send(
+            room_id="!room:example.org",
+            data=b"\x00" * 512,
+            filename="reply.ogg",
+            content_type="audio/ogg",
+            msgtype="m.audio",
+            is_voice=is_voice,
+            voice_metadata={"duration": 4200, "waveform": [0] * 30} if is_voice else None,
+        )
+    )
+
+    content = sent["content"]
+    assert content["msgtype"] == "m.audio"
+    assert ("org.matrix.msc3245.voice" in content) is expect_flag
+    if expect_flag:
+        # Element uses these to draw the scrubber; absent them the bubble
+        # renders but cannot be seeked.
+        assert content["info"]["duration"] == 4200
+        assert len(content["org.matrix.msc1767.audio"]["waveform"]) == 30
+
+
+def test_extract_media_marks_ogg_as_voice_with_directive():
+    """The directive is what ultimately drives is_voice end to end."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    content = "Here you go.\n[[audio_as_voice]]\nMEDIA:/tmp/reply.ogg"
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert len(media) == 1
+    path, is_voice = media[0]
+    assert path.endswith("/tmp/reply.ogg")
+    assert is_voice is True
+    assert "[[audio_as_voice]]" not in cleaned
+    assert "MEDIA:" not in cleaned
+
+
+def test_extract_media_without_directive_is_not_voice():
+    """Without the directive the file is a plain attachment -- the exact state
+    an agent-authored ``MEDIA:`` tag used to produce."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    media, _cleaned = BasePlatformAdapter.extract_media(
+        "Here you go.\nMEDIA:/tmp/reply.ogg"
+    )
+
+    assert len(media) == 1
+    _path, is_voice = media[0]
+    assert is_voice is False


### PR DESCRIPTION
…opping MSC3245

Matrix voice notes are currently broken in two independent ways.

1. `BasePlatformAdapter` media delivery calls `self.send_voice(..., is_voice=is_voice)` (gateway/platforms/base.py), but `MatrixAdapter.send_voice()` accepts no such parameter and has no `**kwargs`. Every audio attachment therefore raises

       TypeError: MatrixAdapter.send_voice() got an unexpected keyword
       argument 'is_voice'

   and is logged as "[Matrix] Error sending media". `_send_local_file()` already accepts `is_voice`, so the parameter is added and forwarded.

2. Element only draws an inline player for an `m.audio` event carrying the MSC3245 `org.matrix.msc3245.voice` flag, which is set only when `is_voice` is true. `is_voice` comes from an `[[audio_as_voice]]` directive in the response text, which `GatewayRunner` auto-appends from tool results — but only `if "MEDIA:" not in final_response`. An agent that synthesises its own audio and emits its own `MEDIA:` tag suppresses that block entirely and loses the directive, so its voice notes arrive as file cards.

Fixes:

- `MatrixAdapter.send_voice()` takes `is_voice` (default True) plus `**kwargs` and forwards it, and forces it True for `.ogg`/`.oga`/`.opus` — that is precisely the container MSC3245 voice messages use, so the flag should not depend on the caller having inferred intent. Non-Ogg input still honours the caller, so a plain `.mp3` attachment is not turned into a voice note.
- `gateway/run.py` recovers the `[[audio_as_voice]]` directive on its own when the agent wrote its own `MEDIA:` tag, without re-appending the MEDIA tags (which would deliver the file twice).

Deciding this in code rather than relying on the model to emit a marker also makes delivery deterministic, which matters on smaller local models that follow such instructions unreliably.

Tests: 11 new cases in tests/gateway/test_matrix_voice_bubble_msc3245.py, covering the TypeError, the flag in both directions (present when is_voice, absent otherwise, so ordinary audio is not converted to voice notes), and the directive-to-is_voice path. All 7 send_voice cases fail on main and pass with this change.


Claude-Session: https://claude.ai/code/session_0196UNhqc3eiwuW7y4xaRHnx

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

