### PR TITLE
fix(transcript): preserve display-only corrections safely

### DIFF
--- a/agent/display_projection.py
+++ b/agent/display_projection.py
@@ -1,0 +1,34 @@
+"""Pure helpers for building user-visible transcript projections."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def is_interim_assistant_message(message: Mapping[str, Any]) -> bool:
+    """Return whether *message* is assistant narration attached to tool calls.
+
+    Hermes persists text emitted alongside ``tool_calls`` so an enabled client
+    can restore the complete narrated timeline. When the user disables
+    ``display.interim_assistant_messages`` only the display projection should
+    hide that text; the durable/model transcript and tool-call metadata remain
+    untouched.
+    """
+
+    if message.get("role") != "assistant" or not message.get("tool_calls"):
+        return False
+    content = message.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    return bool(content)
+
+
+def project_interim_assistant_for_display(
+    message: Mapping[str, Any], *, enabled: bool
+) -> dict[str, Any]:
+    """Return a display copy that hides disabled interim assistant narration."""
+
+    projected = dict(message)
+    if not enabled and is_interim_assistant_message(message):
+        projected["display_kind"] = "hidden"
+    return projected

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -44,6 +44,7 @@ manage_router = APIRouter()
 # monkeypatch-transparent).
 _cron_default_profile = late("_cron_default_profile")
 _cron_profile_home = late("_cron_profile_home")
+_config_profile_scope = late("_config_profile_scope")
 _import_sessions_for_profile = late("_import_sessions_for_profile")
 _maybe_auto_archive_for_profile = late("_maybe_auto_archive_for_profile")
 _open_session_db_for_profile = late("_open_session_db_for_profile")
@@ -655,6 +656,17 @@ async def get_session_messages(
         )
 
     def _read():
+        from hermes_cli.config import load_config
+        from utils import is_truthy_value
+
+        with _config_profile_scope(profile):
+            config = load_config()
+        display_config = config.get("display") if isinstance(config, dict) else {}
+        if not isinstance(display_config, dict):
+            display_config = {}
+        interim_assistant_messages = is_truthy_value(
+            display_config.get("interim_assistant_messages", True)
+        )
         db = _open_session_db_for_profile(profile, read_only=True)
         try:
             sid = _resolve_session_id(db, session_id)
@@ -669,7 +681,7 @@ async def get_session_messages(
             default_page = limit is None
             latest_page = order == "latest" or (order is None and default_page)
             _limit = 500 if default_page else min(limit, 500)
-            return sid, _limit, db.get_messages(
+            return sid, _limit, interim_assistant_messages, db.get_messages(
                 sid,
                 limit=_limit,
                 offset=offset,
@@ -682,12 +694,16 @@ async def get_session_messages(
     result = await asyncio.to_thread(_read)
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    sid, _limit, messages = result
+    sid, _limit, interim_assistant_messages, messages = result
+    from agent.display_projection import project_interim_assistant_for_display
     from agent.compaction_display import project_compaction_message_for_display
     from agent.context_compressor import is_compaction_summary_message
 
     projected_messages = []
     for message in messages:
+        message = project_interim_assistant_for_display(
+            message, enabled=interim_assistant_messages
+        )
         if not is_compaction_summary_message(message):
             projected_messages.append(message)
             continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -108,6 +108,12 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 
 logger = logging.getLogger(__name__)
 
+# Durable rows with these presentation types are intentionally absent from the
+# model-fed resume projection. Their content reached the model through another
+# cache-safe channel (for example a mid-tool steer appended to a tool result),
+# while the physical row exists only so every UI can restore what the user saw.
+_DISPLAY_ONLY_MESSAGE_KINDS = frozenset({"steer_correction"})
+
 MAX_SAFE_RESUME_MESSAGES = 20_000
 MAX_SAFE_EXPORT_MESSAGES = 20_000
 
@@ -13134,6 +13140,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # whole accumulated lineage for every user row.
         exact_user_clones: Dict[Tuple[Any, str], Dict[str, Any]] = {}
         for row in rows:
+            if (
+                repair_alternation
+                and row["display_kind"] in _DISPLAY_ONLY_MESSAGE_KINDS
+            ):
+                continue
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2145,6 +2145,48 @@ class TestWebServerEndpoints:
         contents = [m["content"] for m in resp.json()["messages"]]
         assert contents == ["summary", "live q", "live a"]
 
+    def test_get_session_messages_hides_interim_narration_when_disabled(self):
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "display:\n  interim_assistant_messages: false\n",
+            encoding="utf-8",
+        )
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="hidden-interim", source="desktop")
+            db.append_message(
+                "hidden-interim",
+                role="assistant",
+                content="I will inspect that now.",
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            )
+            db.append_message(
+                "hidden-interim",
+                role="tool",
+                content="done",
+                tool_call_id="call-1",
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/hidden-interim/messages")
+        assert resp.status_code == 200
+        messages = resp.json()["messages"]
+        assert messages[0]["content"] == "I will inspect that now."
+        assert messages[0]["display_kind"] == "hidden"
+        assert messages[1]["content"] == "done"
+        assert not messages[1].get("display_kind")
+
     def test_get_session_messages_include_compacted_surfaces_archived_rows(self):
         """include_compacted=true returns the full display history: archived
         (active=0, compacted=1) rows plus live rows, in insertion order.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -820,12 +820,16 @@ class TestFTS5Search:
         db.append_message("s1", role="user", content="after")
 
         statements = []
