### PR TITLE
Fix/plugin doctor scoped cleanup

### DIFF
--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePath
 from types import SimpleNamespace
 from typing import Any, Literal
 from unittest.mock import patch
@@ -40,36 +40,44 @@ def _doctor_runtime(plugin_path: Path):
     test framework. Registration code executes under a temporary HERMES_HOME
     with outbound socket connects blocked.
     """
-    temporary_home = tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
     stack = ExitStack()
-    home = Path(temporary_home.name)
-    bundled = home / "bundled-plugins"
-    plugins_root = home / "plugins"
-    bundled.mkdir(parents=True)
-    plugins_root.mkdir(parents=True)
-    copied = plugins_root / plugin_path.name
-    shutil.copytree(
-        plugin_path,
-        copied,
-        ignore=shutil.ignore_patterns(
-            ".git", "__pycache__", ".pytest_cache", "*.pyc"
-        ),
-    )
-
-    stack.enter_context(
-        patch.dict(
-            os.environ,
-            {
-                "HERMES_HOME": str(home),
-                "HERMES_BUNDLED_PLUGINS": str(bundled),
-                "HERMES_ENABLE_PROJECT_PLUGINS": "0",
-            },
-            clear=False,
+    try:
+        # The temp dir enters the stack FIRST so any failure below — including
+        # ENOSPC or KeyboardInterrupt inside copytree — deterministically
+        # removes it instead of stranding a hermes-plugin-doctor-* directory
+        # until interpreter GC (or never, on a hard exit).
+        temporary_home = stack.enter_context(
+            tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
         )
-    )
-    stack.enter_context(patch.object(socket, "create_connection", _deny_network))
-    stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
-    stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
+        home = Path(temporary_home)
+        bundled = home / "bundled-plugins"
+        plugins_root = home / "plugins"
+        bundled.mkdir(parents=True)
+        plugins_root.mkdir(parents=True)
+        copied = plugins_root / plugin_path.name
+        shutil.copytree(
+            plugin_path,
+            copied,
+            ignore=shutil.ignore_patterns(".git", "__pycache__", ".pytest_cache", "*.pyc"),
+        )
+
+        stack.enter_context(
+            patch.dict(
+                os.environ,
+                {
+                    "HERMES_HOME": str(home),
+                    "HERMES_BUNDLED_PLUGINS": str(bundled),
+                    "HERMES_ENABLE_PROJECT_PLUGINS": "0",
+                },
+                clear=False,
+            )
+        )
+        stack.enter_context(patch.object(socket, "create_connection", _deny_network))
+        stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
+        stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
+    except BaseException:
+        stack.close()
+        raise
 
     from hermes_cli.plugins import PluginManager
     from tools.registry import registry
@@ -85,13 +93,11 @@ def _doctor_runtime(plugin_path: Path):
             module: set(scopes)
             for module, scopes in registry._plugin_module_scopes.items()
         }
-
     modules_before = {
         name
         for name in sys.modules
         if name == "hermes_plugins" or name.startswith("hermes_plugins.")
     }
-
     manager = PluginManager()
     try:
         manifests = manager._scan_directory(plugins_root, source="user")
@@ -103,20 +109,15 @@ def _doctor_runtime(plugin_path: Path):
             raise _DoctorLoadError(
                 f"Expected one plugin manifest, discovered {len(manifests)} under {copied}"
             )
-
         manifest = manifests[0]
         manager._load_plugin(manifest)
-
         loaded = manager._plugins.get(manifest.key or manifest.name)
         if loaded is None:
             raise _DoctorLoadError("Plugin registration produced no runtime record")
         if loaded.error:
             raise _DoctorLoadError(f"Plugin registration failed: {loaded.error}")
         if not loaded.enabled:
-            raise _DoctorLoadError(
-                "Plugin registration did not enable the runtime record"
-            )
-
+            raise _DoctorLoadError("Plugin registration did not enable the runtime record")
         yield SimpleNamespace(
             manifest=manifest,
             manager=manager,
@@ -148,16 +149,13 @@ def _doctor_runtime(plugin_path: Path):
             )
 
             registry._generation += 1
-
         for name in list(sys.modules):
             if (
                 name not in modules_before
                 and (name == "hermes_plugins" or name.startswith("hermes_plugins."))
             ):
                 sys.modules.pop(name, None)
-
         stack.close()
-        temporary_home.cleanup()
 
 
 @dataclass(frozen=True)
@@ -205,33 +203,88 @@ class DoctorReport:
         return "\n".join(lines)
 
 
+_MANIFEST_NAMES = ("plugin.yaml", "plugin.yml", "plugin.json")
+
+
+def _has_manifest(path: Path) -> bool:
+    return any(
+        (path / name).exists() or (path / name).is_symlink()
+        for name in _MANIFEST_NAMES
+    )
+
+
+def _holds_plugin(path: Path) -> bool:
+    """True when plugin discovery would find a manifest under *path*.
+
+    Mirrors ``PluginManager._scan_directory``: a manifest in *path* itself
+    (flat layout) or in one immediate subdirectory (category layout, where
+    the category directory carries no manifest of its own).
+
+    Doctor copies the resolved directory wholesale before the runtime gets
+    to reject it, so an unvalidated resolve is a disk-usage bug, not just a
+    confusing error: ``hermes plugins doctor`` with no argument defaults to
+    ``.``, and any directory used to satisfy that.
+    """
+    if not path.is_dir():
+        return False
+    if _has_manifest(path):
+        return True
+    try:
+        children = sorted(path.iterdir())
+    except OSError:
+        return False
+    return any(child.is_dir() and _has_manifest(child) for child in children)
+
+
+def _is_plugin_id(raw: str) -> bool:
+    """True when *raw* can name an installed plugin rather than a path.
+
+    Ids are relative and may carry one category segment
+    (``image_gen/openai``). Dot components are excluded: joining ``.``
+    onto a plugins root yields the root itself, which would hand Doctor
+    every installed plugin at once instead of one.
+    """
+    if not raw or PurePath(raw).is_absolute():
+        return False
+    parts = PurePath(raw).parts
+    return bool(parts) and all(part not in {os.curdir, os.pardir} for part in parts)
+
+
 def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     """Resolve an explicit path or an installed/bundled plugin id."""
     raw = os.fspath(target or ".")
     direct = Path(raw).expanduser()
-    if direct.is_dir():
+    direct_is_dir = direct.is_dir()
+    if direct_is_dir and _holds_plugin(direct):
         return direct.resolve()
 
     candidates: list[Path] = []
-    user_root = get_hermes_home() / "plugins"
-    candidates.append(user_root / raw)
-    try:
-        from hermes_cli.plugins import get_bundled_plugins_dir
+    if _is_plugin_id(raw):
+        user_root = get_hermes_home() / "plugins"
+        candidates.append(user_root / raw)
+        try:
+            from hermes_cli.plugins import get_bundled_plugins_dir
 
-        bundled = get_bundled_plugins_dir()
-        candidates.extend(
-            [
-                bundled / raw,
-                bundled / "platforms" / raw,
-                bundled / "model-providers" / raw,
-            ]
-        )
-    except Exception:
-        pass
-    candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
+            bundled = get_bundled_plugins_dir()
+            candidates.extend(
+                [
+                    bundled / raw,
+                    bundled / "platforms" / raw,
+                    bundled / "model-providers" / raw,
+                ]
+            )
+        except Exception:
+            pass
+        candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
     for candidate in candidates:
-        if candidate.is_dir():
+        if _holds_plugin(candidate):
             return candidate.resolve()
+    if direct_is_dir:
+        raise FileNotFoundError(
+            f"{direct.resolve()} holds no plugin manifest "
+            f"({', '.join(_MANIFEST_NAMES)}), and {raw!r} is not an installed "
+            "plugin id. Point Doctor at a plugin directory."
+        )
     raise FileNotFoundError(
         f"Plugin {raw!r} was not found as a path or installed plugin id"
     )

--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path, PurePath
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Literal
 from unittest.mock import patch
@@ -40,55 +40,58 @@ def _doctor_runtime(plugin_path: Path):
     test framework. Registration code executes under a temporary HERMES_HOME
     with outbound socket connects blocked.
     """
