### PR TITLE
fix(telegram): accept iOS rich text inbound messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8263,11 +8263,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 if _is_bot_handle(command_target):
                     mentioned_bot_usernames.add(command_target)
 
-        # Entity-less fallback for older/client-specific updates. If Telegram
-        # supplied entities for a source, trust them and do not regex-rescue
-        # malformed/URL/code spans that the server did not mark as mentions.
+        # Entity-less fallback for older/client-specific updates. Formatting
+        # entities (bold/italic/etc.) are not routing evidence.  Telegram iOS
+        # can send rich-formatted text with formatting entities but no mention
+        # entity for a plain pasted @bot handle; those unrelated entities must
+        # not suppress the raw-text fallback.  Only routing-capable entities
+        # (mention/text_mention/bot_command) make us trust the server parse.
         for raw_text, entities in _iter_sources():
-            if not raw_text or entities:
+            if not raw_text:
+                continue
+            has_routing_entities = any(
+                cls._telegram_entity_type(entity) in cls._TELEGRAM_ROUTE_ENTITY_TYPES
+                for entity in (entities or [])
+            )
+            if has_routing_entities:
                 continue
             for match in re.finditer(r"(?i)(?<![A-Za-z0-9_`/])@([A-Za-z0-9_]{2,31})\b", raw_text):
                 handle = match.group(1).lower()
@@ -8288,6 +8297,141 @@ class TelegramAdapter(BasePlatformAdapter):
             return raw[start:end].decode("utf-16-le")
         except UnicodeDecodeError:
             return ""
