### PR TITLE
fix(gateway): the estop/pause gate must not read a reaped session's stale turn slot as in-flight work

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -214,6 +214,12 @@ class GatewayInboundMixin:
             _estop_state = self._peek_session_state(_estop_key)
             if _estop_state is not None and _estop_state.persistent.update_prompt_pending:
                 return True
+            # #99106 parity: a session already ended in state.db (ws_orphan_reap/agent_close) keeps
+            # its in-memory turn slot alive, so the running-session check below would otherwise read
+            # a dead runtime as "in-flight work" and let a paused gateway process a real turn for it.
+            # Evict first (idempotent, cheap no-op if already evicted or genuinely live) so the check
+            # that follows sees the true state.
+            self._hm_evict_reaped_agent(_estop_key)
             # A running session covers steering plus pending clarify / tool approvals it holds.
             if self._is_session_running(_estop_key):
                 return True
@@ -1191,7 +1197,11 @@ class GatewayInboundMixin:
         if _reply is not None:
             return _reply
 
-        # Evict a leaked/reaped ``_running_agents`` slot before the busy-session fast-path.
+        # Evict a leaked/reaped ``_running_agents`` slot before the busy-session fast-path. Also
+        # called earlier, on ``_estop_key``, from the pause gate's ``_hm_estop_turn_allowed`` (same
+        # key for the same ``source`` — see ``_session_key_for_source``) so a reaped slot can't be
+        # read as "in-flight work" and bypass a global pause. Idempotent: if that earlier call
+        # already evicted this slot, this is a cheap no-op.
         self._hm_evict_idle_stale_agent(_quick_key)
         if self._is_session_running(_quick_key):
             self._hm_evict_reaped_agent(_quick_key)

