### PR TITLE
fix(cli): derive gateway status platform rows from config and runtime state

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5180,6 +5180,169 @@ def _should_seed_interactive(query, image, quiet: bool, oneshot: bool) -> bool:
         return False
 
 
+# Display names for the gateway status panel. Platforms absent from this map
+# fall back to their enum value title-cased, so first-party additions and
+# plugin platforms render without touching this panel again.
+_GATEWAY_PLATFORM_DISPLAY_NAMES: dict = {
+    "telegram": "Telegram",
+    "discord": "Discord",
+    "whatsapp": "WhatsApp",
+    "whatsapp_cloud": "WhatsApp Cloud",
+    "slack": "Slack",
+    "signal": "Signal",
+    "a2a": "A2A",
+    "mattermost": "Mattermost",
+    "matrix": "Matrix",
+    "homeassistant": "HomeAssistant",
+    "email": "Email",
+    "sms": "SMS",
+    "dingtalk": "DingTalk",
+    "api_server": "API Server",
+    "webhook": "Webhook",
+    "msgraph_webhook": "MSGraph Webhook",
+    "feishu": "Feishu",
+    "wecom": "WeCom",
+    "wecom_callback": "WeCom Callback",
+    "weixin": "Weixin",
+    "bluebubbles": "BlueBubbles",
+    "qqbot": "QQBot",
+    "yuanbao": "Yuanbao",
+    "relay": "Relay",
+}
+
+# Credential env var shown next to "Not configured" for token-based
+# platforms. Sourced from the canonical credential map so the hint stays in
+# sync with what config validation actually checks.
+_GATEWAY_PLATFORM_ENV_HINTS: dict = {
+    "telegram": "TELEGRAM_BOT_TOKEN",
+    "discord": "DISCORD_BOT_TOKEN",
+    "slack": "SLACK_BOT_TOKEN",
+    "whatsapp": "WHATSAPP_ENABLED",
+    "mattermost": "MATTERMOST_TOKEN",
+    "matrix": "MATRIX_ACCESS_TOKEN",
+    "weixin": "WEIXIN_TOKEN",
+}
+
+
+def _gateway_platform_display_name(platform) -> str:
+    """Human-readable platform label for the gateway status panel."""
+    value = getattr(platform, "value", str(platform)).lower()
+    return _GATEWAY_PLATFORM_DISPLAY_NAMES.get(value, value.replace("_", " ").title())
+
+
+def _gateway_runtime_platform_state() -> dict:
+    """Live per-platform health states from the gateway runtime snapshot."""
+    try:
+        from gateway.status import read_runtime_status
+
+        runtime = read_runtime_status()
+    except Exception:
+        return {}
+    platforms = (runtime or {}).get("platforms")
+    if not isinstance(platforms, dict):
+        return {}
+    return {
+        str(key).lower(): entry
+        for key, entry in platforms.items()
+        if isinstance(entry, dict)
+    }
+
+
+def _gateway_status_symbol(state: str) -> str:
+    """Panel marker for a platform's runtime state."""
+    if state == "connected":
+        return "✓"
+    if state in ("retrying", "needs_attention"):
+        return "!"
+    return "○"
+
+
+def format_gateway_platform_rows(config) -> list:
+    """Build the gateway status panel's platform rows from actual config.
+
+    Rows come from the platforms present in the loaded ``GatewayConfig`` (so
+    Signal, A2A, and plugin platforms appear by construction) plus any
+    platform the running gateway reports in its runtime snapshot that config
+    alone would miss. Runtime state decorates every enabled row; the classic
+    token platforms keep their credential hints when not configured.
+    """
+    from gateway.config import Platform
+
+    rows: list = []
+    seen: set = set()
+
+    runtime_states = _gateway_runtime_platform_state()
+
+    def _emit(platform, pconfig, runtime_entry=None):
+        key = platform.value.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        name = _gateway_platform_display_name(platform)
+        entry = runtime_entry if runtime_entry is not None else (runtime_states.get(key) or {})
+        state = str(entry.get("state") or "").lower()
+        needs_attention = bool(entry.get("needs_attention"))
+        if pconfig and pconfig.enabled:
+            home = config.get_home_channel(platform)
+            home_str = f" → {home.name}" if home else ""
+            state_str = f" ({state})" if state and state != "connected" else ""
+            att_str = " [needs attention]" if needs_attention else ""
+            symbol = _gateway_status_symbol(state if not needs_attention else "needs_attention")
+            rows.append(
+                f"    {symbol} {name:<12} Enabled{home_str}{state_str}{att_str}"
+            )
+        elif state:
+            # Platform is running (e.g. secondary-profile adapter) but has no
+            # enabled config entry in this profile: still report live state.
+            symbol = _gateway_status_symbol(state if not needs_attention else "needs_attention")
+            att_str = " [needs attention]" if needs_attention else ""
+            rows.append(f"    {symbol} {name:<12} {state}{att_str}")
+        else:
+            env_hint = _GATEWAY_PLATFORM_ENV_HINTS.get(key)
+            hint_str = f" ({env_hint})" if env_hint else ""
+            rows.append(f"    ○ {name:<12} Not configured{hint_str}")
+
+    for platform, pconfig in config.platforms.items():
+        if platform == Platform.LOCAL:
+            continue
+        _emit(platform, pconfig)
+
+    # Runtime-only platforms (multiplexed profiles, plugins that never write
+    # to this profile's config): append after config rows so the panel shows
+    # everything the live gateway is actually running.
+    from gateway.config import Platform as _Platform
+
+    for raw_key, entry in runtime_states.items():
+        key = raw_key
+        if ":" in key:
+            # Secondary-profile entries are "<profile>:<platform>" — surface
+            # the platform part so multiplexed channels aren't lost.
+            key = key.split(":", 1)[1]
+            if key in seen:
+                continue
+        else:
+            entry = None
+        if key in seen:
+            continue
+        try:
+            platform = _Platform(key)
+        except (ValueError, AttributeError):
+            continue
+        _emit(platform, None, runtime_entry=entry)
+
+    if not rows:
+        # Nothing configured anywhere: keep the classic onboarding hints so
+        # an empty setup still tells the user which env vars enable what.
+        for key, env_hint in _GATEWAY_PLATFORM_ENV_HINTS.items():
+            try:
+                platform = _Platform(key)
+            except (ValueError, AttributeError):
+                continue
+            name = _gateway_platform_display_name(platform)
+            rows.append(f"    ○ {name:<12} Not configured ({env_hint})")
+    return rows
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -12440,36 +12603,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _show_gateway_status(self):
         """Show status of the gateway and connected messaging platforms."""
