### PR TITLE
Fix sandbox egress leak: pinned --network dropped for file/code sandboxes and on container reuse

### DIFF
--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -44,6 +44,12 @@ def test_sibling_container_config_sites_carry_docker_network():
                     f"docker_run_as_host_user but without docker_network "
                     f"(line {node.lineno})"
                 )
+                assert "docker_extra_args" in keys, (
+                    f"{module.__name__} builds a container_config with "
+                    f"docker_run_as_host_user but without docker_extra_args "
+                    f"(line {node.lineno}) — the redteam --network=container:"
+                    f"mullvad-vpn would be dropped, leaking the host IP"
+                )
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -47,7 +47,9 @@ def test_sibling_container_config_sites_carry_docker_network():
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 
-def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
+def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool,
+                         extra_args=None, sidecar_id="vpnsidecarfullid0000",
+                         sidecar_present=True):
     """Drive DockerEnvironment through the cross-process reuse path with a
     fake existing container whose NetworkMode is *existing_mode*.
 
@@ -69,7 +71,14 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
             # missing label as "<no value>".
             Result.stdout = "existing-container-id\trunning\t<no value>\n"
         elif len(cmd) > 1 and cmd[1] == "inspect":
-            Result.stdout = f"{existing_mode}\n"
+            if "{{.Id}}" in cmd:
+                # Resolving a container:<ref> network target to its full id.
+                if sidecar_present:
+                    Result.stdout = f"{sidecar_id}\n"
+                else:
+                    Result.returncode = 1
+            else:
+                Result.stdout = f"{existing_mode}\n"
         elif len(cmd) > 1 and cmd[1] == "run":
             Result.stdout = "fresh-container-id\n"
         return Result()
@@ -84,6 +93,7 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
         timeout=60,
         task_id="reuse-guard-test",
         network=network,
+        extra_args=extra_args,
         persist_across_processes=True,
     )
     return commands
@@ -114,3 +124,52 @@ def test_reuse_skips_inspect_when_network_enabled(monkeypatch):
     assert not any(cmd[1] == "inspect" for cmd in commands)
     assert not any(cmd[1] == "rm" for cmd in commands)
     assert not any(cmd[1] == "run" for cmd in commands)
+
+
+# --- redteam VPN egress: reuse must not hand back a container that lost its
+# VPN sidecar (the home-IP leak of 2026-08-26). The redteam profile pins
+# docker_extra_args: ["--network=container:mullvad-vpn"]; a stale bridge
+# container carrying the right labels would otherwise be reused and egress
+# the host IP.
+
+_VPN_ARGS = ["--network=container:mullvad-vpn"]
+
+
+def test_reuse_rejects_bridge_container_when_vpn_network_pinned(monkeypatch):
+    commands = _reuse_guard_harness(
+        monkeypatch, existing_mode="bridge", network=True, extra_args=_VPN_ARGS,
+    )
+    assert any(cmd[1:3] == ["rm", "-f"] for cmd in commands), (
+        "a redteam container on bridge must be removed when the config pins "
+        "--network=container:mullvad-vpn"
+    )
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--network=container:mullvad-vpn" in run_cmd
+
+
+def test_reuse_keeps_container_matching_pinned_vpn_sidecar(monkeypatch):
+    commands = _reuse_guard_harness(
+        monkeypatch,
+        existing_mode="container:vpnsidecarfullid0000",
+        network=True,
+        extra_args=_VPN_ARGS,
+    )
+    assert not any(cmd[1] == "rm" for cmd in commands), (
+        "a container already attached to the live VPN sidecar must be reused"
+    )
+    assert not any(cmd[1] == "run" for cmd in commands)
+
+
+def test_reuse_rejects_container_when_vpn_sidecar_gone(monkeypatch):
+    # Sidecar can't be resolved -> expected mode stays the un-normalized
+    # container:mullvad-vpn, which never matches an actual id -> fail closed.
+    commands = _reuse_guard_harness(
+        monkeypatch,
+        existing_mode="container:staleoldsidecarid00",
+        network=True,
+        extra_args=_VPN_ARGS,
+        sidecar_present=False,
+    )
+    assert any(cmd[1:3] == ["rm", "-f"] for cmd in commands), (
+        "a container whose VPN sidecar is gone must not be reused"
+    )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -926,6 +926,7 @@ def _get_or_create_env(task_id: str):
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
+                "docker_extra_args": config.get("docker_extra_args", []),
             }
 
         ssh_config = None

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1463,17 +1463,30 @@ class DockerEnvironment(BaseEnvironment):
                 # don't get their container churned on every startup.
                 mode_mismatch = False
                 actual_mode = None
+                expected_mode = None
                 if not network:
+                    # Lockdown direction: config wants an air-gapped container
+                    # but a stale one may have been created networked.
+                    expected_mode = "none"
                     actual_mode = self._container_network_mode(container_id)
                     mode_mismatch = actual_mode != "none"
+                else:
+                    # Explicit-network direction: config pins --network to a
+                    # specific mode (e.g. container:<vpn-sidecar> for the
+                    # redteam profile). A stale container on bridge/default —
+                    # or attached to a since-replaced sidecar — would leak the
+                    # host IP, so reuse must confirm the mode still matches.
+                    expected_mode = self._expected_network_mode(all_run_args)
+                    if expected_mode is not None:
+                        actual_mode = self._container_network_mode(container_id)
+                        mode_mismatch = actual_mode != expected_mode
                 if mode_mismatch:
                     logger.warning(
-                        "Existing container %s has NetworkMode=%s but "
-                        "docker_network=false requests an air-gapped "
-                        "container — removing it and starting fresh "
+                        "Existing container %s has NetworkMode=%s but config "
+                        "requires %s — removing it and starting fresh "
                         "(task=%s, profile=%s).",
                         container_id[:12], actual_mode or "unknown",
-                        task_label, profile_name,
+                        expected_mode, task_label, profile_name,
                     )
                     try:
                         subprocess.run(
@@ -1901,6 +1914,64 @@ class DockerEnvironment(BaseEnvironment):
             return None
         mode = result.stdout.strip()
         return mode or None
+
+    def _expected_network_mode(self, run_args) -> Optional[str]:
+        """Return the HostConfig.NetworkMode a fresh container would get from
+        the ``--network``/``--net`` flag in *run_args*, or ``None`` when no
+        explicit network flag is present (default bridge — not pinned).
+
+        A ``container:<ref>`` target is normalized to ``container:<full-id>``
+        so it can be compared against a running container's actual
+        NetworkMode, which Docker reports by id, not by the name the flag
+        used. When the referenced sidecar can't be resolved (e.g. the VPN
+        container is down), the un-normalized value is returned so the
+        comparison fails closed — a redteam container must not be reused
+        without its live VPN sidecar.
+        """
+        requested = None
+        i = 0
+        n = len(run_args)
+        while i < n:
+            arg = run_args[i]
+            if arg in ("--network", "--net"):
+                requested = run_args[i + 1] if i + 1 < n else None
+                i += 2
+                continue
+            for flag in ("--network=", "--net="):
+                if arg.startswith(flag):
+                    requested = arg[len(flag):]
+                    break
+            i += 1
+        if not requested:
+            return None
+        if requested.startswith("container:"):
+            ref = requested.split(":", 1)[1]
+            resolved = self._resolve_container_id(ref)
+            return f"container:{resolved}" if resolved else requested
+        return requested
+
+    def _resolve_container_id(self, ref: str) -> Optional[str]:
+        """Resolve a container name/id *ref* to its full id, or ``None`` when
+        it can't be inspected (e.g. the container isn't running)."""
+        try:
+            result = subprocess.run(
+                [self._docker_exe, "inspect", "--format", "{{.Id}}", ref],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("docker inspect Id failed for %s: %s", ref, e)
+            return None
+        if result.returncode != 0:
+            logger.debug(
+                "docker inspect Id for %s returned %d: %s",
+                ref, result.returncode, result.stderr.strip(),
+            )
+            return None
+        return result.stdout.strip() or None
 
     def _find_reusable_container(
         self,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1535,6 +1535,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "docker_extra_args": config.get("docker_extra_args", []),
                 }
 
             ssh_config = None


### PR DESCRIPTION
A profile that pins `--network=container:<sidecar>` via `docker_extra_args` (e.g. to force all sandbox egress through a VPN sidecar) leaks the host IP:

1. `file_tools.py` and `code_execution_tool.py` build their sandbox `container_config` without `docker_extra_args` — only `terminal_tool` has it — so the pinned `--network` is dropped and those sandboxes run on the default bridge, egressing the host IP while terminal sandboxes are isolated.
2. The cross-process reuse guard only verified the air-gap direction, so a stale bridge container gets reused for a session that requires the pinned network, again defeating the isolation.

Both are fixed here, with regression tests. `tests/tools/test_docker_network_config.py` passes 8/8. The two patches are the two halves of the same leak (0002 is the root cause; 0001 closes a related reuse gap).