### PR TITLE
feat(media): add read-only YouTube account skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,16 @@ agent-browser/
 # Private keys
 *.ppk
 *.pem
+# Google Workspace OAuth credentials and downloaded Desktop client exports.
+# These files contain reusable secrets and must remain profile-local.
+client_secret_*.apps.googleusercontent.com.json
+google_client_secret.json
+google_token.json
+google_oauth_pending.json
+google_oauth_last_url.txt
+youtube_client_secret.json
+youtube_token.json
+youtube_oauth_pending.json
 privvy*
 images/
 __pycache__/

--- a/skills/media/youtube-account/SKILL.md
+++ b/skills/media/youtube-account/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: youtube-account
+description: "Read a user's private YouTube channel, subscriptions, and playlists through a profile-scoped OAuth grant. Use for account-specific YouTube requests, not public transcripts or YouTube Music/TV control."
+metadata:
+  hermes:
+    tags: [YouTube, OAuth, Media]
+---
+
+# YouTube Account
+
+Use this skill for read-only access to the YouTube account authorized in the
+current Hermes profile. The grant is deliberately separate from Google
+Workspace and uses only `https://www.googleapis.com/auth/youtube.readonly`.
+
+For public video transcripts and summaries, use `youtube-content` instead.
+YouTube Music and YouTube TV do not have account-control routes in this skill.
+
+## Setup
+
+`SKILL_DIR` is the directory containing this file. Run scripts with the same
+Hermes-managed Python environment used by the active profile.
+
+1. Check the current profile:
+
+   ```bash
+   python SKILL_DIR/scripts/setup.py --check
+   ```
+
+2. If needed, store a Google Desktop OAuth client. Reusing the same client
+   application as Google Workspace is allowed; the YouTube token remains
+   separate.
+
+   ```bash
+   python SKILL_DIR/scripts/setup.py --client-secret /path/to/client.json
+   ```
+
+3. Generate an authorization URL and give it to the user. Never automate or
+   collect their Google password, MFA, or security-key response.
+
+   ```bash
+   python SKILL_DIR/scripts/setup.py --auth-url
+   ```
+
+4. The redirect to `http://localhost:1` is expected to fail. Ask the user for
+   the full redirected URL, then exchange it (or its raw `code` value):
+
+   ```bash
+   python SKILL_DIR/scripts/setup.py --auth-code 'FULL_REDIRECT_URL_OR_CODE'
+   python SKILL_DIR/scripts/setup.py --check
+   ```
+
+Google Cloud must have YouTube Data API v3 enabled for the OAuth project. Treat
+administrator or Google policy denials as authoritative.
+
+## Read-only commands
+
+```bash
+python SKILL_DIR/scripts/youtube_api.py channel
+python SKILL_DIR/scripts/youtube_api.py subscriptions --max 25
+python SKILL_DIR/scripts/youtube_api.py playlists --max 25
+python SKILL_DIR/scripts/youtube_api.py playlist-items PLAYLIST_ID --max 25
+```
+
+Return only the private account data the user requested. Never print or expose
+the OAuth client, access token, refresh token, or pending PKCE state. This skill
+has no write operations.

--- a/skills/media/youtube-account/agents/openai.yaml
+++ b/skills/media/youtube-account/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "YouTube Account"
+  short_description: "Read private YouTube account data"

