### PR TITLE
fix(desktop): clear persisted unread state on open

### DIFF
--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -7,6 +7,11 @@ const setSessionTileWorkspaceScope = vi.fn()
 const openSessionInNewWindow = vi.fn()
 const canOpenSessionWindow = vi.fn(() => true)
 const workspaceIsPageGet = vi.fn(() => false)
+const clearUnreadOnOpen = vi.fn(async (_sessionId: string) => undefined)
+
+vi.mock('@/store/session-unread-remote', () => ({
+  clearUnreadOnOpen: (sessionId: string) => clearUnreadOnOpen(sessionId)
+}))
 
 vi.mock('@/store/session-states', () => ({
   focusedSessionNeedsRoute: (focused: 'main' | 'tile' | null, workspaceIsPage: boolean) =>
@@ -92,6 +97,7 @@ describe('openSession', () => {
     workspaceIsPageGet.mockReturnValue(false)
     reuseBlankDraftTile.mockReset()
     setSessionTileWorkspaceScope.mockReset()
+    clearUnreadOnOpen.mockClear()
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
   })
@@ -102,6 +108,7 @@ describe('openSession', () => {
     expect(focusOpenSession).toHaveBeenCalledWith('s1', { workspaceMode: 'sessions' })
     expect(navigate).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
+    expect(clearUnreadOnOpen).toHaveBeenCalledWith('s1')
   })
 
   it('in-place focuses main when already selected and not on a page', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -24,6 +24,7 @@ import {
   reuseBlankDraftTile,
   setSessionTileWorkspaceScope
 } from '@/store/session-states'
+import { clearUnreadOnOpen } from '@/store/session-unread-remote'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { $workspaceIsPage, sessionRoute } from './routes'
@@ -94,6 +95,10 @@ export function openSession(
   // already on screen (open tile, or the main session) would otherwise return
   // at focusOpenSession and never clear its unread dot.
   markSessionRead(storedSessionId)
+  // The list row also carries the backend's persisted unread watermark. Clear
+  // it on every explicit open, including focus-only paths where the selected
+  // stored id does not change and setSelectedStoredSessionId never runs.
+  void clearUnreadOnOpen(storedSessionId)
   setSessionTileWorkspaceScope(storedSessionId, workspaceScope)
   const botWorkspaceScope = workspaceScope.workspaceMode === 'bots' ? workspaceScope : undefined
 


### PR DESCRIPTION
## What does this PR do?

Clears the backend-persisted unread watermark whenever a user explicitly opens a session, including focus-only paths where the selected session id does not change. This prevents an already-open tile or main session from keeping a stale unread dot after it is brought to the front.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Call the existing remote unread-clear action on every explicit open.
- Preserve the local immediate read marker and existing focus/navigation behavior.
- Cover the already-open focus path that previously returned before remote clearing.

## How to Test

- Open-session suite: 25 passed.
- Full Desktop TypeScript typecheck passed.
- `git diff --check` passed.

## Checklist

- [x] Uses the existing unread persistence API
- [x] Focus-only and navigation paths remain intact
- [x] No unrelated files or local operational material
- [x] Tested on Windows 11