### PR TITLE
fix(mcp): persist explicit OAuth authorization

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -417,6 +417,63 @@ def _oauth_tokens_present(name: str) -> bool:
         return True
 
 
+def _initiate_explicit_oauth(
+    name: str,
+    config: dict,
+    *,
+    connect_timeout: float,
+) -> None:
+    """Drive user-requested OAuth before probing public MCP methods.
+
+    The MCP SDK normally starts OAuth only after a resource request returns
+    401. Some servers expose ``initialize`` and ``tools/list`` anonymously,
+    so an explicit login must drive the shared provider's authorization path
+    before the ordinary authenticated connection probe.
+    """
+    url = config.get("url")
+    if not url:
+        raise ValueError(f"Server '{name}' has no OAuth-capable URL")
+
+    from tools.mcp_oauth_manager import get_manager
+    from tools.mcp_tool import (
+        _ensure_mcp_loop,
+        _resolve_client_cert,
+        _run_on_mcp_loop,
+        _stop_mcp_loop_if_idle,
+    )
+
+    resolved = _resolve_mcp_server_config(config)
+    provider = get_manager().get_or_build_provider(
+        name,
+        resolved["url"],
+        resolved.get("oauth"),
+    )
+    if provider is None:
+        raise RuntimeError("MCP SDK OAuth support is unavailable")
+
+    ssl_verify = resolved.get("ssl_verify", True)
+    client_cert = _resolve_client_cert(name, resolved)
+
+    async def _authorize() -> None:
+        await provider.authorize_interactively(
+            ssl_verify=ssl_verify,
+            client_cert=client_cert,
+        )
+
+    _ensure_mcp_loop()
+    try:
+        _run_on_mcp_loop(_authorize(), timeout=connect_timeout + 10.0)
+    except BaseException as exc:
+        raise _unwrap_exception_group(exc) from None
+    finally:
+        _stop_mcp_loop_if_idle()
+
+    if not _oauth_tokens_present(name):
+        raise RuntimeError(
+            "OAuth authorization completed without a persisted token"
+        )
+
+
 def _unwrap_exception_group(exc: BaseException) -> Exception:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -856,6 +913,11 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             _login_connect_timeout = 0.0
         _login_connect_timeout = max(_login_connect_timeout, 315.0)
         with force_interactive_oauth():
