### PR TITLE
fix(compression): OpenRouter fallback survives credit-limited 402s by clamping to the affordable budget (salvage #41055)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9048,12 +9048,23 @@ def _build_call_kwargs(
             from hermes_cli.providers import nous_api_mode
 
             _nous_on_messages = nous_api_mode(model) == "anthropic_messages"
+        # OpenRouter budgets credit against the requested output cap; when the
+        # param is omitted it assumes the model's FULL output window (e.g.
+        # 65,536), so low-credit accounts 402 ("can only afford N") even
+        # though the actual summary would cost far less. Preserving the
+        # caller's cap keeps the request affordable (#41035, PR #41055 by
+        # @liuhao1024).
+        _is_openrouter = (
+            _provider_norm == "openrouter"
+            or base_url_host_matches(_effective_base, "openrouter.ai")
+        )
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _nous_on_messages
             or _is_nvidia_nim
             or _is_moa
             or _is_gemini_native
+            or _is_openrouter
         ):
             # Use auxiliary_max_tokens_param() so models that require
             # max_completion_tokens (GPT-5 family, Copilot) get the right
@@ -9435,7 +9446,94 @@ def _provider_requires_stream(provider: str, base_url: Optional[str]) -> bool:
     return False
 
 
+_AFFORDABLE_TOKENS_RE = re.compile(
+    r"can only afford\s+([0-9][0-9,]*)", re.IGNORECASE
+)
+
+# Below this, the affordable budget can't fit a useful auxiliary output
+# (summaries, titles, vision descriptions) — treat as genuine exhaustion.
+_AFFORDABLE_RETRY_FLOOR_TOKENS = 512
+# Headroom under the provider's stated budget so token-count rounding on
+# their side can't 402 the retry (same margin PR #49785 used).
+_AFFORDABLE_RETRY_MARGIN_TOKENS = 64
+
+
+def _affordable_max_tokens_from_error(exc: Exception) -> Optional[int]:
+    """Extract the affordable output budget from a credit-limited 402.
+
+    OpenRouter's insufficient-credit rejection states the budget explicitly:
+    ``402 - This request requires more credits, or fewer max_tokens. You
+    requested up to 65536 tokens, but can only afford 7117.`` The account
+    HAS usable credit — the request just asked for (or defaulted to) an
+    output cap larger than the balance covers. Returns the retryable cap
+    (affordable minus a safety margin), or ``None`` when the error carries
+    no affordable count or the budget is too small to be useful.
+    """
+    if not _is_payment_error(exc):
+        return None
+    match = _AFFORDABLE_TOKENS_RE.search(str(exc))
+    if not match:
+        return None
+    try:
+        affordable = int(match.group(1).replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+    capped = affordable - _AFFORDABLE_RETRY_MARGIN_TOKENS
+    if capped < _AFFORDABLE_RETRY_FLOOR_TOKENS:
+        return None
+    return capped
+
+
 def _create_with_progress(
+    client: Any,
+    kwargs: Dict[str, Any],
+    task: Optional[str] = None,
+    *,
+    force_stream: bool = False,
+) -> Any:
+    """Credit-aware wrapper over :func:`_create_with_progress_once`.
+
+    A 402 that names an affordable output budget ("can only afford N
+    tokens") is NOT terminal billing exhaustion — the account can pay for
+    the call at a lower ``max_tokens``. Retry ONCE with the provider-stated
+    cap (masoria debug bundle, Aug 2026: compression fell back to
+    OpenRouter, which defaulted the omitted cap to the model's full 65,536
+    window and 402'd three times in a row on an account that could afford
+    7,117 tokens — plenty for a summary). Only lowers, never raises, an
+    existing cap; anything else re-raises for the normal recovery chains.
+    """
+    try:
+        return _create_with_progress_once(
+            client, kwargs, task, force_stream=force_stream,
+        )
+    except Exception as exc:
+        affordable = _affordable_max_tokens_from_error(exc)
+        if affordable is None:
+            raise
+        existing_cap = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+        if isinstance(existing_cap, (int, float)) and 0 < existing_cap <= affordable:
+            # The request was already within the stated budget — the error
+            # is something else (e.g. prompt-side cost). Don't spin.
+            raise
+        retry_kwargs = dict(kwargs)
+        retry_kwargs.pop("max_tokens", None)
+        retry_kwargs.pop("max_completion_tokens", None)
+        retry_kwargs.update(
+            auxiliary_max_tokens_param(
+                affordable, model=str(kwargs.get("model") or "") or None,
+            )
+        )
+        logger.info(
+            "Auxiliary %s: credit-limited 402 (affordable=%d tokens); "
+            "retrying once with a clamped output cap instead of failing: %s",
+            task or "call", affordable, exc,
+        )
+        return _create_with_progress_once(
+            client, retry_kwargs, task, force_stream=force_stream,
+        )
+
+
+def _create_with_progress_once(
     client: Any,
     kwargs: Dict[str, Any],
     task: Optional[str] = None,

--- a/tests/agent/test_aux_affordable_402_retry.py
+++ b/tests/agent/test_aux_affordable_402_retry.py
@@ -1,0 +1,197 @@
+"""Credit-limited 402 handling: clamp to the affordable budget and retry.
+
+Regression tests for the masoria stall (Aug 2026): compression fell back to
+OpenRouter, which defaulted the omitted output cap to the model's full 65,536
+window and rejected with ``402 ... can only afford 7117`` — three times in a
+row — on an account whose balance easily covered a summary.
+
+Two coordinated fixes:
+
+1. ``_build_call_kwargs`` preserves an explicit ``max_tokens`` for OpenRouter
+   routes (salvage of PR #41055 by @liuhao1024, issue #41035).
+2. ``_create_with_progress`` retries ONCE with the provider-stated affordable
+   budget when a 402 names one (pattern proven in closed PR #49785 for the
+   main loop; this is the auxiliary-path equivalent).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import (
+    _affordable_max_tokens_from_error,
+    _build_call_kwargs,
+    _create_with_progress,
+)
+
+
+class _Payment402(Exception):
+    status_code = 402
+
+
+_OPENROUTER_402 = (
+    "Error code: 402 - {'error': {'message': 'This request requires more "
+    "credits, or fewer max_tokens. You requested up to 65536 tokens, but can "
+    "only afford 7117. To increase, visit https://openrouter.ai/settings/"
+    "credits and add more credits', 'code': 402}}"
+)
+
+
+class TestAffordableExtraction:
+    def test_extracts_budget_minus_margin(self):
+        assert _affordable_max_tokens_from_error(_Payment402(_OPENROUTER_402)) == 7117 - 64
+
+    def test_plain_exhaustion_returns_none(self):
+        err = _Payment402("Error code: 402 - insufficient funds")
+        assert _affordable_max_tokens_from_error(err) is None
+
+    def test_tiny_budget_treated_as_exhaustion(self):
+        err = _Payment402("You requested up to 65536 tokens, but can only afford 100.")
+        assert _affordable_max_tokens_from_error(err) is None
+
+    def test_non_payment_error_returns_none(self):
+        assert _affordable_max_tokens_from_error(TimeoutError(
+            "Codex auxiliary Responses stream stalled: no new output for 60.0s"
+        )) is None
+
+    def test_comma_grouped_count(self):
+        err = _Payment402("can only afford 12,345 tokens")
+        assert _affordable_max_tokens_from_error(err) == 12345 - 64
+
+
+class _FlakyClient:
+    """402s with the affordable message until max_tokens fits the budget."""
+
+    def __init__(self, affordable=7117):
+        self.calls = []
+        self._affordable = affordable
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+
+    def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        cap = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+        if cap is None or cap > self._affordable:
+            raise _Payment402(_OPENROUTER_402)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(role="assistant", content="summary"),
+                finish_reason="stop",
+            )],
+            model=kwargs.get("model"), usage=None,
+        )
+
+
+class TestCreateWithProgressAffordableRetry:
+    def test_uncapped_402_retries_once_with_affordable_cap(self):
+        client = _FlakyClient()
+        response = _create_with_progress(
+            client,
+            {"model": "google/gemini-3.6-flash",
+             "messages": [{"role": "user", "content": "summarize"}]},
+            "compression",
+        )
+        assert response.choices[0].message.content == "summary"
+        assert len(client.calls) == 2
+        assert client.calls[1]["max_tokens"] == 7117 - 64
+
+    def test_already_affordable_cap_does_not_spin(self):
+        """A 402 on a request already within budget re-raises immediately."""
+        client = _FlakyClient(affordable=100)  # everything 402s
+        with pytest.raises(_Payment402):
+            _create_with_progress(
+                client,
+                {"model": "m", "max_tokens": 5000,
+                 "messages": [{"role": "user", "content": "x"}]},
+                "compression",
+            )
+        # 5000 > 7053 is false → within stated budget → single attempt.
+        assert len(client.calls) == 1
+
+    def test_plain_exhaustion_402_is_not_retried(self):
+        class _Broke:
+            def __init__(self):
+                self.calls = []
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                self.calls.append(kwargs)
+                raise _Payment402("Error code: 402 - insufficient funds")
+
+        client = _Broke()
+        with pytest.raises(_Payment402):
+            _create_with_progress(
+                client,
+                {"model": "m", "messages": [{"role": "user", "content": "x"}]},
+                "compression",
+            )
+        assert len(client.calls) == 1
+
+    def test_retry_402_surfaces_without_spinning(self):
+        """If the clamped retry 402s again, it propagates (single retry)."""
+
+        class _Always402:
+            def __init__(self):
+                self.calls = []
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=self._create)
+                )
+
+            def _create(self, **kwargs):
+                self.calls.append(kwargs)
+                raise _Payment402(_OPENROUTER_402)
+
+        client = _Always402()
+        with pytest.raises(_Payment402):
+            _create_with_progress(
+                client,
+                {"model": "m", "messages": [{"role": "user", "content": "x"}]},
+                "compression",
+            )
+        assert len(client.calls) == 2
+
+
+class TestOpenRouterMaxTokensPreserved:
+    """Salvage of PR #41055 (@liuhao1024): OpenRouter keeps an explicit cap."""
+
+    def test_openrouter_provider_includes_max_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+        )
+        assert kwargs.get("max_tokens") == 2000 or kwargs.get("max_completion_tokens") == 2000
+
+    def test_openrouter_base_url_includes_max_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="google/gemini-3.6-flash",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert kwargs.get("max_tokens") == 2000 or kwargs.get("max_completion_tokens") == 2000
+
+    def test_generic_provider_still_omits_max_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+        )
+        assert "max_tokens" not in kwargs and "max_completion_tokens" not in kwargs
+
+    def test_none_max_tokens_never_included_for_openrouter(self):
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=None,
+        )
+        assert "max_tokens" not in kwargs and "max_completion_tokens" not in kwargs

