### PR TITLE
test(desktop): keep Electron E2E windows hidden

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -249,6 +249,9 @@ export function buildAppEnv(sandbox: Sandbox, extra: Record<string, string> = {}
     // The dev-server check in main.ts looks for this env var; if it's set,
     // it loads from the vite URL instead of the local file.
     ...extra,
+    // Keep Electron fixtures off the user's desktop while Playwright drives
+    // the fully rendered page through Electron's CDP transport.
+    HERMES_DESKTOP_E2E_HIDDEN: '1',
   }
 }
 
@@ -646,7 +649,11 @@ export async function waitForAppReady(fixture: MockBackendFixture | NoProviderFi
   // wireWindowReveal's post-load fallback in production — but the DOM can be
   // ready before that lands. Poll until the window is actually visible so
   // interactions (click, screenshot) don't hit a hidden surface.
-  if (app) {
+  const intentionallyHidden = app
+    ? await app.evaluate(() => process.env.HERMES_DESKTOP_E2E_HIDDEN === '1').catch(() => false)
+    : false
+
+  if (app && !intentionallyHidden) {
     const deadline = Date.now() + timeoutMs
 
     while (Date.now() < deadline) {

--- a/apps/desktop/electron/e2e-window-visibility.test.ts
+++ b/apps/desktop/electron/e2e-window-visibility.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+import { E2E_HIDDEN_WINDOW_ENV, shouldKeepE2EWindowsHidden } from './e2e-window-visibility'
+
+test('keeps E2E windows hidden only when the internal switch is explicit', () => {
+  expect(shouldKeepE2EWindowsHidden({})).toBe(false)
+  expect(shouldKeepE2EWindowsHidden({ [E2E_HIDDEN_WINDOW_ENV]: '0' })).toBe(false)
+  expect(shouldKeepE2EWindowsHidden({ [E2E_HIDDEN_WINDOW_ENV]: '1' })).toBe(true)
+})

--- a/apps/desktop/electron/e2e-window-visibility.ts
+++ b/apps/desktop/electron/e2e-window-visibility.ts
@@ -1,0 +1,9 @@
+export const E2E_HIDDEN_WINDOW_ENV = 'HERMES_DESKTOP_E2E_HIDDEN'
+
+/**
+ * Keep Playwright's Electron windows rendered but off the active desktop.
+ * This is an internal test-process switch, never a user-facing app setting.
+ */
+export function shouldKeepE2EWindowsHidden(env: NodeJS.ProcessEnv): boolean {
+  return env[E2E_HIDDEN_WINDOW_ENV] === '1'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -166,6 +166,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import { shouldKeepE2EWindowsHidden } from './e2e-window-visibility'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
@@ -449,6 +450,7 @@ if (USER_DATA_OVERRIDE) {
 
 const DEV_SERVER = process.env.HERMES_DESKTOP_DEV_SERVER
 const IS_PACKAGED = app.isPackaged || Boolean(process.env.HERMES_DESKTOP_IS_PACKAGED)
+const KEEP_E2E_WINDOWS_HIDDEN = shouldKeepE2EWindowsHidden(process.env)
 const IS_MAC = process.platform === 'darwin'
 const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
@@ -12755,6 +12757,14 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 // `onRevealed` carry the caller's reveal action and post-visible work; whichever
 // path wins runs them exactly once.
 function wireWindowReveal(win, { show, onRevealed }: { show?: () => void; onRevealed?: () => void } = {}) {
+  if (KEEP_E2E_WINDOWS_HIDDEN) {
+    return {
+      dispose: () => {},
+      reveal: () => false,
+      scheduleFallback: () => {}
+    }
+  }
+
   const controller = createWindowRevealController(
     {
       isDestroyed: () => win.isDestroyed(),


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, test-only execution path that keeps Playwright Electron windows rendered but hidden from the active desktop. CDP still drives the real renderer and all normal visibility behavior remains unchanged outside E2E fixtures.

## Type of Change

- [x] Tests
- [x] Desktop test infrastructure

## Changes Made

- Gate window reveal behind an internal E2E-only switch.
- Set the switch in the isolated Playwright fixture environment.
- Skip the fixture's visible-window poll only for that explicit mode.
- Add a truth-table unit test for the gate.

## How to Test

- Electron visibility unit test: 1 passed.
- Full Desktop TypeScript typecheck passed.
- Hidden real Electron smoke (`chat.spec.ts`, send/receive): 1 passed.
- Post-run process audit: 0 `electron.exe` processes remained.
- Production builds without the explicit fixture switch retain the normal reveal path.

## Checklist

- [x] Test-only behavior is explicit and fail-safe
- [x] Real renderer and backend path exercised
- [x] No visible test window or orphan Electron process
- [x] No unrelated files or local operational material