+    temporary_home = tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
     stack = ExitStack()
-    try:
-        # The temp dir enters the stack FIRST so any failure below — including
-        # ENOSPC or KeyboardInterrupt inside copytree — deterministically
-        # removes it instead of stranding a hermes-plugin-doctor-* directory
-        # until interpreter GC (or never, on a hard exit).
-        temporary_home = stack.enter_context(
-            tempfile.TemporaryDirectory(prefix="hermes-plugin-doctor-")
-        )
-        home = Path(temporary_home)
-        bundled = home / "bundled-plugins"
-        plugins_root = home / "plugins"
-        bundled.mkdir(parents=True)
-        plugins_root.mkdir(parents=True)
-        copied = plugins_root / plugin_path.name
-        shutil.copytree(
-            plugin_path,
-            copied,
-            ignore=shutil.ignore_patterns(".git", "__pycache__", ".pytest_cache", "*.pyc"),
-        )
+    home = Path(temporary_home.name)
+    bundled = home / "bundled-plugins"
+    plugins_root = home / "plugins"
+    bundled.mkdir(parents=True)
+    plugins_root.mkdir(parents=True)
+    copied = plugins_root / plugin_path.name
+    shutil.copytree(
+        plugin_path,
+        copied,
+        ignore=shutil.ignore_patterns(
+            ".git", "__pycache__", ".pytest_cache", "*.pyc"
+        ),
+    )
 
