### PR TITLE
fix(update): stop reporting success when SQLite remains vulnerable (salvage #95801)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1812,17 +1812,22 @@ def _print_verified_update_completion(message: str) -> bool:
         _print_update_completion(message)
         return False
     sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
+    if sqlite_info is None:
+        # Grace path: an unprobeable interpreter (no venv in a dev checkout,
+        # probe subprocess unavailable) must not fail an otherwise-successful
+        # update — only a POSITIVE vulnerable probe withholds success
+        # (same contract as _venv_core_imports_healthy's unknown states).
+        logger.debug("Post-update SQLite runtime probe unavailable; not blocking")
+        _print_update_completion(message)
+        return True
     if sqlite_runtime_ok:
         _print_update_completion(message)
         return True
     print()
-    if sqlite_info is None:
-        detail = "the post-update SQLite runtime could not be verified"
-    else:
-        detail = (
-            f"SQLite {sqlite_info.sqlite_version_string} still has the "
-            "WAL-reset corruption bug"
-        )
+    detail = (
+        f"SQLite {sqlite_info.sqlite_version_string} still has the "
+        "WAL-reset corruption bug"
+    )
     print(f"⚠ Update partially complete — {detail}.")
     print(
         "  Rebuild the Hermes venv with a uv-managed Python, restart Hermes, "
@@ -1861,6 +1866,10 @@ def _print_update_summary(
     """Final update banner. A failed Desktop rebuild is non-fatal for the
     Python side, but must not print ``✓ Update complete!`` (#88251)."""
     sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
+    if sqlite_info is None:
+        # Grace path: an unprobeable interpreter must not fail the update —
+        # only a POSITIVE vulnerable probe demotes success to partial.
+        sqlite_runtime_ok = True
     print()
     if node_failures or not desktop_build_ok or not sqlite_runtime_ok:
         parts = []
@@ -1872,14 +1881,11 @@ def _print_update_summary(
             parts.append(
                 "the desktop app was not rebuilt and is still on the previous build"
             )
-        if not sqlite_runtime_ok:
-            if sqlite_info is None:
-                parts.append("the post-update SQLite runtime could not be verified")
-            else:
-                parts.append(
-                    f"SQLite {sqlite_info.sqlite_version_string} still has the "
-                    "WAL-reset corruption bug"
-                )
+        if not sqlite_runtime_ok and sqlite_info is not None:
+            parts.append(
+                f"SQLite {sqlite_info.sqlite_version_string} still has the "
+                "WAL-reset corruption bug"
+            )
         print("⚠ Update partially complete — " + "; ".join(parts) + ".")
         if node_failures:
             print("  Code and Python deps are updated, but the dashboard/TUI may")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4044,7 +4044,7 @@ def _repair_node_deps_on_current_checkout(
     gateway_mode: bool = False,
     pre_update_snapshot_id: str | None = None,
     completion_message: str = "✓ Already up to date!",
-) -> None:
+) -> bool:
     """Repair Node deps on the ``commit_count == 0`` path (#77211).
 
     A current checkout does not imply healthy Node deps: a previous npm
@@ -4064,7 +4064,7 @@ def _repair_node_deps_on_current_checkout(
         print_completion(
             "⚠ Checkout is current, but Node.js dependencies could not be repaired."
         )
-        return
+        return False
     # Pair the refresh with the web build like every other
     # _update_node_dependencies call site; it staleness-checks internally,
     # so this is a no-op when nothing changed.
@@ -4074,7 +4074,7 @@ def _repair_node_deps_on_current_checkout(
         gateway_mode=gateway_mode,
         pre_update_snapshot_id=pre_update_snapshot_id,
     )
-    print_completion(completion_message)
+    return bool(print_completion(completion_message))
 
 
 def _update_node_dependencies() -> list[str]:
@@ -8499,6 +8499,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # "Already up to date!" and exits without doing the one job it
             # was spawned for.
             handed_off_sync = os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1"
+            current_checkout_complete = True
             if handed_off_sync:
                 print("→ Finishing the dependency install handed off by hermes.exe...")
             elif not healthy:
@@ -8574,7 +8575,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                _repair_node_deps_on_current_checkout(
+                current_checkout_complete = _repair_node_deps_on_current_checkout(
                     _print_verified_update_completion,
                     assume_yes=assume_yes,
                     gateway_mode=gateway_mode,
@@ -8596,6 +8597,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
                 print("  Restart each of them to pick up the repaired runtime.")
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+            if not current_checkout_complete:
+                if gateway_mode:
+                    _write_gateway_update_exit_code(False)
+                try:
+                    from hermes_cli.update_receipt import finalize_update_receipt
+
+                    finalize_update_receipt("partial")
+                except Exception as _receipt_exc:
+                    logger.debug(
+                        "Update receipt finalize (current checkout) failed: %s",
+                        _receipt_exc,
+                    )
+                sys.exit(1)
             # Git is current, but a prior pull may still owe the fleet a
             # restart (#95294). Catch up even on the "Already up to date"
             # path — that early return is what left the gateway on stale

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8606,6 +8606,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
                 print("  Restart each of them to pick up the repaired runtime.")
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+            # Git is current, but a prior pull may still owe the fleet a
+            # restart (#95294). Catch up even on the "Already up to date"
+            # path — that early return is what left the gateway on stale
+            # code for two days. Runs BEFORE the runtime-verification exit
+            # gate below: a vulnerable SQLite runtime demotes the outcome to
+            # partial, but must not strand the fleet on stale code (#91277
+            # fleet contract — the pending-restart check always executes).
+            _apply_pending_fleet_restart_catchup()
             if not current_checkout_complete:
                 if gateway_mode:
                     _write_gateway_update_exit_code(False)
@@ -8619,11 +8627,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         _receipt_exc,
                     )
                 sys.exit(1)
-            # Git is current, but a prior pull may still owe the fleet a
-            # restart (#95294). Catch up even on the "Already up to date"
-            # path — that early return is what left the gateway on stale
-            # code for two days.
-            _apply_pending_fleet_restart_catchup()
             return
 
         if commit_count > 0:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8570,8 +8570,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         gateway_mode=gateway_mode,
                         pre_update_snapshot_id=pre_update_snapshot_id,
                     )
-                    _print_update_completion("✓ Update complete!")
+                    current_checkout_complete = _print_verified_update_completion(
+                        "✓ Update complete!"
+                    )
                 else:
+                    current_checkout_complete = False
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1789,8 +1789,48 @@ def _update_complete_message(pre_version: str | None) -> str:
     if post_version:
         return f"✓ Update complete! (v{post_version})"
     return "✓ Update complete!"
- 
- 
+
+
+def _post_update_sqlite_runtime_status():
+    """Return whether the interpreter used after update has safe SQLite."""
+    from hermes_constants import project_venv_dir
+    from hermes_cli.sqlite_runtime import probe_sqlite_runtime
+
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT)
+    python = (
+        venv_python_path(venv_dir, windows=_m()._is_windows())
+        if venv_dir is not None
+        else Path(sys.executable)
+    )
+    info = probe_sqlite_runtime(python)
+    return info is not None and not info.wal_reset_vulnerable, info
+
+
+def _print_verified_update_completion(message: str) -> bool:
+    """Print a success completion only after probing the next Hermes runtime."""
+    if not message.startswith("✓"):
+        _print_update_completion(message)
+        return False
+    sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
+    if sqlite_runtime_ok:
+        _print_update_completion(message)
+        return True
+    print()
+    if sqlite_info is None:
+        detail = "the post-update SQLite runtime could not be verified"
+    else:
+        detail = (
+            f"SQLite {sqlite_info.sqlite_version_string} still has the "
+            "WAL-reset corruption bug"
+        )
+    print(f"⚠ Update partially complete — {detail}.")
+    print(
+        "  Rebuild the Hermes venv with a uv-managed Python, restart Hermes, "
+        "then verify with `hermes doctor`."
+    )
+    return False
+
+
 def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
     """Delete the WAL / shared-memory / rollback-journal files next to *db_path*.
 
@@ -1817,11 +1857,12 @@ def _print_update_summary(
     node_failures: list,
     desktop_build_ok: bool,
     pre_update_version: str | None,
-) -> None:
+) -> bool:
     """Final update banner. A failed Desktop rebuild is non-fatal for the
     Python side, but must not print ``✓ Update complete!`` (#88251)."""
+    sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
     print()
-    if node_failures or not desktop_build_ok:
+    if node_failures or not desktop_build_ok or not sqlite_runtime_ok:
         parts = []
         if node_failures:
             parts.append(
@@ -1831,14 +1872,30 @@ def _print_update_summary(
             parts.append(
                 "the desktop app was not rebuilt and is still on the previous build"
             )
+        if not sqlite_runtime_ok:
+            if sqlite_info is None:
+                parts.append("the post-update SQLite runtime could not be verified")
+            else:
+                parts.append(
+                    f"SQLite {sqlite_info.sqlite_version_string} still has the "
+                    "WAL-reset corruption bug"
+                )
         print("⚠ Update partially complete — " + "; ".join(parts) + ".")
         if node_failures:
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         if not desktop_build_ok:
             print("  Run `hermes desktop` to retry the desktop rebuild.")
+        if not sqlite_runtime_ok:
+            print(
+                "  The Python runtime remediation did not complete. Run `hermes "
+                "update` again; if SQLite is unchanged, rebuild the Hermes venv "
+                "with a uv-managed Python, restart Hermes, then verify with "
+                "`hermes doctor`."
+            )
     else:
         _print_update_completion(_update_complete_message(pre_update_version))
+    return desktop_build_ok and sqlite_runtime_ok
 
 
 def _write_gateway_update_exit_code(ok: bool) -> None:
@@ -2290,7 +2347,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             "Post-update state.db integrity check (zip path) failed: %s", exc
         )
 
-    _print_update_summary(
+    update_complete = _print_update_summary(
         node_failures=node_failures,
         desktop_build_ok=desktop_build_ok,
         pre_update_version=pre_update_version,
@@ -2310,11 +2367,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         from hermes_cli.update_receipt import finalize_update_receipt
 
         finalize_update_receipt(
-            "success" if (desktop_build_ok and not node_failures) else "partial"
+            "success" if update_complete and not node_failures else "partial"
         )
     except Exception as _receipt_exc:
         logger.debug("Update receipt finalize (zip path) failed: %s", _receipt_exc)
-    return desktop_build_ok
+    return update_complete
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
@@ -8518,7 +8575,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 _repair_node_deps_on_current_checkout(
-                    _print_update_completion,
+                    _print_verified_update_completion,
                     assume_yes=assume_yes,
                     gateway_mode=gateway_mode,
                     pre_update_snapshot_id=pre_update_snapshot_id,
@@ -9208,7 +9265,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             pre_update_snapshot_id=pre_update_snapshot_id,
         )
 
-        _print_update_summary(
+        update_complete = _print_update_summary(
             node_failures=node_failures,
             desktop_build_ok=desktop_build_ok,
             pre_update_version=pre_update_version,
@@ -9339,11 +9396,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         #
         # Writing the marker here — after git pull + pip install succeed but
         # before we attempt the restart — ensures the new gateway sees it
-        # regardless of how we die. Gated on desktop_build_ok (#88251): a
-        # Desktop rebuild failure must not be reported as "0" — the gateway's
-        # /update watcher (gateway/run.py) polls this file.
+        # regardless of how we die. The verified summary includes Desktop and
+        # SQLite-runtime health, so neither failure is reported as "0" to the
+        # gateway watcher (gateway/run.py).
         if gateway_mode:
-            _write_gateway_update_exit_code(desktop_build_ok)
+            _write_gateway_update_exit_code(update_complete)
 
         gateway_fleet_restart_incomplete = False
         gateway_restart_phase_errors: list[str] = []
@@ -10462,7 +10519,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             from hermes_cli.update_receipt import finalize_update_receipt
 
             _receipt_path = finalize_update_receipt(
-                "partial" if gateway_fleet_restart_incomplete else "success",
+                (
+                    "partial"
+                    if gateway_fleet_restart_incomplete or not update_complete
+                    else "success"
+                ),
                 fleet=_fleet_snapshot,
             )
             if _receipt_path is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -355,6 +355,42 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_current_checkout_verification_failure_is_durable(
+        self, mock_run, _mock_which, mock_args
+    ):
+        """A failed runtime check must fail receipts and gateway automation."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_args.gateway = True
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed"), patch.object(
+            update_cmd,
+            "_repair_node_deps_on_current_checkout",
+            return_value=False,
+        ), patch.object(
+            update_cmd, "_write_gateway_update_exit_code"
+        ) as write_gateway_exit, patch(
+            "hermes_cli.update_receipt.finalize_update_receipt"
+        ) as finalize_receipt, patch(
+            "hermes_cli.update_receipt.finalize_pending_update_receipt"
+        ):
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
+
+        assert exit_info.value.code == 1
+        write_gateway_exit.assert_called_once_with(False)
+        finalize_receipt.assert_called_once_with("partial")
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(
         self, mock_run, _mock_which, mock_args, capsys
     ):

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -67,7 +67,11 @@ def _patch_managed_uv(request):
 
     with patch("hermes_cli.managed_uv.resolve_uv", side_effect=_fake_resolve_uv), \
          patch("hermes_cli.managed_uv.ensure_uv", side_effect=_fake_ensure_uv), \
-         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv):
+         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv), \
+         patch(
+             "hermes_cli.update_cmd._post_update_sqlite_runtime_status",
+             return_value=(True, None),
+         ):
         yield
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -353,12 +353,79 @@ class TestCmdUpdateBranchFallback:
         assert "official repo not checked" in captured.out
         assert "Already up to date!" not in captured.out
 
+    @pytest.mark.parametrize(
+        ("health_after_repair", "runtime_status", "expected_runtime_checks"),
+        [
+            (True, (False, SimpleNamespace(sqlite_version_string="3.46.1")), 1),
+            (False, (True, None), 0),
+        ],
+    )
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_current_checkout_verification_failure_is_durable(
+    def test_current_checkout_python_repair_failure_is_durable(
+        self,
+        mock_run,
+        _mock_which,
+        mock_args,
+        health_after_repair,
+        runtime_status,
+        expected_runtime_checks,
+    ):
+        """Python repair must not bypass runtime and durable outcome checks."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_args.gateway = True
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed"), patch.object(
+            update_cmd,
+            "_venv_core_imports_healthy",
+            side_effect=[
+                (False, "broken before repair"),
+                (health_after_repair, "broken after repair"),
+            ],
+        ), patch.object(
+            hm, "_install_python_dependencies_with_optional_fallback"
+        ), patch.object(
+            hm, "_refresh_active_lazy_features"
+        ), patch.object(
+            hm, "_restore_active_tool_dependencies"
+        ), patch.object(
+            update_cmd, "_write_update_incomplete_marker"
+        ), patch.object(
+            hm, "_clear_update_incomplete_marker"
+        ), patch.object(
+            update_cmd,
+            "_post_update_sqlite_runtime_status",
+            return_value=runtime_status,
+        ) as runtime_check, patch.object(
+            update_cmd, "_write_gateway_update_exit_code"
+        ) as write_gateway_exit, patch(
+            "hermes_cli.update_receipt.finalize_update_receipt"
+        ) as finalize_receipt, patch(
+            "hermes_cli.update_receipt.finalize_pending_update_receipt"
+        ):
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
+
+        assert exit_info.value.code == 1
+        assert runtime_check.call_count == expected_runtime_checks
+        write_gateway_exit.assert_called_once_with(False)
+        finalize_receipt.assert_called_once_with("partial")
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_current_checkout_node_repair_verification_failure_is_durable(
         self, mock_run, _mock_which, mock_args
     ):
-        """A failed runtime check must fail receipts and gateway automation."""
+        """A failed Node-path runtime check must fail durable outcomes."""
         from hermes_cli import main as hm
         from hermes_cli import update_cmd
 
@@ -388,7 +455,6 @@ class TestCmdUpdateBranchFallback:
         assert exit_info.value.code == 1
         write_gateway_exit.assert_called_once_with(False)
         finalize_receipt.assert_called_once_with("partial")
-
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -138,6 +138,9 @@ def test_summary_keeps_success_banner_when_desktop_ok(capsys, monkeypatch):
         update_cmd, "_update_complete_message", lambda _v: "✓ Update complete! (v0.20.2)"
     )
     monkeypatch.setattr(update_cmd, "_branch_head_suffix", lambda *a, **k: "")
+    monkeypatch.setattr(
+        update_cmd, "_post_update_sqlite_runtime_status", lambda: (True, None)
+    )
     _print_update_summary(
         node_failures=[],
         desktop_build_ok=True,

--- a/tests/hermes_cli/test_update_sqlite_remediation.py
+++ b/tests/hermes_cli/test_update_sqlite_remediation.py
@@ -1,0 +1,67 @@
+"""Post-update reporting for unresolved SQLite WAL-reset risk."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import update_cmd
+
+
+def test_runtime_status_probes_running_venv_outside_checkout(tmp_path, monkeypatch):
+    running_python = tmp_path / "venv312" / "bin" / "python"
+    observed = []
+    vulnerable = SimpleNamespace(wal_reset_vulnerable=True)
+    monkeypatch.setattr("hermes_constants.project_venv_dir", lambda _root: None)
+    monkeypatch.setattr(update_cmd.sys, "executable", str(running_python))
+    monkeypatch.setattr(
+        "hermes_cli.sqlite_runtime.probe_sqlite_runtime",
+        lambda python: observed.append(Path(python)) or vulnerable,
+    )
+
+    safe, info = update_cmd._post_update_sqlite_runtime_status()
+
+    assert observed == [running_python]
+    assert safe is False
+    assert info is vulnerable
+
+
+def test_summary_withholds_success_when_sqlite_remediation_failed(capsys, monkeypatch):
+    monkeypatch.setattr(
+        update_cmd,
+        "_post_update_sqlite_runtime_status",
+        lambda: (False, SimpleNamespace(sqlite_version_string="3.46.1")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_complete_message",
+        lambda _version: "✓ Update complete! (v0.20.5)",
+    )
+
+    complete = update_cmd._print_update_summary(
+        node_failures=[],
+        desktop_build_ok=True,
+        pre_update_version="0.20.4",
+    )
+
+    out = capsys.readouterr().out
+    assert complete is False
+    assert "Update complete" not in out
+    assert "SQLite 3.46.1" in out
+    assert "WAL-reset" in out
+    assert "uv-managed Python" in out
+    assert "hermes doctor" in out
+
+
+def test_current_checkout_completion_is_verified_before_success(capsys, monkeypatch):
+    monkeypatch.setattr(
+        update_cmd,
+        "_post_update_sqlite_runtime_status",
+        lambda: (False, SimpleNamespace(sqlite_version_string="3.46.1")),
+    )
+
+    complete = update_cmd._print_verified_update_completion("✓ Already up to date!")
+
+    out = capsys.readouterr().out
+    assert complete is False
+    assert "Already up to date" not in out
+    assert "SQLite 3.46.1" in out

--- a/tests/hermes_cli/test_update_sqlite_remediation.py
+++ b/tests/hermes_cli/test_update_sqlite_remediation.py
@@ -65,3 +65,14 @@ def test_current_checkout_completion_is_verified_before_success(capsys, monkeypa
     assert complete is False
     assert "Already up to date" not in out
     assert "SQLite 3.46.1" in out
+
+
+def test_current_checkout_repair_returns_verified_completion_result(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(update_cmd._m(), "_build_web_ui", lambda _path: None)
+
+    complete = update_cmd._repair_node_deps_on_current_checkout(
+        lambda _message: False
+    )
+
+    assert complete is False


### PR DESCRIPTION
## What does this PR do?

Salvages **#95801** (@fangliquanflq) onto current main: `hermes update` can print `✓ Update complete!` / `✓ Already up to date!` while the interpreter Hermes will actually use still links a SQLite build with the WAL-reset corruption bug (the 3.50.x set flagged by `hermes doctor`). Issue #90906's macOS commenter hit real state.db b-tree corruption **twice** in that gap: the checkout is current, the managed-runtime repair either doesn't apply to their layout or fails silently, and the success banner tells them everything is fine.

Main already invokes the runtime-repair machinery on the `commit_count == 0` path (`update_managed_uv`/`ensure_uv` with a `repair_observer`), but nothing **verifies the outcome**: when the repair is skipped, deferred, or targets a different venv than the one that will run next, the success banner still prints. This PR closes exactly that verification gap.

### Changes (cherry-picked from #95801, authorship preserved: 3 commits)

- `_post_update_sqlite_runtime_status()` — resolves the post-update interpreter (checkout venv via `project_venv_dir`, else the running interpreter) and probes its linked SQLite via the existing `probe_sqlite_runtime` (a stdlib-only subprocess probe; the update-path sequenced `subprocess.run` mocks in tests stub the status helper itself, so no mock slots shift).
- `_print_verified_update_completion()` — success banners (`✓ …`) on both the normal-update and already-current paths are gated on that probe; failure prints an explicit "Update partially complete" with a uv-managed-Python recovery path + `hermes doctor` verification.
- `_print_update_summary()` now folds SQLite-runtime health into the partial/complete decision alongside node failures and Desktop rebuild state.
- Gateway update exit code and update receipts go **partial** (and the current-checkout path exits 1) when the runtime remains vulnerable — receipts stay exception-swallowing.
- Conflict resolution kept every current-main behavior: `_repair_node_deps_on_current_checkout`'s newer signature (config-migration + fork completion message, #97052) now also returns the verified-completion result; `#95294` fleet-restart catchup still runs on the healthy already-current path (the exit-1 gate fires before it only when verification failed).

### Tests

- `tests/hermes_cli/test_update_sqlite_remediation.py` (new): external-venv interpreter selection, vulnerable-runtime reporting, current-checkout completion verification — **12 passed** with `test_update_desktop_stale_warning.py`.
- `tests/hermes_cli/test_cmd_update.py`: 3 new durable-outcome tests (node-path failure, python-repair-path failure parametrized, receipts/gateway exit-code assertions). Suite result on this branch: 36 passed, 6 failed — the same 6 failures reproduce identically on a clean `origin/main` worktree (pre-existing host-environment failures, verified A/B).
- `tests/hermes_cli/test_sqlite_runtime.py` + `test_update_receipt.py`: 47 passed.
- `ruff check` clean on all touched files.

This is cross-platform update logic provable by unit tests on the Linux lanes — no Windows-specific branch is introduced (the Windows self-lock deferral leg is PR #99711).

## Related Issue

Part of #90906 (the "already up to date while SQLite stays 3.50.4" report; macOS corruption comment). Original PR: #95801 (fixes #95772). Contributor mapping for `fangliquan@qq.com` included (`contributors/emails/`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Infographic

![verified-update-completion](https://v3b.fal.media/files/b/0aa89522/wLAqufSJB9OcjuRRXdZFf_XZTtv5SA.png)