--- a/tests/agent/test_auxiliary_openrouter_max_tokens.py
+++ b/tests/agent/test_auxiliary_openrouter_max_tokens.py
@@ -1,0 +1,72 @@
+"""Test that _build_call_kwargs preserves max_tokens for OpenRouter endpoints.
+
+Regression test for #41035: OpenRouter free-tier credits exhausted when
+max_tokens was stripped, causing HTTP 402 and fallback to text-only model.
+"""
+
+import pytest
+
+from agent.auxiliary_client import _build_call_kwargs
+
+
+class TestOpenRouterMaxTokens:
+    """max_tokens must be included for OpenRouter to prevent free-tier 402."""
+
+    def test_openrouter_provider_includes_max_tokens(self):
+        """Direct openrouter provider keeps max_tokens."""
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+        )
+        assert kwargs["max_tokens"] == 2000
+
+    def test_openrouter_base_url_includes_max_tokens(self):
+        """Custom endpoint with openrouter.ai base_url keeps max_tokens."""
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert kwargs["max_tokens"] == 2000
+
+    def test_generic_provider_omits_max_tokens(self):
+        """Generic OpenAI-compatible provider still omits max_tokens."""
+        kwargs = _build_call_kwargs(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=2000,
+        )
+        assert "max_tokens" not in kwargs
+
+    def test_anthropic_compat_still_includes_max_tokens(self):
+        """Anthropic-compatible endpoints still include max_tokens."""
+        kwargs = _build_call_kwargs(
+            provider="minimax",
+            model="MiniMax-Text-01",
+            messages=[{"role": "user", "content": "test"}],
+            max_tokens=4000,
+        )
+        assert kwargs["max_tokens"] == 4000
+
+    def test_none_max_tokens_never_included(self):
+        """max_tokens=None is never added regardless of provider."""
+        for provider, base_url in [
+            ("openrouter", None),
+            ("openai", "https://openrouter.ai/api/v1"),
+            ("minimax", None),
+        ]:
+            kwargs = _build_call_kwargs(
+                provider=provider,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=None,
+                base_url=base_url,
+            )
+            assert "max_tokens" not in kwargs, (
+                f"max_tokens should not be set when None for {provider}"
+            )