-        read_conn = db._get_read_conn() or db._conn
         traced_connections = [db._conn]
-        if read_conn is not db._conn:
-            traced_connections.append(read_conn)
-        for conn in traced_connections:
-            conn.set_trace_callback(statements.append)
+        # Borrow through the same pool seam as search_messages(), then return
+        # the traced reader to the pool. Calling _get_read_conn() directly here
+        # opens an untracked checkout, so the search correctly uses a different
+        # connection and the trace silently observes nothing.
+        with db._read_ctx() as read_conn:
+            if read_conn is not db._conn:
+                traced_connections.append(read_conn)
+            for conn in traced_connections:
+                conn.set_trace_callback(statements.append)
 
         def context_query_count():
             normalized = (" ".join(sql.upper().split()) for sql in statements)
@@ -4711,6 +4715,30 @@ class TestDisplayMetadataPersistence:
         reloaded = db.get_messages_as_conversation("s1")
         assert reloaded[0]["display_kind"] == "async_delegation_complete"
         assert reloaded[0]["display_metadata"] == meta
+
+    def test_display_only_steer_correction_is_not_model_replayed(self, db):
+        db.create_session("s1", source="desktop")
+        db.append_message("s1", "user", "original prompt")
+        db.append_message(
+            "s1",
+            "user",
+            "use the corrected approach",
+            display_kind="steer_correction",
+        )
+        db.append_message("s1", "assistant", "corrected result")
+
+        model_history, display_history = db.get_resume_conversations("s1")
+
+        assert [message["content"] for message in model_history] == [
+            "original prompt",
+            "corrected result",
+        ]
+        assert [message["content"] for message in display_history] == [
+            "original prompt",
+            "use the corrected approach",
+            "corrected result",
+        ]
+        assert display_history[1]["display_kind"] == "steer_correction"
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11834,6 +11834,39 @@ def test_session_redirect_records_correction_without_erasing_prompt():
     assert snapshot["corrections"] == ["hurry up", "and the worktree ones"]
 
 
+def test_tool_time_correction_persists_for_display_but_not_model(tmp_path):
+    """A steer arrives through a tool result, but its user bubble is durable."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="desktop")
+        session = {
+            "session_key": "s1",
+            "agent": types.SimpleNamespace(_session_db=db),
+        }
+        server._start_inflight_turn(session, "original prompt")
+
+        server._record_inflight_correction(
+            session, "use the corrected approach", persist_display_only=True
+        )
+
+        model_history, display_history = db.get_resume_conversations("s1")
+        assert not any(
+            message.get("content") == "use the corrected approach"
+            for message in model_history
+        )
+        correction = next(
+            message
+            for message in display_history
+            if message.get("content") == "use the corrected approach"
+        )
+        assert correction["role"] == "user"
+        assert correction["display_kind"] == "steer_correction"
+    finally:
+        db.close()
+
+
 def test_inflight_snapshot_carries_arrival_order_offsets():
     """Each correction records how much assistant text had already streamed.
 
