### PR TITLE
fix(desktop): Windows remote connect fails closed on lockfile schema/ownership skew (#95532 parity)

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -16,7 +16,8 @@ import {
   psLiteral,
   reusableWindowsLock,
   terminateOwnedWindowsDashboardForUpdate,
-  validLock
+  validLock,
+  windowsLockSkewReason
 } from './windows-remote-lifecycle'
 
 const ownershipId = '0123456789abcdef0123456789abcdef'
@@ -258,6 +259,165 @@ test('Windows lock validation is scoped and exact', () => {
   // on it) but the reuse gate must reject it separately.
   assert.equal(validLock({ ...lock, port: 0 }, ownershipId), true)
   assert.equal(validLock({ ...lock, port: -1 }, ownershipId), false)
+})
+
+test('windowsLockSkewReason names the failing field, mirroring validLock condition order', () => {
+  const lock = {
+    schemaVersion: 2,
+    protocolVersion: 1,
+    ownershipId,
+    spawnNonce: '0123456789abcdef',
+    pid: 10,
+    creationTimeNs: '1784219690452757504',
+    port: 1234,
+    tokenFingerprint: 'a'.repeat(32),
+    hermesPath: 'C:\\h\\hermes.exe',
+    hermesHome: 'C:\\h'
+  }
+
+  assert.match(windowsLockSkewReason({ ...lock, schemaVersion: 99 }, ownershipId), /schema-version/)
+  assert.match(windowsLockSkewReason({ ...lock, protocolVersion: 99 }, ownershipId), /protocol-version/)
+  assert.equal(windowsLockSkewReason({ ...lock, ownershipId: 'b'.repeat(32) }, ownershipId), 'ownership-mismatch')
+  assert.equal(windowsLockSkewReason({ ...lock, pid: -1 }, ownershipId), 'malformed-pid')
+})
+
+test('Windows connect fails closed on a foreign ownershipId lockfile instead of removing it (#95532 parity)', async () => {
+  // A DIFFERENT desktop build's ownership record: same remote, wrong id.
+  // validLock() rejects it; pre-fix, the caller unconditionally removed it
+  // and spawned over the foreign build's state.
+  const foreignLock = {
+    schemaVersion: 2,
+    protocolVersion: 1,
+    ownershipId: 'f'.repeat(32),
+    spawnNonce: '0123456789abcdef',
+    pid: 10,
+    creationTimeNs: '1784219690452757504',
+    port: 1234,
+    profile: 'default',
+    tokenFingerprint: 'a'.repeat(32),
+    hermesPath: 'C:\\h\\hermes.exe',
+    hermesHome: 'C:\\h'
+  }
+
+  const operations: string[] = []
+
+  const ssh = sshWith(async command => {
+    const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    operations.push(script)
+
+    if (script.includes('Get-Command hermes.exe')) {
+      return JSON.stringify({
+        os: 'Windows',
+        arch: 'AMD64',
+        hermesHome: 'C:\\h',
+        hermesPath: 'C:\\h\\hermes.exe',
+        python: 'C:\\h\\python.exe'
+      })
+    }
+
+    if (script.includes('.hermes-update-in-progress')) {
+      return 'CLEAR'
+    }
+
+    if (script.includes("'inspect'")) {
+      return JSON.stringify({ supported: true, path: 'C:\\h\\hermes.exe', version: '1.0.0' })
+    }
+
+    if (script.includes("'read-lock'")) {
+      return JSON.stringify(foreignLock)
+    }
+
+    throw new Error(`unexpected command after lock read: ${script}`)
+  })
+
+  await assert.rejects(
+    () =>
+      connectWindowsRemote({
+        ssh,
+        ownershipId,
+        pickLocalPort: async () => 50000,
+        forward: async () => {},
+        cancelForward: async () => {},
+        waitForHermes: async () => {},
+        probeReuseProof: async () => 'authenticated-ok'
+      }),
+    (error: any) => error.kind === 'remote-lockfile-skew' && /ownership-mismatch/.test(error.message)
+  )
+
+  assert.equal(
+    operations.some(script => script.includes("'remove-lock'")),
+    false
+  )
+  assert.equal(
+    operations.some(script => script.includes("'write-lock'")),
+    false
+  )
+})
+
+test('Windows connect fails closed on an unknown lockfile schema version (a newer/forked build) instead of removing it', async () => {
+  const futureLock = {
+    schemaVersion: 999,
+    protocolVersion: 1,
+    ownershipId,
+    spawnNonce: '0123456789abcdef',
+    pid: 10,
+    creationTimeNs: '1784219690452757504',
+    port: 1234,
+    profile: 'default',
+    tokenFingerprint: 'a'.repeat(32),
+    hermesPath: 'C:\\h\\hermes.exe',
+    hermesHome: 'C:\\h'
+  }
+
+  const operations: string[] = []
+
+  const ssh = sshWith(async command => {
+    const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    operations.push(script)
+
+    if (script.includes('Get-Command hermes.exe')) {
+      return JSON.stringify({
+        os: 'Windows',
+        arch: 'AMD64',
+        hermesHome: 'C:\\h',
+        hermesPath: 'C:\\h\\hermes.exe',
+        python: 'C:\\h\\python.exe'
+      })
+    }
+
+    if (script.includes('.hermes-update-in-progress')) {
+      return 'CLEAR'
+    }
+
+    if (script.includes("'inspect'")) {
+      return JSON.stringify({ supported: true, path: 'C:\\h\\hermes.exe', version: '1.0.0' })
+    }
+
+    if (script.includes("'read-lock'")) {
+      return JSON.stringify(futureLock)
+    }
+
+    throw new Error(`unexpected command after lock read: ${script}`)
+  })
+
+  await assert.rejects(
+    () =>
+      connectWindowsRemote({
+        ssh,
+        ownershipId,
+        pickLocalPort: async () => 50000,
+        forward: async () => {},
+        cancelForward: async () => {},
+        waitForHermes: async () => {},
+        probeReuseProof: async () => 'authenticated-ok'
+      }),
+    (error: any) => error.kind === 'remote-lockfile-skew' && /schema-version/.test(error.message)
+  )
+
+  assert.equal(
+    operations.some(script => script.includes("'remove-lock'")),
+    false
+  )
 })
 
 test('Windows SSH reuse requires the requested remote profile to match the lock', () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -337,6 +337,54 @@ function validLock(lock, ownershipId) {
   )
 }
 
+// #95532 parity (POSIX fix: 3ee0c62224, remote-lifecycle.ts's lockfileSkew).
+// A lock read back from the remote that EXISTS but fails validLock() (wrong
+// schema/protocol version, foreign ownershipId, malformed shape) is skew --
+// most likely a different (e.g. forked) desktop build owns this remote, or
+// the file is corrupt -- not the same as "no lock". Only called once the
+// caller already knows validLock(lock, ownershipId) is false for a truthy
+// lock, so this never needs to re-check the happy path; it just names which
+// check failed, in validLock's own condition order, for the thrown error.
+function windowsLockSkewReason(lock, ownershipId) {
+  if (lock.schemaVersion !== LOCKFILE_SCHEMA_VERSION) {
+    return `schema-version ${JSON.stringify(lock.schemaVersion ?? null)}`
+  }
+
+  if (lock.protocolVersion !== PROTOCOL_VERSION) {
+    return `protocol-version ${JSON.stringify(lock.protocolVersion ?? null)}`
+  }
+
+  if (lock.ownershipId !== ownershipId) {
+    return 'ownership-mismatch'
+  }
+
+  if (!/^[0-9a-f]{16}$/.test(lock.spawnNonce || '')) {
+    return 'malformed-spawn-nonce'
+  }
+
+  if (!Number.isInteger(lock.pid) || lock.pid <= 0) {
+    return 'malformed-pid'
+  }
+
+  if (!/^[0-9]{10,20}$/.test(lock.creationTimeNs || '')) {
+    return 'malformed-creation-time'
+  }
+
+  if (!Number.isInteger(lock.port) || lock.port < 0 || lock.port > 65535) {
+    return 'malformed-port'
+  }
+
+  if (!/^[0-9a-f]{32}$/.test(lock.tokenFingerprint || '')) {
+    return 'malformed-token-fingerprint'
+  }
+
+  if (typeof lock.hermesPath !== 'string' || typeof lock.hermesHome !== 'string') {
+    return 'malformed-path-fields'
+  }
+
+  return 'unknown-mismatch'
+}
+
 function reusableWindowsLock(lock, state, profile, reuseToken, runtime) {
   return Boolean(
     state.alive &&
@@ -636,8 +684,20 @@ async function connectWindowsRemote(deps) {
       await cleanupOwned(ssh, runtime, ownershipId, lock)
     }
   } else if (lock) {
-    await assertWindowsRemoteInstallUpdateClear(ssh, runtime.hermesHome)
-    await helper(ssh, runtime, 'remove-lock', [ownershipId])
+    // #95532: the lockfile exists but was written by a different (fork)
+    // build or is corrupt. FAIL CLOSED: no reap, no removal, no overwrite,
+    // no spawn on top of foreign live state -- deleting it here is how a
+    // live tunnel some other build depends on gets killed (mirrors the
+    // POSIX-side fix in remote-lifecycle.ts).
+    const reason = windowsLockSkewReason(lock, ownershipId)
+    const error: any = new Error(
+      `The remote ownership record for this connection does not match this Hermes Desktop build (${reason}). ` +
+        'It was probably written by a different or modified desktop build sharing this remote, or the file is corrupt. ' +
+        'Refusing to remove or overwrite it -- that could kill a live SSH backend owned by another build. ' +
+        'If nothing else uses this remote, delete the remote lock file and reconnect.'
+    )
+    error.kind = 'remote-lockfile-skew'
+    throw error
   }
 
   assertBootstrapNotSuperseded(signal)
@@ -779,5 +839,6 @@ export {
   psLiteral,
   reusableWindowsLock,
   terminateOwnedWindowsDashboardForUpdate,
-  validLock
+  validLock,
+  windowsLockSkewReason
 }


### PR DESCRIPTION
## Problem

`connect()`/`disconnect()`/`cleanupStale()` in the POSIX-side `remote-lifecycle.ts` (`3ee0c62224`, #95532) learned that a `backend.lock.json` that EXISTS but doesn't match this build's own schema/ownership (unknown `schemaVersion`, foreign `ownershipId`, malformed shape) is "skew" — most likely a different (e.g. forked) desktop build owns this remote, or the file is corrupt — and is NOT the same as "no lockfile". Reaping/overwriting skew is how a live tunnel some other build depends on gets killed.

The Windows sibling, `connectWindowsRemote()` in `windows-remote-lifecycle.ts`, never got the same treatment. Its own `validLock(lock, ownershipId)` already computes the identical condition set (schema/protocol version, ownershipId, spawnNonce, pid, port, tokenFingerprint, path fields) and correctly returns `false` for a skewed lock — but the caller's fallback for that case was:

```js
} else if (lock) {
  await assertWindowsRemoteInstallUpdateClear(ssh, runtime.hermesHome)
  await helper(ssh, runtime, 'remove-lock', [ownershipId])
}
```

i.e. any lock that's truthy but fails `validLock()` gets unconditionally deleted, and execution falls through to spawning a fresh backend on top of it — the precise foreign-lock-deletion scenario #95532 eliminated on POSIX.

## Fix

Add `windowsLockSkewReason(lock, ownershipId)`, which walks `validLock`'s own condition order to name which check failed, and use it to build a descriptive `'remote-lockfile-skew'` error instead of removing the lock. Mirrors the POSIX fix's error kind and messaging.

## Testing

Added 3 regression tests to `windows-remote-lifecycle.test.ts`:
- `windowsLockSkewReason` names the failing field for a few representative mismatches
- a foreign-ownershipId lock makes `connectWindowsRemote()` reject with `kind: 'remote-lockfile-skew'` and never calls `remove-lock` or `write-lock`
- an unknown/future `schemaVersion` lock does the same

Mutation-verified: stashed `windows-remote-lifecycle.ts` only, confirmed all 3 new tests fail against the pre-fix code (the mocked `ssh.exec` throws on the unexpected `remove-lock` call the buggy branch issues); restored and confirmed all pass.

`npx tsc -p tsconfig.electron.json --noEmit`: clean.
Full `apps/desktop electron/` suite: 1908 passed, 6 pre-existing skips. Two failures are pre-existing and unrelated to this change (confirmed identical on unmodified `main` via `git stash`): `pidIsOurDashboard`'s real-process `ps` probe, and `managed-ssh-update`'s real-shell status code — both real-subprocess timing/environment flakes in different files, untouched by this diff.

## Scope note

Found but **not fixed here**: `atomicWindowsSpawnCommand()`'s embedded PowerShell reservation script (the atomic mkdir-mutex-protected spawn that closes the TOCTOU gap between this TS-side check and the actual remote spawn) does its own, independent read-lock + conditional remove-lock, and that check is weaker than `validLock()` — it only verifies the existing lock's pid is dead, never checking `ownershipId` or `schemaVersion` at all. This is the exact same bug class, one level deeper in the same call chain: a foreign lock could still be deleted by this embedded script even after this fix, in the TOCTOU window between the TS-side check and the atomic spawn.

I already have an open PR (#96167) fixing the identical class of gap on the POSIX side (`buildSpawnCommand()`'s shell reservation script), verified with a real-bash-execution regression test that extracts and runs the actual script block. I could not apply the same rigor here: this sandbox has no `pwsh`/`powershell` available, so I cannot dynamically execute or syntax-check a PowerShell edit to this deeply mutex-protected script the way #96167's tests do for bash — and an unverified syntax error in this exact script would be worse than the bug it fixes (it could break every Windows remote connect, not just the narrow foreign-lock case). Flagging for a dedicated follow-up with access to a real Windows/pwsh test environment, following #96167's verification pattern.

## Checklist

- [x] Mutation-verified each new test fails against the pre-fix code and passes with the fix.
- [x] Ran the full `apps/desktop electron/` suite; only pre-existing, unrelated flakes remain.
- [x] Fresh competitor-PR search turned up nothing open against this specific gap (my own #96167 covers the analogous POSIX-side reservation-script gap, not this one).