### PR TITLE
fix(security): scope key_cmd subprocess environment

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -45,9 +45,26 @@ def materialize_probe_api_key(api_key: object) -> str:
 
 def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
     """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
+    # A configured helper is an external child process, not part of the
+    # trusted Hermes process. Give it the credential-scoped environment for
+    # non-terminal subprocesses. Import lazily to avoid adding environment
+    # machinery to the static-provider import path.
+    try:
+        from tools.environments.local import hermes_subprocess_env
+
+        child_env = hermes_subprocess_env(inherit_credentials=False)
+    except Exception as exc:
+        # Never fall back to implicit full-environment inheritance when the
+        # credential-scoped environment cannot be constructed.
+        raise CommandTokenError(
+            f"key_cmd for provider {label!r} could not prepare a "
+            "credential-scoped environment"
+        ) from exc
+
     try:
         completed = subprocess.run(
-            command, shell=True, capture_output=True, text=True, timeout=_MINT_TIMEOUT_SECONDS,
+            command, shell=True, capture_output=True, text=True,
+            timeout=_MINT_TIMEOUT_SECONDS, env=child_env,
         )
     except subprocess.TimeoutExpired as exc:
         raise CommandTokenError(

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -14,6 +14,7 @@ behaviours that make the feature work:
 
 from __future__ import annotations
 
+import sys
 import time
 from types import SimpleNamespace
 
@@ -88,6 +89,80 @@ class TestNoCredentialLeak:
         with pytest.raises(CommandTokenError) as excinfo:
             source()
         assert "SENTINEL" not in str(excinfo.value)
+
+    def test_helper_env_scrubs_hermes_secrets_without_losing_runtime_config(
+        self, tmp_path, monkeypatch
+    ):
+        """The real helper child loses Hermes secrets, not normal CLI config."""
+        planted_secrets = {
+            "OPENAI_API_KEY": "security-test-openai",
+            "XAI_API_KEY": "security-test-xai",
+            "TELEGRAM_BOT_TOKEN": "security-test-telegram",
+            "AUXILIARY_REVIEW_API_KEY": "security-test-auxiliary",
+            "BUZZ_PRIVATE_KEY": "security-test-buzz",
+        }
+        helper_config = {
+            "KEY_CMD_HELPER_CONFIG": "profile-prod",
+            "CLOUDSDK_CONFIG": str(tmp_path / "gcloud"),
+            "AZURE_CONFIG_DIR": str(tmp_path / "azure"),
+            "VAULT_ADDR": "https://vault.invalid",
+            "DATABRICKS_CONFIG_FILE": str(tmp_path / "databrickscfg"),
+            "AWS_PROFILE": "prod",
+        }
+        for name, value in (planted_secrets | helper_config).items():
+            monkeypatch.setenv(name, value)
+
+        helper = tmp_path / "inspect_key_cmd_env.py"
+        helper.write_text(
+            f"""\
+import os
+
+blocked = {tuple(planted_secrets)!r}
+expected = {helper_config!r}
+secrets_absent = not any(name in os.environ for name in blocked)
+config_preserved = all(
+    os.environ.get(name) == value for name, value in expected.items()
+)
+runtime_preserved = bool(os.environ.get("PATH") and os.environ.get("HOME"))
+print(
+    "scoped-token"
+    if secrets_absent and config_preserved and runtime_preserved
+    else "unsafe-or-broken"
+)
+""",
+            encoding="utf-8",
+        )
+
+        source = CommandTokenSource(f'"{sys.executable}" "{helper}"', "dbx")
+        assert source() == "scoped-token"
+
+    def test_env_builder_failure_never_falls_back_to_full_inheritance(
+        self, monkeypatch
+    ):
+        """A broken scrub boundary must stop the helper rather than fail open."""
+        from tools.environments import local as local_env
+
+        helper_started = False
+
+        def fail_to_build_env(*, inherit_credentials=False):
+            assert inherit_credentials is False
+            raise RuntimeError("env-builder-failure-sentinel")
+
+        def unexpected_run(*args, **kwargs):
+            nonlocal helper_started
+            helper_started = True
+            return SimpleNamespace(returncode=0, stdout="token", stderr="")
+
+        monkeypatch.setattr(local_env, "hermes_subprocess_env", fail_to_build_env)
+        monkeypatch.setattr(
+            "agent.command_token_source.subprocess.run", unexpected_run
+        )
+
+        with pytest.raises(CommandTokenError, match="credential-scoped") as excinfo:
+            _mint("printf token", "dbx")
+
+        assert helper_started is False
+        assert "env-builder-failure-sentinel" not in str(excinfo.value)
 
 
 class TestCaching:


### PR DESCRIPTION
## What does this PR do?

`key_cmd` helper subprocesses were started without an explicit `env`, so they inherited the complete parent process environment, including unrelated Hermes provider and tool credentials.

This PR applies the existing non-terminal subprocess policy through `hermes_subprocess_env(inherit_credentials=False)`. If the scoped environment cannot be prepared, token minting fails closed without starting the helper.

This change only scopes environment variables. It does not change shell parsing or provide filesystem/OS-level containment.

## Related Issue

No public issue was opened for this narrowly scoped bug.

Related: #98913 addresses separate command parsing hardening with argv and `shell=False`. This PR addresses the child environment.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/command_token_source.py`
  - Build the `key_cmd` child environment with the existing non-terminal subprocess sanitizer.
  - Pass the scoped environment explicitly to `subprocess.run`.
  - Fail closed if the environment cannot be prepared.

- `tests/agent/test_command_token_source.py`
  - Verify that Hermes-managed credentials are absent from the real helper subprocess.
  - Verify that required runtime and ordinary CLI configuration remain available.
  - Verify that environment-construction failure does not start the helper or expose the internal error.

## How to Test

1. Run the targeted test suites:

```bash
scripts/run_tests.sh \
  tests/agent/test_command_token_source.py \
  tests/tools/test_hermes_subprocess_env.py \
  tests/agent/test_subprocess_env_guard.py \
  -k 'not test_callable_takes_the_bearer_hook_path'
```

2. Verify the result:

```text
49 passed, 0 failed
```

Targeted regression tests for this change pass (49 tests).

3. Run syntax and diff checks:

```bash
python -m py_compile \
  agent/command_token_source.py \
  tests/agent/test_command_token_source.py

git diff --check
```

The excluded hook-path test requires the optional `anthropic` dependency, which was unavailable in the local environment and is unrelated to this change. The full repository test suite was not run on this PR branch, so the corresponding checklist item remains unchecked.

Tested on macOS 26.6.1 with Python 3.11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no public configuration or user-facing behavior changed
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact for Windows and macOS
- [x] I've updated tool descriptions/schemas — N/A; no tool schema changed

## For New Skills

N/A.

## Screenshots / Logs

N/A.
