### PR TITLE
fix(compression): stop the summary stream at the host's own deadline (#99692)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -453,6 +453,16 @@ _aux_progress = threading.local()
 _aux_dispatch = threading.local()
 _aux_provider_response = threading.local()
 
+# Absolute wall-clock deadline (time.monotonic) of the HOST waiting for this
+# auxiliary call, when it has one (#99692). Liveness alone is not enough: a
+# host also stops waiting at its own total ceiling, and the streamed consumer
+# below bounds itself only by _aux_stream_total_ceiling() — a budget derived
+# from the aux request timeout, which is >= the host ceiling for every
+# configured value AND starts counting later. So the stream that outlives its
+# abandoned host is not an edge case; it is the guaranteed outcome of every
+# total-ceiling timeout.
+_aux_stream_deadline = threading.local()
+
 
 def _notify_aux_progress() -> None:
     """Tick the installed forward-progress hook, if any. Never raises."""
@@ -587,6 +597,38 @@ def aux_progress_hook(hook):
         yield
 
 
+def _current_aux_stream_deadline() -> Optional[float]:
+    """The waiting host's absolute monotonic deadline, if one is installed."""
+    return getattr(_aux_stream_deadline, "value", None)
+
+
+@contextlib.contextmanager
+def aux_stream_deadline(deadline: Optional[float]):
+    """Publish the waiting host's absolute deadline to the stream consumer.
+
+    *deadline* is a ``time.monotonic()`` timestamp — the same instant the host
+    itself stops waiting — or ``None`` for callers with no host deadline (a
+    no-op passthrough, so callers can wire it unconditionally). Re-entrant-safe.
+
+    #99692: the progress hook is a one-way channel (worker -> host). This is the
+    return leg. ``8207862212`` releases the compression OWNER when the fence is
+    cancelled, but the isolated provider daemon
+    (:func:`_run_protected_sync_provider_call`) that holds the socket keeps
+    streaming to its own ``_aux_stream_total_ceiling`` budget — >= the host's
+    ceiling by construction — billing an abandoned summary the commit fence is
+    already guaranteed to refuse, and stacking one fresh orphan per turn on a
+    session that compression never managed to shrink.
+    """
+    previous = getattr(_aux_stream_deadline, "value", None)
+    _aux_stream_deadline.value = (
+        deadline if isinstance(deadline, (int, float)) else previous
+    )
+    try:
+        yield
+    finally:
+        _aux_stream_deadline.value = previous
+
+
 # Back-compat alias — the timing hooks were introduced with this name.
 _aux_timing_hook = _aux_thread_local_hook
 
