### PR TITLE
fix(update): preserve state across Windows reexec

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5184,6 +5184,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_resume_windows_gateways_after_update",
         "_run_pending_fleet_restart",
         "_run_logged_subprocess",
+        "_run_or_resume_pre_update_backup",
         "_run_pre_update_backup",
         "_service_unit_supports_graceful_sigusr1_restart",
         "_should_skip_upstream_prompt",
@@ -9333,9 +9334,13 @@ def _windows_running_hermes_launcher_locked() -> bool:
 
 # Set on the re-exec'd child so it can never spawn another one.
 _UPDATE_REEXEC_ENV = "HERMES_UPDATE_REEXEC"
+_UPDATE_PRE_SNAPSHOT_ENV = "HERMES_UPDATE_PRE_SNAPSHOT_ID"
+_UPDATE_SIBLING_SNAPSHOTS_ENV = "HERMES_UPDATE_SIBLING_SNAPSHOT_IDS"
 
 
-def _reexec_dependency_sync_off_windows_shim() -> bool:
+def _reexec_dependency_sync_off_windows_shim(
+    pre_update_snapshot_id: str | None = None,
+) -> bool:
     """Hand the dependency sync to the venv interpreter, off the console shim.
 
     Returns True when a child was spawned and the caller must exit at once,
@@ -9388,10 +9393,34 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
     python_exe = venv_python_path(shim.parent.parent, windows=True)
     cmd = [str(python_exe), "-m", "hermes_cli.main", *sys.argv[1:]]
     if python_exe.is_file():
+        receipt_handoff = None
+        try:
+            from hermes_cli.update_receipt import (
+                UPDATE_RECEIPT_HANDOFF_ENV,
+                prepare_update_receipt_handoff,
+            )
+
+            receipt_handoff = prepare_update_receipt_handoff()
+        except Exception:
+            receipt_handoff = None
+        child_env = {**os.environ, _UPDATE_REEXEC_ENV: "1"}
+        if pre_update_snapshot_id:
+            child_env[_UPDATE_PRE_SNAPSHOT_ENV] = str(pre_update_snapshot_id)
+        try:
+            from hermes_cli.update_cmd import _LAST_SIBLING_SNAPSHOTS
+
+            if _LAST_SIBLING_SNAPSHOTS:
+                child_env[_UPDATE_SIBLING_SNAPSHOTS_ENV] = json.dumps(
+                    _LAST_SIBLING_SNAPSHOTS
+                )
+        except Exception:
+            pass
+        if receipt_handoff is not None:
+            child_env[UPDATE_RECEIPT_HANDOFF_ENV] = str(receipt_handoff)
         try:
             subprocess.Popen(
                 cmd,
-                env={**os.environ, _UPDATE_REEXEC_ENV: "1"},
+                env=child_env,
                 stdin=subprocess.DEVNULL,
             )
             print(
@@ -9404,6 +9433,13 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
             )
             return True
         except OSError as exc:
+            if receipt_handoff is not None:
+                try:
+                    from hermes_cli.update_receipt import resume_update_receipt_handoff
+
+                    resume_update_receipt_handoff(receipt_handoff)
+                except Exception:
+                    pass
             logger.debug("Dependency-sync hand-off via %s failed: %s", python_exe, exc)
         print(f"  ⚠ Could not hand the dependency install off {shim.name}.")
         print("    Continuing in-process; if it cannot replace the shim, run:")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1949,7 +1949,12 @@ def _restore_state_db_from_snapshot(state_path: Path, snap_state: Path) -> bool:
     return bool(restored.get("valid"))
 
 
-def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> bool:
+def _update_via_zip(
+    args,
+    *,
+    had_desktop_app_before_update: bool = False,
+    pre_update_snapshot_id: str | None = None,
+) -> bool:
     """Update Hermes Agent by downloading a ZIP archive.
 
     Used on Windows when git file I/O is broken (antivirus, NTFS filter
@@ -2167,7 +2172,9 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     # Self-lock deferral (relocated preflight — #86735): the ZIP code swap
     # above is already committed; defer only the dependency sync when this
     # process holds a native extension the sync must rewrite.
-    _m()._abort_dependency_sync_if_self_locked()
+    _m()._abort_dependency_sync_if_self_locked(
+        pre_update_snapshot_id=pre_update_snapshot_id
+    )
     print("→ Updating Python dependencies...")
 
     from hermes_cli.managed_uv import ensure_uv, update_managed_uv
@@ -4872,6 +4879,31 @@ def _run_pre_update_backup(args) -> Optional[str]:
     print()
     return snapshot_id
 
+
+def _run_or_resume_pre_update_backup(args) -> tuple[Optional[str], bool]:
+    """Run the backup once, or reuse the parent snapshot after Windows re-exec."""
+    inherited_snapshot_id = None
+    if os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1":
+        inherited_snapshot_id = os.environ.get(_m()._UPDATE_PRE_SNAPSHOT_ENV)
+    if inherited_snapshot_id:
+        try:
+            sibling_snapshots = json.loads(
+                os.environ.get(_m()._UPDATE_SIBLING_SNAPSHOTS_ENV, "{}")
+            )
+            if isinstance(sibling_snapshots, dict):
+                global _LAST_SIBLING_SNAPSHOTS
+                _LAST_SIBLING_SNAPSHOTS = {
+                    str(profile): str(snapshot_id)
+                    for profile, snapshot_id in sibling_snapshots.items()
+                    if profile and snapshot_id
+                }
+        except (TypeError, ValueError):
+            pass
+        print(f"◆ Pre-update snapshot: {inherited_snapshot_id} (reused from parent)")
+        print()
+        return inherited_snapshot_id, True
+    return _m()._run_pre_update_backup(args), False
+
 def _write_update_planned_stop_marker(profile_path: Path, pid: int) -> bool:
     """Write a planned-stop marker into a specific profile home."""
     try:
@@ -5249,7 +5281,10 @@ def _detect_self_loaded_native_modules() -> list[str]:
     return sorted(set(found))
 
 
-def _abort_dependency_sync_if_self_locked(gateway_resume=None) -> None:
+def _abort_dependency_sync_if_self_locked(
+    gateway_resume=None,
+    pre_update_snapshot_id: str | None = None,
+) -> None:
     """Defer the venv rewrite when THIS process holds something it must replace.
 
     Runs at the last moment before the venv rewrite — after the code swap —
@@ -5276,7 +5311,9 @@ def _abort_dependency_sync_if_self_locked(gateway_resume=None) -> None:
             _m()._resume_windows_gateways_after_update(gateway_resume)
         sys.exit(2)
 
-    if _m()._reexec_dependency_sync_off_windows_shim():
+    if _m()._reexec_dependency_sync_off_windows_shim(
+        pre_update_snapshot_id=pre_update_snapshot_id
+    ):
         if gateway_resume is not None:
             _m()._resume_windows_gateways_after_update(gateway_resume)
         sys.exit(0)
@@ -8006,14 +8043,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # always roll back to the exact state they had before this update.
     # Returns the quick-snapshot id (or None when disabled/failed); the
     # post-update cron-jobs safety net uses it to detect job loss.
-    pre_update_snapshot_id = _m()._run_pre_update_backup(args)
+    pre_update_snapshot_id, backup_reused = _m()._run_or_resume_pre_update_backup(args)
     try:
         from hermes_cli.update_receipt import record_step
 
         record_step(
-            "pre_update_backup",
+            "pre_update_backup_handoff" if backup_reused else "pre_update_backup",
             pre_update_snapshot_id is not None,
-            f"snapshot={pre_update_snapshot_id}" if pre_update_snapshot_id else "disabled or failed",
+            (
+                f"reused snapshot={pre_update_snapshot_id}"
+                if backup_reused
+                else f"snapshot={pre_update_snapshot_id}"
+                if pre_update_snapshot_id
+                else "disabled or failed"
+            ),
         )
     except Exception:
         pass
@@ -8282,6 +8325,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
+                pre_update_snapshot_id=pre_update_snapshot_id,
             )
         finally:
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
@@ -8628,7 +8672,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if handed_off_sync or not healthy:
                 # Self-lock deferral (#86735): the repair rewrites the venv
                 # too — same mapped-extension hazard as the update sync.
-                _m()._abort_dependency_sync_if_self_locked(_windows_gateway_resume)
+                _m()._abort_dependency_sync_if_self_locked(
+                    _windows_gateway_resume,
+                    pre_update_snapshot_id=pre_update_snapshot_id,
+                )
                 _write_update_incomplete_marker()
                 from hermes_cli.managed_uv import ensure_uv
 
@@ -9020,7 +9067,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # holds a native extension the sync must rewrite, defer NOW — after
         # the code swap, so only the dependency install is pending and the
         # next fresh launch completes it via the marker.
-        _m()._abort_dependency_sync_if_self_locked(_windows_gateway_resume)
+        _m()._abort_dependency_sync_if_self_locked(
+            _windows_gateway_resume,
+            pre_update_snapshot_id=pre_update_snapshot_id,
+        )
         #
         # Drop the core-install breadcrumb BEFORE touching the venv. If the
         # install is killed mid-flight (Ctrl-C, terminal close, WSL OOM), the
@@ -10692,6 +10742,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
+                pre_update_snapshot_id=pre_update_snapshot_id,
             )
             if gateway_mode:
                 _write_gateway_update_exit_code(desktop_build_ok)

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 _RECEIPT_DIR_NAME = "update_receipts"
 _RECEIPT_KEEP = 20  # keep the last N receipts per profile home
+_HANDOFF_STALE_SECONDS = 24 * 60 * 60
+UPDATE_RECEIPT_HANDOFF_ENV = "HERMES_UPDATE_RECEIPT_HANDOFF"
 
 # Module-level current receipt. ``hermes update`` is a single-threaded CLI
 # command; a module singleton lets the 7k-line updater record steps from
@@ -156,10 +158,79 @@ def begin_update_receipt() -> None:
     """Start recording a new update receipt. Never raises."""
     global _current
     try:
+        handoff_path = os.environ.pop(UPDATE_RECEIPT_HANDOFF_ENV, "")
+        if handoff_path and resume_update_receipt_handoff(Path(handoff_path)):
+            return
         _current = UpdateReceipt()
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Could not start update receipt: %s", exc)
         _current = None
+
+
+def prepare_update_receipt_handoff() -> Optional[Path]:
+    """Persist the active receipt for a Windows updater re-exec.
+
+    The pending payload also becomes ``latest.json`` so observers never see
+    the parent process's clean exit as terminal success while the child still
+    owns the dependency sync. The active singleton is released only after
+    both files are durable; a spawn failure can resume the handoff in-process.
+    """
+    global _current
+    receipt = _current
+    if receipt is None:
+        return None
+    try:
+        payload = json.loads(json.dumps(receipt.data, default=str))
+        payload["handoff"] = {
+            "state": "pending",
+            "from_pid": os.getpid(),
+            "at": _utc_now_iso(),
+        }
+        directory = _receipt_dir()
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f".handoff_{os.getpid()}_{time.time_ns()}.json"
+        encoded = json.dumps(payload, indent=2, default=str)
+        path.write_text(encoded, encoding="utf-8")
+        (directory / "latest.json").write_text(encoded, encoding="utf-8")
+        _current = None
+        return path
+    except Exception as exc:
+        logger.debug("Could not prepare update receipt handoff: %s", exc)
+        return None
+
+
+def resume_update_receipt_handoff(path: Path) -> bool:
+    """Resume a receipt prepared by :func:`prepare_update_receipt_handoff`."""
+    global _current
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return False
+        handoff = payload.get("handoff")
+        if not isinstance(handoff, dict) or handoff.get("state") != "pending":
+            return False
+        handoff["state"] = "resumed"
+        handoff["to_pid"] = os.getpid()
+        handoff["resumed_at"] = _utc_now_iso()
+        payload["pid"] = os.getpid()
+        receipt = UpdateReceipt.__new__(UpdateReceipt)
+        receipt.data = payload
+        _current = receipt
+        try:
+            latest = _receipt_dir() / "latest.json"
+            latest.write_text(
+                json.dumps(payload, indent=2, default=str), encoding="utf-8"
+            )
+        except OSError:
+            pass
+        try:
+            Path(path).unlink()
+        except OSError:
+            pass
+        return True
+    except Exception as exc:
+        logger.debug("Could not resume update receipt handoff: %s", exc)
+        return False
 
 
 def record_step(name: str, ok: bool, detail: str = "") -> None:
@@ -278,6 +349,17 @@ def _prune_old_receipts(directory: Path) -> None:
         for stale in receipts[_RECEIPT_KEEP:]:
             try:
                 stale.unlink()
+            except OSError:
+                pass
+
+        handoff_cutoff = time.time() - _HANDOFF_STALE_SECONDS
+        for stale_handoff in directory.glob(".handoff_*.json"):
+            try:
+                if (
+                    stale_handoff.is_file()
+                    and stale_handoff.stat().st_mtime < handoff_cutoff
+                ):
+                    stale_handoff.unlink()
             except OSError:
                 pass
     except Exception:

--- a/tests/hermes_cli/test_update_backup_handoff.py
+++ b/tests/hermes_cli/test_update_backup_handoff.py
@@ -1,0 +1,41 @@
+"""Regression tests for pre-update state transferred across Windows re-exec."""
+
+import json
+from argparse import Namespace
+
+
+def test_reexec_reuses_parent_snapshot_without_new_backup(monkeypatch):
+    from hermes_cli import main as cli_main
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
+    monkeypatch.setenv(cli_main._UPDATE_PRE_SNAPSHOT_ENV, "snapshot-123")
+
+    def _unexpected_backup(_args):
+        raise AssertionError("re-exec child must not create another backup")
+
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", _unexpected_backup)
+
+    snapshot_id, reused = update_cmd._run_or_resume_pre_update_backup(
+        Namespace(no_backup=False, backup=True)
+    )
+
+    assert snapshot_id == "snapshot-123"
+    assert reused is True
+
+
+def test_reexec_restores_sibling_snapshot_ids(monkeypatch):
+    from hermes_cli import main as cli_main
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
+    monkeypatch.setenv(cli_main._UPDATE_PRE_SNAPSHOT_ENV, "snapshot-123")
+    monkeypatch.setenv(
+        cli_main._UPDATE_SIBLING_SNAPSHOTS_ENV,
+        json.dumps({"work": "snapshot-work"}),
+    )
+    monkeypatch.setattr(update_cmd, "_LAST_SIBLING_SNAPSHOTS", {})
+
+    update_cmd._run_or_resume_pre_update_backup(Namespace())
+
+    assert update_cmd._LAST_SIBLING_SNAPSHOTS == {"work": "snapshot-work"}

--- a/tests/hermes_cli/test_update_receipt.py
+++ b/tests/hermes_cli/test_update_receipt.py
@@ -12,6 +12,7 @@ Covers:
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -132,6 +133,33 @@ class TestReceiptLifecycle:
         _finalize("success")
         assert ur._current is None
 
+    def test_windows_reexec_resumes_same_receipt(self, receipt_home, monkeypatch):
+        ur.begin_update_receipt()
+        ur.record_step("pre_update_backup", True, "snapshot=abc123")
+        started_at = ur._current.data["started_at"]
+        parent_pid = ur._current.data["pid"]
+
+        handoff_path = ur.prepare_update_receipt_handoff()
+
+        assert handoff_path is not None and handoff_path.is_file()
+        assert ur._current is None
+        latest = ur.read_latest_receipt()
+        assert latest["outcome"] == "running"
+        assert latest["finished_at"] is None
+        assert latest["handoff"]["state"] == "pending"
+
+        monkeypatch.setenv(ur.UPDATE_RECEIPT_HANDOFF_ENV, str(handoff_path))
+        ur.begin_update_receipt()
+        assert not handoff_path.exists()
+        path = ur.finalize_update_receipt("success")
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["started_at"] == started_at
+        assert payload["steps"][0]["detail"] == "snapshot=abc123"
+        assert payload["handoff"]["state"] == "resumed"
+        assert payload["handoff"]["from_pid"] == parent_pid
+        assert payload["handoff"]["to_pid"] == os.getpid()
+
     def test_pruning_keeps_recent(self, receipt_home, monkeypatch):
         monkeypatch.setattr(ur, "_RECEIPT_KEEP", 3)
         directory = receipt_home / "logs" / "update_receipts"
@@ -149,6 +177,24 @@ class TestReceiptLifecycle:
             "update_20260104_000000_1.json",
             "update_20260105_000000_1.json",
         ]
+
+    def test_pruning_removes_only_stale_handoff_files(
+        self, receipt_home, monkeypatch
+    ):
+        monkeypatch.setattr(ur, "_HANDOFF_STALE_SECONDS", 10)
+        directory = receipt_home / "logs" / "update_receipts"
+        directory.mkdir(parents=True)
+        stale = directory / ".handoff_stale.json"
+        recent = directory / ".handoff_recent.json"
+        stale.write_text("{}", encoding="utf-8")
+        recent.write_text("{}", encoding="utf-8")
+        now = time.time()
+        os.utime(stale, (now - 20, now - 20))
+
+        ur._prune_old_receipts(directory)
+
+        assert not stale.exists()
+        assert recent.exists()
 
     def test_read_latest_receipt_missing(self, receipt_home):
         assert ur.read_latest_receipt() is None

--- a/tests/hermes_cli/test_update_shim_self_lock.py
+++ b/tests/hermes_cli/test_update_shim_self_lock.py
@@ -16,6 +16,7 @@ off at all.
 
 from __future__ import annotations
 
+import json
 import sys
 import types
 from pathlib import Path
@@ -152,6 +153,39 @@ def test_reexec_child_runs_unattended(venv, monkeypatch):
     assert calls[0][2]["stdin"] is cli_main.subprocess.DEVNULL
 
 
+def test_reexec_transfers_receipt_and_snapshot(venv, monkeypatch, tmp_path):
+    from hermes_cli import update_receipt
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    calls = _capture_popen(monkeypatch)
+    handoff_path = tmp_path / "receipt-handoff.json"
+    monkeypatch.setattr(
+        update_receipt,
+        "prepare_update_receipt_handoff",
+        lambda: handoff_path,
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_LAST_SIBLING_SNAPSHOTS",
+        {"work": "snapshot-work"},
+    )
+
+    assert (
+        cli_main._reexec_dependency_sync_off_windows_shim(
+            pre_update_snapshot_id="snapshot-123"
+        )
+        is True
+    )
+
+    env = calls[0][1]
+    assert env[update_receipt.UPDATE_RECEIPT_HANDOFF_ENV] == str(handoff_path)
+    assert env[cli_main._UPDATE_PRE_SNAPSHOT_ENV] == "snapshot-123"
+    assert json.loads(env[cli_main._UPDATE_SIBLING_SNAPSHOTS_ENV]) == {
+        "work": "snapshot-work"
+    }
+
+
 def test_reexec_does_not_recurse(venv, monkeypatch):
     monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
     monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
@@ -181,6 +215,28 @@ def test_reexec_falls_through_when_spawn_fails(venv, monkeypatch, capsys):
 
     assert cli_main._reexec_dependency_sync_off_windows_shim() is False
     assert "-m hermes_cli.main update" in capsys.readouterr().out
+
+
+def test_reexec_spawn_failure_resumes_parent_receipt(venv, monkeypatch, tmp_path):
+    from hermes_cli import update_receipt
+
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    _capture_popen(monkeypatch, raises=OSError("no exec"))
+    handoff_path = tmp_path / "receipt-handoff.json"
+    resumed = []
+    monkeypatch.setattr(
+        update_receipt,
+        "prepare_update_receipt_handoff",
+        lambda: handoff_path,
+    )
+    monkeypatch.setattr(
+        update_receipt,
+        "resume_update_receipt_handoff",
+        lambda path: resumed.append(path) or True,
+    )
+
+    assert cli_main._reexec_dependency_sync_off_windows_shim() is False
+    assert resumed == [handoff_path]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep the active update receipt open across the Windows shim re-exec, so `latest.json` remains non-terminal until the child finishes
- transfer the parent default/sibling snapshot IDs and reuse them instead of creating a second pre-update backup
- restore the parent receipt if child spawn fails and prune stale handoff files defensively

## Root cause

The Windows dependency-sync handoff re-ran `hermes update` with the original arguments. The parent finalized its receipt as `success` when it exited, while the child started a new receipt and executed the pre-update backup again. A full backup therefore ran twice and observers could see premature success during the child phase.

## Test plan

- `uv run --with pytest python -m pytest tests/hermes_cli/test_update_receipt.py tests/hermes_cli/test_update_shim_self_lock.py tests/hermes_cli/test_update_backup_handoff.py -q` — 55 passed
- `uv run --with ruff ruff check hermes_cli/main.py hermes_cli/update_cmd.py hermes_cli/update_receipt.py tests/hermes_cli/test_update_receipt.py tests/hermes_cli/test_update_shim_self_lock.py tests/hermes_cli/test_update_backup_handoff.py` — passed

## Baseline note

The wider ordered `tests/hermes_cli/test_update*.py` run reaches the pre-existing Windows order-dependent failure `test_cold_start_raises_when_process_does_not_survive` after 60 passes and 1 skip. The same command fails at the same test on an untouched `upstream/main` worktree.
