### PR TITLE
fix(desktop): retry late local backend startup

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1205,14 +1205,32 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($connection.get()).toBeNull()
   })
 
-  it('a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout, not only when main eventually gives up (#93454)', async () => {
+  it('a late local backend self-heals after the renderer startup deadline instead of leaving a stale failure overlay', async () => {
     // boot()'s getConnection() had no bound of its own — only main's own
-    // eventual timeout (e.g. waitForHermes, ~45s) ever settled it. A wedge
-    // that main never resolves (not even a rejection) must not hang
-    // "Starting Hermes…" forever; the renderer needs to own its own bound
-    // here too, same as attemptReconnect() and softSwitch().
+    // eventual timeout ever settled it. The renderer owns a 45s bound, but a
+    // Windows orphan-process sweep can keep main's shared startup attempt alive
+    // a little longer and then succeed. Before this fix the renderer published
+    // a terminal error and ignored that late success, leaving the user on a
+    // stale "Hermes couldn't start" screen while the backend was healthy.
     const desktop = fakeDesktop()
-    desktop.getConnection = vi.fn(() => new Promise(() => undefined))
+    let connectionReady = false
+
+    desktop.getConnection = vi.fn(
+      () =>
+        new Promise(resolve => {
+          const settle = () => {
+            if (connectionReady) {
+              resolve(primaryConn)
+
+              return
+            }
+
+            setTimeout(settle, 100)
+          }
+
+          settle()
+        })
+    )
     ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
 
     render(<Harness />)
@@ -1220,14 +1238,23 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($desktopBoot.get().error).toBeNull()
 
-    // Advance past the shared backend-boot budget (45s) — the
-    // stalled await must reject on its own so boot()'s catch runs instead of
-    // waiting indefinitely on main.
+    // Cross the renderer's deadline while main's startup remains live. The
+    // boot overlay stays in a retrying state instead of becoming terminal.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(45_000)
     })
 
-    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().error).toBeNull()
+
+    // The backend becomes ready moments later. The bounded retry joins it and
+    // completes boot without a click on Retry or Repair install.
+    connectionReady = true
+    await advanceBackoff()
+
+    expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(1)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
   })
 
   it('softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever (#93454)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -8,7 +8,12 @@ import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+import {
+  BACKEND_BOOT_WAIT_TIMEOUT_MS,
+  isTimeoutError,
+  RECONNECT_ATTEMPT_TIMEOUT_MS,
+  withTimeout
+} from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -1067,18 +1072,24 @@ export function useGatewayBoot({
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
 
-          // Transient remote failure (dropped SSH/HTTP registered connection,
-          // mint timeout): self-heal with bounded, jittered retries instead of
-          // parking on "Desktop boot failed" until the user re-enters the same
-          // connection details (#82679). Main already cleared the failed cached
-          // descriptor, so the next getConnection() rebuilds the connection —
-          // exactly what manual re-entry forced. Exhausted retries, local
-          // failures, and confirmed reauth rejections end in the real recovery
-          // affordance (the boot-failure overlay), never an infinite spinner.
-          if (bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS && (await bootFailureIsRetryable()) && !cancelled) {
+          // Transient remote failures AND the renderer's own startup deadline
+          // self-heal with bounded, jittered retries instead of parking on
+          // "Desktop boot failed". The latter matters on Windows: orphan-process
+          // cleanup can keep main's shared getConnection() attempt alive past
+          // this renderer deadline even though the backend subsequently becomes
+          // ready. A retry joins that still-live main-process attempt and clears
+          // the overlay automatically. Other local failures and confirmed reauth
+          // rejections still end in the real recovery affordance immediately.
+          const retryable = isTimeoutError(err) || (await bootFailureIsRetryable())
+
+          if (bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS && retryable && !cancelled) {
             const delay = reconnectBackoffDelayMs(bootRetryAttempt, { baseDelayMs: BOOT_RETRY_BASE_DELAY_MS })
             bootRetryAttempt += 1
-            resumeDesktopBootForRetry(translateNow('boot.steps.retryingRemoteBackend'))
+            resumeDesktopBootForRetry(
+              translateNow(
+                isTimeoutError(err) ? 'boot.steps.startingDesktopConnection' : 'boot.steps.retryingRemoteBackend'
+              )
+            )
             clearBootRetryTimer()
             bootRetryTimer = setTimeout(() => {
               bootRetryTimer = null


### PR DESCRIPTION
## What does this PR do?

Lets Desktop recover when the renderer's startup deadline expires just before a local backend becomes ready. That timeout now enters the existing bounded retry path instead of publishing a stale terminal failure overlay while the shared main-process startup continues successfully.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Classify the renderer startup timeout as retryable.
- Keep retries bounded with the existing jitter/backoff limits.
- Preserve terminal handling for non-timeout local failures and rejected reauthorization.
- Add a real-hook regression that crosses the deadline and then completes late startup.

## How to Test

- Gateway boot hook suite: 42 passed.
- Full Desktop TypeScript typecheck passed.
- `git diff --check` passed.

## Checklist

- [x] Retry count remains bounded
- [x] Non-retryable errors still surface normally
- [x] No unrelated files or local operational material
- [x] Tested on Windows 11