-        stack.enter_context(
-            patch.dict(
-                os.environ,
-                {
-                    "HERMES_HOME": str(home),
-                    "HERMES_BUNDLED_PLUGINS": str(bundled),
-                    "HERMES_ENABLE_PROJECT_PLUGINS": "0",
-                },
-                clear=False,
-            )
+    stack.enter_context(
+        patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": str(home),
+                "HERMES_BUNDLED_PLUGINS": str(bundled),
+                "HERMES_ENABLE_PROJECT_PLUGINS": "0",
+            },
+            clear=False,
         )
-        stack.enter_context(patch.object(socket, "create_connection", _deny_network))
-        stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
-        stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
-    except BaseException:
-        stack.close()
-        raise
+    )
+    stack.enter_context(patch.object(socket, "create_connection", _deny_network))
+    stack.enter_context(patch.object(socket.socket, "connect", _deny_network))
+    stack.enter_context(patch.object(socket.socket, "connect_ex", _deny_network))
 
     from hermes_cli.plugins import PluginManager
     from tools.registry import registry
 
-    entries_before = {entry.name: entry for entry in registry._snapshot_entries()}
-    policy_before = dict(registry._plugin_override_policy)
+    with registry._lock:
+        tools_before = dict(registry._tools)
+        scoped_tools_before = {
+            scope: dict(entries)
+            for scope, entries in registry._scoped_tools.items()
+        }
+        policy_before = dict(registry._plugin_override_policy)
+        module_scopes_before = {
+            module: set(scopes)
+            for module, scopes in registry._plugin_module_scopes.items()
+        }
+
     modules_before = {
         name
         for name in sys.modules
         if name == "hermes_plugins" or name.startswith("hermes_plugins.")
     }
+
     manager = PluginManager()
     try:
         manifests = manager._scan_directory(plugins_root, source="user")
@@ -100,15 +103,20 @@ def _doctor_runtime(plugin_path: Path):
             raise _DoctorLoadError(
                 f"Expected one plugin manifest, discovered {len(manifests)} under {copied}"
             )
+
         manifest = manifests[0]
         manager._load_plugin(manifest)