--- a/skills/media/youtube-account/scripts/setup.py
+++ b/skills/media/youtube-account/scripts/setup.py
@@ -1,0 +1,254 @@
+"""Profile-scoped OAuth setup for read-only YouTube account access."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+SCOPES = ["https://www.googleapis.com/auth/youtube.readonly"]
+REDIRECT_URI = "http://localhost:1"
+HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+CLIENT_PATH = HERMES_HOME / "youtube_client_secret.json"
+TOKEN_PATH = HERMES_HOME / "youtube_token.json"
+PENDING_PATH = HERMES_HOME / "youtube_oauth_pending.json"
+
+
+def _ensure_dependencies() -> None:
+    try:
+        import google.auth  # noqa: F401
+        import google_auth_oauthlib  # noqa: F401
+        import googleapiclient  # noqa: F401
+        return
+    except ImportError:
+        pass
+
+    uv = shutil.which("uv")
+    if not uv:
+        raise RuntimeError(
+            "Google API dependencies are missing and uv is unavailable. "
+            "Install google-auth, google-auth-oauthlib, and google-api-python-client."
+        )
+    subprocess.run(
+        [
+            uv,
+            "pip",
+            "install",
+            "google-auth",
+            "google-auth-oauthlib",
+            "google-api-python-client",
+        ],
+        check=True,
+    )
+
+
+def _secure_file(path: Path) -> None:
+    if os.name != "nt":
+        path.chmod(0o600)
+        return
+
+    domain = os.environ.get("USERDOMAIN", "").strip()
+    username = os.environ.get("USERNAME", getpass.getuser()).strip()
+    identity = f"{domain}\\{username}" if domain else username
+    result = subprocess.run(
+        [
+            "icacls",
+            str(path),
+            "/inheritance:r",
+            "/grant:r",
+            f"{identity}:F",
+            "NT AUTHORITY\\SYSTEM:F",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not protect {path}: {result.stderr.strip()}")
+
+
+def _write_private_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _secure_file(path)
+
+
+def _client_payload(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    client = payload.get("installed") or payload.get("web")
+    if not isinstance(client, dict):
+        raise ValueError("Expected a Google OAuth client JSON with installed or web settings")
+    if not client.get("client_id") or not client.get("client_secret"):
+        raise ValueError("OAuth client JSON is missing client_id or client_secret")
+    return payload
+
+
+def store_client(source: str) -> None:
+    payload = _client_payload(Path(source).expanduser().resolve())
+    _write_private_json(CLIENT_PATH, payload)
+    print(f"OK: YouTube OAuth client saved to {CLIENT_PATH}")
+
+
+def _credentials():
+    _ensure_dependencies()
+    from google.oauth2.credentials import Credentials
+
+    return Credentials.from_authorized_user_file(str(TOKEN_PATH))
+
+
+def check() -> bool:
+    if not TOKEN_PATH.exists():
+        print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
+        return False
+
+    _ensure_dependencies()
+    from google.auth.transport.requests import Request
+    from googleapiclient.discovery import build
+
+    try:
+        credentials = _credentials()
+        if credentials.expired and credentials.refresh_token:
+            credentials.refresh(Request())
+            _write_private_json(TOKEN_PATH, json.loads(credentials.to_json()))
+        if not credentials.valid:
+            print("NOT_AUTHENTICATED: YouTube token is invalid")
+            return False
+        granted = set(credentials.scopes or [])
+        if not set(SCOPES).issubset(granted):
+            print("NOT_AUTHENTICATED: Token is missing youtube.readonly")
+            return False
+        (
+            build("youtube", "v3", credentials=credentials, cache_discovery=False)
+            .channels()
+            .list(part="id", mine=True, maxResults=1)
+            .execute()
+        )
+    except Exception as error:
+        print(f"NOT_AUTHENTICATED: {type(error).__name__}")
+        return False
+
+    print(f"AUTHENTICATED: Read-only YouTube grant is valid at {TOKEN_PATH}")
+    return True
+
+
+def auth_url() -> None:
+    if not CLIENT_PATH.exists():
+        raise FileNotFoundError("No YouTube OAuth client is stored; run --client-secret first")
+
+    _ensure_dependencies()
+    from google_auth_oauthlib.flow import Flow
+
+    flow = Flow.from_client_secrets_file(
+        str(CLIENT_PATH),
+        scopes=SCOPES,
+        redirect_uri=REDIRECT_URI,
+        autogenerate_code_verifier=True,
+    )
+    url, state = flow.authorization_url(access_type="offline", prompt="consent")
+    _write_private_json(
+        PENDING_PATH,
+        {
+            "state": state,
+            "code_verifier": flow.code_verifier,
+            "redirect_uri": REDIRECT_URI,
+        },
+    )
+    print(url)
+
+
+def _code_and_state(value: str) -> tuple[str, str | None]:
+    if not value.startswith("http"):
+        return value, None
+    query = parse_qs(urlparse(value).query)
+    code = (query.get("code") or [""])[0]
+    if not code:
+        raise ValueError("Redirect URL does not contain an OAuth code")
+    return code, (query.get("state") or [None])[0]
+
+
+def exchange(value: str) -> None:
+    if not CLIENT_PATH.exists() or not PENDING_PATH.exists():
+        raise FileNotFoundError("Run --client-secret and --auth-url before --auth-code")
+
+    pending = json.loads(PENDING_PATH.read_text(encoding="utf-8"))
+    code, returned_state = _code_and_state(value)
+    if returned_state and returned_state != pending.get("state"):
+        raise ValueError("OAuth state mismatch; generate a fresh authorization URL")
+
+    _ensure_dependencies()
+    from google_auth_oauthlib.flow import Flow
+
+    flow = Flow.from_client_secrets_file(
+        str(CLIENT_PATH),
+        scopes=SCOPES,
+        redirect_uri=pending.get("redirect_uri", REDIRECT_URI),
+        state=pending["state"],
+        code_verifier=pending["code_verifier"],
+    )
+    flow.fetch_token(code=code)
+    _write_private_json(TOKEN_PATH, json.loads(flow.credentials.to_json()))
+    PENDING_PATH.unlink(missing_ok=True)
+    print(f"OK: Read-only YouTube token saved to {TOKEN_PATH}")
+
+
+def revoke() -> None:
+    if not TOKEN_PATH.exists():
+        PENDING_PATH.unlink(missing_ok=True)
+        print("No YouTube token to revoke")
+        return
+
+    credentials = _credentials()
+    token = credentials.refresh_token or credentials.token
+    if token:
+        try:
+            request = urllib.request.Request(
+                f"https://oauth2.googleapis.com/revoke?token={token}", method="POST"
+            )
+            urllib.request.urlopen(request, timeout=15).read()
+        except Exception:
+            pass
+    TOKEN_PATH.unlink(missing_ok=True)
+    PENDING_PATH.unlink(missing_ok=True)
+    print("YouTube token deleted")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Set up read-only YouTube OAuth")
+    actions = parser.add_mutually_exclusive_group(required=True)
+    actions.add_argument("--check", action="store_true")
+    actions.add_argument("--client-secret", metavar="PATH")
+    actions.add_argument("--auth-url", action="store_true")
+    actions.add_argument("--auth-code", metavar="CODE_OR_URL")
+    actions.add_argument("--revoke", action="store_true")
+    actions.add_argument("--install-deps", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.check:
+            raise SystemExit(0 if check() else 1)
+        if args.client_secret:
+            store_client(args.client_secret)
+        elif args.auth_url:
+            auth_url()
+        elif args.auth_code:
+            exchange(args.auth_code)
+        elif args.revoke:
+            revoke()
+        elif args.install_deps:
+            _ensure_dependencies()
+            print("Dependencies installed")
+    except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/media/youtube-account/scripts/youtube_api.py
+++ b/skills/media/youtube-account/scripts/youtube_api.py
@@ -1,0 +1,185 @@
+"""Read-only YouTube Data API commands for the active Hermes profile."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+
+HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+TOKEN_PATH = HERMES_HOME / "youtube_token.json"
+
+
+def service():
+    if not TOKEN_PATH.exists():
+        raise FileNotFoundError("No youtube_token.json in the active Hermes profile")
+    credentials = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+    if credentials.expired and credentials.refresh_token:
+        credentials.refresh(Request())
+        TOKEN_PATH.write_text(credentials.to_json(), encoding="utf-8")
+    return build("youtube", "v3", credentials=credentials, cache_discovery=False)
+
+
+def channel(youtube) -> dict:
+    response = (
+        youtube.channels()
+        .list(part="snippet,contentDetails,statistics", mine=True, maxResults=1)
+        .execute()
+    )
+    items = response.get("items", [])
+    if not items:
+        return {"channel": None}
+    item = items[0]
+    snippet = item.get("snippet", {})
+    return {
+        "channel": {
+            "id": item.get("id"),
+            "title": snippet.get("title"),
+            "description": snippet.get("description"),
+            "custom_url": snippet.get("customUrl"),
+            "published_at": snippet.get("publishedAt"),
+            "statistics": item.get("statistics", {}),
+            "related_playlists": item.get("contentDetails", {}).get(
+                "relatedPlaylists", {}
+            ),
+        }
+    }
+
+
+def subscriptions(youtube, maximum: int) -> dict:
+    response = (
+        youtube.subscriptions()
+        .list(
+            part="snippet",
+            mine=True,
+            maxResults=maximum,
+            order="alphabetical",
+        )
+        .execute()
+    )
+    return {
+        "subscriptions": [
+            {
+                "id": item.get("id"),
+                "channel_id": item.get("snippet", {})
+                .get("resourceId", {})
+                .get("channelId"),
+                "title": item.get("snippet", {}).get("title"),
+            }
+            for item in response.get("items", [])
+        ],
+        "next_page_token": response.get("nextPageToken"),
+    }
+
+
+def _is_channel_not_found(error: HttpError) -> bool:
+    if getattr(error.resp, "status", None) != 404:
+        return False
+    try:
+        payload = json.loads(error.content.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    details = payload.get("error", {}).get("errors", [])
+    return any(detail.get("reason") == "channelNotFound" for detail in details)
+
+
+def playlists(youtube, maximum: int) -> dict:
+    try:
+        response = (
+            youtube.playlists()
+            .list(part="snippet,status,contentDetails", mine=True, maxResults=maximum)
+            .execute()
+        )
+    except HttpError as error:
+        # YouTube returns 404/channelNotFound for valid Google identities that
+        # have never created a YouTube channel. Treat that as an empty account,
+        # while preserving every other API error.
+        if not _is_channel_not_found(error):
+            raise
+        response = {"items": []}
+    return {
+        "playlists": [
+            {
+                "id": item.get("id"),
+                "title": item.get("snippet", {}).get("title"),
+                "description": item.get("snippet", {}).get("description"),
+                "privacy": item.get("status", {}).get("privacyStatus"),
+                "item_count": item.get("contentDetails", {}).get("itemCount"),
+            }
+            for item in response.get("items", [])
+        ],
+        "next_page_token": response.get("nextPageToken"),
+    }
+
+
+def playlist_items(youtube, playlist_id: str, maximum: int) -> dict:
+    response = (
+        youtube.playlistItems()
+        .list(part="snippet,contentDetails", playlistId=playlist_id, maxResults=maximum)
+        .execute()
+    )
+    return {
+        "items": [
+            {
+                "id": item.get("id"),
+                "video_id": item.get("contentDetails", {}).get("videoId"),
+                "title": item.get("snippet", {}).get("title"),
+                "channel_title": item.get("snippet", {}).get("videoOwnerChannelTitle"),
+                "published_at": item.get("contentDetails", {}).get("videoPublishedAt"),
+            }
+            for item in response.get("items", [])
+        ],
+        "next_page_token": response.get("nextPageToken"),
+    }
+
+
+def _bounded(value: str) -> int:
+    number = int(value)
+    if not 1 <= number <= 50:
+        raise argparse.ArgumentTypeError("--max must be between 1 and 50")
+    return number
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Read private YouTube account data")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("channel")
+
+    subscription_parser = commands.add_parser("subscriptions")
+    subscription_parser.add_argument("--max", type=_bounded, default=25)
+
+    playlist_parser = commands.add_parser("playlists")
+    playlist_parser.add_argument("--max", type=_bounded, default=25)
+
+    item_parser = commands.add_parser("playlist-items")
+    item_parser.add_argument("playlist_id")
+    item_parser.add_argument("--max", type=_bounded, default=25)
+    args = parser.parse_args()
+
+    try:
+        youtube = service()
+        if args.command == "channel":
+            result = channel(youtube)
+        elif args.command == "subscriptions":
+            result = subscriptions(youtube, args.max)
+        elif args.command == "playlists":
+            result = playlists(youtube, args.max)
+        else:
+            result = playlist_items(youtube, args.playlist_id, args.max)
+    except Exception as error:
+        print(f"ERROR: {type(error).__name__}: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

Adds a read-only YouTube account skill for listing the signed-in user's channels, subscriptions, playlists, and recent uploads through the official YouTube Data API.

## Type of Change

- [x] New skill
- [x] Documentation and scripts

## Changes Made

- Add the skill instructions and discovery metadata.
- Add an installed-app OAuth setup helper with local token storage.
- Add a read-only API helper with explicit subcommands.
- Ignore local OAuth client and token artifacts.

## How to Test

- `python -m py_compile skills/media/youtube-account/scripts/setup.py skills/media/youtube-account/scripts/youtube_api.py`
- `python skills/media/youtube-account/scripts/setup.py --help`
- `python skills/media/youtube-account/scripts/youtube_api.py --help`
- `ruff check` and `git diff --check` passed.

## Security and scope

- OAuth requests only `youtube.readonly`.
- Credentials and refresh tokens are local ignored artifacts, not repository content.
- No core tool-schema footprint or external dependency was added.

## Checklist

- [x] Skill follows the bundled skill structure
- [x] Read-only scope and secret handling are documented
- [x] No unrelated files or local operational material
- [x] Cross-platform Python entry points validated on Windows 11