### PR TITLE
fix(update): refresh Linux launcher when desktop is current

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -759,6 +759,7 @@ from hermes_cli.main_desktop import (  # frozen updater surface: update_cmd*.py 
     _desktop_dist_exists,
     _desktop_macos_relaunchable_fixup,
     _desktop_packaged_executable,
+    _register_linux_desktop_entry,
 )
 from hermes_cli.main_web_build import (
     _sweep_stale_bytecode_if_checkout_changed,

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -836,6 +836,10 @@ def _rebuild_desktop_after_update(
         skip_desktop_build = False
     if skip_desktop_build:
         print("  ✓ Desktop app up to date")
+        # Re-render persistence artifacts even when Electron itself is current:
+        # an update may have changed launcher resolution while the existing
+        # desktop entry still points at a retired interpreter.
+        _m()._register_linux_desktop_entry()
         return True
 
     desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1148,6 +1148,31 @@ class TestNodeRuntimeNpmResolution:
             env=ANY,
         )
 
+    def test_update_refreshes_linux_desktop_entry_when_build_is_current(
+        self, tmp_path, monkeypatch
+    ):
+        """An up-to-date build must still repair a stale Linux launcher."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        desktop_dir = tmp_path / "apps" / "desktop"
+        desktop_dir.mkdir(parents=True)
+        (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+        packaged_exe = desktop_dir / "release" / "linux-unpacked" / "Hermes"
+
+        monkeypatch.setattr(hm, "_desktop_packaged_executable", lambda _dir: packaged_exe)
+        monkeypatch.setattr(hm, "_desktop_dist_exists", lambda _dir: False)
+        monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
+        monkeypatch.setattr(hm, "_desktop_build_needed", lambda *_args, **_kwargs: False)
+        calls = []
+        monkeypatch.setattr(hm, "_register_linux_desktop_entry", lambda: calls.append(True))
+
+        assert update_cmd._rebuild_desktop_after_update(
+            desktop_dir,
+            had_desktop_app_before_update=False,
+        )
+        assert calls == [True]
+
     def test_git_failure_zip_fallback_rebuilds_missing_desktop(self, tmp_path, monkeypatch):
         """The Windows ZIP fallback keeps Desktop intact when replacing ``apps/``.
 

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -34,7 +34,7 @@ def desktop_env(tmp_path, monkeypatch):
     desktop_dir.mkdir(parents=True)
     (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
 
-    calls = {"builds": 0, "build_needed": True}
+    calls = {"builds": 0, "build_needed": True, "registrations": 0}
 
     class _FakeMain:
         PROJECT_ROOT = tmp_path
@@ -46,6 +46,10 @@ def desktop_env(tmp_path, monkeypatch):
         @staticmethod
         def _desktop_build_needed(*_a, **_kw):
             return calls["build_needed"]
+
+        @staticmethod
+        def _register_linux_desktop_entry():
+            calls["registrations"] += 1
 
         @staticmethod
         def _run_logged_subprocess(cmd, cwd=None, env=None):
@@ -96,6 +100,7 @@ def test_up_to_date_desktop_returns_true_without_spawning(desktop_env):
     calls["build_needed"] = False
     assert _run(desktop_dir) is True
     assert calls["builds"] == 0
+    assert calls["registrations"] == 1
 
 
 def test_desktop_never_installed_returns_true(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary

- Re-register the Linux desktop entry on update even when the Electron build is already current.
- Self-heal stale launcher entries that still point at retired or de-virtualized Python interpreters.
- Add a regression test for the skipped-build update path.

Context

Current main already contains the venv-aware Exec resolution fix, but existing desktop entries are persistence artifacts. If an update does not rebuild Electron, the fast path returns before rewriting the entry, leaving the taskbar/menu icon broken until Hermes is launched some other way.

This is a clean, minimal port of the still-needed update hook from #97307 onto current main; that PR is now conflicted after the broader launcher-resolution work landed. Credit to @kasimali59 for the original fix and regression-test shape.

Tests

- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py::TestNodeRuntimeNpmResolution::test_update_refreshes_linux_desktop_entry_when_build_is_current -v` — 1 passed
- `scripts/run_tests.sh tests/hermes_cli/test_update_desktop_stale_warning.py` — 8 passed
- `scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_entry.py` — 41 passed
- `git diff --check`
- `python -m py_compile hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_desktop_stale_warning.py`

Additional validation

- Reproduced before the fix: the regression test failed with `assert [] == [True]`.
- Regenerated a real KDE launcher entry; `desktop-file-validate` passed and the entry now uses `/home/kadir/.local/bin/hermes desktop` rather than the uv base interpreter.

Notes

The full `test_cmd_update.py` file currently has six unrelated live-environment failures on this workstation because a real running gateway is detected by the live-system guard. The new targeted regression and the complete Linux desktop-entry suite pass.
