### PR TITLE
docs(windows): document Smart App Control blocking of unsigned binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ If attestation says "Verification succeeded" and the last line prints `True`, yo
 
 For more context, see the upstream Astral reports: [astral-sh/uv#13553](https://github.com/astral-sh/uv/issues/13553), [astral-sh/uv#15011](https://github.com/astral-sh/uv/issues/15011), [astral-sh/uv#10079](https://github.com/astral-sh/uv/issues/10079).
 
+#### Windows 11 Smart App Control blocks Hermes before it ever runs
+
+Smart App Control (SAC) ships in evaluation mode on new Windows 11 installs and may switch itself on. When on, it blocks unsigned binaries — `hermes.exe` and the bundled `uv.exe` both qualify — before the app or Node ever gets to run them, typically with a "Smart App Control blocked this app" dialog. SAC has **no per-app or per-folder allowlist**, so unlike the Defender case above there is no targeted exclusion: the only way to run Hermes alongside SAC is to turn SAC off entirely (**Settings → Privacy & security → Windows Security → App & browser control → Smart App Control settings → Off**). That is a one-way switch — Windows will not let you re-enable SAC afterwards without resetting the device.
+
+SAC blocks do **not** appear in Windows Security's Protection History. To confirm SAC is what blocked a binary, open **Event Viewer → Applications and Services Logs → Microsoft → Windows → CodeIntegrity → Operational** and look for events naming the blocked file (Microsoft's [SAC testing guide](https://learn.microsoft.com/en-us/windows/apps/develop/smart-app-control/test-your-app-with-smart-app-control) documents this log).
+
+The Sigstore/GitHub-attestation provenance above verifies authenticity, but it is not the Authenticode signature type SAC checks — running with SAC enabled would require signed Windows release binaries ([#99766](https://github.com/NousResearch/hermes-agent/issues/99766)).
+
 ---
 
 ## Getting Started

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -288,7 +288,10 @@ Consequence: any codepath that said "check if this PID is alive" via `os.kill(pi
 ## Common pitfalls
 
 **`hermes: command not found` right after install.**
-Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\bin` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA\hermes\bin\hermes.exe"`.
+Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\bin` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA%\hermes\bin\hermes.exe"`.
+
+**Hermes is blocked at launch on a brand-new Windows 11 machine — a "Smart App Control blocked this app" dialog, and nothing ever runs.**
+Smart App Control (SAC) ships in evaluation mode on new Windows 11 installs and may switch itself on; when on, it blocks unsigned binaries such as `hermes.exe` and the bundled `uv.exe` before they execute. SAC has no per-app or per-folder allowlist, so the only way forward is turning it off in **Settings → Privacy & security → Windows Security → App & browser control → Smart App Control settings → Off** — a one-way switch Windows won't let you undo without a reset. SAC blocks never appear in Protection History; confirm the blocker in **Event Viewer → Applications and Services Logs → Microsoft → Windows → CodeIntegrity → Operational**. See the README's troubleshooting section for the full story.
 
 **`WinError 193: %1 is not a valid Win32 application` when running a tool.**
 You hit a shebang-script invocation that bypassed the `.cmd` shim. Hermes resolves commands through `shutil.which(cmd, path=local_bin)` so PATHEXT picks up `.CMD` — if you're invoking the tool via a hardcoded path instead, switch to the `.cmd` variant (e.g., `npx.cmd`, not `npx`).


### PR DESCRIPTION
## What does this PR do?

Documents Windows 11 Smart App Control (SAC) as a distinct launch blocker for Hermes on Windows. The README already covers Windows Defender and Bitdefender false positives with per-app exclusion steps, but SAC behaves differently and has no documented path: it blocks unsigned binaries (`hermes.exe`, the bundled `uv.exe`) before they ever execute, offers **no per-app or per-folder allowlist**, and never surfaces the block in Windows Security's Protection History — so an affected user has no self-service guidance today (reported in #99766, where the reporter ended up leaving Hermes disabled rather than flipping a system-wide one-way switch blind).

The new content covers, in both the README troubleshooting section and the Windows (Native) guide's Common pitfalls:

- What SAC is (evaluation mode on new Windows 11 installs, may switch itself on) and what the block looks like ("Smart App Control blocked this app" dialog, nothing runs).
- The only way forward: turning SAC off, with the exact settings path, and an explicit warning that it is a one-way switch.
- Where the block can actually be inspected: **Event Viewer → Applications and Services Logs → Microsoft → Windows → CodeIntegrity → Operational** (not Protection History), per Microsoft's [SAC testing guide](https://learn.microsoft.com/en-us/windows/apps/develop/smart-app-control/test-your-app-with-smart-app-control).
- A pointer that the existing Sigstore/GitHub-attestation provenance verifies authenticity but is not the Authenticode signature type SAC checks — running with SAC enabled would require signed Windows release binaries, which stays a maintainer decision and is out of scope for a docs change.

## Related Issue

Fixes #99766

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `README.md` — new troubleshooting subsection "Windows 11 Smart App Control blocks Hermes before it ever runs" directly after the existing Defender/Bitdefender false-positive section, cross-referencing it (SAC has no targeted exclusion, unlike Defender).
- `website/docs/user-guide/windows-native.md` — new Common pitfalls entry for the "blocked at launch on a brand-new Windows 11 machine" symptom, with the settings path, one-way-switch warning, and the CodeIntegrity event log location.

## How to Test

1. Docs-only change; observed result: `git diff` shows 12 insertions / 1 deletion across exactly the two files above, no code touched.
2. Rendered review: the README section renders as a `####` subsection under Troubleshooting consistent with the existing antivirus section, and the pitfall entry follows the established bold-symptom + explanation format of the Windows (Native) guide.
3. Fact-check against Microsoft's documentation: SAC's evaluation-mode defaulting, the absence of a per-app allowlist, the one-way nature of turning it off, and the CodeIntegrity → Operational event log as the place blocks are recorded (Protection History does not show them) — all match the [SAC testing guide](https://learn.microsoft.com/en-us/windows/apps/develop/smart-app-control/test-your-app-with-smart-app-control) and [App Control event ID reference](https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/operations/event-id-explanations).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — documentation-only change, no code paths touched)
- [x] I've added tests for my changes (N/A — documentation-only change)
- [x] I've tested on my platform: macOS 26 (docs authored and fact-checked against Microsoft's Windows 11 documentation; the change itself is platform-independent Markdown)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR *is* the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change documents a Windows-only launcher behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
