### PR TITLE
fix(desktop): scope terminal backend picker to profile

### DIFF
--- a/apps/desktop/src/api/toolsets.ts
+++ b/apps/desktop/src/api/toolsets.ts
@@ -109,16 +109,19 @@ export function runToolsetPostSetup(
   })
 }
 
-export function getTerminalBackends(): Promise<TerminalBackendsResponse> {
-  return hermesApi<TerminalBackendsResponse>({
-    ...profileScoped(),
+export function getTerminalBackends(profile?: ProfileScope): Promise<TerminalBackendsResponse> {
+  return window.hermesDesktop.api<TerminalBackendsResponse>({
+    ...capabilityScoped(profile),
     path: '/api/tools/terminal/backends'
   })
 }
 
-export function selectTerminalBackend(backend: string): Promise<{ ok: boolean; backend: string }> {
-  return hermesApi<{ ok: boolean; backend: string }>({
-    ...profileScoped(),
+export function selectTerminalBackend(
+  backend: string,
+  profile?: ProfileScope
+): Promise<{ ok: boolean; backend: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; backend: string }>({
+    ...capabilityScoped(profile),
     path: '/api/tools/terminal/backend',
     method: 'PUT',
     body: { backend }

--- a/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
+++ b/apps/desktop/src/app/settings/terminal-backend-panel.test.tsx
@@ -7,8 +7,8 @@ const getTerminalBackends = vi.fn()
 const selectTerminalBackend = vi.fn()
 
 vi.mock('@/hermes', () => ({
-  getTerminalBackends: () => getTerminalBackends(),
-  selectTerminalBackend: (backend: string) => selectTerminalBackend(backend)
+  getTerminalBackends: (profile?: string) => getTerminalBackends(profile),
+  selectTerminalBackend: (backend: string, profile?: string) => selectTerminalBackend(backend, profile)
 }))
 
 vi.mock('@/store/notifications', () => ({
@@ -96,7 +96,7 @@ describe('TerminalBackendPanel', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /SSH/ }))
 
-    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('ssh'))
+    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('ssh', undefined))
     await waitFor(() => expect(onConfiguredChange).toHaveBeenCalled())
     // Active highlight moves without a refetch.
     const ssh = screen.getByRole('button', { name: /SSH/ })
@@ -110,7 +110,7 @@ describe('TerminalBackendPanel', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /Docker/ }))
 
-    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('docker'))
+    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('docker', undefined))
     // The guidance detail stays visible on the now-active row.
     expect(screen.getByText(/Docker daemon not reachable/)).toBeTruthy()
   })
@@ -123,5 +123,16 @@ describe('TerminalBackendPanel', () => {
 
     await new Promise(resolve => setTimeout(resolve, 50))
     expect(selectTerminalBackend).not.toHaveBeenCalled()
+  })
+
+  it('reads and writes the profile currently selected by Capabilities', async () => {
+    const { TerminalBackendPanel } = await import('./terminal-backend-panel')
+    render(<TerminalBackendPanel onConfiguredChange={vi.fn()} profile="research" />)
+
+    await waitFor(() => expect(getTerminalBackends).toHaveBeenCalledWith('research'))
+
+    fireEvent.click(await screen.findByRole('button', { name: /SSH/ }))
+
+    await waitFor(() => expect(selectTerminalBackend).toHaveBeenCalledWith('ssh', 'research'))
   })
 })