+
+    _TELEGRAM_ROUTE_ENTITY_TYPES = {"mention", "text_mention", "bot_command"}
+    _TELEGRAM_CANONICAL_ENTITY_TYPES = {
+        "bold",
+        "italic",
+        "underline",
+        "strikethrough",
+        "spoiler",
+        "code",
+        "pre",
+        "text_link",
+        "blockquote",
+        "expandable_blockquote",
+        "custom_emoji",
+    }
+
+    @classmethod
+    def _telegram_entity_bounds(cls, source_text: str, offset: int, length: int) -> tuple[int, int] | None:
+        """Convert Telegram UTF-16 entity offsets into Python string indexes."""
+        if offset < 0 or length <= 0:
+            return None
+        try:
+            raw = source_text.encode("utf-16-le")
+            start_b = offset * 2
+            end_b = (offset + length) * 2
+            if start_b < 0 or end_b > len(raw) or start_b >= end_b:
+                return None
+            start = len(raw[:start_b].decode("utf-16-le"))
+            end = len(raw[:end_b].decode("utf-16-le"))
+            return (start, end)
+        except UnicodeDecodeError:
+            return None
+
+    @staticmethod
+    def _telegram_entity_type(entity: Any) -> str:
+        return str(getattr(entity, "type", "")).split(".")[-1].lower()
+
+    @classmethod
+    def _canonical_telegram_entities(cls, source_text: str, entities: Any) -> list[dict[str, Any]]:
+        """Return sanitized Telegram formatting/routing entity metadata."""
+        canonical: list[dict[str, Any]] = []
+        for entity in entities or []:
+            try:
+                offset = int(getattr(entity, "offset", -1))
+                length = int(getattr(entity, "length", 0))
+            except (TypeError, ValueError):
+                continue
+            bounds = cls._telegram_entity_bounds(source_text, offset, length)
+            if bounds is None:
+                continue
+            entity_type = cls._telegram_entity_type(entity)
+            entry: dict[str, Any] = {
+                "type": entity_type,
+                "offset_utf16": offset,
+                "length_utf16": length,
+                "start": bounds[0],
+                "end": bounds[1],
+                "text": source_text[bounds[0]:bounds[1]],
+            }
+            if entity_type == "text_link":
+                entry["url"] = getattr(entity, "url", None)
+            if entity_type == "pre":
+                language = getattr(entity, "language", None)
+                if language:
+                    entry["language"] = language
+            if entity_type == "custom_emoji":
+                custom_emoji_id = getattr(entity, "custom_emoji_id", None)
+                if custom_emoji_id:
+                    entry["custom_emoji_id"] = str(custom_emoji_id)
+            canonical.append(entry)
+        return canonical
+
+    @classmethod
+    def _telegram_entities_to_markdown(cls, source_text: str, entities: Any) -> str:
+        """Render Telegram rich-text entities as canonical internal Markdown.
+
+        Telegram reports offsets in UTF-16 code units.  The agent runtime wants
+        one text string, so supported formatting entities are converted while the
+        raw plain text remains available in event metadata as a fallback.
+        Unsupported or malformed entities are ignored rather than making an
+        otherwise authorized message undispatchable.
+        """
+        if not source_text:
+            return ""
+        spans: list[tuple[int, int, str, str]] = []
+        for entry in cls._canonical_telegram_entities(source_text, entities):
+            entity_type = entry["type"]
+            if entity_type not in cls._TELEGRAM_CANONICAL_ENTITY_TYPES:
+                continue
+            start, end = int(entry["start"]), int(entry["end"])
+            if not (0 <= start < end <= len(source_text)):
+                continue
+            if entity_type == "bold":
+                before, after = "**", "**"
+            elif entity_type == "italic":
+                before, after = "*", "*"
+            elif entity_type == "underline":
+                before, after = "<u>", "</u>"
+            elif entity_type == "strikethrough":
+                before, after = "~~", "~~"
+            elif entity_type == "spoiler":
+                before, after = "||", "||"
+            elif entity_type == "code":
+                before, after = "`", "`"
+            elif entity_type == "pre":
+                lang = str(entry.get("language") or "").strip()
+                before, after = f"```{lang}\n", "\n```"
+            elif entity_type == "text_link":
+                url = entry.get("url") or ""
+                before, after = "[", f"]({url})" if url else "]"
+            elif entity_type in {"blockquote", "expandable_blockquote"}:
+                before, after = "> ", ""
+            elif entity_type == "custom_emoji":
+                before, after = "", ""
+            else:
+                continue
+            spans.append((start, end, before, after))
+        if not spans:
+            return source_text
+        opens: dict[int, list[str]] = {}
+        closes: dict[int, list[str]] = {}
+        for start, end, before, after in spans:
+            if before:
+                opens.setdefault(start, []).append(before)
+            if after:
+                closes.setdefault(end, []).append(after)
+        out: list[str] = []
+        for idx, ch in enumerate(source_text):
+            if idx in opens:
+                out.extend(opens[idx])
+            out.append(ch)
+            end_idx = idx + 1
+            if end_idx in closes:
+                out.extend(reversed(closes[end_idx]))
+        return "".join(out)
 
     def _message_mentions_bot(self, message: Message) -> bool:
         if not self._bot:
@@ -8924,13 +9068,26 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        batch_key = self._text_batch_key(event)
         if not self._should_process_message(msg):
+            # Telegram iOS/Desktop split long rich text into consecutive updates.
+            # Only the first chunk may contain the bot trigger; continuation
+            # chunks are often plain or carry unrelated formatting entities. If
+            # a batch is already open for this chat/user/topic, treat this text
+            # as a continuation and enqueue it exactly once instead of dropping
+            # it at the mention gate.
+            if batch_key in self._pending_text_batches:
+                event.text = self._clean_bot_trigger_text(event.text)
+                await self._cache_replied_media(msg, event)
+                event = self._apply_telegram_group_observe_attribution(event)
+                self._enqueue_text_event(event)
+                return
             if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
+                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id, event=event)
             return
         await self._ensure_forum_commands(update.message)
 