--- a/tests/agent/test_auxiliary_openrouter_max_tokens.py
+++ b/tests/agent/test_auxiliary_openrouter_max_tokens.py
@@ -20,7 +20,7 @@ class TestOpenRouterMaxTokens:
             messages=[{"role": "user", "content": "test"}],
             max_tokens=2000,
         )
-        assert kwargs["max_tokens"] == 2000
+        assert kwargs.get("max_tokens") == 2000 or kwargs.get("max_completion_tokens") == 2000
 
     def test_openrouter_base_url_includes_max_tokens(self):
         """Custom endpoint with openrouter.ai base_url keeps max_tokens."""
@@ -31,7 +31,7 @@ class TestOpenRouterMaxTokens:
             max_tokens=2000,
             base_url="https://openrouter.ai/api/v1",
         )
-        assert kwargs["max_tokens"] == 2000
+        assert kwargs.get("max_tokens") == 2000 or kwargs.get("max_completion_tokens") == 2000
 
     def test_generic_provider_omits_max_tokens(self):
         """Generic OpenAI-compatible provider still omits max_tokens."""


### PR DESCRIPTION
## Summary

Compression's OpenRouter fallback no longer dies on credit-limited 402s — when the provider says "can only afford N tokens", Hermes retries once with that budget instead of failing the summary. This closes the second leg of the masoria 20-minute "Summarizing thread" stall (Aug 31 2026 bundle): after each Codex timeout, the fallback to OpenRouter defaulted the omitted output cap to the model's full 65,536-token window and 402'd on an account that could afford 7,117 tokens — plenty for a summary. Three fallbacks, three 402s, zero summaries.