+            _initiate_explicit_oauth(
+                name,
+                server_config,
+                connect_timeout=_login_connect_timeout,
+            )
             tools = _probe_single_server(
                 name, server_config, connect_timeout=_login_connect_timeout
             )

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -338,6 +338,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -360,7 +361,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -88,6 +88,7 @@ from hermes_cli.config import (
     redact_key,
     write_platform_config_field,
     _deep_merge,
+    _preserve_env_ref_templates,
 )
 from plugins.memory.config_schema import (
     ProviderConfigSchema,
@@ -7270,7 +7271,14 @@ async def get_config(profile: Optional[str] = None):
     # override stays scoped to the worker thread.
     def _run():
         with _profile_scope(profile):
-            return _normalize_config_for_web(load_config())
+            # ``load_config()`` expands ${env:VAR} references for runtime use.
+            # Returning that expanded document to the Desktop renderer exposes
+            # live credentials in otherwise-safe editable fields such as MCP
+            # Authorization headers. Restore only raw templates whose current
+            # expansion matches the loaded value; literal config values remain
+            # literal and unrelated defaults/managed settings stay intact.
+            config = _preserve_env_ref_templates(load_config(), read_raw_config())
+            return _normalize_config_for_web(config)
 
     config = await asyncio.to_thread(_run)
     # Strip internal keys that the frontend shouldn't see or send back
@@ -13764,6 +13772,7 @@ def _mcp_oauth_transaction(flow) -> threading.Lock:
 def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
     """Run the normal MCP probe with dashboard redirect/callback handlers."""
     from hermes_cli.mcp_config import (
+        _initiate_explicit_oauth,
         _oauth_tokens_present,
         _probe_single_server,
         _save_mcp_server,
@@ -13793,15 +13802,23 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
                         flow.server_name,
                         hermes_home=flow.hermes_home,
                     )
+                    auth_timeout = max(
+                        float(cfg.get("connect_timeout", 0) or 0),
+                        315.0,
+                    )
+                    _initiate_explicit_oauth(
+                        flow.server_name,
+                        cfg,
+                        connect_timeout=auth_timeout,
+                    )
                     tools = _probe_single_server(
                         flow.server_name,
                         cfg,
-                        connect_timeout=max(float(cfg.get("connect_timeout", 0) or 0), 315),
+                        connect_timeout=auth_timeout,
                     )
                     if not _oauth_tokens_present(flow.server_name):
                         raise RuntimeError(
-                            "The server responded, but no OAuth token was obtained — "
-                            "this provider may require a manually-registered OAuth client."
+                            "OAuth authorization completed without a persisted token."
                         )
                     _save_mcp_server(flow.server_name, cfg)
                     flow.tools = [{"name": t, "description": d} for t, d in tools]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -722,11 +722,11 @@ class TestMcpLogin:
 
 
     def test_login_false_success_no_token(self, tmp_path, capsys, monkeypatch):
-        """Probe lists tools without auth (Google Drive), but no token landed.
+        """Final token check rejects a broken explicit-auth driver.
 
-        The server allows tools/list without auth (DCR 400'd), so the probe
-        succeeds yet no OAuth token exists. Login must NOT claim success — it
-        should warn and point the user at pre-registered client_id config.
+        Even after proactive authorization, a defensive persisted-token check
+        must stop an anonymously successful tools/list probe from claiming the
+        login worked.
         """
         _seed_config(tmp_path, {
             "googledrive": {
@@ -740,6 +740,10 @@ class TestMcpLogin:
             lambda name, cfg, connect_timeout=30: [
                 ("search_files", "d"), ("read_file_content", "d"),
             ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._initiate_explicit_oauth",
+            lambda name, cfg, connect_timeout: None,
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -763,7 +767,15 @@ class TestMcpLogin:
         # probe drops a token file, mirroring a successful authorization.
         seen = {}
 
+        def mock_authorize(name, cfg, connect_timeout):
+            seen["authorized"] = True
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._initiate_explicit_oauth", mock_authorize
+        )
+
         def mock_probe(name, cfg, connect_timeout=30):
+            assert seen.get("authorized") is True
             seen["connect_timeout"] = connect_timeout
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -80,10 +80,11 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
 
     response = TestClient(web_server.app).get(
         "/api/mcp/oauth/callback/reports?code=abc&state=expected"
+        "&iss=https%3A%2F%2Fidp.example"
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    assert flow._callback == ("abc", "expected", "https://idp.example")
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
@@ -113,6 +114,60 @@ def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, mon
         response = _client().post("/api/mcp/servers/reports/auth?profile=work")
 
     assert response.status_code != 409
+
+
+def test_dashboard_worker_initiates_oauth_before_public_probe(tmp_path, monkeypatch):
+    """Desktop Authenticate must not rely on an anonymous tools/list probe."""
+    import asyncio
+
+    from hermes_cli import mcp_config, web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow, get_dashboard_oauth_flow
+
+    events = []
+
+    def fake_initiate(name, cfg, connect_timeout):
+        events.append("authorize")
+        assert name == "hugging_face"
+        assert connect_timeout >= 315
+        flow = get_dashboard_oauth_flow()
+        assert flow is not None
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://huggingface.co/oauth/authorize?state=expected"
+            )
+        )
+
+    def fake_probe(name, cfg, connect_timeout=30):
+        assert events == ["authorize"]
+        events.append("probe")
+        return [("hf_fs", "Browse Hugging Face")]
+
+    monkeypatch.setattr(mcp_config, "_initiate_explicit_oauth", fake_initiate)
+    monkeypatch.setattr(mcp_config, "_probe_single_server", fake_probe)
+    monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda _name: True)
+    monkeypatch.setattr(mcp_config, "_save_mcp_server", lambda _name, _cfg: True)
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-explicit-auth",
+        server_name="hugging_face",
+        profile=None,
+        hermes_home=str(tmp_path),
+        redirect_uri="http://127.0.0.1:43123/callback",
+    )
+    web_server._run_dashboard_mcp_oauth(
+        flow,
+        {
+            "url": "https://huggingface.co/mcp",
+            "auth": "oauth",
+            "oauth": {"scope": "openid profile read-mcp"},
+        },
+    )
+
+    assert events == ["authorize", "probe"]
+    assert flow.status == "approved"
+    assert flow.authorization_url.startswith("https://huggingface.co/oauth/authorize")
+    assert flow.tools == [{"name": "hf_fs", "description": "Browse Hugging Face"}]
+    assert flow.worker_done is True
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2515,6 +2515,37 @@ class TestConfigRoundTrip:
             "Shallow-merge regression: agent.x_dashboard_invisible_test_key " \
             "was wiped when the frontend sent a partial agent dict."
 
+    def test_get_config_keeps_mcp_environment_references_unexpanded(self, monkeypatch):
+        """Editable Desktop config must never receive an expanded MCP secret.
+
+        The runtime still needs the resolved header, but the renderer must see
+        the safe on-disk template so opening the mcp.json editor cannot expose a
+        credential or write it back as plaintext on an unrelated save.
+        """
+        from hermes_cli.config import load_config, save_config
+
+        secret = "github-secret-that-must-not-cross-the-api"
+        template = "Bearer ${env:DESKTOP_MCP_TEST_TOKEN}"
+        monkeypatch.setenv("DESKTOP_MCP_TEST_TOKEN", secret)
+        save_config({
+            "mcp_servers": {
+                "github": {
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "headers": {"Authorization": template},
+                },
+            },
+        })
+
+        # Runtime callers continue to receive the expanded credential.
+        assert load_config()["mcp_servers"]["github"]["headers"]["Authorization"] == f"Bearer {secret}"
+
+        response = self.client.get("/api/config")
+        assert response.status_code == 200
+        web_config = response.json()
+        authorization = web_config["mcp_servers"]["github"]["headers"]["Authorization"]
+        assert authorization == template
+        assert secret not in json.dumps(web_config["mcp_servers"])
+
     def test_schema_types_match_config_values(self):
         """Every schema field should have a matching-type value in the config."""
         config = self.client.get("/api/config").json()

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -26,8 +26,17 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
         "error": None,
     }
 
-    flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    flow.deliver_callback(
+        code="code-1",
+        state="s1",
+        error=None,
+        iss="https://idp.example",
+    )
+    assert asyncio.run(flow.wait_for_callback()) == (
+        "code-1",
+        "s1",
+        "https://idp.example",
+    )
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():
@@ -91,11 +100,20 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
                 "https://idp.example/authorize?state=state-4"
             )
         )
-        flow.deliver_callback(code="code-4", state="state-4", error=None)
+        flow.deliver_callback(
+            code="code-4",
+            state="state-4",
+            error=None,
+            iss="https://idp.example",
+        )
         # mcp 2.0's callback_handler contract returns an
         # AuthorizationCodeResult, not the legacy (code, state) tuple.
         result = asyncio.run(_make_callback_waiter(0)())
-        assert (result.code, result.state) == ("code-4", "state-4")
+        assert (result.code, result.state, result.iss) == (
+            "code-4",
+            "state-4",
+            "https://idp.example",
+        )
 
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -111,6 +111,75 @@ class TestHermesTokenStorage:
             f"token parent dir mode {oct(parent_mode)} != 0o700 — siblings can traverse"
         )
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows DACL test")
+    def test_token_file_and_directory_have_private_windows_acl(
+        self, tmp_path, monkeypatch
+    ):
+        """Windows token state must not inherit repository-wide read access."""
+        import win32api
+        import win32con
+        import win32security
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        legacy_client_path = token_dir / "private-windows-server.client.json"
+        legacy_client_path.write_text('{"client_id": "legacy"}', encoding="utf-8")
+        storage = HermesTokenStorage("private-windows-server")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "secret-access",
+            "token_type": "Bearer",
+            "refresh_token": "secret-refresh",
+        }
+        asyncio.run(storage.set_tokens(mock_token))
+
+        process_token = win32security.OpenProcessToken(
+            win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+        )
+        try:
+            current_user = win32security.GetTokenInformation(
+                process_token, win32security.TokenUser
+            )[0]
+        finally:
+            process_token.Close()
+        allowed_sids = {
+            win32security.ConvertSidToStringSid(current_user),
+            win32security.ConvertSidToStringSid(
+                win32security.ConvertStringSidToSid("S-1-5-18")
+            ),
+        }
+        allow_types = {
+            win32security.ACCESS_ALLOWED_ACE_TYPE,
+            win32security.ACCESS_ALLOWED_OBJECT_ACE_TYPE,
+            getattr(win32security, "ACCESS_ALLOWED_CALLBACK_ACE_TYPE", 9),
+            getattr(win32security, "ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE", 11),
+        }
+
+        for path in (
+            token_dir,
+            token_dir / "private-windows-server.json",
+            legacy_client_path,
+        ):
+            descriptor = win32security.GetNamedSecurityInfo(
+                str(path),
+                win32security.SE_FILE_OBJECT,
+                win32security.DACL_SECURITY_INFORMATION,
+            )
+            control, _ = descriptor.GetSecurityDescriptorControl()
+            assert control & win32security.SE_DACL_PROTECTED
+            dacl = descriptor.GetSecurityDescriptorDacl()
+            assert dacl is not None
+            observed_sids = set()
+            for index in range(dacl.GetAceCount()):
+                ace = dacl.GetAce(index)
+                if ace[0][0] not in allow_types or not ace[1]:
+                    continue
+                sid = win32security.ConvertSidToStringSid(ace[-1])
+                assert sid in allowed_sids
+                observed_sids.add(sid)
+            assert observed_sids == allowed_sids
+
     def test_client_info_with_secret_uses_client_secret_post(self, tmp_path, monkeypatch):
         from mcp.shared.auth import OAuthClientInformationFull
 
@@ -485,6 +554,94 @@ class TestCallbackPortReservation:
         assert port == 49399
         assert cfg["_resolved_port"] == 49399
         assert 49399 not in mod._reserved_sockets
+
+    @pytest.mark.parametrize(
+        "cached_uri",
+        [
+            "http://127.0.0.1:54649/api/mcp/oauth/callback/railway",
+            "http://localhost:49399/callback",
+        ],
+    )
+    def test_cached_loopback_redirect_is_reused_exactly(
+        self, cached_uri, tmp_path, monkeypatch
+    ):
+        """A cached DCR client keeps its complete registered redirect URI.
+
+        Railway exposed the non-default-path case after a Desktop callback
+        registration survived a backend restart. Reusing only its port changed
+        the path to ``/callback`` and the authorization server rejected the
+        client before consent.
+        """
+        import json
+        from urllib.parse import urlparse
+
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = mod.HermesTokenStorage("railway")
+        storage._client_info_path().parent.mkdir(parents=True, exist_ok=True)
+        storage._client_info_path().write_text(
+            json.dumps(
+                {
+                    "client_id": "dcr-issued",
+                    "redirect_uris": [cached_uri],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cfg = {"cimd": False}
+        port = mod._configure_callback_port(cfg, storage)
+        metadata = mod._build_client_metadata(cfg)
+
+        assert port == urlparse(cached_uri).port
+        assert cfg["redirect_uri"] == cached_uri
+        assert str(metadata.redirect_uris[0]) == cached_uri
+
+    def test_cached_desktop_callback_path_round_trips(
+        self, tmp_path, monkeypatch
+    ):
+        """The local waiter accepts the exact cached Desktop callback path."""
+        import asyncio
+        import json
+        import threading
+
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+        port = mod._reserve_callback_port()
+        cached_uri = (
+            f"http://127.0.0.1:{port}/api/mcp/oauth/callback/railway"
+        )
+        storage = mod.HermesTokenStorage("railway")
+        storage._client_info_path().parent.mkdir(parents=True, exist_ok=True)
+        storage._client_info_path().write_text(
+            json.dumps(
+                {
+                    "client_id": "dcr-issued",
+                    "redirect_uris": [cached_uri],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cfg = {"cimd": False}
+        assert mod._configure_callback_port(cfg, storage) == port
+
+        async def drive():
+            task = asyncio.create_task(mod._make_callback_waiter(port)())
+            threading.Thread(
+                target=_hit_callback_when_ready,
+                args=(f"{cached_uri}?code=railway-code&state=railway-state",),
+                daemon=True,
+            ).start()
+            return await asyncio.wait_for(task, timeout=20)
+
+        result = asyncio.run(drive())
+        assert result.code == "railway-code"
+        assert result.state == "railway-state"
 
     def test_wait_for_callback_adopts_reserved_socket(self, monkeypatch):
         """E2E: reserve → _wait_for_callback binds the SAME socket and the

--- a/tests/tools/test_mcp_oauth_authorization_url.py
+++ b/tests/tools/test_mcp_oauth_authorization_url.py
@@ -1,0 +1,90 @@
+"""Regression tests for query-bearing MCP OAuth authorization endpoints."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+from unittest.mock import patch
+
+import pytest
+
+from tools.mcp_oauth_manager import (
+    _HERMES_PROVIDER_CLS,
+    _merge_authorization_endpoint_query,
+)
+
+
+RAILWAY_ENDPOINT = (
+    "https://backboard.railway.com/oauth/auth?"
+    "resource=https%3A%2F%2Fbackboard.railway.com"
+)
+
+
+def test_merges_sdk_parameters_with_existing_endpoint_query() -> None:
+    malformed = (
+        f"{RAILWAY_ENDPOINT}?response_type=code&client_id=client-1&"
+        "redirect_uri=http%3A%2F%2F127.0.0.1%3A1234%2Fcallback"
+    )
+
+    repaired = _merge_authorization_endpoint_query(malformed, RAILWAY_ENDPOINT)
+    parsed = urlsplit(repaired)
+    params = parse_qs(parsed.query)
+
+    assert repaired.count("?") == 1
+    assert params["resource"] == ["https://backboard.railway.com"]
+    assert params["response_type"] == ["code"]
+    assert params["client_id"] == ["client-1"]
+
+
+@pytest.mark.parametrize(
+    ("generated", "endpoint"),
+    [
+        (
+            "https://idp.example/authorize?response_type=code",
+            "https://idp.example/authorize",
+        ),
+        (
+            "https://other.example/authorize?response_type=code",
+            "https://idp.example/authorize?audience=reports",
+        ),
+        ("https://idp.example/authorize?response_type=code", None),
+    ],
+)
+def test_leaves_non_matching_urls_unchanged(generated: str, endpoint: str | None) -> None:
+    assert _merge_authorization_endpoint_query(generated, endpoint) == generated
+
+
+@pytest.mark.asyncio
+async def test_provider_repairs_url_before_desktop_redirect_handler() -> None:
+    if _HERMES_PROVIDER_CLS is None:
+        pytest.skip("MCP SDK OAuth support is unavailable")
+
+    captured: list[str] = []
+
+    async def original_redirect(url: str) -> None:
+        captured.append(url)
+
+    provider = object.__new__(_HERMES_PROVIDER_CLS)
+    provider.context = SimpleNamespace(
+        oauth_metadata=SimpleNamespace(authorization_endpoint=RAILWAY_ENDPOINT),
+        redirect_handler=original_redirect,
+    )
+
+    async def fake_sdk_grant(_self):
+        await _self.context.redirect_handler(
+            f"{RAILWAY_ENDPOINT}?response_type=code&client_id=client-1"
+        )
+        return "authorization-code", "pkce-verifier"
+
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    with patch.object(
+        OAuthClientProvider,
+        "_perform_authorization_code_grant",
+        fake_sdk_grant,
+    ):
+        result = await provider._perform_authorization_code_grant()
+
+    assert result == ("authorization-code", "pkce-verifier")
+    assert parse_qs(urlsplit(captured[0]).query)["response_type"] == ["code"]
+    assert provider.context.redirect_handler is original_redirect

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -307,6 +307,116 @@ async def test_long_lived_resource_request_does_not_block_concurrent_post(
         await get_flow.asend(httpx.Response(200, request=get_retry))
 
 
+@pytest.mark.asyncio
+async def test_explicit_authorization_drives_401_branch_without_mcp_request(
+    tmp_path, monkeypatch
+):
+    """Explicit login must open OAuth when public MCP discovery returns 200."""
+    from urllib.parse import parse_qs, urlparse
+
+    from mcp.shared.auth import AuthorizationCodeResult, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS
+    from tools.mcp_tool import sdk_httpx
+
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    httpx = sdk_httpx()
+    real_async_client = httpx.AsyncClient
+    requested_paths: list[str] = []
+    token_bodies: list[str] = []
+
+    async def handler(request):
+        path = request.url.path
+        requested_paths.append(path)
+        if path.startswith("/.well-known/oauth-protected-resource"):
+            return httpx.Response(200, request=request, json={
+                "resource": "https://mcp.example/mcp",
+                "authorization_servers": ["https://auth.example"],
+                "scopes_supported": ["openid", "profile", "read-mcp"],
+            })
+        if path == "/.well-known/oauth-authorization-server":
+            return httpx.Response(200, request=request, json={
+                "issuer": "https://auth.example",
+                "authorization_endpoint": "https://auth.example/authorize",
+                "token_endpoint": "https://auth.example/token",
+                "registration_endpoint": "https://auth.example/register",
+                "response_types_supported": ["code"],
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["openid", "profile", "read-mcp"],
+            })
+        if path == "/register":
+            return httpx.Response(201, request=request, json={
+                "client_id": "dynamic-client",
+                "redirect_uris": ["http://127.0.0.1:48765/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+            })
+        if path == "/token":
+            token_bodies.append(request.content.decode())
+            return httpx.Response(200, request=request, json={
+                "access_token": "oauth-access-token",
+                "refresh_token": "oauth-refresh-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "openid profile read-mcp",
+            })
+        raise AssertionError(
+            f"unexpected outbound request: {request.method} {request.url}"
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    authorization: dict[str, str] = {}
+
+    async def redirect_handler(url: str) -> None:
+        authorization["url"] = url
+
+    async def callback_handler() -> AuthorizationCodeResult:
+        state = parse_qs(urlparse(authorization["url"]).query)["state"][0]
+        return AuthorizationCodeResult(code="authorization-code", state=state)
+
+    storage = HermesTokenStorage("anonymous-server")
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:48765/callback")],
+        client_name="Hermes Agent",
+        scope="openid profile read-mcp",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="anonymous-server",
+        server_url="https://mcp.example/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+
+    await provider.authorize_interactively()
+
+    assert "/mcp" not in requested_paths
+    assert "/register" in requested_paths
+    assert "/token" in requested_paths
+    assert parse_qs(urlparse(authorization["url"]).query)["scope"] == [
+        "openid profile read-mcp"
+    ]
+    assert parse_qs(token_bodies[0])["code"] == ["authorization-code"]
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.access_token == "oauth-access-token"
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
     return None

--- a/tests/tools/test_mcp_oauth_issuer_compat.py
+++ b/tests/tools/test_mcp_oauth_issuer_compat.py
@@ -1,0 +1,114 @@
+"""Narrow compatibility coverage for malformed provider OAuth metadata."""
+
+import json
+
+import pytest
+
+
+def _metadata(issuer: str):
+    from mcp.shared.auth import OAuthMetadata
+
+    return OAuthMetadata(
+        issuer=issuer,
+        authorization_endpoint=f"{issuer.rstrip('/')}/authorize",
+        token_endpoint=f"{issuer.rstrip('/')}/token",
+        response_types_supported=["code"],
+    )
+
+
+def test_trailing_slash_compat_is_strictly_byte_preserving():
+    from tools.mcp_oauth_manager import _differs_only_by_one_trailing_slash
+
+    assert _differs_only_by_one_trailing_slash(
+        "https://secure.indeed.com",
+        "https://secure.indeed.com/",
+    )
+    assert not _differs_only_by_one_trailing_slash(
+        "https://SECURE.indeed.com",
+        "https://secure.indeed.com/",
+    )
+    assert not _differs_only_by_one_trailing_slash(
+        "https://secure.indeed.com/oauth",
+        "https://secure.indeed.com/",
+    )
+    assert not _differs_only_by_one_trailing_slash(
+        "https://secure.indeed.com?tenant=x",
+        "https://secure.indeed.com/",
+    )
+
+
+def test_sdk_validator_remains_strict_without_provider_opt_in():
+    from mcp.client.auth import oauth2
+    from mcp.client.auth.oauth2 import OAuthFlowError
+
+    import tools.mcp_oauth_manager  # noqa: F401 - installs scoped wrapper
+
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        oauth2.validate_metadata_issuer(
+            _metadata("https://secure.indeed.com"),
+            "https://secure.indeed.com/",
+        )
+
+
+def test_sdk_validator_accepts_only_the_scoped_trailing_slash_case():
+    from mcp.client.auth import oauth2
+    from mcp.client.auth.oauth2 import OAuthFlowError
+    from tools.mcp_oauth_manager import _issuer_trailing_slash_compat_enabled
+
+    token = _issuer_trailing_slash_compat_enabled.set(True)
+    try:
+        oauth2.validate_metadata_issuer(
+            _metadata("https://secure.indeed.com"),
+            "https://secure.indeed.com/",
+        )
+        with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+            oauth2.validate_metadata_issuer(
+                _metadata("https://attacker.example"),
+                "https://secure.indeed.com/",
+            )
+    finally:
+        _issuer_trailing_slash_compat_enabled.reset(token)
+
+
+def _registration_request_body():
+    from mcp.client.auth import oauth2
+    from mcp.shared.auth import OAuthClientMetadata
+
+    metadata = _metadata("https://secure.indeed.com")
+    metadata.registration_endpoint = "https://secure.indeed.com/register"
+    client = OAuthClientMetadata(
+        client_name="Hermes Agent",
+        redirect_uris=["http://127.0.0.1:27892/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",
+        scope="job_seeker.jobs.search offline_access",
+    )
+    request = oauth2.create_client_registration_request(
+        metadata,
+        client,
+        "https://secure.indeed.com",
+    )
+    return json.loads(request.content), client
+
+
+def test_registration_scope_is_preserved_without_provider_opt_in():
+    import tools.mcp_oauth_manager  # noqa: F401 - installs scoped wrapper
+
+    body, client = _registration_request_body()
+
+    assert body["scope"] == "job_seeker.jobs.search offline_access"
+    assert client.scope == "job_seeker.jobs.search offline_access"
+
+
+def test_registration_scope_omission_is_scoped_and_keeps_authorization_scope():
+    from tools.mcp_oauth_manager import _registration_omit_scope_enabled
+
+    token = _registration_omit_scope_enabled.set(True)
+    try:
+        body, client = _registration_request_body()
+    finally:
+        _registration_omit_scope_enabled.reset(token)
+
+    assert "scope" not in body
+    assert client.scope == "job_seeker.jobs.search offline_access"

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -32,7 +32,9 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None, str | None] | None = field(
+        default=None, init=False, repr=False
+    )
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _callback_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
@@ -65,6 +67,7 @@ class DashboardOAuthFlow:
         code: str | None,
         state: str | None,
         error: str | None,
+        iss: str | None = None,
     ) -> None:
         with self._lock:
             if self._callback_ready.is_set():
@@ -78,12 +81,18 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                # RFC 9207 authorization-response issuer. Providers that
+                # advertise support require the SDK to validate this value;
+                # dropping it here turns a successful browser consent into a
+                # rejected token exchange and a recurring authorization loop.
+                self._callback = (code, state, iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(
+        self, timeout: float = 300.0
+    ) -> tuple[str, str | None, str | None]:
         ready = await asyncio.to_thread(self._callback_ready.wait, timeout)
         if not ready:
             raise TimeoutError("Timed out waiting for MCP OAuth callback")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -206,6 +206,74 @@ def _safe_filename(name: str) -> str:
     return re.sub(r"[^\w\-]", "_", name).strip("_")[:128] or "default"
 
 
+def _secure_windows_credential_acl(path: Path, *, directory: bool) -> None:
+    """Restrict a Windows credential path to the current user and SYSTEM.
+
+    POSIX mode bits do not enforce access on Windows. Token files created
+    below a repository-scoped ``HERMES_HOME`` would otherwise inherit that
+    repository's broader read ACL. A protected DACL on the directory also
+    makes future OAuth state inherit the same private boundary.
+    """
+    if os.name != "nt" or not path.exists():
+        return
+
+    try:
+        import ntsecuritycon
+        import win32api
+        import win32con
+        import win32security
+    except ImportError as exc:  # pragma: no cover - pywin32 is a Windows dep
+        logger.warning("Cannot restrict Windows OAuth credential ACL: %s", exc)
+        return
+
+    try:
+        process_token = win32security.OpenProcessToken(
+            win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+        )
+        try:
+            current_user = win32security.GetTokenInformation(
+                process_token, win32security.TokenUser
+            )[0]
+        finally:
+            process_token.Close()
+        system = win32security.ConvertStringSidToSid("S-1-5-18")
+        inherit_flags = 0
+        if directory:
+            inherit_flags = (
+                win32security.OBJECT_INHERIT_ACE
+                | win32security.CONTAINER_INHERIT_ACE
+            )
+
+        acl = win32security.ACL()
+        for sid in (current_user, system):
+            acl.AddAccessAllowedAceEx(
+                win32security.ACL_REVISION,
+                inherit_flags,
+                ntsecuritycon.FILE_ALL_ACCESS,
+                sid,
+            )
+
+        security_info = (
+            win32security.DACL_SECURITY_INFORMATION
+            | win32security.PROTECTED_DACL_SECURITY_INFORMATION
+        )
+        win32security.SetNamedSecurityInfo(
+            str(path),
+            win32security.SE_FILE_OBJECT,
+            security_info,
+            None,
+            None,
+            acl,
+            None,
+        )
+    except OSError as exc:
+        # Persistence remains available if a locked-down enterprise host
+        # refuses DACL changes, but the failure is visible to operators.
+        logger.warning(
+            "Failed to restrict OAuth credential ACL for %s: %s", path, exc
+        )
+
+
 def _find_free_port() -> int:
     """Find an available TCP port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -269,15 +337,23 @@ def _reserve_callback_port() -> int:
     return port
 
 
-def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
-    """Return the loopback callback port from cached client registration.
+def _cached_loopback_redirect(
+    storage: "HermesTokenStorage | None",
+) -> tuple[str, int] | None:
+    """Return the exact loopback URI and port from cached registration.
 
     OAuth providers bind a dynamically-registered ``client_id`` to the exact
     redirect URI that was registered with it. If Hermes restarts and chooses a
     new random callback port while reusing the stored ``client_id``, providers
-    such as Summ reject the authorization request with ``redirect_uri does not
-    match any registered URIs``. Reusing the cached redirect port keeps the
-    authorization request consistent with the stored client registration.
+    such as Summ and Railway reject the authorization request with
+    ``redirect_uri does not match any registered URIs``.
+
+    Preserve the complete URI, not only its port. Desktop OAuth callbacks use a
+    server-specific ``/api/mcp/oauth/callback/<name>`` path, and ``localhost``
+    is not interchangeable with ``127.0.0.1`` for exact redirect matching. The
+    local callback handler accepts any path and extracts only the OAuth query,
+    so it can safely receive a callback at the originally registered path after
+    a Desktop/backend restart.
     """
     if storage is None:
         return None
@@ -297,11 +373,19 @@ def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
         if (
             parsed.scheme == "http"
             and parsed.hostname in {"127.0.0.1", "localhost"}
-            and parsed.path == "/callback"
             and parsed.port is not None
+            and parsed.username is None
+            and parsed.password is None
+            and not parsed.fragment
         ):
-            return int(parsed.port)
+            return str(uri), int(parsed.port)
     return None
+
+
+def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
+    """Backward-compatible port-only view of the cached loopback redirect."""
+    cached = _cached_loopback_redirect(storage)
+    return cached[1] if cached is not None else None
 
 
 def _cached_redirect_uri(storage: "HermesTokenStorage | None") -> str | None:
@@ -427,6 +511,7 @@ def _write_json(path: Path, data: dict) -> None:
     # secure_parent_dir refuses to chmod /, top-level dirs, or the
     # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(path)
+    _secure_windows_credential_acl(path.parent, directory=True)
     # Per-process random suffix avoids collisions between concurrent
     # writers and stale leftovers from a prior crashed write.
     tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
@@ -441,6 +526,7 @@ def _write_json(path: Path, data: dict) -> None:
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(tmp, path)
+        _secure_windows_credential_acl(path, directory=False)
     except OSError:
         try:
             tmp.unlink(missing_ok=True)
@@ -468,6 +554,16 @@ class HermesTokenStorage:
     def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
         self._server_name = _safe_filename(server_name)
         self._hermes_home = Path(hermes_home) if hermes_home is not None else None
+        # One-time migration for OAuth state written before Windows DACL
+        # hardening. Only this sanitized server's known credential files are
+        # touched; unrelated files in the directory are left alone.
+        if os.name == "nt":
+            token_dir = _get_token_dir(self._hermes_home)
+            if token_dir.exists():
+                _secure_windows_credential_acl(token_dir, directory=True)
+                for suffix in (".json", ".client.json", ".meta.json", ".cimd-off"):
+                    candidate = token_dir / f"{self._server_name}{suffix}"
+                    _secure_windows_credential_acl(candidate, directory=False)
 
     def _tokens_path(self) -> Path:
         return _get_token_dir(self._hermes_home) / f"{self._server_name}.json"
@@ -670,6 +766,8 @@ class HermesTokenStorage:
             return
         token_dir = _get_token_dir(self._hermes_home)
         token_dir.mkdir(parents=True, exist_ok=True)
+        secure_parent_dir(token_dir / "credential-state")
+        _secure_windows_credential_acl(token_dir, directory=True)
         for fname, data in snapshot.items():
             path = token_dir / fname
             try:
@@ -680,6 +778,7 @@ class HermesTokenStorage:
                 )
                 with os.fdopen(fd, "wb") as fh:
                     fh.write(data)
+                _secure_windows_credential_acl(path, directory=False)
             except OSError as exc:
                 logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
 
@@ -952,10 +1051,10 @@ def _make_callback_waiter(
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # The dashboard flow still speaks the legacy tuple; normalize it
-            # here so both callback sources hand the SDK one shape.
-            dash_code, dash_state = await dashboard_flow.wait_for_callback()
-            return _authorization_code_result(dash_code, dash_state)
+            # Normalize the dashboard bridge result so both callback sources
+            # hand the SDK the installed AuthorizationCodeResult shape.
+            dash_code, dash_state, dash_iss = await dashboard_flow.wait_for_callback()
+            return _authorization_code_result(dash_code, dash_state, dash_iss)
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code
@@ -1580,6 +1679,19 @@ def _configure_callback_port(
         _oauth_port = port
         return port
     requested = int(cfg.get("redirect_port", 0))
+    cached_loopback = _cached_loopback_redirect(storage)
+    if (
+        not cfg.get("redirect_uri")
+        and not requested
+        and not cfg.get("redirect_host")
+        and cached_loopback is not None
+    ):
+        cached_uri, port = cached_loopback
+        cfg["redirect_uri"] = cached_uri
+        cfg["_resolved_port"] = port
+        _note_assigned_cimd_port(port)
+        _oauth_port = port
+        return port
     # Precedence: explicit config port → cached client-registration port →
     # fresh ephemeral port. The cached port keeps re-auth consistent with the
     # redirect URI pinned at dynamic client registration (providers reject a

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -35,6 +35,7 @@ Design reference:
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import re
 import threading
@@ -43,6 +44,143 @@ from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+_EXPLICIT_OAUTH_HTTP_TIMEOUT_SECONDS = 30.0
+
+
+_issuer_trailing_slash_compat_enabled: contextvars.ContextVar[bool] = (
+    contextvars.ContextVar(
+        "mcp_oauth_issuer_trailing_slash_compat_enabled",
+        default=False,
+    )
+)
+
+_registration_omit_scope_enabled: contextvars.ContextVar[bool] = (
+    contextvars.ContextVar(
+        "mcp_oauth_registration_omit_scope_enabled",
+        default=False,
+    )
+)
+
+
+def _differs_only_by_one_trailing_slash(actual: str, expected: str) -> bool:
+    """Return True only for an otherwise byte-identical issuer URL.
+
+    RFC 8414 normally requires exact string equality. A small number of
+    providers publish a protected-resource ``authorization_servers`` value
+    with a trailing slash while their authorization-server metadata omits it.
+    This predicate deliberately does not normalize case, escapes, ports,
+    paths, queries, or fragments.
+    """
+    return (
+        actual != expected
+        and actual.endswith("/") != expected.endswith("/")
+        and actual.removesuffix("/") == expected.removesuffix("/")
+        and "?" not in actual
+        and "?" not in expected
+        and "#" not in actual
+        and "#" not in expected
+    )
+
+
+def _install_scoped_issuer_validator() -> None:
+    """Install a task-scoped SDK compatibility wrapper exactly once."""
+    from mcp.client.auth import oauth2
+
+    current = oauth2.validate_metadata_issuer
+    if getattr(current, "_hermes_scoped_issuer_validator", False):
+        return
+
+    def _validate(oauth_metadata: Any, expected_issuer: str) -> None:
+        actual = str(oauth_metadata.issuer)
+        if (
+            _issuer_trailing_slash_compat_enabled.get()
+            and _differs_only_by_one_trailing_slash(actual, expected_issuer)
+        ):
+            logger.warning(
+                "MCP OAuth: accepting provider metadata issuer that differs "
+                "from its discovery issuer only by one trailing slash"
+            )
+            return
+        current(oauth_metadata, expected_issuer)
+
+    _validate._hermes_scoped_issuer_validator = True  # type: ignore[attr-defined]
+    oauth2.validate_metadata_issuer = _validate
+
+
+def _install_scoped_registration_scope_filter() -> None:
+    """Install a task-scoped DCR scope filter exactly once.
+
+    Indeed's MCP metadata correctly advertises its supported scopes, but its
+    dynamic-registration endpoint rejects the optional RFC 7591 ``scope``
+    client-metadata field.  Keep the scopes on the live client metadata so the
+    authorization request still asks for them; omit them only while building
+    the registration request, and only for providers that explicitly opt in.
+    """
+    from mcp.client.auth import oauth2
+
+    current = oauth2.create_client_registration_request
+    if getattr(current, "_hermes_scoped_registration_scope_filter", False):
+        return
+
+    def _create(oauth_metadata: Any, client_metadata: Any, fallback_base_url: str):
+        registration_metadata = client_metadata
+        if (
+            _registration_omit_scope_enabled.get()
+            and getattr(client_metadata, "scope", None)
+        ):
+            registration_metadata = client_metadata.model_copy(
+                update={"scope": None}
+            )
+            logger.warning(
+                "MCP OAuth: omitting provider scopes from dynamic client "
+                "registration while preserving them for authorization"
+            )
+        return current(oauth_metadata, registration_metadata, fallback_base_url)
+
+    _create._hermes_scoped_registration_scope_filter = True  # type: ignore[attr-defined]
+    oauth2.create_client_registration_request = _create
+
+
+def _merge_authorization_endpoint_query(
+    generated_url: str,
+    authorization_endpoint: str | None,
+) -> str:
+    """Repair SDK authorization URLs when the endpoint already has a query.
+
+    MCP Python SDK 2.0 currently builds the browser URL with
+    ``f"{authorization_endpoint}?{urlencode(params)}"``.  If provider metadata
+    already includes a query (Railway advertises ``?resource=...``), the
+    resulting second question mark nests ``response_type=code`` inside the
+    existing value and the authorization server rejects the request.  Preserve
+    the provider's original query bytes and join the SDK parameters with ``&``.
+
+    The exact-prefix guard keeps this narrowly scoped to the discovered
+    authorization endpoint rather than rewriting arbitrary redirect URLs.
+    """
+    if not authorization_endpoint:
+        return generated_url
+
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        endpoint = urlsplit(authorization_endpoint)
+    except ValueError:
+        return generated_url
+    if not endpoint.query:
+        return generated_url
+
+    malformed_prefix = f"{authorization_endpoint}?"
+    if not generated_url.startswith(malformed_prefix):
+        return generated_url
+
+    sdk_query = generated_url[len(malformed_prefix) :]
+    merged_query = endpoint.query
+    if sdk_query:
+        merged_query = f"{merged_query}&{sdk_query}"
+    return urlunsplit(
+        (endpoint.scheme, endpoint.netloc, endpoint.path, merged_query, endpoint.fragment)
+    )
 
 
 def _same_endpoint(a: str, b: str) -> bool:
@@ -114,6 +252,9 @@ def _make_hermes_provider_class() -> Optional[type]:
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
 
+    _install_scoped_issuer_validator()
+    _install_scoped_registration_scope_filter()
+
     class HermesMCPOAuthProvider(OAuthClientProvider):
         """OAuthClientProvider with pre-flow disk-mtime reload.
 
@@ -135,6 +276,8 @@ def _make_hermes_provider_class() -> Optional[type]:
             server_name: str = "",
             preregistered: bool = False,
             token_user_agent: "str | None" = None,
+            issuer_trailing_slash_compat: bool = False,
+            registration_omit_scope: bool = False,
             **kwargs: Any,
         ):
             super().__init__(*args, **kwargs)
@@ -158,6 +301,10 @@ def _make_hermes_provider_class() -> Optional[type]:
             # oauth.user_agent — stamped onto token-endpoint requests only;
             # some authorization servers/WAFs reject httpx's default (#75576).
             self._hermes_token_user_agent = token_user_agent
+            self._hermes_issuer_trailing_slash_compat = (
+                issuer_trailing_slash_compat
+            )
+            self._hermes_registration_omit_scope = registration_omit_scope
 
         def _stamp_token_user_agent(self, request):
             ua = getattr(self, "_hermes_token_user_agent", None)
@@ -192,6 +339,35 @@ def _make_hermes_provider_class() -> Optional[type]:
             self._coerce_client_secret_post()
             request = await super()._exchange_token_authorization_code(*args, **kwargs)
             return self._stamp_token_user_agent(request)
+
+        async def _perform_authorization_code_grant(self):
+            """Keep SDK OAuth parameters top-level for query-bearing endpoints."""
+            original_redirect_handler = self.context.redirect_handler
+            metadata = getattr(self.context, "oauth_metadata", None)
+            authorization_endpoint = (
+                str(metadata.authorization_endpoint)
+                if metadata is not None
+                and getattr(metadata, "authorization_endpoint", None)
+                else None
+            )
+
+            if original_redirect_handler is None or authorization_endpoint is None:
+                return await super()._perform_authorization_code_grant()
+
+            async def query_safe_redirect_handler(url: str) -> None:
+                await original_redirect_handler(
+                    _merge_authorization_endpoint_query(url, authorization_endpoint)
+                )
+
+            self.context.redirect_handler = query_safe_redirect_handler
+            try:
+                return await super()._perform_authorization_code_grant()
+            finally:
+                # The SDK serializes one provider's OAuth flow, but restore the
+                # shared context defensively so later refresh/reauth calls keep
+                # the original Hermes callback.
+                if self.context.redirect_handler is query_safe_redirect_handler:
+                    self.context.redirect_handler = original_redirect_handler
 
         async def _refresh_token(self):
             self._coerce_client_secret_post()
@@ -543,8 +719,24 @@ def _make_hermes_provider_class() -> Optional[type]:
             resource_lock_released = False
             sent_access_token = None
             retry_after_concurrent_auth = False
+
+            async def _advance(incoming: Any = None, *, first: bool = False):
+                issuer_token = _issuer_trailing_slash_compat_enabled.set(
+                    getattr(self, "_hermes_issuer_trailing_slash_compat", False)
+                )
+                registration_token = _registration_omit_scope_enabled.set(
+                    getattr(self, "_hermes_registration_omit_scope", False)
+                )
+                try:
+                    if first:
+                        return await inner.__anext__()
+                    return await inner.asend(incoming)
+                finally:
+                    _registration_omit_scope_enabled.reset(registration_token)
+                    _issuer_trailing_slash_compat_enabled.reset(issuer_token)
+
             try:
-                outgoing = await inner.__anext__()
+                outgoing = await _advance(first=True)
                 while True:
                     # The SDK holds context.lock for its entire generator,
                     # including while HTTPX waits on the actual MCP request.
@@ -574,13 +766,12 @@ def _make_hermes_provider_class() -> Optional[type]:
                         and tokens.access_token != sent_access_token
                     ):
                         self._add_auth_header(request)