+
         loaded = manager._plugins.get(manifest.key or manifest.name)
         if loaded is None:
             raise _DoctorLoadError("Plugin registration produced no runtime record")
         if loaded.error:
             raise _DoctorLoadError(f"Plugin registration failed: {loaded.error}")
         if not loaded.enabled:
-            raise _DoctorLoadError("Plugin registration did not enable the runtime record")
+            raise _DoctorLoadError(
+                "Plugin registration did not enable the runtime record"
+            )
+
         yield SimpleNamespace(
             manifest=manifest,
             manager=manager,
@@ -116,30 +124,40 @@ def _doctor_runtime(plugin_path: Path):
             registered_hooks=tuple(loaded.hooks_registered),
         )
     finally:
-        entries_after = {entry.name: entry for entry in registry._snapshot_entries()}
-        changed_names = {
-            name
-            for name in set(entries_before) | set(entries_after)
-            if entries_after.get(name) is not entries_before.get(name)
-        }
         with registry._lock:
-            for name in changed_names:
-                previous = entries_before.get(name)
-                if previous is None:
-                    registry._tools.pop(name, None)
-                else:
-                    registry._tools[name] = previous
+            registry._tools.clear()
+            registry._tools.update(tools_before)
+
+            registry._scoped_tools.clear()
+            registry._scoped_tools.update(
+                {
+                    scope: dict(entries)
+                    for scope, entries in scoped_tools_before.items()
+                }
+            )
+
             registry._plugin_override_policy.clear()
             registry._plugin_override_policy.update(policy_before)
-            if changed_names:
-                registry._generation += 1
+
+            registry._plugin_module_scopes.clear()
+            registry._plugin_module_scopes.update(
+                {
+                    module: set(scopes)
+                    for module, scopes in module_scopes_before.items()
+                }
+            )
+
+            registry._generation += 1
+
         for name in list(sys.modules):
             if (
                 name not in modules_before
                 and (name == "hermes_plugins" or name.startswith("hermes_plugins."))
             ):
                 sys.modules.pop(name, None)
+
         stack.close()
+        temporary_home.cleanup()
 
 
 @dataclass(frozen=True)
@@ -187,88 +205,33 @@ class DoctorReport:
         return "\n".join(lines)
 
 
-_MANIFEST_NAMES = ("plugin.yaml", "plugin.yml", "plugin.json")
-
-
-def _has_manifest(path: Path) -> bool:
-    return any(
-        (path / name).exists() or (path / name).is_symlink()
-        for name in _MANIFEST_NAMES
-    )
-
-
-def _holds_plugin(path: Path) -> bool:
-    """True when plugin discovery would find a manifest under *path*.
-
-    Mirrors ``PluginManager._scan_directory``: a manifest in *path* itself
-    (flat layout) or in one immediate subdirectory (category layout, where
-    the category directory carries no manifest of its own).
-
-    Doctor copies the resolved directory wholesale before the runtime gets
-    to reject it, so an unvalidated resolve is a disk-usage bug, not just a
-    confusing error: ``hermes plugins doctor`` with no argument defaults to
-    ``.``, and any directory used to satisfy that.
-    """
-    if not path.is_dir():
-        return False
-    if _has_manifest(path):
-        return True
-    try:
-        children = sorted(path.iterdir())
-    except OSError:
-        return False
-    return any(child.is_dir() and _has_manifest(child) for child in children)
-
-
-def _is_plugin_id(raw: str) -> bool:
-    """True when *raw* can name an installed plugin rather than a path.
-
-    Ids are relative and may carry one category segment
-    (``image_gen/openai``). Dot components are excluded: joining ``.``
-    onto a plugins root yields the root itself, which would hand Doctor
-    every installed plugin at once instead of one.
-    """
-    if not raw or PurePath(raw).is_absolute():
-        return False
-    parts = PurePath(raw).parts
-    return bool(parts) and all(part not in {os.curdir, os.pardir} for part in parts)
-
-
 def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     """Resolve an explicit path or an installed/bundled plugin id."""
     raw = os.fspath(target or ".")
     direct = Path(raw).expanduser()
