### PR TITLE
fix(gateway): persist routing identity on lazily-created session rows (salvage of #88804 leg 1)

### DIFF
--- a/contributors/emails/dev@solovision.local
+++ b/contributors/emails/dev@solovision.local
@@ -1,0 +1,1 @@
+solovision24

--- a/run_agent.py
+++ b/run_agent.py
@@ -103,6 +103,51 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
     return platform or "cli"
 
 
+def _gateway_origin_json(agent: "AIAgent") -> Optional[str]:
+    """Build the gateway routing ``origin_json`` for a session row.
+
+    Mirrors the shape of ``SessionSource.to_dict()`` (platform, chat_id,
+    chat_name, chat_type, user_id, user_name, thread_id, optional
+    user_id_alt / profile) so consumers that read ``origin_json`` from
+    state.db (channel directory, mcp_serve, mirror) see the same fields the
+    gateway's own ``record_gateway_session_peer`` would write. Returns None
+    when the agent carries no gateway identity (plain CLI session), matching
+    the previous identity-less creation.
+    """
+    chat_id = getattr(agent, "_chat_id", None)
+    session_key = getattr(agent, "_gateway_session_key", None)
+    user_id = getattr(agent, "_user_id", None)
+    if not (chat_id or session_key or user_id):
+        return None
+    origin: Dict[str, Any] = {
+        "platform": getattr(agent, "platform", None) or "",
+        "chat_id": chat_id,
+        "chat_name": getattr(agent, "_chat_name", None),
+        "chat_type": getattr(agent, "_chat_type", None) or "dm",
+        "user_id": user_id,
+        "user_name": getattr(agent, "_user_name", None),
+        "thread_id": getattr(agent, "_thread_id", None),
+    }
+    user_id_alt = getattr(agent, "_user_id_alt", None)
+    if user_id_alt:
+        origin["user_id_alt"] = user_id_alt
+    profile = getattr(agent, "_profile_name", None)
+    if not profile:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile = get_active_profile_name()
+            if profile == "default":
+                profile = None
+        except Exception:
+            profile = None
+    if profile:
+        origin["profile"] = profile
+    try:
+        return json.dumps(origin)
+    except Exception:
+        return None
+
+
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
 # The other `# noqa: F401` re-exports below cover names accessed via
@@ -678,13 +723,34 @@ class AIAgent:
                     _init_model_config["yolo_mode"] = True
             except Exception:
                 pass
+            # Persist the gateway routing identity with the row. The gateway's
+            # SessionStore normally creates the row first (db_create_kwargs) and
+            # record_gateway_session_peer self-heals a missing row (#82616), but
+            # when the default/global state.db is corrupt or unavailable at
+            # gateway startup the SessionStore degrades to a JSONL fallback
+            # (_db=None) and the peer recorder no-ops. In that degraded mode
+            # this lazy creation is the ONLY durable write for the session, so
+            # it must carry session_key/chat_id/chat_type/thread_id/user_id/
+            # display_name/origin_json or the row is identity-less and
+            # unrecoverable by find_latest_gateway_session_for_peer (regression:
+            # Telegram rows with chat_id=NULL/session_key=NULL under multiplexed
+            # profile routes).
             self._session_db.create_session(
                 session_id=self.session_id,
                 source=source,
                 model=self.model,
                 model_config=_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=getattr(self, "_user_id", None),
+                session_key=getattr(self, "_gateway_session_key", None),
+                chat_id=getattr(self, "_chat_id", None),
+                chat_type=getattr(self, "_chat_type", None),
+                thread_id=getattr(self, "_thread_id", None),
+                display_name=(
+                    getattr(self, "_chat_name", None)
+                    or getattr(self, "_user_name", None)
+                ),
+                origin_json=_gateway_origin_json(self),
                 parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,

--- a/tests/gateway/test_session_degraded_db_continuity.py
+++ b/tests/gateway/test_session_degraded_db_continuity.py
@@ -1,0 +1,144 @@
+"""Regression tests: session continuity when the default/global state.db is unavailable.
+
+Root cause (live incident, 2026-08-17): when the default/global state.db is
+corrupt or unreadable at gateway startup, ``SessionStore._db`` degrades to
+None (JSONL routing fallback) and ``GatewayRunner._session_db`` is None.
+Under multiplexed profile routes the AIAgent lazily opens the PROFILE's
+state.db (``AIAgent._get_session_db_for_recall``) and its
+``_ensure_db_session`` created the session row WITHOUT routing identity
+(session_key/chat_id/chat_type/thread_id/user_id/origin_json/display_name
+all NULL), so the row was unrecoverable by
+``find_latest_gateway_session_for_peer``. The gateway's own
+``record_gateway_session_peer`` self-heal never ran because ``_db`` was None.
+On the next message, ``SessionStore.load_transcript`` returned [] even though
+the transcript existed in the profile DB -> the agent lost prior context.
+
+These tests pin fix 1 (routing identity on lazy row creation):
+``AIAgent._ensure_db_session`` persists the full routing identity the
+agent already carries, so the lazily-created row is recoverable. (The
+transcript-recovery half of the original report is covered separately by
+the scope-aware session DB resolution on main.)
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SESSION_ID = "degraded-db-continuity-session"
+CHAT_ID = "-1001234567890"
+THREAD_ID = "42"
+SESSION_KEY = "agent:orion:telegram:group:-1001234567890:8148316720"
+
+
+def _make_gateway_agent(session_db):
+    """Build an AIAgent carrying gateway routing identity (multiplex profile route)."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=SESSION_ID,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="telegram",
+            user_id="8148316720",
+            user_name="testuser",
+            chat_id=CHAT_ID,
+            chat_name="Test Group",
+            chat_type="group",
+            thread_id=THREAD_ID,
+            gateway_session_key=SESSION_KEY,
+        )
+    # The multiplexed profile scope would resolve the active profile name to
+    # the route's profile (e.g. "orion"); pin it so the row + origin_json
+    # carry the profile deterministically.
+    with patch("hermes_cli.profiles.get_active_profile_name", return_value="orion"):
+        agent._ensure_db_session()
+    return agent
+
+
+class TestEnsureDbSessionPersistsRoutingIdentity:
+    def test_lazy_creation_writes_session_key_and_chat_identity(self):
+        """First-created row must carry gateway routing metadata (not identity-less)."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                _make_gateway_agent(db)
+                row = db.get_session(SESSION_ID)
+                assert row is not None
+                assert row["session_key"] == SESSION_KEY
+                assert row["chat_id"] == CHAT_ID
+                assert row["chat_type"] == "group"
+                assert row["thread_id"] == THREAD_ID
+                assert row["user_id"] == "8148316720"
+                assert row["display_name"] == "Test Group"
+                assert row["source"] == "telegram"
+                assert row["profile_name"] == "orion"
+                origin = json.loads(row["origin_json"])
+                assert origin["platform"] == "telegram"
+                assert origin["chat_id"] == CHAT_ID
+                assert origin["chat_name"] == "Test Group"
+                assert origin["chat_type"] == "group"
+                assert origin["user_id"] == "8148316720"
+                assert origin["user_name"] == "testuser"
+                assert origin["thread_id"] == THREAD_ID
+                assert origin["profile"] == "orion"
+            finally:
+                db.close()
+
+    def test_row_recoverable_by_peer_lookup(self):
+        """find_latest_gateway_session_for_peer must find the lazily-created row."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                _make_gateway_agent(db)
+                # The peer lookup keys on session_key + source; the regression
+                # left session_key NULL so this returned None on every restart.
+                found = db.find_latest_gateway_session_for_peer(
+                    session_key=SESSION_KEY,
+                    source="telegram",
+                )
+                assert found is not None
+                assert found["id"] == SESSION_ID
+            finally:
+                db.close()
+
+    def test_cli_session_stays_identity_less(self):
+        """A plain CLI agent (no gateway fields) keeps the old shape — no origin_json."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                    from run_agent import AIAgent
+
+                    agent = AIAgent(
+                        api_key="test-key",
+                        base_url="https://openrouter.ai/api/v1",
+                        model="test/model",
+                        quiet_mode=True,
+                        session_db=db,
+                        session_id=SESSION_ID + "-cli",
+                        skip_context_files=True,
+                        skip_memory=True,
+                    )
+                agent._ensure_db_session()
+                row = db.get_session(SESSION_ID + "-cli")
+                assert row is not None
+                assert row["session_key"] is None
+                assert row["chat_id"] is None
+                assert row["origin_json"] is None
+            finally:
+                db.close()


### PR DESCRIPTION
Salvage of #88804 (leg 1 only) by @solovision24 — cherry-picked onto current main with original authorship preserved.

## Summary

When the default/global state.db is corrupt at gateway startup, `SessionStore._db` degrades to None and `record_gateway_session_peer` never self-heals. Under multiplexed profile routes the AIAgent's lazy `_ensure_db_session` is then the ONLY durable write for the session — and on current main it creates the row **identity-less** (`session_key`/`chat_id`/`chat_type`/`thread_id`/`user_id`/`origin_json` all NULL). `find_latest_gateway_session_for_peer` can never recover such a row, so Telegram chats forget prior turns (the live 2026-08-17 incident: 67-message row with `chat_id=NULL`).

Fix: `_ensure_db_session` persists the gateway routing identity the agent already carries into `create_session`, plus a `_gateway_origin_json` helper mirroring `SessionSource.to_dict()`. Plain CLI sessions keep the old identity-less shape (pinned by test).

## Scope: why leg 1 only

The original PR had two legs. Leg 2 (`SessionStore.load_transcript` scoped-DB fallback) is **superseded** by the scope-aware session DB resolution already landed on main (`17ba992108`, `6f2dbf3a05` — resolve the session DB inside the active profile scope / widen to the runner). This PR carries only leg 1, which is still broken on main, with the leg-1 regression tests (3 tests; the leg-2 test class was dropped).

## Live repro (before/after on this box)

Real `AIAgent` + real `SessionDB` on a temp file, agent carrying a multiplexed Telegram group route (`/tmp/repro_88804.py`):

- **before (origin/main):** `{"session_key": null, "chat_id": null, "chat_type": null, "user_id": null, "origin_json_present": false, "peer_lookup_recovers_row": false}`
- **after (this branch):** `{"session_key": "agent:orion:telegram:group:-5287315359:8148316720", "chat_id": "-5287315359", "chat_type": "group", "user_id": "8148316720", "origin_json_present": true, "peer_lookup_recovers_row": true}`

## Verification

- `tests/gateway/test_session_degraded_db_continuity.py`: 3 passed; `tests/gateway/test_session_continuity_82616.py`: 11 passed. ruff clean.
- Branch based on current main (0 behind); contributor mapping `contributors/emails/dev@solovision.local → solovision24` included in the commit.

Closes #88804 (leg 1 salvaged here; leg 2 superseded on main).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8951f/lnZkjGMpEse9Eij6ZYxhE_pCwChB9H.png)