-                        await inner.aclose()
                         retry_after_concurrent_auth = True
                         break
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
-                    outgoing = await inner.asend(incoming)
+                    outgoing = await _advance(incoming)
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the
                 # 401 branch so a subsequent cold-load skips discovery.
@@ -598,10 +789,106 @@ def _make_hermes_provider_class() -> Optional[type]:
                     with anyio.CancelScope(shield=True):
                         await self.context.lock.acquire()
 
+                # Keep the SDK generator's anyio lock acquisition and release
+                # in this task. Letting an interrupted flow reach async-gen GC
+                # can finalize it in another task, where anyio correctly
+                # rejects releasing a lock that task does not own.
+                await inner.aclose()
+
             if retry_after_concurrent_auth:
                 yield request
                 self._persist_oauth_metadata_if_changed()
                 return
+
+        async def authorize_interactively(
+            self,
+            *,
+            ssl_verify: Any = True,
+            client_cert: Any = None,
+        ) -> None:
+            """Complete OAuth even when the MCP endpoint is anonymously listable.
+
+            The SDK begins authorization only after an MCP request returns HTTP
+            401. Some servers, including Hugging Face, allow ``initialize`` and
+            ``tools/list`` without a token. An explicit Authenticate action
+            therefore needs to drive the provider's normal 401 branch directly.
+
+            The synthetic challenge stays inside the SDK auth generator; Hermes
+            never sends a fabricated MCP request to the remote server. Metadata
+            discovery, registration, browser redirect, callback validation, and
+            token exchange still use the SDK's real requests and responses.
+            """
+            from mcp.shared.inbound import MCP_PROTOCOL_VERSION_HEADER
+            from mcp_types import LATEST_PROTOCOL_VERSION
+            from tools.mcp_tool import sdk_httpx
+
+            httpx = sdk_httpx()
+            if httpx is None:  # pragma: no cover - provider proves availability
+                raise RuntimeError("MCP SDK HTTP support is unavailable")
+
+            scope = getattr(self.context.client_metadata, "scope", None)
+            challenge = "Bearer"
+            if scope:
+                # RFC 6749 scope-token excludes DQUOTE, backslash, controls,
+                # and non-ASCII bytes. Validate before reflecting local config
+                # into a synthetic WWW-Authenticate header.
+                valid_scope = all(
+                    char == " "
+                    or ord(char) == 0x21
+                    or 0x23 <= ord(char) <= 0x5B
+                    or 0x5D <= ord(char) <= 0x7E
+                    for char in scope
+                )
+                if not valid_scope or not scope.split():
+                    raise ValueError("OAuth scope contains invalid characters")
+                challenge = f'Bearer scope="{scope}"'
+
+            original_request = httpx.Request(
+                "POST",
+                self.context.server_url,
+                headers={MCP_PROTOCOL_VERSION_HEADER: LATEST_PROTOCOL_VERSION},
+            )
+            auth_flow = self.async_auth_flow(original_request)
+            client_kwargs: dict[str, Any] = {
+                "follow_redirects": True,
+                "timeout": _EXPLICIT_OAUTH_HTTP_TIMEOUT_SECONDS,
+                "verify": ssl_verify,
+            }
+            if client_cert is not None:
+                client_kwargs["cert"] = client_cert
+
+            try:
+                outgoing = await auth_flow.__anext__()
+                challenged = False
+                async with httpx.AsyncClient(**client_kwargs) as client:
+                    while True:
+                        if outgoing is original_request:
+                            if not challenged and not self.context.is_token_valid():
+                                response = httpx.Response(
+                                    401,
+                                    request=outgoing,
+                                    headers={"www-authenticate": challenge},
+                                )
+                                challenged = True
+                            else:
+                                # Acknowledge the post-auth retry locally; it
+                                # is not a real MCP request.
+                                response = httpx.Response(204, request=outgoing)
+                        else:
+                            response = await client.send(outgoing)
+
+                        try:
+                            outgoing = await auth_flow.asend(response)
+                        except StopAsyncIteration:
+                            break
+            finally:
+                await auth_flow.aclose()
+
+            tokens = self.context.current_tokens
+            if tokens is None or not getattr(tokens, "access_token", None):
+                raise RuntimeError(
+                    "OAuth authorization completed without an access token"
+                )
 
     return HermesMCPOAuthProvider
 
