### PR TITLE
fix(desktop): reject incomplete Python runtimes

### DIFF
--- a/apps/desktop/electron/backend-python-coherence.test.ts
+++ b/apps/desktop/electron/backend-python-coherence.test.ts
@@ -51,6 +51,12 @@ test('findPythonForRoot preference order includes .venv before venv (context for
   )
 })
 
+test('findPythonForRoot rejects an incomplete interpreter before launching the backend', () => {
+  const fn = extractFunction(mainTsSource, 'findPythonForRoot')
+  assert.match(fn, /canImportHermesCli\(candidate, \{ env: probeEnv \}\)/)
+  assert.match(fn, /systemPython && canImportHermesCli\(systemPython, \{ env: probeEnv \}\)/)
+})
+
 // Fixed: createPythonBackend derives venvRoot from the selected interpreter
 // via venvRootForPython(python, root), falling back to root/venv only for a
 // system python. This test guards against re-hardcoding the venv path.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2422,15 +2422,21 @@ function findPythonForRoot(root) {
     ? [path.join('.venv', 'Scripts', 'python.exe'), path.join('venv', 'Scripts', 'python.exe')]
     : [path.join('.venv', 'bin', 'python'), path.join('venv', 'bin', 'python')]
 
+  const probeEnv = {
+    PYTHONPATH: [root, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+  }
+
   for (const relativePath of relativePaths) {
     const candidate = path.join(root, relativePath)
 
-    if (fileExists(candidate)) {
+    if (fileExists(candidate) && canImportHermesCli(candidate, { env: probeEnv })) {
       return candidate
     }
   }
 
-  return findSystemPython()
+  const systemPython = findSystemPython()
+
+  return systemPython && canImportHermesCli(systemPython, { env: probeEnv }) ? systemPython : null
 }
 
 function findSystemPython() {


### PR DESCRIPTION
## What does this PR do?

Prevents Desktop from launching the Hermes backend with a Python interpreter that exists on disk but cannot import the checkout's `hermes_cli` and dependencies. Candidate venvs and the system fallback are now probed with the same checkout on `PYTHONPATH` before selection.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Probe each discovered checkout interpreter before selecting it.
- Probe the system fallback under the same import environment.
- Return no interpreter instead of launching a backend guaranteed to crash at import time.

## How to Test

- Backend interpreter coherence suite: 5 passed.
- Full Desktop TypeScript typecheck passed.
- `git diff --check` passed.

## Checklist

- [x] Existing explicit Python override remains unchanged
- [x] Candidate ordering remains `.venv`, then `venv`, then system
- [x] No unrelated files or local operational material
- [x] Tested on Windows 11