--- a/apps/desktop/src/app/settings/terminal-backend-panel.tsx
+++ b/apps/desktop/src/app/settings/terminal-backend-panel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import type { ProfileScope } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { getTerminalBackends, selectTerminalBackend } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -14,6 +15,8 @@ interface TerminalBackendPanelProps {
   /** Re-read the parent toolset list after a backend change so any derived
    *  pills stay in sync. */
   onConfiguredChange?: () => void
+  /** Capabilities can edit a profile other than the app-wide active one. */
+  profile?: ProfileScope
 }
 
 function StatusPill({ backend }: { backend: TerminalBackendInfo }) {
@@ -45,7 +48,7 @@ function StatusPill({ backend }: { backend: TerminalBackendInfo }) {
  * dropdown. Selecting a needs-setup backend is allowed — the row shows what's
  * missing rather than blocking, matching the CLI configurator.
  */
-export function TerminalBackendPanel({ onConfiguredChange }: TerminalBackendPanelProps) {
+export function TerminalBackendPanel({ onConfiguredChange, profile }: TerminalBackendPanelProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets.terminalBackend
   const [data, setData] = useState<TerminalBackendsResponse | null>(null)
@@ -56,13 +59,13 @@ export function TerminalBackendPanel({ onConfiguredChange }: TerminalBackendPane
     setLoading(true)
 
     try {
-      setData(await getTerminalBackends())
+      setData(await getTerminalBackends(profile))
     } catch (err) {
       notifyError(err, copy.failedLoad)
     } finally {
       setLoading(false)
     }
-  }, [copy.failedLoad])
+  }, [copy.failedLoad, profile])
 
   useEffect(() => {
     void refresh()
@@ -76,7 +79,7 @@ export function TerminalBackendPanel({ onConfiguredChange }: TerminalBackendPane
     setSelecting(backend.name)
 
     try {
-      await selectTerminalBackend(backend.name)
+      await selectTerminalBackend(backend.name, profile)
       // Mirror the backend write locally so the active highlight tracks the
       // new selection without a refetch (probes are unchanged by a select).
       setData(current =>

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -1171,7 +1171,9 @@ function ToolsetDetail({
           config option users kept missing because its only GUI home was the
           generic Settings → Config editor. */}
       {toolset.name === 'browser' && <BrowserRealProfilePanel profile={profile} />}
-      {toolset.name === 'terminal' && <TerminalBackendPanel onConfiguredChange={onConfiguredChange} />}
+      {toolset.name === 'terminal' && (
+        <TerminalBackendPanel onConfiguredChange={onConfiguredChange} profile={profile} />
+      )}
       <ToolsetConfigPanel
         key={`${toolset.name}:${profileScopeKey(profile)}`}
         onConfiguredChange={onConfiguredChange}

--- a/apps/desktop/src/hermes-capability-scope.test.ts
+++ b/apps/desktop/src/hermes-capability-scope.test.ts
@@ -5,11 +5,13 @@ import {
   getMcpCatalog,
   getSkillContent,
   getSkills,
+  getTerminalBackends,
   getToolsets,
   getUsageAnalytics,
   installSkillFromHub,
   profileScopeKey,
   saveMcpServers,
+  selectTerminalBackend,
   setApiRequestConnection,
   setApiRequestProfile,
   setSkillEnabled,
@@ -72,6 +74,29 @@ describe('capability helpers are connection-scoped', () => {
 
     expect(last().profile).toBe('coder')
     expect(last().connectionId).toBe('gw-tailscale')
+  })
+
+  it('routes terminal backend reads and writes through the rendered capability scope', () => {
+    // The terminal picker used to bypass capabilityScoped() and fall back to
+    // this stale ambient profile, silently writing another profile's config.
+    setApiRequestProfile('stale-sidebar-profile')
+    setApiRequestConnection('gw-tailscale')
+
+    void getTerminalBackends('research')
+    expect(last()).toMatchObject({
+      connectionId: 'gw-tailscale',
+      path: '/api/tools/terminal/backends',
+      profile: 'research'
+    })
+
+    void selectTerminalBackend('docker', { connectionId: 'homelab', profile: 'research' })
+    expect(last()).toMatchObject({
+      body: { backend: 'docker' },
+      connectionId: 'homelab',
+      method: 'PUT',
+      path: '/api/tools/terminal/backend',
+      profile: 'research'
+    })
   })
 
   it('object scopes pin every read and write to the named connection', () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop Capabilities routing bug: Terminal Backend reads and writes previously used the mutable ambient API profile. If that profile was stale relative to the Capabilities panel, selecting a backend could persist `terminal.backend` to another profile.

The panel now receives its rendered `ProfileScope` and forwards it to both terminal backend API helpers. Those helpers use the existing `capabilityScoped` route, preserving explicit connection pins as well as the displayed profile.

Base: `29112bef099274229cadff79cdff7bf7b99c4b77`
Head: `fa96a15792262ea55180b0f4c51c4a56578a4d76`

## Related Issue

Fixes #99720

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Thread the selected Capabilities profile from `ToolsetDetail` through `TerminalBackendPanel`.
- Route terminal backend GET/PUT calls with `capabilityScoped(profile)`.
- Add component coverage for a non-ambient profile and API contract coverage for explicit profile and connection scopes.

## How to Test

1. On baseline `29112bef`, the panel renders a selected `research` profile but the backend helper receives `undefined`, allowing the stale ambient profile to win.
2. On head `fa96a157`, the panel passes `research` for both GET and PUT; the API contract proves GET carries the rendered profile and PUT preserves an explicit `homelab` connection pin.
3. Run:
   - `npm run typecheck`
   - `npm run test:ui -- src/app/settings/terminal-backend-panel.test.tsx src/hermes-capability-scope.test.ts` (`14 passed`)
   - `npm exec eslint -- src/api/toolsets.ts src/app/settings/terminal-backend-panel.tsx src/app/settings/terminal-backend-panel.test.tsx src/app/skills/index.tsx src/hermes-capability-scope.test.ts`
   - `npm exec prettier -- --check src/api/toolsets.ts src/app/settings/terminal-backend-panel.tsx src/app/settings/terminal-backend-panel.test.tsx src/app/skills/index.tsx src/hermes-capability-scope.test.ts`
   - `trufflehog git --no-update --fail --since-commit 29112bef099274229cadff79cdff7bf7b99c4b77 --branch fix/desktop-terminal-profile-99720 file://$PWD` (`0 verified / 0 unverified`)

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I have run `pytest tests/ -q` and all tests pass (not run: this is a focused TypeScript Desktop change).
- [x] I have added tests for my changes.
- [x] I have tested on macOS via the Desktop typecheck and UI test projects.

### Documentation & Housekeeping

- [x] Relevant documentation is N/A: no user-facing config or behavior contract changes.
- [x] `cli-config.yaml.example` is N/A: no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A: no architecture or workflow changes.
- [x] Cross-platform impact is N/A: this changes only renderer request-scope propagation.
- [x] Tool descriptions/schemas are N/A: no tool behavior changed.

## Screenshots / Logs

Focused regression result: `2 files, 14 passed`. The API contract asserts the exact bridge requests, including the selected profile and explicit remote connection identifier, rather than relying on the mutable ambient profile.