@@ -764,6 +1051,12 @@ class MCPOAuthManager:
             redirect_handler=redirect_handler,
             callback_handler=callback_handler,
             token_user_agent=token_request_user_agent(cfg),
+            issuer_trailing_slash_compat=bool(
+                cfg.get("issuer_trailing_slash_compat", False)
+            ),
+            registration_omit_scope=bool(
+                cfg.get("registration_omit_scope", False)
+            ),
             **cimd_provider_kwargs(cfg),
         )
 

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -132,10 +132,11 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
+            iss = (qs.get("iss") or [None])[0]
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
-                flow.deliver_callback(code=code, state=state, error=error)
+                flow.deliver_callback(code=code, state=state, error=error, iss=iss)
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400
@@ -171,6 +172,7 @@ def _worker(session_id: str, hermes_home: str, server_name: str, cfg: dict, reco
     is (re)saved into the profile's config.yaml.
     """
     from hermes_cli.mcp_config import (
+        _initiate_explicit_oauth,
         _oauth_tokens_present,
         _probe_single_server,
         _save_mcp_server,
@@ -201,15 +203,23 @@ def _worker(session_id: str, hermes_home: str, server_name: str, cfg: dict, reco
                 previous_entry = None
                 try:
                     previous_entry = manager.remove(server_name, hermes_home=hermes_home)
+                    auth_timeout = max(
+                        float(cfg.get("connect_timeout", 0) or 0),
+                        315.0,
+                    )
+                    _initiate_explicit_oauth(
+                        server_name,
+                        cfg,
+                        connect_timeout=auth_timeout,
+                    )
                     tools = _probe_single_server(
                         server_name,
                         cfg,
-                        connect_timeout=max(float(cfg.get("connect_timeout", 0) or 0), 315),
+                        connect_timeout=auth_timeout,
                     )
                     if not _oauth_tokens_present(server_name):
                         raise RuntimeError(
-                            "The server responded, but no OAuth token was obtained — "
-                            "this provider may require a manually-registered OAuth client."
+                            "OAuth authorization completed without a persisted token."
                         )
                     _save_mcp_server(server_name, cfg)
                     if flow is not None:


### PR DESCRIPTION
## What does this PR do?

Makes MCP OAuth authorization explicit and durable across dashboard, TUI, and direct manager flows. Hermes now records the authorization URL/state, accepts the returned redirect URL when an automatic callback cannot complete, and preserves the resulting OAuth client/token metadata through the normal store.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Persist pending authorization state and registered OAuth client metadata.
- Support explicit redirect-URL completion without weakening state validation.
- Keep dashboard and TUI session handling consistent with the shared manager.
- Cover authorization URL, issuer compatibility, bidirectional completion, and web API flows.

## How to Test

- `python -m pytest tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_dashboard_oauth.py tests/hermes_cli/test_web_server.py tests/tools/test_mcp_dashboard_oauth.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_authorization_url.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_issuer_compat.py -q`
- Result on Windows 11: 303 passed, 5 skipped.
- `ruff check` and `git diff --check` passed.

## Checklist

- [x] OAuth state validation remains fail-closed
- [x] No tokens, credentials, or local operational material are present
- [x] Tests cover the shared manager plus dashboard and TUI callers
- [x] No unrelated commits