### PR TITLE
fix(agent): judge natural response ending by visible character (VS15/VS16 + markdown tables)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1788,12 +1788,20 @@ class AIAgent:
         stripped = content.rstrip()
         if not stripped:
             return False
+        # VS15/VS16 presentation modifiers (e.g. 🎖️ = U+1F396 + U+FE0F) are
+        # invisible tail codepoints below 0x1F300, so an emoji-with-style
+        # ending reads as unnatural. Judge by the last VISIBLE character.
+        unstyled = re.sub(r"[\ufe0e\ufe0f]+$", "", stripped)
+        if unstyled:
+            stripped = unstyled
         if stripped.endswith("```"):
             return True
         if stripped.endswith('^'):
             return True
+        # '|' and '%' close markdown tables and percent figures — complete
+        # response endings (e.g. status boards ending in '|').
         last = stripped[-1]
-        if last in '.!?:)"\']}。！？：）】」』》^':
+        if last in ".!?:)\"']}。！？：）】」』》^%|%":
             return True
         # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
         if ord(last) >= 0x1F300:


### PR DESCRIPTION
## Symptom
On Ollama/GLM models, turns ending with an emoji carrying a variation selector (🎖️ = U+1F396 + U+FE0F) — or with a markdown table — trigger the conservative stop→length path:
```
Treating suspicious Ollama/GLM stop response as truncated
Response truncated (finish_reason='length') - model hit max output tokens (x4)
Response still truncated after 4 continuation attempts
```
4 futile continuation API calls + user-facing error dialog on fully complete, short responses. 15+ occurrences/day on one workstation profile (GLM via Ollama gateway).

## Root cause
`_has_natural_response_ending` (run_agent.py) evaluates the last codepoint. A VS15/VS16 emoji sequence ends with the invisible modifier (U+FE0F, ord 65024 < 0x1F300) — reads as unnatural. Table pipes not in the natural set. Heuristic fails on finished text -> `_should_treat_stop_as_truncated` fires.

## Fix
- Trim trailing VS15/VS16 modifiers before terminal-character judgment (last VISIBLE character).
- Admit '|' and '%' as natural closers.

## Verification
Behavior battery vs live source: both bug cases flip False->True; period, bare emoji >= U+1F300, quote, fenced code, real truncation, empty-string cases unchanged (9/9). Real truncations remain flagged — conservative path intact.

## Risk
Contained to tail-character judgment; no continuation/streaming/provider changes.