-    direct_is_dir = direct.is_dir()
-    if direct_is_dir and _holds_plugin(direct):
+    if direct.is_dir():
         return direct.resolve()
 
     candidates: list[Path] = []
-    if _is_plugin_id(raw):
-        user_root = get_hermes_home() / "plugins"
-        candidates.append(user_root / raw)
-        try:
-            from hermes_cli.plugins import get_bundled_plugins_dir
+    user_root = get_hermes_home() / "plugins"
+    candidates.append(user_root / raw)
+    try:
+        from hermes_cli.plugins import get_bundled_plugins_dir
 
-            bundled = get_bundled_plugins_dir()
-            candidates.extend(
-                [
-                    bundled / raw,
-                    bundled / "platforms" / raw,
-                    bundled / "model-providers" / raw,
-                ]
-            )
-        except Exception:
-            pass
-        candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
-    for candidate in candidates:
-        if _holds_plugin(candidate):
-            return candidate.resolve()
-    if direct_is_dir:
-        raise FileNotFoundError(
-            f"{direct.resolve()} holds no plugin manifest "
-            f"({', '.join(_MANIFEST_NAMES)}), and {raw!r} is not an installed "
-            "plugin id. Point Doctor at a plugin directory."
+        bundled = get_bundled_plugins_dir()
+        candidates.extend(
+            [
+                bundled / raw,
+                bundled / "platforms" / raw,
+                bundled / "model-providers" / raw,
+            ]
         )
+    except Exception:
+        pass
+    candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate.resolve()
     raise FileNotFoundError(
         f"Plugin {raw!r} was not found as a path or installed plugin id"
     )

--- a/tests/hermes_cli/test_plugin_dev.py
+++ b/tests/hermes_cli/test_plugin_dev.py
@@ -259,3 +259,47 @@ def test_doctor_removes_temp_home_when_staging_copy_fails(
     # exact window where a stranded hermes-plugin-doctor-* dir was observed.
     leftovers = list(scratch.glob("hermes-plugin-doctor-*"))
     assert leftovers == [], f"stranded doctor temp dirs: {leftovers}"
+
+
+def test_doctor_restores_scoped_registry_state(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+    from tools.registry import registry
+
+    target = tmp_path / "scoped-cleanup-plugin"
+    target.mkdir()
+    (target / "plugin.yaml").write_text(
+        "name: scoped-cleanup-plugin\nprovides_tools: [scoped_cleanup_ping]\n",
+        encoding="utf-8",
+    )
+    (target / "__init__.py").write_text(
+        "import json\n\n"
+        "def ping(args, **kwargs):\n"
+        "    return json.dumps({'ok': True})\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_tool("
+        "name='scoped_cleanup_ping', "
+        "toolset='cleanup', "
+        "schema={'name': 'scoped_cleanup_ping', "
+        "'description': 'test', "
+        "'parameters': {'type': 'object'}}, "
+        "handler=ping)\n",
+        encoding="utf-8",
+    )
+
+    with registry._lock:
+        scoped_before = {
+            scope: dict(entries)
+            for scope, entries in registry._scoped_tools.items()
+        }
+        module_scopes_before = {
+            module: set(scopes)
+            for module, scopes in registry._plugin_module_scopes.items()
+        }
+
+    report = doctor_plugin(target)
+
+    assert report.ok, report.format_text()
+
+    with registry._lock:
+        assert registry._scoped_tools == scoped_before
+        assert registry._plugin_module_scopes == module_scopes_before


### PR DESCRIPTION
## Summary
- restore scoped registry state after plugin doctor runs
- restore plugin module scope tracking and override policy
- prevent temporary doctor registrations from leaking into global registry state
- preserve cleanup of temporary doctor runtime

## Tests
- python -m pytest -q tests/hermes_cli/test_plugin_dev.py
- 11 passed
- git diff --cached --check

