### PR TITLE
fix(checkpoints): skip the shared macOS temp root

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 import pytest
 from pathlib import Path
@@ -159,6 +160,33 @@ class TestTakeCheckpoint:
         # Never snapshot the filesystem root or the user's home.
         assert mgr.ensure_checkpoint("/", "root") is False
         assert mgr.ensure_checkpoint(str(Path.home()), "home") is False
+
+    @pytest.mark.macos_only
+    def test_shared_tmp_root_is_refused_without_checkpointing(self, mgr, monkeypatch):
+        attempts = []
+
+        def record_take(working_dir, reason):
+            attempts.append((working_dir, reason))
+            return True
+
+        monkeypatch.setattr(mgr, "_take", record_take)
+        shared_tmp = str(Path("/tmp").resolve())
+
+        assert mgr.ensure_checkpoint("/tmp", "symlink spelling") is False
+        mgr.new_turn()
+        assert mgr.ensure_checkpoint(shared_tmp, "canonical spelling") is False
+        assert attempts == []
+
+    @pytest.mark.macos_only
+    def test_workspace_under_shared_tmp_root_stays_checkpointable(self, mgr):
+        workspace = Path(tempfile.mkdtemp(prefix="hermes-checkpoint-test-", dir="/tmp"))
+        try:
+            assert workspace.resolve().parent == Path("/tmp").resolve()
+            (workspace / "payload.txt").write_text("owned by this test\n")
+
+            assert mgr.ensure_checkpoint(str(workspace), "nested workspace") is True
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
 
     def test_new_turn_resets_dedup_but_needs_changes(self, mgr, work_dir):
         assert mgr.ensure_checkpoint(str(work_dir), "turn 1") is True

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -911,8 +911,9 @@ class CheckpointManager:
 
         abs_dir = str(_normalize_path(working_dir))
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in {"/", str(Path.home())}:
+        # Skip root, home, the shared /tmp root, and other overly broad dirs.
+        # Resolve /tmp because it is /private/tmp on macOS; nested paths stay eligible.
+        if abs_dir in {"/", str(Path.home()), str(Path("/tmp").resolve())}:
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 


### PR DESCRIPTION
## What does this PR do?

A direct file write under `/tmp` can resolve to `/private/tmp` on macOS. When no project marker is found above the file, `CheckpointManager` receives that shared root and currently treats it as a workspace, allowing `_take` to run `git add -A` across unrelated temporary files.

This adds the canonical `/tmp` path to the existing exact-match broad-directory guard. Only the root is rejected; workspaces nested beneath it remain checkpointable.

## Related work

- #20627 attempted a similar guard using `tempfile.gettempdir()`, which does not necessarily identify `/tmp` on macOS.
- #99526 is a concurrent, broader proposal covering several temporary roots and home-path resolution. This PR is the minimal two-file alternative for the reproduced macOS `/tmp` failure.

## Type of change

- [x] Bug fix
- [x] Tests

## Changes made

- Refuse both `/tmp` and its canonical macOS spelling, `/private/tmp`, before checkpoint creation.
- Preserve checkpointing for real workspaces nested below the shared root.
- Add macOS regression coverage that stubs `_take` for the unsafe root and exercises a real checkpoint in a test-owned nested workspace.

## How to test

```bash
scripts/run_tests.sh \
  tests/tools/test_checkpoint_manager.py \
  tests/agent/test_tool_executor_checkpoint_paths.py \
  -q
```

Result on macOS: 56 passed, 0 failed.

## Checklist

- [x] I read the contributing guide.
- [x] The commit follows Conventional Commits.
- [x] I searched existing issues and pull requests; the overlapping broader proposal is disclosed above.
- [x] The diff contains only this fix and its focused tests.
- [x] I added regression coverage and ran the repository's canonical test wrapper.
- [x] Tested on macOS.
- [x] Cross-platform impact considered; the new runtime comparison uses the same canonical `Path.resolve()` form as the input path.
- [x] Documentation, configuration, architecture, and tool-schema updates are not required for this focused guard correction.
