### PR TITLE
fix(dashboard): touch-scroll the chat transcript on mobile browsers

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -222,6 +222,23 @@ code { font-size: 0.875rem; }
   display: none;
 }
 
+/* Touch devices: the xterm transcript scrollbar is the only native scroll
+   affordance and its default width is nearly impossible to grab with a
+   finger. Fatten it (and give the thumb visible contrast) on coarse
+   pointers; desktop styling is untouched. */
+@media (pointer: coarse) {
+  .xterm .xterm-viewport {
+    scrollbar-width: auto;
+  }
+  .xterm .xterm-viewport::-webkit-scrollbar {
+    width: 16px;
+  }
+  .xterm .xterm-viewport::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, currentColor 35%, transparent);
+    border-radius: 8px;
+  }
+}
+
 /* System UI-monospace stack — distinct from `font-courier` (Courier
    Prime), used for dense data readouts where the display font would
    break the grid. Routes through the theme's mono stack so themes

--- a/web/src/lib/pty-touch-scroll.test.ts
+++ b/web/src/lib/pty-touch-scroll.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  attachTouchScroll,
+  TOUCH_SCROLL_SLOP_PX,
+  type TouchScrollTerminal,
+} from "./pty-touch-scroll";
+
+function makeTerm(): TouchScrollTerminal & {
+  scrollLines: ReturnType<typeof vi.fn<(amount: number) => void>>;
+} {
+  return {
+    rows: 24,
+    element: undefined, // unmeasurable → fallback cell height 18
+    scrollLines: vi.fn<(amount: number) => void>(),
+  };
+}
+
+function touch(type: string, ys: number[]): Event {
+  const ev = new Event(type, { cancelable: true });
+  Object.defineProperty(ev, "touches", {
+    value: ys.map((clientY) => ({ clientY })),
+  });
+  return ev;
+}
+
+describe("attachTouchScroll", () => {
+  it("scrolls down when the finger moves up past the slop threshold", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [200]));
+    host.dispatchEvent(touch("touchmove", [150])); // 50px up → 2 lines at 18px fallback
+
+    expect(term.scrollLines).toHaveBeenCalledExactlyOnceWith(2);
+  });
+
+  it("scrolls up when the finger moves down", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [100]));
+    host.dispatchEvent(touch("touchmove", [150])); // 50px down
+
+    expect(term.scrollLines).toHaveBeenCalledExactlyOnceWith(-2);
+  });
+
+  it("ignores movement below the slop threshold so taps still focus", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [100]));
+    host.dispatchEvent(touch("touchmove", [100 - (TOUCH_SCROLL_SLOP_PX - 1)]));
+    host.dispatchEvent(touch("touchend", []));
+
+    expect(term.scrollLines).not.toHaveBeenCalled();
+  });
+
+  it("accumulates sub-cell drags across move events (no lost remainder)", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [200]));
+    // 8px slop activates, then four 6px drags: 8+6+6+6+6=32px → 1 line (18px)
+    host.dispatchEvent(touch("touchmove", [192]));
+    host.dispatchEvent(touch("touchmove", [186]));
+    host.dispatchEvent(touch("touchmove", [180]));
+    host.dispatchEvent(touch("touchmove", [174]));
+
+    expect(term.scrollLines).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it("ignores multi-touch gestures", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [200, 300]));
+    host.dispatchEvent(touch("touchmove", [100, 200]));
+
+    expect(term.scrollLines).not.toHaveBeenCalled();
+  });
+
+  it("preventDefaults active drags (blocks rubber-banding / pull-to-refresh)", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    attachTouchScroll(host, term);
+
+    host.dispatchEvent(touch("touchstart", [200]));
+    const move = touch("touchmove", [150]);
+    host.dispatchEvent(move);
+
+    expect(move.defaultPrevented).toBe(true);
+  });
+
+  it("stops scrolling after cleanup", () => {
+    const host = new EventTarget();
+    const term = makeTerm();
+    const detach = attachTouchScroll(host, term);
+
+    detach();
+    host.dispatchEvent(touch("touchstart", [200]));
+    host.dispatchEvent(touch("touchmove", [100]));
+
+    expect(term.scrollLines).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/pty-touch-scroll.ts
+++ b/web/src/lib/pty-touch-scroll.ts
@@ -1,0 +1,100 @@
+/**
+ * Touch scrolling for the embedded xterm.js chat transcript.
+ *
+ * xterm.js has no built-in touch scrolling: its viewport only reacts to
+ * wheel events and scrollbar drags, so on phones/tablets the transcript
+ * cannot be swiped and the thin overlay scrollbar is nearly impossible to
+ * grab with a finger. This mirrors the dashboard's wheel handler — vertical
+ * one-finger drags become scrollLines() on the browser-side transcript and
+ * are never turned into PTY mouse-protocol bytes.
+ *
+ * Returns a cleanup function that detaches all listeners.
+ */
+
+/** Minimal terminal surface this helper needs (keeps it unit-testable). */
+export interface TouchScrollTerminal {
+  readonly rows: number;
+  /** Live terminal element; used to measure the rendered cell height. */
+  readonly element: HTMLElement | undefined;
+  scrollLines(amount: number): void;
+}
+
+/** Movement (px) below which a touch is still a tap, not a scroll. */
+export const TOUCH_SCROLL_SLOP_PX = 8;
+
+/** Fallback cell height when the rows element is not measurable yet. */
+const FALLBACK_CELL_HEIGHT_PX = 18;
+
+interface TouchLike {
+  readonly clientY: number;
+}
+
+interface TouchEventLike {
+  readonly touches: ArrayLike<TouchLike>;
+  preventDefault(): void;
+}
+
+export function attachTouchScroll(
+  host: EventTarget,
+  term: TouchScrollTerminal,
+): () => void {
+  const state = { active: false, lastY: 0, carryPx: 0 };
+
+  const cellHeightPx = () => {
+    const rows = term.element?.querySelector(".xterm-rows");
+    return rows && term.rows > 0
+      ? rows.clientHeight / term.rows
+      : FALLBACK_CELL_HEIGHT_PX;
+  };
+
+  const onTouchStart = (ev: Event) => {
+    const touches = (ev as unknown as TouchEventLike).touches;
+    if (!touches || touches.length !== 1) {
+      state.active = false;
+      return;
+    }
+    state.lastY = touches[0].clientY;
+    state.carryPx = 0;
+  };
+
+  const onTouchMove = (ev: Event) => {
+    const tev = ev as unknown as TouchEventLike;
+    if (!tev.touches || tev.touches.length !== 1) return;
+    const y = tev.touches[0].clientY;
+    const dyPx = state.lastY - y; // finger up => scroll down
+    if (!state.active) {
+      // Stay below the slop threshold so taps still focus the terminal (and
+      // bring up the soft keyboard) instead of becoming scrolls.
+      if (Math.abs(dyPx) < TOUCH_SCROLL_SLOP_PX) return;
+      state.active = true;
+    }
+    state.lastY = y;
+    const cell = cellHeightPx();
+    state.carryPx += dyPx;
+    const lines = Math.trunc(state.carryPx / cell);
+    if (lines !== 0) {
+      state.carryPx -= lines * cell;
+      term.scrollLines(lines);
+    }
+    // Block rubber-banding / pull-to-refresh while the transcript is being
+    // dragged. Requires passive: false on the listener.
+    tev.preventDefault();
+  };
+
+  const onTouchEnd = () => {
+    state.active = false;
+    state.carryPx = 0;
+  };
+
+  host.addEventListener("touchstart", onTouchStart, { passive: true });
+  host.addEventListener("touchmove", onTouchMove, { passive: false });
+  host.addEventListener("touchend", onTouchEnd, { passive: true });
+  host.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+  return () => {
+    host.removeEventListener("touchstart", onTouchStart);
+    host.removeEventListener("touchmove", onTouchMove);
+    host.removeEventListener("touchend", onTouchEnd);
+    host.removeEventListener("touchcancel", onTouchEnd);
+  };
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -61,6 +61,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { attachTouchScroll } from "@/lib/pty-touch-scroll";
 import { computeKeyboardInset, shouldPinScroll } from "@/lib/keyboard-inset";
 import {
   resolvePtyKeyboardShortcut,
@@ -808,6 +809,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return false;
     });
 
