### PR TITLE
fix(cli): honor every explicitly named id in /skills and /memory approve/reject

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -39,7 +39,7 @@ def _fmt_pending_list(subsystem: str) -> str:
         origin = r.get("origin", "foreground")
         tag = " [auto]" if origin == "background_review" else ""
         lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}")
-    where = "/{s} approve <id>".format(s=subsystem)
+    where = "/{s} approve <id...>".format(s=subsystem)
     lines.append("")
     lines.append(f"Apply: {where}   Reject: /{subsystem} reject <id>")
     if subsystem == wa.SKILLS:
@@ -99,31 +99,56 @@ def handle_pending_subcommand(
     return None  # not ours — caller handles
 
 
-def _resolve_one(subsystem: str, rest: List[str]):
+def _resolve_targets(subsystem: str, rest: List[str]):
+    """Resolve the tokens after approve/reject into target ids.
+
+    One or more explicit ids are all honored; the literal keyword ``all``
+    expands to every pending id. Tokens after the first used to be silently
+    dropped (#99704), so ``approve id1 id2`` only applied ``id1``.
+    """
     if not rest:
-        return None, f"Usage: /{subsystem} approve|reject <id>  (or 'all')"
-    return rest[0], None
+        return None, f"Usage: /{subsystem} approve|reject <id...>  (or 'all')"
+    return rest, None
+
+
+def _expand_targets(subsystem: str, targets: List[str], records: List[dict]):
+    """Map id tokens (or 'all') to pending records, de-duplicated in order.
+
+    Unknown ids are collected separately so the caller can report them
+    per-id instead of silently skipping them.
+    """
+    resolved, unknown, seen = [], [], set()
+    for target in targets:
+        if target.lower() == "all":
+            candidates = records
+        else:
+            rec = wa.get_pending(subsystem, target)
+            if not rec:
+                unknown.append(target)
+                continue
+            candidates = [rec]
+        for rec in candidates:
+            if rec["id"] not in seen:
+                seen.add(rec["id"])
+                resolved.append(rec)
+    return resolved, unknown
 
 
 def _approve(subsystem: str, rest: List[str], memory_store) -> str:
-    target, err = _resolve_one(subsystem, rest)
-    if err or target is None:
-        return err or f"Usage: /{subsystem} approve <id>"
+    targets, err = _resolve_targets(subsystem, rest)
+    if err or not targets:
+        return err or f"Usage: /{subsystem} approve <id...>"
 
     records = wa.list_pending(subsystem)
     if not records:
         return f"No pending {subsystem} writes."
 
-    if target.lower() == "all":
-        targets = list(records)
-    else:
-        rec = wa.get_pending(subsystem, target)
-        if not rec:
-            return f"No pending {subsystem} write with id '{target}'."
-        targets = [rec]
+    resolved, unknown = _expand_targets(subsystem, targets, records)
 
-    applied, failed = 0, []
-    for rec in targets:
+    applied, failed = 0, [
+        f"{t}: no pending {subsystem} write with this id" for t in unknown
+    ]
+    for rec in resolved:
         ok, msg = _apply_one(subsystem, rec, memory_store)
         if ok:
             wa.discard_pending(subsystem, rec["id"])
@@ -156,18 +181,31 @@ def _apply_one(subsystem: str, rec, memory_store):
 
 
 def _reject(subsystem: str, rest: List[str]) -> str:
-    target, err = _resolve_one(subsystem, rest)
-    if err or target is None:
-        return err or f"Usage: /{subsystem} reject <id>"
-    if target.lower() == "all":
-        n = 0
-        for rec in wa.list_pending(subsystem):
-            if wa.discard_pending(subsystem, rec["id"]):
-                n += 1
-        return f"Rejected {n} pending {subsystem} write(s)."
-    if wa.discard_pending(subsystem, target):
-        return f"Rejected pending {subsystem} write '{target}'."
-    return f"No pending {subsystem} write with id '{target}'."
+    targets, err = _resolve_targets(subsystem, rest)
+    if err or not targets:
+        return err or f"Usage: /{subsystem} reject <id...>"
+
+    records = wa.list_pending(subsystem)
+    if not records:
+        return f"No pending {subsystem} writes."
+
+    resolved, unknown = _expand_targets(subsystem, targets, records)
+    rejected, failed = 0, [
+        f"{t}: no pending {subsystem} write with this id" for t in unknown
+    ]
+    for rec in resolved:
+        if wa.discard_pending(subsystem, rec["id"]):
+            rejected += 1
+        else:
+            failed.append(f"{rec['id']}: no longer pending")
+
+    if rejected == 1 and len(resolved) == 1 and not unknown:
+        return f"Rejected pending {subsystem} write '{resolved[0]['id']}'."
+    out = [f"Rejected {rejected} pending {subsystem} write(s)."]
+    if failed:
+        out.append("Failed:")
+        out.extend(f"  {f}" for f in failed)
+    return "\n".join(out)
 
 
 def _diff(rest: List[str]) -> str:

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -177,6 +177,98 @@ def test_handle_approve_all(hermes_home):
     assert len(store.user_entries) == 2
 
 
+def _stage_memory_writes(count):
+    """Stage ``count`` memory writes and return their pending ids in order."""
+    from tools import write_approval as wa
+    ids = []
+    for i in range(count):
+        rec = wa.stage_write(
+            "memory", {"action": "add", "target": "user", "content": f"m{i}"},
+            summary=f"m{i}", origin="foreground")
+        ids.append(rec["id"])
+    return ids
+
+
+def test_handle_approve_multiple_ids_all_applied(hermes_home):
+    """#99704: '/<subsystem> approve id1 id2' used to silently apply only the
+    first id (``_resolve_one`` took ``rest[0]`` and dropped the rest) while
+    reporting a bare success count. Every explicit id must be applied."""
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+    store = MemoryStore(); store.load_from_disk()
+    id1, id2, id3 = _stage_memory_writes(3)
+
+    out = handle_pending_subcommand(
+        wa.MEMORY, ["approve", id1, id2, id3], memory_store=store)
+
+    assert "Approved 3" in out, out
+    assert "Failed" not in out
+    assert wa.pending_count("memory") == 0
+    assert len(store.user_entries) == 3
+
+
+def test_handle_approve_multiple_ids_reports_unknown_per_id(hermes_home):
+    """A mixed batch must not look like full success: unknown ids are listed
+    per-id under Failed while the known ids still apply."""
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+    store = MemoryStore(); store.load_from_disk()
+    id1, _ = _stage_memory_writes(2)
+
+    out = handle_pending_subcommand(
+        wa.MEMORY, ["approve", id1, "deadbeef"], memory_store=store)
+
+    assert "Approved 1" in out, out
+    assert "deadbeef" in out, out
+    assert "Failed" in out, out
+    assert wa.pending_count("memory") == 1  # second write still pending
+    assert len(store.user_entries) == 1
+
+
+def test_handle_approve_duplicate_ids_applied_once(hermes_home):
+    """Repeating an id must not double-apply the same pending write."""
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+    store = MemoryStore(); store.load_from_disk()
+    id1, = _stage_memory_writes(1)
+
+    out = handle_pending_subcommand(
+        wa.MEMORY, ["approve", id1, id1], memory_store=store)
+
+    assert "Approved 1" in out, out
+    assert wa.pending_count("memory") == 0
+    assert len(store.user_entries) == 1
+
+
+def test_handle_reject_multiple_ids_all_rejected(hermes_home):
+    """#99704 (reject side): reject shared the same first-token-only resolver,
+    so '/<subsystem> reject id1 id2' silently rejected only id1."""
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    id1, id2 = _stage_memory_writes(2)
+
+    out = handle_pending_subcommand(wa.MEMORY, ["reject", id1, id2])
+
+    assert "Rejected 2" in out, out
+    assert "Failed" not in out
+    assert wa.pending_count("memory") == 0
+
+
+def test_handle_reject_unknown_id_reports_failure(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    id1, = _stage_memory_writes(1)
+
+    out = handle_pending_subcommand(wa.MEMORY, ["reject", "deadbeef"])
+
+    assert "Rejected 0" in out, out
+    assert "deadbeef" in out, out
+    assert wa.pending_count("memory") == 1  # the real write stays pending
+
+
 def test_handle_approval_on(hermes_home):
     from hermes_cli.write_approval_commands import handle_pending_subcommand
     from tools import write_approval as wa


### PR DESCRIPTION
## What does this PR do?

`/skills approve <id1> <id2> <id3>` (and the `/memory` equivalents, plus both `reject` variants) silently applied **only the first id** and reported a bare success count like `Approved 1`, so a user approving a batch by pasting several ids believed the whole batch went through while the rest stayed in the pending queue with no error and no per-id status.

Root cause: `hermes_cli/write_approval_commands.py::_resolve_one()` hard-coded `return rest[0], None` — it took the first token after the subcommand and silently discarded everything after it. There was no loop over multiple explicitly-named ids anywhere; the only supported shapes were a single id or the literal keyword `all`.

This PR resolves **all** id tokens instead, reusing the loop-and-per-id-failure structure the `all` path already had:

- each explicit id is applied/rejected individually, in the order given;
- unknown ids are reported per-id under `Failed:` instead of aborting or being skipped silently;
- repeated ids are applied once (de-duplicated), so `approve id1 id1` cannot double-apply a pending write;
- `all` still expands to every pending record, and `all` mixed with explicit ids de-duplicates naturally.

Scope note: #99704 bundles three distinct findings. The patch-type diff-preview rendering gap is handled separately in #99722 (different file, `tools/write_approval.py`); the `***`-redaction display-truncation finding is also out of scope here. This PR fixes only the multi-id approve/reject resolution bug (the `hermes_cli/write_approval_commands.py` write path).

## Related Issue

Fixes #99704

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/write_approval_commands.py`
  - `_resolve_one()` → `_resolve_targets()`: returns all id tokens instead of just `rest[0]`; usage line now shows `<id...>`.
  - New `_expand_targets()`: maps id tokens (or `all`) to pending records, de-duplicated in order, collecting unknown ids separately.
  - `_approve()`: iterates every resolved record (existing per-record apply loop), unknown ids surface as per-id `Failed:` lines.
  - `_reject()`: same multi-id resolution; single-target success keeps its existing one-line message; adds the empty-queue early return that `_approve` already had.
  - Pending-list hint updated to `approve <id...>` to advertise the supported shape.
- `tests/tools/test_write_approval.py`
  - 5 regression tests: all-ids-applied for a 3-id batch, mixed known+unknown batch (per-id failure, partial success), duplicate id applied once, reject of 2 ids in one call, reject of an unknown id.

## How to Test

1. `pytest tests/tools/test_write_approval.py -q` — Observed result: **20 passed** (15 pre-existing + 5 new). The new `test_handle_approve_multiple_ids_all_applied` fails on `main` (verified via single-file stash: the old first-token-only resolver applies 1 of 3) and passes with this change.
2. Adjacent surfaces unchanged: `pytest tests/hermes_cli/test_approvals_command.py tests/gateway/test_approve_deny_commands.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q` — Observed result: **58 passed**.
3. Manual shape check: stage 2+ gated memory writes (`memory.write_approval = on`), then `/memory approve <id1> <id2>` in one invocation — both writes should be applied, `pending` should be empty, and the reply should read `Approved 2 memory write(s).` with no `Failed:` section. Adding a bogus id to the batch should yield `Approved 1 ...` plus a `Failed:` line naming that id.
4. `ruff check hermes_cli/write_approval_commands.py tests/tools/test_write_approval.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites for the touched files: `tests/tools/test_write_approval.py`, `tests/hermes_cli/test_approvals_command.py`, `tests/gateway/test_approve_deny_commands.py`, `tests/hermes_cli/test_dashboard_admin_endpoints.py` — all green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the usage strings shown by the slash commands themselves were updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python token handling, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