-        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
@@ -9059,6 +9216,24 @@ class TelegramAdapter(BasePlatformAdapter):
             # Append text from the follow-up chunk
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing_meta = getattr(existing, "metadata", None) or {}
+            event_meta = getattr(event, "metadata", None) or {}
+            if event_meta:
+                if event_meta.get("telegram_plain_text"):
+                    existing_meta["telegram_plain_text"] = (
+                        f"{existing_meta.get('telegram_plain_text', '')}\n{event_meta['telegram_plain_text']}"
+                        if existing_meta.get("telegram_plain_text")
+                        else event_meta["telegram_plain_text"]
+                    )
+                if event_meta.get("telegram_canonical_text"):
+                    existing_meta["telegram_canonical_text"] = (
+                        f"{existing_meta.get('telegram_canonical_text', '')}\n{event_meta['telegram_canonical_text']}"
+                        if existing_meta.get("telegram_canonical_text")
+                        else event_meta["telegram_canonical_text"]
+                    )
+                if event_meta.get("telegram_entities"):
+                    existing_meta.setdefault("telegram_entities", []).extend(event_meta["telegram_entities"])
+                existing.metadata = existing_meta
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             # Merge any media that might be attached
             if event.media_urls:
@@ -9907,8 +10082,18 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
+        plain_text = message.text or message.caption or ""
+        raw_entities = getattr(message, "entities", None) or getattr(message, "caption_entities", None) or []
+        canonical_entities = self._canonical_telegram_entities(plain_text, raw_entities)
+        canonical_text = self._telegram_entities_to_markdown(plain_text, raw_entities)
+        metadata = {
+            "telegram_plain_text": plain_text,
+            "telegram_canonical_text": canonical_text,
+            "telegram_entities": canonical_entities,
+        }
+
         return MessageEvent(
-            text=message.text or "",
+            text=canonical_text or plain_text,
             message_type=msg_type,
             source=source,
             raw_message=message,
@@ -9918,6 +10103,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            metadata=metadata,
             timestamp=message.date,
         )
 

--- a/tests/gateway/fixtures/telegram_ios_rich_text_updates.json
+++ b/tests/gateway/fixtures/telegram_ios_rich_text_updates.json
@@ -1,0 +1,126 @@
+{
+  "ios_formatted": {
+    "update_type": "message",
+    "effective_message": "message",
+    "message_id": 100,
+    "chat": {
+      "type": "supergroup",
+      "id": "[CHAT_ID]",
+      "message_thread_id": "[THREAD_ID]"
+    },
+    "from_user": {
+      "id": "[USER_ID]"
+    },
+    "text": "@hermes_bot bold italic under strike spoil code pre link quote expand 😎 custom",
+    "caption": null,
+    "entities": [
+      {
+        "type": "bold",
+        "offset": 12,
+        "length": 4
+      },
+      {
+        "type": "italic",
+        "offset": 17,
+        "length": 6
+      },
+      {
+        "type": "underline",
+        "offset": 24,
+        "length": 5
+      },
+      {
+        "type": "strikethrough",
+        "offset": 30,
+        "length": 6
+      },
+      {
+        "type": "spoiler",
+        "offset": 37,
+        "length": 5
+      },
+      {
+        "type": "code",
+        "offset": 43,
+        "length": 4
+      },
+      {
+        "type": "pre",
+        "offset": 48,
+        "length": 3,
+        "language": "python"
+      },
+      {
+        "type": "text_link",
+        "offset": 52,
+        "length": 4,
+        "url": "https://example.com"
+      },
+      {
+        "type": "blockquote",
+        "offset": 57,
+        "length": 5
+      },
+      {
+        "type": "expandable_blockquote",
+        "offset": 63,
+        "length": 6
+      },
+      {
+        "type": "custom_emoji",
+        "offset": 70,
+        "length": 2,
+        "custom_emoji_id": "[CUSTOM_EMOJI_ID]"
+      }
+    ],
+    "caption_entities": [],
+    "routing_expectation": "formatting entities do not suppress raw @bot fallback; dispatch allowed"
+  },
+  "ios_plain": {
+    "update_type": "message",
+    "effective_message": "message",
+    "message_id": 101,
+    "chat": {
+      "type": "supergroup",
+      "id": "[CHAT_ID]",
+      "message_thread_id": "[THREAD_ID]"
+    },
+    "from_user": {
+      "id": "[USER_ID]"
+    },
+    "text": "@hermes_bot plain instruction",
+    "caption": null,
+    "entities": [],
+    "caption_entities": [],
+    "routing_expectation": "raw @bot fallback dispatch allowed"
+  },
+  "macos_formatted": {
+    "update_type": "message",
+    "effective_message": "message",
+    "message_id": 102,
+    "chat": {
+      "type": "supergroup",
+      "id": "[CHAT_ID]",
+      "message_thread_id": "[THREAD_ID]"
+    },
+    "from_user": {
+      "id": "[USER_ID]"
+    },
+    "text": "@hermes_bot bold instruction",
+    "caption": null,
+    "entities": [
+      {
+        "type": "mention",
+        "offset": 0,
+        "length": 11
+      },
+      {
+        "type": "bold",
+        "offset": 12,
+        "length": 4
+      }
+    ],
+    "caption_entities": [],
+    "routing_expectation": "mention entity dispatch allowed; formatting canonicalized"
+  }
+}

