### PR TITLE
feat(acp): expose session reasoning selector

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -46,6 +46,8 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -653,6 +655,8 @@ class HermesACPAgent(acp.Agent):
     )
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
+    _REASONING_EFFORT_CONFIG_ID = "reasoning_effort"
+    _REASONING_EFFORT_DEFAULT = "medium"
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
     _MODE_DEFAULT = "default"
     _MODE_ACCEPT_EDITS = "accept_edits"
@@ -716,6 +720,27 @@ class HermesACPAgent(acp.Agent):
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
         return policy, state.cwd
+
+    @classmethod
+    def _session_config_options(cls, state: SessionState) -> list[SessionConfigOptionSelect]:
+        """Expose Hermes' existing reasoning control through native ACP config."""
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        current = state.reasoning_effort or cls._REASONING_EFFORT_DEFAULT
+        return [
+            SessionConfigOptionSelect(
+                id=cls._REASONING_EFFORT_CONFIG_ID,
+                name="Reasoning",
+                description="Reasoning effort for this session.",
+                category="thought_level",
+                type="select",
+                current_value=current,
+                options=[
+                    SessionConfigSelectOption(name=level.title(), value=level)
+                    for level in ("none", *VALID_REASONING_EFFORTS)
+                ],
+            )
+        ]
 
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
@@ -1602,6 +1627,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return NewSessionResponse(
             session_id=state.session_id,
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
@@ -1650,6 +1676,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_available_commands_update(session_id)
         self._schedule_usage_update(state)
         return LoadSessionResponse(
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
@@ -1686,6 +1713,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
         return ResumeSessionResponse(
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
@@ -1730,6 +1758,7 @@ class HermesACPAgent(acp.Agent):
             self._schedule_available_commands_update(new_id)
         return ForkSessionResponse(
             session_id=new_id,
+            config_options=self._session_config_options(state) if state is not None else None,
             models=self._build_model_state(state) if state is not None else None,
             modes=self._session_modes(state) if state is not None else None,
         )
@@ -2582,6 +2611,7 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            reasoning_effort = state.reasoning_effort
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -2590,6 +2620,10 @@ class HermesACPAgent(acp.Agent):
                 base_url=current_base_url,
                 api_mode=current_api_mode,
             )
+            if reasoning_effort:
+                from hermes_constants import parse_reasoning_effort
+
+                state.agent.reasoning_config = parse_reasoning_effort(reasoning_effort)
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",
@@ -2626,7 +2660,16 @@ class HermesACPAgent(acp.Agent):
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
 
-        if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
+        if str(config_id) == self._REASONING_EFFORT_CONFIG_ID:
+            from hermes_constants import parse_reasoning_effort
+
+            reasoning = parse_reasoning_effort(value)
+            if reasoning is None:
+                logger.warning("Session %s: invalid reasoning effort %r", session_id, value)
+                return None
+            state.agent.reasoning_config = reasoning
+            state.reasoning_effort = str(value).strip().lower()
+        elif str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
         else:
@@ -2637,4 +2680,6 @@ class HermesACPAgent(acp.Agent):
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(
+            config_options=self._session_config_options(state)
+        )

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2623,7 +2623,13 @@ class HermesACPAgent(acp.Agent):
             if reasoning_effort:
                 from hermes_constants import parse_reasoning_effort
 
-                state.agent.reasoning_config = parse_reasoning_effort(reasoning_effort)
+                # Same guard as _restore: a bad value must not clobber the
+                # freshly built agent's default reasoning config.
+                switched_config = parse_reasoning_effort(reasoning_effort)
+                if switched_config is None:
+                    state.reasoning_effort = ""
+                else:
+                    state.agent.reasoning_config = switched_config
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -174,6 +174,7 @@ class SessionState:
     agent: Any  # AIAgent instance
     cwd: str = "."
     model: str = ""
+    reasoning_effort: str = ""
     history: List[Dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
     is_running: bool = False
@@ -442,6 +443,8 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
+        if state.reasoning_effort:
+            session_meta["reasoning_effort"] = state.reasoning_effort
         cwd_json = json.dumps(session_meta)
 
         try:
@@ -532,6 +535,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        restored_reasoning_effort = ""
         mc = row.get("model_config")
         if mc:
             try:
@@ -541,6 +545,7 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    restored_reasoning_effort = str(meta.get("reasoning_effort") or "")
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -578,8 +583,13 @@ class SessionManager:
             cwd=cwd,
             model=model or getattr(agent, "model", "") or "",
             history=history,
+            reasoning_effort=restored_reasoning_effort,
             cancel_event=threading.Event(),
         )
+        if restored_reasoning_effort:
+            from hermes_constants import parse_reasoning_effort
+
+            agent.reasoning_config = parse_reasoning_effort(restored_reasoning_effort)
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -589,7 +589,13 @@ class SessionManager:
         if restored_reasoning_effort:
             from hermes_constants import parse_reasoning_effort
 
-            agent.reasoning_config = parse_reasoning_effort(restored_reasoning_effort)
+            # Keep the agent's own default when a persisted value is
+            # unparseable (e.g. a hand-edited DB) instead of nulling it.
+            restored_config = parse_reasoning_effort(restored_reasoning_effort)
+            if restored_config is None:
+                state.reasoning_effort = ""
+            else:
+                agent.reasoning_config = restored_config
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -61,7 +61,12 @@ def agent(mock_manager):
 async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
     resp = await agent.new_session(cwd="/tmp")
 
-    assert resp.config_options is None
+    # Edit approval is a *mode*, never a config option. Other config options
+    # (e.g. the thought_level reasoning selector) may legitimately be
+    # advertised, so assert the invariant rather than an empty list.
+    assert not any(
+        option.id == "edit_approval_policy" for option in (resp.config_options or [])
+    )
     assert isinstance(resp.modes, SessionModeState)
     assert resp.modes.current_mode_id == "default"
     assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [
@@ -82,7 +87,9 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     state = agent.session_manager.get_session(resp.session_id)
 
     assert isinstance(update, SetSessionConfigOptionResponse)
-    assert update.config_options == []
+    assert not any(
+        option.id == "edit_approval_policy" for option in (update.config_options or [])
+    )
     assert getattr(state, "mode", None) == "accept_edits"
 
 
@@ -390,7 +397,14 @@ class TestSessionConfiguration:
         )
 
         assert mode_result == {}
-        assert config_result["configOptions"] == []
+        # The point of this test is that the router accepts both stable
+        # methods and returns a well-formed payload. The exact option list is
+        # asserted by the config-option tests, so don't snapshot it here.
+        assert "configOptions" in config_result
+        assert not any(
+            option["id"] == "approval_mode"
+            for option in (config_result["configOptions"] or [])
+        )
 
 
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -137,8 +137,46 @@ async def test_acp_steer_slash_command_injects_into_running_agent():
 
 
 
+@pytest.mark.asyncio
+async def test_acp_advertises_and_applies_reasoning_level():
+    acp_agent, state, fake, _conn = make_agent_and_state()
 
+    reasoning = next(
+        option
+        for option in acp_agent._session_config_options(state)
+        if option.category == "thought_level"
+    )
+    assert reasoning.current_value == "medium"
+    assert [option.value for option in reasoning.options] == [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
 
+    update = await acp_agent.set_config_option(
+        config_id="reasoning_effort",
+        session_id=state.session_id,
+        value="high",
+    )
+
+    assert fake.reasoning_config == {"enabled": True, "effort": "high"}
+    assert update.config_options[0].current_value == "high"
+
+    await acp_agent.set_session_model(
+        session_id=state.session_id,
+        model_id="fake-provider:next-model",
+    )
+    assert state.agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    response = await acp_agent.new_session(cwd=".")
+    assert any(
+        option.category == "thought_level" for option in response.config_options
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -180,6 +180,28 @@ async def test_acp_advertises_and_applies_reasoning_level():
 
 
 @pytest.mark.asyncio
+async def test_acp_model_switch_keeps_agent_default_on_unparseable_effort():
+    """A corrupt persisted effort must not null the new agent's default."""
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    # Stand in for whatever reasoning config the rebuilt agent comes up with.
+    agent_default = {"enabled": True, "effort": "medium"}
+    fake.reasoning_config = agent_default
+
+    # Only reachable via a hand-edited DB: the set path validates first.
+    state.reasoning_effort = "not-a-real-effort"
+
+    await acp_agent.set_session_model(
+        session_id=state.session_id,
+        model_id="fake-provider:next-model",
+    )
+
+    # Default preserved (not overwritten with None) and the bad value dropped.
+    assert state.agent.reasoning_config == agent_default
+    assert state.reasoning_effort == ""
+
+
+@pytest.mark.asyncio
 async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     acp_agent, state, fake, _conn = make_agent_and_state()
     state.is_running = True


### PR DESCRIPTION
## Summary

- advertise Hermes reasoning effort as the standard ACP `thought_level` session option
- apply selection changes to the live agent without changing the global default
- preserve the session choice across model switches and persisted-session restores

This lets ACP clients such as Paseo render their native reasoning selector for Hermes instead of treating `/reasoning high` as chat text.

## Verification

- regression test observed failing before implementation (`config_options` was `None`)
- `python -m pytest tests/acp_adapter -q -o 'addopts='` — 16 passed
- `python -m py_compile acp_adapter/server.py acp_adapter/session.py tests/acp_adapter/test_acp_commands.py`
- `git diff --check`

*Written by Terminus (AI Assistant)*