@@ -629,6 +671,11 @@ def _run_protected_sync_provider_call(
     # the protected daemon path is taken.
     dispatch_hook = getattr(_aux_dispatch, "hook", None)
     provider_response_hook = getattr(_aux_provider_response, "hook", None)
+    # #99692: the stream is consumed on the daemon below, and thread-locals do
+    # not cross that boundary — an owner-thread-only deadline would leave the
+    # fix inert on exactly the path large-session compression takes (protected
+    # call + hard-cancel source installed).
+    host_deadline = _current_aux_stream_deadline()
     provider_context = contextvars.copy_context()
     done = threading.Event()
     outcome: dict[str, Any] = {}
@@ -639,6 +686,7 @@ def _run_protected_sync_provider_call(
                 aux_progress_hook(progress_hook),
                 _aux_thread_local_hook(_aux_dispatch, dispatch_hook),
                 _aux_thread_local_hook(_aux_provider_response, provider_response_hook),
+                aux_stream_deadline(host_deadline),
                 aux_interrupt_protection(cancel_check=cancel_check),
             ):
                 outcome["result"] = callback(kwargs)
@@ -9712,7 +9760,11 @@ def _aggregate_chat_stream(
     Accumulation is shared with the async mirror via
     :class:`_ChatStreamAccumulator`.
     """
-    acc = _ChatStreamAccumulator(model=model, total_ceiling=total_ceiling)
+    acc = _ChatStreamAccumulator(
+        model=model,
+        total_ceiling=total_ceiling,
+        host_deadline=_current_aux_stream_deadline(),
+    )
     try:
         for chunk in chunks:
             acc.feed(chunk)
@@ -9734,9 +9786,20 @@ class _ChatStreamAccumulator:
     tool-call delta reassembly, same "timed out" ceiling phrasing).
     """
 
-    def __init__(self, model: str = "", total_ceiling: Optional[float] = None):
+    def __init__(
+        self,
+        model: str = "",
+        total_ceiling: Optional[float] = None,
+        host_deadline: Optional[float] = None,
+    ):
         self._started = time.monotonic()
         self._total_ceiling = total_ceiling
+        # #99692: absolute instant the WAITING HOST gives up. Checked as well
+        # as (not instead of) the ceiling above: the ceiling still bounds
+        # callers with no host deadline, and the host deadline is absolute, so
+        # it is unaffected by however long dispatch and TTFT took before this
+        # accumulator was constructed.
+        self._host_deadline = host_deadline
         self.content_parts: List[str] = []
         self.reasoning_parts: List[str] = []
         self.reasoning_details: List[Any] = []
@@ -9759,6 +9822,16 @@ class _ChatStreamAccumulator:
             raise TimeoutError(
                 f"Auxiliary streamed call timed out after {self._total_ceiling:.0f}s "
                 "total ceiling (stream still open but over budget)"
+            )
+        if (
+            self._host_deadline is not None
+            and time.monotonic() >= self._host_deadline
+        ):
+            raise TimeoutError(
+                "Auxiliary streamed call timed out at the host compression "
+                f"deadline after {time.monotonic() - self._started:.0f}s "
+                "(the caller already stopped waiting; streaming on would only "
+                "pin its session lease)"
             )
         self.resp_id = getattr(chunk, "id", None) or self.resp_id
         self.resp_model = getattr(chunk, "model", None) or self.resp_model
@@ -9871,7 +9944,11 @@ async def _aggregate_chat_stream_async(
     the sync helper raises. Same accumulation and ceiling semantics via
     :class:`_ChatStreamAccumulator`.
     """
-    acc = _ChatStreamAccumulator(model=model, total_ceiling=total_ceiling)
+    acc = _ChatStreamAccumulator(
+        model=model,
+        total_ceiling=total_ceiling,
+        host_deadline=_current_aux_stream_deadline(),
+    )
     try:
         async for chunk in chunks:
             acc.feed(chunk)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -748,6 +748,20 @@ class CompressionCommitFence:
         deadline = self._deadline
         return deadline is not None and time.monotonic() >= deadline
 
+    @property
+    def deadline_monotonic(self) -> float | None:
+        """The armed deadline as an absolute ``time.monotonic()`` instant.
+
+        :meth:`set_total_ceiling_seconds` documents this deadline as "shared by
+        the host and worker", but until #99692 only the host could read it —
+        ``deadline_exceeded`` answers "is it past?" for a caller that is already
+        polling, which is useless to a worker blocked inside a provider stream.
+        Publishing the instant itself lets the worker's stream consumer stop at
+        exactly the moment the host stops waiting (see
+        ``auxiliary_client.aux_stream_deadline``).
+        """
+        return self._deadline
+
     def seconds_since_progress(self) -> float:
         """Seconds since the worker last reported forward progress."""
         return max(0.0, time.monotonic() - self._last_progress)
@@ -3992,10 +4006,27 @@ def compress_context(
         from agent.auxiliary_client import (
             aux_interrupt_protection,
             aux_progress_hook,
+            aux_stream_deadline,
         )
         _progress_hook = (
             commit_fence.touch_progress if commit_fence is not None
             else (lambda: None)
+        )
+        # #99692: the progress hook above is the worker -> host leg; this is the
+        # return leg. _compression_cancel_requested (below) releases the compression
+        # OWNER when the host gives up, but the isolated provider daemon that
+        # actually holds the socket keeps streaming to its own budget —
+        # ``_aux_stream_total_ceiling`` = max(600, 4 * aux_timeout), which is >=
+        # the host's total ceiling for every configured timeout and starts
+        # counting later (after admission, serialization, prompt build and TTFT).
+        # With ``auxiliary.compression.timeout: 600`` that is 2400s of an
+        # orphaned 500K-token summary the commit fence is already guaranteed to
+        # refuse: paid tokens, a pinned HTTP connection, and — since every new
+        # turn re-triggers compression on a session that never shrank — a fresh
+        # orphan stacked on top of the last one. Sharing the host's absolute
+        # deadline makes the stream stop when the host it serves stops waiting.
+        _host_stream_deadline = (
+            commit_fence.deadline_monotonic if commit_fence is not None else None
         )
         # F4 state-ordering (#76354): a LATE successful summary must not undo
         # the timeout cooldown the host recorded. Install a cancellation
@@ -4042,7 +4073,9 @@ def compress_context(
                 )
                 compressed = messages
             else:
-                with aux_progress_hook(_progress_hook), aux_interrupt_protection(
+                with aux_progress_hook(_progress_hook), aux_stream_deadline(
+                    _host_stream_deadline
+                ), aux_interrupt_protection(
                     cancel_check=_compression_cancel_requested
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)

--- a/tests/agent/test_aux_stream_host_deadline.py
+++ b/tests/agent/test_aux_stream_host_deadline.py
@@ -1,0 +1,295 @@
+"""#99692 — the streamed auxiliary summary must not outlive its compression host.
+
+Background
+----------
+``run_compress_context_with_progress_timeout`` arms a wall-clock deadline on the
+``CompressionCommitFence`` (``set_total_ceiling_seconds``), whose docstring calls
+it "the wall-clock deadline **shared by the host and worker**".  Only the host
+ever read it.
+
+``8207862212`` (fix(compression): stop timeout paths from blocking retries)
+closed the first half: a cancelled fence now releases the compression OWNER,
+which frees the pool slot and the session lease.  It left the second half open
+by design — its own comment says the isolated provider daemon runs on "until
+the auxiliary stream's longer absolute ceiling expires".
+
+That ceiling is ``_aux_stream_total_ceiling`` = ``max(600, 4 * aux_timeout)``:
+>= the default host ceiling (600s) for every configured timeout, and it starts
+counting later (after pool admission, serialization, prompt build and TTFT).
+So the daemon holding the socket is *always* still streaming when its host gives
+up — 2400s with the reporter's ``auxiliary.compression.timeout: 600`` — billing
+every token of a summary the fence is already guaranteed to refuse, and stacking
+one fresh orphan per turn because the session never shrank.
+
+These tests pin the missing half of that shared deadline: the stream consumer
+must stop at the host's deadline, including on the isolated provider daemon
+that ``_run_protected_sync_provider_call`` spawns.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent import auxiliary_client as aux
+from agent.conversation_compression import (
+    DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS,
+    CompressionCommitFence,
+)
+
+
+def _chunk(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="resp-1",
+        model="test-model",
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                index=0,
+                finish_reason=None,
+                delta=SimpleNamespace(content=text, tool_calls=None),
+            )
+        ],
+    )
+
+
+class _Stream:
+    """Chunk iterator that records how far the consumer drained it."""
+
+    def __init__(self, count: int = 50) -> None:
+        self._count = count
+        self.yielded = 0
+        self.closed = False
+
+    def __iter__(self):
+        for _ in range(self._count):
+            self.yielded += 1
+            yield _chunk("x")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AsyncStream(_Stream):
+    async def __aiter__(self):  # pragma: no cover - exercised via asyncio.run
+        for _ in range(self._count):
+            self.yielded += 1
+            yield _chunk("x")
+
+
+# ── The structural gap the bug lives in ──────────────────────────────────
+
+
+def test_stream_ceiling_structurally_outlives_the_default_host_ceiling():
+    """The worker's own budget is >= the host's for every configured timeout.
+
+    This is the arithmetic that guarantees the orphan: there is no aux timeout
+    for which ``_aux_stream_total_ceiling`` lands below the 600s default host
+    ceiling, and the reporter's ``auxiliary.compression.timeout: 600`` puts it
+    at 2400s — a 30-minute window in which an abandoned provider daemon keeps
+    streaming a summary nobody can commit.
+    """
+    for aux_timeout in (None, 0, 30.0, 120.0, 300.0):
+        assert (
+            aux._aux_stream_total_ceiling(aux_timeout)
+            >= DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS
+        )
+    assert aux._aux_stream_total_ceiling(600.0) == 2400.0
+    assert (
+        aux._aux_stream_total_ceiling(600.0)
+        - DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS
+        == 1800.0
+    )
+
+
+# ── The fence must publish the deadline it already owns ──────────────────
+
+
+def test_commit_fence_publishes_its_shared_deadline():
+    fence = CompressionCommitFence()
+    assert fence.deadline_monotonic is None
+
+    fence.set_total_ceiling_seconds(600.0)
+    published = fence.deadline_monotonic
+    assert published is not None
+    assert 590.0 < published - time.monotonic() <= 600.0
+    assert not fence.deadline_exceeded
+
+    fence.set_total_ceiling_seconds(0.001)
+    time.sleep(0.01)
+    assert fence.deadline_exceeded
+    assert fence.deadline_monotonic <= time.monotonic()
+
+
+# ── The stream consumer must honour it ───────────────────────────────────
+
+
+def test_streamed_summary_stops_at_an_elapsed_host_deadline():
+    """A host that already gave up must not leave the worker streaming on."""
+    stream = _Stream(count=50)
+    with aux.aux_stream_deadline(time.monotonic() - 1.0):
+        with pytest.raises(TimeoutError) as excinfo:
+            aux._aggregate_chat_stream(stream, model="m", total_ceiling=2400.0)
+
+    # "timed out" keeps _is_timeout_error classification identical to a
+    # request timeout, so the existing recovery chains are unchanged.
+    assert "timed out" in str(excinfo.value)
+    assert "host compression deadline" in str(excinfo.value)
+    # Stopped on the first frame instead of draining the whole stream, and the
+    # HTTP response was closed rather than left dangling.
+    assert stream.yielded == 1
+    assert stream.closed is True
+
+
+def test_streamed_summary_runs_to_completion_under_a_live_host_deadline():
+    stream = _Stream(count=5)
+    with aux.aux_stream_deadline(time.monotonic() + 600.0):
+        response = aux._aggregate_chat_stream(
+            stream, model="m", total_ceiling=2400.0
+        )
+    assert response.choices[0].message.content == "xxxxx"
+    assert stream.yielded == 5
+
+
+def test_no_host_deadline_keeps_the_historical_ceiling_behaviour():
+    """Every non-compression aux caller must be byte-for-byte unchanged."""
+    stream = _Stream(count=5)
+    response = aux._aggregate_chat_stream(stream, model="m", total_ceiling=2400.0)
+    assert response.choices[0].message.content == "xxxxx"
+    assert stream.yielded == 5
+
+    # An installed-then-exited scope must not leak into the next call.
+    with aux.aux_stream_deadline(time.monotonic() - 1.0):
+        pass
+    stream2 = _Stream(count=3)
+    assert (
+        aux._aggregate_chat_stream(
+            stream2, model="m", total_ceiling=2400.0
+        ).choices[0].message.content
+        == "xxx"
+    )
+
+
+def test_none_deadline_is_a_no_op_passthrough():
+    """Callers wire the scope unconditionally; a fenceless call must not break."""
+    stream = _Stream(count=3)
+    with aux.aux_stream_deadline(None):
+        response = aux._aggregate_chat_stream(
+            stream, model="m", total_ceiling=2400.0
+        )
+    assert response.choices[0].message.content == "xxx"
+
+
+def test_nested_none_inherits_rather_than_escaping_the_host_deadline():
+    """A fenceless aux call nested inside a fenced one stays bounded.
+
+    ``None`` means "I have no deadline of my own", not "clear the one in
+    force" — mirroring ``_aux_thread_local_hook``'s passthrough contract. If it
+    cleared, any nested auxiliary call made during compression would escape the
+    host ceiling that the whole attempt is supposed to live inside.
+    """
+    outer = time.monotonic() - 1.0
+    stream = _Stream(count=50)
+    with aux.aux_stream_deadline(outer):
+        with aux.aux_stream_deadline(None):
+            assert aux._current_aux_stream_deadline() == outer
+            with pytest.raises(TimeoutError):
+                aux._aggregate_chat_stream(stream, model="m", total_ceiling=2400.0)
+    assert stream.yielded == 1
+
+
+def test_deadline_scope_restores_the_previous_value():
+    outer = time.monotonic() + 900.0
+    with aux.aux_stream_deadline(outer):
+        assert aux._current_aux_stream_deadline() == outer
+        with aux.aux_stream_deadline(time.monotonic() + 10.0):
+            assert aux._current_aux_stream_deadline() != outer
+        assert aux._current_aux_stream_deadline() == outer
+    assert aux._current_aux_stream_deadline() is None
+
+
+def test_async_stream_mirror_honours_the_host_deadline():
+    """The async consumer must not drift from the sync one."""
+    stream = _AsyncStream(count=50)
+
+    async def _run():
+        with aux.aux_stream_deadline(time.monotonic() - 1.0):
+            return await aux._aggregate_chat_stream_async(
+                stream, model="m", total_ceiling=2400.0
+            )
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(_run())
+    assert stream.yielded == 1
+
+
+# ── The isolated provider daemon must inherit it ─────────────────────────
+
+
+def test_protected_provider_daemon_inherits_the_host_deadline():
+    """``_run_protected_sync_provider_call`` runs the stream on ANOTHER thread.
+
+    Thread-locals do not cross that boundary, so without explicit propagation
+    the fix would be inert on exactly the path large-session compression takes
+    (protected + hard-cancel source installed).
+    """
+    seen: dict[str, object] = {}
+
+    def _callback(_kwargs):
+        seen["deadline"] = aux._current_aux_stream_deadline()
+        seen["thread"] = threading.current_thread().name
+        return "ok"
+
+    deadline = time.monotonic() + 42.0
+    cancel_event = threading.Event()
+    with aux.aux_progress_hook(lambda: None), aux.aux_interrupt_protection(
+        cancel_event=cancel_event
+    ), aux.aux_stream_deadline(deadline):
+        assert aux._run_protected_sync_provider_call(_callback, {}) == "ok"
+
+    assert seen["thread"] == "hermes-protected-aux-provider"
+    assert seen["deadline"] == deadline
+
+
+# ── The compression worker must actually install it ──────────────────────
+
+
+def _summary_dispatch_source() -> str:
+    from agent import conversation_compression
+
+    path = Path(inspect.getsourcefile(conversation_compression))
+    return path.read_text(encoding="utf-8")
+
+
+def test_compression_summary_dispatch_installs_the_fence_deadline():
+    """Source guard: the wiring is one line and trivially droppable.
+
+    A behavioural test would have to drive the whole ``compress_context`` body
+    (durable lock, watermark, telemetry, commit). This asserts the seam itself:
+    the same ``with`` statement that installs the progress hook must also
+    install the stream deadline.
+    """
+    tree = ast.parse(_summary_dispatch_source())
+    wired = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        names = set()
+        for item in node.items:
+            call = item.context_expr
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name):
+                names.add(call.func.id)
+        if "aux_progress_hook" in names:
+            assert "aux_stream_deadline" in names, (
+                "the summary dispatch scope installs the progress hook but not "
+                "the host stream deadline — #99692 would regress"
+            )
+            wired = True
+    assert wired, "summary dispatch scope not found"


