### PR TITLE
fix(desktop): do not steer a leftover busy runtime after switching chats

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -13,6 +13,8 @@ import {
   setSecretRequest,
   setSudoRequest
 } from '@/store/prompts'
+import { $sessions } from '@/store/session'
+import { $sessionStates, clearAllSessionStates } from '@/store/session-states'
 
 import { type ComposerTarget, requestComposerSubmit } from '../focus'
 import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
@@ -25,6 +27,7 @@ interface SubmitHarnessOptions {
   compacting?: boolean
   inputDisabled?: boolean
   scopeTarget?: ComposerTarget
+  sessionId?: string
   sessionKey?: string | null
   submitOnHide?: boolean
   surfaceId?: string | null
@@ -40,6 +43,7 @@ function renderSubmitHook({
   compacting = false,
   inputDisabled = false,
   scopeTarget = 'main',
+  sessionId = 'runtime-session',
   sessionKey = 'stored-session',
   submitOnHide = false,
   surfaceId,
@@ -113,7 +117,7 @@ function renderSubmitHook({
         queueCurrentDraft,
         queueEdit: null,
         queuedPrompts: [],
-        sessionId: 'runtime-session',
+        sessionId,
         setComposerText: vi.fn(),
         stashAt: vi.fn()
       }),
@@ -352,6 +356,39 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onSteer).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
     expect(queueCurrentDraft).not.toHaveBeenCalled()
+  })
+
+  it('does not steer a leftover busy runtime after the composer moved to another chat', async () => {
+    $sessions.set([
+      { id: 'stored-a', _lineage_root_id: 'stored-a' },
+      { id: 'stored-b', _lineage_root_id: 'stored-b' }
+    ] as never)
+    $sessionStates.set({
+      'runtime-a': { storedSessionId: 'stored-a', busy: true }
+    } as never)
+
+    const { hook, onCancel, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      sessionId: 'runtime-a',
+      sessionKey: 'stored-b',
+      text: 'how can I tell how much context is left in hermes desktop?'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith('how can I tell how much context is left in hermes desktop?', {
+        composerScope: 'stored-b'
+      })
+    )
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+    expect(onCancel).not.toHaveBeenCalled()
+
+    $sessions.set([])
+    clearAllSessionStates()
   })
 
   it('submits a normal turn while idle', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -270,6 +270,10 @@ describe('useComposerSubmit external request routing', () => {
 
 describe('useComposerSubmit busy-turn routing', () => {
   afterEach(() => {
+    // Reset the store seeds used by the leftover-runtime tests unconditionally,
+    // so a mid-test throw can't leak $sessions/$sessionStates into later tests.
+    $sessions.set([])
+    clearAllSessionStates()
     cleanup()
     vi.restoreAllMocks()
   })
@@ -388,6 +392,55 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onCancel).not.toHaveBeenCalled()
 
     $sessions.set([])
+    clearAllSessionStates()
+  })
+
+  it('still steers on a busy Enter when the runtime state has no stored id yet', async () => {
+    // Runtime known busy but no storedSessionId attached — insufficient
+    // evidence to declare a scope mismatch, keep the historical steer path.
+    $sessions.set([{ id: 'stored-session', _lineage_root_id: 'stored-session' }] as never)
+    $sessionStates.set({
+      'runtime-session': { busy: true }
+    } as never)
+
+    const { hook, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'course correction mid-turn'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('course correction mid-turn'))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+
+    $sessions.set([])
+    clearAllSessionStates()
+  })
+
+  it('still steers on a busy Enter when the session list has not loaded yet', async () => {
+    // Same evidence gap as missing ids — refuse to demote a steer to a fresh
+    // submit without proof the runtime belongs to a different scope.
+    $sessions.set([] as never)
+    $sessionStates.set({
+      'runtime-session': { storedSessionId: 'stored-session', busy: true }
+    } as never)
+
+    const { hook, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'course correction mid-turn'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('course correction mid-turn'))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+
     clearAllSessionStates()
   })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -9,6 +9,8 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
 import { hasMcpSetupRequest, skipMcpSetupRequest } from '@/store/mcp-setup'
 import { hasBlockingPromptRequest } from '@/store/prompts'
+import { $sessions, runtimeBelongsToComposerScope } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
@@ -206,7 +208,20 @@ export function useComposerSubmit({
         // Cursor-style stop-and-correct: interrupt the live turn and redirect
         // it with this text. redirect() preserves the shown reasoning/work; if
         // the turn already ended, steerDraft re-queues so nothing is lost.
-        steerDraft()
+        //
+        // Do NOT steer a leftover busy runtime after the composer/route has
+        // already moved to another chat — that injects B's text into A's
+        // in-flight turn (observed 2026-08-31: Qwen prompt answered in the
+        // still-running grok session). Start a real turn on this composer.
+        const runtimeStoredId = sessionId ? $sessionStates.get()[sessionId]?.storedSessionId : null
+
+        if (runtimeBelongsToComposerScope(runtimeStoredId, activeQueueSessionKey, $sessions.get())) {
+          steerDraft()
+        } else {
+          triggerHaptic('submit')
+          clearDraft()
+          dispatchSubmit(text)
+        }
       } else if (payloadPresent) {
         // Attachments can't ride a redirect (no tool-result image carriage) —
         // queue the whole payload for the next turn. Same for a turn parked on

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -213,6 +213,12 @@ export function useComposerSubmit({
         // already moved to another chat — that injects B's text into A's
         // in-flight turn (observed 2026-08-31: Qwen prompt answered in the
         // still-running grok session). Start a real turn on this composer.
+        //
+        // Read the two stores imperatively here (not via useStore) — this is
+        // a one-shot decision on the submit boundary and must not subscribe
+        // the hook to $sessions / $sessionStates. Re-rendering the composer
+        // on every session-list refetch would burn cache and trigger the
+        // very race this guard exists to avoid.
         const runtimeStoredId = sessionId ? $sessionStates.get()[sessionId]?.storedSessionId : null
 
         if (runtimeBelongsToComposerScope(runtimeStoredId, activeQueueSessionKey, $sessions.get())) {

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -41,6 +41,7 @@ import {
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
+  runtimeBelongsToComposerScope,
   sessionBelongsToProfile,
   sessionPinId,
   setCurrentCwd,
@@ -262,6 +263,30 @@ describe('resolveComposerSessionKey', () => {
 
   it('falls back to the live id when the tip row is not loaded yet', () => {
     expect(resolveComposerSessionKey('tip-new', [])).toBe('tip-new')
+  })
+})
+
+describe('runtimeBelongsToComposerScope', () => {
+  it('keeps historical steer when either id is missing', () => {
+    expect(runtimeBelongsToComposerScope(null, 'root-b', [])).toBe(true)
+    expect(runtimeBelongsToComposerScope('root-a', null, [])).toBe(true)
+  })
+
+  it('allows the same conversation across compression tip rotation', () => {
+    const sessions = [session({ id: 'tip-a', _lineage_root_id: 'root-a' })]
+
+    expect(runtimeBelongsToComposerScope('tip-a', 'root-a', sessions)).toBe(true)
+    expect(runtimeBelongsToComposerScope('root-a', 'tip-a', sessions)).toBe(true)
+  })
+
+  it('refuses to treat a leftover busy runtime as the composer that already moved', () => {
+    const sessions = [
+      session({ id: 'tip-a', _lineage_root_id: 'root-a' }),
+      session({ id: 'tip-b', _lineage_root_id: 'root-b' })
+    ]
+
+    expect(runtimeBelongsToComposerScope('tip-a', 'root-b', sessions)).toBe(false)
+    expect(runtimeBelongsToComposerScope('root-a', 'root-b', sessions)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -272,6 +272,13 @@ describe('runtimeBelongsToComposerScope', () => {
     expect(runtimeBelongsToComposerScope('root-a', null, [])).toBe(true)
   })
 
+  it('keeps historical steer when the session list has not loaded yet', () => {
+    // Both ids present but no lineage evidence available — treat as unknown
+    // rather than declaring a mismatch and dropping into a real submit.
+    expect(runtimeBelongsToComposerScope('root-a', 'root-b', [])).toBe(true)
+    expect(runtimeBelongsToComposerScope('tip-a', 'root-a', [])).toBe(true)
+  })
+
   it('allows the same conversation across compression tip rotation', () => {
     const sessions = [session({ id: 'tip-a', _lineage_root_id: 'root-a' })]
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -393,6 +393,29 @@ export function idsShareLineage(
 }
 
 /**
+ * Whether a live runtime still belongs to the composer's durable session key.
+ *
+ * Mid-switch the route/composer key can already be chat B while the leftover
+ * busy runtime is still chat A (#59305 sibling). Steering then injects B's
+ * text into A's in-flight turn. Missing either id is insufficient evidence
+ * (keep historical steer). Same conversation across compression tips is yes.
+ */
+export function runtimeBelongsToComposerScope(
+  runtimeStoredSessionId: string | null | undefined,
+  composerKey: string | null | undefined,
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]
+): boolean {
+  const stored = runtimeStoredSessionId?.trim()
+  const key = composerKey?.trim()
+
+  if (!stored || !key) {
+    return true
+  }
+
+  return idsShareLineage(stored, key, sessions)
+}
+
+/**
  * Whether a composer draft/queue key should move from `fromKey` onto `toKey`.
  *
  * Only same-conversation rekeys are allowed (compression tip → lineage root).

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -398,7 +398,10 @@ export function idsShareLineage(
  * Mid-switch the route/composer key can already be chat B while the leftover
  * busy runtime is still chat A (#59305 sibling). Steering then injects B's
  * text into A's in-flight turn. Missing either id is insufficient evidence
- * (keep historical steer). Same conversation across compression tips is yes.
+ * (keep historical steer). An unpopulated session list is the same evidence
+ * gap — the runtime may genuinely be this composer's own chat, we just can't
+ * prove lineage yet (list refetching, profile switch, first paint). Same
+ * conversation across compression tips is yes.
  */
 export function runtimeBelongsToComposerScope(
   runtimeStoredSessionId: string | null | undefined,
@@ -409,6 +412,10 @@ export function runtimeBelongsToComposerScope(
   const key = composerKey?.trim()
 
   if (!stored || !key) {
+    return true
+  }
+
+  if (sessions.length === 0) {
     return true
   }
 


### PR DESCRIPTION
## What does this PR do?

While Desktop session A is mid-turn, the composer/route key can already be session B (#59305 sibling). Enter was treated as `session.redirect` into A's live turn, so B's prompt landed in A's in-flight request and transcript.

Observed 2026-08-31: a Qwen-chat prompt was injected into a still-running grok session (`Delivered /steer` with no `tui prompt accepted`).

Steer only when that runtime still belongs to this composer's session key (including compression lineage). Otherwise start a real turn on the composer that received the text.

## Related Issue

No existing issue. Searched open PRs for overlapping Desktop steer/session routing (`#95880`, `#90172`, `#97381`); this is a leftover-runtime inject after a chat switch, not those.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session.ts` — add `runtimeBelongsToComposerScope()` so a leftover busy runtime is recognized as a different conversation (including compression lineage)
- `apps/desktop/src/store/session.test.ts` — unit tests for that helper (missing ids, same lineage, cross-session)
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts` — on busy Enter, steer only if that runtime still owns this composer key; otherwise `prompt.submit` on the chat that received the text
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx` — regression: busy runtime A + composer key B must not call `onSteer`

## How to Test

1. Start a long tool-using turn in chat A so it stays busy.
2. Switch to idle chat B and send a prompt.
3. B must get `tui prompt accepted` / `prompt.submit` for B. A must **not** log `Delivered /steer` or `session.redirect` with B's text.
4. Same-session control: type in A while A is still running — that still steers into A.
5. Desktop: `cd apps/desktop && npx vitest run src/store/session.test.ts src/app/chat/composer/hooks/use-composer-submit.test.tsx` — 119 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
2026-08-31 14:26:45 INFO [20260831_142214_675240] run_agent: Delivered /steer to agent after tool batch (37 chars): wiat are you cos or trader right now?
2026-08-31 14:27:10 INFO tui_gateway.server: tui prompt accepted: ... agent_session_id=20260831_141820_221482 kind=user chars=58
```
