### PR TITLE
fix(mcp): coerce legacy string mcp_servers default on save

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -484,7 +484,8 @@ def _write_tools_filter(name: str, mode: str, values: Optional[List[str]]) -> No
     """Persist ``mcp_servers.<name>.tools.<mode>`` (``include``/``exclude``), clearing the other
     mode; ``values=None`` drops the whole tools block (no filter)."""
     cfg = load_config()
-    servers = cfg.setdefault("mcp_servers", {})
+    from hermes_cli.mcp_config import _ensure_mcp_servers_dict
+    servers = _ensure_mcp_servers_dict(cfg)
     server_entry = servers.get(name) or {}
     if values is None:
         server_entry.pop("tools", None)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -60,6 +60,21 @@ def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
     return servers if servers and isinstance(servers, dict) else {}
 
 
+def _ensure_mcp_servers_dict(config: dict) -> Dict[str, dict]:
+    """Return the ``mcp_servers`` dict, coercing a non-dict (e.g. the legacy
+    ``mcp_servers: ''`` string default) to an empty dict in place.
+
+    ``config.setdefault("mcp_servers", {})`` returns the existing value when
+    the key is present — so a string ``''`` (the historical default) is
+    returned as-is and indexing it raises ``TypeError``. Coerce instead.
+    """
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        servers = {}
+        config["mcp_servers"] = servers
+    return servers
+
+
 def _tool_filters(cfg: dict) -> Tuple[Optional[list], Optional[list]]:
     """Return the ``(include, exclude)`` tool lists from a server config (non-empty lists only)."""
     tools_cfg = cfg.get("tools", {})
@@ -80,7 +95,8 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     if not _validate_or_warn(name, server_config):
         return False
     config = load_config()
-    config.setdefault("mcp_servers", {})[name] = server_config
+    servers = _ensure_mcp_servers_dict(config)
+    servers[name] = server_config
     save_config(config)
     return True
 
@@ -852,7 +868,8 @@ def cmd_mcp_configure(args):
         server_entry["tools"]["include"] = [tool_names[i] for i in sorted(chosen)]
         server_entry["tools"].pop("exclude", None)
 
-    config.setdefault("mcp_servers", {})[name] = server_entry
+    config = _ensure_mcp_servers_dict(config)
+    config[name] = server_entry
     save_config(config)
     _success(f"Updated config: {len(chosen)}/{total} tools enabled")
     _info("Start a new session for changes to take effect.")

--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -161,11 +161,11 @@ def _write_profile_mcp_servers(profile_dir: Path, servers: List["MCPServerCreate
     profile-create write is one config save. Returns the number of servers written.
     """
     from hermes_cli.config import load_config, save_config
-    from hermes_cli.mcp_config import _save_bearer_auth_token
+    from hermes_cli.mcp_config import _ensure_mcp_servers_dict, _save_bearer_auth_token
     written = 0
     with _hermes_home_scope(profile_dir):
         cfg = load_config()
-        mcp = cfg.setdefault("mcp_servers", {})
+        mcp = _ensure_mcp_servers_dict(cfg)
         for server in servers:
             try:
                 name, entry, bearer_token = _normalize_mcp_server_create(server)

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -69,6 +69,17 @@ def _seed_config(tmp_path: Path, mcp_servers: dict):
         yaml.safe_dump(config, f)
 
 
+def _seed_string_mcp_servers(tmp_path: Path):
+    """Write a config.yaml whose ``mcp_servers`` is the legacy ``''`` string
+    default — the shape every save path used to crash on."""
+    import yaml
+
+    config = {"mcp_servers": "", "_config_version": 9}
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config, f)
+
+
 class FakeTool:
     """Mimics an MCP tool object returned by the SDK."""
 
@@ -658,6 +669,33 @@ class TestConfigHelpers:
         servers = _get_mcp_servers()
         assert "mysvr" in servers
         assert servers["mysvr"]["url"] == "https://example.com/mcp"
+
+
+    def test_save_mcp_server_coerces_legacy_string_default(self, tmp_path):
+        """``hermes mcp add`` must not crash when config has the legacy
+        ``mcp_servers: ''`` string default — it must coerce to a dict, save the
+        server, and persist the key as a dict."""
+        _seed_string_mcp_servers(tmp_path)
+        from hermes_cli.mcp_config import _save_mcp_server, _get_mcp_servers
+
+        assert _save_mcp_server("gbrain", {"url": "https://example.com/mcp"}) is True
+        servers = _get_mcp_servers()
+        assert "gbrain" in servers
+        assert servers["gbrain"]["url"] == "https://example.com/mcp"
+
+        from hermes_cli.config import load_config
+
+        assert isinstance(load_config()["mcp_servers"], dict)
+
+
+    def test_remove_mcp_server_coerces_legacy_string_default(self, tmp_path):
+        """Removing with a string ``mcp_servers`` default must not crash (the
+        ``or {}`` guard returns an empty dict) and must report the server as
+        absent without raising."""
+        _seed_string_mcp_servers(tmp_path)
+        from hermes_cli.mcp_config import _remove_mcp_server
+
+        assert _remove_mcp_server("missing") is False
 
 
     def test_env_key_for_server(self):


### PR DESCRIPTION
## What does this PR do?

`hermes mcp add <name>` crashes with `TypeError: 'str' object does not support item assignment` when `config.yaml` has the legacy `mcp_servers: ''` string default.

Root cause: `_save_mcp_server` does `config.setdefault("mcp_servers", {})[name] = server_config`. `setdefault` returns the **existing** value when the key is present — so with `mcp_servers: ''` it returns the string, and indexing it raises `TypeError`. The command had already connected, discovered tools, and printed a success message before the crash, so the server was never persisted.

This adds `_ensure_mcp_servers_dict()` which coerces a non-dict `mcp_servers` value to an empty dict in place, and uses it in every save path that mutates the map.

## Changes Made

Note: this PR was re-based onto current `main` (Sep 2026) — the code shape moved since the original Aug-31 commit (`mcp_catalog` unified `_write_tools_include`/`_exclude` into `_write_tools_filter`; MCP web code split out of `web_server.py` into `web_routers/` + `web_server_profiles.py`). The bug is still live today and the four mutation paths now fixed are:

- `hermes_cli/mcp_config.py`: add `_ensure_mcp_servers_dict()`; use it in `_save_mcp_server` and `cmd_mcp_configure`'s tool-selection save
- `hermes_cli/mcp_catalog.py`: use it in `_write_tools_filter`
- `hermes_cli/web_server_profiles.py`: use it in `_write_profile_mcp_servers`
- `tests/hermes_cli/test_mcp_config.py`: regression tests for save + remove against a seeded `mcp_servers: ''` string default

## How to Test

1. Set `mcp_servers: ''` in `~/.hermes/config.yaml` (the legacy default)
2. Run `hermes mcp add gbrain --url https://example.com/mcp --auth header`
3. Before: crashes with `TypeError` after printing success. After: saves the server, `hermes mcp list` shows it, and `config.yaml` now has `mcp_servers:` as a dict

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite — `test_mcp_config.py` (40) + `test_mcp_catalog.py` (35) + `test_web_server_profile_unification.py` (30) all pass; regression test is red on base (reproduces the `TypeError`), green on the fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] Updated relevant docs or N/A
- [x] Updated `cli-config.yaml.example` if config keys changed — N/A
- [x] Updated `CONTRIBUTING.md`/`AGENTS.md` if architecture changed — N/A
- [x] Considered cross-platform impact — N/A (pure config write)
