### PR TITLE
feat(lmstudio): manage local model memory

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1825,6 +1825,8 @@ def init_agent(
     # explicit for backward compatibility; users with LM Studio Auto-Evict can
     # opt into JIT via ``model.lmstudio_load_mode: jit``.
     agent.lmstudio_load_mode = "explicit"
+    agent.lmstudio_parallel = None
+    agent.lmstudio_idle_unload_seconds = 0
     try:
         _model_section = _agent_cfg.get("model", {})
         if isinstance(_model_section, dict):
@@ -1836,8 +1838,33 @@ def init_agent(
                     "Invalid model.lmstudio_load_mode=%r; expected 'explicit' or 'jit'. Using explicit.",
                     _model_section.get("lmstudio_load_mode"),
                 )
+            _parallel = _model_section.get("lmstudio_parallel")
+            if _parallel is not None:
+                if isinstance(_parallel, int) and not isinstance(_parallel, bool) and _parallel > 0:
+                    agent.lmstudio_parallel = _parallel
+                else:
+                    logger.warning(
+                        "Invalid model.lmstudio_parallel=%r; expected a positive integer. Using LM Studio's default.",
+                        _parallel,
+                    )
+            _idle_unload = _model_section.get("lmstudio_idle_unload_seconds")
+            if _idle_unload is not None:
+                if (
+                    isinstance(_idle_unload, int)
+                    and not isinstance(_idle_unload, bool)
+                    and _idle_unload >= 0
+                ):
+                    agent.lmstudio_idle_unload_seconds = _idle_unload
+                else:
+                    logger.warning(
+                        "Invalid model.lmstudio_idle_unload_seconds=%r; expected "
+                        "a non-negative integer. Idle unloading is disabled.",
+                        _idle_unload,
+                    )
     except Exception:
         agent.lmstudio_load_mode = "explicit"
+        agent.lmstudio_parallel = None
+        agent.lmstudio_idle_unload_seconds = 0
 
     try:
         agent._tool_guardrails = ToolCallGuardrailController(

--- a/agent/lmstudio_idle.py
+++ b/agent/lmstudio_idle.py
@@ -1,0 +1,210 @@
+"""Process-wide idle unloading for explicitly managed LM Studio models."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+logger = logging.getLogger(__name__)
+
+IdleKey = tuple[str, str]
+TimerFactory = Callable[..., threading.Timer]
+UnloadFunction = Callable[[str, str, str], bool]
+
+
+@dataclass
+class _IdleEntry:
+    model: str
+    base_url: str
+    api_key: str
+    timeout_seconds: int
+    active_turns: int = 0
+    generation: int = 0
+    timer: Optional[threading.Timer] = None
+
+
+class LMStudioIdleUnloadCoordinator:
+    """Unload explicitly loaded models after all local turns become idle.
+
+    The coordinator is process-wide because a Desktop backend can keep more
+    than one cached agent for the same LM Studio runtime. A single lock fences
+    timer expiry against a new turn; a turn that arrives after an unload then
+    performs the normal explicit-load verification before inference begins.
+    """
+
+    def __init__(
+        self,
+        *,
+        timer_factory: TimerFactory = threading.Timer,
+        unload_fn: Optional[UnloadFunction] = None,
+    ) -> None:
+        self._timer_factory = timer_factory
+        self._unload_fn = unload_fn
+        self._lock = threading.RLock()
+        self._entries: dict[IdleKey, _IdleEntry] = {}
+
+    @staticmethod
+    def _key(model: str, base_url: str) -> IdleKey:
+        return (str(base_url or "").rstrip("/").lower(), str(model or ""))
+
+    def _resolve_unload_fn(self) -> UnloadFunction:
+        if self._unload_fn is not None:
+            return self._unload_fn
+        from hermes_cli.models import unload_lmstudio_model
+
+        return unload_lmstudio_model
+
+    def _cancel_locked(self, entry: _IdleEntry) -> None:
+        timer = entry.timer
+        entry.timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _schedule_locked(self, key: IdleKey, entry: _IdleEntry) -> None:
+        self._cancel_locked(entry)
+        if entry.active_turns or entry.timeout_seconds <= 0:
+            return
+        entry.generation += 1
+        generation = entry.generation
+        timer = self._timer_factory(
+            entry.timeout_seconds,
+            self._expire,
+            args=(key, generation),
+        )
+        timer.daemon = True
+        entry.timer = timer
+        timer.start()
+
+    def arm(
+        self,
+        *,
+        model: str,
+        base_url: str,
+        api_key: str,
+        timeout_seconds: int,
+    ) -> Optional[IdleKey]:
+        """Remember a verified load and schedule eviction when currently idle."""
+        if timeout_seconds <= 0 or not model or not base_url:
+            return None
+        key = self._key(model, base_url)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                entry = _IdleEntry(model, base_url, api_key, timeout_seconds)
+                self._entries[key] = entry
+            else:
+                entry.model = model
+                entry.base_url = base_url
+                entry.api_key = api_key
+                entry.timeout_seconds = timeout_seconds
+            self._schedule_locked(key, entry)
+        return key
+
+    def begin(
+        self,
+        *,
+        model: str,
+        base_url: str,
+        api_key: str,
+        timeout_seconds: int,
+    ) -> Optional[IdleKey]:
+        """Cancel pending eviction and register one active LM Studio turn."""
+        if timeout_seconds <= 0 or not model or not base_url:
+            return None
+        key = self._key(model, base_url)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                entry = _IdleEntry(model, base_url, api_key, timeout_seconds)
+                self._entries[key] = entry
+            else:
+                entry.model = model
+                entry.base_url = base_url
+                entry.api_key = api_key
+                entry.timeout_seconds = timeout_seconds
+            self._cancel_locked(entry)
+            entry.generation += 1
+            entry.active_turns += 1
+        return key
+
+    def end(self, key: Optional[IdleKey]) -> None:
+        """Release one active turn and schedule eviction after the quiet period."""
+        if key is None:
+            return
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return
+            entry.active_turns = max(0, entry.active_turns - 1)
+            if entry.active_turns == 0:
+                self._schedule_locked(key, entry)
+
+    def _expire(self, key: IdleKey, generation: int) -> None:
+        # Hold the lock through the bounded local management request. A new
+        # turn waits here, then runs its normal explicit-load verification, so
+        # inference cannot race an in-progress unload.
+        with self._lock:
+            entry = self._entries.get(key)
+            if (
+                entry is None
+                or entry.generation != generation
+                or entry.active_turns != 0
+            ):
+                return
+            entry.timer = None
+            unloaded = self._resolve_unload_fn()(
+                entry.model,
+                entry.base_url,
+                entry.api_key,
+            )
+            if unloaded:
+                logger.info(
+                    "LM Studio model %s unloaded after %ss idle",
+                    entry.model,
+                    entry.timeout_seconds,
+                )
+                self._entries.pop(key, None)
+            else:
+                logger.warning(
+                    "LM Studio idle unload failed for %s; leaving runtime state unchanged",
+                    entry.model,
+                )
+
+
+IDLE_UNLOAD_COORDINATOR = LMStudioIdleUnloadCoordinator()
+
+
+def configured_idle_seconds(agent: object) -> int:
+    value = getattr(agent, "lmstudio_idle_unload_seconds", 0)
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else 0
+    )
+
+
+def arm_agent_idle_unload(agent: object) -> Optional[IdleKey]:
+    return IDLE_UNLOAD_COORDINATOR.arm(
+        model=str(getattr(agent, "model", "") or ""),
+        base_url=str(getattr(agent, "base_url", "") or ""),
+        api_key=str(getattr(agent, "api_key", "") or ""),
+        timeout_seconds=configured_idle_seconds(agent),
+    )
+
+
+def begin_agent_turn(agent: object) -> Optional[IdleKey]:
+    if str(getattr(agent, "provider", "") or "").strip().lower() != "lmstudio":
+        return None
+    return IDLE_UNLOAD_COORDINATOR.begin(
+        model=str(getattr(agent, "model", "") or ""),
+        base_url=str(getattr(agent, "base_url", "") or ""),
+        api_key=str(getattr(agent, "api_key", "") or ""),
+        timeout_seconds=configured_idle_seconds(agent),
+    )
+
+
+def end_agent_turn(key: Optional[IdleKey]) -> None:
+    IDLE_UNLOAD_COORDINATOR.end(key)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5089,6 +5089,72 @@ class LMStudioLoadResult(NamedTuple):
     rejected: bool = False
 
 
+def unload_lmstudio_model(
+    model: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: float = 30.0,
+) -> bool:
+    """Unload every active instance of ``model`` from one LM Studio server.
+
+    Returns ``True`` when the model is already idle or every discovered
+    instance was unloaded. Network, authentication, and malformed-state
+    failures return ``False`` so an idle helper never claims memory was freed
+    when the management request could not be verified.
+    """
+    server_root = _lmstudio_server_root(base_url)
+    if not server_root or not model:
+        return False
+    try:
+        raw_models = _lmstudio_fetch_raw_models(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=min(timeout, 10.0),
+        )
+    except Exception:
+        return False
+    if raw_models is None:
+        return False
+
+    target = next(
+        (
+            entry
+            for entry in raw_models
+            if isinstance(entry, dict)
+            and (entry.get("key") == model or entry.get("id") == model)
+        ),
+        None,
+    )
+    if target is None:
+        return False
+    instances = target.get("loaded_instances")
+    if not isinstance(instances, list):
+        return False
+    instance_ids = [
+        str(instance.get("id") or "").strip()
+        for instance in instances
+        if isinstance(instance, dict) and str(instance.get("id") or "").strip()
+    ]
+    if not instance_ids:
+        return True
+
+    headers = _lmstudio_request_headers(api_key)
+    headers["Content-Type"] = "application/json"
+    for instance_id in instance_ids:
+        request = urllib.request.Request(
+            server_root + "/api/v1/models/unload",
+            data=json.dumps({"instance_id": instance_id}).encode(),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with _urlopen_model_catalog_request(request, timeout=timeout) as response:
+                response.read()
+        except Exception:
+            return False
+    return True
+
+
 def ensure_lmstudio_model_loaded(
     model: str,
     base_url: Optional[str],
@@ -5097,6 +5163,7 @@ def ensure_lmstudio_model_loaded(
     timeout: float = 120.0,
     *,
     return_load_result: bool = False,
+    parallel: Optional[int] = None,
 ) -> Optional[int] | LMStudioLoadResult:
     """Ensure ``model`` is loaded and return verified runtime context.
 
@@ -5119,7 +5186,7 @@ def ensure_lmstudio_model_loaded(
             return value
         return None
 
-    def _loaded_context(entry: dict) -> Optional[int]:
+    def _loaded_instance(entry: dict) -> Optional[tuple[str, dict, int]]:
         instances = entry.get("loaded_instances")
         if not isinstance(instances, list):
             return None
@@ -5127,8 +5194,9 @@ def ensure_lmstudio_model_loaded(
             config = instance.get("config") if isinstance(instance, dict) else None
             context = config.get("context_length") if isinstance(config, dict) else None
             parsed = _positive_int(context)
-            if parsed is not None:
-                return parsed
+            instance_id = str(instance.get("id") or "").strip() if isinstance(instance, dict) else ""
+            if parsed is not None and instance_id and isinstance(config, dict):
+                return instance_id, config, parsed
         return None
 
     def _find_entry(raw_models: list[dict]) -> Optional[dict]:
@@ -5144,6 +5212,9 @@ def ensure_lmstudio_model_loaded(
     explicit_context = _positive_int(target_context_length)
     if target_context_length is not None and explicit_context is None:
         return _result(None)
+    explicit_parallel = _positive_int(parallel)
+    if parallel is not None and explicit_parallel is None:
+        return _result(None, rejected=True)
 
     headers = _lmstudio_request_headers(api_key)
 
@@ -5162,17 +5233,39 @@ def ensure_lmstudio_model_loaded(
     if explicit_context is not None and max_ctx is not None and explicit_context > max_ctx:
         return _result(None, rejected=True)
 
-    current_context = _loaded_context(target_entry)
-    if current_context is not None:
-        return _result(current_context)
+    current_instance = _loaded_instance(target_entry)
+    if current_instance is not None:
+        instance_id, current_config, current_context = current_instance
+        current_parallel = _positive_int(current_config.get("parallel"))
+        if explicit_parallel is None or current_parallel == explicit_parallel:
+            return _result(current_context)
+
+        unload_body = json.dumps({"instance_id": instance_id}).encode()
+        unload_headers = dict(headers)
+        unload_headers["Content-Type"] = "application/json"
+        try:
+            unload_request = urllib.request.Request(
+                server_root + "/api/v1/models/unload",
+                data=unload_body,
+                headers=unload_headers,
+                method="POST",
+            )
+            with _urlopen_model_catalog_request(unload_request, timeout=timeout) as resp:
+                resp.read()
+        except Exception:
+            return _result(None, load_attempted=True)
 
     loaded_instances = target_entry.get("loaded_instances")
-    if not isinstance(loaded_instances, list) or loaded_instances:
+    if not isinstance(loaded_instances, list) or (
+        loaded_instances and current_instance is None
+    ):
         return _result(None)
 
     load_payload: dict[str, Any] = {"model": model, "echo_load_config": True}
     if explicit_context is not None:
         load_payload["context_length"] = explicit_context
+    if explicit_parallel is not None:
+        load_payload["parallel"] = explicit_parallel
     body = json.dumps(load_payload).encode()
     load_headers = dict(headers)
     load_headers["Content-Type"] = "application/json"
@@ -5208,7 +5301,8 @@ def ensure_lmstudio_model_loaded(
     if refreshed_models is None:
         return _result(None, load_attempted=True)
     refreshed_entry = _find_entry(refreshed_models)
-    refreshed_context = _loaded_context(refreshed_entry) if refreshed_entry is not None else None
+    refreshed_instance = _loaded_instance(refreshed_entry) if refreshed_entry is not None else None
+    refreshed_context = refreshed_instance[2] if refreshed_instance is not None else None
     return _result(refreshed_context, load_attempted=True)
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -964,13 +964,25 @@ class AIAgent:
 
         if config_context_length is None:
             config_context_length = getattr(self, "_config_context_length", None)
-        return ensure_lmstudio_model_loaded(
+        load_result = ensure_lmstudio_model_loaded(
             self.model,
             self.base_url,
             getattr(self, "api_key", ""),
             config_context_length,
             return_load_result=True,
+            parallel=getattr(self, "lmstudio_parallel", None),
         )
+        if not AIAgent._lmstudio_load_was_unverified(load_result):
+            try:
+                from agent.lmstudio_idle import arm_agent_idle_unload
+
+                arm_agent_idle_unload(self)
+            except Exception:
+                logger.warning(
+                    "Could not arm LM Studio idle unloading",
+                    exc_info=True,
+                )
+        return load_result
 
     def switch_model(
         self,
@@ -9052,6 +9064,7 @@ class AIAgent:
         task_started = False
         task_finished = False
         relay_outcome = "failed"
+        lmstudio_idle_token = None
 
         def _stop_durable_turn_lease_refresher() -> None:
             nonlocal durable_turn_lease_turn_active
@@ -9084,6 +9097,21 @@ class AIAgent:
                     _clear_if_owned()
 
         try:
+            try:
+                from agent.lmstudio_idle import begin_agent_turn
+
+                lmstudio_idle_token = begin_agent_turn(self)
+                if lmstudio_idle_token is not None:
+                    # Re-verify the explicit parallel/context contract after an
+                    # idle timer may have unloaded the model.
+                    self._ensure_lmstudio_runtime_loaded(
+                        getattr(self, "_config_context_length", None)
+                    )
+            except Exception:
+                logger.warning(
+                    "Could not prepare LM Studio idle-unload lifecycle",
+                    exc_info=True,
+                )
             # Serialize the full load -> run -> flush region across Hermes
             # processes. Gateway's asyncio lease closes alias routing inside one
             # process; this durable lease covers Desktop, CLI resume, gateway,
@@ -9621,6 +9649,15 @@ class AIAgent:
                         reset_accounting_context(acct_token)
                     if token is not None:
                         reset_conversation_context(token)
+                    try:
+                        from agent.lmstudio_idle import end_agent_turn
+
+                        end_agent_turn(lmstudio_idle_token)
+                    except Exception:
+                        logger.warning(
+                            "Could not finalize LM Studio idle-unload lifecycle",
+                            exc_info=True,
+                        )
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/agent/test_lmstudio_idle.py
+++ b/tests/agent/test_lmstudio_idle.py
@@ -1,0 +1,110 @@
+from agent.lmstudio_idle import LMStudioIdleUnloadCoordinator
+
+
+class _FakeTimer:
+    def __init__(self, interval, callback, args=()):
+        self.interval = interval
+        self.callback = callback
+        self.args = args
+        self.cancelled = False
+        self.started = False
+        self.daemon = False
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        self.callback(*self.args)
+
+
+def test_idle_timer_is_cancelled_for_turn_and_rearmed_afterward():
+    timers = []
+    unloaded = []
+
+    def timer_factory(*args, **kwargs):
+        timer = _FakeTimer(*args, **kwargs)
+        timers.append(timer)
+        return timer
+
+    coordinator = LMStudioIdleUnloadCoordinator(
+        timer_factory=timer_factory,
+        unload_fn=lambda model, base_url, api_key: (
+            not unloaded.append((model, base_url, api_key))
+        ),
+    )
+
+    coordinator.arm(
+        model="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="local",
+        timeout_seconds=300,
+    )
+    assert timers[0].started is True
+    assert timers[0].interval == 300
+
+    token = coordinator.begin(
+        model="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="local",
+        timeout_seconds=300,
+    )
+    assert timers[0].cancelled is True
+    timers[0].fire()
+    assert unloaded == []
+
+    coordinator.end(token)
+    assert len(timers) == 2
+    assert timers[1].started is True
+    timers[1].fire()
+    assert unloaded == [("qwen", "http://127.0.0.1:1234/v1", "local")]
+
+
+def test_last_overlapping_turn_arms_one_idle_timer():
+    timers = []
+
+    def timer_factory(*args, **kwargs):
+        timer = _FakeTimer(*args, **kwargs)
+        timers.append(timer)
+        return timer
+
+    coordinator = LMStudioIdleUnloadCoordinator(
+        timer_factory=timer_factory,
+        unload_fn=lambda *_args: True,
+    )
+    first = coordinator.begin(
+        model="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="",
+        timeout_seconds=60,
+    )
+    second = coordinator.begin(
+        model="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="",
+        timeout_seconds=60,
+    )
+
+    coordinator.end(first)
+    assert timers == []
+    coordinator.end(second)
+    assert len(timers) == 1
+
+
+def test_zero_timeout_disables_idle_tracking():
+    coordinator = LMStudioIdleUnloadCoordinator(
+        timer_factory=lambda *_args, **_kwargs: None,
+        unload_fn=lambda *_args: True,
+    )
+
+    assert (
+        coordinator.begin(
+            model="qwen",
+            base_url="http://127.0.0.1:1234/v1",
+            api_key="",
+            timeout_seconds=0,
+        )
+        is None
+    )

--- a/tests/hermes_cli/test_lmstudio_context_policy.py
+++ b/tests/hermes_cli/test_lmstudio_context_policy.py
@@ -23,18 +23,23 @@ class _JsonResponse:
         return self._body
 
 
-def _catalog(*, loaded_context=None, maximum=262_144):
+def _catalog(*, loaded_context=None, loaded_parallel=None, maximum=262_144):
     loaded_instances = []
     if loaded_context is not None:
+        config = {"context_length": loaded_context}
+        if loaded_parallel is not None:
+            config["parallel"] = loaded_parallel
         loaded_instances.append({
             "id": f"{MODEL}:active",
-            "config": {"context_length": loaded_context},
+            "config": config,
         })
-    return [{
-        "key": MODEL,
-        "max_context_length": maximum,
-        "loaded_instances": loaded_instances,
-    }]
+    return [
+        {
+            "key": MODEL,
+            "max_context_length": maximum,
+            "loaded_instances": loaded_instances,
+        }
+    ]
 
 
 def _capture_load(monkeypatch, response_payload):
@@ -46,10 +51,6 @@ def _capture_load(monkeypatch, response_payload):
 
     monkeypatch.setattr(models, "_urlopen_model_catalog_request", fake_open)
     return requests
-
-
-
-
 
 
 def test_missing_echo_refreshes_loaded_state(monkeypatch):
@@ -89,3 +90,115 @@ def test_explicit_override_above_known_maximum_rejects_even_when_loaded(monkeypa
     assert result.context_length is None
     assert result.load_attempted is False
     assert result.rejected is True
+
+
+def test_explicit_load_forwards_parallel_limit(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: _catalog(),
+    )
+    requests = _capture_load(
+        monkeypatch,
+        {"load_config": {"context_length": 65_536, "parallel": 1}},
+    )
+
+    result = models.ensure_lmstudio_model_loaded(
+        MODEL,
+        BASE_URL,
+        api_key="",
+        target_context_length=65_536,
+        parallel=1,
+        return_load_result=True,
+    )
+
+    assert result.context_length == 65_536
+    assert result.load_attempted is True
+    assert requests[0][2]["parallel"] == 1
+
+
+def test_invalid_parallel_limit_is_rejected_before_load(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: _catalog(),
+    )
+    monkeypatch.setattr(
+        models,
+        "_urlopen_model_catalog_request",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid parallel value must not be posted"
+        ),
+    )
+
+    result = models.ensure_lmstudio_model_loaded(
+        MODEL,
+        BASE_URL,
+        api_key="",
+        target_context_length=65_536,
+        parallel=0,
+        return_load_result=True,
+    )
+
+    assert result.context_length is None
+    assert result.load_attempted is False
+    assert result.rejected is True
+
+
+def test_loaded_parallel_mismatch_is_reconfigured(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: _catalog(loaded_context=65_536, loaded_parallel=4),
+    )
+    requests = _capture_load(
+        monkeypatch,
+        {"load_config": {"context_length": 65_536, "parallel": 1}},
+    )
+
+    result = models.ensure_lmstudio_model_loaded(
+        MODEL,
+        BASE_URL,
+        api_key="",
+        target_context_length=65_536,
+        parallel=1,
+        return_load_result=True,
+    )
+
+    assert result.context_length == 65_536
+    assert result.load_attempted is True
+    assert requests[0][0].full_url.endswith("/api/v1/models/unload")
+    assert requests[0][2] == {"instance_id": f"{MODEL}:active"}
+    assert requests[1][0].full_url.endswith("/api/v1/models/load")
+    assert requests[1][2]["parallel"] == 1
+
+
+def test_unload_lmstudio_model_posts_every_loaded_instance(monkeypatch):
+    catalog = _catalog(loaded_context=65_536, loaded_parallel=1)
+    catalog[0]["loaded_instances"].append({
+        "id": f"{MODEL}:second",
+        "config": {"context_length": 65_536},
+    })
+    monkeypatch.setattr(models, "_lmstudio_fetch_raw_models", lambda **_kwargs: catalog)
+    requests = _capture_load(monkeypatch, {"status": "unloaded"})
+
+    assert models.unload_lmstudio_model(MODEL, BASE_URL, api_key="") is True
+    assert [payload for _request, _timeout, payload in requests] == [
+        {"instance_id": f"{MODEL}:active"},
+        {"instance_id": f"{MODEL}:second"},
+    ]
+
+
+def test_unload_lmstudio_model_treats_known_idle_model_as_success(monkeypatch):
+    monkeypatch.setattr(
+        models,
+        "_lmstudio_fetch_raw_models",
+        lambda **_kwargs: _catalog(),
+    )
+    monkeypatch.setattr(
+        models,
+        "_urlopen_model_catalog_request",
+        lambda *_args, **_kwargs: pytest.fail("idle model must not post unload"),
+    )
+
+    assert models.unload_lmstudio_model(MODEL, BASE_URL, api_key="") is True

--- a/tests/run_agent/test_lmstudio_load_mode.py
+++ b/tests/run_agent/test_lmstudio_load_mode.py
@@ -33,8 +33,41 @@ def test_lmstudio_jit_load_mode_skips_explicit_preload(monkeypatch):
     assert calls == []
 
 
+def test_lmstudio_explicit_load_forwards_parallel_limit(monkeypatch):
+    calls = []
+    agent = _agent("explicit")
+    agent.lmstudio_parallel = 1
+
+    def fake_ensure(*args, **kwargs):
+        calls.append((args, kwargs))
+        return LMStudioLoadResult(64_000)
+
+    monkeypatch.setattr("hermes_cli.models.ensure_lmstudio_model_loaded", fake_ensure)
+
+    result = AIAgent._ensure_lmstudio_runtime_loaded(cast(Any, agent))
+
+    assert result == LMStudioLoadResult(64_000)
+    assert calls[0][1]["parallel"] == 1
 
 
+def test_lmstudio_verified_explicit_load_arms_idle_unload(monkeypatch):
+    agent = _agent("explicit")
+    agent.lmstudio_idle_unload_seconds = 300
+    armed = []
+
+    monkeypatch.setattr(
+        "hermes_cli.models.ensure_lmstudio_model_loaded",
+        lambda *_args, **_kwargs: LMStudioLoadResult(64_000),
+    )
+    monkeypatch.setattr(
+        "agent.lmstudio_idle.arm_agent_idle_unload",
+        lambda candidate: armed.append(candidate),
+    )
+
+    result = AIAgent._ensure_lmstudio_runtime_loaded(cast(Any, agent))
+
+    assert result == LMStudioLoadResult(64_000)
+    assert armed == [agent]
 
 
 def test_explicit_budget_below_loaded_runtime_limits_effective_context():
@@ -44,5 +77,3 @@ def test_explicit_budget_below_loaded_runtime_limits_effective_context():
     )
 
     assert result == 80_000
-
-

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -955,6 +955,27 @@ Set it back to the default explicit preload behavior with:
 hermes config set model.lmstudio_load_mode explicit
 ```
 
+For memory-constrained systems, Hermes can also cap LM Studio's concurrent
+predictions when it explicitly loads the model:
+
+```bash
+hermes config set model.lmstudio_parallel 1
+```
+
+Leave this setting unset to use LM Studio's configured default.
+
+When Hermes uses explicit loading, it can release the model after a quiet
+period while retaining the configured context and parallel limit on the next
+turn:
+
+```bash
+hermes config set model.lmstudio_idle_unload_seconds 300
+```
+
+The default is `0` (disabled). The timer is reset while any LM Studio turn is
+active in the Hermes process. When the model is needed again, Hermes verifies
+and reloads it before sending the request.
+
 **Tool calling:** Supported since LM Studio 0.3.6. Models with native tool-calling training (Qwen 2.5, Llama 3.x, Mistral, Hermes) are auto-detected and shown with a tool badge. Other models use a generic fallback that may be less reliable.
 
 ---


### PR DESCRIPTION
## What does this PR do?

Adds an LM Studio memory manager for local models so Hermes can unload idle models, preserve a warm primary model when configured, and choose context/load settings from the local machine's available resources.

## Type of Change

- [x] New feature
- [x] Tests

## Changes Made

- Add idle-model tracking and bounded unload behavior.
- Wire LM Studio load mode and context policy into agent initialization.
- Expose the controls through the existing model configuration path.
- Document the LM Studio provider behavior.

## How to Test

- `python -m pytest tests/agent/test_lmstudio_idle.py tests/hermes_cli/test_lmstudio_context_policy.py tests/run_agent/test_lmstudio_load_mode.py -q`
- Result: 14 passed.
- `ruff check` and `git diff --check` passed.

## Checklist

- [x] Configuration uses existing config surfaces
- [x] No new model tool or permanent tool-schema footprint
- [x] Tests cover idle, context, and load-mode behavior
- [x] No unrelated files or local operational material