### PR TITLE
fix(tui): restore uppercase for Shift+letter under kitty/modifyOtherKeys

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseMultipleKeypresses } from '../parse-keypress.js'
+import { type ParsedKey, parseMultipleKeypresses } from '../parse-keypress.js'
 
 import { InputEvent } from './input-event.js'
 
-function parseOne(sequence: string) {
+function parseOne(sequence: string): ParsedKey {
   const [keys] = parseMultipleKeypresses({ incomplete: '', mode: 'NORMAL' }, sequence)
   expect(keys).toHaveLength(1)
 
-  return keys[0]!
+  const key = keys[0]!
+  expect(key.kind).toBe('key')
+
+  return key as ParsedKey
 }
 
 describe('enhanced keyboard modifier parsing', () => {
@@ -61,5 +64,47 @@ describe('enhanced keyboard modifier parsing', () => {
 
     expect(right.key.rightArrow).toBe(true)
     expect(right.key.super).toBe(true)
+  })
+})
+
+describe('shifted-letter text input under enhanced keyboard protocols', () => {
+  // keycodeToName() lowercases the letter for case-stable keybinding identity,
+  // and the CSI-u / modifyOtherKeys branches reuse that name as typed text. The
+  // uppercase must be restored for input, or Shift+A types "a" (regressed on
+  // Ghostty over SSH, where modifyOtherKeys is pushed).
+  it('types uppercase for Shift+letter via kitty CSI-u', () => {
+    const shiftA = new InputEvent(parseOne('\u001b[65;2u'))
+
+    expect(shiftA.input).toBe('A')
+    expect(shiftA.key.shift).toBe(true)
+  })
+
+  it('types uppercase for Shift+letter via modifyOtherKeys', () => {
+    const shiftA = new InputEvent(parseOne('\u001b[27;2;65~'))
+    const shiftZ = new InputEvent(parseOne('\u001b[27;2;90~'))
+
+    expect(shiftA.input).toBe('A')
+    expect(shiftA.key.shift).toBe(true)
+    expect(shiftZ.input).toBe('Z')
+  })
+
+  it('leaves lowercase letters and shifted symbols unchanged', () => {
+    const a = new InputEvent(parseOne('\u001b[97u'))
+    const at = new InputEvent(parseOne('\u001b[27;2;64~')) // Shift+2 -> @
+    const question = new InputEvent(parseOne('\u001b[27;2;63~')) // Shift+/ -> ?
+
+    expect(a.input).toBe('a')
+    expect(at.input).toBe('@')
+    expect(question.input).toBe('?')
+  })
+
+  it('does not inject a letter for ctrl/meta chords', () => {
+    const ctrlA = new InputEvent(parseOne('\u001b[27;5;97~'))
+    const metaA = new InputEvent(parseOne('\u001b[27;3;97~'))
+
+    expect(ctrlA.key.ctrl).toBe(true)
+    expect(ctrlA.input).not.toBe('A')
+    expect(metaA.key.meta).toBe(true)
+    expect(metaA.input).not.toBe('A')
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -151,6 +151,27 @@ function parseKey(keypress: ParsedKey): [Key, string] {
     input = ''
   }
 
+  // Kitty keyboard / xterm modifyOtherKeys report a shifted letter as its
+  // LOWERCASE key name plus a shift flag — keycodeToName() lowercases so that
+  // keybinding identity is case-stable (ctrl+a === ctrl+A). But the special-
+  // sequence branches above reuse that name as the literal typed text, which
+  // drops the capital: Shift+A types "a" (notably Ghostty over SSH, where we
+  // push modifyOtherKeys). Restore the uppercase form for text input. Only for
+  // bare Shift — ctrl/meta/super are chords, not text, and must not inject a
+  // letter into the prompt.
+  if (
+    processedAsSpecialSequence &&
+    keypress.shift &&
+    !keypress.ctrl &&
+    !keypress.meta &&
+    !keypress.super &&
+    input.length === 1 &&
+    input >= 'a' &&
+    input <= 'z'
+  ) {
+    input = input.toUpperCase()
+  }
+
   // Set shift=true for uppercase letters (A-Z)
   // Must check it's actually a letter, not just any char unchanged by toUpperCase
   if (input.length === 1 && typeof input[0] === 'string' && input[0] >= 'A' && input[0] <= 'Z') {


### PR DESCRIPTION
## Summary

Under the kitty keyboard protocol (CSI-u) or xterm modifyOtherKeys, a shifted letter arrives as its **lowercase** key name plus a shift flag. `keycodeToName()` in `parse-keypress.ts` lowercases deliberately so keybinding identity stays case-stable (`ctrl+a` === `ctrl+A`), but the CSI-u / modifyOtherKeys branches in `input-event.ts` reuse that lowercased name as the literal typed text — so **Shift+A types `a`**.

This reliably reproduces on **Ghostty over SSH**, where the app pushes modifyOtherKeys (`CSI >4;2m`) via `App.tsx`. Every capital letter is silently lowercased at the composer; plain letters (no enhanced protocol) keep their case, which is what makes the bug look intermittent.

## Root cause

`ui-tui/packages/hermes-ink/src/ink/events/input-event.ts` derives `input` from `keypress.name` for CSI-u and modifyOtherKeys sequences (the `processedAsSpecialSequence` branches). `name` is intentionally lowercased upstream, so the capital is lost even though `keypress.shift` is correctly set.

## Fix

Restore the uppercase form for text input **only** when:
- the key came through an enhanced-protocol branch (`processedAsSpecialSequence`),
- it's a bare Shift (no ctrl/meta/super — those are chords, not text),
- and `input` is a single ASCII letter `a`–`z`.

Shifted symbols (`@`, `?`) are unaffected (lowercasing never changed them), and ctrl/meta/super chords never inject a letter into the prompt.

## Evidence

Feeding the real parser the exact byte sequences:

```
Shift+A modifyOtherKeys (ESC[27;2;65~)  before: "a"  after: "A"  shift=true
Shift+A kitty CSI-u     (ESC[65;2u)     before: "a"  after: "A"  shift=true
plain A (no protocol)                   "A" (unchanged)
Shift+2 -> @            (ESC[27;2;64~)  "@" (unchanged)
Ctrl+A chord            (ESC[27;5;97~)  no letter injected, ctrl=true
Meta+a chord            (ESC[27;3;97~)  no letter injected, meta=true
```

## Test plan

- [x] New regression tests in `cmd-shortcuts.test.ts` (CSI-u + modifyOtherKeys shifted letters, shifted symbols, lowercase passthrough, ctrl/meta chord non-injection) — all pass
- [x] Existing `parse-keypress` suites pass (37 tests)
- [x] `npm run build:ink` + `npm run build` succeed