Salvages PR #41055 by @liuhao1024 (issue #41035; commit authorship preserved) and applies the affordable-clamp pattern from closed PR #49785 (@Perseus-Computing-LLC, main loop) to the auxiliary path.

## Changes

- `agent/auxiliary_client.py`:
  - `_create_with_progress` is now a credit-aware wrapper: a 402 naming an affordable budget retries ONCE with that cap (minus 64-token margin, 512-token usefulness floor). Plain-exhaustion 402s and 402s on already-within-budget requests re-raise unchanged. One funnel covers the primary, fallback, and credential-retry call sites.
  - `_build_call_kwargs` preserves an explicit `max_tokens` for OpenRouter routes (provider match + `openrouter.ai` base_url match) — salvaged from #41055, reapplied onto the current `auxiliary_max_tokens_param` gate. `max_tokens=None` still omits the param.
- Tests: `test_aux_affordable_402_retry.py` (12 tests: extraction, single-retry, no-spin guards, OpenRouter cap preservation) + the contributor's `test_auxiliary_openrouter_max_tokens.py` (5 tests, adapted to the max_completion_tokens-aware gate).

## Validation

| Scenario (real OpenAI SDK → mock OpenRouter enforcing 7,117-token budget → real `_create_with_progress`) | Before (main) | After |
|---|---|---|
| Compression fallback, no max_tokens (masoria shape) | `402 ... requested up to 65536 ... can only afford 7117` — summary fails | one clamped retry → summary returned |

- New tests: 17 passed; sibling suites `test_auxiliary_client.py` + `test_aux_progress_streaming.py` — 254 passed total
- `ruff check` clean

**Live repro:** A/B above, identical harness on origin/main vs this branch; main reproduces the exact 402 from the debug bundle.

## Infographic

![Pay what you can afford](https://v3b.fal.media/files/b/0aa89563/LKOnLFa0k-afOnamK6IyI_u7SgHbQI.png)
