### PR TITLE
fix(gateway): restart failed Windows launchers

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -64,6 +64,7 @@ _TASK_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 _TASK_LOGON_DELAY = "PT30S"
 _TASK_RESTART_INTERVAL = "PT1M"
 _TASK_RESTART_COUNT = 999
+_STARTUP_RESTART_DELAY_MS = 60_000
 
 
 def _schtasks_encoding() -> str:
@@ -495,7 +496,7 @@ def _build_gateway_vbs_script(
     lines = [
         f"' {_TASK_DESCRIPTION}",
         "Option Explicit",
-        "Dim sh, env, existing_pp",
+        "Dim sh, env, existing_pp, exit_code",
         'Set sh = CreateObject("WScript.Shell")',
         'Set env = sh.Environment("PROCESS")',
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
@@ -512,34 +513,47 @@ def _build_gateway_vbs_script(
         f"  env.Item({_quote_vbs_string('PYTHONPATH')}) = {_quote_vbs_string(static_pythonpath)}",
         "End If",
         f"sh.CurrentDirectory = {_quote_vbs_string(working_dir)}",
-        # Window style 0 = hidden; bWaitOnReturn False = detached/async. The
-        # console python's one console is created hidden and inherited by all
-        # descendants, so nothing ever flashes.
-        f"sh.Run {_quote_vbs_string(command_line)}, 0, False",
+        # Window style 0 = hidden; bWaitOnReturn True keeps the launcher alive
+        # for the lifetime of the gateway. Scheduled Task can therefore observe
+        # a later crash and apply RestartOnFailure. Propagating the child's exit
+        # code also distinguishes an intentional, clean stop from a failure.
+        f"exit_code = sh.Run({_quote_vbs_string(command_line)}, 0, True)",
+        "WScript.Quit exit_code",
     ]
     return "\r\n".join(lines) + "\r\n"
 
 
 def _build_startup_launcher(script_path: Path) -> str:
-    """The tiny .vbs that goes in the Startup folder and chains hidden.
+    """Build the hidden Startup-folder watchdog.
 
     Defense-in-depth: bail out silently if the target script is gone. Test
     fixtures historically wrote Startup entries pointing at pytest tmp_path
     directories that vanish after the test session. Without the existence
     guard, every subsequent Windows login could attempt a stale launcher. The
     check + ``WScript.Quit 0`` keeps that case silent.
+
+    The inner launcher waits for the gateway and returns its exit code. A clean
+    exit means the user intentionally stopped/restarted the gateway, so this
+    watchdog exits too. A non-zero exit means an unexpected termination; retry
+    after a bounded delay. This gives machines that cannot register a Scheduled
+    Task the same practical crash recovery without spawning duplicate gateways.
     """
     target = str(script_path.with_suffix(".vbs"))
     command = subprocess.list2cmdline(["wscript.exe", target])
     lines = [
         f"' {_TASK_DESCRIPTION}",
         "Option Explicit",
-        "Dim fso, sh, target",
+        "Dim fso, sh, target, command, exit_code",
         f"target = {_quote_vbs_string(target)}",
         'Set fso = CreateObject("Scripting.FileSystemObject")',
         "If Not fso.FileExists(target) Then WScript.Quit 0",
         'Set sh = CreateObject("WScript.Shell")',
-        f"sh.Run {_quote_vbs_string(command)}, 0, False",
+        f"command = {_quote_vbs_string(command)}",
+        "Do",
+        "  exit_code = sh.Run(command, 0, True)",
+        "  If exit_code = 0 Then WScript.Quit 0",
+        f"  WScript.Sleep {_STARTUP_RESTART_DELAY_MS}",
+        "Loop",
     ]
     return "\r\n".join(lines) + "\r\n"
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,9 +314,8 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
-def test_gateway_vbs_script_is_console_less(monkeypatch):
-    """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
-    (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""
+def test_gateway_vbs_script_is_console_less_and_reports_child_exit(monkeypatch):
+    """The task launcher stays hidden and reports gateway failure to Scheduler."""
     monkeypatch.setattr(
         gateway_windows,
         "_resolve_detached_python",
@@ -333,10 +332,23 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert "pythonw.exe" in content
     assert "hermes_cli.main" in content
     assert "gateway run" in content
-    assert ", 0, False" in content  # hidden window, detached/async
+    assert ", 0, True)" in content  # hidden window, wait for the gateway
+    assert "WScript.Quit exit_code" in content
     for var in ("HERMES_HOME", "PYTHONIOENCODING", "HERMES_GATEWAY_DETACHED", "VIRTUAL_ENV", "PYTHONPATH"):
         assert var in content
     assert "--profile" in content and "work" in content
+    assert content.endswith("\r\n")
+
+
+def test_startup_launcher_restarts_only_after_gateway_failure(tmp_path):
+    """The non-admin Startup fallback supervises crashes but honors clean stops."""
+    content = gateway_windows._build_startup_launcher(tmp_path / "Hermes_Gateway.cmd")
+
+    assert "Do\r\n" in content
+    assert "exit_code = sh.Run(command, 0, True)" in content
+    assert "If exit_code = 0 Then WScript.Quit 0" in content
+    assert f"WScript.Sleep {gateway_windows._STARTUP_RESTART_DELAY_MS}" in content
+    assert "Loop\r\n" in content
     assert content.endswith("\r\n")
 
 
@@ -362,7 +374,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Makes the Windows gateway launchers observable and recoverable after an unexpected backend exit. The scheduled-task launcher now returns the child exit code, and the Startup fallback retries only failed exits with a bounded delay.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Wait for the hidden gateway child instead of detaching immediately.
- Propagate its exit code so Scheduled Task RestartOnFailure can work.
- Add a hidden Startup-folder watchdog for machines where task registration is unavailable.
- Stop cleanly on an intentional zero exit and avoid duplicate launch loops.

## How to Test

- `python -m pytest tests/hermes_cli/test_gateway_windows.py -q`
- Result: 10 passed.
- `ruff check` and `git diff --check` passed.

## Checklist

- [x] Existing hidden-window behavior preserved
- [x] Clean stop and crash paths covered
- [x] No unrelated files or local operational material
- [x] Tested on Windows 11