+    // Touch scrolling (mobile) — see lib/pty-touch-scroll.ts. xterm.js has
+    // no built-in touch scrolling, so on phones the transcript cannot be
+    // swiped; this converts one-finger vertical drags into scrollLines() on
+    // the browser-side transcript, mirroring the wheel handler above.
+    const detachTouchScroll = attachTouchScroll(host, term);
+
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
     term.unicode.activeVersion = "11";
@@ -1512,6 +1519,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);
+      detachTouchScroll();
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       keyboardInsetSyncRef.current = null;


### PR DESCRIPTION
## What does this PR do?

The dashboard chat tab is an xterm.js terminal, and xterm.js has no built-in touch scrolling: its viewport only reacts to wheel events and scrollbar drags. **On a phone, swiping the conversation does nothing at all** — the only way to scroll back through the transcript is dragging xterm's thin overlay scrollbar, which is nearly impossible to grab with a finger.

This PR mirrors the dashboard's existing custom wheel handler for touch input: vertical one-finger drags become `term.scrollLines()` on the browser-side transcript, and are never turned into PTY mouse-protocol bytes. It also fattens the transcript scrollbar to 16px on coarse pointers so the fallback stays usable.

## Related Issue

No existing issue found — searched open/closed PRs and issues for "touch scroll" / "mobile scroll" before implementing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/pty-touch-scroll.ts` (new) — `attachTouchScroll(host, term)` helper:
  - 8px slop threshold so taps still focus the terminal (and open the soft keyboard) instead of becoming scrolls
  - sub-cell drags accumulate (`carryPx`) so slow swipes still scroll whole lines
  - `preventDefault()` on active drags blocks rubber-banding / pull-to-refresh (listener is `passive: false`)
  - single-finger only; multi-touch gestures are ignored
  - cell height measured from the live `.xterm-rows` element (18px fallback)
- `web/src/lib/pty-touch-scroll.test.ts` (new) — 7 unit tests: direction, slop threshold, remainder accumulation, multi-touch ignore, preventDefault, cleanup detaches listeners
- `web/src/pages/ChatPage.tsx` — wire `attachTouchScroll(host, term)` next to the wheel handler; detach in the effect cleanup
- `web/src/index.css` — `@media (pointer: coarse)`: `.xterm-viewport` scrollbar 16px wide with a visible thumb; desktop styling untouched

## How to Test

1. `cd web && npx vitest run src/lib/pty-touch-scroll.test.ts` → 7/7 pass (full suite: 288/288)
2. `npm run typecheck` clean; `npx eslint` on touched files: 0 errors, no new warnings
3. Manual: open the dashboard on a phone (or Chrome DevTools device emulation), start a chat with enough history to overflow, then:
   - swipe up/down on the conversation → transcript scrolls
   - tap the terminal → focuses and opens the soft keyboard (not hijacked by scrolling)
   - the right-hand scrollbar is visibly wider and draggable

Verified on a real device (Android 17, Chrome 135 / MiuiBrowser) against a self-hosted dashboard.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the web test suite (`npx vitest run` — 38 files, 288 tests, all pass) and all tests pass
- [x] I've added tests for my changes