--- a/tests/gateway/test_reaped_session_recovery.py
+++ b/tests/gateway/test_reaped_session_recovery.py
@@ -144,6 +144,93 @@ async def test_reaped_session_message_reaches_cold_path(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_reaped_session_does_not_bypass_global_pause(tmp_path):
+    """A reaped session's stale turn slot must not be read as "in-flight
+    work" by the estop/pause gate.
+
+    Before the fix, the pause gate's own _is_session_running(key) check
+    (inside _hm_estop_turn_allowed) ran BEFORE the #99106 durable-reaped
+    guard (which only ran later in _handle_message, after the gate had
+    already returned). A session ended in state.db while its in-memory slot
+    stayed alive made the gate treat it as a live "steering" turn and let
+    the message through -- reaching the cold path and getting a REAL agent
+    reply -- despite the gateway being globally paused.
+    """
+    store = _store(tmp_path)
+    src = _source(chat_id="555004")
+    entry = store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+
+    runner = _make_runner(store)
+    agent = _DeadReapedAgent()
+    _occupy_turn_slot(runner, key, agent)
+
+    # The durable row is ended out from under the live slot (the reap).
+    store._db.end_session(entry.session_id, "ws_orphan_reap")
+    assert store._is_session_ended_in_db(entry.session_id) is True
+
+    event = MessageEvent(
+        text="hello, are you there?",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+
+    cold_path = AsyncMock(return_value="COLD_PATH_REPLY")
+    with (
+        patch("agent.estop.paused_reply", return_value="⏸️ Hermes is paused."),
+        patch.object(GatewayRunner, "_handle_message_with_agent", cold_path),
+        patch.object(GatewayRunner, "_run_post_turn_hooks", AsyncMock()),
+        patch.object(GatewayRunner, "_clear_durable_active_turn", AsyncMock()),
+        patch.object(GatewayRunner, "_persist_active_agents", lambda self: None),
+    ):
+        result = await runner._handle_message(event)
+
+    # The pause notice must win -- the reaped slot must not count as
+    # "in-flight work" the pause gate is supposed to let through.
+    assert result == "⏸️ Hermes is paused."
+    assert cold_path.await_count == 0
+    assert agent.interrupts == []
+
+
+@pytest.mark.asyncio
+async def test_alive_session_still_steers_through_global_pause(tmp_path):
+    """Control: a GENUINELY live (not reaped) session must still be allowed
+    through a global pause to steer/interrupt its in-flight turn -- the
+    #99106 guard must only evict provably-reaped slots, never a real one."""
+    store = _store(tmp_path)
+    src = _source(chat_id="555005")
+    store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+
+    runner = _make_runner(store)
+    agent = _DeadReapedAgent()
+    _occupy_turn_slot(runner, key, agent)
+
+    event = MessageEvent(
+        text="steer while paused",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+
+    cold_path = AsyncMock(return_value="COLD_PATH_REPLY")
+    with (
+        patch("agent.estop.paused_reply", return_value="⏸️ Hermes is paused."),
+        patch.object(GatewayRunner, "_handle_message_with_agent", cold_path),
+        patch.object(GatewayRunner, "_agent_has_active_subagents", lambda self, a: False),
+        patch.object(
+            GatewayRunner,
+            "_session_has_compression_in_flight",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        result = await runner._handle_message(event)
+
+    assert result is None
+    assert cold_path.await_count == 0
+    assert agent.interrupts == ["steer while paused"]
+
+
+@pytest.mark.asyncio
 async def test_alive_session_keeps_priority_interrupt_path(tmp_path):
     """Control: with the durable row still open, the PRIORITY interrupt
     fast-path must behave exactly as before (no eviction)."""


### PR DESCRIPTION
## Problem

#99531 (merged today, salvage of #99183) taught `_handle_message()` to evict a session's in-memory turn slot when its durable routing row was already ended in state.db (`ws_orphan_reap`/`agent_close`) while the gateway process stayed alive — otherwise `_is_session_running()` keeps reading `True` for a runtime that's actually dead, and the next message gets `interrupt()`-delivered into nothing instead of healing through `get_or_create_session`.

That guard runs too late to protect one caller of `_is_session_running()`: the global emergency-stop (estop/pause) gate, a few hundred lines earlier in the same function. Its own "steering in-flight work" exception —

```python
if not _estop_allow and self._is_session_running(_estop_key):
    _estop_allow = True
```

— exists so a paused gateway still lets a user interrupt/steer a turn that's genuinely running. But it reads the exact same stale `_is_session_running()` the #99531 guard was written to distrust, and the #99531 guard itself doesn't run until later, after the gate has already decided. A session reaped while the gateway is paused (or reaped shortly before `/pause` is issued — exactly the incident-response window an operator would run `/pause` in) makes the gate treat a dead runtime as "in-flight work", bypass the pause, and let the message reach a real cold-path turn — the opposite of what `/pause` promises.

## Fix

Extract the #99531 guard's body into a new method, `_evict_if_durably_reaped` (idempotent: a second call for an already-evicted key, or a stubbed `session_store`, is a cheap no-op). Call it from the estop gate, on `_estop_key`, right before the gate's own `_is_session_running()` check — `_estop_key` and the function's later `_quick_key` are the same value for the same message (both `_session_key_for_source(source)`), so evicting early here means the guard's original call site later in the function naturally becomes a no-op for the same session, with no behavior change there.

## Testing

Added 2 regression tests to `tests/gateway/test_reaped_session_recovery.py`, reusing its existing `GatewayRunner`+`SessionStore` harness:

- `test_reaped_session_does_not_bypass_global_pause`: a session ended in state.db via `ws_orphan_reap`, live turn slot, gateway paused (`agent.estop.paused_reply` mocked to return a notice) — the pause notice must win; the mocked cold-path handler must never be called.
- `test_alive_session_still_steers_through_global_pause`: a GENUINELY live session (not reaped) must still steer through a global pause via `interrupt()` — the fix must not touch the legitimate exception, only the reaped-session false positive.

Mutation-verified: stashed `gateway/run.py` only, confirmed `test_reaped_session_does_not_bypass_global_pause` fails against the pre-fix code — result was `'COLD_PATH_REPLY'` (a real agent reply) instead of the pause notice, with the pre-fix guard's own log line showing it fired AFTER the estop gate had already let the message through; the control test (genuinely alive session) passed even pre-fix, confirming it isolates the right behavior. Restored and confirmed both new tests pass, plus the 3 pre-existing tests in the same file (unaffected by the refactor into `_evict_if_durably_reaped`).

```
tests/test_estop.py + tests/gateway/test_reaped_session_recovery.py: 30 passed.
Full tests/gateway/ suite: 7237 passed, 14 pre-existing failures confirmed
unrelated (spread across discord_send, scale_to_zero, systemd_notify,
wecom_callback, teams_dotenv_isolation, and others -- none touch
_handle_message, _is_session_running, agent.estop, or the new method;
reproduced identically with gateway/run.py stashed).
```

## Checklist

- [x] Mutation-verified: the bug is dynamically reproduced (not just read from source) and the fix's regression test fails/passes exactly as expected.
- [x] Ran the full `tests/gateway/` suite (7237 tests); all 14 failures confirmed pre-existing/unrelated via `git stash`.
- [x] Fresh competitor-PR search for this specific estop/reaped-session interaction turned up nothing open.

## Update (rebased)

Rewritten onto current `upstream/main` after the 2026-09-04 whole-codebase-simplification merge (#102117), which moved this logic from `gateway/run.py` into `gateway/run_inbound.py` (`_evict_if_durably_reaped` → `_hm_evict_reaped_agent`, `_handle_message`'s inline estop check → `_hm_estop_gate`/`_hm_estop_turn_allowed`). Re-verified the bug empirically still live on current `main` before writing the fix: the eviction guard had exactly one call site (inside `_handle_message`, after the pause gate), so `_hm_estop_turn_allowed()`'s `_is_session_running()` check still read a reaped session's stale slot as in-flight work. Same root cause, same fix shape (call the existing idempotent eviction helper one step earlier), same 2 regression tests, mutation-verified again on the new file layout — reverting the fix makes `test_reaped_session_does_not_bypass_global_pause` fail with the exact predicted symptom (`COLD_PATH_REPLY` instead of the pause notice); the control test correctly passes either way. Full `tests/gateway/test_reaped_session_recovery.py` (5) + `tests/test_estop.py` (targeted) green on the rewritten branch.
