### PR TITLE
fix(retry): Z.AI overload retry must not be keyed to one model id

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -11,6 +11,7 @@ import time
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any, Optional
+from urllib.parse import urlsplit as _urlsplit
 
 # Monotonic counter for jitter seed uniqueness within the same process.
 # Protected by a lock to avoid race conditions in concurrent retry paths
@@ -139,24 +140,45 @@ def _error_text(error: Any) -> str:
     return " ".join(str(part) for part in parts if part is not None).lower()
 
 
-def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
-    """Return True for Z.AI Coding Plan transient overload 429s.
+def _is_zai_host(base_url):
+    """True when ``base_url`` names Z.AI's API, on any of its paths.
 
-    The coding-plan endpoint reports overload as HTTP 429 with body code 1305
-    and message "The service may be temporarily overloaded...". Treat only
-    that narrow shape specially so ordinary quota/billing 429s still fail fast
-    through the existing classifier.
+    PARSED, not substring-matched: ``"z.ai" in base_url`` would also accept a
+    lookalike like ``api.z.ai.example.com``, and this decides how long Hermes
+    waits on someone's endpoint. Bare ``host/path`` still resolves.
     """
-    base = (base_url or "").lower()
-    model_name = (model or "").lower()
-    status = getattr(error, "status_code", None)
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    host = (_urlsplit(raw).hostname or "").lower()
+    if not host:
+        host = raw.split("/", 1)[0].split(":", 1)[0].lower()
+    return host == "z.ai" or host.endswith(".z.ai")
+
+
+def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
+    """Return True for Z.AI transient overload 429s.
+
+    Z.AI reports overload as HTTP 429 with body code 1305 and message "The
+    service may be temporarily overloaded...". Treat only that narrow shape
+    specially so ordinary quota/billing 429s (e.g. 1310 "Weekly/Monthly Limit
+    Exhausted") still fail fast through the existing classifier.
+
+    The shape that matters is (429, Z.AI host, 1305) — deliberately NOT the
+    model id. Z.AI moves model aliases under users (``glm-4.7`` was retired
+    and redirected), so a gate naming one model silently stops matching the
+    moment the account's primary changes, and the whole long-backoff schedule
+    becomes unreachable while this function still reads as correct.
+
+    ``model`` is kept in the signature for call-site compatibility and is
+    intentionally unused.
+    """
+    if getattr(error, "status_code", None) != 429:
+        return False
+    if not _is_zai_host(base_url):
+        return False
     text = _error_text(error)
-    return (
-        status == 429
-        and "api.z.ai/api/coding/paas/v4" in base
-        and "glm-5.2" in model_name
-        and ("1305" in text or "temporarily overloaded" in text)
-    )
+    return "1305" in text or "temporarily overloaded" in text
 
 
 def adaptive_rate_limit_backoff(

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -208,3 +208,105 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+# ---------------------------------------------------------------------------
+# is_zai_coding_overload_error — which 429s earn the long-backoff schedule
+# ---------------------------------------------------------------------------
+
+
+class TestIsZaiCodingOverloadError:
+    ZAI_CODING = "https://api.z.ai/api/coding/paas/v4"
+
+    def test_production_model_qualifies(self):
+        """A gate keyed to one model id is dead code the moment the id moves.
+
+        z.ai retired the ``glm-4.7`` alias and began redirecting it, so an
+        install whose primary is ``glm-5.3-flash`` got no retry at all while
+        the function still looked correct.
+        """
+        assert is_zai_coding_overload_error(
+            base_url=self.ZAI_CODING, model="glm-5.3-flash", error=_zai_overload_error()
+        )
+
+    def test_any_model_on_a_zai_host_qualifies(self):
+        """1305 is the endpoint's condition, not one model's."""
+        for model in ("glm-5.2", "glm-5.3", "glm-5", "glm-4.5v", "", None):
+            assert is_zai_coding_overload_error(
+                base_url=self.ZAI_CODING, model=model, error=_zai_overload_error()
+            ), model
+
+    def test_host_is_parsed_not_substring_matched(self):
+        """This decides how long Hermes waits on someone's endpoint, so a
+        lookalike hostname must not inherit Z.AI's retry schedule."""
+        for base in (
+            "https://api.z.ai.example.com/v4",
+            "https://z.ai.evil.test/api/coding/paas/v4",
+            "https://notz.ai/v4",
+        ):
+            assert not is_zai_coding_overload_error(
+                base_url=base, model="glm-5.3-flash", error=_zai_overload_error()
+            ), base
+
+    def test_zai_hosts_and_paths_accepted(self):
+        """Any path on a Z.AI host, with or without a scheme."""
+        for base in (
+            "https://api.z.ai/api/coding/paas/v4",
+            "https://api.z.ai/api/paas/v4",
+            "https://z.ai/v4",
+            "api.z.ai/api/coding/paas/v4",
+        ):
+            assert is_zai_coding_overload_error(
+                base_url=base, model="glm-5.3-flash", error=_zai_overload_error()
+            ), base
+
+    def test_non_429_is_not_an_overload(self):
+        err = _zai_overload_error()
+        err.status_code = 500
+        assert not is_zai_coding_overload_error(
+            base_url=self.ZAI_CODING, model="glm-5.3-flash", error=err
+        )
+
+    def test_ordinary_quota_429_still_fails_fast(self):
+        """1310 is a spent subscription: retrying it just delays the fallback."""
+        err = SimpleNamespace(
+            status_code=429,
+            body={"error": {"code": "1310", "message": "Weekly/Monthly Limit Exhausted."}},
+        )
+        assert not is_zai_coding_overload_error(
+            base_url=self.ZAI_CODING, model="glm-5.3-flash", error=err
+        )
+
+    def test_missing_base_url_is_not_an_overload(self):
+        for base in (None, "", "   "):
+            assert not is_zai_coding_overload_error(
+                base_url=base, model="glm-5.3-flash", error=_zai_overload_error()
+            )
+
+    def test_another_provider_with_the_same_text_is_rejected(self):
+        assert not is_zai_coding_overload_error(
+            base_url="https://api.deepseek.com/v1",
+            model="deepseek-v4-pro",
+            error=_zai_overload_error(),
+        )
+
+    def test_long_schedule_reachable_for_production_model(self, monkeypatch):
+        """The regression end to end: with the model gate in place the long
+        tier was unreachable for the model actually serving traffic."""
+        monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+        from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+        err = _zai_overload_error()
+        long_waits = []
+        for attempt in range(1, zai_coding_overload_retry_ceiling()):
+            wait, policy = adaptive_rate_limit_backoff(
+                attempt,
+                base_url=self.ZAI_CODING,
+                model="glm-5.3-flash",
+                error=err,
+                default_wait=1.0,
+            )
+            if policy == "zai_coding_overload_long":
+                long_waits.append(wait)
+
+        assert long_waits == [30.0, 60.0, 90.0, 120.0]


### PR DESCRIPTION
## The problem

`is_zai_coding_overload_error` gates the Z.AI transient-overload retry on two things that both rot:

```python
status == 429
and "api.z.ai/api/coding/paas/v4" in base
and "glm-5.2" in model_name
and ("1305" in text or "temporarily overloaded" in text)
```

**1. The model gate silently disables the feature when an alias moves.**
Z.AI changes what model ids resolve to under existing accounts (the `glm-4.7` alias was retired and
redirected). On an install whose primary became `glm-5.3-flash`, every `1305` stopped matching — so
`zai_coding_overload_retry_ceiling` and the whole 30/60/90/120s long-backoff schedule became
unreachable, while the function still reads as correct.

Measured on a live install, 12 consecutive events in one minute:

```
📋 Details: {'code': '1305', 'message': 'The service may be temporarily overloaded, please try again later'}
❌ API failed after 3 retries — HTTP 429: The service may be temporarily overloaded, please try again later
```

Three short retries and death, which is exactly the behaviour the long tier exists to prevent.

**2. The substring test on `base_url` accepts lookalike hosts.**
`"api.z.ai/api/coding/paas/v4" in base` is a substring match on a URL. This function decides how long
Hermes waits on someone else's endpoint, so the host deserves parsing.

## The change

The shape that identifies the condition is **(429, Z.AI host, 1305)**. The model is not part of it.

- `status_code != 429` and non-Z.AI hosts return early.
- New `_is_zai_host()` parses with `urlsplit` and accepts `z.ai` or any subdomain, with a bare
  `host/path` fallback for base URLs written without a scheme.
- The path requirement is dropped: `1305` is the endpoint's condition, not one route's.
- `model` stays in the signature so no call site changes.

Ordinary quota/billing 429s still fail fast — `1310 Weekly/Monthly Limit Exhausted` does not match,
so it goes through the existing classifier to the fallback chain instead of waiting 5 minutes on a
spent subscription.

## Tests

`is_zai_coding_overload_error` was imported by `tests/test_retry_utils.py` but never called directly.
This adds `TestIsZaiCodingOverloadError` — 9 cases covering the production model, model-independence,
lookalike-host rejection, scheme-less base URLs, non-429, `1310` fail-fast, empty/absent base URL,
another provider carrying the same text, and the long schedule end to end.

They discriminate: **4 of the 9 fail on the previous implementation**, and the 16 pre-existing tests
in the file pass unchanged.

```
# on this branch
20 passed

# with agent/retry_utils.py reverted to main, tests kept
4 failed, 16 passed
  test_production_model_qualifies
  test_any_model_on_a_zai_host_qualifies
  test_zai_hosts_and_paths_accepted
  test_long_schedule_reachable_for_production_model
```
