### PR TITLE
fix(gateway): Discord stops reply-pinging on every interim progress message

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2714,10 +2714,16 @@ class GatewayStreamConsumer:
             # duplicate (live finding, 2026-08-16 canary).
             _md = self._metadata_for_send(final=False) or {}
             _md["_interim_send"] = True
+            # Only pass reply_to for platforms that use reply-anchoring for
+            # threading. Discord/Telegram use native thread_id in metadata;
+            # passing reply_to on every commentary creates reply spam.
+            _plat = getattr(getattr(self.adapter, "platform", None), "value", None)
+            _platform_name = str(_plat or getattr(self.adapter, "name", "")).lower()
+            _needs_reply_anchor = _platform_name in ("buzz", "slack", "mattermost", "feishu")
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                reply_to=self._initial_reply_to_id,
+                reply_to=self._initial_reply_to_id if _needs_reply_anchor else None,
                 metadata=_md,
             )
             # Note: do NOT set _already_sent = True here.


### PR DESCRIPTION
## Summary
Discord no longer reply-pings the user on every interim progress/commentary message — stream commentary now posts flat on platforms with native threading, while Buzz/Slack/Mattermost/Feishu keep their reply-to anchors.

Root cause: 66fa6e41c4 ("fix(buzz): reply in-thread instead of flat channel posts") added `reply_to=self._initial_reply_to_id` unconditionally to `GatewayStreamConsumer._send_commentary`. `_initial_reply_to_id` is the user's triggering message id, so on Discord every interim assistant commentary bubble arrived as a fresh reply to the user's message — a notification ping every few seconds for the whole turn (community report, Discord screenshot with per-update reply chains).

## Changes
- `gateway/stream_consumer.py`: `_send_commentary` gates `reply_to` on the adapter's platform — only `buzz` / `slack` / `mattermost` / `feishu` (the platforms whose threading is reply-anchor based) pass the anchor; Discord/Telegram/etc. send flat (threading still flows via `metadata.thread_id`, untouched).

## Validation
| Check | Result |
|---|---|
| Real-import E2E (`_send_commentary` per platform) | discord → `reply_to=None`, telegram → `reply_to=None`, buzz → `999888`, slack → `999888` |
| `tests/gateway/test_stream_consumer*.py` + thread routing + buzz adapter + discord send | 267 passed |

**Live repro:** community Discord screenshot (HermesLydia bot) — every interim commentary landed as a reply ping to the user's message after the 66fa6e41c4 update; E2E above confirms the exact send call now carries no reply anchor on Discord while Buzz retains the behavior 66fa6e41c4 fixed.

## Infographic

![Reply spam terminated](https://v3b.fal.media/files/b/0aa898d2/T7LMUZjqt3Ubj5VSGIlBB_JXeaf6IX.png)
