### PR TITLE
fix(dashboard): one unstat-able entry no longer fails the whole /api/files listing

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2719,6 +2719,36 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
     }
 
 
+def _managed_dir_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, Any]:
+    """One row of a directory listing: ``_managed_file_entry``, degraded not raised.
+
+    A listing aggregates entries the caller never named, so one bad entry must
+    not fail the whole directory. A dangling symlink (stat -> ENOENT), an
+    entry deleted mid-scan, or a symlink whose resolution escapes the managed
+    root previously turned the entire ``/api/files`` response into a 500/403
+    that clients render as "workspace unreachable". Such entries now come back
+    marked ``unavailable`` with lstat-based metadata; direct single-path
+    requests keep the raising behavior.
+    """
+    try:
+        return _managed_file_entry(policy, target)
+    except HTTPException:
+        mtime = None
+        try:
+            mtime = target.lstat().st_mtime
+        except OSError:
+            pass
+        return {
+            "name": target.name or str(target),
+            "path": str(target),
+            "is_directory": False,
+            "size": None,
+            "mtime": mtime,
+            "mime_type": None,
+            "unavailable": True,
+        }
+
+
 def _decode_data_url(data_url: str) -> tuple[bytes, str]:
     text = (data_url or "").strip()
     if not text.startswith("data:") or "," not in text:
@@ -2838,7 +2868,7 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
     try:
         with os.scandir(target) as scan:
             entries = [
-                _managed_file_entry(policy, Path(entry.path))
+                _managed_dir_entry(policy, Path(entry.path))
                 for entry in scan
                 if not _is_sensitive_path(Path(entry.path))
             ]

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -375,3 +375,50 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+
+
+def test_listing_survives_a_dangling_symlink(forced_files_client):
+    """One unstat-able entry must not 500 the whole directory (dangling
+    symlinks like Steam's ~/.steampath are common in real homes)."""
+    client, root = forced_files_client
+    _seed_file(client, root, name="healthy.txt")
+    (root / "dangling").symlink_to(root / "no-such-target")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    entries = {entry["name"]: entry for entry in listing.json()["entries"]}
+
+    assert "healthy.txt" in entries
+    assert not entries["healthy.txt"].get("unavailable")
+    broken = entries["dangling"]
+    assert broken["unavailable"] is True
+    assert broken["is_directory"] is False
+    assert broken["size"] is None
+    assert broken["mime_type"] is None
+
+
+def test_listing_marks_a_jail_escaping_symlink_unavailable(forced_files_client, tmp_path):
+    """A symlink resolving outside the locked root is listed but unreadable —
+    previously its 403 killed the listing."""
+    client, root = forced_files_client
+    _seed_file(client, root, name="healthy.txt")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    (root / "escape").symlink_to(outside)
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    entries = {entry["name"]: entry for entry in listing.json()["entries"]}
+
+    assert entries["escape"]["unavailable"] is True
+    assert not entries["healthy.txt"].get("unavailable")
+
+
+def test_direct_request_for_a_missing_path_still_raises(forced_files_client):
+    """Degradation is a listing behavior only: naming a vanished path directly
+    keeps the explicit error."""
+    client, root = forced_files_client
+    _seed_file(client, root, name="healthy.txt")
+
+    response = client.get("/api/files", params={"path": str(root / "gone")})
+    assert response.status_code == 404


### PR DESCRIPTION
## Problem

A directory listing aggregates entries the caller never named, so one bad entry fails the whole `/api/files` response: a dangling symlink whose target resolves *inside* the managed root raises the stat 500 (`Could not stat path: [Errno 2] … ` — Steam's `~/.steampath` is a common real-home example), and one whose target resolves *outside* the root turns the entire listing into a 403. Either way the client renders the whole file browser as unreachable because one symlink is broken.

## Fix

`list_managed_files` now builds rows through `_managed_dir_entry`, which degrades a failing entry instead of raising: the entry comes back with lstat-based metadata and `"unavailable": true`, and the rest of the listing is unaffected. Naming a vanished path *directly* keeps the explicit 404/500 — only aggregation degrades. The `unavailable` flag lets clients decide how to render (skip, grey out) rather than guessing from missing fields.

## Verification

`tests/hermes_cli/test_web_server_files.py` (+3 tests: dangling-inside, symlink-escaping-root, direct-request still raises) — 11 passed on current main. Live-verified against a real dangling symlink: 200, healthy entries intact, the broken entry marked unavailable; both failure shapes reproduced without the patch.

Related: #97785 also touches the inside-root stat failure (lstat fallback) as part of a three-topic PR. This one is single-topic, additionally isolates the outside-root 403 case, and adds the explicit `unavailable` contract for clients; happy to reconcile with that PR if the maintainers prefer its approach for the stat fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125TN9SYXt6No2vHN286PoC