--- a/tests/gateway/test_telegram_inbound_rich_text.py
+++ b/tests/gateway/test_telegram_inbound_rich_text.py
@@ -1,0 +1,159 @@
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _utf16_span(text: str, needle: str) -> tuple[int, int]:
+    start = text.index(needle)
+    prefix = text[:start]
+    return (
+        len(prefix.encode("utf-16-le")) // 2,
+        len(needle.encode("utf-16-le")) // 2,
+    )
+
+
+def _entity(text: str, typ: str, needle: str, **extra):
+    offset, length = _utf16_span(text, needle)
+    return SimpleNamespace(type=typ, offset=offset, length=length, **extra)
+
+
+def _make_adapter(*, require_mention=True, bot_username="hermes_bot"):
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="[REDACTED]",
+        extra={
+            "require_mention": require_mention,
+            "allowed_chats": ["-100"],
+            "allowed_topics": [],
+            "group_allowed_chats": ["-100"],
+        },
+    )
+    adapter._bot = SimpleNamespace(id=999, username=bot_username)
+    adapter._message_handler = AsyncMock(return_value="response produced")
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.01
+    adapter._mention_patterns = []
+    adapter._forum_lock = asyncio.Lock()
+    adapter._forum_command_registered = set()
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._dm_topic_chat_ids = set()
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    adapter._is_user_authorized_from_message = lambda _msg: True
+    adapter._apply_topic_recovery = lambda _event: None
+    adapter._should_drop_delayed_delivery = lambda: False
+    async def _handle_message(event):
+        await adapter._message_handler(event)
+    adapter.handle_message = _handle_message
+    return adapter
+
+
+def _group_message(text: str, *, entities, message_id=42):
+    return SimpleNamespace(
+        message_id=message_id,
+        text=text,
+        caption=None,
+        entities=entities,
+        caption_entities=[],
+        message_thread_id=7,
+        is_topic_message=True,
+        chat=SimpleNamespace(id=-100, type="supergroup", title="Jay Command Center", is_forum=True),
+        from_user=SimpleNamespace(id=111, full_name="Andres", first_name="Andres", is_bot=False),
+        reply_to_message=None,
+        date=None,
+    )
+
+
+def test_canonicalizes_supported_ios_rich_text_entities_with_utf16_offsets():
+    text = "@hermes_bot bold italic under strike spoil code pre link quote expand 😎 custom"
+    entities = [
+        _entity(text, "bold", "bold"),
+        _entity(text, "italic", "italic"),
+        _entity(text, "underline", "under"),
+        _entity(text, "strikethrough", "strike"),
+        _entity(text, "spoiler", "spoil"),
+        _entity(text, "code", "code"),
+        _entity(text, "pre", "pre", language="python"),
+        _entity(text, "text_link", "link", url="https://example.com"),
+        _entity(text, "blockquote", "quote"),
+        _entity(text, "expandable_blockquote", "expand"),
+        _entity(text, "custom_emoji", "😎", custom_emoji_id="emoji-1"),
+    ]
+
+    msg = _group_message(text, entities=entities)
+    event = _make_adapter()._build_message_event(msg, msg_type=__import__("gateway.platforms.base", fromlist=["MessageType"]).MessageType.TEXT, update_id=7001)
+
+    assert event.metadata["telegram_plain_text"] == text
+    assert {e["type"] for e in event.metadata["telegram_entities"]} >= {
+        "bold", "italic", "underline", "strikethrough", "spoiler", "code", "pre",
+        "text_link", "blockquote", "expandable_blockquote", "custom_emoji",
+    }
+    assert "**bold**" in event.text
+    assert "*italic*" in event.text
+    assert "<u>under</u>" in event.text
+    assert "~~strike~~" in event.text
+    assert "||spoil||" in event.text
+    assert "`code`" in event.text
+    assert "```python\npre\n```" in event.text
+    assert "[link](https://example.com)" in event.text
+    assert "> quote" in event.text
+    assert "> expand" in event.text
+    assert "😎" in event.text
+
+
+def test_unrelated_ios_formatting_entities_do_not_suppress_raw_mention_fallback():
+    text = "**client-rendered** @hermes_bot please handle this iOS rich instruction"
+    # iOS-style formatted paste may include formatting entities but no mention entity.
+    entities = [_entity(text, "bold", "client-rendered")]
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._message_mentions_bot(_group_message(text, entities=entities)) is True
+    assert adapter._should_process_message(_group_message(text, entities=entities)) is True
+
+
+def test_ios_rich_update_reaches_dispatch_with_canonical_markdown_once():
+    async def _run():
+        text = "@hermes_bot run bold instruction part 1 " + "x" * 3900
+        text2 = "continue with italic part 2"
+        msg1 = _group_message(text, entities=[_entity(text, "bold", "bold")], message_id=100)
+        msg2 = _group_message(text2, entities=[_entity(text2, "italic", "italic")], message_id=101)
+        adapter = _make_adapter(require_mention=True)
+
+        await adapter._handle_text_message(SimpleNamespace(update_id=8001, message=msg1, effective_message=msg1), SimpleNamespace())
+        await adapter._handle_text_message(SimpleNamespace(update_id=8002, message=msg2, effective_message=msg2), SimpleNamespace())
+        await asyncio.sleep(0.03)
+
+        adapter._message_handler.assert_awaited_once()
+        event = adapter._message_handler.await_args.args[0]
+        assert "**bold**" in event.text
+        assert "*italic*" in event.text
+        assert event.text.count("continue with") == 1
+        assert event.metadata["telegram_plain_text"].startswith("@hermes_bot run bold")
+        assert event.platform_update_id == 8001
+
+    asyncio.run(_run())
+
+
+def test_sanitized_ios_fixture_reproduces_routing_and_normalization_contract():
+    fixture = json.loads((Path(__file__).parent / "fixtures" / "telegram_ios_rich_text_updates.json").read_text())
+    ios = fixture["ios_formatted"]
+    text = ios["text"]
+    entities = [SimpleNamespace(**entity) for entity in ios["entities"]]
+    msg = _group_message(text, entities=entities)
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(msg) is True
+    event = adapter._build_message_event(msg, msg_type=__import__("gateway.platforms.base", fromlist=["MessageType"]).MessageType.TEXT, update_id=9001)
+    assert event.metadata["telegram_plain_text"] == text
+    assert event.metadata["telegram_canonical_text"] == event.text
+    assert "**bold**" in event.text
+    assert "[link](https://example.com)" in event.text


### PR DESCRIPTION
Fixes Telegram iOS rich-text inbound drops by treating formatting entities as non-routing metadata, preserving raw @bot fallback, canonicalizing supported Telegram entities into MessageEvent metadata/Markdown, and reassembling long formatted continuation chunks exactly once.\n\nVerification:\n- uv run python -m pytest tests/gateway/test_telegram_inbound_rich_text.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_caption_merge.py tests/gateway/test_telegram_voice_duration.py -q\n- uv run ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_inbound_rich_text.py