### PR TITLE
fix(cron): guard 2 orphaned schedule=None crash sites left behind by a jobs.py refactor

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3020,6 +3020,17 @@ def _mark_job_run_locked(
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                # Malformed "schedule" (direct jobs.json edit, old writers,
+                # corruption): job.get("schedule", {}) only falls back to {}
+                # when the key is ABSENT, not when it's present with value
+                # None, so a null schedule still reaches .get("kind") below
+                # and raises AttributeError, aborting mark_job_run() before
+                # save_jobs() -- the exact failure _get_due_jobs_locked
+                # already guards against at scan time. Repair here too so a
+                # completion for a job whose schedule got corrupted between
+                # the scan and this call doesn't crash instead of persisting.
+                if not isinstance(job.get("schedule"), dict):
+                    job["schedule"] = {}
                 if expected_fire_owner is not None:
                     claim = job.get("fire_claim")
                     if not isinstance(claim, dict) or claim.get("by") != expected_fire_owner:
@@ -3490,6 +3501,13 @@ def _claim_job_for_fire_locked(
         for job in jobs:
             if job["id"] != job_id:
                 continue
+            # Same malformed-"schedule" repair as _mark_job_run_locked /
+            # _get_due_jobs_locked: job.get("schedule", {}) only falls back
+            # to {} when the key is absent, not when it's present with value
+            # None, so a null schedule still reaches .get("kind") below and
+            # raises AttributeError before save_jobs() persists the claim.
+            if not isinstance(job.get("schedule"), dict):
+                job["schedule"] = {}
             if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 return False
             # enabled + pause markers must both clear — a half-paused record

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -868,6 +868,57 @@ class TestGetDueJobs:
         assert any(d.get("id") == healthy["id"] for d in due)
 
 
+    def test_mark_job_run_with_null_schedule_does_not_crash(self, tmp_cron_dir):
+        """A job whose "schedule" is present but null (direct jobs.json edit,
+        corruption) must not crash mark_job_run().
+
+        _get_due_jobs_locked() already repairs a malformed schedule before
+        scanning (test_idless_job_does_not_crash_or_block_sibling_jobs's
+        sibling coverage), but mark_job_run()/_mark_job_run_locked() reads
+        load_jobs() fresh and indexes "schedule" raw: job.get("schedule", {})
+        only substitutes {} when the key is ABSENT, not when it's present
+        with value None, so a null schedule still reached .get("kind") and
+        raised AttributeError -- aborting the completion write entirely, so
+        the run's last_status/last_error/next_run_at were never persisted.
+        """
+        save_jobs([{
+            "id": "null-schedule-job",
+            "name": "Corrupted schedule",
+            "prompt": "does not matter",
+            "schedule": None,
+            "enabled": True,
+            "no_agent": True,
+        }])
+
+        # Must not raise AttributeError: 'NoneType' object has no attribute 'get'.
+        assert mark_job_run("null-schedule-job", True) is True
+
+        updated = get_job("null-schedule-job")
+        assert updated["last_status"] == "ok"
+        assert updated["schedule"] == {}
+
+    def test_claim_job_for_fire_with_null_schedule_does_not_crash(self, tmp_cron_dir):
+        """Same null-"schedule" corruption as mark_job_run, for the external
+        fire-claim path: claim_job_for_fire()/_claim_job_for_fire_locked()
+        also reads job.get("schedule", {}).get("kind") raw and crashed
+        before persisting the claim."""
+        save_jobs([{
+            "id": "null-schedule-fire-job",
+            "name": "Corrupted schedule",
+            "prompt": "does not matter",
+            "schedule": None,
+            "enabled": True,
+            "no_agent": True,
+        }])
+
+        # Must not raise AttributeError: 'NoneType' object has no attribute 'get'.
+        assert claim_job_for_fire("null-schedule-fire-job") is True
+
+        updated = get_job("null-schedule-fire-job")
+        assert updated["fire_claim"] is not None
+        assert updated["schedule"] == {}
+
+
     def test_long_execution_does_not_perpetually_defer(self, tmp_cron_dir, monkeypatch):
         """#33315: a recurring job whose runtime exceeds interval+grace must still
         run once when the tick comes back, not skip forever.


### PR DESCRIPTION
## Problem

The recurring "non-dict schedule crashes N direct-call sites" class (the due-scan's own repair in `_get_due_jobs_locked` only protects the periodic tick, not every direct caller) has two open PRs against it: #61758 (6 sites, opened 2026-07-10) and #96723 (3 sites: `rearm_oneshot`, `heartbeat_run_claim`, `clear_run_claim`, my own open PR).

`_mark_job_run_locked()` and `_claim_job_for_fire_locked()` are orphaned by this class fix: commit `acaafcc6bb` ("make immediate execution race-safe", 2026-08-14) split the old inline `mark_job_run()`/`claim_job_for_fire()` bodies into thin public wrappers + these two `_locked` helpers, and #61758's patch (opened before that refactor) still targets the OLD function signatures — its hunks for `def mark_job_run(job_id: str, success: bool, error...)` and `def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300)` don't match what's on `main` anymore. Verified: PR #61758's base commit predates `acaafcc6bb` via `git merge-base --is-ancestor`. #96723 targets three different functions entirely.

Both `_mark_job_run_locked` (`job.get("schedule", {}).get("kind")`, two occurrences) and `_claim_job_for_fire_locked` (same pattern once, plus `job["schedule"]` passed to `compute_next_run` — already null-safe there) read `load_jobs()` fresh and index `"schedule"` raw. `job.get("schedule", {})` only substitutes `{}` when the key is **absent**, not when it's present with value `None`, so a job whose schedule got corrupted (direct `jobs.json` edit, old writer, crash mid-write) after the last due-scan crashes `mark_job_run()`/`claim_job_for_fire()` with `AttributeError` before `save_jobs()` persists anything — the run's `last_status`/`last_error`/`next_run_at`, or the external fire-claim, is silently dropped.

## Fix

Mirror `_get_due_jobs_locked`'s own established repair idiom (`if not isinstance(job.get("schedule"), dict): job["schedule"] = {}`) at the top of the matched-job branch in both functions, before any `"schedule"` access.

## Testing

Added 2 regression tests to `tests/cron/test_jobs.py`: `test_mark_job_run_with_null_schedule_does_not_crash` and `test_claim_job_for_fire_with_null_schedule_does_not_crash` — each saves a job record with `"schedule": None` directly (bypassing `create_job`, same as the existing `test_idless_job_does_not_crash_or_block_sibling_jobs` convention for a different corruption shape) and calls the public `mark_job_run()`/`claim_job_for_fire()` wrapper.

Mutation-verified: stashed `cron/jobs.py` only, confirmed both new tests fail against the pre-fix code with the exact `AttributeError` (`'NoneType' object has no attribute 'get'`) at the `.get("kind")` call; restored and confirmed both pass.

```
tests/cron/ (full directory): 1083 passed, 1 skipped.
```

## Checklist

- [x] Mutation-verified both new tests fail against the pre-fix code and pass with the fix.
- [x] Ran the full `tests/cron/` suite — no regressions.
- [x] Verified via `git merge-base --is-ancestor` (not just "looks old") that #61758's patch predates the refactor that split these two functions out — its hunks target function signatures that no longer exist in this shape.
- [x] Fresh competitor-PR search turned up nothing else open against these two specific sites.