@@ -15702,6 +15735,10 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
     monkeypatch.setattr(
         "hermes_cli.auth.is_provider_explicitly_configured",
         lambda _slug: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory._anthropic_oauth_credentials_present",
+        lambda: False,
     )
     monkeypatch.setattr("hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None)

--- a/tests/tui_gateway/test_interim_assistant_callback.py
+++ b/tests/tui_gateway/test_interim_assistant_callback.py
@@ -16,6 +16,38 @@ def test_load_interim_assistant_messages_defaults_true():
         assert _load_interim_assistant_messages() is True
 
 
+def test_history_projection_hides_persisted_interim_when_disabled():
+    from tui_gateway.server import _history_to_messages
+
+    history = [
+        {"role": "user", "content": "run it"},
+        {
+            "role": "assistant",
+            "content": "Checking the service now.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": '{"command":"status"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "ready"},
+        {"role": "assistant", "content": "The service is ready."},
+    ]
+
+    with patch("tui_gateway.server._load_cfg", return_value={
+        "display": {"interim_assistant_messages": False}
+    }):
+        projected = _history_to_messages(history)
+
+    assert [message.get("text") for message in projected if message["role"] != "tool"] == [
+        "run it",
+        "The service is ready.",
+    ]
+    assert any(message["role"] == "tool" for message in projected)
+
+
 def test_agent_cbs_includes_interim_callback_when_enabled():
     """_agent_cbs() includes interim_assistant_callback when the config is on.
 
@@ -48,5 +80,4 @@ def test_agent_cbs_includes_interim_callback_when_enabled():
     assert emitted[0][1] == "test-session"
     assert emitted[0][2]["text"] == "hello world"
     assert emitted[0][2]["already_streamed"] is True
-
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3632,7 +3632,7 @@ def _(rid, params: dict) -> dict:
         # rebuilds the transcript from the inflight snapshot and the steered
         # text has no user bubble — the "my message vanished on reload" loss.
         with session["history_lock"]:
-            _record_inflight_correction(session, text)
+            _record_inflight_correction(session, text, persist_display_only=True)
             # #84417: steer does not cancel the live original, but a server
             # queue self-copy of that original must still not re-fire after
             # settle (same class as redirect).
@@ -3667,12 +3667,17 @@ def _(rid, params: dict) -> dict:
     ):
         return _err(rid, 4010, "agent does not support active-turn redirect")
     try:
+        persist_display_only = bool(getattr(agent, "_executing_tools", False)) or (
+            getattr(agent, "api_mode", None) == "codex_app_server"
+        )
         accepted = agent.redirect(text)
     except Exception as exc:
         return _err(rid, 5000, f"redirect failed: {exc}")
     if accepted:
         with session["history_lock"]:
-            _record_inflight_correction(session, text)
+            _record_inflight_correction(
+                session, text, persist_display_only=persist_display_only
+            )
             # #84417: purge server-queue self-duplicates of the live original
             # so post-turn drain cannot restart the pre-correction prompt.
             _drop_queued_duplicates_of_inflight_user(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9607,6 +9607,9 @@ def _legacy_display_kind(role: str, text: str) -> str | None:
 
 
 def _history_to_messages(history: list[dict]) -> list[dict]:
+    from agent.display_projection import is_interim_assistant_message
+
+    include_interim_assistant = _load_interim_assistant_messages()
     messages = []
     tool_call_args = {}
 
@@ -9639,6 +9642,8 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
+            if not include_interim_assistant and is_interim_assistant_message(m):
+                content_text = ""
             if not content_text.strip():
                 continue
         if role == "tool":
@@ -9794,7 +9799,46 @@ def _append_inflight_delta(session: dict, delta: Any) -> None:
     session["inflight_turn"] = turn
 
 
-def _record_inflight_correction(session: dict, text: Any) -> None:
+def _persist_display_only_correction(session: dict, correction: str) -> None:
+    """Persist a tool-time steer for display without replaying it to the model.
+
+    The agent already delivers this text through the newest tool result. A
+    tagged durable row keeps the user's bubble after settle/restart; SessionDB
+    omits ``steer_correction`` rows from the model-fed resume projection.
+    """
+
+    session_key = str(session.get("session_key") or "").strip()
+    if not session_key:
+        return
+    agent = session.get("agent")
+    db = getattr(agent, "_session_db", None) if agent is not None else None
+    try:
+        if db is not None:
+            db.append_message(
+                session_key,
+                role="user",
+                content=correction,
+                timestamp=time.time(),
+                display_kind="steer_correction",
+            )
+            return
+        _ensure_session_db_row(session)
+        with _session_db(session) as scoped_db:
+            if scoped_db is not None:
+                scoped_db.append_message(
+                    session_key,
+                    role="user",
+                    content=correction,
+                    timestamp=time.time(),
+                    display_kind="steer_correction",
+                )
+    except Exception:
+        logger.debug("failed to persist display-only steer correction", exc_info=True)
+
+
+def _record_inflight_correction(
+    session: dict, text: Any, *, persist_display_only: bool = False
+) -> None:
     """Record an accepted mid-turn correction on the live turn.
 
     The correction is appended, never written over ``user``: a resuming client
@@ -9822,6 +9866,8 @@ def _record_inflight_correction(session: dict, text: Any) -> None:
     turn["correction_offsets"] = offsets
     turn["updated_at"] = time.time()
     session["inflight_turn"] = turn
+    if persist_display_only:
+        _persist_display_only_correction(session, correction)
 
 
 def _clear_inflight_turn(session: dict) -> None:
@@ -10248,7 +10294,9 @@ def _handle_busy_submit(
         try:
             if agent.steer(plain_text):
                 with session["history_lock"]:
-                    _record_inflight_correction(session, plain_text)
+                    _record_inflight_correction(
+                        session, plain_text, persist_display_only=True
+                    )
                     _drop_queued_duplicates_of_inflight_user(session)
                     session["last_active"] = time.time()
                 return _ok(rid, {"status": "steered"})
@@ -10266,9 +10314,16 @@ def _handle_busy_submit(
         and hasattr(agent, "redirect")
     ):
         try:
+            persist_display_only = bool(getattr(agent, "_executing_tools", False)) or (
+                getattr(agent, "api_mode", None) == "codex_app_server"
+            )
             if agent.redirect(plain_text):
                 with session["history_lock"]:
-                    _record_inflight_correction(session, plain_text)
+                    _record_inflight_correction(
+                        session,
+                        plain_text,
+                        persist_display_only=persist_display_only,
+                    )
                     # #84417: do not re-fire the live turn's original user text
                     # from a stale server-queue self-duplicate after settle.
                     _drop_queued_duplicates_of_inflight_user(session)


### PR DESCRIPTION
## What does this PR do?

Separates durable/model transcript state from the user-visible projection for two cases: tool-time corrections that must survive restart without being replayed to the model, and interim assistant narration that a user has disabled for display.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Persist accepted tool-time corrections as display-only rows.
- Exclude those rows from model resume while retaining them in display history.
- Apply the interim-assistant display preference to REST and TUI history projections without mutating durable content.
- Add endpoint, persistence, and projection regression coverage.

## How to Test

- Focused persistence, REST, and TUI projection tests: 6 passed.
- `ruff check` and `git diff --check` passed.

## Invariants

- Durable messages are not rewritten to satisfy presentation preferences.
- Display-only corrections are never replayed into model context.
- Tool-call metadata remains intact for resume and audit.

## Checklist

- [x] Focused transcript/display boundary
- [x] Behavior-contract tests added
- [x] No unrelated files or local operational material
- [x] Tested on Windows 11