### PR TITLE
fix(tts): forward tts.openai.consent_attestation to OpenAI-compatible TTS

### DIFF
--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -116,6 +116,53 @@ class TestOpenaiTtsLangCode:
 
 
 # ---------------------------------------------------------------------------
+# OpenAI TTS consent_attestation (cloned voices on OpenAI-compatible endpoints)
+# ---------------------------------------------------------------------------
+
+class TestOpenaiTtsConsentAttestation:
+    def _run(self, tts_config, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None, False)):
+            from tools.tts_tool import _generate_openai_tts
+            _generate_openai_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+        return mock_client.audio.speech.create
+
+    def test_consent_attestation_forwarded(self, tmp_path, monkeypatch):
+        """consent_attestation config is forwarded via extra_body."""
+        create = self._run(
+            {"openai": {"consent_attestation": "I have the speaker's consent"}},
+            tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["extra_body"]["consent_attestation"] == "I have the speaker's consent"
+
+    def test_consent_attestation_coexists_with_language(self, tmp_path, monkeypatch):
+        """consent_attestation merges with lang_code instead of overwriting it."""
+        create = self._run(
+            {"openai": {"consent_attestation": "I have the speaker's consent",
+                        "language": "es"}},
+            tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["extra_body"] == {
+            "consent_attestation": "I have the speaker's consent",
+            "lang_code": "es",
+        }
+
+    def test_empty_consent_attestation_omitted(self, tmp_path, monkeypatch):
+        """Empty-string consent_attestation is not forwarded."""
+        create = self._run({"openai": {"consent_attestation": ""}},
+                           tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert "extra_body" not in kwargs
+
+
+# ---------------------------------------------------------------------------
 # MiniMax TTS (t2a_v2 endpoint: nested voice_setting/audio_setting,
 # JSON response with hex-encoded audio.  Falls back to the legacy
 # text_to_speech endpoint shape when the base_url points at it.)

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -155,6 +155,73 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     assert captured["client"]["api_key"] == "cfg-key"
 
 
+def _run_openai_streamer(monkeypatch, openai_section):
+    """Run OpenAIStreamer.stream() against a mocked SDK; return create kwargs."""
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            captured["create"] = kwargs
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
+    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {"provider": "openai", "openai": dict(openai_section)}
+    streamer = ts.resolve_streaming_provider(config)
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    return captured["create"]
+
+
+def test_openai_streamer_forwards_extra_body_fields(monkeypatch):
+    """language + consent_attestation merge into one extra_body dict."""
+    create = _run_openai_streamer(
+        monkeypatch,
+        {
+            "api_key": "cfg-key",
+            "language": "es",
+            "consent_attestation": "I have the speaker's consent",
+        },
+    )
+    assert create["extra_body"] == {
+        "lang_code": "es",
+        "consent_attestation": "I have the speaker's consent",
+    }
+
+
+def test_openai_streamer_omits_extra_body_when_unset(monkeypatch):
+    """No optional fields configured → no extra_body kwarg at all."""
+    create = _run_openai_streamer(monkeypatch, {"api_key": "cfg-key"})
+    assert "extra_body" not in create
+    assert create["response_format"] == "pcm"
+
+
+def test_openai_streamer_empty_consent_attestation_omitted(monkeypatch):
+    """Empty-string consent_attestation is not forwarded."""
+    create = _run_openai_streamer(
+        monkeypatch, {"api_key": "cfg-key", "consent_attestation": ""}
+    )
+    assert "extra_body" not in create
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -25,7 +25,7 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
 from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
@@ -284,11 +284,28 @@ class OpenAIStreamer(StreamingTTSProvider):
         )
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")
+        # Mirror the sync provider (_generate_openai_tts): forward optional
+        # tts.openai fields via extra_body, omitted when unset so strict
+        # OpenAI-compatible servers that reject unknown fields are unaffected.
+        # lang_code and consent_attestation merge — configuring both forwards
+        # both.
+        extra_body: Dict[str, Any] = {}
+        language = self.section.get("language")
+        if language:
+            extra_body["lang_code"] = language
+        consent_attestation = self.section.get("consent_attestation")
+        if consent_attestation:
+            extra_body["consent_attestation"] = consent_attestation
+        create_kwargs: Dict[str, Any] = {
+            "model": model,
+            "voice": voice,
+            "input": text,
+            "response_format": "pcm",
+        }
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
         with client.audio.speech.with_streaming_response.create(
-            model=model,
-            voice=voice,
-            input=text,
-            response_format="pcm",
+            **create_kwargs
         ) as response:
             yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1849,6 +1849,12 @@ def _generate_openai_tts(
             OpenAI-compatible servers that reject unknown kwargs are
             unaffected.
 
+    Optional ``tts.openai`` fields forwarded via ``extra_body``:
+        ``language`` (as ``lang_code``, for multilingual OpenAI-compatible
+        backends) and ``consent_attestation`` (required by some
+        OpenAI-compatible servers for cloned voices). Both are omitted when
+        unset so strict servers that reject unknown fields are unaffected.
+
     Returns:
         Path to the saved audio file.
     """
@@ -1879,6 +1885,7 @@ def _generate_openai_tts(
         speed_default = tts_config.get("speed", 1.0) if isinstance(tts_config, dict) else 1.0
         speed = float(oai_config.get("speed", speed_default))
     language = oai_config.get("language")
+    consent_attestation = oai_config.get("consent_attestation")
 
     # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
     # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there with
@@ -1914,8 +1921,15 @@ def _generate_openai_tts(
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         if instructions:
             create_kwargs["instructions"] = instructions
+        # lang_code and consent_attestation share extra_body — merge rather
+        # than overwrite so configuring both forwards both.
+        extra_body: Dict[str, Any] = {}
         if language:
-            create_kwargs["extra_body"] = {"lang_code": language}
+            extra_body["lang_code"] = language
+        if consent_attestation:
+            extra_body["consent_attestation"] = consent_attestation
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)


### PR DESCRIPTION
## What does this PR do?

OpenAI-compatible TTS servers that serve cloned voices reject speech requests without a `consent_attestation` field (HTTP 400 `consent_required`), so a configured custom `base_url` + cloned voice failed and Hermes silently fell back to Edge TTS — there was no config channel to supply the attestation at all.

This adds an optional `tts.openai.consent_attestation` string. When set, it is forwarded to `audio.speech.create` via `extra_body`, the same pass-through mechanism `tts.openai.language` already uses for `lang_code`. The two `extra_body` entries are merged (rather than each overwriting the other), and both stay omitted when unset so strict OpenAI endpoints that reject unknown fields are unaffected.

## Related Issue

Fixes #99775

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` — `_generate_openai_tts` now reads `tts.openai.consent_attestation` and forwards it through a merged `extra_body` dict (`lang_code` + `consent_attestation`), instead of assigning `extra_body` from `language` alone; docstring documents both optional pass-through fields.

## How to Test

1. `pytest tests/tools/test_tts_speed.py -q` — Observed result: `17 passed` (14 pre-existing + 3 new).
2. New `TestOpenaiTtsConsentAttestation` covers: attestation forwarded via `extra_body` when configured; merges with `lang_code` when both `language` and `consent_attestation` are set (no overwrite); empty string is omitted entirely (`extra_body` absent).
3. Stashing only the `tools/tts_tool.py` change makes the first two tests fail (`2 failed, 1 passed`), confirming the tests exercise the new pass-through; restoring the fix turns them green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring in `_generate_openai_tts` documents the new field
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (the example has no `tts.openai` block today; the existing `tts.openai.language` pass-through isn't listed there either)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (config read + kwarg forwarding, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill changes.

## Screenshots / Logs

Not applicable — covered by the unit tests above.