-        from gateway.config import load_gateway_config, Platform
-        
+        from gateway.config import load_gateway_config
+
         print()
         print("+" + "-" * 60 + "+")
         print("|" + " " * 15 + "(✿◠‿◠) Gateway Status" + " " * 17 + "|")
         print("+" + "-" * 60 + "+")
         print()
-        
+
         try:
             config = load_gateway_config()
-            
+
             print("  Messaging Platform Configuration:")
             print("  " + "-" * 55)
-            
-            platform_status = {
-                Platform.TELEGRAM: ("Telegram", "TELEGRAM_BOT_TOKEN"),
-                Platform.DISCORD: ("Discord", "DISCORD_BOT_TOKEN"),
-                Platform.SLACK: ("Slack", "SLACK_BOT_TOKEN"),
-                Platform.WHATSAPP: ("WhatsApp", "WHATSAPP_ENABLED"),
-            }
-            
-            for platform, (name, env_var) in platform_status.items():
-                pconfig = config.platforms.get(platform)
-                if pconfig and pconfig.enabled:
-                    home = config.get_home_channel(platform)
-                    home_str = f" → {home.name}" if home else ""
-                    print(f"    ✓ {name:<12} Enabled{home_str}")
-                else:
-                    print(f"    ○ {name:<12} Not configured ({env_var})")
-            
+
+            for line in format_gateway_platform_rows(config):
+                print(line)
+
             print()
             print("  Session Reset Policy:")
             print("  " + "-" * 55)
@@ -12477,14 +12627,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"    Mode: {policy.mode}")
             print(f"    Daily reset at: {policy.at_hour}:00")
             print(f"    Idle timeout: {policy.idle_minutes} minutes")
-            
+
             print()
             print("  To start the gateway:")
             print("    python cli.py --gateway")
             print()
             print(f"  Configuration file: {display_hermes_home()}/config.yaml")
             print()
-            
+
         except Exception as e:
             print(f"  Error loading gateway config: {e}")
             print()
@@ -12494,7 +12644,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("       DISCORD_BOT_TOKEN=your_token")
             print(f"    2. Or configure settings in {display_hermes_home()}/config.yaml")
             print()