### PR DESCRIPTION
Fixes #99692

## TL;DR

`CompressionCommitFence.set_total_ceiling_seconds()` documents its deadline as **"the wall-clock deadline shared by the host and worker"**. Only the host ever read it. The worker's streamed summary bounds itself with a *different, always-larger* budget, so **every** total-ceiling timeout leaves a provider stream running past the host that abandoned it. This PR gives the worker the half of the shared deadline it never had.

---

## 1. Cause

### 1.1 Two independent clocks that were never reconciled

| Clock | Where | Value | Starts at |
|---|---|---|---|
| **Host** ceiling | `conversation_compression.py:1548` (`wait_started`), armed at `:1443-1444` | `compression.total_ceiling_seconds`, default **600s** | Before pool admission |
| **Worker** stream ceiling | `auxiliary_client.py:_aux_stream_total_ceiling()` | `max(600, 4 × aux_timeout)` | At the **first streamed chunk** |

The worker's budget is **≥ the host's for every configurable value** — the floor alone (`_AUX_STREAM_CEILING_FLOOR_SECONDS = 600.0`) equals the host default — *and* it starts counting later, after pool admission, `_serialize_for_summary`, prompt build and TTFT.

A stream outliving its abandoned host is therefore **not a race and not an edge case. It is the arithmetic guarantee of every total-ceiling timeout.** With the reporter's `auxiliary.compression.timeout: 600`:

```
host ceiling      : 600s
worker ceiling    : max(600, 4 × 600) = 2400s
guaranteed excess : 1800s (30 min) + serialization + TTFT
```

The first test in this PR pins exactly that arithmetic.

### 1.2 The progress hook is a one-way channel

`aux_progress_hook` gives the aux layer a **worker → host** liveness channel (`_notify_aux_progress` → `CompressionCommitFence.touch_progress`), so a slow-but-generating summarizer is not killed while tokens move. There was no **host → worker** return leg. `deadline_exceeded` answers *"is it past?"* for a caller that is already polling — useless to a worker blocked inside `for chunk in chunks`.

### 1.3 What `8207862212` already fixed, and what it deliberately left

`8207862212` (*fix(compression): stop timeout paths from blocking retries*, **Aug 30 23:53** — one day **after** the reporter's build `v0.20.6 / upstream 22131283`) wired the fence into the aux cancel channel via `_compression_cancel_requested`. That closed the first half: a cancelled fence now releases the compression **owner**, which frees its pool slot and its session lease.

It left the second half open, and says so in its own comment:

> *"…so the compression owner unwinds promptly while an isolated provider stream finishes or closes in its daemon worker. Otherwise four timed-out streams retain all four shared compression-pool slots **until the auxiliary stream's longer absolute ceiling expires**."*

That "longer absolute ceiling" is the residue this PR removes. The owner is freed; the **daemon holding the socket is not**.

---

## 2. Consequence

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["Turn N - 555K tokens, above threshold"] --> B["Compression host arms fence: deadline = now + 600s"]
    B --> C["Worker streams summary - own budget max(600, 4 x timeout) = 2400s"]
    C --> D{"Host ceiling reached at 600s"}
    D -->|"fence cancelled"| E["Owner released (8207862212) - pool slot + session lease freed"]
    D -->|"never reached"| F["Provider daemon keeps streaming 1800s past its host"]
    F --> G["Paid tokens for a summary the fence is guaranteed to refuse"]
    F --> H["HTTP connection pinned - full summary buffered in memory"]
    E --> I["Session never shrank"]
    I --> J["Turn N+1 re-triggers compression"]
    J --> K["A SECOND orphan daemon stacked on the first"]
    K --> L["53 aux calls / 20 min - 0 commits"]
    G --> L
    H --> L
```

**Observable damage on current `main`:**

1. **Billed tokens for output nobody can use.** Each orphan streams a full summary of a ~500K-token middle. The commit fence is already cancelled, so `begin_commit()` will refuse the result the instant it arrives — the tokens are paid for and discarded 100% of the time.
2. **Orphans stack, one per turn.** The abandoned attempt did not shrink the session, so the next user message re-enters compression immediately. With a 40-minute orphan lifetime and a user posting every couple of minutes, ~20 concurrent daemons each hold an open stream of a ~500K-token request against the same provider.
3. **Provider-side back-pressure feeds the loop.** That self-inflicted concurrency is exactly what makes the *next* attempt slower, which makes it likelier to hit the ceiling, which spawns another orphan.
4. **Memory.** Every orphan accumulates the full summary in `_ChatStreamAccumulator.content_parts` before it is thrown away.

**On the reporter's build (pre-`8207862212`), the same root cause also produced the reported lock leak:** the owner never unwound, so it missed the 5s `_join_cancelled_worker` grace at `conversation_compression.py:1667`, `retain_compression_lock_until_worker_done()` kept the lease pinned, `release_cancelled_compression_lock()` early-returned at `:915`, and every following attempt aborted at `:3487` with `failure_class="lock_contended"` — his 28 consecutive contended aborts, cleared only by restarting the desktop app.

---

## 3. Solution

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph LR
    subgraph HOST["Compression Host"]
      F["CompressionCommitFence.deadline_monotonic"]
    end
    subgraph BRIDGE["Shared Deadline"]
      S["aux_stream_deadline() - thread-local scope"]
    end
    subgraph WORKER["Auxiliary Worker"]
      D["hermes-protected-aux-provider daemon thread"]
      A["_ChatStreamAccumulator.feed()"]
    end
    F -->|"absolute monotonic instant"| S
    S -->|"explicit propagation"| D
    D --> A
    A -->|"monotonic() >= deadline"| STOP["TimeoutError - stream closed"]
    A -->|"progress tick"| F
```

Three small pieces, `+114 / −4` across two files:

**a. Publish what the fence already owns** — `CompressionCommitFence.deadline_monotonic` returns `self._deadline` as an absolute `time.monotonic()` instant. Read-only accessor; nothing else changes.

**b. Give the aux layer the return leg** — `aux_stream_deadline(deadline)`, a re-entrant thread-local scope mirroring the existing `aux_progress_hook` idiom. `_ChatStreamAccumulator.feed()` raises `TimeoutError` once the instant passes, right beside the existing ceiling check, so the **sync and async consumers cannot drift**.

**c. Propagate onto the provider daemon** — `_run_protected_sync_provider_call` runs the callback on `hermes-protected-aux-provider`. Thread-locals do not cross that boundary, so an owner-thread-only install would have been **inert on exactly the path large-session compression takes**. The daemon now re-installs it alongside the progress/dispatch/response hooks it already inherits.

Wired at the one summary-dispatch site in `compress_context`, in the same `with` statement that installs the progress hook.

### Design decisions

| Decision | Why |
|---|---|
| **Absolute** instant, not "remaining seconds" | Unaffected by however long dispatch, `_serialize_for_summary` and TTFT took before the accumulator was constructed. A relative budget would silently re-inflate by exactly the time that already elapsed — the original bug in miniature. |
| Checked **as well as**, not instead of, `_aux_stream_total_ceiling` | The ceiling still bounds every caller that has no host deadline. Non-compression aux callers are byte-for-byte unchanged. |
| `"timed out"` in the message | Keeps `_is_timeout_error` classification identical to a request timeout, so the existing recovery/cooldown chains behave exactly as they do for any other timeout. |
| `None` **inherits** rather than clears | Matches `_aux_thread_local_hook`'s passthrough contract, and means a nested fenceless aux call made during compression still lives inside the host's ceiling instead of escaping it. Pinned by a test. |
| No change to `_client_streams_internally` providers | Codex / Anthropic / Bedrock consume their stream inside `.create()` and are governed by `_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS`. Out of scope; untouched. |

---

## 4. Evidence & tests

`tests/agent/test_aux_stream_host_deadline.py` — **11 tests, 10 of which fail on `origin/main`** (verified by stashing the source change and re-running; the 11th is the arithmetic characterization that documents the gap and passes on both sides).

| Test | Pins |
|---|---|
| `test_stream_ceiling_structurally_outlives_the_default_host_ceiling` | The gap is structural: no aux timeout puts the worker budget below the 600s host default; `600 → 2400` is a 1800s excess |
| `test_commit_fence_publishes_its_shared_deadline` | `deadline_monotonic` arming, `None` before arming, agreement with `deadline_exceeded` |
| `test_streamed_summary_stops_at_an_elapsed_host_deadline` | Stops on frame 1 of 50, closes the response, `"timed out"` phrasing preserved |
| `test_streamed_summary_runs_to_completion_under_a_live_host_deadline` | A live deadline never truncates a healthy summary |
| `test_no_host_deadline_keeps_the_historical_ceiling_behaviour` | Every non-compression caller unchanged; an exited scope does not leak |
| `test_none_deadline_is_a_no_op_passthrough` | Fenceless callers can wire it unconditionally |
| `test_nested_none_inherits_rather_than_escaping_the_host_deadline` | A nested aux call cannot escape the host ceiling |
| `test_deadline_scope_restores_the_previous_value` | Re-entrancy / restore |
| `test_async_stream_mirror_honours_the_host_deadline` | The async consumer cannot drift from the sync one |
| `test_protected_provider_daemon_inherits_the_host_deadline` | The daemon thread actually receives it — without this the fix is inert |
| `test_compression_summary_dispatch_installs_the_fence_deadline` | AST source guard: the progress-hook scope must also install the deadline |

### Regression runs (local, Python 3.14)

| Suite | Result |
|---|---|
| `test_aux_stream_host_deadline.py` | **11 passed** |
| `test_aux_progress_streaming.py`, `test_auxiliary_explicit_cancellation.py`, `test_codex_aux_no_progress_timeout.py`, + new | **83 passed, 0 failed** |
| `test_auxiliary_client.py`, `test_auxiliary_concurrency.py`, `test_compress_context_progress_timeout.py` | **215 passed, 10 failed** |
| compression fence/worker/stall set (7 files) | **43 passed, 15 failed** — **identical to the clean `origin/main` baseline** (verified by stashing) |

Every failure in those two rows is the same pre-existing Python 3.14 breakage, unrelated to this change:

```
tools/daemon_pool.py:58: AttributeError:
  'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

**Zero regressions introduced.**

---

## 5. Scope boundaries — what this PR deliberately does *not* do

#99692 is three independent layers. This PR takes only the unowned one.

| Layer | Owner | Status |
|---|---|---|
| Fence cancel must release the compression **owner** | `8207862212` (@convernaticspeter) | Already on `main` |
| The abandoned **provider stream** must stop too | **this PR** | here |
| Gateway-hygiene host needs the same bounded-grace lease join | #99313 (@nftpoetrist) | untouched |
| Total ceiling enforced *across* attempts | #97512 (@fangliquanflq) | untouched |
| Bounding the compaction middle for very large sessions | #93241 (@Alish3r) | untouched |

### Known remainder, explicitly not fixed here

The reporter's headline — *"compression never completes"* — is ultimately a **budget** question, not a lifetime one: he measured a successful commit at **~7.8 min (468s)** with a fast aux model, against a **600s** default ceiling. A slower summarizer on the same session simply does not fit. This PR makes the failure **cheap and non-compounding** instead of expensive and self-amplifying; it does not make a 900-second summary fit in a 600-second budget. That belongs to the chunking / adaptive-ceiling lane (#93241, #97512).

Two further observations from the reporter's follow-up, recorded for maintainers and out of scope here:

- Concurrent user messages during a long compression cancel the in-flight commit (`commit_fence_cancelled`, *"session grew before lease"*).
- The desktop app shows no progress indicator while `/compress` runs — an 8-minute successful compression is indistinguishable from a freeze.

---

 
