### PR TITLE
fix(cli): list configured platforms beyond the bot-token four in gateway status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12454,21 +12454,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("  Messaging Platform Configuration:")
             print("  " + "-" * 55)
             
+            # Bot-token platforms stay listed even when unconfigured so the
+            # panel keeps guiding setup; every other platform present in the
+            # loaded config (Signal, A2A, plugin adapters, ...) joins the
+            # listing from the config instead of a hardcoded subset (#99788).
             platform_status = {
                 Platform.TELEGRAM: ("Telegram", "TELEGRAM_BOT_TOKEN"),
                 Platform.DISCORD: ("Discord", "DISCORD_BOT_TOKEN"),
                 Platform.SLACK: ("Slack", "SLACK_BOT_TOKEN"),
                 Platform.WHATSAPP: ("WhatsApp", "WHATSAPP_ENABLED"),
             }
-            
+            for platform in config.platforms:
+                if platform is not Platform.LOCAL and platform not in platform_status:
+                    platform_status[platform] = (platform.value.title(), None)
+
             for platform, (name, env_var) in platform_status.items():
                 pconfig = config.platforms.get(platform)
                 if pconfig and pconfig.enabled:
                     home = config.get_home_channel(platform)
                     home_str = f" → {home.name}" if home else ""
                     print(f"    ✓ {name:<12} Enabled{home_str}")
-                else:
+                elif env_var:
                     print(f"    ○ {name:<12} Not configured ({env_var})")
+                else:
+                    print(f"    ○ {name:<12} Disabled")
             
             print()
             print("  Session Reset Policy:")

--- a/tests/cli/test_cli_gateway_status_panel.py
+++ b/tests/cli/test_cli_gateway_status_panel.py
@@ -1,0 +1,73 @@
+"""Tests for the TUI /gateway status panel platform listing (#99788).
+
+The panel used to enumerate a hardcoded subset of four bot-token platforms,
+so platforms like Signal or A2A that were configured and connected were
+reported as absent. The listing must include every platform present in the
+loaded gateway config while keeping the bot-token setup hints.
+"""
+
+from cli import HermesCLI
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+def _config_with(platforms):
+    config = GatewayConfig()
+    for platform, pconfig in platforms.items():
+        config.platforms[platform] = pconfig
+    return config
+
+
+def _run_panel(monkeypatch, tmp_path, config):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._show_gateway_status()
+
+
+def test_gateway_status_lists_configured_first_party_platforms(
+    monkeypatch, tmp_path, capsys
+):
+    """Signal and A2A configured+enabled must be listed as Enabled (#99788)."""
+    config = _config_with({
+        Platform.SIGNAL: PlatformConfig(enabled=True),
+        Platform("a2a"): PlatformConfig(enabled=True),
+    })
+
+    _run_panel(monkeypatch, tmp_path, config)
+    out = capsys.readouterr().out
+
+    assert "Signal" in out and "Enabled" in out
+    assert "A2A" in out
+    assert "Signal      Not configured" not in out
+
+
+def test_gateway_status_keeps_bot_token_setup_hints(monkeypatch, tmp_path, capsys):
+    """Unconfigured bot-token platforms keep their env-var setup hints."""
+    _run_panel(monkeypatch, tmp_path, GatewayConfig())
+    out = capsys.readouterr().out
+
+    assert "Telegram" in out and "Not configured (TELEGRAM_BOT_TOKEN)" in out
+    assert "Not configured (DISCORD_BOT_TOKEN)" in out
+    assert "Not configured (SLACK_BOT_TOKEN)" in out
+    assert "Not configured (WHATSAPP_ENABLED)" in out
+
+
+def test_gateway_status_reports_disabled_extra_platform(monkeypatch, tmp_path, capsys):
+    """A configured-but-disabled non-bot-token platform shows Disabled, not a hint."""
+    config = _config_with({Platform.SIGNAL: PlatformConfig(enabled=False)})
+
+    _run_panel(monkeypatch, tmp_path, config)
+    out = capsys.readouterr().out
+
+    assert "Signal       Disabled" in out
+    assert "Not configured (SIGNAL" not in out
+
+
+def test_gateway_status_skips_local_platform(monkeypatch, tmp_path, capsys):
+    """The LOCAL pseudo-platform never appears in the messaging listing."""
+    config = _config_with({Platform.LOCAL: PlatformConfig(enabled=True)})
+
+    _run_panel(monkeypatch, tmp_path, config)
+    out = capsys.readouterr().out
+
+    assert "Local" not in out


### PR DESCRIPTION
## What does this PR do?

The TUI `/gateway` status panel (`_show_gateway_status` in `cli.py`) enumerated a hardcoded subset of exactly four bot-token platforms (Telegram, Discord, Slack, WhatsApp). Any other configured platform — Signal, A2A, or a plugin-provided adapter — was never listed, so a user running only Signal + A2A saw every platform reported as "Not configured" while the gateway was connected (#99788).

The listing now joins the platforms present in the loaded `GatewayConfig` (skipping the `LOCAL` pseudo-platform) onto the bot-token four:

- configured + enabled → `✓ Signal  Enabled` (with home channel, as before)
- configured but disabled → `○ Signal  Disabled`
- unconfigured bot-token platforms keep their env-var setup hints (`Not configured (TELEGRAM_BOT_TOKEN)`), preserving the existing guided-setup behavior

Platform display names come from `Platform.value.title()`, which renders `signal` → `Signal` and `a2a` → `A2A`.

## Related Issue

Fixes #99788

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `_show_gateway_status`: merge platforms from `config.platforms` into the listing instead of the hardcoded four-entry dict; add a `Disabled` line for configured-but-disabled non-bot-token platforms.
- `tests/cli/test_cli_gateway_status_panel.py` — new regression tests: Signal/A2A listed when configured, bot-token hints preserved when unconfigured, `Disabled` state for configured-but-disabled platforms, `LOCAL` never listed.

## How to Test

1. `python -m pytest tests/cli/test_cli_gateway_status_panel.py -q` → 4 passed.
2. `python -m pytest tests/cli/ tests/gateway/test_status_command.py -q` → all pass except `test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode`, which fails identically on clean `upstream/main` when the whole directory is run (pre-existing order-dependent flake, unrelated to this change).
3. Manual: configure `platforms: { signal: { enabled: true } }` in `config.yaml`, run the TUI and open the gateway status panel → observed result: `✓ Signal  Enabled` line appears next to the bot-token four (before the fix, Signal was absent entirely).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: `tests/cli/` + `tests/gateway/test_status_command.py`; the one failure quoted above reproduces on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (display-only change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python display logic, no platform-specific APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Panel with `signal` and `a2a` configured and enabled:

```
  Messaging Platform Configuration:
  -------------------------------------------------------
    ○ Telegram     Not configured (TELEGRAM_BOT_TOKEN)
    ○ Discord      Not configured (DISCORD_BOT_TOKEN)
    ○ Slack        Not configured (SLACK_BOT_TOKEN)
    ○ WhatsApp     Not configured (WHATSAPP_ENABLED)
    ✓ Signal       Enabled
    ✓ A2A          Enabled
```