-    
     def process_command(self, command: str) -> bool:
         """
         Process a slash command.

--- a/tests/hermes_cli/test_gateway_status_panel.py
+++ b/tests/hermes_cli/test_gateway_status_panel.py
@@ -1,0 +1,86 @@
+"""Gateway status panel platform rows (TUI `/gateway status` display)."""
+
+from unittest.mock import patch
+
+from cli import format_gateway_platform_rows
+from gateway.config import GatewayConfig, Platform, PlatformConfig, SessionResetPolicy
+
+
+def _config_with(platforms):
+    return GatewayConfig(
+        platforms=platforms,
+        default_reset_policy=SessionResetPolicy(),
+    )
+
+
+def test_signal_and_a2a_only_configuration_renders_connected(tmp_path):
+    """Signal+A2A-only setups show real runtime state, not four 'Not configured' rows."""
+    a2a = Platform("a2a")  # bundled plugin platform
+    config = _config_with(
+        {
+            Platform.SIGNAL: PlatformConfig(enabled=True),
+            a2a: PlatformConfig(enabled=True),
+        }
+    )
+
+    runtime_snapshot = {
+        "platforms": {
+            "signal": {"state": "connected", "needs_attention": False},
+            "a2a": {"state": "connected", "needs_attention": False},
+        }
+    }
+
+    with patch("gateway.status.read_runtime_status", return_value=runtime_snapshot):
+        rows = format_gateway_platform_rows(config)
+
+    text = "\n".join(rows)
+    assert "Signal" in text
+    assert "A2A" in text
+    # No platform reports "Not configured": both are enabled and connected.
+    assert "Not configured" not in text
+    # Enabled rows keep the checkmark.
+    assert sum(1 for r in rows if "✓" in r) == 2
+
+
+def test_runtime_state_decorates_enabled_rows(tmp_path):
+    """A retrying platform shows its live state instead of a bare 'Enabled'."""
+    config = _config_with({Platform.SIGNAL: PlatformConfig(enabled=True)})
+    runtime_snapshot = {
+        "platforms": {
+            "signal": {"state": "retrying", "needs_attention": True},
+        }
+    }
+    with patch("gateway.status.read_runtime_status", return_value=runtime_snapshot):
+        rows = format_gateway_platform_rows(config)
+    text = "\n".join(rows)
+    assert "Signal" in text
+    assert "retrying" in text
+    assert "needs attention" in text
+    assert "✓" not in text
+
+
+def test_classic_token_platforms_keep_env_hints(tmp_path):
+    """Unconfigured classic platforms still show their credential env var."""
+    config = _config_with({})
+    with patch("gateway.status.read_runtime_status", return_value=None):
+        rows = format_gateway_platform_rows(config)
+    text = "\n".join(rows)
+    assert "TELEGRAM_BOT_TOKEN" in text
+    assert "DISCORD_BOT_TOKEN" in text
+    assert "SLACK_BOT_TOKEN" in text
+    assert "WHATSAPP_ENABLED" in text
+
+
+def test_runtime_only_platform_appended(tmp_path):
+    """A platform the gateway runs but config misses still gets a row."""
+    config = _config_with({})
+    runtime_snapshot = {
+        "platforms": {
+            "work:signal": {"state": "connected", "needs_attention": False},
+        }
+    }
+    with patch("gateway.status.read_runtime_status", return_value=runtime_snapshot):
+        rows = format_gateway_platform_rows(config)
+    text = "\n".join(rows)
+    assert "Signal" in text
+    assert "connected" in text


### PR DESCRIPTION
## Summary

`_show_gateway_status` in `cli.py` built the platform panel from a hardcoded four-entry dict (`TELEGRAM`/`DISCORD`/`SLACK`/`WHATSAPP`), so a Signal+A2A-only setup rendered every platform as "Not configured" even while `gateway_state.json` reported both connected.

Root cause: the panel enumerated a literal subset of `Platform` instead of the platforms actually present in the loaded `GatewayConfig` (and any platform the running gateway reports in its runtime snapshot).

- New module-level helpers in `cli.py`:
  - `format_gateway_platform_rows(config)` builds the rows from `config.platforms` (any platform — Signal, A2A, plugin platforms — appears by construction), then appends runtime-only entries (including `<profile>:<platform>` multiplex keys) the config layer misses.
  - `_gateway_runtime_platform_state()` reads the live per-platform health from `gateway_state.json` via the existing `read_runtime_status()` — the same source the desktop gateway panel and `/api/status` use.
  - Display names cover the built-in enum values with a title-case fallback; credential env hints keep the classic onboarding rows for the token platforms.
- Enabled rows now show runtime state decoration: `(retrying)` and `[needs attention]` markers come from the live snapshot, `✓` only for `connected`.
- Empty configs keep the previous four "Not configured (<ENV_VAR>)" onboarding hints, so a fresh setup still tells the user what to set.
- `_show_gateway_status` itself is now a thin renderer; the row builder is directly testable.

## Testing

- `tests/hermes_cli/test_gateway_status_panel.py` — 4 new tests: Signal+A2A-only config renders two connected rows (the exact repro from the issue); retrying+needs_attention decoration; classic env hints on empty config; runtime-only `<profile>:<platform>` entry gets a row.
- `~/.hermes/hermes-agent/.venv -m pytest tests/hermes_cli/test_gateway_status_panel.py -q` → **4 passed**
- Neighbor suite unaffected: `pytest tests/gateway/test_config.py -q` → **62 passed**
- `ruff check cli.py tests/hermes_cli/test_gateway_status_panel.py` → **clean**
- Live smoke with a temp `HERMES_HOME` (`platforms: {signal: {enabled: true}, a2a: {enabled: true}}` + matching `gateway_state.json`), calling `HermesCLI._show_gateway_status()` directly:

```
  Messaging Platform Configuration:
  -------------------------------------------------------
    ✓ Signal       Enabled
    ✓ A2A          Enabled
```

instead of four "Not configured" rows.

Fixes #99788